### PR TITLE
chore: bump version to v0.4.2-20260314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-03-14
+
+### Added
+
+- Add CLI deploy command and FAQ to deploy page (#238) (@houko)
+- Auto-sync model catalog on daemon startup (#237) (@houko)
+- Add channel sidecar protocol for external adapters (#228) (@houko)
+- Integrate model-catalog sync with dashboard UI (#227) (@houko)
+- Add cargo feature flags for channel adapters (#223) (@houko)
+- Improve community organization and version governance (#212) (@houko)
+
+### Fixed
+
+- Daemon env vars, MCP probe, and SSE parsing (#211) (@houko)
+
+### Changed
+
+- Replace hardcoded model catalog with include_str TOML (#235) (@houko)
+- Replace provider match with static registry (#224) (@houko)
+
+### Documentation
+
+- Add integration test writing guide to CONTRIBUTING.md (#232) (@houko)
+- Add channel adapter contribution example (#231) (@houko)
+
+### Maintenance
+
+- Trigger deploy worker auto-deploy (#239) (@houko)
+- Add pre-commit hooks and i18n contribution guide (#233) (@houko)
+- Add justfile for unified dev commands (#230) (@houko)
+- Upgrade GitHub Actions for Node.js 24 compatibility (#229) (@houko)
+
 ## [0.4.0] - 2026-03-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes",
  "async-trait",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "hex",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9443,7 +9443,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/agents/analyst/agent.toml
+++ b/agents/analyst/agent.toml
@@ -1,5 +1,5 @@
 name = "analyst"
-version = "0.4.0"
+version = "0.4.2"
 description = "Data analyst. Processes data, generates insights, creates reports."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/architect/agent.toml
+++ b/agents/architect/agent.toml
@@ -1,5 +1,5 @@
 name = "architect"
-version = "0.4.0"
+version = "0.4.2"
 description = "System architect. Designs software architectures, evaluates trade-offs, creates technical specifications."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/assistant/agent.toml
+++ b/agents/assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "assistant"
-version = "0.4.0"
+version = "0.4.2"
 description = "General-purpose assistant agent. The default OpenClaw agent for everyday tasks, questions, and conversations."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/code-reviewer/agent.toml
+++ b/agents/code-reviewer/agent.toml
@@ -1,5 +1,5 @@
 name = "code-reviewer"
-version = "0.4.0"
+version = "0.4.2"
 description = "Senior code reviewer. Reviews PRs, identifies issues, suggests improvements with production standards."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/coder/agent.toml
+++ b/agents/coder/agent.toml
@@ -1,5 +1,5 @@
 name = "coder"
-version = "0.4.0"
+version = "0.4.2"
 description = "Expert software engineer. Reads, writes, and analyzes code."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/customer-support/agent.toml
+++ b/agents/customer-support/agent.toml
@@ -1,5 +1,5 @@
 name = "customer-support"
-version = "0.4.0"
+version = "0.4.2"
 description = "Customer support agent for ticket handling, issue resolution, and customer communication."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/data-scientist/agent.toml
+++ b/agents/data-scientist/agent.toml
@@ -1,5 +1,5 @@
 name = "data-scientist"
-version = "0.4.0"
+version = "0.4.2"
 description = "Data scientist. Analyzes datasets, builds models, creates visualizations, performs statistical analysis."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/debugger/agent.toml
+++ b/agents/debugger/agent.toml
@@ -1,5 +1,5 @@
 name = "debugger"
-version = "0.4.0"
+version = "0.4.2"
 description = "Expert debugger. Traces bugs, analyzes stack traces, performs root cause analysis."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/devops-lead/agent.toml
+++ b/agents/devops-lead/agent.toml
@@ -1,5 +1,5 @@
 name = "devops-lead"
-version = "0.4.0"
+version = "0.4.2"
 description = "DevOps lead. Manages CI/CD, infrastructure, deployments, monitoring, and incident response."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/doc-writer/agent.toml
+++ b/agents/doc-writer/agent.toml
@@ -1,5 +1,5 @@
 name = "doc-writer"
-version = "0.4.0"
+version = "0.4.2"
 description = "Technical writer. Creates documentation, README files, API docs, tutorials, and architecture guides."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/email-assistant/agent.toml
+++ b/agents/email-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "email-assistant"
-version = "0.4.0"
+version = "0.4.2"
 description = "Email triage, drafting, scheduling, and inbox management agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/health-tracker/agent.toml
+++ b/agents/health-tracker/agent.toml
@@ -1,5 +1,5 @@
 name = "health-tracker"
-version = "0.4.0"
+version = "0.4.2"
 description = "Wellness tracking agent for health metrics, medication reminders, fitness goals, and lifestyle habits."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/hello-world/agent.toml
+++ b/agents/hello-world/agent.toml
@@ -1,5 +1,5 @@
 name = "hello-world"
-version = "0.4.0"
+version = "0.4.2"
 description = "A friendly greeting agent that can read files, search the web, and answer everyday questions."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/home-automation/agent.toml
+++ b/agents/home-automation/agent.toml
@@ -1,5 +1,5 @@
 name = "home-automation"
-version = "0.4.0"
+version = "0.4.2"
 description = "Smart home control agent for IoT device management, automation rules, and home monitoring."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/legal-assistant/agent.toml
+++ b/agents/legal-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "legal-assistant"
-version = "0.4.0"
+version = "0.4.2"
 description = "Legal assistant agent for contract review, legal research, compliance checking, and document drafting."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/meeting-assistant/agent.toml
+++ b/agents/meeting-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "meeting-assistant"
-version = "0.4.0"
+version = "0.4.2"
 description = "Meeting notes, action items, agenda preparation, and follow-up tracking agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/ops/agent.toml
+++ b/agents/ops/agent.toml
@@ -1,5 +1,5 @@
 name = "ops"
-version = "0.4.0"
+version = "0.4.2"
 description = "DevOps agent. Monitors systems, runs diagnostics, manages deployments."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/orchestrator/agent.toml
+++ b/agents/orchestrator/agent.toml
@@ -1,5 +1,5 @@
 name = "orchestrator"
-version = "0.4.0"
+version = "0.4.2"
 description = "Meta-agent that decomposes complex tasks, delegates to specialist agents, and synthesizes results."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/personal-finance/agent.toml
+++ b/agents/personal-finance/agent.toml
@@ -1,5 +1,5 @@
 name = "personal-finance"
-version = "0.4.0"
+version = "0.4.2"
 description = "Personal finance agent for budget tracking, expense analysis, savings goals, and financial planning."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/planner/agent.toml
+++ b/agents/planner/agent.toml
@@ -1,5 +1,5 @@
 name = "planner"
-version = "0.4.0"
+version = "0.4.2"
 description = "Project planner. Creates project plans, breaks down epics, estimates effort, identifies risks and dependencies."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/recruiter/agent.toml
+++ b/agents/recruiter/agent.toml
@@ -1,5 +1,5 @@
 name = "recruiter"
-version = "0.4.0"
+version = "0.4.2"
 description = "Recruiting agent for resume screening, candidate outreach, job description writing, and hiring pipeline management."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/researcher/agent.toml
+++ b/agents/researcher/agent.toml
@@ -1,5 +1,5 @@
 name = "researcher"
-version = "0.4.0"
+version = "0.4.2"
 description = "Research agent. Fetches web content and synthesizes information."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/router/agent.toml
+++ b/agents/router/agent.toml
@@ -1,5 +1,5 @@
 name = "router"
-version = "0.4.0"
+version = "0.4.2"
 description = "Native deterministic router. Dispatches tasks to hands, specialist templates, or assistant without using shell_exec."
 author = "librefang"
 module = "builtin:router"

--- a/agents/sales-assistant/agent.toml
+++ b/agents/sales-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "sales-assistant"
-version = "0.4.0"
+version = "0.4.2"
 description = "Sales assistant agent for CRM updates, outreach drafting, pipeline management, and deal tracking."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/security-auditor/agent.toml
+++ b/agents/security-auditor/agent.toml
@@ -1,5 +1,5 @@
 name = "security-auditor"
-version = "0.4.0"
+version = "0.4.2"
 description = "Security specialist. Reviews code for vulnerabilities, checks configurations, performs threat modeling."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/social-media/agent.toml
+++ b/agents/social-media/agent.toml
@@ -1,5 +1,5 @@
 name = "social-media"
-version = "0.4.0"
+version = "0.4.2"
 description = "Social media content creation, scheduling, and engagement strategy agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/test-engineer/agent.toml
+++ b/agents/test-engineer/agent.toml
@@ -1,5 +1,5 @@
 name = "test-engineer"
-version = "0.4.0"
+version = "0.4.2"
 description = "Quality assurance engineer. Designs test strategies, writes tests, validates correctness."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/translator/agent.toml
+++ b/agents/translator/agent.toml
@@ -1,5 +1,5 @@
 name = "translator"
-version = "0.4.0"
+version = "0.4.2"
 description = "Multi-language translation agent for document translation, localization, and cross-cultural communication."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/travel-planner/agent.toml
+++ b/agents/travel-planner/agent.toml
@@ -1,5 +1,5 @@
 name = "travel-planner"
-version = "0.4.0"
+version = "0.4.2"
 description = "Trip planning agent for itinerary creation, booking research, budget estimation, and travel logistics."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/tutor/agent.toml
+++ b/agents/tutor/agent.toml
@@ -1,5 +1,5 @@
 name = "tutor"
-version = "0.4.0"
+version = "0.4.2"
 description = "Teaching and explanation agent for learning, tutoring, and educational content creation."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/writer/agent.toml
+++ b/agents/writer/agent.toml
@@ -1,5 +1,5 @@
 name = "writer"
-version = "0.4.0"
+version = "0.4.2"
 description = "Content writer. Creates documentation, articles, and technical writing."
 author = "librefang"
 module = "builtin:chat"

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.4.0",
+    version="0.4.2",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Summary
- Bump all crate versions, JS SDK, and Python SDK to v0.4.2
- Tag: v0.4.2-20260314