### PR TITLE
fix: release script uses PR instead of direct push

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -188,13 +188,11 @@ $RELEASE_BODY"
         --head "$RELEASE_BRANCH")
 
     echo "→ $PR_URL"
-    echo ""
-    echo "After PR is merged, create the GitHub Release:"
-    echo "  gh release create $TAG --repo librefang/librefang --title 'LibreFang $VERSION' --generate-notes"
 else
     echo ""
     echo "gh CLI not found. Create a PR manually for branch '$RELEASE_BRANCH'."
 fi
 
 echo ""
-echo "Release branch $RELEASE_BRANCH pushed. Merge the PR to complete the release."
+echo "Tag $TAG pushed — release.yml workflow will auto-create the GitHub Release."
+echo "Merge the PR to land the version bump on main."


### PR DESCRIPTION
## Summary
- `release.sh` now creates a feature branch and opens a PR instead of pushing directly to `main`
- Fixes the protected branch rejection issue
- GitHub Release creation deferred to after PR merge

## Test plan
- [ ] Run `./scripts/release.sh` and verify it creates a branch + PR
- [ ] Verify tag is pushed correctly