### PR TITLE
fix: don't break streaming bridge on intermediate ContentComplete

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -175,7 +175,18 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                             break; // receiver dropped
                         }
                     }
-                    StreamEvent::ContentComplete { .. } => break,
+                    StreamEvent::ContentComplete { .. } => {
+                        // Do NOT break here. ContentComplete fires at the end of each
+                        // LLM turn (iteration), not at the end of the entire agent loop.
+                        // In a multi-iteration scenario — e.g. the router agent's first
+                        // turn is a tool call (no text) and the second turn contains the
+                        // actual text response — breaking here would cause us to exit
+                        // before the text-bearing iteration is even reached.
+                        //
+                        // The loop naturally terminates when `event_rx.recv()` returns
+                        // `None`, which happens when the kernel drops the sender after
+                        // the full agent loop completes.
+                    }
                     _ => {
                         // ToolUseStart, ToolInputDelta, ThinkingDelta, etc. — skip
                         debug!("Streaming bridge: skipping non-text event");


### PR DESCRIPTION
## Summary

- Fix streaming bridge breaking on first `ContentComplete` event, which drops all subsequent text from multi-iteration agent loops
- When the router agent's first LLM turn is a tool call (no text), `ContentComplete` fires after that turn. The bridge previously broke out of the loop, never forwarding the actual text response from the second iteration
- This caused Telegram (and other streaming-capable channels) to receive empty responses whenever the agent dispatched via tool calls before replying

## Root Cause

In `channel_bridge.rs` `send_message_streaming()`, the `StreamEvent::ContentComplete` arm had `break`, terminating the event loop after the first LLM iteration. `ContentComplete` fires per-iteration, not per-agent-loop. The sender is only dropped when the full agent loop finishes, so the correct behavior is to let `event_rx.recv()` return `None` naturally.

## Test plan

- [ ] Send a greeting message via Telegram → should still get a direct reply (single iteration, no tool call)
- [ ] Send a question that triggers router dispatch (tool call) → should now receive the text response from the second iteration
- [ ] Verify streaming progressive updates still work for single-turn responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)