### PR TITLE
fix: resolve agent names to UUIDs in message and kill commands

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -7569,7 +7569,7 @@ fn cmd_memory_set(agent: &str, key: &str, value: &str) {
     } else {
         ui::success(&i18n::t_args(
             "memory-set",
-            &[("key", key), ("agent", agent)],
+            &[("key", key), ("agent", &agent)],
         ));
     }
 }
@@ -7591,7 +7591,7 @@ fn cmd_memory_delete(agent: &str, key: &str) {
     } else {
         ui::success(&i18n::t_args(
             "memory-deleted",
-            &[("key", key), ("agent", agent)],
+            &[("key", key), ("agent", &agent)],
         ));
     }
 }


### PR DESCRIPTION
## Summary
- `librefang message assistant "hello"` returned "Invalid agent ID" because agent name was passed directly to the API which only accepts UUIDs
- Added `resolve_agent_id()` helper that queries `GET /api/agents` and matches by name field, skipping lookup if input is already a valid UUID
- Applied to both `cmd_message()` and `cmd_agent_kill()` daemon paths

## Test plan
- [ ] `librefang message assistant "say hi"` works with agent name
- [ ] `librefang message <uuid> "say hi"` still works with UUID
- [ ] `librefang kill assistant` works with agent name
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes