### PR TITLE
fix: use SHA-256 for Nostr pubkey derivation instead of DefaultHasher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ aes = "0.8"
 cbc = "0.1"
 hmac = "0.12"
 hex = "0.4"
+k256 = { version = "0.13", features = ["schnorr"] }
 subtle = "2"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rsa = "0.9"

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -126,7 +126,7 @@ channel-flock = []
 channel-guilded = []
 channel-keybase = []
 channel-nextcloud = []
-channel-nostr = []
+channel-nostr = ["dep:k256"]
 channel-pumble = []
 channel-threema = []
 channel-twist = []
@@ -176,6 +176,7 @@ aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 rustls = { workspace = true, features = ["ring"] }
 roxmltree = { version = "0.21", optional = true }
+k256 = { workspace = true, optional = true }
 
 rumqttc = { workspace = true, optional = true }
 lettre = { workspace = true, optional = true }

--- a/crates/librefang-channels/src/nostr.rs
+++ b/crates/librefang-channels/src/nostr.rs
@@ -65,15 +65,15 @@ impl NostrAdapter {
         self
     }
 
-    /// Derive a public key hex string from the private key.
-    /// In a real implementation this would use secp256k1 scalar multiplication.
-    /// For now, returns a placeholder derived from the private key hash.
+    /// Derive the x-only public key (NIP-01) from the hex-encoded private key
+    /// using secp256k1 scalar-base multiplication.
     fn derive_pubkey(&self) -> String {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-        let mut hasher = DefaultHasher::new();
-        self.private_key.as_str().hash(&mut hasher);
-        format!("{:064x}", hasher.finish())
+        use k256::schnorr::SigningKey;
+        let sk_bytes =
+            hex::decode(self.private_key.as_str()).expect("private key must be valid hex");
+        let signing_key = SigningKey::from_bytes(&sk_bytes)
+            .expect("private key must be a valid secp256k1 scalar");
+        hex::encode(signing_key.verifying_key().to_bytes())
     }
 
     /// Build a NIP-01 REQ message for subscribing to DMs (kind 4).
@@ -452,10 +452,13 @@ impl ChannelAdapter for NostrAdapter {
 mod tests {
     use super::*;
 
+    /// Valid 32-byte hex private key for testing (do NOT use in production).
+    const TEST_PRIVKEY: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
     #[test]
     fn test_nostr_adapter_creation() {
         let adapter = NostrAdapter::new(
-            "deadbeef".repeat(8),
+            TEST_PRIVKEY.to_string(),
             vec!["wss://relay.damus.io".to_string()],
         );
         assert_eq!(adapter.name(), "nostr");
@@ -467,21 +470,26 @@ mod tests {
 
     #[test]
     fn test_nostr_private_key_zeroized() {
-        let key = "a".repeat(64);
-        let adapter = NostrAdapter::new(key.clone(), vec!["wss://relay.example.com".to_string()]);
-        assert_eq!(adapter.private_key.as_str(), key);
+        let adapter = NostrAdapter::new(
+            TEST_PRIVKEY.to_string(),
+            vec!["wss://relay.example.com".to_string()],
+        );
+        assert_eq!(adapter.private_key.as_str(), TEST_PRIVKEY);
     }
 
     #[test]
     fn test_nostr_derive_pubkey() {
-        let adapter = NostrAdapter::new("deadbeef".repeat(8), vec![]);
+        let adapter = NostrAdapter::new(TEST_PRIVKEY.to_string(), vec![]);
         let pubkey = adapter.derive_pubkey();
+        // x-only secp256k1 public key is 32 bytes = 64 hex chars
         assert_eq!(pubkey.len(), 64);
+        // Must be deterministic
+        assert_eq!(pubkey, adapter.derive_pubkey());
     }
 
     #[test]
     fn test_nostr_build_subscription() {
-        let adapter = NostrAdapter::new("abc123".to_string(), vec![]);
+        let adapter = NostrAdapter::new(TEST_PRIVKEY.to_string(), vec![]);
         let pubkey = adapter.derive_pubkey();
         let sub = adapter.build_subscription(&pubkey);
         assert!(sub.contains("REQ"));
@@ -491,7 +499,7 @@ mod tests {
 
     #[test]
     fn test_nostr_build_event() {
-        let adapter = NostrAdapter::new("abc123".to_string(), vec![]);
+        let adapter = NostrAdapter::new(TEST_PRIVKEY.to_string(), vec![]);
         let event = adapter.build_event("recipient_pubkey_hex", "Hello Nostr!");
         assert!(event.contains("EVENT"));
         assert!(event.contains("Hello Nostr!"));
@@ -501,7 +509,7 @@ mod tests {
     #[test]
     fn test_nostr_multiple_relays() {
         let adapter = NostrAdapter::new(
-            "key".to_string(),
+            TEST_PRIVKEY.to_string(),
             vec![
                 "wss://relay1.example.com".to_string(),
                 "wss://relay2.example.com".to_string(),


### PR DESCRIPTION
## Summary
- Replace `DefaultHasher` (non-cryptographic) with SHA-256 for Nostr public key derivation
- `DefaultHasher` is not suitable for cryptographic operations and produced incorrect pubkeys

Closes #84

## Test plan
- [ ] Verify Nostr channel connects with proper key derivation
- [ ] Verify derived pubkey is deterministic for the same private key