### PR TITLE
fix: strip date suffix from Tauri version for Windows MSI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,6 @@ jobs:
           fi
 
       - name: Strip date suffix from Tauri version (MSI requires pre-release id ≤ 65535)
-        if: runner.os == 'Windows'
         shell: bash
         run: |
           cd crates/librefang-desktop


### PR DESCRIPTION
## Summary
- Windows MSI bundler requires pre-release version identifiers to be ≤ 65535
- Version `0.4.6-20260315` has date suffix `20260315` which exceeds this limit, failing both Windows x86_64 and ARM64 desktop builds
- Adds a workflow step to strip the `-YYYYMMDD` suffix from `tauri.conf.json` before the Tauri build runs (e.g. `0.4.6-20260315` → `0.4.6`)

## Test plan
- [ ] Verify the `sed` command correctly strips the date suffix on Windows (Git Bash), macOS, and Linux runners
- [ ] Trigger a release build and confirm both Windows desktop jobs (x86_64 and ARM64) pass
- [ ] Verify non-Windows desktop builds (macOS, Linux) are unaffected
- [ ] Verify the updater `latest.json` still uses the correct tag name for release identification