### PR TITLE
fix: replace unsafe pointer mutation with OnceLock for peer_registry/peer_node

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -985,7 +985,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             return "OFP peer network is disabled. Set network_enabled = true in config.toml."
                 .to_string();
         }
-        match &self.kernel.peer_registry {
+        match self.kernel.peer_registry.get() {
             Some(registry) => {
                 let peers = registry.all_peers();
                 if peers.is_empty() {

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -67,7 +67,7 @@ pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResp
         && !state.kernel.config.network.shared_secret.is_empty();
 
     let (node_id, listen_address, connected_peers, total_peers) =
-        if let Some(ref peer_node) = state.kernel.peer_node {
+        if let Some(peer_node) = state.kernel.peer_node.get() {
             let registry = peer_node.registry();
             (
                 peer_node.node_id().to_string(),

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -615,7 +615,7 @@ pub async fn build_router(
     let state = Arc::new(AppState {
         kernel: kernel.clone(),
         started_at: Instant::now(),
-        peer_registry: kernel.peer_registry.as_ref().map(|r| Arc::new(r.clone())),
+        peer_registry: kernel.peer_registry.get().map(|r| Arc::new(r.clone())),
         bridge_manager: tokio::sync::Mutex::new(bridge),
         channels_config: tokio::sync::RwLock::new(channels_config),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -912,7 +912,7 @@ async fn handle_command(
             let msg = if !state.kernel.config.network_enabled {
                 "OFP network disabled.".to_string()
             } else {
-                match &state.kernel.peer_registry {
+                match state.kernel.peer_registry.get() {
                     Some(registry) => {
                         let peers = registry.all_peers();
                         if peers.is_empty() {

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -143,10 +143,10 @@ pub struct LibreFangKernel {
     pub hooks: librefang_runtime::hooks::HookRegistry,
     /// Persistent process manager for interactive sessions (REPLs, servers).
     pub process_manager: Arc<librefang_runtime::process_manager::ProcessManager>,
-    /// OFP peer registry — tracks connected peers.
-    pub peer_registry: Option<librefang_wire::PeerRegistry>,
-    /// OFP peer node — the local networking node.
-    pub peer_node: Option<Arc<librefang_wire::PeerNode>>,
+    /// OFP peer registry — tracks connected peers (set once during OFP startup).
+    pub peer_registry: OnceLock<librefang_wire::PeerRegistry>,
+    /// OFP peer node — the local networking node (set once during OFP startup).
+    pub peer_node: OnceLock<Arc<librefang_wire::PeerNode>>,
     /// Boot timestamp for uptime calculation.
     pub booted_at: std::time::Instant,
     /// WhatsApp Web gateway child process PID (for shutdown cleanup).
@@ -1018,8 +1018,8 @@ impl LibreFangKernel {
             auto_reply_engine,
             hooks: librefang_runtime::hooks::HookRegistry::new(),
             process_manager: Arc::new(librefang_runtime::process_manager::ProcessManager::new(5)),
-            peer_registry: None,
-            peer_node: None,
+            peer_registry: OnceLock::new(),
+            peer_node: OnceLock::new(),
             booted_at: std::time::Instant::now(),
             whatsapp_gateway_pid: Arc::new(std::sync::Mutex::new(None)),
             channel_adapters: dashmap::DashMap::new(),
@@ -4344,14 +4344,9 @@ impl LibreFangKernel {
                     "OFP peer node started"
                 );
 
-                // SAFETY: These fields are only written once during startup.
-                // We use unsafe to set them because start_background_agents runs
-                // after the Arc is created and the kernel is otherwise immutable.
-                let self_ptr = Arc::as_ptr(self) as *mut LibreFangKernel;
-                unsafe {
-                    (*self_ptr).peer_registry = Some(registry.clone());
-                    (*self_ptr).peer_node = Some(node.clone());
-                }
+                // Safe one-time initialization via OnceLock (replaces previous unsafe pointer mutation).
+                let _ = self.peer_registry.set(registry.clone());
+                let _ = self.peer_node.set(node.clone());
 
                 // Connect to bootstrap peers
                 for peer_addr_str in &self.config.network.bootstrap_peers {


### PR DESCRIPTION
## Summary
- Replace undefined behavior (`unsafe` raw pointer mutation through `Arc`) with safe `OnceLock` for `peer_registry` and `peer_node` fields on `LibreFangKernel`
- Both fields are write-once during OFP startup, making `OnceLock` a perfect fit
- Update all read sites across `routes.rs`, `ws.rs`, `channel_bridge.rs`, and `server.rs` to use `OnceLock::get()` instead of `Option` pattern matching

Closes #298

## Test plan
- [ ] `cargo build --workspace --lib` compiles cleanly
- [ ] `cargo test --workspace` passes all existing tests
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [ ] OFP networking still initializes correctly with `network_enabled = true`