### PR TITLE
fix: remove unnecessary card width constraint on deploy page

### DIFF
--- a/deploy/worker/src/index.js
+++ b/deploy/worker/src/index.js
@@ -241,7 +241,6 @@ const HTML = `<!DOCTYPE html>
       transform: translateY(-2px);
       box-shadow: 0 4px 20px rgba(139, 92, 246, 0.15);
     }
-    .platform-grid .platform-card:last-child:nth-child(odd) { max-width: calc(50% - 7px); }
     .platform-card.accent-purple:hover { border-color: var(--accent); box-shadow: 0 4px 20px rgba(139, 92, 246, 0.15); }
     .platform-card.accent-green:hover { border-color: var(--green); box-shadow: 0 4px 20px rgba(52, 211, 153, 0.15); }
     .platform-card.accent-blue:hover { border-color: var(--blue); box-shadow: 0 4px 20px rgba(96, 165, 250, 0.15); }


### PR DESCRIPTION
The `max-width: calc(50% - 7px)` rule was actually making the last card narrower than others. CSS Grid's `1fr 1fr` already ensures consistent widths.