### PR TITLE
fix: use PR instead of direct push for star history workflow

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}
@@ -30,15 +31,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/generate_star_history.py librefang/librefang public/assets/star-history.svg
 
-      - name: Commit updated SVG
-        run: |
-          if git diff --quiet -- public/assets/star-history.svg; then
-            echo "Star history SVG is already current."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add public/assets/star-history.svg
-          git commit -m "docs: update star history"
-          git push
+      - name: Create PR with updated SVG
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-star-history
+          commit-message: "docs: update star history"
+          title: "docs: update star history"
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Star history workflow was failing because it tried to `git push` directly to protected `main` branch
- Replace manual commit+push with `peter-evans/create-pull-request@v7` action
- Add `pull-requests: write` permission for the action to create PRs

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify it creates a PR instead of pushing directly