### PR TITLE
fix: update static linking check to match static-pie binaries

### DIFF
--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -194,7 +194,7 @@ jobs:
         run: |
           FILE_OUT=$(file target/${{ matrix.target }}/release/librefang)
           echo "$FILE_OUT"
-          if ! echo "$FILE_OUT" | grep -q "statically linked"; then
+          if ! echo "$FILE_OUT" | grep -qE "statically linked|static-pie linked"; then
             echo "::error::Binary is not statically linked!"
             exit 1
           fi

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -829,13 +829,9 @@ async fn parse_telegram_update(
     // Extract reply-to-message context (Telegram `reply_to_message` field).
     // Prepend the quoted original text so the agent sees what the user is replying to.
     let content = if let Some(reply) = message.get("reply_to_message") {
-        let reply_text = reply["text"]
-            .as_str()
-            .or_else(|| reply["caption"].as_str());
+        let reply_text = reply["text"].as_str().or_else(|| reply["caption"].as_str());
         if let Some(quoted) = reply_text {
-            let reply_sender = reply["from"]["first_name"]
-                .as_str()
-                .unwrap_or("Someone");
+            let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
             let prefix = format!("[Replying to {reply_sender}: \"{quoted}\"]\n");
             match content {
                 ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
@@ -1717,7 +1713,9 @@ mod tests {
         let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
             .await
             .unwrap();
-        assert!(matches!(msg.content, ChannelContent::Text(ref t) if t == "What was that sticker?"));
+        assert!(
+            matches!(msg.content, ChannelContent::Text(ref t) if t == "What was that sticker?")
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -194,7 +194,11 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
 
         let names: Vec<String> = arr
             .iter()
-            .filter_map(|m| m.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+            .filter_map(|m| {
+                m.get("name")
+                    .and_then(|n| n.as_str())
+                    .map(|s| s.to_string())
+            })
             .collect();
 
         let info: Vec<DiscoveredModelInfo> = arr


### PR DESCRIPTION
## Summary
- Fix false-negative failure in `x86_64-unknown-linux-musl (static)` release CI verification step
- Newer musl/cross toolchains produce static-PIE executables where `file` reports `static-pie linked` instead of `statically linked`
- Update grep pattern from literal match to regex that accepts both formats

## Test plan
- [ ] Re-trigger release workflow and verify `x86_64-unknown-linux-musl (static)` job passes
- [ ] Confirm other musl targets (e.g. `aarch64-unknown-linux-musl`) are unaffected