### PR TITLE
release: v0.5.2-20260316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-03-16
+
+### Fixed
+
+- Auto-update contributors list from GitHub API (#512) (@houko)
+- Use local SVG for contributors with circular avatars (#513) (@houko)
+- WeCom secret env pattern + add pre-commit fmt hook (#518) (@houko)
+
+### Maintenance
+
+- Auto-merge release PRs after CI passes (#511) (@houko)
+
+### Other
+
+- V0.5.1-20260316 (#510) (@houko)
+
 ## [0.5.1] - 2026-03-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "async-trait",
  "axum",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "aes",
  "async-trait",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "chrono",
  "hex",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9397,7 +9397,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1-20260316"
+version = "0.5.2-20260316"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.5.1-20260316",
+  "version": "0.5.2-20260316",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.5.1-20260316",
+  "version": "0.5.2-20260316",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.5.1-20260316",
+  "version": "0.5.2-20260316",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.5.1-20260316",
+    version="0.5.2-20260316",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.5.2-20260316


### Fixed

- Auto-update contributors list from GitHub API (#512) (@houko)
- Use local SVG for contributors with circular avatars (#513) (@houko)
- WeCom secret env pattern + add pre-commit fmt hook (#518) (@houko)

### Maintenance

- Auto-merge release PRs after CI passes (#511) (@houko)

### Other

- V0.5.1-20260316 (#510) (@houko)