### PR TITLE
feat: add webhooks management API

### DIFF
--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -16,4 +16,5 @@ pub mod stream_dedup;
 pub mod types;
 pub mod versioning;
 pub mod webchat;
+pub mod webhook_store;
 pub mod ws;

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -72,4 +72,6 @@ pub struct AppState {
     /// Avoids blocking the `/api/providers` endpoint on TCP timeouts to
     /// unreachable local services. 60-second TTL.
     pub provider_probe_cache: librefang_runtime::provider_health::ProbeCache,
+    /// Webhook subscription store for outbound event notifications.
+    pub webhook_store: crate::webhook_store::WebhookStore,
 }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2320,6 +2320,328 @@ pub async fn delete_event_webhook(Path(id): Path<String>) -> impl IntoResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Outbound webhook management endpoints (file-persisted subscriptions)
+// ---------------------------------------------------------------------------
+
+/// GET /api/webhooks — List all webhook subscriptions (secrets redacted).
+pub async fn list_webhooks(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let webhooks: Vec<_> = state
+        .webhook_store
+        .list()
+        .iter()
+        .map(crate::webhook_store::redact_webhook_secret)
+        .collect();
+    let total = webhooks.len();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"webhooks": webhooks, "total": total})),
+    )
+}
+
+/// GET /api/webhooks/{id} — Get a single webhook subscription (secret redacted).
+pub async fn get_webhook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let wh_id = match uuid::Uuid::parse_str(&id) {
+        Ok(uuid) => crate::webhook_store::WebhookId(uuid),
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Invalid webhook ID"})),
+            );
+        }
+    };
+    match state.webhook_store.get(wh_id) {
+        Some(wh) => {
+            let redacted = crate::webhook_store::redact_webhook_secret(&wh);
+            match serde_json::to_value(&redacted) {
+                Ok(v) => (StatusCode::OK, Json(v)),
+                Err(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "serialization error"})),
+                ),
+            }
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Webhook not found"})),
+        ),
+    }
+}
+
+/// POST /api/webhooks — Create a new webhook subscription.
+pub async fn create_webhook(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<crate::webhook_store::CreateWebhookRequest>,
+) -> impl IntoResponse {
+    match state.webhook_store.create(req) {
+        Ok(webhook) => {
+            let redacted = crate::webhook_store::redact_webhook_secret(&webhook);
+            match serde_json::to_value(&redacted) {
+                Ok(v) => (StatusCode::CREATED, Json(v)),
+                Err(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "serialization error"})),
+                ),
+            }
+        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+/// PUT /api/webhooks/{id} — Update a webhook subscription.
+pub async fn update_webhook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<crate::webhook_store::UpdateWebhookRequest>,
+) -> impl IntoResponse {
+    match uuid::Uuid::parse_str(&id) {
+        Ok(uuid) => {
+            let wh_id = crate::webhook_store::WebhookId(uuid);
+            match state.webhook_store.update(wh_id, req) {
+                Ok(webhook) => {
+                    let redacted = crate::webhook_store::redact_webhook_secret(&webhook);
+                    match serde_json::to_value(&redacted) {
+                        Ok(v) => (StatusCode::OK, Json(v)),
+                        Err(_) => (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({"error": "serialization error"})),
+                        ),
+                    }
+                }
+                Err(e) => (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": e}))),
+            }
+        }
+        Err(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid webhook ID"})),
+        ),
+    }
+}
+
+/// DELETE /api/webhooks/{id} — Delete a webhook subscription.
+pub async fn delete_webhook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match uuid::Uuid::parse_str(&id) {
+        Ok(uuid) => {
+            let wh_id = crate::webhook_store::WebhookId(uuid);
+            if state.webhook_store.delete(wh_id) {
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({"status": "deleted"})),
+                )
+            } else {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "Webhook not found"})),
+                )
+            }
+        }
+        Err(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid webhook ID"})),
+        ),
+    }
+}
+
+/// POST /api/webhooks/{id}/test — Send a test event to a webhook.
+///
+/// Includes HMAC-SHA256 signature in `X-Webhook-Signature` header when
+/// the webhook has a secret configured.
+pub async fn test_webhook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let wh_id = match uuid::Uuid::parse_str(&id) {
+        Ok(uuid) => crate::webhook_store::WebhookId(uuid),
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Invalid webhook ID"})),
+            );
+        }
+    };
+
+    let webhook = match state.webhook_store.get(wh_id) {
+        Some(w) => w,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Webhook not found"})),
+            );
+        }
+    };
+
+    // Re-validate the URL against SSRF rules before sending
+    if let Err(e) = crate::webhook_store::validate_webhook_url(&webhook.url) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("Webhook URL is not safe: {e}")})),
+        );
+    }
+
+    let test_payload = serde_json::json!({
+        "event": "test",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "webhook_id": webhook.id.to_string(),
+        "message": "This is a test event from LibreFang.",
+    });
+
+    let payload_bytes = serde_json::to_vec(&test_payload).unwrap_or_default();
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap_or_default();
+
+    let mut request = client
+        .post(&webhook.url)
+        .header("Content-Type", "application/json")
+        .header("User-Agent", "LibreFang-Webhook/1.0");
+
+    // Add HMAC signature if secret is configured
+    if let Some(ref secret) = webhook.secret {
+        let signature = crate::webhook_store::compute_hmac_signature(secret, &payload_bytes);
+        request = request.header("X-Webhook-Signature", signature);
+    }
+
+    match request.body(payload_bytes).send().await {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "sent",
+                    "response_status": status,
+                    "webhook_id": id,
+                })),
+            )
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({
+                "status": "error",
+                "error": format!("Failed to reach webhook URL: {e}"),
+                "webhook_id": id,
+            })),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task queue management endpoints (#184)
+// ---------------------------------------------------------------------------
+
+/// GET /api/tasks/status — Summary counts of tasks by status.
+pub async fn task_queue_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.kernel.task_list(None).await {
+        Ok(tasks) => {
+            let mut pending = 0u64;
+            let mut in_progress = 0u64;
+            let mut completed = 0u64;
+            let mut failed = 0u64;
+            for t in &tasks {
+                match t["status"].as_str().unwrap_or("") {
+                    "pending" => pending += 1,
+                    "in_progress" => in_progress += 1,
+                    "completed" => completed += 1,
+                    "failed" => failed += 1,
+                    _ => {}
+                }
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "total": tasks.len(),
+                    "pending": pending,
+                    "in_progress": in_progress,
+                    "completed": completed,
+                    "failed": failed,
+                })),
+            )
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+/// GET /api/tasks/list — List tasks, optionally filtered by ?status=pending|in_progress|completed|failed.
+pub async fn task_queue_list(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let status_filter = params.get("status").map(|s| s.as_str());
+    match state.kernel.task_list(status_filter).await {
+        Ok(tasks) => {
+            let total = tasks.len();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"tasks": tasks, "total": total})),
+            )
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+/// DELETE /api/tasks/{id} — Remove a task from the queue.
+pub async fn task_queue_delete(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.kernel.task_delete(&id).await {
+        Ok(true) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "deleted", "id": id})),
+        ),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Task not found"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+/// POST /api/tasks/{id}/retry — Re-queue a completed or failed task back to pending.
+///
+/// In-progress tasks cannot be retried to prevent duplicate execution.
+pub async fn task_queue_retry(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.kernel.task_retry(&id).await {
+        Ok(true) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "retried", "id": id})),
+        ),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "Task not found or not in a retryable state (must be completed or failed)"
+            })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Event Webhook Tests
 // ---------------------------------------------------------------------------
 #[cfg(test)]
@@ -2632,111 +2954,5 @@ mod event_webhook_tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Task queue management endpoints (#184)
-// ---------------------------------------------------------------------------
-
-/// GET /api/tasks/status — Summary counts of tasks by status.
-pub async fn task_queue_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    match state.kernel.task_list(None).await {
-        Ok(tasks) => {
-            let mut pending = 0u64;
-            let mut in_progress = 0u64;
-            let mut completed = 0u64;
-            let mut failed = 0u64;
-            for t in &tasks {
-                match t["status"].as_str().unwrap_or("") {
-                    "pending" => pending += 1,
-                    "in_progress" => in_progress += 1,
-                    "completed" => completed += 1,
-                    "failed" => failed += 1,
-                    _ => {}
-                }
-            }
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "total": tasks.len(),
-                    "pending": pending,
-                    "in_progress": in_progress,
-                    "completed": completed,
-                    "failed": failed,
-                })),
-            )
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e})),
-        ),
-    }
-}
-
-/// GET /api/tasks/list — List tasks, optionally filtered by ?status=pending|in_progress|completed|failed.
-pub async fn task_queue_list(
-    State(state): State<Arc<AppState>>,
-    Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
-    let status_filter = params.get("status").map(|s| s.as_str());
-    match state.kernel.task_list(status_filter).await {
-        Ok(tasks) => {
-            let total = tasks.len();
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({"tasks": tasks, "total": total})),
-            )
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e})),
-        ),
-    }
-}
-
-/// DELETE /api/tasks/{id} — Remove a task from the queue.
-pub async fn task_queue_delete(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    match state.kernel.task_delete(&id).await {
-        Ok(true) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "deleted", "id": id})),
-        ),
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "Task not found"})),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e})),
-        ),
-    }
-}
-
-/// POST /api/tasks/{id}/retry — Re-queue a completed or failed task back to pending.
-///
-/// In-progress tasks cannot be retried to prevent duplicate execution.
-pub async fn task_queue_retry(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    match state.kernel.task_retry(&id).await {
-        Ok(true) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "retried", "id": id})),
-        ),
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({
-                "error": "Task not found or not in a retryable state (must be completed or failed)"
-            })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e})),
-        ),
     }
 }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -516,6 +516,21 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
             "/webhooks/events/{id}",
             axum::routing::put(routes::update_event_webhook).delete(routes::delete_event_webhook),
         )
+        // Outbound webhook management endpoints (#179)
+        .route(
+            "/webhooks",
+            axum::routing::get(routes::list_webhooks).post(routes::create_webhook),
+        )
+        .route(
+            "/webhooks/{id}",
+            axum::routing::get(routes::get_webhook)
+                .put(routes::update_webhook)
+                .delete(routes::delete_webhook),
+        )
+        .route(
+            "/webhooks/{id}/test",
+            axum::routing::post(routes::test_webhook),
+        )
         // Webhook trigger endpoints (external event injection)
         .route("/hooks/wake", axum::routing::post(routes::webhook_wake))
         .route("/hooks/agent", axum::routing::post(routes::webhook_agent))
@@ -645,6 +660,9 @@ pub async fn build_router(
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: crate::webhook_store::WebhookStore::load(
+            kernel.config.home_dir.join("webhooks.json"),
+        ),
     });
 
     // CORS: allow localhost origins by default. If API key is set, the API

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -1,0 +1,747 @@
+//! In-process webhook subscription store with file persistence.
+//!
+//! Manages outbound webhook subscriptions — when system events occur,
+//! registered webhooks receive HTTP POST notifications.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::RwLock;
+use uuid::Uuid;
+
+/// Unique identifier for a webhook subscription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WebhookId(pub Uuid);
+
+impl std::fmt::Display for WebhookId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Events that can trigger a webhook notification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookEvent {
+    /// Agent spawned.
+    AgentSpawned,
+    /// Agent stopped/killed.
+    AgentStopped,
+    /// Message received by an agent.
+    MessageReceived,
+    /// Message response completed.
+    MessageCompleted,
+    /// Agent error occurred.
+    AgentError,
+    /// Cron job fired.
+    CronFired,
+    /// Trigger fired.
+    TriggerFired,
+    /// Wildcard — all events.
+    All,
+}
+
+impl std::fmt::Display for WebhookEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AgentSpawned => write!(f, "agent_spawned"),
+            Self::AgentStopped => write!(f, "agent_stopped"),
+            Self::MessageReceived => write!(f, "message_received"),
+            Self::MessageCompleted => write!(f, "message_completed"),
+            Self::AgentError => write!(f, "agent_error"),
+            Self::CronFired => write!(f, "cron_fired"),
+            Self::TriggerFired => write!(f, "trigger_fired"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+
+/// A webhook subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookSubscription {
+    pub id: WebhookId,
+    /// Human-readable label.
+    pub name: String,
+    /// URL to POST event payloads to.
+    pub url: String,
+    /// Optional shared secret for HMAC-SHA256 signature verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
+    /// Events this webhook subscribes to.
+    pub events: Vec<WebhookEvent>,
+    /// Whether the webhook is active.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// When the subscription was created.
+    pub created_at: DateTime<Utc>,
+    /// When the subscription was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Return a copy of a webhook with its secret redacted for API responses.
+pub fn redact_webhook_secret(wh: &WebhookSubscription) -> WebhookSubscription {
+    let mut redacted = wh.clone();
+    if redacted.secret.is_some() {
+        redacted.secret = Some("***".to_string());
+    }
+    redacted
+}
+
+/// Compute HMAC-SHA256 signature for a payload using the given secret.
+pub fn compute_hmac_signature(secret: &str, payload: &[u8]) -> String {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    mac.update(payload);
+    let result = mac.finalize();
+    let bytes = result.into_bytes();
+    format!("sha256={}", hex::encode(bytes))
+}
+
+/// Validate that a URL is safe to send webhooks to (mitigate SSRF).
+/// Only allows http and https schemes, blocks private/link-local IPs.
+pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(url_str).map_err(|_| "url is not a valid URL".to_string())?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "url scheme '{}' is not allowed, only http/https",
+                other
+            ))
+        }
+    }
+
+    // Block private/link-local IPs to mitigate SSRF
+    if let Some(host) = parsed.host_str() {
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
+                return Err(
+                    "url must not point to a private, loopback, or link-local address".to_string(),
+                );
+            }
+        }
+        // Also block common internal hostnames
+        let lower = host.to_lowercase();
+        if lower == "localhost"
+            || lower == "metadata.google.internal"
+            || lower.ends_with(".internal")
+        {
+            return Err("url must not point to an internal/localhost address".to_string());
+        }
+    }
+
+    Ok(())
+}
+
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_private() || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
+            // 100.64.0.0/10
+        }
+        std::net::IpAddr::V6(_) => false, // Simplified; production should check IPv6 ULA
+    }
+}
+
+fn is_link_local(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.is_link_local() || v4.octets()[0] == 169,
+        std::net::IpAddr::V6(_) => false,
+    }
+}
+
+/// Request body for creating a webhook.
+#[derive(Debug, Deserialize)]
+pub struct CreateWebhookRequest {
+    pub name: String,
+    pub url: String,
+    #[serde(default)]
+    pub secret: Option<String>,
+    pub events: Vec<WebhookEvent>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+/// Request body for updating a webhook.
+#[derive(Debug, Deserialize)]
+pub struct UpdateWebhookRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub secret: Option<String>,
+    #[serde(default)]
+    pub events: Option<Vec<WebhookEvent>>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// Maximum number of webhook subscriptions.
+const MAX_WEBHOOKS: usize = 100;
+/// Maximum name length.
+const MAX_NAME_LEN: usize = 128;
+/// Maximum URL length.
+const MAX_URL_LEN: usize = 2048;
+/// Maximum secret length.
+const MAX_SECRET_LEN: usize = 256;
+
+impl CreateWebhookRequest {
+    /// Validate the create request.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.name.trim().is_empty() {
+            return Err("name must not be empty".to_string());
+        }
+        if self.name.len() > MAX_NAME_LEN {
+            return Err(format!(
+                "name exceeds maximum length of {} chars",
+                MAX_NAME_LEN
+            ));
+        }
+        if self.url.trim().is_empty() {
+            return Err("url must not be empty".to_string());
+        }
+        if self.url.len() > MAX_URL_LEN {
+            return Err(format!(
+                "url exceeds maximum length of {} chars",
+                MAX_URL_LEN
+            ));
+        }
+        validate_webhook_url(&self.url)?;
+        if let Some(ref s) = self.secret {
+            if s.len() > MAX_SECRET_LEN {
+                return Err(format!(
+                    "secret exceeds maximum length of {} chars",
+                    MAX_SECRET_LEN
+                ));
+            }
+        }
+        if self.events.is_empty() {
+            return Err("events must not be empty".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Persisted webhook store.
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct StoreData {
+    webhooks: Vec<WebhookSubscription>,
+}
+
+/// Thread-safe webhook subscription store with file persistence.
+pub struct WebhookStore {
+    data: RwLock<StoreData>,
+    path: PathBuf,
+}
+
+impl WebhookStore {
+    /// Load or create a webhook store at the given path.
+    pub fn load(path: PathBuf) -> Self {
+        let data = if path.exists() {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+                Err(_) => StoreData::default(),
+            }
+        } else {
+            StoreData::default()
+        };
+        Self {
+            data: RwLock::new(data),
+            path,
+        }
+    }
+
+    /// Persist current state to disk.
+    fn persist(&self, data: &StoreData) -> Result<(), String> {
+        let json =
+            serde_json::to_string_pretty(data).map_err(|e| format!("serialize error: {e}"))?;
+        // Ensure parent directory exists
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        // Set restrictive permissions on the file (contains secrets)
+        std::fs::write(&self.path, json).map_err(|e| format!("write error: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
+    }
+
+    /// List all webhook subscriptions.
+    pub fn list(&self) -> Vec<WebhookSubscription> {
+        self.data
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .webhooks
+            .clone()
+    }
+
+    /// Get a single webhook by ID.
+    pub fn get(&self, id: WebhookId) -> Option<WebhookSubscription> {
+        self.data
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .webhooks
+            .iter()
+            .find(|w| w.id == id)
+            .cloned()
+    }
+
+    /// Create a new webhook subscription.
+    pub fn create(&self, req: CreateWebhookRequest) -> Result<WebhookSubscription, String> {
+        req.validate()?;
+        let mut data = self.data.write().unwrap_or_else(|e| e.into_inner());
+        if data.webhooks.len() >= MAX_WEBHOOKS {
+            return Err(format!(
+                "maximum number of webhooks ({}) reached",
+                MAX_WEBHOOKS
+            ));
+        }
+        let now = Utc::now();
+        let webhook = WebhookSubscription {
+            id: WebhookId(Uuid::new_v4()),
+            name: req.name,
+            url: req.url,
+            secret: req.secret,
+            events: req.events,
+            enabled: req.enabled,
+            created_at: now,
+            updated_at: now,
+        };
+        data.webhooks.push(webhook.clone());
+        if let Err(e) = self.persist(&data) {
+            tracing::warn!("Failed to persist webhook store: {e}");
+        }
+        Ok(webhook)
+    }
+
+    /// Update an existing webhook subscription.
+    pub fn update(
+        &self,
+        id: WebhookId,
+        req: UpdateWebhookRequest,
+    ) -> Result<WebhookSubscription, String> {
+        let mut data = self.data.write().unwrap_or_else(|e| e.into_inner());
+        let webhook = data
+            .webhooks
+            .iter_mut()
+            .find(|w| w.id == id)
+            .ok_or_else(|| "webhook not found".to_string())?;
+
+        if let Some(ref name) = req.name {
+            if name.trim().is_empty() {
+                return Err("name must not be empty".to_string());
+            }
+            if name.len() > MAX_NAME_LEN {
+                return Err(format!(
+                    "name exceeds maximum length of {} chars",
+                    MAX_NAME_LEN
+                ));
+            }
+            webhook.name = name.clone();
+        }
+        if let Some(ref url_str) = req.url {
+            if url_str.trim().is_empty() {
+                return Err("url must not be empty".to_string());
+            }
+            if url_str.len() > MAX_URL_LEN {
+                return Err(format!(
+                    "url exceeds maximum length of {} chars",
+                    MAX_URL_LEN
+                ));
+            }
+            validate_webhook_url(url_str)?;
+            webhook.url = url_str.clone();
+        }
+        if let Some(ref secret) = req.secret {
+            if secret.is_empty() {
+                // Treat empty string as "clear the secret"
+                webhook.secret = None;
+            } else if secret.len() > MAX_SECRET_LEN {
+                return Err(format!(
+                    "secret exceeds maximum length of {} chars",
+                    MAX_SECRET_LEN
+                ));
+            } else {
+                webhook.secret = Some(secret.clone());
+            }
+        }
+        if let Some(ref events) = req.events {
+            if events.is_empty() {
+                return Err("events must not be empty".to_string());
+            }
+            webhook.events = events.clone();
+        }
+        if let Some(enabled) = req.enabled {
+            webhook.enabled = enabled;
+        }
+        webhook.updated_at = Utc::now();
+        let updated = webhook.clone();
+        if let Err(e) = self.persist(&data) {
+            tracing::warn!("Failed to persist webhook store: {e}");
+        }
+        Ok(updated)
+    }
+
+    /// Delete a webhook subscription.
+    pub fn delete(&self, id: WebhookId) -> bool {
+        let mut data = self.data.write().unwrap_or_else(|e| e.into_inner());
+        let before = data.webhooks.len();
+        data.webhooks.retain(|w| w.id != id);
+        let removed = data.webhooks.len() < before;
+        if removed {
+            if let Err(e) = self.persist(&data) {
+                tracing::warn!("Failed to persist webhook store: {e}");
+            }
+        }
+        removed
+    }
+}
+
+// hex encoding helper (avoids pulling in another crate)
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        bytes.as_ref().iter().map(|b| format!("{b:02x}")).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (WebhookStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("webhooks.json");
+        (WebhookStore::load(path), dir)
+    }
+
+    fn valid_create_req() -> CreateWebhookRequest {
+        CreateWebhookRequest {
+            name: "test-hook".to_string(),
+            url: "https://example.com/hook".to_string(),
+            secret: Some("my-secret".to_string()),
+            events: vec![WebhookEvent::AgentSpawned],
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn create_and_list() {
+        let (store, _dir) = temp_store();
+        assert!(store.list().is_empty());
+        let wh = store.create(valid_create_req()).unwrap();
+        assert_eq!(wh.name, "test-hook");
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[test]
+    fn create_validates_empty_name() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.name = String::new();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("name must not be empty"));
+    }
+
+    #[test]
+    fn create_validates_empty_url() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = String::new();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("url must not be empty"));
+    }
+
+    #[test]
+    fn create_validates_invalid_url() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = "not a url".to_string();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("not a valid URL"));
+    }
+
+    #[test]
+    fn create_validates_empty_events() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.events = vec![];
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("events must not be empty"));
+    }
+
+    #[test]
+    fn create_rejects_private_ip_url() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = "http://192.168.1.1/hook".to_string();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("private"));
+    }
+
+    #[test]
+    fn create_rejects_localhost_url() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = "http://localhost:8080/hook".to_string();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("internal/localhost"));
+    }
+
+    #[test]
+    fn create_rejects_link_local_url() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = "http://169.254.169.254/metadata".to_string();
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("private") || err.contains("link-local"));
+    }
+
+    #[test]
+    fn get_by_id() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        let found = store.get(wh.id).unwrap();
+        assert_eq!(found.name, "test-hook");
+        assert!(store.get(WebhookId(Uuid::new_v4())).is_none());
+    }
+
+    #[test]
+    fn update_webhook() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        let updated = store
+            .update(
+                wh.id,
+                UpdateWebhookRequest {
+                    name: Some("renamed".to_string()),
+                    url: None,
+                    secret: None,
+                    events: None,
+                    enabled: Some(false),
+                },
+            )
+            .unwrap();
+        assert_eq!(updated.name, "renamed");
+        assert!(!updated.enabled);
+        assert!(updated.updated_at > wh.updated_at);
+    }
+
+    #[test]
+    fn update_clears_secret_with_empty_string() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        assert!(wh.secret.is_some());
+        let updated = store
+            .update(
+                wh.id,
+                UpdateWebhookRequest {
+                    name: None,
+                    url: None,
+                    secret: Some(String::new()),
+                    events: None,
+                    enabled: None,
+                },
+            )
+            .unwrap();
+        assert!(updated.secret.is_none());
+    }
+
+    #[test]
+    fn update_not_found() {
+        let (store, _dir) = temp_store();
+        let err = store
+            .update(
+                WebhookId(Uuid::new_v4()),
+                UpdateWebhookRequest {
+                    name: Some("x".to_string()),
+                    url: None,
+                    secret: None,
+                    events: None,
+                    enabled: None,
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn delete_webhook() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        assert!(store.delete(wh.id));
+        assert!(store.list().is_empty());
+        assert!(!store.delete(wh.id));
+    }
+
+    #[test]
+    fn persistence_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("webhooks.json");
+
+        // Create and persist
+        {
+            let store = WebhookStore::load(path.clone());
+            store.create(valid_create_req()).unwrap();
+        }
+
+        // Reload and verify
+        {
+            let store = WebhookStore::load(path);
+            assert_eq!(store.list().len(), 1);
+            assert_eq!(store.list()[0].name, "test-hook");
+        }
+    }
+
+    #[test]
+    fn max_webhooks_enforced() {
+        let (store, _dir) = temp_store();
+        for i in 0..MAX_WEBHOOKS {
+            let req = CreateWebhookRequest {
+                name: format!("hook-{i}"),
+                url: format!("https://example.com/hook/{i}"),
+                secret: None,
+                events: vec![WebhookEvent::All],
+                enabled: true,
+            };
+            store.create(req).unwrap();
+        }
+        let err = store.create(valid_create_req()).unwrap_err();
+        assert!(err.contains("maximum number of webhooks"));
+    }
+
+    #[test]
+    fn webhook_event_serde_roundtrip() {
+        let events = vec![
+            WebhookEvent::AgentSpawned,
+            WebhookEvent::AgentStopped,
+            WebhookEvent::MessageReceived,
+            WebhookEvent::MessageCompleted,
+            WebhookEvent::AgentError,
+            WebhookEvent::CronFired,
+            WebhookEvent::TriggerFired,
+            WebhookEvent::All,
+        ];
+        let json = serde_json::to_string(&events).unwrap();
+        let back: Vec<WebhookEvent> = serde_json::from_str(&json).unwrap();
+        assert_eq!(events, back);
+    }
+
+    #[test]
+    fn name_too_long() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.name = "x".repeat(MAX_NAME_LEN + 1);
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("name exceeds maximum length"));
+    }
+
+    #[test]
+    fn url_too_long() {
+        let (store, _dir) = temp_store();
+        let mut req = valid_create_req();
+        req.url = format!("https://example.com/{}", "x".repeat(MAX_URL_LEN));
+        let err = store.create(req).unwrap_err();
+        assert!(err.contains("url exceeds maximum length"));
+    }
+
+    #[test]
+    fn update_validates_empty_name() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        let err = store
+            .update(
+                wh.id,
+                UpdateWebhookRequest {
+                    name: Some(String::new()),
+                    url: None,
+                    secret: None,
+                    events: None,
+                    enabled: None,
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("name must not be empty"));
+    }
+
+    #[test]
+    fn update_validates_invalid_url() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        let err = store
+            .update(
+                wh.id,
+                UpdateWebhookRequest {
+                    name: None,
+                    url: Some("not-a-url".to_string()),
+                    secret: None,
+                    events: None,
+                    enabled: None,
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("not a valid URL"));
+    }
+
+    #[test]
+    fn update_validates_empty_events() {
+        let (store, _dir) = temp_store();
+        let wh = store.create(valid_create_req()).unwrap();
+        let err = store
+            .update(
+                wh.id,
+                UpdateWebhookRequest {
+                    name: None,
+                    url: None,
+                    secret: None,
+                    events: Some(vec![]),
+                    enabled: None,
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("events must not be empty"));
+    }
+
+    #[test]
+    fn redact_secret_works() {
+        let wh = WebhookSubscription {
+            id: WebhookId(Uuid::new_v4()),
+            name: "test".to_string(),
+            url: "https://example.com".to_string(),
+            secret: Some("super-secret".to_string()),
+            events: vec![WebhookEvent::All],
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let redacted = redact_webhook_secret(&wh);
+        assert_eq!(redacted.secret, Some("***".to_string()));
+
+        let no_secret = WebhookSubscription { secret: None, ..wh };
+        let redacted2 = redact_webhook_secret(&no_secret);
+        assert!(redacted2.secret.is_none());
+    }
+
+    #[test]
+    fn hmac_signature_is_deterministic() {
+        let sig1 = compute_hmac_signature("secret", b"payload");
+        let sig2 = compute_hmac_signature("secret", b"payload");
+        assert_eq!(sig1, sig2);
+        assert!(sig1.starts_with("sha256="));
+
+        let sig3 = compute_hmac_signature("other", b"payload");
+        assert_ne!(sig1, sig3);
+    }
+}

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -94,6 +94,9 @@ async fn start_test_server_with_provider(
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
     });
 
     let app = Router::new()
@@ -887,6 +890,9 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
     });
 
     let api_key_state = state.kernel.config.api_key.clone();

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -115,6 +115,9 @@ async fn test_full_daemon_lifecycle() {
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
     });
 
     let app = Router::new()
@@ -240,6 +243,9 @@ async fn test_server_immediate_responsiveness() {
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -59,6 +59,9 @@ async fn start_test_server() -> TestServer {
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         clawhub_cache: dashmap::DashMap::new(),
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
     });
 
     let app = Router::new()

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.5.5-20260317"
+    "version": "0.5.6-20260317"
   },
   "paths": {
     "/.well-known/agent.json": {
@@ -6079,6 +6079,14 @@
           "new_name"
         ],
         "properties": {
+          "include_skills": {
+            "type": "boolean",
+            "description": "Whether to copy skills from the source agent (default: true)."
+          },
+          "include_tools": {
+            "type": "boolean",
+            "description": "Whether to copy tools from the source agent (default: true)."
+          },
           "new_name": {
             "type": "string"
           }


### PR DESCRIPTION
## Summary
- Add webhook CRUD endpoints: GET/POST/PUT/DELETE `/api/webhooks`, POST `/api/webhooks/{id}/test`
- Runtime webhook management without config restart

Closes #179