### PR TITLE
fix: add mime_type to ChannelContent::Image for correct vision handling

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -700,9 +700,10 @@ async fn dispatch_message(
     if let ChannelContent::Image {
         ref url,
         ref caption,
+        ref mime_type,
     } = message.content
     {
-        let blocks = download_image_to_blocks(url, caption.as_deref()).await;
+        let blocks = download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await;
         if blocks
             .iter()
             .any(|b| matches!(b, ContentBlock::Image { .. }))
@@ -730,6 +731,7 @@ async fn dispatch_message(
         ChannelContent::Image {
             ref url,
             ref caption,
+            ..
         } => {
             // Fallback when image download failed
             match caption {
@@ -1199,7 +1201,15 @@ fn media_type_from_url(url: &str) -> String {
 /// Returns a `Vec<ContentBlock>` containing an image block (base64-encoded) and
 /// optionally a text block for the caption. If the download fails, returns a
 /// text-only block describing the failure.
-async fn download_image_to_blocks(url: &str, caption: Option<&str>) -> Vec<ContentBlock> {
+///
+/// `mime_type_hint` is an optional MIME type pre-detected by the channel adapter
+/// (e.g. from a Telegram file path). When present it takes priority over the
+/// HTTP Content-Type header because many APIs return `application/octet-stream`.
+async fn download_image_to_blocks(
+    url: &str,
+    caption: Option<&str>,
+    mime_type_hint: Option<&str>,
+) -> Vec<ContentBlock> {
     use base64::Engine;
 
     // 5 MB limit to prevent memory abuse from oversized images
@@ -1238,11 +1248,15 @@ async fn download_image_to_blocks(url: &str, caption: Option<&str>) -> Vec<Conte
         }
     };
 
-    // Three-tier media type detection:
-    // 1. Trusted Content-Type header (only if image/*)
-    // 2. Magic byte sniffing (most reliable for binary data)
-    // 3. URL extension fallback
-    let media_type = header_type
+    // Four-tier media type detection:
+    // 1. Adapter-provided hint (e.g. Telegram file path extension) — most
+    //    reliable because many APIs return application/octet-stream in headers
+    // 2. Trusted Content-Type header (only if image/*)
+    // 3. Magic byte sniffing (most reliable for binary data)
+    // 4. URL extension fallback
+    let media_type = mime_type_hint
+        .map(|s| s.to_string())
+        .or(header_type)
         .unwrap_or_else(|| detect_image_magic(&bytes).unwrap_or_else(|| media_type_from_url(url)));
 
     if bytes.len() > MAX_IMAGE_BYTES {

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -459,7 +459,7 @@ impl ChannelAdapter for LineAdapter {
             ChannelContent::Text(text) => {
                 self.api_push_message(&user.platform_id, &text).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 // LINE supports image messages with a preview
                 let body = serde_json::json!({
                     "to": user.platform_id,

--- a/crates/librefang-channels/src/messenger.rs
+++ b/crates/librefang-channels/src/messenger.rs
@@ -390,7 +390,7 @@ impl ChannelAdapter for MessengerAdapter {
             ChannelContent::Text(text) => {
                 self.api_send_message(&user.platform_id, &text).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 // Send image attachment via Messenger
                 let api_url = format!(
                     "{}/me/messages?access_token={}",

--- a/crates/librefang-channels/src/revolt.rs
+++ b/crates/librefang-channels/src/revolt.rs
@@ -490,7 +490,7 @@ impl ChannelAdapter for RevoltAdapter {
             ChannelContent::Text(text) => {
                 self.api_send_message(&user.platform_id, &text).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 // Revolt supports embedding images in messages via markdown
                 let markdown = if let Some(cap) = caption {
                     format!("![{}]({})", cap, url)

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -506,7 +506,7 @@ impl TelegramAdapter {
             ChannelContent::Text(text) => {
                 self.api_send_message(chat_id, &text, thread_id).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 self.api_send_photo(chat_id, &url, caption.as_deref(), thread_id)
                     .await?;
             }
@@ -914,6 +914,31 @@ async fn telegram_get_file_url(
     Some(format!("{api_base_url}/file/bot{token}/{file_path}"))
 }
 
+/// Detect image MIME type from a Telegram file path or download URL.
+///
+/// Telegram file paths typically look like `photos/file_42.jpg` so the
+/// extension is a reliable signal. Falls back to `None` if no known
+/// image extension is found, letting downstream code use magic-byte
+/// detection or a safe default.
+fn mime_type_from_telegram_path(url_or_path: &str) -> Option<String> {
+    let lower = url_or_path.to_ascii_lowercase();
+    if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
+        Some("image/jpeg".to_string())
+    } else if lower.ends_with(".png") {
+        Some("image/png".to_string())
+    } else if lower.ends_with(".gif") {
+        Some("image/gif".to_string())
+    } else if lower.ends_with(".webp") {
+        Some("image/webp".to_string())
+    } else if lower.ends_with(".bmp") {
+        Some("image/bmp".to_string())
+    } else if lower.ends_with(".tiff") || lower.ends_with(".tif") {
+        Some("image/tiff".to_string())
+    } else {
+        None
+    }
+}
+
 async fn parse_telegram_update(
     update: &serde_json::Value,
     allowed_users: &[String],
@@ -1024,7 +1049,14 @@ async fn parse_telegram_update(
             .unwrap_or("");
         let caption = message["caption"].as_str().map(String::from);
         match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::Image { url, caption },
+            Some(url) => {
+                let mime_type = mime_type_from_telegram_path(&url);
+                ChannelContent::Image {
+                    url,
+                    caption,
+                    mime_type,
+                }
+            }
             None => ChannelContent::Text(format!(
                 "[Photo received{}]",
                 caption

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -45,6 +45,12 @@ pub enum ChannelContent {
     Image {
         url: String,
         caption: Option<String>,
+        /// MIME type of the image (e.g. `image/jpeg`, `image/png`).
+        /// When present, this is passed through to the vision/LLM layer so that
+        /// the correct media type is used instead of the generic
+        /// `application/octet-stream` default.
+        #[serde(default)]
+        mime_type: Option<String>,
     },
     File {
         url: String,

--- a/crates/librefang-channels/src/viber.rs
+++ b/crates/librefang-channels/src/viber.rs
@@ -394,7 +394,7 @@ impl ChannelAdapter for ViberAdapter {
             ChannelContent::Text(text) => {
                 self.api_send_message(&user.platform_id, &text).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 let mut sender = serde_json::json!({
                     "name": self.sender_name,
                 });

--- a/crates/librefang-channels/src/whatsapp.rs
+++ b/crates/librefang-channels/src/whatsapp.rs
@@ -257,7 +257,7 @@ impl ChannelAdapter for WhatsAppAdapter {
             ChannelContent::Text(text) => {
                 self.api_send_message(&user.platform_id, &text).await?;
             }
-            ChannelContent::Image { url, caption } => {
+            ChannelContent::Image { url, caption, .. } => {
                 let body = serde_json::json!({
                     "messaging_product": "whatsapp",
                     "to": user.platform_id,

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -7111,6 +7111,7 @@ impl KernelHandle for LibreFangKernel {
             "image" => librefang_channels::types::ChannelContent::Image {
                 url: media_url.to_string(),
                 caption: caption.map(|s| s.to_string()),
+                mime_type: None,
             },
             "file" => librefang_channels::types::ChannelContent::File {
                 url: media_url.to_string(),


### PR DESCRIPTION
## Summary
- Add `mime_type: Option<String>` field to `ChannelContent::Image` variant
- Detect image MIME type from Telegram API responses
- Update all pattern matches across channel adapters (telegram, slack, whatsapp, line, messenger, revolt, viber)
- Pass correct MIME type through to vision/LLM pipeline

Closes #874

## Test plan
- [ ] Send an image via Telegram to the bot
- [ ] Verify the media_type is correctly set (image/jpeg, image/png) instead of application/octet-stream
- [ ] Verify vision/image understanding works with the correct MIME type
- [ ] Verify other channel adapters still compile and handle images