### PR TITLE
fix: Docker deploy card links to correct README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ librefang start
 >
 > **GCP** — Free forever (e2-micro), 30 GB persistent storage, requires Terraform and a GCP account. [Setup guide →](infra/gcp/README.md)
 
+<a id="docker"></a>
+
 **Or run with Docker:**
 ```bash
 docker compose up --build

--- a/deploy/worker/src/index.js
+++ b/deploy/worker/src/index.js
@@ -470,7 +470,7 @@ const HTML = `<!DOCTYPE html>
           <div class="platform-desc">Free forever (e2-micro), 30GB storage</div>
         </a>
 
-        <a class="platform-card accent-blue" href="https://github.com/librefang/librefang#quick-start" target="_blank" rel="noopener">
+        <a class="platform-card accent-blue" href="https://github.com/librefang/librefang#docker" target="_blank" rel="noopener">
           <div class="platform-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12H2"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></svg></div>
           <div class="platform-name">Docker</div>
           <div class="platform-desc">Self-host anywhere</div>


### PR DESCRIPTION
## Summary
- Add `<a id="docker">` anchor to README before Docker section
- Update deploy hub Docker card to link to `#docker` instead of `#quick-start`