### PR TITLE
ci: bump setup-python v5→v6 and create-pull-request v7→v8

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.WEBSITE_REPO_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create PR with updated SVG
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           branch: chore/update-contributors

--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.WEBSITE_REPO_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create PR with updated SVG
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           branch: chore/update-star-history


### PR DESCRIPTION
## Summary
- Bump `actions/setup-python` from v5 to v6 in 3 workflows
- Bump `peter-evans/create-pull-request` from v7 to v8 in 2 workflows
- Fixes Node.js 20 deprecation warnings (Node.js 20 actions deprecated, forced to Node.js 24 starting June 2026)

## Files changed
- `.github/workflows/update-star-history.yml`
- `.github/workflows/update-contributors.yml`
- `.github/workflows/release-sdk.yml`