### PR TITLE
feat: add include_skills and include_tools flags to agent clone API

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1200,7 +1200,9 @@ pub async fn get_agent(
                 "color": entry.identity.color,
             },
             "skills": entry.manifest.skills,
-            "skills_mode": if entry.manifest.skills.is_empty() { "all" } else { "allowlist" },
+            "skills_mode": skill_assignment_mode(&entry.manifest),
+            "skills_disabled": entry.manifest.skills_disabled,
+            "tools_disabled": entry.manifest.tools_disabled,
             "mcp_servers": entry.manifest.mcp_servers,
             "mcp_servers_mode": if entry.manifest.mcp_servers.is_empty() { "all" } else { "allowlist" },
             "fallback_models": entry.manifest.fallback_models,
@@ -1738,6 +1740,7 @@ pub async fn get_agent_tools(
         Json(serde_json::json!({
             "tool_allowlist": entry.manifest.tool_allowlist,
             "tool_blocklist": entry.manifest.tool_blocklist,
+            "disabled": entry.manifest.tools_disabled,
         })),
     )
 }
@@ -1843,17 +1846,13 @@ pub async fn get_agent_skills(
         .read()
         .unwrap_or_else(|e| e.into_inner())
         .skill_names();
-    let mode = if entry.manifest.skills.is_empty() {
-        "all"
-    } else {
-        "allowlist"
-    };
     (
         StatusCode::OK,
         Json(serde_json::json!({
             "assigned": entry.manifest.skills,
             "available": available,
-            "mode": mode,
+            "mode": skill_assignment_mode(&entry.manifest),
+            "disabled": entry.manifest.skills_disabled,
         })),
     )
 }
@@ -2550,6 +2549,42 @@ pub async fn patch_agent_config(
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 pub struct CloneAgentRequest {
     pub new_name: String,
+    /// Whether to copy skills from the source agent (default: true).
+    #[serde(default = "default_clone_true")]
+    pub include_skills: bool,
+    /// Whether to copy tools from the source agent (default: true).
+    #[serde(default = "default_clone_true")]
+    pub include_tools: bool,
+}
+
+fn default_clone_true() -> bool {
+    true
+}
+
+fn apply_clone_inclusion_flags(
+    manifest: &mut librefang_types::agent::AgentManifest,
+    req: &CloneAgentRequest,
+) {
+    if !req.include_skills {
+        manifest.skills.clear();
+        manifest.skills_disabled = true;
+    }
+    if !req.include_tools {
+        manifest.tools.clear();
+        manifest.tool_allowlist.clear();
+        manifest.tool_blocklist.clear();
+        manifest.tools_disabled = true;
+    }
+}
+
+fn skill_assignment_mode(manifest: &librefang_types::agent::AgentManifest) -> &'static str {
+    if manifest.skills_disabled {
+        "none"
+    } else if manifest.skills.is_empty() {
+        "all"
+    } else {
+        "allowlist"
+    }
 }
 
 /// POST /api/agents/{id}/clone — Clone an agent with its workspace files.
@@ -2606,6 +2641,9 @@ pub async fn clone_agent(
     let mut cloned_manifest = source.manifest.clone();
     cloned_manifest.name = req.new_name.clone();
     cloned_manifest.workspace = None; // Let kernel assign a new workspace
+
+    // Conditionally strip skills and tools based on request flags.
+    apply_clone_inclusion_flags(&mut cloned_manifest, &req);
 
     // Spawn the cloned agent
     let new_id = match state.kernel.spawn_agent(cloned_manifest) {
@@ -3264,4 +3302,108 @@ pub async fn get_agent_deliveries(
             "receipts": receipts,
         })),
     )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone_request_defaults() {
+        let json = r#"{"new_name": "clone-1"}"#;
+        let req: CloneAgentRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.new_name, "clone-1");
+        assert!(req.include_skills);
+        assert!(req.include_tools);
+    }
+
+    #[test]
+    fn test_clone_request_explicit_false() {
+        let json = r#"{"new_name": "clone-2", "include_skills": false, "include_tools": false}"#;
+        let req: CloneAgentRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.new_name, "clone-2");
+        assert!(!req.include_skills);
+        assert!(!req.include_tools);
+    }
+
+    #[test]
+    fn test_clone_request_partial_flags() {
+        let json = r#"{"new_name": "clone-3", "include_skills": false}"#;
+        let req: CloneAgentRequest = serde_json::from_str(json).unwrap();
+        assert!(!req.include_skills);
+        assert!(req.include_tools);
+
+        let json = r#"{"new_name": "clone-4", "include_tools": false}"#;
+        let req: CloneAgentRequest = serde_json::from_str(json).unwrap();
+        assert!(req.include_skills);
+        assert!(!req.include_tools);
+    }
+
+    #[test]
+    fn test_clone_manifest_strips_skills_when_excluded() {
+        let manifest = librefang_types::agent::AgentManifest {
+            skills: vec!["skill-a".to_string(), "skill-b".to_string()],
+            tools: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "tool-a".to_string(),
+                    librefang_types::agent::ToolConfig {
+                        params: std::collections::HashMap::new(),
+                    },
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        let mut cloned = manifest.clone();
+        apply_clone_inclusion_flags(
+            &mut cloned,
+            &CloneAgentRequest {
+                new_name: "clone-1".to_string(),
+                include_skills: false,
+                include_tools: true,
+            },
+        );
+        assert!(cloned.skills.is_empty());
+        assert!(cloned.skills_disabled);
+        assert_eq!(skill_assignment_mode(&cloned), "none");
+        assert!(!cloned.tools.is_empty());
+    }
+
+    #[test]
+    fn test_clone_manifest_disables_tools_when_excluded() {
+        let manifest = librefang_types::agent::AgentManifest {
+            tools: {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "tool-a".to_string(),
+                    librefang_types::agent::ToolConfig {
+                        params: std::collections::HashMap::new(),
+                    },
+                );
+                m
+            },
+            tool_allowlist: vec!["allowed-tool".to_string()],
+            tool_blocklist: vec!["blocked-tool".to_string()],
+            ..Default::default()
+        };
+
+        let mut cloned = manifest.clone();
+        apply_clone_inclusion_flags(
+            &mut cloned,
+            &CloneAgentRequest {
+                new_name: "clone-2".to_string(),
+                include_skills: true,
+                include_tools: false,
+            },
+        );
+        assert!(cloned.tools.is_empty());
+        assert!(cloned.tool_allowlist.is_empty());
+        assert!(cloned.tool_blocklist.is_empty());
+        assert!(cloned.tools_disabled);
+    }
 }

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1756,8 +1756,16 @@ impl LibreFangKernel {
                 base_system_prompt: manifest.model.system_prompt.clone(),
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
                 recalled_memories: vec![],
-                skill_summary: self.build_skill_summary(&manifest.skills),
-                skill_prompt_context: self.collect_prompt_context(&manifest.skills),
+                skill_summary: if manifest.skills_disabled {
+                    String::new()
+                } else {
+                    self.build_skill_summary(&manifest.skills)
+                },
+                skill_prompt_context: if manifest.skills_disabled {
+                    String::new()
+                } else {
+                    self.collect_prompt_context(&manifest.skills)
+                },
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
                 } else {
@@ -2445,8 +2453,16 @@ impl LibreFangKernel {
                 base_system_prompt: manifest.model.system_prompt.clone(),
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
                 recalled_memories: vec![], // Recalled in agent_loop, not here
-                skill_summary: self.build_skill_summary(&manifest.skills),
-                skill_prompt_context: self.collect_prompt_context(&manifest.skills),
+                skill_summary: if manifest.skills_disabled {
+                    String::new()
+                } else {
+                    self.build_skill_summary(&manifest.skills)
+                },
+                skill_prompt_context: if manifest.skills_disabled {
+                    String::new()
+                } else {
+                    self.collect_prompt_context(&manifest.skills)
+                },
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
                 } else {
@@ -5042,13 +5058,17 @@ impl LibreFangKernel {
 
         // Look up agent entry for profile, skill/MCP allowlists, and declared tools
         let entry = self.registry.get(agent_id);
-        let (skill_allowlist, mcp_allowlist, tool_profile) = entry
+        if entry.as_ref().is_some_and(|e| e.manifest.tools_disabled) {
+            return Vec::new();
+        }
+        let (skill_allowlist, mcp_allowlist, tool_profile, skills_disabled) = entry
             .as_ref()
             .map(|e| {
                 (
                     e.manifest.skills.clone(),
                     e.manifest.mcp_servers.clone(),
                     e.manifest.profile.clone(),
+                    e.manifest.skills_disabled,
                 )
             })
             .unwrap_or_default();
@@ -5097,8 +5117,10 @@ impl LibreFangKernel {
         };
 
         // Step 2: Add skill-provided tools (filtered by agent's skill allowlist,
-        // then by declared tools).
-        let skill_tools = {
+        // then by declared tools). Skip entirely when skills are disabled.
+        let skill_tools = if skills_disabled {
+            vec![]
+        } else {
             let registry = self
                 .skill_registry
                 .read()
@@ -6598,6 +6620,43 @@ mod tests {
         assert!(
             entry.manifest.tool_blocklist.is_empty(),
             "hand activation should not set a runtime blocklist by default"
+        );
+
+        kernel.shutdown();
+    }
+
+    #[test]
+    fn test_available_tools_returns_empty_when_tools_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home_dir = tmp.path().join("librefang-kernel-tools-disabled-test");
+        std::fs::create_dir_all(&home_dir).unwrap();
+
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+
+        let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+        let manifest = AgentManifest {
+            name: "no-tools".to_string(),
+            description: "agent with tools disabled".to_string(),
+            author: "test".to_string(),
+            module: "builtin:chat".to_string(),
+            profile: Some(librefang_types::agent::ToolProfile::Full),
+            capabilities: ManifestCapabilities {
+                tools: vec!["file_read".to_string(), "web_fetch".to_string()],
+                ..Default::default()
+            },
+            tools_disabled: true,
+            ..Default::default()
+        };
+
+        let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+        let tools = kernel.available_tools(agent_id);
+        assert!(
+            tools.is_empty(),
+            "disabled tools should suppress all builtin, skill, and MCP tools"
         );
 
         kernel.shutdown();

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -214,6 +214,7 @@ impl AgentRegistry {
             .get_mut(&id)
             .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
         entry.manifest.skills = skills;
+        entry.manifest.skills_disabled = false;
         entry.last_active = chrono::Utc::now();
         Ok(())
     }
@@ -246,6 +247,7 @@ impl AgentRegistry {
         if let Some(bl) = blocklist {
             entry.manifest.tool_blocklist = bl;
         }
+        entry.manifest.tools_disabled = false;
         entry.last_active = chrono::Utc::now();
         Ok(())
     }
@@ -404,5 +406,48 @@ mod tests {
         registry.register(entry).unwrap();
         registry.remove(id).unwrap();
         assert!(registry.get(id).is_none());
+    }
+
+    #[test]
+    fn test_update_skills_reenables_disabled_skills() {
+        let registry = AgentRegistry::new();
+        let mut entry = test_entry("skills-disabled");
+        entry.manifest.skills_disabled = true;
+        let id = entry.id;
+        registry.register(entry).unwrap();
+
+        registry
+            .update_skills(id, vec!["review".to_string()])
+            .expect("update should succeed");
+
+        let updated = registry.get(id).expect("agent should exist");
+        assert_eq!(updated.manifest.skills, vec!["review".to_string()]);
+        assert!(
+            !updated.manifest.skills_disabled,
+            "updating skills should re-enable skill resolution"
+        );
+    }
+
+    #[test]
+    fn test_update_tool_filters_reenables_disabled_tools() {
+        let registry = AgentRegistry::new();
+        let mut entry = test_entry("tools-disabled");
+        entry.manifest.tools_disabled = true;
+        let id = entry.id;
+        registry.register(entry).unwrap();
+
+        registry
+            .update_tool_filters(id, Some(vec!["file_read".to_string()]), None)
+            .expect("update should succeed");
+
+        let updated = registry.get(id).expect("agent should exist");
+        assert_eq!(
+            updated.manifest.tool_allowlist,
+            vec!["file_read".to_string()]
+        );
+        assert!(
+            !updated.manifest.tools_disabled,
+            "updating tool filters should re-enable tool resolution"
+        );
     }
 }

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -169,6 +169,7 @@ impl SetupWizard {
             capabilities: caps,
             tools: HashMap::new(),
             skills: intent.skills.clone(),
+            skills_disabled: false,
             mcp_servers: vec![],
             metadata: HashMap::new(),
             tags: vec![],
@@ -182,6 +183,7 @@ impl SetupWizard {
             exec_policy: None,
             tool_allowlist: vec![],
             tool_blocklist: vec![],
+            tools_disabled: false,
         };
 
         let skills_to_install: Vec<String> = intent

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -464,6 +464,9 @@ pub struct AgentManifest {
     /// Installed skill references (empty = all skills available).
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub skills: Vec<String>,
+    /// Explicitly disable all skills, overriding the empty-list = all-skills default.
+    #[serde(default)]
+    pub skills_disabled: bool,
     /// MCP server allowlist (empty = all connected MCP servers available).
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub mcp_servers: Vec<String>,
@@ -499,6 +502,9 @@ pub struct AgentManifest {
     /// Tool blocklist — these tools are excluded (applied after allowlist).
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub tool_blocklist: Vec<String>,
+    /// Explicitly disable all tools, overriding profile / capability / filter expansion.
+    #[serde(default)]
+    pub tools_disabled: bool,
 }
 
 fn default_true() -> bool {
@@ -522,6 +528,7 @@ impl Default for AgentManifest {
             profile: None,
             tools: HashMap::new(),
             skills: Vec::new(),
+            skills_disabled: false,
             mcp_servers: Vec::new(),
             metadata: HashMap::new(),
             tags: Vec::new(),
@@ -533,6 +540,7 @@ impl Default for AgentManifest {
             exec_policy: None,
             tool_allowlist: Vec::new(),
             tool_blocklist: Vec::new(),
+            tools_disabled: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `include_skills` (bool, default: true) and `include_tools` (bool, default: true) fields to `POST /api/agents/{id}/clone` request body
- When `include_skills: false`, the cloned agent starts with an empty skills list
- When `include_tools: false`, the cloned agent starts with empty tools, tool_allowlist, and tool_blocklist
- Add 5 unit tests covering deserialization defaults, explicit flags, partial flags, and manifest stripping behavior

Closes #180

## Test plan

- [x] `cargo build --workspace --lib` compiles cleanly
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test -p librefang-api` — all 42 tests pass (5 new)
- [x] `cargo fmt --all` applied
- [ ] Live integration test: `curl -X POST /api/agents/{id}/clone -d '{"new_name":"test","include_skills":false}'` returns cloned agent without skills