### PR TITLE
release: v0.4.7-20260315

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-03-15
+
+### Added
+
+- Add backup and restore functionality for kernel state (#444) (@houko)
+- Add thread_id and attachments to CommsSendRequest (#469) (@TJUEZ)
+
+### Fixed
+
+- Resolve WhatsApp Web gateway E2EE, agent UUID, and auto-connect failures (#440) (@houko)
+- Wire thread_id and attachments in comms_send handler (#479) (@houko)
+- Include tauri.conf.json in release script git add (#482) (@houko)
+- Strip date suffix from Tauri version for Windows MSI builds (#485) (@houko)
+
+### Documentation
+
+- Translate getting-started.md to French (#442) (@houko)
+- Translate skill-development.md to Chinese (#447) (@houko)
+
+### Other
+
+- V0.4.6-20260315 (#478) (@houko)
+
 ## [0.4.6] - 2026-03-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "async-trait",
  "axum",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "aes",
  "async-trait",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "chrono",
  "hex",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9446,7 +9446,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.6-20260315"
+version = "0.4.7-20260315"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.4.6-20260315",
+  "version": "0.4.7-20260315",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.4.6-20260315",
+  "version": "0.4.7-20260315",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.4.6-20260315",
+  "version": "0.4.7-20260315",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.4.6-20260315",
+    version="0.4.7-20260315",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.4.7-20260315


### Added

- Add backup and restore functionality for kernel state (#444) (@houko)
- Add thread_id and attachments to CommsSendRequest (#469) (@TJUEZ)

### Fixed

- Resolve WhatsApp Web gateway E2EE, agent UUID, and auto-connect failures (#440) (@houko)
- Wire thread_id and attachments in comms_send handler (#479) (@houko)
- Include tauri.conf.json in release script git add (#482) (@houko)
- Strip date suffix from Tauri version for Windows MSI builds (#485) (@houko)

### Documentation

- Translate getting-started.md to French (#442) (@houko)
- Translate skill-development.md to Chinese (#447) (@houko)

### Other

- V0.4.6-20260315 (#478) (@houko)