### PR TITLE
fix: re-fetch PREV_TAG after deleting old tag in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -131,6 +131,9 @@ if git -C "$REPO_ROOT" rev-parse "$TAG" &>/dev/null; then
     if command -v gh &>/dev/null; then
         gh release delete "$TAG" --repo librefang/librefang --yes 2>/dev/null || true
     fi
+
+    # Re-fetch PREV_TAG since we just deleted the old one
+    PREV_TAG=$(git -C "$REPO_ROOT" tag --sort=-creatordate | grep -E '^v[0-9]' | grep -vE '(alpha|beta|rc)' | head -1 || true)
 fi
 
 # --- Generate changelog ---


### PR DESCRIPTION
## Summary
- When re-releasing the same version, `release.sh` deletes the old tag but `PREV_TAG` still referenced it
- `generate-changelog.sh` then fails with `fatal: ambiguous argument 'v0.5.4-20260317..HEAD': unknown revision`
- Fix: re-fetch `PREV_TAG` after the tag deletion so it points to the next most recent tag

## Test plan
- [ ] Run `release.sh` and choose option 4 (re-release current version)
- [ ] Verify changelog generation succeeds