### PR TITLE
fix: correct ModelCatalog import path in providers route

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -252,7 +252,7 @@ fn attach_probe_result(
     entry: &mut serde_json::Value,
     probe: &librefang_runtime::provider_health::ProbeResult,
     provider_id: &str,
-    catalog: &std::sync::RwLock<librefang_types::model_catalog::ModelCatalog>,
+    catalog: &std::sync::RwLock<librefang_runtime::model_catalog::ModelCatalog>,
 ) {
     entry["is_local"] = serde_json::json!(true);
     entry["reachable"] = serde_json::json!(probe.reachable);
@@ -433,7 +433,12 @@ pub async fn get_provider(
         )
         .await;
 
-        attach_probe_result(&mut entry, &probe, &provider.id, &state.kernel.model_catalog);
+        attach_probe_result(
+            &mut entry,
+            &probe,
+            &provider.id,
+            &state.kernel.model_catalog,
+        );
     } else if librefang_runtime::provider_health::is_local_provider(&provider.id) {
         entry["is_local"] = serde_json::json!(true);
     }


### PR DESCRIPTION
## Summary
- Fix broken `ModelCatalog` import: `librefang_types::model_catalog::ModelCatalog` → `librefang_runtime::model_catalog::ModelCatalog`
- This was introduced in #1090 and breaks CI for all PRs

## Test plan
- [x] Fixes compilation error on main