### PR TITLE
feat: add GCP free-tier deployment with Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ librefang start
 
 **Or deploy to the cloud:**
 
-[![Deploy to Fly.io](https://img.shields.io/badge/Deploy%20to-Fly.io-purple?style=for-the-badge&logo=fly.io)](https://deploy.librefang.ai) [![Deploy to Render](https://img.shields.io/badge/Deploy%20to-Render-46E3B7?style=for-the-badge&logo=render)](https://render.com/deploy?repo=https://github.com/librefang/librefang)
+[![Deploy to Fly.io](https://img.shields.io/badge/Deploy%20to-Fly.io-purple?style=for-the-badge&logo=fly.io)](https://deploy.librefang.ai) [![Deploy to Render](https://img.shields.io/badge/Deploy%20to-Render-46E3B7?style=for-the-badge&logo=render)](https://render.com/deploy?repo=https://github.com/librefang/librefang) [![Deploy to GCP](https://img.shields.io/badge/Deploy%20to-GCP-4285F4?style=for-the-badge&logo=googlecloud)](infra/gcp/README.md)
 
 > **Fly.io** — Free forever, persistent storage, paste an API token to deploy.
 >
 > **Render** — True one-click OAuth, but free tier sleeps after 15 min and has no persistent storage (data is lost on each deploy/restart).
+>
+> **GCP** — Free forever (e2-micro), 30 GB persistent storage, requires Terraform and a GCP account. [Setup guide →](infra/gcp/README.md)
 
 **Or run with Docker:**
 ```bash

--- a/infra/gcp/.gitignore
+++ b/infra/gcp/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+.terraform.lock.hcl

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -1,0 +1,72 @@
+# Deploy LibreFang to GCP (Free Tier)
+
+Deploy LibreFang on a GCP `e2-micro` VM with 30 GB persistent storage — **free forever** within GCP's always-free tier.
+
+## Prerequisites
+
+- [GCP account](https://cloud.google.com/free) with a project
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed and authenticated
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- At least one LLM API key (Groq, OpenAI, or Anthropic)
+
+## Deploy
+
+```bash
+cd infra/gcp
+
+# Authenticate with GCP
+gcloud auth application-default login
+
+# Configure
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your project_id and API keys
+
+# Deploy (~2 minutes)
+terraform init
+terraform apply
+```
+
+Terraform will output:
+- `dashboard_url` — open in browser to access LibreFang
+- `ssh_command` — SSH into the VM
+
+## Verify
+
+```bash
+# Wait ~1 minute for cloud-init to finish, then:
+curl http://<external_ip>:4545/api/health
+```
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────┐
+│         GCP Free Tier           │
+│                                 │
+│  ┌───────────────────────────┐  │
+│  │   e2-micro VM (0.25 vCPU) │  │
+│  │   30 GB pd-standard disk  │  │
+│  │                           │  │
+│  │   librefang (systemd)     │  │
+│  │   :4545 ← dashboard/API  │  │
+│  └───────────────────────────┘  │
+│                                 │
+│  Firewall: SSH(22) + HTTP(4545) │
+└─────────────────────────────────┘
+```
+
+## Cost
+
+| Resource | Free Tier Limit | Usage |
+|----------|----------------|-------|
+| e2-micro | 1 instance/month | 1 |
+| Standard disk | 30 GB/month | 30 GB |
+| Egress | 1 GB/month | minimal |
+
+> **$0/month** within free tier limits. Only egress beyond 1 GB/month is billed.

--- a/infra/gcp/cloud-init.yml.tpl
+++ b/infra/gcp/cloud-init.yml.tpl
@@ -1,0 +1,75 @@
+#cloud-config
+
+users:
+  - name: librefang
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+
+package_update: true
+packages:
+  - curl
+  - jq
+  - htop
+  - fail2ban
+
+write_files:
+  - path: /etc/systemd/system/librefang.service
+    content: |
+      [Unit]
+      Description=LibreFang Agent OS
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      User=librefang
+      Environment=LIBREFANG_HOME=/data
+      Environment=LIBREFANG_BIND=0.0.0.0:4545
+      Environment=GROQ_API_KEY=${groq_api_key}
+      Environment=OPENAI_API_KEY=${openai_api_key}
+      Environment=ANTHROPIC_API_KEY=${anthropic_api_key}
+      ExecStart=/usr/local/bin/librefang start
+      Restart=on-failure
+      RestartSec=5
+
+      # Hardening
+      ProtectSystem=strict
+      ReadWritePaths=/data
+      PrivateTmp=true
+      NoNewPrivileges=true
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  # Create data directory
+  - mkdir -p /data
+  - chown librefang:librefang /data
+
+  # Download LibreFang binary
+  - |
+    VERSION="${librefang_version}"
+    ARCH=$(uname -m)
+    case "$ARCH" in
+      x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+      aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+      *)       echo "Unsupported arch: $ARCH"; exit 1 ;;
+    esac
+
+    if [ "$VERSION" = "latest" ]; then
+      DOWNLOAD_URL=$(curl -fsSL https://api.github.com/repos/librefang/librefang/releases/latest \
+        | jq -r ".assets[] | select(.name | contains(\"$TARGET\")) | select(.name | endswith(\".tar.gz\")) | .browser_download_url")
+    else
+      DOWNLOAD_URL="https://github.com/librefang/librefang/releases/download/$VERSION/librefang-$TARGET.tar.gz"
+    fi
+
+    curl -fsSL "$DOWNLOAD_URL" -o /tmp/librefang.tar.gz
+    tar xzf /tmp/librefang.tar.gz -C /usr/local/bin/
+    chmod +x /usr/local/bin/librefang
+    rm -f /tmp/librefang.tar.gz
+
+  # Start service
+  - systemctl daemon-reload
+  - systemctl enable librefang
+  - systemctl start librefang

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+# --- Network ---
+
+resource "google_compute_network" "librefang" {
+  name                    = "librefang-vpc"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "librefang" {
+  name          = "librefang-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  network       = google_compute_network.librefang.id
+}
+
+# --- Firewall ---
+
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "librefang-allow-ssh"
+  network = google_compute_network.librefang.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["librefang"]
+}
+
+resource "google_compute_firewall" "allow_http" {
+  name    = "librefang-allow-http"
+  network = google_compute_network.librefang.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4545"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["librefang"]
+}
+
+# --- Compute ---
+
+resource "google_compute_instance" "librefang" {
+  name         = "librefang"
+  machine_type = "e2-micro"
+  tags         = ["librefang"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+      size  = 30
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.librefang.id
+    access_config {} # ephemeral public IP
+  }
+
+  metadata = {
+    ssh-keys  = "librefang:${file(pathexpand(var.ssh_pub_key_path))}"
+    user-data = templatefile("${path.module}/cloud-init.yml.tpl", {
+      librefang_version = var.librefang_version
+      groq_api_key      = var.groq_api_key
+      openai_api_key    = var.openai_api_key
+      anthropic_api_key = var.anthropic_api_key
+    })
+  }
+
+  labels = {
+    app = "librefang"
+  }
+}

--- a/infra/gcp/outputs.tf
+++ b/infra/gcp/outputs.tf
@@ -1,0 +1,14 @@
+output "external_ip" {
+  description = "Public IP of the LibreFang VM"
+  value       = google_compute_instance.librefang.network_interface[0].access_config[0].nat_ip
+}
+
+output "ssh_command" {
+  description = "SSH into the VM"
+  value       = "ssh librefang@${google_compute_instance.librefang.network_interface[0].access_config[0].nat_ip}"
+}
+
+output "dashboard_url" {
+  description = "LibreFang dashboard URL"
+  value       = "http://${google_compute_instance.librefang.network_interface[0].access_config[0].nat_ip}:4545"
+}

--- a/infra/gcp/terraform.tfvars.example
+++ b/infra/gcp/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Required
+project_id = "my-gcp-project-id"
+
+# Optional (defaults shown)
+# region           = "us-central1"
+# zone             = "us-central1-a"
+# ssh_pub_key_path = "~/.ssh/id_rsa.pub"
+# librefang_version = "latest"
+
+# At least one LLM API key is required
+groq_api_key      = ""
+# openai_api_key    = ""
+# anthropic_api_key = ""

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -1,0 +1,49 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "ssh_pub_key_path" {
+  description = "Path to SSH public key"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "librefang_version" {
+  description = "LibreFang release tag (e.g. v0.4.2-20260314), or 'latest'"
+  type        = string
+  default     = "latest"
+}
+
+variable "groq_api_key" {
+  description = "Groq API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "openai_api_key" {
+  description = "OpenAI API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "anthropic_api_key" {
+  description = "Anthropic API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
Closes #250

## Summary
Add Terraform configs for deploying LibreFang to GCP free tier (e2-micro + 30GB persistent disk).

## Usage

```bash
cd infra/gcp
cp terraform.tfvars.example terraform.tfvars
# Edit terraform.tfvars: set project_id and at least one API key

gcloud auth application-default login
terraform init
terraform apply
```

Dashboard will be available at `http://<output_ip>:4545`.

## Files
- `infra/gcp/main.tf` — VPC, firewall, e2-micro VM
- `infra/gcp/variables.tf` — project_id, API keys, version
- `infra/gcp/outputs.tf` — IP, SSH command, dashboard URL
- `infra/gcp/cloud-init.yml.tpl` — auto-setup on boot
- `infra/gcp/README.md` — full setup guide