### PR TITLE
fix: inherit environment variables when spawning daemon

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1678,7 +1678,8 @@ fn spawn_detached_daemon(
         .args(detached_daemon_args(config))
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr));
+        .stderr(Stdio::from(stderr))
+        .envs(std::env::vars());
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Summary
- Pass environment variables to the detached daemon process

## Problem
When `librefang start` spawns a detached daemon, the new process doesn't inherit environment variables from the parent. This causes API keys (like `MINIMAX_API_KEY`) to be unavailable in the daemon.

## Solution
Use `.envs(std::env::vars())` to pass all current environment variables to the spawned daemon process.

## Test plan
- [ ] Start daemon with API keys in .env
- [ ] Verify API keys are available in daemon process

🤖 Generated with [Claude Code](https://claude.com/claude-code)