### PR TITLE
fix: resolve clippy warnings, test failures, and add agent list validation

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -600,7 +600,17 @@ pub async fn list_agents(
     let total = agents.len();
 
     // -- Sorting --
+    const VALID_SORT_FIELDS: &[&str] = &["name", "created_at", "last_active", "state"];
     let sort_field = params.sort.as_deref().unwrap_or("name");
+    if !VALID_SORT_FIELDS.contains(&sort_field) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("Invalid sort field: '{}'. Valid fields: {:?}", sort_field, VALID_SORT_FIELDS)
+            })),
+        )
+            .into_response();
+    }
     let descending = params
         .order
         .as_deref()
@@ -623,8 +633,9 @@ pub async fn list_agents(
 
     // -- Pagination --
     let offset = params.offset.unwrap_or(0);
-    let agents: Vec<librefang_types::agent::AgentEntry> = if let Some(limit) = params.limit {
-        agents.into_iter().skip(offset).take(limit).collect()
+    let limit = params.limit.map(|l| l.min(100));
+    let agents: Vec<librefang_types::agent::AgentEntry> = if let Some(lim) = limit {
+        agents.into_iter().skip(offset).take(lim).collect()
     } else {
         agents.into_iter().skip(offset).collect()
     };
@@ -638,8 +649,9 @@ pub async fn list_agents(
         items,
         total,
         offset,
-        limit: params.limit,
+        limit,
     })
+    .into_response()
 }
 
 /// Resolve uploaded file attachments into ContentBlock::Image blocks.

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -91,6 +91,7 @@ pub struct WorkflowStep {
     /// The prompt template. Use `{{input}}` for previous output, `{{var_name}}` for variables.
     pub prompt_template: String,
     /// Execution mode for this step.
+    #[serde(default)]
     pub mode: StepMode,
     /// Maximum time for this step in seconds (default: 120).
     #[serde(default = "default_timeout")]
@@ -352,9 +353,9 @@ impl WorkflowEngine {
     /// Returns `true` if the workflow existed and was updated.
     pub async fn update_workflow(&self, id: WorkflowId, mut workflow: Workflow) -> bool {
         let mut workflows = self.workflows.write().await;
-        if workflows.contains_key(&id) {
+        if let std::collections::hash_map::Entry::Occupied(mut entry) = workflows.entry(id) {
             workflow.id = id; // ensure ID stays the same
-            workflows.insert(id, workflow);
+            entry.insert(workflow);
             true
         } else {
             false
@@ -1688,7 +1689,7 @@ name = "agent-a"
     fn test_load_from_dir_sync_duplicate_workflow() {
         let dir = tempfile::tempdir().unwrap();
         let id = Uuid::new_v4();
-        let toml1 = format!(
+        let _toml1 = format!(
             r#"
 [id]
 # WorkflowId is a newtype over Uuid, serialised transparently

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -491,14 +491,12 @@ impl SemanticStore {
             .prepare("SELECT embedding FROM memories WHERE id = ?1 AND deleted = 0")
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         for id in ids {
-            if let Ok(bytes) = stmt.query_row(rusqlite::params![*id], |row| {
+            if let Ok(Some(b)) = stmt.query_row(rusqlite::params![*id], |row| {
                 let b: Option<Vec<u8>> = row.get(0)?;
                 Ok(b)
             }) {
-                if let Some(b) = bytes {
-                    if !b.is_empty() {
-                        map.insert(id.to_string(), embedding_from_bytes(&b));
-                    }
+                if !b.is_empty() {
+                    map.insert(id.to_string(), embedding_from_bytes(&b));
                 }
             }
         }
@@ -912,14 +910,12 @@ impl VectorStore for SqliteVectorStore {
             .prepare("SELECT embedding FROM memories WHERE id = ?1 AND deleted = 0")
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         for id in ids {
-            if let Ok(bytes) = stmt.query_row(rusqlite::params![*id], |row| {
+            if let Ok(Some(b)) = stmt.query_row(rusqlite::params![*id], |row| {
                 let b: Option<Vec<u8>> = row.get(0)?;
                 Ok(b)
             }) {
-                if let Some(b) = bytes {
-                    if !b.is_empty() {
-                        map.insert(id.to_string(), embedding_from_bytes(&b));
-                    }
+                if !b.is_empty() {
+                    map.insert(id.to_string(), embedding_from_bytes(&b));
                 }
             }
         }

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -828,8 +828,7 @@ mod tests {
         std::fs::create_dir_all(&plugin_dir).unwrap();
 
         // Test manifest parsing from scaffold content
-        let manifest_content = format!(
-            r#"name = "test-scaffold"
+        let manifest_content = r#"name = "test-scaffold"
 version = "0.1.0"
 description = "Test scaffold"
 author = ""
@@ -837,9 +836,8 @@ author = ""
 [hooks]
 ingest = "hooks/ingest.py"
 after_turn = "hooks/after_turn.py"
-"#
-        );
-        let manifest: PluginManifest = toml::from_str(&manifest_content).unwrap();
+"#;
+        let manifest: PluginManifest = toml::from_str(manifest_content).unwrap();
         assert_eq!(manifest.name, "test-scaffold");
         assert_eq!(manifest.version, "0.1.0");
         assert_eq!(manifest.hooks.ingest.as_deref(), Some("hooks/ingest.py"));

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -908,28 +908,28 @@ mod tests {
 
     #[test]
     fn test_channel_telegram() {
-        let section = build_channel_section("telegram");
+        let section = build_channel_section("telegram", None, None);
         assert!(section.contains("4096"));
         assert!(section.contains("Telegram"));
     }
 
     #[test]
     fn test_channel_discord() {
-        let section = build_channel_section("discord");
+        let section = build_channel_section("discord", None, None);
         assert!(section.contains("2000"));
         assert!(section.contains("Discord"));
     }
 
     #[test]
     fn test_channel_irc() {
-        let section = build_channel_section("irc");
+        let section = build_channel_section("irc", None, None);
         assert!(section.contains("512"));
         assert!(section.contains("plain text"));
     }
 
     #[test]
     fn test_channel_unknown_gets_default() {
-        let section = build_channel_section("smoke_signal");
+        let section = build_channel_section("smoke_signal", None, None);
         assert!(section.contains("4096"));
         assert!(section.contains("smoke_signal"));
     }


### PR DESCRIPTION
## Summary
- Fix 5 clippy warnings across semantic.rs, workflow.rs, plugin_manager.rs (collapsible_match, contains_key+insert, useless format!, needless borrow)
- Add `#[serde(default)]` to `WorkflowStep.mode` field — fixes 4 workflow deserialization test failures
- Fix `build_channel_section` test calls with missing sender_name/sender_id args
- Add sort field validation (returns 400 for invalid fields) and limit clamping (max 100) to agent list endpoint

## Test plan
- [x] `cargo build --workspace --lib` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass (2700+, 0 failures)