### PR TITLE
ci: auto-cancel old release runs when tag is re-pushed

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-create-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_release:
     name: Create Release

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-desktop-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: release-docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Wait for the GitHub Release to be created ────────────────────────────
   wait_for_release:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: release-sdk-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Wait for the GitHub Release to be created ────────────────────────────
   wait_for_release:

--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-shell-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Added `concurrency` with `cancel-in-progress: true` to all 5 release workflows
- When a tag is force-pushed, the old run is automatically cancelled instead of failing with `"ref does not point to expected commit"`
- Each workflow uses its own concurrency group scoped to the tag ref

## Test plan
- [ ] Force-push a tag — verify old runs are cancelled (not failed)
- [ ] New runs complete successfully