### PR TITLE
chore: auto-merge release PRs after CI passes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -212,6 +212,9 @@ $RELEASE_BODY"
         --head "$RELEASE_BRANCH")
 
     echo "→ $PR_URL"
+
+    # Auto-merge the release PR (squash) once CI passes
+    gh pr merge "$PR_URL" --auto --squash --repo librefang/librefang
 else
     echo ""
     echo "gh CLI not found. Create a PR manually for branch '$RELEASE_BRANCH'."


### PR DESCRIPTION
## Summary
- Add `gh pr merge --auto --squash` to `scripts/release.sh`
- Release version-bump PRs will auto-merge once CI passes
- Only affects PRs created by the release script — other PRs are **not** affected

## Prerequisite
Enable "Allow auto-merge" in repo Settings → General → Pull Requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)