### PR TITLE
fix: avoid blocking tokio on session saves

### DIFF
--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -149,6 +149,15 @@ impl MemorySubstrate {
         self.sessions.save_session(session)
     }
 
+    /// Save a session asynchronously on a blocking worker thread.
+    pub async fn save_session_async(&self, session: &Session) -> LibreFangResult<()> {
+        let sessions = self.sessions.clone();
+        let session = session.clone();
+        tokio::task::spawn_blocking(move || sessions.save_session(&session))
+            .await
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?
+    }
+
     /// Create a new empty session for an agent.
     pub fn create_session(&self, agent_id: AgentId) -> LibreFangResult<Session> {
         self.sessions.create_session(agent_id)

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -385,7 +385,8 @@ pub async fn run_agent_loop(
                         .messages
                         .push(Message::assistant("[no reply needed]".to_string()));
                     memory
-                        .save_session(session)
+                        .save_session_async(session)
+                        .await
                         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                     return Ok(AgentLoopResult {
                         response: String::new(),
@@ -453,7 +454,8 @@ pub async fn run_agent_loop(
 
                 // Save session
                 memory
-                    .save_session(session)
+                    .save_session_async(session)
+                    .await
                     .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
                 // Remember this interaction (with embedding if available)
@@ -567,7 +569,7 @@ pub async fn run_agent_loop(
                         LoopGuardVerdict::CircuitBreak(msg) => {
                             warn!(tool = %tool_call.name, "Circuit breaker triggered");
                             // Save session before bailing
-                            if let Err(e) = memory.save_session(session) {
+                            if let Err(e) = memory.save_session_async(session).await {
                                 warn!("Failed to save session on circuit break: {e}");
                             }
                             // Fire AgentLoopEnd hook on circuit break
@@ -765,7 +767,7 @@ pub async fn run_agent_loop(
                 messages.push(tool_results_msg);
 
                 // Interim save after tool execution to prevent data loss on crash
-                if let Err(e) = memory.save_session(session) {
+                if let Err(e) = memory.save_session_async(session).await {
                     warn!("Failed to interim-save session: {e}");
                 }
             }
@@ -780,7 +782,7 @@ pub async fn run_agent_loop(
                         text
                     };
                     session.messages.push(Message::assistant(&text));
-                    if let Err(e) = memory.save_session(session) {
+                    if let Err(e) = memory.save_session_async(session).await {
                         warn!("Failed to save session on max continuations: {e}");
                     }
                     warn!(
@@ -822,7 +824,7 @@ pub async fn run_agent_loop(
     }
 
     // Save session before failing so conversation history is preserved
-    if let Err(e) = memory.save_session(session) {
+    if let Err(e) = memory.save_session_async(session).await {
         warn!("Failed to save session on max iterations: {e}");
     }
 
@@ -1365,7 +1367,8 @@ pub async fn run_agent_loop_streaming(
                         .messages
                         .push(Message::assistant("[no reply needed]".to_string()));
                     memory
-                        .save_session(session)
+                        .save_session_async(session)
+                        .await
                         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                     return Ok(AgentLoopResult {
                         response: String::new(),
@@ -1432,7 +1435,8 @@ pub async fn run_agent_loop_streaming(
                 crate::session_repair::prune_heartbeat_turns(&mut session.messages, 10);
 
                 memory
-                    .save_session(session)
+                    .save_session_async(session)
+                    .await
                     .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
                 // Remember this interaction (with embedding if available)
@@ -1542,7 +1546,7 @@ pub async fn run_agent_loop_streaming(
                     match &verdict {
                         LoopGuardVerdict::CircuitBreak(msg) => {
                             warn!(tool = %tool_call.name, "Circuit breaker triggered (streaming)");
-                            if let Err(e) = memory.save_session(session) {
+                            if let Err(e) = memory.save_session_async(session).await {
                                 warn!("Failed to save session on circuit break: {e}");
                             }
                             // Fire AgentLoopEnd hook on circuit break
@@ -1752,7 +1756,7 @@ pub async fn run_agent_loop_streaming(
                 session.messages.push(tool_results_msg.clone());
                 messages.push(tool_results_msg);
 
-                if let Err(e) = memory.save_session(session) {
+                if let Err(e) = memory.save_session_async(session).await {
                     warn!("Failed to interim-save session: {e}");
                 }
             }
@@ -1766,7 +1770,7 @@ pub async fn run_agent_loop_streaming(
                         text
                     };
                     session.messages.push(Message::assistant(&text));
-                    if let Err(e) = memory.save_session(session) {
+                    if let Err(e) = memory.save_session_async(session).await {
                         warn!("Failed to save session on max continuations: {e}");
                     }
                     warn!(
@@ -1806,7 +1810,7 @@ pub async fn run_agent_loop_streaming(
         }
     }
 
-    if let Err(e) = memory.save_session(session) {
+    if let Err(e) = memory.save_session_async(session).await {
         warn!("Failed to save session on max iterations: {e}");
     }
 


### PR DESCRIPTION
## Summary
- add `save_session_async()` to offload SQLite writes with `spawn_blocking`
- switch async agent loop save points to `save_session_async().await`
- keep the synchronous `save_session()` API for non-async callers

## Why
`save_session()` currently runs synchronous SQLite writes on the tokio worker thread. Under low-core deployments that can block unrelated async work and degrade daemon responsiveness.

## Upstream reference
- RightNow-AI/openfang#534

## Testing
- `cargo fmt --all --check`
- `cargo check -p librefang-memory -p librefang-runtime`

Closes #14