### PR TITLE
feat: replace native-tls with rustls for IMAP channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,8 +138,8 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 
 # Email (SMTP + IMAP)
 lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
-imap = "2"
-native-tls = { version = "0.2", features = ["vendored"] }
+imap = { version = "2", default-features = false }
+rustls-connector = "0.22"
 mailparse = "0.16"
 
 # Testing

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -71,7 +71,7 @@ channel-telegram = []
 channel-discord = []
 channel-slack = []
 channel-matrix = []
-channel-email = ["dep:lettre", "dep:imap", "dep:native-tls", "dep:mailparse"]
+channel-email = ["dep:lettre", "dep:imap", "dep:rustls-connector", "dep:mailparse"]
 channel-webhook = []
 channel-whatsapp = []
 channel-signal = []
@@ -143,7 +143,7 @@ roxmltree = { version = "0.21", optional = true }
 
 lettre = { workspace = true, optional = true }
 imap = { workspace = true, optional = true }
-native-tls = { workspace = true, optional = true }
+rustls-connector = { workspace = true, optional = true }
 mailparse = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -218,12 +218,15 @@ fn fetch_unseen_emails(
     password: &str,
     folders: &[String],
 ) -> Result<Vec<(String, String, String, String)>, String> {
-    let tls = native_tls::TlsConnector::builder()
-        .build()
+    let tcp = std::net::TcpStream::connect((host, port))
+        .map_err(|e| format!("TCP connect failed: {e}"))?;
+    let tls = rustls_connector::RustlsConnector::new_with_native_certs()
         .map_err(|e| format!("TLS connector error: {e}"))?;
+    let tls_stream = tls
+        .connect(host, tcp)
+        .map_err(|e| format!("TLS handshake failed: {e}"))?;
 
-    let client =
-        imap::connect((host, port), host, &tls).map_err(|e| format!("IMAP connect failed: {e}"))?;
+    let client = imap::Client::new(tls_stream);
 
     // Try LOGIN first; fall back to AUTHENTICATE PLAIN for servers like Lark
     // that reject LOGIN and only support AUTH=PLAIN (SASL).


### PR DESCRIPTION
## Summary
- Replace `native-tls` (OpenSSL) with `rustls-connector` for IMAP TLS connections in the email channel adapter
- Disable default `native-tls` feature on the `imap` crate (`default-features = false`)
- Remove `native-tls` workspace dependency entirely (no other crate uses it)

This eliminates the OpenSSL system library dependency for IMAP, matching the approach already used by `lettre` (SMTP) which uses `tokio1-rustls-tls`. Enables clean builds on Alpine Linux and musl-based distros without OpenSSL development headers.

Closes #385
Ref: #333

## Changes
- **Cargo.toml** (workspace): `imap` set to `default-features = false`, replaced `native-tls` with `rustls-connector = "0.22"`
- **crates/librefang-channels/Cargo.toml**: `channel-email` feature uses `rustls-connector` instead of `native-tls`
- **crates/librefang-channels/src/email.rs**: `fetch_unseen_emails()` now uses `RustlsConnector::new_with_native_certs()` + `TcpStream` + `imap::Client::new()` instead of `native_tls::TlsConnector` + `imap::connect()`