### PR TITLE
fix: use prebuilt GHCR image in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,7 @@
-# NOTE: The GHCR image (ghcr.io/librefang/librefang) is not yet published.
-# For now, build from source using `docker compose up --build`.
-# See: https://github.com/librefang/librefang/issues
-
-version: "3.8"
 services:
   librefang:
-    build: .
-    # image: ghcr.io/librefang/librefang:latest  # Uncomment when GHCR is published
+    image: ghcr.io/librefang/librefang:latest
+    # build: .  # Uncomment to build from source
     ports:
       - "4545:4545"
     volumes:


### PR DESCRIPTION
## Summary
- Default to `ghcr.io/librefang/librefang:latest` instead of building from source
- Remove deprecated `version: "3.8"`
- Remove outdated NOTE comment about unpublished image