### PR TITLE
docs: use docker run across all README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ librefang start
 
 **Or run with Docker:**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # Dashboard live at http://localhost:4545
 ```
 
@@ -420,6 +420,13 @@ librefang start
 <details>
 <summary><strong>Docker</strong></summary>
 
+**Quick start (pre-built image):**
+```bash
+docker run -p 4545:4545 ghcr.io/librefang/librefang
+# Dashboard live at http://localhost:4545
+```
+
+**Or build from source with docker-compose:**
 ```bash
 git clone https://github.com/librefang/librefang.git
 cd librefang

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -95,9 +95,11 @@ brew tap librefang/tap
 brew install librefang
 ```
 
+<a id="docker"></a>
+
 **Oder mit Docker ausführen:**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # Dashboard: http://localhost:4545
 ```
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -95,9 +95,11 @@ brew tap librefang/tap
 brew install librefang
 ```
 
+<a id="docker"></a>
+
 **O ejecuta con Docker:**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # Panel: http://localhost:4545
 ```
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -95,9 +95,11 @@ brew tap librefang/tap
 brew install librefang
 ```
 
+<a id="docker"></a>
+
 **または Docker で実行：**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # ダッシュボード：http://localhost:4545
 ```
 

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -95,9 +95,11 @@ brew tap librefang/tap
 brew install librefang
 ```
 
+<a id="docker"></a>
+
 **또는 Docker로 실행:**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # 대시보드: http://localhost:4545
 ```
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -95,9 +95,11 @@ brew tap librefang/tap
 brew install librefang
 ```
 
+<a id="docker"></a>
+
 **或者使用 Docker 运行：**
 ```bash
-docker compose up --build
+docker run -p 4545:4545 ghcr.io/librefang/librefang
 # 仪表板地址：http://localhost:4545
 ```
 


### PR DESCRIPTION
## Summary
- Replace `docker compose up --build` with `docker run -p 4545:4545 ghcr.io/librefang/librefang` in quick start sections
- Updated: README.md, README.ko.md, README.ja.md, README.zh.md, README.de.md, README.es.md
- Added `<a id="docker"></a>` anchor to all i18n READMEs
- Docker details section in main README keeps docker-compose commands, adds docker run as quick alternative