### PR TITLE
fix: prevent long commands from stretching deploy cards

### DIFF
--- a/deploy/worker/src/index.js
+++ b/deploy/worker/src/index.js
@@ -235,6 +235,7 @@ const HTML = `<!DOCTYPE html>
       text-decoration: none;
       color: var(--text);
       display: block;
+      min-width: 0;
     }
     .platform-card:hover {
       border-color: var(--accent);
@@ -280,6 +281,7 @@ const HTML = `<!DOCTYPE html>
       align-items: center;
       gap: 6px;
       max-width: 100%;
+      overflow: hidden;
     }
     .platform-cmd code { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .copy-btn {


### PR DESCRIPTION
Long commands like `curl -fsSL ...` were stretching cards wider than others, causing 2/3 vs 1/3 column split. Fix: `min-width: 0` on cards + `overflow: hidden` on command blocks.