### PR TITLE
feat: add configurable message queue with concurrency settings

### DIFF
--- a/crates/librefang-api/src/routes.rs
+++ b/crates/librefang-api/src/routes.rs
@@ -12854,6 +12854,31 @@ fn hostname_string() -> String {
         .unwrap_or_else(|_| "unknown".to_string())
 }
 
+/// GET /api/queue/status — Command queue status and occupancy.
+pub async fn queue_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let occupancy = state.kernel.command_queue.occupancy();
+    let lanes: Vec<serde_json::Value> = occupancy
+        .iter()
+        .map(|o| {
+            serde_json::json!({
+                "lane": o.lane.to_string(),
+                "active": o.active,
+                "capacity": o.capacity,
+            })
+        })
+        .collect();
+
+    let queue_cfg = &state.kernel.config.queue;
+    Json(serde_json::json!({
+        "lanes": lanes,
+        "config": {
+            "max_depth_per_agent": queue_cfg.max_depth_per_agent,
+            "max_depth_global": queue_cfg.max_depth_global,
+            "task_ttl_secs": queue_cfg.task_ttl_secs,
+        },
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -465,6 +465,8 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
             "/cron/jobs/{id}/status",
             axum::routing::get(routes::cron_job_status),
         )
+        // Queue status endpoint
+        .route("/queue/status", axum::routing::get(routes::queue_status))
         // Backup / Restore endpoints
         .route("/backup", axum::routing::post(routes::create_backup))
         .route("/backups", axum::routing::get(routes::list_backups))

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -164,6 +164,8 @@ pub struct LibreFangKernel {
     /// Per-agent decision traces from the most recent message exchange.
     /// Stored for retrieval via `/api/agents/{id}/traces`.
     pub decision_traces: dashmap::DashMap<AgentId, Vec<librefang_types::tool::DecisionTrace>>,
+    /// Command queue with lane-based concurrency control.
+    pub command_queue: librefang_runtime::command_lane::CommandQueue,
     /// Weak self-reference for trigger dispatch (set after Arc wrapping).
     self_handle: OnceLock<Weak<LibreFangKernel>>,
 }
@@ -965,6 +967,13 @@ impl LibreFangKernel {
         let initial_broadcast = config.broadcast.clone();
         let auto_reply_engine = crate::auto_reply::AutoReplyEngine::new(config.auto_reply.clone());
 
+        // Initialize command queue with configured concurrency limits
+        let command_queue = librefang_runtime::command_lane::CommandQueue::with_capacities(
+            config.queue.concurrency.main_lane as u32,
+            config.queue.concurrency.cron_lane as u32,
+            config.queue.concurrency.subagent_lane as u32,
+        );
+
         let kernel = Self {
             config,
             registry: AgentRegistry::new(),
@@ -1014,6 +1023,7 @@ impl LibreFangKernel {
             default_model_override: std::sync::RwLock::new(None),
             agent_msg_locks: dashmap::DashMap::new(),
             decision_traces: dashmap::DashMap::new(),
+            command_queue,
             self_handle: OnceLock::new(),
         };
 

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1069,6 +1069,72 @@ pub struct SidecarChannelConfig {
     pub channel_type: Option<String>,
 }
 
+/// Message queue configuration.
+///
+/// Controls queue depth limits and task TTL for the agent command queue.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [queue]
+/// max_depth_per_agent = 100
+/// max_depth_global = 1000
+/// task_ttl_secs = 3600
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct QueueConfig {
+    /// Max queue depth per agent (0 = unlimited).
+    pub max_depth_per_agent: u32,
+    /// Max queue depth globally (0 = unlimited).
+    pub max_depth_global: u32,
+    /// Task TTL in seconds (unprocessed tasks expire, 0 = unlimited).
+    pub task_ttl_secs: u64,
+    /// Per-lane concurrency limits.
+    #[serde(default)]
+    pub concurrency: QueueConcurrencyConfig,
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            max_depth_per_agent: 0,
+            max_depth_global: 0,
+            task_ttl_secs: 3600,
+            concurrency: QueueConcurrencyConfig::default(),
+        }
+    }
+}
+
+/// Per-lane concurrency limits for the command queue.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [queue.concurrency]
+/// main_lane = 1
+/// cron_lane = 2
+/// subagent_lane = 3
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct QueueConcurrencyConfig {
+    /// Main lane concurrent limit (user messages).
+    pub main_lane: usize,
+    /// Cron lane concurrent limit (scheduled jobs).
+    pub cron_lane: usize,
+    /// Subagent lane concurrent limit (child agents).
+    pub subagent_lane: usize,
+}
+
+impl Default for QueueConcurrencyConfig {
+    fn default() -> Self {
+        Self {
+            main_lane: 1,
+            cron_lane: 2,
+            subagent_lane: 3,
+        }
+    }
+}
+
 /// Top-level kernel configuration.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1220,6 +1286,9 @@ pub struct KernelConfig {
     /// - **OpenAI**: automatic prefix caching (response cache stats are parsed).
     #[serde(default = "default_prompt_caching")]
     pub prompt_caching: bool,
+    /// Message queue configuration (depth limits, TTL, concurrency).
+    #[serde(default)]
+    pub queue: QueueConfig,
 }
 
 /// OAuth client ID overrides for PKCE flows.
@@ -1474,6 +1543,7 @@ impl Default for KernelConfig {
             oauth: OAuthConfig::default(),
             sidecar_channels: Vec::new(),
             prompt_caching: default_prompt_caching(),
+            queue: QueueConfig::default(),
         }
     }
 }
@@ -1592,6 +1662,7 @@ impl std::fmt::Debug for KernelConfig {
                 "provider_api_keys",
                 &format!("{} mapping(s)", self.provider_api_keys.len()),
             )
+            .field("queue", &self.queue)
             .finish()
     }
 }
@@ -3775,6 +3846,17 @@ impl KernelConfig {
             self.web.fetch.timeout_secs = 30;
         } else if self.web.fetch.timeout_secs > 120 {
             self.web.fetch.timeout_secs = 120;
+        }
+
+        // Queue concurrency: min 1 per lane (0 would deadlock)
+        if self.queue.concurrency.main_lane == 0 {
+            self.queue.concurrency.main_lane = 1;
+        }
+        if self.queue.concurrency.cron_lane == 0 {
+            self.queue.concurrency.cron_lane = 1;
+        }
+        if self.queue.concurrency.subagent_lane == 0 {
+            self.queue.concurrency.subagent_lane = 1;
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #515 (Phase 1)

- Add `[queue]` and `[queue.concurrency]` config sections
- Make `CommandLane` concurrency limits configurable (previously hardcoded 1/2/3)
- Add clamping to prevent zero-concurrency deadlocks
- Add `GET /api/queue/status` endpoint showing per-lane occupancy and config

## Config Example

```toml
[queue]
max_depth_per_agent = 100
max_depth_global = 1000
task_ttl_secs = 3600

[queue.concurrency]
main_lane = 1
cron_lane = 2
subagent_lane = 3
```

All values have safe defaults, fully backward-compatible.

## Scope

This is Phase 1 of #515. Future phases:
- Phase 2: SQLite-backed persistent queue + task recovery on restart
- Phase 3: Retry with backoff, dead letter queue, ack semantics

## Test plan

- [x] `cargo build --workspace --lib` compiles
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo fmt --all` applied
- [ ] Live test: start daemon with custom `[queue.concurrency]` values, verify lanes respect config
- [ ] Live test: `curl /api/queue/status` returns lane occupancy and config