### PR TITLE
fix(ci): make release creation idempotent

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -64,6 +64,13 @@ jobs:
             echo '```'
           } > /tmp/release-body.md
 
-          gh release create "$TAG" \
-            --title "LibreFang $TAG" \
-            --notes-file /tmp/release-body.md
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists, updating..."
+            gh release edit "$TAG" \
+              --title "LibreFang $TAG" \
+              --notes-file /tmp/release-body.md
+          else
+            gh release create "$TAG" \
+              --title "LibreFang $TAG" \
+              --notes-file /tmp/release-body.md
+          fi


### PR DESCRIPTION
## Summary
- `gh release create` in `release-create.yml` fails with HTTP 422 when the release already exists (e.g. workflow re-runs or race with parallel pipelines)
- Added `gh release view` check before creation: if the release exists, update it with `gh release edit`; otherwise create normally

## Test plan
- [ ] Push a new tag to trigger first-time release creation — verify it succeeds
- [ ] Re-run the same tag's workflow — verify no 422 error