### PR TITLE
fix: include last_active in agent detail endpoint

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1289,6 +1289,7 @@ pub async fn get_agent(
             "mode": entry.mode,
             "profile": entry.manifest.profile,
             "created_at": entry.created_at.to_rfc3339(),
+            "last_active": entry.last_active.to_rfc3339(),
             "session_id": entry.session_id.0.to_string(),
             "model": {
                 "provider": entry.manifest.model.provider,


### PR DESCRIPTION
## Summary
- `GET /api/agents/{id}` was missing the `last_active` field
- `GET /api/agents` (list) already includes it, making the two responses inconsistent
- Dashboard and CLI tools need this field to show agent activity status

## Test plan
- [ ] `curl /api/agents/{id}` response now includes `last_active` timestamp
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes