### PR TITLE
fix: log warnings instead of silently ignoring errors in API endpoints

### DIFF
--- a/crates/librefang-api/src/routes.rs
+++ b/crates/librefang-api/src/routes.rs
@@ -473,7 +473,9 @@ pub async fn get_agent_session(
                                     if let Ok(bytes) =
                                         base64::engine::general_purpose::STANDARD.decode(data)
                                     {
-                                        if let Err(e) = std::fs::write(upload_dir.join(&file_id), &bytes) {
+                                        if let Err(e) =
+                                            std::fs::write(upload_dir.join(&file_id), &bytes)
+                                        {
                                             tracing::warn!("Failed to write upload file: {e}");
                                         }
                                         UPLOAD_REGISTRY.insert(
@@ -7099,7 +7101,9 @@ pub async fn set_provider_key(
             if let Ok(existing) = std::fs::read_to_string(&config_path) {
                 // Remove existing [default_model] section if present, then append
                 let cleaned = remove_toml_section(&existing, "default_model");
-                if let Err(e) = std::fs::write(&config_path, format!("{}\n{}", cleaned.trim(), update_toml)) {
+                if let Err(e) =
+                    std::fs::write(&config_path, format!("{}\n{}", cleaned.trim(), update_toml))
+                {
                     tracing::warn!("Failed to write config file: {e}");
                 }
             } else if let Err(e) = std::fs::write(&config_path, update_toml) {


### PR DESCRIPTION
## Summary
- Replace 18 instances of `let _ =` with `if let Err(e) = ... { tracing::warn!(...) }` 
- Affected operations: file I/O, secret management, registry loading, agent persistence, config writes, file permissions, MCP reloading, structured data storage, cron persistence

Closes #158

## Test plan
- [ ] Verify no regression in existing functionality
- [ ] Check logs for new warning messages on error conditions