### PR TITLE
release: v0.5.0-20260316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-16
+
+### Added
+
+- Add GET /api/commands/:name endpoint (#369) (@houko)
+- Add recipe-assistant agent template (#393) (@houko)
+- Add Nix flake support (#412) (@houko)
+- Add Qwen Code CLI as LLM provider (#417) (@houko)
+- Add LLM provider prompt caching support (#381) (#424) (@houko)
+- Add decision trace layer for tool selection reasoning (#426) (@houko)
+- Add stable_prefix_mode for cache-friendly prompts (#427) (@houko)
+- Replace native-tls with rustls for IMAP channel (#432) (@houko)
+- Add API endpoint versioning support (#450) (@houko)
+
+### Fixed
+
+- Use default_model from config in Web UI agent creation (#402) (@houko)
+- Apply log_level from config.toml to tracing subscriber (#404) (@houko)
+- Correctly read nested tokens.id_token for Codex CLI OAuth (#406) (@houko)
+- Use deterministic UUIDs for hand agents to persist across restarts (#407) (@houko)
+- Update nix flake for nixpkgs darwin SDK migration (#491) (@houko)
+- Update nix flake for darwin SDK and crane warnings (#493) (@houko)
+- Add git to devShell and preserve user PATH (#494) (@houko)
+
+### Documentation
+
+- Improve CLI --help descriptions for all subcommands (#453) (@houko)
+
+### Other
+
+- V0.4.7-20260315 (#486) (@houko)
+
 ## [0.4.7] - 2026-03-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2113,21 +2113,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2140,12 +2131,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2248,6 +2233,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3102,7 +3098,6 @@ dependencies = [
  "chrono",
  "imap-proto",
  "lazy_static",
- "native-tls",
  "nom 5.1.3",
  "regex",
 ]
@@ -3526,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "async-trait",
  "axum",
@@ -3566,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "aes",
  "async-trait",
@@ -3583,11 +3578,11 @@ dependencies = [
  "lettre",
  "librefang-types",
  "mailparse",
- "native-tls",
  "regex-lite",
  "reqwest",
  "roxmltree",
  "rustls",
+ "rustls-connector",
  "serde",
  "serde_json",
  "sha1",
@@ -3604,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3636,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3662,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3690,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3707,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3764,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3783,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3820,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "chrono",
  "hex",
@@ -3843,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3862,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4164,23 +4159,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -4533,58 +4511,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -5892,6 +5822,20 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-connector"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f510f2d983baf4a45354ae8ca5abf5a6cdb3c47244ea22f705499d6d9c09a912"
+dependencies = [
+ "futures-rustls",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -9453,7 +9397,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.7-20260315"
+version = "0.5.0-20260316"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.4.7-20260315",
+  "version": "0.5.0-20260316",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.4.7-20260315",
+  "version": "0.5.0-20260316",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.4.7-20260315",
+  "version": "0.5.0-20260316",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.4.7-20260315",
+    version="0.5.0-20260316",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.5.0-20260316


### Added

- Add GET /api/commands/:name endpoint (#369) (@houko)
- Add recipe-assistant agent template (#393) (@houko)
- Add Nix flake support (#412) (@houko)
- Add Qwen Code CLI as LLM provider (#417) (@houko)
- Add LLM provider prompt caching support (#381) (#424) (@houko)
- Add decision trace layer for tool selection reasoning (#426) (@houko)
- Add stable_prefix_mode for cache-friendly prompts (#427) (@houko)
- Replace native-tls with rustls for IMAP channel (#432) (@houko)
- Add API endpoint versioning support (#450) (@houko)

### Fixed

- Use default_model from config in Web UI agent creation (#402) (@houko)
- Apply log_level from config.toml to tracing subscriber (#404) (@houko)
- Correctly read nested tokens.id_token for Codex CLI OAuth (#406) (@houko)
- Use deterministic UUIDs for hand agents to persist across restarts (#407) (@houko)
- Update nix flake for nixpkgs darwin SDK migration (#491) (@houko)
- Update nix flake for darwin SDK and crane warnings (#493) (@houko)
- Add git to devShell and preserve user PATH (#494) (@houko)

### Documentation

- Improve CLI --help descriptions for all subcommands (#453) (@houko)

### Other

- V0.4.7-20260315 (#486) (@houko)