### PR TITLE
feat(doctor): add version update and network connectivity checks

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3040,8 +3040,16 @@ decay_rate = 0.05
             ("ANTHROPIC_API_KEY", "Anthropic", "api.anthropic.com:443"),
             ("GROQ_API_KEY", "Groq", "api.groq.com:443"),
             ("DEEPSEEK_API_KEY", "DeepSeek", "api.deepseek.com:443"),
-            ("GEMINI_API_KEY", "Gemini", "generativelanguage.googleapis.com:443"),
-            ("GOOGLE_API_KEY", "Google", "generativelanguage.googleapis.com:443"),
+            (
+                "GEMINI_API_KEY",
+                "Gemini",
+                "generativelanguage.googleapis.com:443",
+            ),
+            (
+                "GOOGLE_API_KEY",
+                "Google",
+                "generativelanguage.googleapis.com:443",
+            ),
             ("OPENROUTER_API_KEY", "OpenRouter", "openrouter.ai:443"),
             ("TOGETHER_API_KEY", "Together", "api.together.xyz:443"),
             ("MISTRAL_API_KEY", "Mistral", "api.mistral.ai:443"),


### PR DESCRIPTION
## Summary
- Add **version update check**: fetches latest release from GitHub API, compares with current CLI version, warns if outdated
- Add **network connectivity check**: TCP connect test to configured LLM provider endpoints (only checks providers with API keys set)

Both checks have 3s timeouts and fail gracefully.

Closes #201

## Test plan
- [ ] Run `librefang doctor` with outdated version — should show update warning
- [ ] Run `librefang doctor` with latest version — should show "up to date"
- [ ] Run `librefang doctor` offline — should warn "network unavailable"
- [ ] Run `librefang doctor --json` — new checks included in JSON output
- [ ] Set API keys and verify network connectivity checks appear
- [ ] Block a provider endpoint and verify "unreachable" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)