### PR TITLE
fix: return 409 Conflict when spawning duplicate agent

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -179,11 +179,13 @@ pub async fn spawn_agent(
         ),
         Err(e) => {
             tracing::warn!("Spawn failed: {e}");
-            let t = ErrorTranslator::new(l);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": t.t("api-error-agent-spawn-failed")})),
-            )
+            let status = match &e {
+                librefang_kernel::error::KernelError::LibreFang(
+                    librefang_types::error::LibreFangError::AgentAlreadyExists(_),
+                ) => StatusCode::CONFLICT,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            (status, Json(serde_json::json!({"error": format!("{e}")})))
         }
     }
 }


### PR DESCRIPTION
## Summary
- `librefang agent new coder` returned HTTP 500 when the agent already existed
- The spawn handler mapped all errors to `INTERNAL_SERVER_ERROR` without inspecting the error type
- Now matches `AgentAlreadyExists` → 409 Conflict with the actual error message (e.g. "Agent already exists: coder")

## Test plan
- [ ] `librefang agent new <existing>` returns 409 with clear error message instead of 500
- [ ] `librefang agent new <new-template>` still returns 201 Created
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes