### PR TITLE
fix: include tauri.conf.json in release script git add

### DIFF
--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.4.5-20260315",
+  "version": "0.4.6-20260315",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -139,7 +139,8 @@ git -C "$REPO_ROOT" add \
     CHANGELOG.md \
     sdk/javascript/package.json \
     sdk/python/setup.py \
-    packages/whatsapp-gateway/package.json
+    packages/whatsapp-gateway/package.json \
+    crates/librefang-desktop/tauri.conf.json
 git -C "$REPO_ROOT" commit -m "chore: bump version to $TAG"
 git -C "$REPO_ROOT" tag "$TAG"
 


### PR DESCRIPTION
## Summary
- The `git add` in `release.sh` was missing `crates/librefang-desktop/tauri.conf.json`, causing the desktop app version to always lag one release behind
- Added the missing file to `git add` and corrected the current `tauri.conf.json` version (`0.4.5` → `0.4.6`)

## Test plan
- [ ] Run `./scripts/release.sh` in dry-run and verify `git diff --cached` includes `tauri.conf.json`
- [ ] Verify `tauri.conf.json` version matches `Cargo.toml` workspace version