### PR TITLE
release: v0.5.4-20260317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add logging for X-API-Version header insertion failures (#524) (@houko)
 - Fix SDK publishing (PyPI, npm, crates.io, GHCR) (#537) (@houko)
 - Make release creation idempotent (#539) (@houko)
+- Force-push tag in release.sh to handle re-releases (#540) (@houko)
+- Use file instead of ldd to verify static linking (#541) (@houko)
+- Allow re-release to overwrite existing assets (#542) (@houko)
+- Allow desktop re-release to overwrite existing assets (#543) (@houko)
+- Make SDK publishing idempotent for re-releases (#544) (@houko)
+- Re-fetch PREV_TAG after deleting old tag in release.sh (#545) (@houko)
 
 ### Changed
 


### PR DESCRIPTION
## Release v0.5.4-20260317


### Added

- Add bulk operations API for agents (#397) (@houko)
- Add Z.AI and Kimi 2 model support (#409) (@houko)
- Add static Linux binary builds with musl target (#438) (@houko)
- Add multi-provider OAuth/OIDC authentication support (#454) (@houko)
- Add session retention policy with automatic cleanup (#516) (@houko)
- Add configurable message queue with concurrency settings (#517) (@houko)
- Add multi-language SDKs (JavaScript, Python, Go, Rust) (#531) (@houko)
- Auto-generate OpenAPI spec with utoipa (#534) (@houko)

### Fixed

- Complete vertex ai config wiring (#498) (@houko)
- Trim message history at safe turn boundaries (#521) (@houko)
- Add logging for X-API-Version header insertion failures (#524) (@houko)
- Fix SDK publishing (PyPI, npm, crates.io, GHCR) (#537) (@houko)
- Make release creation idempotent (#539) (@houko)
- Force-push tag in release.sh to handle re-releases (#540) (@houko)
- Use file instead of ldd to verify static linking (#541) (@houko)
- Allow re-release to overwrite existing assets (#542) (@houko)
- Allow desktop re-release to overwrite existing assets (#543) (@houko)
- Make SDK publishing idempotent for re-releases (#544) (@houko)
- Re-fetch PREV_TAG after deleting old tag in release.sh (#545) (@houko)

### Changed

- Split monolithic routes.rs into domain-specific modules (#452) (@houko)

### Maintenance

- Move binary size check from PR to release-only (#528) (@houko)
- Split release workflow into independent parallel pipelines (#533) (@houko)

### Other

- V0.5.2-20260316 (#519) (@houko)
- V0.5.3-20260317 (#536) (@houko)
- V0.5.4-20260317 (#538) (@houko)