### PR TITLE
ci: fix wrangler-action, force Node.js 24

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
v4 doesn't exist. Revert to v3 and add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to suppress deprecation warning.