### PR TITLE
feat: add GET /api/tools/:name endpoint

### DIFF
--- a/crates/librefang-api/src/routes.rs
+++ b/crates/librefang-api/src/routes.rs
@@ -4893,6 +4893,48 @@ pub async fn list_tools(State(state): State<Arc<AppState>>) -> impl IntoResponse
     Json(serde_json::json!({"tools": tools, "total": tools.len()}))
 }
 
+/// GET /api/tools/:name — Get a single tool definition by name.
+pub async fn get_tool(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Search built-in tools first
+    for t in builtin_tool_definitions() {
+        if t.name == name {
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.input_schema,
+                })),
+            );
+        }
+    }
+
+    // Search MCP tools
+    if let Ok(mcp_tools) = state.kernel.mcp_tools.lock() {
+        for t in mcp_tools.iter() {
+            if t.name == name {
+                return (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "name": t.name,
+                        "description": t.description,
+                        "input_schema": t.input_schema,
+                        "source": "mcp",
+                    })),
+                );
+            }
+        }
+    }
+
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"error": format!("Tool '{}' not found", name)})),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Config endpoint
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -429,8 +429,9 @@ pub async fn build_router(
         )
         .route("/api/comms/send", axum::routing::post(routes::comms_send))
         .route("/api/comms/task", axum::routing::post(routes::comms_task))
-        // Tools endpoint
+        // Tools endpoints
         .route("/api/tools", axum::routing::get(routes::list_tools))
+        .route("/api/tools/{name}", axum::routing::get(routes::get_tool))
         // Config endpoints
         .route("/api/config", axum::routing::get(routes::get_config))
         .route(

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -120,6 +120,8 @@ async fn start_test_server_with_provider(
             "/api/workflows/{id}/runs",
             axum::routing::get(routes::list_workflow_runs),
         )
+        .route("/api/tools", axum::routing::get(routes::list_tools))
+        .route("/api/tools/{name}", axum::routing::get(routes::get_tool))
         .route("/api/shutdown", axum::routing::post(routes::shutdown))
         .layer(axum::middleware::from_fn(middleware::request_logging))
         .layer(TraceLayer::new_for_http())
@@ -856,4 +858,72 @@ async fn test_auth_disabled_when_no_key() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Tool endpoints
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_tools() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{}/api/tools", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["tools"].is_array());
+    assert!(body["total"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn test_get_tool_found() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // First list tools to get a known tool name
+    let resp = client
+        .get(format!("{}/api/tools", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let first_tool_name = body["tools"][0]["name"].as_str().unwrap().to_string();
+
+    // Now fetch that specific tool
+    let resp = client
+        .get(format!("{}/api/tools/{}", server.base_url, first_tool_name))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let tool: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(tool["name"].as_str().unwrap(), first_tool_name);
+    assert!(tool["description"].is_string());
+    assert!(tool["input_schema"].is_object());
+}
+
+#[tokio::test]
+async fn test_get_tool_not_found() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "{}/api/tools/nonexistent_tool_xyz",
+            server.base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["error"].as_str().unwrap().contains("not found"));
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/tools/{name}` endpoint to retrieve a single tool definition by name
- Searches built-in tools first, then MCP tools
- Returns 404 with error message if tool not found
- Follows existing patterns from `list_tools` handler

Closes #161

## Changes
- `crates/librefang-api/src/routes.rs`: New `get_tool` handler
- `crates/librefang-api/src/server.rs`: Route registration for `/api/tools/{name}`
- `crates/librefang-api/tests/api_integration_test.rs`: Integration tests for list, found, and not-found cases

## Test plan
- [x] `cargo build --workspace --lib` compiles
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] Integration tests cover: listing tools, fetching by name, 404 for missing tool