### PR TITLE
fix: handle paginated response in agents list and chat resolver

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2632,7 +2632,10 @@ fn cmd_agent_list(config: Option<PathBuf>, json: bool) {
             return;
         }
 
-        let agents = body.as_array();
+        let agents = body
+            .get("items")
+            .and_then(|v| v.as_array())
+            .or_else(|| body.as_array());
 
         match agents {
             Some(agents) if agents.is_empty() => println!("{}", i18n::t("agent-no-agents")),

--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -570,7 +570,10 @@ impl StandaloneChat {
     fn resolve_daemon_agent(&mut self, base_url: &str, agent_name: Option<&str>) {
         let client = crate::daemon_client();
         let body = crate::daemon_json(client.get(format!("{base_url}/api/agents")).send());
-        let agents = body.as_array();
+        let agents = body
+            .get("items")
+            .and_then(|v| v.as_array())
+            .or_else(|| body.as_array());
 
         // Try to find by name/id
         let found = match agent_name {


### PR DESCRIPTION
## Summary
- `librefang agents` returned "No agents running" even when 17 agents were active
- `GET /api/agents` returns a `PaginatedResponse` (`{"items": [...], "total": N, ...}`) but `cmd_agent_list()` and `resolve_daemon_agent()` called `body.as_array()` directly, which always returned `None` on an object
- Now extracts from `body["items"]` first, with fallback for plain arrays

## Test plan
- [ ] `librefang agents` shows all running agents
- [ ] `librefang chat` resolves daemon agents correctly
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes