### PR TITLE
fix: handle Slack app_mention events

### DIFF
--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -594,12 +594,8 @@ mod tests {
         });
 
         // Channel C789 is not in the allowed list
-        let msg = parse_slack_event(
-            &event,
-            &bot_id,
-            &["C111".to_string(), "C222".to_string()],
-        )
-        .await;
+        let msg =
+            parse_slack_event(&event, &bot_id, &["C111".to_string(), "C222".to_string()]).await;
         assert!(
             msg.is_none(),
             "app_mention in a channel not in allowed_channels should be filtered out"


### PR DESCRIPTION
## Summary
- accept Slack `app_mention` events in the Socket Mode adapter
- set `metadata["was_mentioned"] = true` for `app_mention` messages
- add a targeted parser test for the mention metadata path

## Why
The current Slack adapter only parses `message` events, so pure @mentions can be ignored when Slack emits `app_mention`.

## Upstream reference
- RightNow-AI/openfang#540

## Testing
- `cargo fmt --all --check`
- `cargo check -p librefang-channels`
- `cargo test -p librefang-channels test_parse_slack_app_mention_sets_was_mentioned`

Closes #16