### PR TITLE
release: v0.5.3-20260317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-03-17
+
+### Added
+
+- Add bulk operations API for agents (#397) (@houko)
+- Add Z.AI and Kimi 2 model support (#409) (@houko)
+- Add static Linux binary builds with musl target (#438) (@houko)
+- Add multi-provider OAuth/OIDC authentication support (#454) (@houko)
+- Add session retention policy with automatic cleanup (#516) (@houko)
+- Add configurable message queue with concurrency settings (#517) (@houko)
+- Add multi-language SDKs (JavaScript, Python, Go, Rust) (#531) (@houko)
+- Auto-generate OpenAPI spec with utoipa (#534) (@houko)
+
+### Fixed
+
+- Complete vertex ai config wiring (#498) (@houko)
+- Trim message history at safe turn boundaries (#521) (@houko)
+- Add logging for X-API-Version header insertion failures (#524) (@houko)
+
+### Changed
+
+- Split monolithic routes.rs into domain-specific modules (#452) (@houko)
+
+### Maintenance
+
+- Move binary size check from PR to release-only (#528) (@houko)
+- Split release workflow into independent parallel pipelines (#533) (@houko)
+
+### Other
+
+- V0.5.2-20260316 (#519) (@houko)
+
 ## [0.5.2] - 2026-03-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "async-trait",
  "axum",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "aes",
  "async-trait",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "chrono",
  "hex",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9481,7 +9481,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2-20260316"
+version = "0.5.3-20260317"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.5.2-20260316",
+  "version": "0.5.3-20260317",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.5.2-20260316",
+  "version": "0.5.3-20260317",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.5.2-20260316",
+  "version": "0.5.3-20260317",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.5.2-20260316",
+    version="0.5.3-20260317",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.5.3-20260317


### Added

- Add bulk operations API for agents (#397) (@houko)
- Add Z.AI and Kimi 2 model support (#409) (@houko)
- Add static Linux binary builds with musl target (#438) (@houko)
- Add multi-provider OAuth/OIDC authentication support (#454) (@houko)
- Add session retention policy with automatic cleanup (#516) (@houko)
- Add configurable message queue with concurrency settings (#517) (@houko)
- Add multi-language SDKs (JavaScript, Python, Go, Rust) (#531) (@houko)
- Auto-generate OpenAPI spec with utoipa (#534) (@houko)

### Fixed

- Complete vertex ai config wiring (#498) (@houko)
- Trim message history at safe turn boundaries (#521) (@houko)
- Add logging for X-API-Version header insertion failures (#524) (@houko)

### Changed

- Split monolithic routes.rs into domain-specific modules (#452) (@houko)

### Maintenance

- Move binary size check from PR to release-only (#528) (@houko)
- Split release workflow into independent parallel pipelines (#533) (@houko)

### Other

- V0.5.2-20260316 (#519) (@houko)