### PR TITLE
fix: allow multi-segment prerelease in semver validation

### DIFF
--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -40,7 +40,7 @@ fi
 if [ $# -ge 1 ]; then
     VERSION="$1"
     # Validate semver format
-    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
         echo "Error: '$VERSION' is not a valid semver (expected: X.Y.Z or X.Y.Z-suffix)" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

- Fix regex in `sync-versions.sh` to accept compound prerelease versions like `0.4.3-beta-20260314`
- Previously the character class `[a-zA-Z0-9.]` didn't include `-`, so only single-segment suffixes worked

## Test plan

- [ ] `./scripts/release.sh 0.4.3-beta` completes without validation error