### PR TITLE
feat: add thread_id and attachments to CommsSendRequest

### DIFF
--- a/crates/librefang-types/src/comms.rs
+++ b/crates/librefang-types/src/comms.rs
@@ -92,6 +92,28 @@ pub struct CommsSendRequest {
     pub from_agent_id: String,
     pub to_agent_id: String,
     pub message: String,
+    /// Optional thread ID for threaded conversations (e.g., Telegram forum topics).
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    /// Optional file attachments to send with the message.
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+}
+
+/// A file attachment for channel messages.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Attachment {
+    /// File URL or upload ID.
+    pub url: String,
+    /// Optional filename.
+    #[serde(default)]
+    pub filename: Option<String>,
+    /// Optional MIME type.
+    #[serde(default)]
+    pub content_type: Option<String>,
+    /// Optional caption (for images).
+    #[serde(default)]
+    pub caption: Option<String>,
 }
 
 /// Request body for POST /api/comms/task.


### PR DESCRIPTION
## Summary

Add `thread_id: Option<String>` and `attachments: Vec<Attachment>` fields to `CommsSendRequest` for cross-channel threading and file attachment support.

## Changes

- Added `Attachment` struct with url, filename, content_type, and caption fields
- Extended `CommsSendRequest` with optional thread_id and attachments

## Notes

The `channel_send` tool already supports `thread_id` and `file_path` parameters. This change adds the same capabilities to the `CommsSendRequest` API type for consistency.

Ref: #389