### PR TITLE
fix: add git to devShell and preserve user PATH

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
 use flake 2> >(grep -v '/bin/bash:' >&2)
+
+# Preserve user's local bin paths for tools not in nixpkgs (e.g. claude)
+PATH_add "$HOME/.npm-global/bin"
+PATH_add "$HOME/.local/bin"

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,9 @@
             # Development tools
             just
             gh
+            git
+            nodejs
+            python3
           ];
 
           inputsFrom = [ librefang ];


### PR DESCRIPTION
## Summary
- Add `git` to nix devShell packages — it was missing, causing `git` to be unavailable after `direnv` activation
- Add `PATH_add` directives in `.envrc` to preserve user-local bin paths (`~/.npm-global/bin`, `~/.local/bin`) for tools not in nixpkgs (e.g. `claude`)

## Test plan
- [ ] `direnv allow && direnv reload` in project directory
- [ ] Verify `git --version` works
- [ ] Verify `claude --version` works (if installed in `~/.npm-global/bin`)
- [ ] Verify `cargo build` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)