### PR TITLE
fix: remove default-features=false to enable channel features

### DIFF
--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 librefang-types = { path = "../librefang-types" }
 librefang-kernel = { path = "../librefang-kernel" }
-librefang-api = { path = "../librefang-api", default-features = false }
+librefang-api = { path = "../librefang-api" }
 librefang-migrate = { path = "../librefang-migrate" }
 librefang-skills = { path = "../librefang-skills" }
 librefang-extensions = { path = "../librefang-extensions" }


### PR DESCRIPTION
## Summary
- Remove `default-features = false` from `librefang-api` dependency in `crates/librefang-cli/Cargo.toml`
- This bug caused all channel features (telegram, discord, slack, etc.) to be disabled in the built binary

## Root Cause
When `librefang-api` is built with `default-features = false`, it doesn't compile `librefang-channels/default` which includes `channel-telegram`, `channel-discord`, `channel-slack`, etc.

## Test Plan
- [ ] Verify Telegram messages are received after rebuild
- [ ] Verify other channels (Discord, Slack) also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)