### PR TITLE
fix: send empty object instead of null for parameterless tool calls (fixes #918)

### DIFF
--- a/crates/librefang-runtime/src/drivers/anthropic.rs
+++ b/crates/librefang-runtime/src/drivers/anthropic.rs
@@ -579,13 +579,13 @@ impl LlmDriver for AnthropicDriver {
 /// When a tool has no parameters the value may be `null` (e.g. from
 /// `Value::default()` or a missing field); this helper normalises it to `{}`.
 fn ensure_object(v: serde_json::Value) -> serde_json::Value {
-    if v.is_object() {
-        v
-    } else {
-        if !v.is_null() {
-            warn!(value = ?v, "Tool input was not an object or null, replacing with empty object");
+    match &v {
+        serde_json::Value::Object(_) => v,
+        serde_json::Value::Null => serde_json::json!({}),
+        other => {
+            warn!(value = ?other, "Tool input was not an object or null, replacing with empty object");
+            serde_json::json!({})
         }
-        serde_json::json!({})
     }
 }
 
@@ -781,6 +781,13 @@ mod tests {
         let input = serde_json::json!({"query": "rust lang"});
         let result = ensure_object(input.clone());
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_ensure_object_non_object_becomes_empty_object() {
+        assert_eq!(ensure_object(serde_json::json!("string")), serde_json::json!({}));
+        assert_eq!(ensure_object(serde_json::json!(42)), serde_json::json!({}));
+        assert_eq!(ensure_object(serde_json::json!([1, 2, 3])), serde_json::json!({}));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/drivers/openai.rs
+++ b/crates/librefang-runtime/src/drivers/openai.rs
@@ -1526,7 +1526,7 @@ fn parse_groq_failed_tool_call(body: &str) -> Option<CompletionResponse> {
 
         // Parse args as JSON Value
         let args_value: serde_json::Value =
-            serde_json::from_str(args).unwrap_or(serde_json::json!({}));
+            ensure_object(serde_json::from_str(args).unwrap_or_default());
 
         tool_calls.push(ToolCall {
             id: format!("groq_recovered_{}", tool_calls.len()),
@@ -1574,13 +1574,13 @@ fn parse_groq_failed_tool_call(body: &str) -> Option<CompletionResponse> {
 /// has no parameters the deserialized value may be `null` (e.g. from
 /// `Value::default()` on empty/invalid input); this helper normalises it to `{}`.
 fn ensure_object(v: serde_json::Value) -> serde_json::Value {
-    if v.is_object() {
-        v
-    } else {
-        if !v.is_null() {
-            warn!(value = ?v, "Tool input was not an object or null, replacing with empty object");
+    match &v {
+        serde_json::Value::Object(_) => v,
+        serde_json::Value::Null => serde_json::json!({}),
+        other => {
+            warn!(value = ?other, "Tool input was not an object or null, replacing with empty object");
+            serde_json::json!({})
         }
-        serde_json::json!({})
     }
 }
 
@@ -1615,6 +1615,17 @@ mod tests {
         assert!(result.is_some());
         let resp = result.unwrap();
         assert_eq!(resp.tool_calls[0].name, "shell_exec");
+    }
+
+    #[test]
+    fn test_ensure_object_null_becomes_empty_object() {
+        assert_eq!(ensure_object(serde_json::Value::Null), serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_ensure_object_preserves_existing_object() {
+        let obj = serde_json::json!({"key": "value"});
+        assert_eq!(ensure_object(obj.clone()), obj);
     }
 
     // ----- rejects_temperature tests -----


### PR DESCRIPTION
## Summary
- Send empty object `{}` instead of `null` for parameterless tool calls to Anthropic API

## Test plan
- [ ] Verify parameterless tools work with Claude models