### PR TITLE
ci: upgrade wrangler-action to v4 for Node.js 24

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Fix Node.js 20 deprecation warning by upgrading `cloudflare/wrangler-action@v3` to `@v4`.