### PR TITLE
fix: parse model aliases from API response correctly

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6854,7 +6854,18 @@ fn cmd_models_aliases(json: bool) {
             );
             return;
         }
-        if let Some(obj) = body.as_object() {
+        if let Some(arr) = body.get("aliases").and_then(|v| v.as_array()) {
+            println!("{:<30} RESOLVES TO", "ALIAS");
+            println!("{}", "-".repeat(60));
+            for entry in arr {
+                println!(
+                    "{:<30} {}",
+                    entry["alias"].as_str().unwrap_or("?"),
+                    entry["model_id"].as_str().unwrap_or("?"),
+                );
+            }
+        } else if let Some(obj) = body.as_object() {
+            // Fallback for plain {alias: model_id} format
             println!("{:<30} RESOLVES TO", "ALIAS");
             println!("{}", "-".repeat(60));
             for (alias, target) in obj {


### PR DESCRIPTION
## Summary
- `librefang models aliases` displayed "aliases → ?" and "total → ?" instead of actual alias mappings
- The API returns `{"aliases": [{"alias": "...", "model_id": "..."}], "total": N}` but the CLI treated the top-level object as a flat alias→model map
- Now correctly extracts the `aliases` array and reads `alias`/`model_id` fields from each entry

## Test plan
- [ ] `librefang models aliases` shows correct alias→model mappings
- [ ] `librefang models aliases --json` still works
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes