### PR TITLE
fix: add logging for X-API-Version header insertion failures

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -105,6 +105,8 @@ pub async fn api_version_headers(request: Request<Body>, next: Next) -> Response
 
     if let Ok(val) = version.parse() {
         response.headers_mut().insert("x-api-version", val);
+    } else {
+        tracing::warn!("Failed to set X-API-Version header: {:?}", version);
     }
 
     response


### PR DESCRIPTION
## Summary
- Add warn-level logging when X-API-Version header fails to parse
- Makes debugging version-related issues easier

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)