### PR TITLE
feat: propagate sender identity from channels to agent context

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -6,7 +6,7 @@
 use librefang_channels::bridge::{BridgeManager, ChannelBridgeHandle};
 use librefang_channels::router::AgentRouter;
 use librefang_channels::sidecar::SidecarAdapter;
-use librefang_channels::types::ChannelAdapter;
+use librefang_channels::types::{ChannelAdapter, SenderContext};
 
 // Feature-gated adapter imports
 #[cfg(feature = "channel-discord")]
@@ -225,6 +225,47 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         });
 
         Ok(rx)
+    }
+
+    async fn send_message_with_sender(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<String, String> {
+        let result = self
+            .kernel
+            .send_message_with_sender_context(agent_id, message, sender)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(result.response)
+    }
+
+    async fn send_message_with_blocks_and_sender(
+        &self,
+        agent_id: AgentId,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+        sender: &SenderContext,
+    ) -> Result<String, String> {
+        let text: String = blocks
+            .iter()
+            .filter_map(|b| match b {
+                librefang_types::message::ContentBlock::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = if text.is_empty() {
+            "[Image]".to_string()
+        } else {
+            text
+        };
+        let result = self
+            .kernel
+            .send_message_with_blocks_and_sender(agent_id, &text, blocks, sender)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(result.response)
     }
 
     async fn find_agent_by_name(&self, name: &str) -> Result<Option<AgentId>, String> {

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -8,7 +8,7 @@ use crate::rate_limiter::ChannelRateLimiter;
 use crate::router::AgentRouter;
 use crate::types::{
     default_phase_emoji, AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage, ChannelUser,
-    LifecycleReaction,
+    LifecycleReaction, SenderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -46,6 +46,33 @@ pub trait ChannelBridgeHandle: Send + Sync {
             .collect::<Vec<_>>()
             .join("\n");
         self.send_message(agent_id, &text).await
+    }
+
+    /// Send a message to an agent with sender identity context.
+    ///
+    /// The sender context is propagated to the agent's system prompt so it knows
+    /// who is talking and from which channel. Default falls back to `send_message()`.
+    async fn send_message_with_sender(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<String, String> {
+        let _ = sender;
+        self.send_message(agent_id, message).await
+    }
+
+    /// Send a multimodal message with sender identity context.
+    ///
+    /// Default falls back to `send_message_with_blocks()`.
+    async fn send_message_with_blocks_and_sender(
+        &self,
+        agent_id: AgentId,
+        blocks: Vec<ContentBlock>,
+        sender: &SenderContext,
+    ) -> Result<String, String> {
+        let _ = sender;
+        self.send_message_with_blocks(agent_id, blocks).await
     }
 
     /// Find an agent by name, returning its ID.
@@ -375,6 +402,17 @@ fn channel_type_str(channel: &crate::types::ChannelType) -> &str {
 
 /// Metadata key for the actual sender user ID (distinct from platform_id in DMs).
 pub const SENDER_USER_ID_KEY: &str = "sender_user_id";
+
+/// Build a `SenderContext` from an incoming `ChannelMessage`.
+fn build_sender_context(message: &ChannelMessage) -> SenderContext {
+    SenderContext {
+        channel: channel_type_str(&message.channel).to_string(),
+        user_id: sender_user_id(message).to_string(),
+        display_name: message.sender.display_name.clone(),
+        is_group: message.is_group,
+        thread_id: message.thread_id.clone(),
+    }
+}
 
 /// Extract the sender identity used for RBAC and per-user rate limiting.
 fn sender_user_id(message: &ChannelMessage) -> &str {
@@ -953,6 +991,9 @@ async fn dispatch_message(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
+    // Build sender context to propagate identity to the agent
+    let sender_ctx = build_sender_context(message);
+
     // Streaming path: if the adapter supports progressive output, pipe text
     // deltas directly to it instead of waiting for the full response.
     if adapter.supports_streaming() {
@@ -1066,8 +1107,11 @@ async fn dispatch_message(
         }
     }
 
-    // Non-streaming path: send to agent and relay the complete response.
-    match handle.send_message(agent_id, &text).await {
+    // Non-streaming path: send to agent and relay response (with sender identity).
+    match handle
+        .send_message_with_sender(agent_id, &text, &sender_ctx)
+        .await
+    {
         Ok(response) => {
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
             // Empty response means the agent intentionally chose to stay silent
@@ -1087,6 +1131,7 @@ async fn dispatch_message(
                 .await;
         }
         Err(e) => {
+            let sender_ctx_retry = sender_ctx.clone();
             handle_send_error(
                 &e,
                 agent_id,
@@ -1102,7 +1147,10 @@ async fn dispatch_message(
                 |new_id| {
                     let h = handle.clone();
                     let t = text.clone();
-                    async move { h.send_message(new_id, &t).await }
+                    async move {
+                        h.send_message_with_sender(new_id, &t, &sender_ctx_retry)
+                            .await
+                    }
                 },
             )
             .await;
@@ -1325,8 +1373,11 @@ async fn dispatch_with_blocks(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
+    // Build sender context to propagate identity to the agent
+    let sender_ctx = build_sender_context(message);
+
     match handle
-        .send_message_with_blocks(agent_id, blocks.clone())
+        .send_message_with_blocks_and_sender(agent_id, blocks.clone(), &sender_ctx)
         .await
     {
         Ok(response) => {
@@ -1346,6 +1397,7 @@ async fn dispatch_with_blocks(
                 .await;
         }
         Err(e) => {
+            let sender_ctx_retry = sender_ctx.clone();
             handle_send_error(
                 &e,
                 agent_id,
@@ -1360,7 +1412,10 @@ async fn dispatch_with_blocks(
                 output_format,
                 |new_id| {
                     let h = handle.clone();
-                    async move { h.send_message_with_blocks(new_id, blocks).await }
+                    async move {
+                        h.send_message_with_blocks_and_sender(new_id, blocks, &sender_ctx_retry)
+                            .await
+                    }
                 },
             )
             .await;

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -102,6 +102,26 @@ pub struct ChannelMessage {
     pub metadata: HashMap<String, serde_json::Value>,
 }
 
+/// Sender identity context passed from channels to the kernel.
+///
+/// Carries enough information for agents to know who is talking to them
+/// and from which channel, without depending on kernel-level types.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SenderContext {
+    /// Channel name (e.g. "telegram", "discord", "slack").
+    pub channel: String,
+    /// Platform-specific user ID.
+    pub user_id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Whether the message came from a group chat (vs DM).
+    #[serde(default)]
+    pub is_group: bool,
+    /// Thread ID for threaded conversations (platform-specific).
+    #[serde(default)]
+    pub thread_id: Option<String>,
+}
+
 /// Agent lifecycle phase for UX indicators.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -37,6 +37,7 @@ use librefang_types::memory::Memory;
 use librefang_types::tool::ToolDefinition;
 
 use async_trait::async_trait;
+use librefang_channels::types::SenderContext;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock, Weak};
@@ -1713,6 +1714,42 @@ impl LibreFangKernel {
             .await
     }
 
+    /// Send a message to an agent with sender identity context from a channel.
+    ///
+    /// The sender context (channel name, user ID, display name) is injected into
+    /// the agent's system prompt so it knows who is talking and from which channel.
+    pub async fn send_message_with_sender_context(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> KernelResult<AgentLoopResult> {
+        let handle: Option<Arc<dyn KernelHandle>> = self
+            .self_handle
+            .get()
+            .and_then(|w| w.upgrade())
+            .map(|arc| arc as Arc<dyn KernelHandle>);
+        self.send_message_full(agent_id, message, handle, None, Some(sender))
+            .await
+    }
+
+    /// Send a multimodal message with sender identity context from a channel.
+    pub async fn send_message_with_blocks_and_sender(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+        sender: &SenderContext,
+    ) -> KernelResult<AgentLoopResult> {
+        let handle: Option<Arc<dyn KernelHandle>> = self
+            .self_handle
+            .get()
+            .and_then(|w| w.upgrade())
+            .map(|arc| arc as Arc<dyn KernelHandle>);
+        self.send_message_full(agent_id, message, handle, Some(blocks), Some(sender))
+            .await
+    }
+
     /// Send a message with an optional kernel handle for inter-agent tools.
     pub async fn send_message_with_handle(
         &self,
@@ -1720,7 +1757,7 @@ impl LibreFangKernel {
         message: &str,
         kernel_handle: Option<Arc<dyn KernelHandle>>,
     ) -> KernelResult<AgentLoopResult> {
-        self.send_message_with_handle_and_blocks(agent_id, message, kernel_handle, None)
+        self.send_message_full(agent_id, message, kernel_handle, None, None)
             .await
     }
 
@@ -1739,6 +1776,23 @@ impl LibreFangKernel {
         message: &str,
         kernel_handle: Option<Arc<dyn KernelHandle>>,
         content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+    ) -> KernelResult<AgentLoopResult> {
+        self.send_message_full(agent_id, message, kernel_handle, content_blocks, None)
+            .await
+    }
+
+    /// Internal: send a message with all optional parameters (content blocks + sender context).
+    ///
+    /// This is the unified entry point for all message dispatch. When `sender_context`
+    /// is provided, the agent's system prompt includes the sender's identity (channel,
+    /// user ID, display name) so the agent knows who is talking and from where.
+    async fn send_message_full(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn KernelHandle>>,
+        content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+        sender_context: Option<&SenderContext>,
     ) -> KernelResult<AgentLoopResult> {
         // Acquire per-agent lock to serialize concurrent messages for the same agent.
         // This prevents session corruption when multiple messages arrive in quick
@@ -1775,8 +1829,15 @@ impl LibreFangKernel {
             }
             _ => {
                 // Default: LLM agent loop (builtin:chat or any unrecognized module)
-                self.execute_llm_agent(&entry, agent_id, message, kernel_handle, content_blocks)
-                    .await
+                self.execute_llm_agent(
+                    &entry,
+                    agent_id,
+                    message,
+                    kernel_handle,
+                    content_blocks,
+                    sender_context,
+                )
+                .await
             }
         };
 
@@ -2920,6 +2981,7 @@ impl LibreFangKernel {
         message: &str,
         kernel_handle: Option<Arc<dyn KernelHandle>>,
         content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+        sender_context: Option<&SenderContext>,
     ) -> KernelResult<AgentLoopResult> {
         // Check metering quota before starting
         self.metering
@@ -3036,7 +3098,9 @@ impl LibreFangKernel {
                         .and_then(|(s, _)| s)
                 },
                 user_name,
-                channel_type: None,
+                channel_type: sender_context.map(|s| s.channel.clone()),
+                sender_display_name: sender_context.map(|s| s.display_name.clone()),
+                sender_user_id: sender_context.map(|s| s.user_id.clone()),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -37,6 +37,10 @@ pub struct PromptContext {
     pub user_name: Option<String>,
     /// Channel type (telegram, discord, web, etc.).
     pub channel_type: Option<String>,
+    /// Sender's display name (from channel message).
+    pub sender_display_name: Option<String>,
+    /// Sender's platform user ID (from channel message).
+    pub sender_user_id: Option<String>,
     /// Whether this agent was spawned as a subagent.
     pub is_subagent: bool,
     /// Whether this agent has autonomous config.
@@ -144,7 +148,11 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
     // Section 9 — Channel Awareness (skip for subagents)
     if !ctx.is_subagent {
         if let Some(ref channel) = ctx.channel_type {
-            sections.push(build_channel_section(channel));
+            sections.push(build_channel_section(
+                channel,
+                ctx.sender_display_name.as_deref(),
+                ctx.sender_user_id.as_deref(),
+            ));
         }
     }
 
@@ -407,7 +415,11 @@ fn build_user_section(user_name: Option<&str>) -> String {
     }
 }
 
-fn build_channel_section(channel: &str) -> String {
+fn build_channel_section(
+    channel: &str,
+    sender_name: Option<&str>,
+    sender_id: Option<&str>,
+) -> String {
     let (limit, hints) = match channel {
         "telegram" => (
             "4096",
@@ -436,11 +448,27 @@ fn build_channel_section(channel: &str) -> String {
         "teams" => ("28000", "Use Teams-compatible markdown."),
         _ => ("4096", "Use markdown formatting where supported."),
     };
-    format!(
+    let mut section = format!(
         "## Channel\n\
          You are responding via {channel}. Keep messages under {limit} chars.\n\
          {hints}"
-    )
+    );
+    // Append sender identity when available from channel bridge
+    match (sender_name, sender_id) {
+        (Some(name), Some(id)) => {
+            section.push_str(&format!(
+                "\nThe current message is from user \"{name}\" (platform ID: {id})."
+            ));
+        }
+        (Some(name), None) => {
+            section.push_str(&format!("\nThe current message is from user \"{name}\"."));
+        }
+        (None, Some(id)) => {
+            section.push_str(&format!("\nThe current message is from platform ID: {id}."));
+        }
+        (None, None) => {}
+    }
+    section
 }
 
 fn build_peer_agents_section(self_name: &str, peers: &[(String, String, String)]) -> String {


### PR DESCRIPTION
## Summary
- Add `SenderContext` struct with channel name, user ID, and display name
- Pass sender identity through channel bridge to kernel message handling
- Inject sender info into agent system prompt so agents know who is talking
- Update channel adapters to extract and forward sender metadata

Closes #300

## Test plan
- [ ] Send a message via Slack/Telegram/Discord to the bot
- [ ] Verify the agent's context includes sender identity
- [ ] Ask the agent "who am I?" and verify it knows the sender's name/ID