### PR TITLE
release: v0.4.3-beta4-20260314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3-beta4] - 2026-03-14
+
+### Added
+
+- Add GET /api/schedules/:id endpoint (#291) (@houko)
+- Add GET /api/a2a/agents/:id endpoint (#290) (@houko)
+- Add PUT /api/cron/jobs/:id endpoint for updating cron jobs (#289) (@houko)
+- Horizontal scroll for long commands on deploy page (#276) (@houko)
+- Add tooltip for truncated commands on deploy page (#275) (@houko)
+- Add copy buttons to install commands on deploy hub (#258) (@houko)
+- Add macOS, Linux, Windows install options to deploy hub (#257) (@houko)
+- Deploy hub with multi-platform support (#251) (@houko)
+- Add GCP free-tier deployment with Terraform (#249) (@houko)
+- Support multi-bot routing per platform (#240) (@houko)
+
+### Fixed
+
+- Catalog sync fails to parse remote files missing provider field (#362) (@houko)
+- Remove VOLUME directive from Dockerfile (#294) (@houko)
+- Render card empty due to nested anchor tags (#292) (@houko)
+- Log warnings instead of silently ignoring errors in API endpoints (#288) (@houko)
+- Add URL validation to A2A discover endpoint to prevent SSRF (#287) (@houko)
+- Validate environment variable names in channel config API (#286) (@houko)
+- Use agent_id path parameter in KV memory endpoints (#285) (@houko)
+- Use WEBSITE_REPO_TOKEN for star history workflow (#281) (@houko)
+- Auto-merge star history PR after creation (#280) (@houko)
+- Use PR instead of direct push for star history workflow (#279) (@houko)
+- Move Fly.io-specific badges from header to deploy form (#278) (@houko)
+- Revert wrangler-action to v3 (v4 does not exist) (#274) (@houko)
+- Add explicit Tauri version for MSI compatibility (#272) (@houko)
+- Prevent long commands from stretching deploy cards (#269) (@houko)
+- Remove unnecessary card width constraint on deploy page (#268) (@houko)
+- Consistent card widths on deploy page (#266) (@houko)
+- Allow multi-segment prerelease in semver validation (#263) (@houko)
+- Use docker run command on deploy hub (#262) (@houko)
+- Use prebuilt GHCR image in docker-compose.yml (#261) (@houko)
+- Docker deploy card links to correct README section (#260) (@houko)
+- Add catalog directory to Dockerfile (#256) (@houko)
+- Correct Railway URL and use prebuilt image for Render (#255) (@houko)
+- Deploy page home button links to deploy.librefang.ai (#254) (@houko)
+- Replace emoji with SVG icons and add home button (#253) (@houko)
+- Prevent release notes from being lost due to race condition (#252) (@houko)
+- Remove disk config for Render free tier (#247) (@houko)
+
+### Documentation
+
+- Update star history (#297) (@houko)
+- Update star history (#293) (@houko)
+- Update star history (#284) (@houko)
+- Update star history (#283) (@houko)
+- Update star history (#282) (@houko)
+- Use docker run across all README translations (#267) (@houko)
+- Separate Fly.io and Render deploy descriptions (#248) (@houko)
+
+### Maintenance
+
+- Add workflow_dispatch to deploy-worker (#273) (@houko)
+- Fix wrangler-action, force Node.js 24 (#271) (@houko)
+- Upgrade wrangler-action to v4 for Node.js 24 (#270) (@houko)
+- Add 'release' to allowed PR title types. (#246) (@houko)
+- Update star history workflow schedule to run hourly. (#245) (@houko)
+
+### Other
+
+- V0.4.3-beta3-20260314 (#296) (@houko)
+- V0.4.3-beta2-20260314 (#277) (@houko)
+- V0.4.3-beta-20260314 (#264) (@houko)
+- V0.4.2-20260314 (#244) (@houko)
+
 ## [0.4.3-beta3] - 2026-03-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "async-trait",
  "axum",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "aes",
  "async-trait",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "chrono",
  "hex",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9444,7 +9444,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/agents/analyst/agent.toml
+++ b/agents/analyst/agent.toml
@@ -1,5 +1,5 @@
 name = "analyst"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Data analyst. Processes data, generates insights, creates reports."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/architect/agent.toml
+++ b/agents/architect/agent.toml
@@ -1,5 +1,5 @@
 name = "architect"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "System architect. Designs software architectures, evaluates trade-offs, creates technical specifications."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/assistant/agent.toml
+++ b/agents/assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "assistant"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "General-purpose assistant agent. The default OpenClaw agent for everyday tasks, questions, and conversations."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/code-reviewer/agent.toml
+++ b/agents/code-reviewer/agent.toml
@@ -1,5 +1,5 @@
 name = "code-reviewer"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Senior code reviewer. Reviews PRs, identifies issues, suggests improvements with production standards."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/coder/agent.toml
+++ b/agents/coder/agent.toml
@@ -1,5 +1,5 @@
 name = "coder"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Expert software engineer. Reads, writes, and analyzes code."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/customer-support/agent.toml
+++ b/agents/customer-support/agent.toml
@@ -1,5 +1,5 @@
 name = "customer-support"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Customer support agent for ticket handling, issue resolution, and customer communication."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/data-scientist/agent.toml
+++ b/agents/data-scientist/agent.toml
@@ -1,5 +1,5 @@
 name = "data-scientist"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Data scientist. Analyzes datasets, builds models, creates visualizations, performs statistical analysis."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/debugger/agent.toml
+++ b/agents/debugger/agent.toml
@@ -1,5 +1,5 @@
 name = "debugger"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Expert debugger. Traces bugs, analyzes stack traces, performs root cause analysis."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/devops-lead/agent.toml
+++ b/agents/devops-lead/agent.toml
@@ -1,5 +1,5 @@
 name = "devops-lead"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "DevOps lead. Manages CI/CD, infrastructure, deployments, monitoring, and incident response."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/doc-writer/agent.toml
+++ b/agents/doc-writer/agent.toml
@@ -1,5 +1,5 @@
 name = "doc-writer"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Technical writer. Creates documentation, README files, API docs, tutorials, and architecture guides."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/email-assistant/agent.toml
+++ b/agents/email-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "email-assistant"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Email triage, drafting, scheduling, and inbox management agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/health-tracker/agent.toml
+++ b/agents/health-tracker/agent.toml
@@ -1,5 +1,5 @@
 name = "health-tracker"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Wellness tracking agent for health metrics, medication reminders, fitness goals, and lifestyle habits."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/hello-world/agent.toml
+++ b/agents/hello-world/agent.toml
@@ -1,5 +1,5 @@
 name = "hello-world"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "A friendly greeting agent that can read files, search the web, and answer everyday questions."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/home-automation/agent.toml
+++ b/agents/home-automation/agent.toml
@@ -1,5 +1,5 @@
 name = "home-automation"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Smart home control agent for IoT device management, automation rules, and home monitoring."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/legal-assistant/agent.toml
+++ b/agents/legal-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "legal-assistant"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Legal assistant agent for contract review, legal research, compliance checking, and document drafting."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/meeting-assistant/agent.toml
+++ b/agents/meeting-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "meeting-assistant"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Meeting notes, action items, agenda preparation, and follow-up tracking agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/ops/agent.toml
+++ b/agents/ops/agent.toml
@@ -1,5 +1,5 @@
 name = "ops"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "DevOps agent. Monitors systems, runs diagnostics, manages deployments."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/orchestrator/agent.toml
+++ b/agents/orchestrator/agent.toml
@@ -1,5 +1,5 @@
 name = "orchestrator"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Meta-agent that decomposes complex tasks, delegates to specialist agents, and synthesizes results."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/personal-finance/agent.toml
+++ b/agents/personal-finance/agent.toml
@@ -1,5 +1,5 @@
 name = "personal-finance"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Personal finance agent for budget tracking, expense analysis, savings goals, and financial planning."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/planner/agent.toml
+++ b/agents/planner/agent.toml
@@ -1,5 +1,5 @@
 name = "planner"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Project planner. Creates project plans, breaks down epics, estimates effort, identifies risks and dependencies."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/recruiter/agent.toml
+++ b/agents/recruiter/agent.toml
@@ -1,5 +1,5 @@
 name = "recruiter"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Recruiting agent for resume screening, candidate outreach, job description writing, and hiring pipeline management."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/researcher/agent.toml
+++ b/agents/researcher/agent.toml
@@ -1,5 +1,5 @@
 name = "researcher"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Research agent. Fetches web content and synthesizes information."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/router/agent.toml
+++ b/agents/router/agent.toml
@@ -1,5 +1,5 @@
 name = "router"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Native deterministic router. Dispatches tasks to hands, specialist templates, or assistant without using shell_exec."
 author = "librefang"
 module = "builtin:router"

--- a/agents/sales-assistant/agent.toml
+++ b/agents/sales-assistant/agent.toml
@@ -1,5 +1,5 @@
 name = "sales-assistant"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Sales assistant agent for CRM updates, outreach drafting, pipeline management, and deal tracking."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/security-auditor/agent.toml
+++ b/agents/security-auditor/agent.toml
@@ -1,5 +1,5 @@
 name = "security-auditor"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Security specialist. Reviews code for vulnerabilities, checks configurations, performs threat modeling."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/social-media/agent.toml
+++ b/agents/social-media/agent.toml
@@ -1,5 +1,5 @@
 name = "social-media"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Social media content creation, scheduling, and engagement strategy agent."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/test-engineer/agent.toml
+++ b/agents/test-engineer/agent.toml
@@ -1,5 +1,5 @@
 name = "test-engineer"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Quality assurance engineer. Designs test strategies, writes tests, validates correctness."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/translator/agent.toml
+++ b/agents/translator/agent.toml
@@ -1,5 +1,5 @@
 name = "translator"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Multi-language translation agent for document translation, localization, and cross-cultural communication."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/travel-planner/agent.toml
+++ b/agents/travel-planner/agent.toml
@@ -1,5 +1,5 @@
 name = "travel-planner"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Trip planning agent for itinerary creation, booking research, budget estimation, and travel logistics."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/tutor/agent.toml
+++ b/agents/tutor/agent.toml
@@ -1,5 +1,5 @@
 name = "tutor"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Teaching and explanation agent for learning, tutoring, and educational content creation."
 author = "librefang"
 module = "builtin:chat"

--- a/agents/writer/agent.toml
+++ b/agents/writer/agent.toml
@@ -1,5 +1,5 @@
 name = "writer"
-version = "0.4.3-beta3-20260314"
+version = "0.4.3-beta4-20260314"
 description = "Content writer. Creates documentation, articles, and technical writing."
 author = "librefang"
 module = "builtin:chat"

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.4.3-beta3-20260314",
+  "version": "0.4.3-beta4-20260314",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.4.3-beta3-20260314",
+  "version": "0.4.3-beta4-20260314",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.4.3-beta3-20260314",
+    version="0.4.3-beta4-20260314",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.4.3-beta4-20260314


### Added

- Add GET /api/schedules/:id endpoint (#291) (@houko)
- Add GET /api/a2a/agents/:id endpoint (#290) (@houko)
- Add PUT /api/cron/jobs/:id endpoint for updating cron jobs (#289) (@houko)
- Horizontal scroll for long commands on deploy page (#276) (@houko)
- Add tooltip for truncated commands on deploy page (#275) (@houko)
- Add copy buttons to install commands on deploy hub (#258) (@houko)
- Add macOS, Linux, Windows install options to deploy hub (#257) (@houko)
- Deploy hub with multi-platform support (#251) (@houko)
- Add GCP free-tier deployment with Terraform (#249) (@houko)
- Support multi-bot routing per platform (#240) (@houko)

### Fixed

- Catalog sync fails to parse remote files missing provider field (#362) (@houko)
- Remove VOLUME directive from Dockerfile (#294) (@houko)
- Render card empty due to nested anchor tags (#292) (@houko)
- Log warnings instead of silently ignoring errors in API endpoints (#288) (@houko)
- Add URL validation to A2A discover endpoint to prevent SSRF (#287) (@houko)
- Validate environment variable names in channel config API (#286) (@houko)
- Use agent_id path parameter in KV memory endpoints (#285) (@houko)
- Use WEBSITE_REPO_TOKEN for star history workflow (#281) (@houko)
- Auto-merge star history PR after creation (#280) (@houko)
- Use PR instead of direct push for star history workflow (#279) (@houko)
- Move Fly.io-specific badges from header to deploy form (#278) (@houko)
- Revert wrangler-action to v3 (v4 does not exist) (#274) (@houko)
- Add explicit Tauri version for MSI compatibility (#272) (@houko)
- Prevent long commands from stretching deploy cards (#269) (@houko)
- Remove unnecessary card width constraint on deploy page (#268) (@houko)
- Consistent card widths on deploy page (#266) (@houko)
- Allow multi-segment prerelease in semver validation (#263) (@houko)
- Use docker run command on deploy hub (#262) (@houko)
- Use prebuilt GHCR image in docker-compose.yml (#261) (@houko)
- Docker deploy card links to correct README section (#260) (@houko)
- Add catalog directory to Dockerfile (#256) (@houko)
- Correct Railway URL and use prebuilt image for Render (#255) (@houko)
- Deploy page home button links to deploy.librefang.ai (#254) (@houko)
- Replace emoji with SVG icons and add home button (#253) (@houko)
- Prevent release notes from being lost due to race condition (#252) (@houko)
- Remove disk config for Render free tier (#247) (@houko)

### Documentation

- Update star history (#297) (@houko)
- Update star history (#293) (@houko)
- Update star history (#284) (@houko)
- Update star history (#283) (@houko)
- Update star history (#282) (@houko)
- Use docker run across all README translations (#267) (@houko)
- Separate Fly.io and Render deploy descriptions (#248) (@houko)

### Maintenance

- Add workflow_dispatch to deploy-worker (#273) (@houko)
- Fix wrangler-action, force Node.js 24 (#271) (@houko)
- Upgrade wrangler-action to v4 for Node.js 24 (#270) (@houko)
- Add 'release' to allowed PR title types. (#246) (@houko)
- Update star history workflow schedule to run hourly. (#245) (@houko)

### Other

- V0.4.3-beta3-20260314 (#296) (@houko)
- V0.4.3-beta2-20260314 (#277) (@houko)
- V0.4.3-beta-20260314 (#264) (@houko)
- V0.4.2-20260314 (#244) (@houko)