### PR TITLE
feat: add community contribution tooling and guides

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit hooks for LibreFang
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+# Docs: https://pre-commit.com
+
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt-check
+        name: cargo fmt check
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy (warnings as errors)
+        entry: cargo clippy --workspace --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ This guide covers everything you need to get started, from setting up your devel
 - [How to Add a New Channel Adapter](#how-to-add-a-new-channel-adapter)
 - [How to Add a New LLM Provider](#how-to-add-a-new-llm-provider)
 - [How to Add a New Tool](#how-to-add-a-new-tool)
+- [How to Write Integration Tests](#how-to-write-integration-tests)
 - [Pull Request Process](#pull-request-process)
 - [Code of Conduct](#code-of-conduct)
 
@@ -504,6 +505,86 @@ tools = ["my_tool"]
 5. Write tests for the tool function.
 
 6. If the tool requires kernel access (e.g., inter-agent communication), accept `Option<&Arc<dyn KernelHandle>>` and handle the `None` case gracefully.
+
+---
+
+## How to Write Integration Tests
+
+Integration tests verify that crates work correctly with their dependencies and real I/O. They live alongside unit tests but in dedicated directories.
+
+### Where Integration Tests Live
+
+```
+crates/librefang-kernel/tests/   # Kernel integration tests
+crates/librefang-runtime/tests/  # Runtime integration tests
+crates/librefang-memory/tests/   # Memory/SQLite integration tests
+crates/librefang-channels/tests/ # Channel adapter tests
+```
+
+Each crate can have a `tests/` directory at its root. Cargo automatically treats `.rs` files in `tests/` as integration test binaries.
+
+### How to Structure a Test
+
+```rust
+// crates/librefang-memory/tests/session_store.rs
+
+use librefang_memory::MemoryStore;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_session_roundtrip() {
+    // 1. Set up isolated test fixtures
+    let tmp = TempDir::new().unwrap();
+    let store = MemoryStore::open(tmp.path().join("test.db")).await.unwrap();
+
+    // 2. Exercise the feature
+    store.save_session("agent-1", "Hello!").await.unwrap();
+    let sessions = store.list_sessions("agent-1").await.unwrap();
+
+    // 3. Assert expected outcomes
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].content, "Hello!");
+
+    // 4. Cleanup is automatic (TempDir drops)
+}
+```
+
+### Key Patterns
+
+- **Filesystem isolation**: Always use `tempfile::TempDir` for tests that touch the filesystem.
+- **Network isolation**: Use `0` as the port (OS assigns a random free port) for tests that bind a socket.
+- **Skip when no API key**: For tests that need a real LLM, check the env var and skip gracefully:
+
+```rust
+#[tokio::test]
+async fn test_groq_completion() {
+    let api_key = match std::env::var("GROQ_API_KEY") {
+        Ok(k) => k,
+        Err(_) => {
+            eprintln!("Skipping: GROQ_API_KEY not set");
+            return;
+        }
+    };
+    // ... test with real API
+}
+```
+
+### Running Tests
+
+```bash
+# Run all tests across the workspace
+cargo test --workspace
+
+# Run tests for a specific crate
+cargo test -p librefang-kernel
+cargo test -p librefang-memory
+
+# Run a single test by name
+cargo test -p librefang-memory test_session_roundtrip
+
+# Run with output (useful for debugging skipped tests)
+cargo test -p librefang-runtime -- --nocapture
+```
 
 ---
 

--- a/examples/custom-channel/README.md
+++ b/examples/custom-channel/README.md
@@ -1,0 +1,41 @@
+# Custom Channel Adapter Example
+
+This example demonstrates how to implement a custom channel adapter for LibreFang.
+
+## Overview
+
+Channel adapters bridge external messaging platforms to the LibreFang kernel. Every adapter implements the `ChannelAdapter` trait defined in `crates/librefang-channels/src/types.rs`.
+
+For full documentation, see [docs/channel-adapters.md](../../docs/channel-adapters.md).
+
+## The `ChannelAdapter` Trait
+
+The core trait requires four methods and provides several optional ones:
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `name()` | Yes | Human-readable adapter name |
+| `channel_type()` | Yes | Returns a `ChannelType` variant |
+| `start()` | Yes | Begin receiving messages; returns a `Stream<Item = ChannelMessage>` |
+| `send()` | Yes | Send a response to a user |
+| `stop()` | Yes | Clean shutdown |
+| `send_typing()` | No | Send a typing indicator (default: no-op) |
+| `send_reaction()` | No | Send a lifecycle reaction emoji (default: no-op) |
+| `status()` | No | Report adapter health (default: disconnected) |
+| `send_in_thread()` | No | Reply in a thread (default: falls back to `send()`) |
+
+## Minimal Example
+
+See `adapter.rs` in this directory for a minimal implementation that polls a directory for `.txt` files as incoming messages and writes responses to an output directory.
+
+## Integration Steps
+
+After implementing the trait:
+
+1. Add your module to `crates/librefang-channels/src/lib.rs`
+2. Wire it into the channel bridge in `crates/librefang-api/src/channel_bridge.rs`
+3. Add config support in `librefang-types` config structs
+4. Write tests
+5. Submit a PR
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#how-to-add-a-new-channel-adapter) for the full walkthrough.

--- a/examples/custom-channel/adapter.rs
+++ b/examples/custom-channel/adapter.rs
@@ -1,0 +1,133 @@
+//! Minimal custom channel adapter example.
+//!
+//! This is a standalone example showing the structure of a `ChannelAdapter`
+//! implementation. It is NOT a compilable crate — it demonstrates the pattern
+//! you would follow inside `crates/librefang-channels/src/`.
+//!
+//! This example adapter watches a directory for `.txt` files (simulating
+//! incoming messages) and writes responses to an output directory.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures::Stream;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+// These imports come from `crate::types` when inside librefang-channels.
+use librefang_channels::types::{
+    ChannelAdapter, ChannelContent, ChannelMessage, ChannelStatus, ChannelType, ChannelUser,
+    LifecycleReaction,
+};
+
+/// A minimal channel adapter that reads messages from a directory.
+pub struct FileChannelAdapter {
+    /// Directory to watch for incoming `.txt` files.
+    inbox_dir: String,
+    /// Directory to write outbound responses.
+    outbox_dir: String,
+    /// Shutdown signal sender.
+    shutdown_tx: Arc<watch::Sender<bool>>,
+    /// Shutdown signal receiver.
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl FileChannelAdapter {
+    pub fn new(inbox_dir: String, outbox_dir: String) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            inbox_dir,
+            outbox_dir,
+            shutdown_tx: Arc::new(shutdown_tx),
+            shutdown_rx,
+        }
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for FileChannelAdapter {
+    fn name(&self) -> &str {
+        "file-channel"
+    }
+
+    fn channel_type(&self) -> ChannelType {
+        ChannelType::Custom("file".to_string())
+    }
+
+    async fn start(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>, Box<dyn std::error::Error>>
+    {
+        let inbox = self.inbox_dir.clone();
+        let mut shutdown = self.shutdown_rx.clone();
+
+        // Create a stream that polls the inbox directory for new .txt files.
+        let stream = async_stream::stream! {
+            let mut seen = std::collections::HashSet::new();
+            loop {
+                tokio::select! {
+                    _ = shutdown.changed() => break,
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+                }
+
+                if let Ok(entries) = std::fs::read_dir(&inbox) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.extension().map_or(false, |e| e == "txt")
+                            && seen.insert(path.clone())
+                        {
+                            if let Ok(text) = std::fs::read_to_string(&path) {
+                                yield ChannelMessage {
+                                    channel: ChannelType::Custom("file".to_string()),
+                                    platform_message_id: path.display().to_string(),
+                                    sender: ChannelUser {
+                                        platform_id: "file-user".to_string(),
+                                        display_name: "File User".to_string(),
+                                        librefang_user: None,
+                                    },
+                                    content: ChannelContent::Text(text),
+                                    target_agent: None,
+                                    timestamp: Utc::now(),
+                                    is_group: false,
+                                    thread_id: None,
+                                    metadata: HashMap::new(),
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn send(
+        &self,
+        user: &ChannelUser,
+        content: ChannelContent,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if let ChannelContent::Text(text) = &content {
+            let filename = format!(
+                "{}/response-{}.txt",
+                self.outbox_dir,
+                Utc::now().timestamp_millis()
+            );
+            std::fs::write(&filename, text)?;
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.shutdown_tx.send(true);
+        Ok(())
+    }
+
+    fn status(&self) -> ChannelStatus {
+        ChannelStatus {
+            connected: !*self.shutdown_rx.borrow(),
+            ..Default::default()
+        }
+    }
+}

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,50 @@
+# LibreFang Internationalization (i18n)
+
+This directory contains translated versions of the project README.
+
+## Current Translations
+
+| Language | File | Status |
+|----------|------|--------|
+| English | [README.md](../README.md) | Source |
+| Chinese (中文) | [README.zh.md](README.zh.md) | Complete |
+| Japanese (日本語) | [README.ja.md](README.ja.md) | Complete |
+| Korean (한국어) | [README.ko.md](README.ko.md) | Complete |
+| Spanish (Español) | [README.es.md](README.es.md) | Complete |
+| German (Deutsch) | [README.de.md](README.de.md) | Complete |
+
+## Translation File Structure
+
+Each translation is a complete copy of the main `README.md`, translated into the target language. Files follow the naming convention `README.<lang-code>.md` where `<lang-code>` is an [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) two-letter language code.
+
+All translated READMEs live in this `i18n/` directory. The English source `README.md` stays at the repository root.
+
+## How to Add a New Language
+
+1. **Copy the English README** as your starting point:
+
+   ```bash
+   cp README.md i18n/README.<lang-code>.md
+   ```
+
+2. **Translate the content**. Keep the same Markdown structure (headings, tables, code blocks). Do NOT translate:
+   - Code snippets and command-line examples
+   - File paths and crate names
+   - API endpoint paths
+   - Brand names (LibreFang, Rust, GitHub, etc.)
+
+3. **Update the language selector** at the top of your translated file to include all languages, with yours marked as current.
+
+4. **Update this README** by adding your language to the table above.
+
+5. **Add the language link** to the language selector in every other translated README and the root `README.md`.
+
+6. **Submit a PR** with the title `docs: add <Language> translation`.
+
+## Style Guidelines
+
+- **Tone**: Match the original — friendly, direct, and technical.
+- **Terminology**: Use widely accepted technical terms in your language. If a term has no standard translation (e.g., "agent", "kernel"), keep the English term.
+- **Formatting**: Preserve all Markdown formatting, badges, and links. Only translate human-readable text.
+- **Consistency**: If a term appears multiple times, translate it the same way throughout.
+- **Updates**: When the English README changes, translations may need updating. Check `git log -- README.md` to see what changed.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,44 @@
+# LibreFang Development Commands
+# Install just: https://github.com/casey/just
+
+# Build all workspace crates (library targets)
+build:
+    cargo build --workspace --lib
+
+# Run all workspace tests
+test:
+    cargo test --workspace
+
+# Run clippy with warnings as errors
+lint:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Format all code
+fmt:
+    cargo fmt --all
+
+# Check all workspace crates (fast compile check, no codegen)
+check:
+    cargo check --workspace
+
+# Run local CI simulation: format check + lint + test
+ci:
+    cargo fmt --all -- --check
+    cargo clippy --workspace --all-targets -- -D warnings
+    cargo test --workspace
+
+# Generate workspace documentation
+doc:
+    cargo doc --workspace --no-deps
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Sync version numbers across all crates
+sync-versions:
+    ./scripts/sync-versions.sh
+
+# Create a release
+release:
+    ./scripts/release.sh


### PR DESCRIPTION
## Summary

- **justfile**: Unified dev commands (`just build`, `just test`, `just lint`, `just ci`, etc.) so contributors don't need to memorize cargo flags
- **Channel adapter example**: `examples/custom-channel/` with a README explaining the `ChannelAdapter` trait and a minimal file-based adapter implementation showing the full pattern
- **Integration test guide**: New "How to Write Integration Tests" section in CONTRIBUTING.md covering test location, structure patterns, isolation techniques, and run commands
- **Pre-commit hooks**: `.pre-commit-config.yaml` with cargo fmt check (on commit) and cargo clippy (on push)
- **i18n contribution guide**: `i18n/README.md` documenting the translation file structure, how to add a new language, and style guidelines

## Test plan

- [x] `cargo build --workspace --lib` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [ ] Verify `just ci` works with [just](https://github.com/casey/just) installed
- [ ] Verify `pre-commit run --all-files` works with pre-commit installed