### PR TITLE
fix: use WEBSITE_REPO_TOKEN for star history workflow

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "17 * * * *"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -20,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.WEBSITE_REPO_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,13 +26,14 @@ jobs:
 
       - name: Generate star history SVG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WEBSITE_REPO_TOKEN }}
         run: python3 scripts/generate_star_history.py librefang/librefang public/assets/star-history.svg
 
       - name: Create PR with updated SVG
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           branch: chore/update-star-history
           commit-message: "docs: update star history"
           title: "docs: update star history"
@@ -43,5 +42,5 @@ jobs:
       - name: Auto-merge PR
         if: steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WEBSITE_REPO_TOKEN }}
         run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` 没有权限在受保护分支上创建 PR
- 所有步骤改用 `WEBSITE_REPO_TOKEN` PAT：checkout、SVG 生成、PR 创建、自动合并
- 移除不再需要的 `permissions` 块

## Test plan
- [ ] 通过 `workflow_dispatch` 手动触发，验证 PR 自动创建并合并