### PR TITLE
fix: raise main_lane default concurrency from 1 to 3

### DIFF
--- a/crates/librefang-runtime/src/command_lane.rs
+++ b/crates/librefang-runtime/src/command_lane.rs
@@ -2,7 +2,7 @@
 //!
 //! Routes different types of work through separate lanes with independent
 //! concurrency limits to prevent starvation:
-//! - Main: user messages (serialized, 1 at a time)
+//! - Main: user messages (3 concurrent by default)
 //! - Cron: scheduled jobs (2 concurrent)
 //! - Subagent: spawned child agents (3 concurrent)
 
@@ -12,7 +12,7 @@ use tokio::sync::Semaphore;
 /// Command lane type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Lane {
-    /// User-facing message processing (1 concurrent).
+    /// User-facing message processing (3 concurrent by default).
     Main,
     /// Cron/scheduled job execution (2 concurrent).
     Cron,
@@ -56,10 +56,10 @@ impl CommandQueue {
     /// Create a new command queue with default capacities.
     pub fn new() -> Self {
         Self {
-            main_sem: Arc::new(Semaphore::new(1)),
+            main_sem: Arc::new(Semaphore::new(3)),
             cron_sem: Arc::new(Semaphore::new(2)),
             subagent_sem: Arc::new(Semaphore::new(3)),
-            main_capacity: 1,
+            main_capacity: 3,
             cron_capacity: 2,
             subagent_capacity: 3,
         }
@@ -147,11 +147,11 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     #[tokio::test]
-    async fn test_main_lane_serialization() {
+    async fn test_main_lane_submit() {
         let queue = CommandQueue::new();
         let counter = Arc::new(AtomicU32::new(0));
 
-        // Main lane has capacity 1 — tasks should serialize
+        // Main lane accepts and executes tasks
         let c1 = counter.clone();
         let result = queue
             .submit(Lane::Main, async move {
@@ -194,7 +194,7 @@ mod tests {
         let occ = queue.occupancy();
         assert_eq!(occ.len(), 3);
         assert_eq!(occ[0].active, 0);
-        assert_eq!(occ[0].capacity, 1);
+        assert_eq!(occ[0].capacity, 3);
         assert_eq!(occ[1].capacity, 2);
         assert_eq!(occ[2].capacity, 3);
     }

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1141,7 +1141,7 @@ impl Default for QueueConfig {
 /// Configure in config.toml:
 /// ```toml
 /// [queue.concurrency]
-/// main_lane = 1
+/// main_lane = 3
 /// cron_lane = 2
 /// subagent_lane = 3
 /// ```
@@ -1159,7 +1159,7 @@ pub struct QueueConcurrencyConfig {
 impl Default for QueueConcurrencyConfig {
     fn default() -> Self {
         Self {
-            main_lane: 1,
+            main_lane: 3,
             cron_lane: 2,
             subagent_lane: 3,
         }


### PR DESCRIPTION
## Summary
- Raise `main_lane` default from 1 to 3 so multi-channel setups don't serialize all user messages through a single slot
- Per-agent locks in the kernel already ensure session integrity — this only gates system-level throughput

## Test plan
- [ ] Verify existing tests pass (test_occupancy assertion updated from 1→3)
- [ ] Multi-channel setup processes messages concurrently

Closes #523