### PR TITLE
chore: keep at least 1 machine running to avoid cold starts

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = "nrt"
   force_https = true
   auto_stop_machines = "suspend"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [mounts]
   source = "librefang_data"


### PR DESCRIPTION
## Summary
- Set `min_machines_running` from `0` to `1` to avoid cold start latency
- Still within Fly.io free tier (3 shared-cpu-1x VMs)

## Changes
- `fly.toml`: `min_machines_running = 0` → `min_machines_running = 1`