### PR TITLE
fix: inject vault secrets into process env at startup

### DIFF
--- a/crates/librefang-cli/src/dotenv.rs
+++ b/crates/librefang-cli/src/dotenv.rs
@@ -26,9 +26,39 @@ pub fn env_file_path() -> Option<PathBuf> {
 /// (but both yield to system env vars).
 /// Silently does nothing if the files don't exist.
 pub fn load_dotenv() {
+    // Vault takes highest priority (after system env vars).
+    load_vault();
     load_env_file(env_file_path());
     // Also load secrets.env (written by dashboard "Set API Key" button)
     load_env_file(secrets_env_path());
+}
+
+/// Try to unlock the credential vault and inject secrets into process env.
+///
+/// Vault secrets have higher priority than `.env` but lower than system env vars.
+/// Silently does nothing if vault is not initialized or cannot be unlocked.
+fn load_vault() {
+    let vault_path = match dotenv_librefang_home() {
+        Some(h) => h.join("vault.enc"),
+        None => return,
+    };
+
+    if !vault_path.exists() {
+        return;
+    }
+
+    let mut vault = librefang_extensions::vault::CredentialVault::new(vault_path);
+    if vault.unlock().is_err() {
+        return;
+    }
+
+    for key in vault.list_keys() {
+        if std::env::var(key).is_err() {
+            if let Some(val) = vault.get(key) {
+                std::env::set_var(key, val.as_str());
+            }
+        }
+    }
 }
 
 /// Return the path to `~/.librefang/secrets.env`.


### PR DESCRIPTION
## Summary
- The credential vault (`vault.enc`) was never loaded during CLI/daemon startup
- All API key resolution used `std::env::var()` directly, skipping vault entirely
- `librefang vault set` stored secrets correctly, but nothing ever read them back

## Fix
Add `load_vault()` to `dotenv::load_dotenv()` — unlocks the vault and injects secrets into process env vars before `.env` is loaded. This is the same pattern `.env` loading already uses (`std::env::set_var`).

**Resolution order**: system env > vault > `.env` > `secrets.env`

## Verified
- `librefang config test-key minimax` — was "not set", now **OK**
- `librefang config test-key deepseek` — was "not set", now **OK**  
- `librefang doctor` — providers correctly detected from vault
- All existing dotenv + vault tests pass

## Test plan
- [ ] `librefang vault init` + `librefang vault set GROQ_API_KEY` (without .env entry)
- [ ] `librefang config test-key groq` should resolve from vault
- [ ] Remove key from .env, verify daemon still boots with vault-only keys
- [ ] Verify system env vars still take priority over vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)