### PR TITLE
fix: add missing discovered_model_info field in ProbeResult test

### DIFF
--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -403,6 +403,7 @@ mod tests {
             reachable: true,
             latency_ms: 42,
             discovered_models: vec!["llama3".into()],
+            discovered_model_info: vec![],
             error: None,
         };
         cache.insert("ollama", result.clone());


### PR DESCRIPTION
## Summary
- `ProbeResult` struct added `discovered_model_info` field but the test in `provider_health.rs:402` was not updated, causing macOS CI build failure

## Test plan
- [x] `cargo test -p librefang-runtime --lib provider_health` — 12 passed