### PR TITLE
feat: enrich Ollama model discovery with metadata

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -324,6 +324,9 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
                     catalog.merge_discovered_models(&p.id, &probe.discovered_models);
                 }
             }
+            if !probe.discovered_model_info.is_empty() {
+                entry["discovered_model_info"] = serde_json::json!(probe.discovered_model_info);
+            }
             if let Some(err) = &probe.error {
                 entry["error"] = serde_json::json!(err);
             }
@@ -958,6 +961,9 @@ pub async fn set_provider_url(
     });
     if !probe.discovered_models.is_empty() {
         resp["discovered_models"] = serde_json::json!(probe.discovered_models);
+    }
+    if !probe.discovered_model_info.is_empty() {
+        resp["discovered_model_info"] = serde_json::json!(probe.discovered_model_info);
     }
 
     (StatusCode::OK, Json(resp))

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -10,6 +10,25 @@
 use dashmap::DashMap;
 use std::time::{Duration, Instant};
 
+/// Enriched metadata for a discovered model (Ollama-specific fields are optional).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DiscoveredModelInfo {
+    /// Model name/ID (e.g., "llama3.2:latest").
+    pub name: String,
+    /// Parameter count string from Ollama (e.g., "8.0B").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameter_size: Option<String>,
+    /// Quantization level (e.g., "Q4_K_M", "Q8_0").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantization_level: Option<String>,
+    /// Model family (e.g., "llama", "gemma").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    /// On-disk size in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+}
+
 /// Result of probing a provider endpoint.
 #[derive(Debug, Clone, Default)]
 pub struct ProbeResult {
@@ -19,6 +38,8 @@ pub struct ProbeResult {
     pub latency_ms: u64,
     /// Model IDs discovered from the provider's listing endpoint.
     pub discovered_models: Vec<String>,
+    /// Enriched model metadata (populated for Ollama, empty for others).
+    pub discovered_model_info: Vec<DiscoveredModelInfo>,
     /// Error message if the probe failed.
     pub error: Option<String>,
 }
@@ -162,37 +183,64 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
 
     let latency_ms = start.elapsed().as_millis() as u64;
 
-    // Parse model names
-    let models = if is_ollama {
-        // Ollama: { "models": [ { "name": "llama3.2:latest", ... }, ... ] }
-        body.get("models")
+    // Parse model names and metadata
+    let (models, model_info) = if is_ollama {
+        // Ollama: { "models": [ { "name": "llama3.2:latest", "size": 12345, "details": { ... } }, ... ] }
+        let arr = body
+            .get("models")
             .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|m| {
-                        m.get("name")
-                            .and_then(|n| n.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .collect()
+            .cloned()
+            .unwrap_or_default();
+
+        let names: Vec<String> = arr
+            .iter()
+            .filter_map(|m| m.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+            .collect();
+
+        let info: Vec<DiscoveredModelInfo> = arr
+            .iter()
+            .filter_map(|m| {
+                let name = m.get("name").and_then(|n| n.as_str())?.to_string();
+                let details = m.get("details");
+                Some(DiscoveredModelInfo {
+                    name,
+                    parameter_size: details
+                        .and_then(|d| d.get("parameter_size"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    quantization_level: details
+                        .and_then(|d| d.get("quantization_level"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    family: details
+                        .and_then(|d| d.get("family"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    size: m.get("size").and_then(|v| v.as_u64()),
+                })
             })
-            .unwrap_or_default()
+            .collect();
+
+        (names, info)
     } else {
         // OpenAI-compatible: { "data": [ { "id": "model-name", ... }, ... ] }
-        body.get("data")
+        let names = body
+            .get("data")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
                     .filter_map(|m| m.get("id").and_then(|n| n.as_str()).map(|s| s.to_string()))
                     .collect()
             })
-            .unwrap_or_default()
+            .unwrap_or_default();
+        (names, vec![])
     };
 
     ProbeResult {
         reachable: true,
         latency_ms,
         discovered_models: models,
+        discovered_model_info: model_info,
         error: None,
     }
 }
@@ -365,5 +413,37 @@ mod tests {
         let cache = ProbeCache::default();
         assert!(cache.get("anything").is_none());
         assert_eq!(cache.ttl, Duration::from_secs(PROBE_CACHE_TTL_SECS));
+    }
+
+    #[test]
+    fn test_discovered_model_info_serialization() {
+        let info = DiscoveredModelInfo {
+            name: "llama3.2:latest".to_string(),
+            parameter_size: Some("3.2B".to_string()),
+            quantization_level: Some("Q4_K_M".to_string()),
+            family: Some("llama".to_string()),
+            size: Some(1_928_000_000),
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["name"], "llama3.2:latest");
+        assert_eq!(json["parameter_size"], "3.2B");
+        assert_eq!(json["quantization_level"], "Q4_K_M");
+        assert_eq!(json["family"], "llama");
+        assert_eq!(json["size"], 1_928_000_000_u64);
+    }
+
+    #[test]
+    fn test_discovered_model_info_skips_none_fields() {
+        let info = DiscoveredModelInfo {
+            name: "gpt-4".to_string(),
+            parameter_size: None,
+            quantization_level: None,
+            family: None,
+            size: None,
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["name"], "gpt-4");
+        assert!(json.get("parameter_size").is_none());
+        assert!(json.get("quantization_level").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Add `DiscoveredModelInfo` struct with `parameter_size`, `quantization_level`, `family`, `size`
- Parse these from Ollama `/api/tags` response `details` field
- Expose as `discovered_model_info` array in `/api/providers` response (backward compatible — existing `discovered_models` unchanged)
- Includes 2 unit tests for serialization (with/without optional fields)

## Test plan
- [ ] Unit tests for `DiscoveredModelInfo` serialization
- [ ] With Ollama running: verify `/api/providers` returns enriched metadata

Closes #388