### PR TITLE
feat: add workflow trigger support to cron jobs

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -643,6 +643,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                             librefang_types::scheduler::CronAction::Workflow {
                                 workflow_id,
                                 input,
+                                ..
                             } => {
                                 // Resolve workflow by UUID or name
                                 let resolved = if let Ok(uuid) = uuid::Uuid::parse_str(workflow_id)

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -4104,10 +4104,13 @@ impl LibreFangKernel {
                             librefang_types::scheduler::CronAction::Workflow {
                                 workflow_id,
                                 input,
+                                timeout_secs,
                             } => {
                                 tracing::debug!(job = %job_name, workflow = %workflow_id, "Cron: firing workflow");
                                 let input_text = input.clone().unwrap_or_default();
                                 let delivery = job.delivery.clone();
+                                let timeout_s = timeout_secs.unwrap_or(300);
+                                let timeout = std::time::Duration::from_secs(timeout_s);
 
                                 // Resolve workflow by UUID first, then by name
                                 let resolved_id =
@@ -4124,8 +4127,13 @@ impl LibreFangKernel {
 
                                 match resolved_id {
                                     Some(wf_id) => {
-                                        match kernel.run_workflow(wf_id, input_text).await {
-                                            Ok((_run_id, output)) => {
+                                        match tokio::time::timeout(
+                                            timeout,
+                                            kernel.run_workflow(wf_id, input_text),
+                                        )
+                                        .await
+                                        {
+                                            Ok(Ok((_run_id, output))) => {
                                                 tracing::info!(job = %job_name, "Cron workflow completed successfully");
                                                 kernel.cron_scheduler.record_success(job_id);
                                                 cron_deliver_response(
@@ -4133,12 +4141,19 @@ impl LibreFangKernel {
                                                 )
                                                 .await;
                                             }
-                                            Err(e) => {
+                                            Ok(Err(e)) => {
                                                 let err_msg = format!("{e}");
                                                 tracing::warn!(job = %job_name, error = %err_msg, "Cron workflow failed");
                                                 kernel
                                                     .cron_scheduler
                                                     .record_failure(job_id, &err_msg);
+                                            }
+                                            Err(_) => {
+                                                tracing::warn!(job = %job_name, timeout_s, "Cron workflow timed out");
+                                                kernel.cron_scheduler.record_failure(
+                                                    job_id,
+                                                    &format!("workflow timed out after {timeout_s}s"),
+                                                );
                                             }
                                         }
                                     }

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -132,6 +132,9 @@ pub enum CronAction {
         /// Optional input text passed to the first workflow step.
         #[serde(default)]
         input: Option<String>,
+        /// Timeout in seconds (1..=3600). Defaults to 300 (5 min) if unset.
+        #[serde(default)]
+        timeout_secs: Option<u64>,
     },
 }
 
@@ -310,7 +313,11 @@ impl CronJob {
                     }
                 }
             }
-            CronAction::Workflow { workflow_id, .. } => {
+            CronAction::Workflow {
+                workflow_id,
+                timeout_secs,
+                ..
+            } => {
                 if workflow_id.is_empty() {
                     return Err("workflow_id must not be empty".into());
                 }
@@ -319,6 +326,16 @@ impl CronJob {
                         "workflow_id too long ({} chars, max {MAX_WORKFLOW_ID_LEN})",
                         workflow_id.len()
                     ));
+                }
+                if let Some(t) = timeout_secs {
+                    if *t == 0 {
+                        return Err("workflow timeout_secs must be > 0".into());
+                    }
+                    if *t > 3600 {
+                        return Err(format!(
+                            "workflow timeout_secs too large ({t}, max 3600)"
+                        ));
+                    }
                 }
             }
         }
@@ -895,6 +912,7 @@ mod tests {
         job.action = CronAction::Workflow {
             workflow_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             input: None,
+            timeout_secs: None,
         };
         assert!(job.validate(0).is_ok());
     }
@@ -905,6 +923,7 @@ mod tests {
         job.action = CronAction::Workflow {
             workflow_id: "daily-report-pipeline".into(),
             input: Some("generate report".into()),
+            timeout_secs: None,
         };
         assert!(job.validate(0).is_ok());
     }
@@ -915,6 +934,7 @@ mod tests {
         job.action = CronAction::Workflow {
             workflow_id: String::new(),
             input: None,
+            timeout_secs: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("empty"), "{err}");
@@ -926,9 +946,56 @@ mod tests {
         job.action = CronAction::Workflow {
             workflow_id: "x".repeat(257),
             input: None,
+            timeout_secs: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("too long"), "{err}");
+    }
+
+    #[test]
+    fn workflow_action_timeout_valid() {
+        let mut job = valid_job();
+        job.action = CronAction::Workflow {
+            workflow_id: "my-workflow".into(),
+            input: None,
+            timeout_secs: Some(60),
+        };
+        assert!(job.validate(0).is_ok());
+    }
+
+    #[test]
+    fn workflow_action_timeout_max_boundary() {
+        let mut job = valid_job();
+        job.action = CronAction::Workflow {
+            workflow_id: "my-workflow".into(),
+            input: None,
+            timeout_secs: Some(3600),
+        };
+        assert!(job.validate(0).is_ok());
+    }
+
+    #[test]
+    fn workflow_action_timeout_zero_rejected() {
+        let mut job = valid_job();
+        job.action = CronAction::Workflow {
+            workflow_id: "my-workflow".into(),
+            input: None,
+            timeout_secs: Some(0),
+        };
+        let err = job.validate(0).unwrap_err();
+        assert!(err.contains("must be > 0"), "{err}");
+    }
+
+    #[test]
+    fn workflow_action_timeout_too_large() {
+        let mut job = valid_job();
+        job.action = CronAction::Workflow {
+            workflow_id: "my-workflow".into(),
+            input: None,
+            timeout_secs: Some(3601),
+        };
+        let err = job.validate(0).unwrap_err();
+        assert!(err.contains("too large"), "{err}");
     }
 
     #[test]
@@ -936,6 +1003,7 @@ mod tests {
         let action = CronAction::Workflow {
             workflow_id: "my-workflow".into(),
             input: Some("hello".into()),
+            timeout_secs: None,
         };
         let json = serde_json::to_string(&action).unwrap();
         assert!(json.contains("\"kind\":\"workflow\""));
@@ -948,12 +1016,19 @@ mod tests {
         let action = CronAction::Workflow {
             workflow_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             input: None,
+            timeout_secs: Some(120),
         };
         let json = serde_json::to_string(&action).unwrap();
         let back: CronAction = serde_json::from_str(&json).unwrap();
-        if let CronAction::Workflow { workflow_id, input } = back {
+        if let CronAction::Workflow {
+            workflow_id,
+            input,
+            timeout_secs,
+        } = back
+        {
             assert_eq!(workflow_id, "550e8400-e29b-41d4-a716-446655440000");
             assert!(input.is_none());
+            assert_eq!(timeout_secs, Some(120));
         } else {
             panic!("expected Workflow variant");
         }


### PR DESCRIPTION
## Summary

Adds a new `CronAction::Workflow` variant that allows cron jobs to trigger workflow executions directly by ID or name, without routing through an agent message.

- Adds `Workflow { workflow_id, input }` variant to `CronAction` enum in `librefang-types`
- Resolves workflows by UUID first, falling back to name lookup
- Handles workflow execution in the kernel cron tick loop with success/failure recording and delivery
- Adds manual trigger support via channel bridge (`/schedule run`)
- Includes validation and serde tests for the new variant

Closes #387

## Test plan

- [ ] Verify `CronAction::Workflow` serializes with `"kind":"workflow"` tag
- [ ] Verify validation rejects empty `workflow_id`
- [ ] Verify validation rejects `workflow_id` longer than 256 chars
- [ ] Verify cron tick loop resolves workflow by UUID and by name
- [ ] Verify channel bridge `/schedule run` works for workflow-type jobs