### PR TITLE
release: v0.6.0-20260318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-03-18
+
+### Added
+
+- Add filtering, pagination and sorting to agent list endpoint (#399) (@houko)
+- Add HTTP proxy support for all outbound connections (#415) (@houko)
+- Auto-register local workflow definitions at daemon startup (#418) (@houko)
+- Add multimedia support for Telegram and Discord channels (#422) (@houko)
+- Add Telegram streaming output with progressive message updates (#423) (@houko)
+- Add NVIDIA NIM as dedicated LLM provider (#428) (@houko)
+- Add MQTT pub/sub channel adapter for IoT integration (#430) (@houko)
+- Add workflow trigger support to cron jobs (#431) (@houko)
+- Add hierarchical Goals system with REST API and dashboard UI (#434) (@houko)
+- Bundle Python and Node.js runtimes in Docker image (#334) (#436) (@houko)
+- Add Vertex AI driver with OAuth2 authentication (#448) (@houko)
+- Add GET /api/providers/:name endpoint (#1090) (@houko)
+- Add GET /api/workflows/:id endpoint (#1091) (@houko)
+- Add GET /api/channels/:name endpoint (#1092) (@houko)
+- Add GET /api/cron/jobs/:id endpoint (#1093) (@houko)
+- Add GET /api/mcp_servers/:name endpoint (#1094) (@houko)
+- Add PUT/DELETE /api/workflows/:id endpoints (#1095) (@houko)
+- Add DELETE /api/agents/:id/files/:filename endpoint (#1097) (@houko)
+- Add Workflow variant to CronAction for cron-triggered workflows (#1102) (@houko)
+- Propagate sender identity from channels to agent context (#1105) (@houko)
+- Auto-register local workflow definitions at daemon startup (fixes #382) (#1107) (@houko)
+- Implement mem0-style proactive memory system (#1111) (@houko)
+- Web search key rotation, data-driven hand routing, and health-aware LLM fallback (#1127) (@houko)
+- Improve context engine accuracy and resilience (#1146) (@houko)
+- Add context engine plugin management system (#1152) (@houko)
+- Support multiple custom plugin registries (#1154) (@houko)
+
+### Fixed
+
+- Extract thread_ts from Slack events for thread replies (#1099) (@houko)
+- Add mime_type to ChannelContent::Image for correct vision handling (#1100) (@houko)
+- Use SHA-256 for Nostr pubkey derivation instead of DefaultHasher (#1101) (@houko)
+- Prevent silent message dropping in Telegram dispatch (#1103) (@houko)
+- Handle thought chunks in Gemini streaming for thinking models (#1104) (@houko)
+- Don't break streaming bridge on intermediate ContentComplete (#1126) (@houko)
+- Fall back to bundled Mozilla CA roots when system certs unavailable (#1142) (@houko)
+- Upstream parity — 10 bug fixes from release comparison (#1143) (@houko)
+- Resolve clippy warnings, test failures, and add agent list validation (#1162) (@houko)
+
+### Documentation
+
+- Slim down README (#1124) (@houko)
+
+### Maintenance
+
+- Skip version bump PRs in changelog generation (#1123) (@houko)
+- Bump setup-python v5→v6 and create-pull-request v7→v8 (#1161) (@houko)
+
+### Other
+
+- V0.5.7-20260318 (#1116) (@houko)
+
 ## [0.5.7] - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "async-trait",
  "axum",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "aes",
  "async-trait",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "chrono",
  "hex",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9967,7 +9967,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.7-20260318"
+version = "0.6.0-20260318"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-0.6.0.md
+++ b/articles/release-0.6.0.md
@@ -1,0 +1,91 @@
+```markdown
+---
+title: "LibreFang 0.6.0 Released"
+published: true
+description: "LibreFang v0.6.0 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v0.6.0-20260318
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 0.6.0 Released
+
+We're thrilled to release **LibreFang v0.6.0**—packed with enterprise-grade features, expanded LLM provider support, and a more powerful API for building intelligent agents. Here's what changed.
+
+## 🧠 Memory & Context Intelligence
+
+LibreFang now ships with **mem0-style proactive memory**, letting agents learn and evolve from past conversations. We've also significantly improved the **context engine**—it's now more accurate, more resilient, and ships with a plugin management system that lets you customize how agents retrieve and reason over context. For advanced use cases, you can register multiple custom plugin registries.
+
+## 🤖 LLM Provider Ecosystem
+
+This release dramatically expands LLM flexibility:
+
+- **NVIDIA NIM** is now a first-class provider—ideal for organizations running local or on-prem inference
+- **Vertex AI** joins the lineup with full OAuth2 authentication support
+- **Intelligent LLM fallback**: Web search key rotation, data-driven routing, and health-aware LLM selection ensure your agents gracefully degrade if a provider goes down
+
+## 📡 Channels & Real-Time Messaging
+
+Agents can now reach more users through richer channels:
+
+- **Telegram streaming** with progressive message updates (no more "typing..." delays)
+- **Multimedia support** for Telegram and Discord—images, video, audio all work seamlessly
+- **Improved dispatch reliability**—silent message drops are a thing of the past
+- **Sender identity propagation**—channels now forward the original sender's identity to agent context, enabling personalized responses
+
+## ⚙️ Workflows & Automation Overhaul
+
+Workflows are now deeply integrated with your infrastructure:
+
+- **Cron-triggered workflows**: Schedule agents to wake up on a timer and execute tasks automatically
+- **Auto-registration at startup**: Local workflow definitions load without manual wiring
+- **New workflow REST endpoints**: Full CRUD operations on workflows with `/api/workflows/:id`
+
+## 📊 API Expansion
+
+We added **8 new REST endpoints** to give you finer-grained control:
+
+- `GET /api/providers/:name`, `GET /api/workflows/:id`, `GET /api/channels/:name`, `GET /api/cron/jobs/:id`, `GET /api/mcp_servers/:name`
+- `PUT/DELETE /api/workflows/:id` for workflow lifecycle management
+- `DELETE /api/agents/:id/files/:filename` for file cleanup
+- **Agent list improvements**: filtering, pagination, and sorting for handling thousands of agents
+
+## 🌐 Infrastructure & Developer Experience
+
+- **HTTP proxy support** for all outbound connections (essential for enterprise environments)
+- **Docker image now bundles Python and Node.js runtimes**—no more installing dependencies after pulling the image
+- **Streaming improvements**: Better handling of chunked responses from thinking models (Gemini's `o1` style)
+- **SSL/TLS reliability**: Falls back to bundled Mozilla CA roots if system certificates are unavailable
+
+## 🔧 Bug Fixes & Maintenance
+
+- Fixed Slack thread detection for proper conversation threading
+- Corrected MIME type handling for vision models on images
+- SHA-256 Nostr pubkey derivation for security compliance
+- 10 upstream parity bug fixes to stay in sync with the broader ecosystem
+- Full validation of agent list operations
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v0.6.0-20260318)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)
+```

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.5.7-20260318",
+  "version": "0.6.0-20260318",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.5.7-20260318",
+  "version": "0.6.0-20260318",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.5.7-20260318",
+  "version": "0.6.0-20260318",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.5.7-20260318",
+    version="0.6.0-20260318",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.6.0-20260318


### Added

- Add filtering, pagination and sorting to agent list endpoint (#399) (@houko)
- Add HTTP proxy support for all outbound connections (#415) (@houko)
- Auto-register local workflow definitions at daemon startup (#418) (@houko)
- Add multimedia support for Telegram and Discord channels (#422) (@houko)
- Add Telegram streaming output with progressive message updates (#423) (@houko)
- Add NVIDIA NIM as dedicated LLM provider (#428) (@houko)
- Add MQTT pub/sub channel adapter for IoT integration (#430) (@houko)
- Add workflow trigger support to cron jobs (#431) (@houko)
- Add hierarchical Goals system with REST API and dashboard UI (#434) (@houko)
- Bundle Python and Node.js runtimes in Docker image (#334) (#436) (@houko)
- Add Vertex AI driver with OAuth2 authentication (#448) (@houko)
- Add GET /api/providers/:name endpoint (#1090) (@houko)
- Add GET /api/workflows/:id endpoint (#1091) (@houko)
- Add GET /api/channels/:name endpoint (#1092) (@houko)
- Add GET /api/cron/jobs/:id endpoint (#1093) (@houko)
- Add GET /api/mcp_servers/:name endpoint (#1094) (@houko)
- Add PUT/DELETE /api/workflows/:id endpoints (#1095) (@houko)
- Add DELETE /api/agents/:id/files/:filename endpoint (#1097) (@houko)
- Add Workflow variant to CronAction for cron-triggered workflows (#1102) (@houko)
- Propagate sender identity from channels to agent context (#1105) (@houko)
- Auto-register local workflow definitions at daemon startup (fixes #382) (#1107) (@houko)
- Implement mem0-style proactive memory system (#1111) (@houko)
- Web search key rotation, data-driven hand routing, and health-aware LLM fallback (#1127) (@houko)
- Improve context engine accuracy and resilience (#1146) (@houko)
- Add context engine plugin management system (#1152) (@houko)
- Support multiple custom plugin registries (#1154) (@houko)

### Fixed

- Extract thread_ts from Slack events for thread replies (#1099) (@houko)
- Add mime_type to ChannelContent::Image for correct vision handling (#1100) (@houko)
- Use SHA-256 for Nostr pubkey derivation instead of DefaultHasher (#1101) (@houko)
- Prevent silent message dropping in Telegram dispatch (#1103) (@houko)
- Handle thought chunks in Gemini streaming for thinking models (#1104) (@houko)
- Don't break streaming bridge on intermediate ContentComplete (#1126) (@houko)
- Fall back to bundled Mozilla CA roots when system certs unavailable (#1142) (@houko)
- Upstream parity — 10 bug fixes from release comparison (#1143) (@houko)
- Resolve clippy warnings, test failures, and add agent list validation (#1162) (@houko)

### Documentation

- Slim down README (#1124) (@houko)

### Maintenance

- Skip version bump PRs in changelog generation (#1123) (@houko)
- Bump setup-python v5→v6 and create-pull-request v7→v8 (#1161) (@houko)

### Other

- V0.5.7-20260318 (#1116) (@houko)