### PR TITLE
feat: add Vertex AI driver with OAuth2 authentication

### DIFF
--- a/crates/librefang-runtime/src/drivers/vertex_ai.rs
+++ b/crates/librefang-runtime/src/drivers/vertex_ai.rs
@@ -2,23 +2,26 @@
 //!
 //! Uses the same Gemini generateContent API format but authenticates via
 //! Google Cloud OAuth2 (service account JSON key or Application Default
-//! Credentials) instead of API keys.
-
-use async_trait::async_trait;
-use std::sync::Arc;
-use tokio::sync::RwLock;
+//! Credentials via gcloud CLI) instead of API keys.
+//!
+//! Endpoint format:
+//! ```text
+//! https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:generateContent
+//! ```
+//!
+//! Token acquisition supports two methods:
+//! 1. **Service account JSON** — reads the key file and exchanges a JWT for a token
+//! 2. **gcloud CLI** — runs `gcloud auth print-access-token` (fallback default)
+//!
+//! Tokens are cached with a ~50 minute TTL and auto-refreshed before expiry.
 
 use crate::llm_driver::{
     CompletionRequest, CompletionResponse, DriverConfig, LlmDriver, LlmError, StreamEvent,
 };
-
-/// Vertex AI LLM driver.
-pub struct VertexAiDriver {
-    project_id: String,
-    region: String,
-    token_manager: Arc<RwLock<TokenManager>>,
-    client: reqwest::Client,
-}
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::debug;
 
 // ─── OAuth2 token management ────────────────────────────────────────
 
@@ -296,7 +299,6 @@ fn asn1_read_content(data: &[u8]) -> Result<(&[u8], &[u8]), String> {
         }
         (len, 1 + num_bytes)
     };
-
     if data.len() < offset + len {
         return Err("ASN.1 content exceeds available data".into());
     }
@@ -543,7 +545,15 @@ impl BigUint {
     }
 }
 
-// ─── Driver construction ────────────────────────────────────────────
+// ─── Vertex AI driver ───────────────────────────────────────────────
+
+/// Vertex AI LLM driver.
+pub struct VertexAiDriver {
+    project_id: String,
+    region: String,
+    token_manager: Arc<RwLock<TokenManager>>,
+    client: reqwest::Client,
+}
 
 impl VertexAiDriver {
     /// Create a new Vertex AI driver.
@@ -737,12 +747,13 @@ impl LlmDriver for VertexAiDriver {
         );
 
         let mut last_error = None;
-        for attempt in 0..3 {
+        for attempt in 0..3u64 {
             if attempt > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(500 * (1 << attempt))).await;
             }
 
             let token = self.token_manager.write().await.get_token().await?;
+            debug!(url = %url, attempt, "Sending Vertex AI request");
 
             let resp = self
                 .client
@@ -817,12 +828,13 @@ impl LlmDriver for VertexAiDriver {
         );
 
         let mut last_error = None;
-        for attempt in 0..3 {
+        for attempt in 0..3u64 {
             if attempt > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(500 * (1 << attempt))).await;
             }
 
             let token = self.token_manager.write().await.get_token().await?;
+            debug!(url = %url, attempt, "Sending Vertex AI streaming request");
 
             let resp = self
                 .client
@@ -944,6 +956,22 @@ mod tests {
         };
         let region = resolve_region(&config);
         assert_eq!(region, "us-central1");
+    }
+
+    #[test]
+    fn test_resolve_region_explicit() {
+        let config = DriverConfig {
+            provider: "vertex-ai".to_string(),
+            api_key: None,
+            base_url: None,
+            vertex_ai: librefang_types::config::VertexAiConfig {
+                region: Some("europe-west4".to_string()),
+                ..Default::default()
+            },
+            skip_permissions: true,
+        };
+        let region = resolve_region(&config);
+        assert_eq!(region, "europe-west4");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a Google Cloud Vertex AI driver that reuses the Gemini wire format but authenticates via OAuth2 instead of API keys. Closes #367.

### Changes

- **`catalog/providers/vertex-ai.toml`** — 6 Gemini models available on Vertex AI (2.5-pro, 2.5-flash, 2.0-flash, 2.0-flash-lite, 1.5-pro, 1.5-flash)
- **`crates/librefang-runtime/src/drivers/vertex_ai.rs`** — New driver with:
  - OAuth2 token management with automatic refresh (~50 min TTL, 5 min margin)
  - Service account JSON key support (inline JSON, file path, or env vars)
  - `gcloud auth print-access-token` fallback for Application Default Credentials
  - Pure-Rust RSA-SHA256 JWT signing (no extra crate dependencies)
  - Project ID resolution from env vars, base_url, or service account JSON
  - Region resolution from env vars or base_url (defaults to us-central1)
  - Retry logic with exponential backoff for 429/503
- **`crates/librefang-runtime/src/drivers/gemini.rs`** — Extracted shared helpers (`build_request`, `parse_and_convert_response`, `stream_gemini_sse`) as `pub(crate)` functions
- **`crates/librefang-runtime/src/drivers/mod.rs`** — Registered `vertex-ai` provider with `VertexAI` API format variant
- **Model catalog registration** in both runtime and types crates

### Authentication Priority

1. Explicit `api_key` config (JSON string or file path)
2. `VERTEX_AI_SERVICE_ACCOUNT_JSON` env var
3. `GOOGLE_APPLICATION_CREDENTIALS` env var (file path)
4. `gcloud auth print-access-token` CLI fallback

### Configuration

```toml
[agents.my-agent]
provider = "vertex-ai"
model = "vertex-ai/gemini-2.5-pro"
# api_key = "/path/to/service-account.json"  # optional if using ADC
```

Environment variables: `VERTEX_AI_PROJECT_ID`, `VERTEX_AI_REGION`, `VERTEX_AI_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`