### PR TITLE
fix: resolve secret scanning alert for MongoDB example URI

### DIFF
--- a/crates/librefang-extensions/integrations/mongodb.toml
+++ b/crates/librefang-extensions/integrations/mongodb.toml
@@ -13,7 +13,7 @@ args = ["-y", "@mongodb-js/mongodb-mcp-server"]
 [[required_env]]
 name = "MONGODB_URI"
 label = "MongoDB Connection URI"
-help = "A full MongoDB connection string (e.g., mongodb+srv://user:password@cluster.mongodb.net/dbname)"
+help = "A full MongoDB connection string (e.g., mongodb+srv://<user>:<password>@<cluster>.mongodb.net/<dbname>)"
 is_secret = true
 get_url = ""
 


### PR DESCRIPTION
## Summary
- Replace example MongoDB connection URI `mongodb+srv://user:password@cluster.mongodb.net/dbname` with angle-bracket placeholders `<user>:<password>@<cluster>` in the integration help text
- Resolves https://github.com/librefang/librefang/security/secret-scanning/1

This was never a real credential — just a sample in a help string — but replacing it clears the alert.

## Test plan
- [x] Verify the help text still shows a valid URI format example