### PR TITLE
feat: add GET /api/peers/{id} endpoint

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -248,6 +248,7 @@ use crate::types;
 
         // ── Network / Peers / Comms ──
         routes::list_peers,
+        routes::get_peer,
         routes::network_status,
         routes::comms_topology,
         routes::comms_events,

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -53,6 +53,54 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse
     }
 }
 
+/// GET /api/peers/{id} — Get a single peer by node ID.
+#[utoipa::path(
+    get,
+    path = "/api/peers/{id}",
+    tag = "network",
+    params(("id" = String, Path, description = "Peer node ID")),
+    responses(
+        (status = 200, description = "Peer details", body = serde_json::Value),
+        (status = 404, description = "Peer not found")
+    )
+)]
+pub async fn get_peer(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let registry = match state.peer_registry {
+        Some(ref r) => r,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Peer networking is not enabled"})),
+            );
+        }
+    };
+
+    match registry.get_peer(&id) {
+        Some(p) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "node_id": p.node_id,
+                "node_name": p.node_name,
+                "address": p.address.to_string(),
+                "state": format!("{:?}", p.state),
+                "agents": p.agents.iter().map(|a| serde_json::json!({
+                    "id": a.id,
+                    "name": a.name,
+                })).collect::<Vec<_>>(),
+                "connected_at": p.connected_at.to_rfc3339(),
+                "protocol_version": p.protocol_version,
+            })),
+        ),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Peer not found"})),
+        ),
+    }
+}
+
 /// GET /api/network/status — OFP network status summary.
 #[utoipa::path(
     get,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -326,6 +326,7 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
         .route("/audit/verify", axum::routing::get(routes::audit_verify))
         .route("/logs/stream", axum::routing::get(routes::logs_stream))
         .route("/peers", axum::routing::get(routes::list_peers))
+        .route("/peers/{id}", axum::routing::get(routes::get_peer))
         .route(
             "/network/status",
             axum::routing::get(routes::network_status),


### PR DESCRIPTION
## Summary
- Add `GET /api/peers/{id}` endpoint to retrieve a single peer by node ID
- Returns 404 when peer not found or peer networking is not enabled
- Response format matches the per-peer structure in `GET /api/peers` list endpoint
- Registered in OpenAPI schema for documentation

Closes #160

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `curl /api/peers/{valid_id}` returns peer JSON
- [ ] `curl /api/peers/{invalid_id}` returns 404