### PR TITLE
fix: handle thought chunks in Gemini streaming for thinking models

### DIFF
--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -645,7 +645,7 @@ impl SessionStore {
                             ContentBlock::Image { media_type, .. } => {
                                 text_parts.push(format!("[image: {media_type}]"));
                             }
-                            ContentBlock::Thinking { thinking } => {
+                            ContentBlock::Thinking { thinking, .. } => {
                                 text_parts.push(format!(
                                     "[thinking: {}]",
                                     librefang_types::truncate_str(thinking, 200)

--- a/crates/librefang-runtime/src/drivers/anthropic.rs
+++ b/crates/librefang-runtime/src/drivers/anthropic.rs
@@ -534,7 +534,10 @@ impl LlmDriver for AnthropicDriver {
                         });
                     }
                     ContentBlockAccum::Thinking(thinking) => {
-                        content.push(ContentBlock::Thinking { thinking });
+                        content.push(ContentBlock::Thinking {
+                            thinking,
+                            provider_metadata: None,
+                        });
                     }
                     ContentBlockAccum::ToolUse {
                         id,
@@ -671,7 +674,10 @@ fn convert_response(api: ApiResponse) -> CompletionResponse {
                 tool_calls.push(ToolCall { id, name, input });
             }
             ResponseContentBlock::Thinking { thinking } => {
-                content.push(ContentBlock::Thinking { thinking });
+                content.push(ContentBlock::Thinking {
+                    thinking,
+                    provider_metadata: None,
+                });
             }
         }
     }

--- a/crates/librefang-runtime/src/drivers/gemini.rs
+++ b/crates/librefang-runtime/src/drivers/gemini.rs
@@ -319,7 +319,21 @@ pub(crate) fn convert_messages(
                                 },
                             });
                         }
-                        ContentBlock::Thinking { .. } => {}
+                        ContentBlock::Thinking {
+                            thinking,
+                            provider_metadata,
+                        } => {
+                            let thought_signature = provider_metadata
+                                .as_ref()
+                                .and_then(|m| m.get("thought_signature"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                            parts.push(GeminiPart::Text {
+                                text: thinking.clone(),
+                                thought: true,
+                                thought_signature,
+                            });
+                        }
                         _ => {}
                     }
                 }
@@ -413,7 +427,14 @@ fn convert_response(resp: GeminiResponse) -> Result<CompletionResponse, LlmError
                             if thought {
                                 // Internal reasoning from a thinking model —
                                 // surface as a Thinking block, not regular text.
-                                content.push(ContentBlock::Thinking { thinking: text });
+                                // Preserve thought_signature so it can be
+                                // echoed back on subsequent requests.
+                                let provider_metadata = thought_signature
+                                    .map(|sig| serde_json::json!({ "thought_signature": sig }));
+                                content.push(ContentBlock::Thinking {
+                                    thinking: text,
+                                    provider_metadata,
+                                });
                             } else {
                                 // Preserve thought_signature in provider_metadata so
                                 // it gets echoed back on the next request.  Gemini
@@ -534,6 +555,7 @@ pub(crate) async fn stream_gemini_sse(
     let mut text_content = String::new();
     let mut thinking_content = String::new();
     let mut text_thought_sig: Option<String> = None;
+    let mut thinking_thought_sig: Option<String> = None;
     let mut fn_calls: Vec<(String, serde_json::Value, Option<String>)> = Vec::new();
     let mut finish_reason: Option<String> = None;
     let mut usage = TokenUsage::default();
@@ -588,15 +610,22 @@ pub(crate) async fn stream_gemini_sse(
                                         let _ = tx
                                             .send(StreamEvent::ThinkingDelta { text: text.clone() })
                                             .await;
+                                        // Capture thought_signature for the
+                                        // thinking block separately from text.
+                                        if thought_signature.is_some() {
+                                            thinking_thought_sig = thought_signature.clone();
+                                        }
                                     } else {
                                         text_content.push_str(text);
                                         let _ = tx
                                             .send(StreamEvent::TextDelta { text: text.clone() })
                                             .await;
+                                        // Capture thought_signature for text
+                                        // parts (last one wins across chunks).
+                                        if thought_signature.is_some() {
+                                            text_thought_sig = thought_signature.clone();
+                                        }
                                     }
-                                }
-                                if thought_signature.is_some() {
-                                    text_thought_sig = thought_signature.clone();
                                 }
                             }
                             GeminiPart::FunctionCall {
@@ -643,8 +672,11 @@ pub(crate) async fn stream_gemini_sse(
 
     // Thinking blocks come first (matches Anthropic convention).
     if !thinking_content.is_empty() {
+        let provider_metadata = thinking_thought_sig
+            .map(|sig| serde_json::json!({ "thought_signature": sig }));
         content.push(ContentBlock::Thinking {
             thinking: thinking_content,
+            provider_metadata,
         });
     }
 
@@ -865,6 +897,8 @@ impl LlmDriver for GeminiDriver {
             let mut thinking_content = String::new();
             // Thought signature for accumulated text content (last one wins)
             let mut text_thought_sig: Option<String> = None;
+            // Thought signature for accumulated thinking content (last one wins)
+            let mut thinking_thought_sig: Option<String> = None;
             // Track function calls: (name, args_json, thought_signature)
             let mut fn_calls: Vec<(String, serde_json::Value, Option<String>)> = Vec::new();
             let mut finish_reason: Option<String> = None;
@@ -924,6 +958,12 @@ impl LlmDriver for GeminiDriver {
                                                         text: text.clone(),
                                                     })
                                                     .await;
+                                                // Capture thought_signature for the
+                                                // thinking block separately from text.
+                                                if thought_signature.is_some() {
+                                                    thinking_thought_sig =
+                                                        thought_signature.clone();
+                                                }
                                             } else {
                                                 text_content.push_str(text);
                                                 let _ = tx
@@ -931,12 +971,12 @@ impl LlmDriver for GeminiDriver {
                                                         text: text.clone(),
                                                     })
                                                     .await;
+                                                // Capture thought_signature for text
+                                                // parts (last one wins across chunks).
+                                                if thought_signature.is_some() {
+                                                    text_thought_sig = thought_signature.clone();
+                                                }
                                             }
-                                        }
-                                        // Capture thought signature for text parts
-                                        // (last one wins across streamed chunks).
-                                        if thought_signature.is_some() {
-                                            text_thought_sig = thought_signature.clone();
                                         }
                                     }
                                     GeminiPart::FunctionCall {
@@ -983,8 +1023,11 @@ impl LlmDriver for GeminiDriver {
 
             // Thinking blocks come first (matches Anthropic convention).
             if !thinking_content.is_empty() {
+                let provider_metadata = thinking_thought_sig
+                    .map(|sig| serde_json::json!({ "thought_signature": sig }));
                 content.push(ContentBlock::Thinking {
                     thinking: thinking_content,
+                    provider_metadata,
                 });
             }
 
@@ -1855,5 +1898,158 @@ mod tests {
             serialized["functionCall"].get("thoughtSignature").is_none(),
             "thoughtSignature must be at part level, NOT inside functionCall"
         );
+    }
+
+    // --- Issue #825: Thinking block thought_signature round-trip tests ---
+
+    #[test]
+    fn test_thought_true_produces_thinking_block() {
+        // A GeminiResponse with thought: true should produce ContentBlock::Thinking
+        let resp = GeminiResponse {
+            candidates: vec![GeminiCandidate {
+                content: Some(GeminiContent {
+                    role: Some("model".to_string()),
+                    parts: vec![GeminiPart::Text {
+                        text: "Let me reason through this...".to_string(),
+                        thought: true,
+                        thought_signature: None,
+                    }],
+                }),
+                finish_reason: Some("STOP".to_string()),
+            }],
+            usage_metadata: Some(GeminiUsageMetadata {
+                prompt_token_count: 10,
+                candidates_token_count: 8,
+            }),
+        };
+
+        let completion = convert_response(resp).unwrap();
+        assert_eq!(completion.content.len(), 1);
+        match &completion.content[0] {
+            ContentBlock::Thinking { thinking, .. } => {
+                assert_eq!(thinking, "Let me reason through this...");
+            }
+            other => panic!("Expected Thinking block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_thought_signature_preserved_on_thinking() {
+        // thought=true + thought_signature should store the signature
+        // in the Thinking block's provider_metadata
+        let resp = GeminiResponse {
+            candidates: vec![GeminiCandidate {
+                content: Some(GeminiContent {
+                    role: Some("model".to_string()),
+                    parts: vec![GeminiPart::Text {
+                        text: "Internal reasoning here".to_string(),
+                        thought: true,
+                        thought_signature: Some("think_sig_999".to_string()),
+                    }],
+                }),
+                finish_reason: Some("STOP".to_string()),
+            }],
+            usage_metadata: None,
+        };
+
+        let completion = convert_response(resp).unwrap();
+        match &completion.content[0] {
+            ContentBlock::Thinking {
+                thinking,
+                provider_metadata,
+            } => {
+                assert_eq!(thinking, "Internal reasoning here");
+                let meta = provider_metadata
+                    .as_ref()
+                    .expect("provider_metadata should be set on thinking block with signature");
+                assert_eq!(meta["thought_signature"], "think_sig_999");
+            }
+            other => panic!("Expected Thinking block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_thinking_block_round_trip() {
+        // A ContentBlock::Thinking with provider_metadata should convert back
+        // to GeminiPart::Text { thought: true, thought_signature } via
+        // convert_messages().
+        let messages = vec![
+            Message::user("Explain quantum computing"),
+            Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::Thinking {
+                        thinking: "Let me think step by step...".to_string(),
+                        provider_metadata: Some(
+                            serde_json::json!({ "thought_signature": "think_sig_round" }),
+                        ),
+                    },
+                    ContentBlock::Text {
+                        text: "Here is my explanation.".to_string(),
+                        provider_metadata: None,
+                    },
+                ]),
+            },
+        ];
+
+        let (contents, _) = convert_messages(&messages, &None);
+        let model_turn = &contents[1];
+        assert_eq!(model_turn.role.as_deref(), Some("model"));
+        assert_eq!(model_turn.parts.len(), 2);
+
+        // First part: thinking -> Text { thought: true }
+        match &model_turn.parts[0] {
+            GeminiPart::Text {
+                text,
+                thought,
+                thought_signature,
+            } => {
+                assert_eq!(text, "Let me think step by step...");
+                assert!(thought, "thought should be true for thinking blocks");
+                assert_eq!(
+                    thought_signature.as_deref(),
+                    Some("think_sig_round"),
+                    "thought_signature should be preserved from provider_metadata"
+                );
+            }
+            other => panic!("Expected Text part, got {:?}", other),
+        }
+
+        // Second part: regular text -> Text { thought: false }
+        match &model_turn.parts[1] {
+            GeminiPart::Text {
+                text,
+                thought,
+                thought_signature,
+            } => {
+                assert_eq!(text, "Here is my explanation.");
+                assert!(!thought, "thought should be false for regular text");
+                assert!(
+                    thought_signature.is_none(),
+                    "thought_signature should be None for text without metadata"
+                );
+            }
+            other => panic!("Expected Text part, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_thought_false_serde_skip() {
+        // When thought is false, it should not appear in the serialized JSON
+        let part = GeminiPart::Text {
+            text: "Regular text".to_string(),
+            thought: false,
+            thought_signature: None,
+        };
+        let json = serde_json::to_value(&part).unwrap();
+        assert!(
+            json.get("thought").is_none(),
+            "thought: false should be skipped in serialization"
+        );
+        assert!(
+            json.get("thoughtSignature").is_none(),
+            "thoughtSignature: None should be skipped in serialization"
+        );
+        assert_eq!(json["text"], "Regular text");
     }
 }

--- a/crates/librefang-runtime/src/drivers/openai.rs
+++ b/crates/librefang-runtime/src/drivers/openai.rs
@@ -591,6 +591,7 @@ impl LlmDriver for OpenAIDriver {
                     );
                     content.push(ContentBlock::Thinking {
                         thinking: reasoning.clone(),
+                        provider_metadata: None,
                     });
                 }
             }
@@ -605,6 +606,7 @@ impl LlmDriver for OpenAIDriver {
                         if choice.message.reasoning_content.is_none() {
                             content.push(ContentBlock::Thinking {
                                 thinking: think_text,
+                                provider_metadata: None,
                             });
                         }
                     }
@@ -631,7 +633,7 @@ impl LlmDriver for OpenAIDriver {
                 let thinking_text = content
                     .iter()
                     .find_map(|b| match b {
-                        ContentBlock::Thinking { thinking } => Some(thinking.as_str()),
+                        ContentBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
                         _ => None,
                     })
                     .unwrap_or("");
@@ -1260,6 +1262,7 @@ impl LlmDriver for OpenAIDriver {
             if !reasoning_content.is_empty() {
                 content.push(ContentBlock::Thinking {
                     thinking: reasoning_content.clone(),
+                    provider_metadata: None,
                 });
             }
 
@@ -1271,6 +1274,7 @@ impl LlmDriver for OpenAIDriver {
                     if reasoning_content.is_empty() {
                         content.push(ContentBlock::Thinking {
                             thinking: think_text,
+                            provider_metadata: None,
                         });
                     }
                 }
@@ -1295,7 +1299,7 @@ impl LlmDriver for OpenAIDriver {
                 let thinking_text = content
                     .iter()
                     .find_map(|b| match b {
-                        ContentBlock::Thinking { thinking } => Some(thinking.as_str()),
+                        ContentBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
                         _ => None,
                     })
                     .unwrap_or("");

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -89,6 +89,11 @@ pub enum ContentBlock {
     Thinking {
         /// The thinking/reasoning text.
         thinking: String,
+        /// Provider-specific metadata (e.g. Gemini `thoughtSignature`).
+        /// Opaque to the core — drivers read/write this to round-trip
+        /// fields the provider requires on subsequent requests.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_metadata: Option<serde_json::Value>,
     },
     /// Catch-all for unrecognized content block types (forward compatibility).
     #[serde(other)]
@@ -141,7 +146,7 @@ impl MessageContent {
                 .map(|b| match b {
                     ContentBlock::Text { text, .. } => text.len(),
                     ContentBlock::ToolResult { content, .. } => content.len(),
-                    ContentBlock::Thinking { thinking } => thinking.len(),
+                    ContentBlock::Thinking { thinking, .. } => thinking.len(),
                     ContentBlock::ToolUse { .. }
                     | ContentBlock::Image { .. }
                     | ContentBlock::Unknown => 0,


### PR DESCRIPTION
## Summary
- Add proper handling for Gemini thinking/reasoning model thought chunks
- Surface thought chunks as `ContentBlock::Thinking` blocks instead of failing
- Handle `thought_signature` in provider metadata for Gemini 3.x models
- Fix both non-streaming and streaming paths

Closes #825

## Test plan
- [ ] Use a Gemini thinking model (e.g., gemini-2.5-flash-thinking)
- [ ] Verify streaming responses complete without errors
- [ ] Verify thought blocks are properly separated from content