### PR TITLE
feat: add truncation and metadata for Telegram reply-to-message

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -832,7 +832,13 @@ async fn parse_telegram_update(
         let reply_text = reply["text"].as_str().or_else(|| reply["caption"].as_str());
         if let Some(quoted) = reply_text {
             let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
-            let prefix = format!("[Replying to {reply_sender}: \"{quoted}\"]\n");
+            // 截断长引用，避免给 LLM 塞过多无关 context
+            let truncated = if quoted.len() > 200 {
+                format!("{}...", &quoted[..quoted.floor_char_boundary(200)])
+            } else {
+                quoted.to_string()
+            };
+            let prefix = format!("[Replying to {reply_sender}: \"{truncated}\"]\n");
             match content {
                 ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
                 other => other, // 对 Command/Image 等不修改
@@ -852,6 +858,27 @@ async fn parse_telegram_update(
 
     // Detect @mention of the bot in entities / caption_entities for MentionOnly group policy.
     let mut metadata = HashMap::new();
+
+    // Store reply-to-message metadata for downstream consumers.
+    if let Some(reply) = message.get("reply_to_message") {
+        let reply_message_id = reply["message_id"].as_i64().unwrap_or(0);
+        let reply_text = reply["text"]
+            .as_str()
+            .or_else(|| reply["caption"].as_str())
+            .unwrap_or("");
+        let reply_sender = reply
+            .get("from")
+            .and_then(|f| f["first_name"].as_str())
+            .unwrap_or("Unknown");
+        metadata.insert(
+            "reply_to".to_string(),
+            serde_json::json!({
+                "message_id": reply_message_id,
+                "sender": reply_sender,
+                "text": reply_text,
+            }),
+        );
+    }
     if is_group {
         if let Some(bot_uname) = bot_username {
             let was_mentioned = check_mention_entities(message, bot_uname);
@@ -1716,6 +1743,77 @@ mod tests {
         assert!(
             matches!(msg.content, ChannelContent::Text(ref t) if t == "What was that sticker?")
         );
+    }
+
+    #[tokio::test]
+    async fn test_parse_telegram_reply_truncates_long_text() {
+        let long_text = "a".repeat(300);
+        let update = serde_json::json!({
+            "update_id": 702,
+            "message": {
+                "message_id": 102,
+                "from": { "id": 123, "first_name": "Bob" },
+                "chat": { "id": 123, "type": "private" },
+                "date": 1700000000,
+                "text": "reply",
+                "reply_to_message": {
+                    "message_id": 99,
+                    "from": { "id": 456, "first_name": "Alice" },
+                    "chat": { "id": 123, "type": "private" },
+                    "date": 1699999900,
+                    "text": long_text
+                }
+            }
+        });
+
+        let client = test_client();
+        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+            .await
+            .unwrap();
+        match &msg.content {
+            ChannelContent::Text(t) => {
+                // Quoted text should be truncated, not the full 300 chars
+                assert!(t.contains("..."), "long quote should be truncated with ...");
+                assert!(
+                    !t.contains(&"a".repeat(300)),
+                    "full 300-char text should not appear"
+                );
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_telegram_reply_stores_metadata() {
+        let update = serde_json::json!({
+            "update_id": 703,
+            "message": {
+                "message_id": 103,
+                "from": { "id": 123, "first_name": "Bob" },
+                "chat": { "id": 123, "type": "private" },
+                "date": 1700000000,
+                "text": "I agree",
+                "reply_to_message": {
+                    "message_id": 50,
+                    "from": { "id": 456, "first_name": "Alice" },
+                    "chat": { "id": 123, "type": "private" },
+                    "date": 1699999900,
+                    "text": "Let's meet tomorrow"
+                }
+            }
+        });
+
+        let client = test_client();
+        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+            .await
+            .unwrap();
+        let reply_to = msg
+            .metadata
+            .get("reply_to")
+            .expect("reply_to metadata should exist");
+        assert_eq!(reply_to["message_id"], 50);
+        assert_eq!(reply_to["sender"], "Alice");
+        assert_eq!(reply_to["text"], "Let's meet tomorrow");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Truncate quoted text at 200 chars with safe UTF-8 boundary (`floor_char_boundary`) to prevent long replies from bloating LLM context
- Store `reply_to` metadata (message_id, sender, text) in `ChannelMessage.metadata` for downstream consumers (logging, filtering, UI)
- Add 2 new tests: truncation verification + metadata presence check

Improvements adopted from #403 (now closed as superseded by #553).

## Test plan
- [x] `cargo test -p librefang-channels -- telegram::tests::test_parse_telegram_reply` — 4 tests pass
- [ ] CI passes