### PR TITLE
fix: remove markdown fence wrapper from dev.to articles

### DIFF
--- a/.github/workflows/devto-publish.yml
+++ b/.github/workflows/devto-publish.yml
@@ -81,15 +81,17 @@ jobs:
 
             if [ -n "$EXISTING" ]; then
               echo "Updating: $TITLE (id=$EXISTING)"
-              curl -s -X PUT "https://dev.to/api/articles/$EXISTING" \
+              RESP=$(curl -s -X PUT "https://dev.to/api/articles/$EXISTING" \
                 -H "api-key: $DEVTO_API_KEY" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD" | python3 -c "import json,sys;print(json.load(sys.stdin).get('url',''))" 2>/dev/null
+                -d "$PAYLOAD")
+              echo "$RESP" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('url',''))" 2>/dev/null || echo "Warning: failed to parse response for '$TITLE'"
             else
               echo "Creating: $TITLE"
-              curl -s -X POST "https://dev.to/api/articles" \
+              RESP=$(curl -s -X POST "https://dev.to/api/articles" \
                 -H "api-key: $DEVTO_API_KEY" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD" | python3 -c "import json,sys;print(json.load(sys.stdin).get('url',''))" 2>/dev/null
+                -d "$PAYLOAD")
+              echo "$RESP" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('url',''))" 2>/dev/null || echo "Warning: failed to parse response for '$TITLE'"
             fi
           done

--- a/articles/release-0.5.6.md
+++ b/articles/release-0.5.6.md
@@ -1,4 +1,3 @@
-```markdown
 ---
 title: "LibreFang 0.5.6 Released"
 published: true
@@ -55,4 +54,3 @@ pip install librefang-sdk
 - [GitHub](https://github.com/librefang/librefang)
 - [Discord](https://discord.gg/DzTYqAZZmc)
 - [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)
-```

--- a/articles/release-0.5.7.md
+++ b/articles/release-0.5.7.md
@@ -1,4 +1,3 @@
-```markdown
 ---
 title: "LibreFang 0.5.7 Released"
 published: true
@@ -70,4 +69,3 @@ pip install librefang-sdk
 - [GitHub](https://github.com/librefang/librefang)
 - [Discord](https://discord.gg/DzTYqAZZmc)
 - [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)
-```

--- a/articles/release-0.6.0.md
+++ b/articles/release-0.6.0.md
@@ -1,4 +1,3 @@
-```markdown
 ---
 title: "LibreFang 0.6.0 Released"
 published: true
@@ -88,4 +87,3 @@ pip install librefang-sdk
 - [GitHub](https://github.com/librefang/librefang)
 - [Discord](https://discord.gg/DzTYqAZZmc)
 - [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)
-```


### PR DESCRIPTION
## Summary
- Remove `\`\`\`markdown` / `\`\`\`` wrapper from 3 release articles that broke dev.to publishing
- Add error handling to curl pipelines in devto-publish workflow so one article failure doesn't abort the run

Fixes the "Publish to Dev.to" workflow failure on `chore: bump version to v0.6.0-20260318 (#1164)`.

## Test plan
- [x] Verify article files start with `---` front matter (no code fence)
- [x] Verify workflow has `|| true` fallback on response parsing