### PR TITLE
release: v0.5.5-20260317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2026-03-17
+
+### Added
+
+- Add Telegram reply-to-message context (#553) (@SenZhangAI)
+- Enrich Ollama model discovery with metadata (#554) (@SenZhangAI)
+- Add GET /api/peers/{id} endpoint (#557) (@SenZhangAI)
+
+### Fixed
+
+- Improve Telegram markdown formatting for headings, lists, code blocks and blockquotes (#405) (@houko)
+- Normalize OpenRouter model IDs to prevent 400 errors (#408) (@houko)
+- Improve python3 detection and Chromium sandbox handling for Linux (#410) (@houko)
+- Prevent Mastodon adapter from re-delivering old notifications and posting errors publicly (#411) (@houko)
+- Replace unsafe pointer mutation with OnceLock for peer_registry/peer_node (#414) (@houko)
+- Raise main_lane default concurrency from 1 to 3 (#552) (@SenZhangAI)
+- Update static linking check to match static-pie binaries (#558) (@houko)
+
+### Performance
+
+- Optimize channel hot-path with reduced allocations and Criterion benchmarks (#451) (@houko)
+
+### Documentation
+
+- Update contributors (#555) (@houko)
+
+### Maintenance
+
+- Auto-cancel old release runs when tag is re-pushed (#547) (@houko)
+
+### Other
+
+- V0.5.4-20260317 (#546) (@houko)
+
 ## [0.5.4] - 2026-03-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +850,33 @@ checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown 0.14.5",
  "stacker",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1223,6 +1262,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "cron"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1390,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -2686,6 +2767,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3337,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3536,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "async-trait",
  "axum",
@@ -3580,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "aes",
  "async-trait",
@@ -3588,6 +3700,7 @@ dependencies = [
  "base64 0.22.1",
  "cbc",
  "chrono",
+ "criterion",
  "dashmap",
  "futures",
  "hex",
@@ -3606,6 +3719,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "smallvec",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3618,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3650,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3676,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3704,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3721,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3759,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3778,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3797,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3834,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "chrono",
  "hex",
@@ -3857,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3876,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4531,6 +4645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5004,6 +5124,34 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5482,7 +5630,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -5534,7 +5682,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -7398,6 +7546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,7 +8081,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -8457,7 +8615,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -9481,7 +9639,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4-20260317"
+version = "0.5.5-20260317"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.5.4-20260317",
+  "version": "0.5.5-20260317",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.5.4-20260317",
+  "version": "0.5.5-20260317",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.5.4-20260317",
+  "version": "0.5.5-20260317",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.5.4-20260317",
+    version="0.5.5-20260317",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.5.5-20260317


### Added

- Add Telegram reply-to-message context (#553) (@SenZhangAI)
- Enrich Ollama model discovery with metadata (#554) (@SenZhangAI)
- Add GET /api/peers/{id} endpoint (#557) (@SenZhangAI)

### Fixed

- Improve Telegram markdown formatting for headings, lists, code blocks and blockquotes (#405) (@houko)
- Normalize OpenRouter model IDs to prevent 400 errors (#408) (@houko)
- Improve python3 detection and Chromium sandbox handling for Linux (#410) (@houko)
- Prevent Mastodon adapter from re-delivering old notifications and posting errors publicly (#411) (@houko)
- Replace unsafe pointer mutation with OnceLock for peer_registry/peer_node (#414) (@houko)
- Raise main_lane default concurrency from 1 to 3 (#552) (@SenZhangAI)
- Update static linking check to match static-pie binaries (#558) (@houko)

### Performance

- Optimize channel hot-path with reduced allocations and Criterion benchmarks (#451) (@houko)

### Documentation

- Update contributors (#555) (@houko)

### Maintenance

- Auto-cancel old release runs when tag is re-pushed (#547) (@houko)

### Other

- V0.5.4-20260317 (#546) (@houko)