### PR TITLE
fix: A2A agent card uses service config instead of random agent

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -148,25 +148,48 @@ pub async fn a2a_agent_card(State(state): State<Arc<AppState>>) -> impl IntoResp
     let agents = state.kernel.registry.list();
     let base_url = format!("http://{}", state.kernel.config.api_listen);
 
-    if let Some(first) = agents.first() {
-        let card = librefang_runtime::a2a::build_agent_card(&first.manifest, &base_url);
-        (
-            StatusCode::OK,
-            Json(serde_json::to_value(&card).unwrap_or_default()),
-        )
+    // Use service-level A2A config for the well-known card when available.
+    let (service_name, service_description) = if let Some(ref a2a_cfg) = state.kernel.config.a2a {
+        let name = if a2a_cfg.name.is_empty() {
+            "LibreFang Agent OS".to_string()
+        } else {
+            a2a_cfg.name.clone()
+        };
+        (name, a2a_cfg.description.clone())
     } else {
-        let card = serde_json::json!({
-            "name": "librefang",
-            "description": "LibreFang Agent OS — no agents spawned yet",
-            "url": format!("{base_url}/a2a"),
-            "version": librefang_types::VERSION,
-            "capabilities": { "streaming": true },
-            "skills": [],
-            "defaultInputModes": ["text"],
-            "defaultOutputModes": ["text"],
-        });
-        (StatusCode::OK, Json(card))
-    }
+        (
+            "LibreFang Agent OS".to_string(),
+            String::new(),
+        )
+    };
+
+    // Aggregate skills from ALL agents.
+    let skills: Vec<librefang_runtime::a2a::AgentSkill> = agents
+        .iter()
+        .flat_map(|entry| {
+            librefang_runtime::a2a::build_agent_card(&entry.manifest, &base_url).skills
+        })
+        .collect();
+
+    let card = librefang_runtime::a2a::AgentCard {
+        name: service_name,
+        description: service_description,
+        url: format!("{base_url}/a2a"),
+        version: librefang_types::VERSION.to_string(),
+        capabilities: librefang_runtime::a2a::AgentCapabilities {
+            streaming: true,
+            push_notifications: false,
+            state_transition_history: true,
+        },
+        skills,
+        default_input_modes: vec!["text".to_string()],
+        default_output_modes: vec!["text".to_string()],
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(&card).unwrap_or_default()),
+    )
 }
 
 /// GET /a2a/agents — List all A2A agent cards.

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -740,6 +740,8 @@ mod tests {
 
         let config = A2aConfig {
             enabled: true,
+            name: "LibreFang Agent OS".to_string(),
+            description: "Test description".to_string(),
             listen_path: "/a2a".to_string(),
             external_agents: vec![ExternalAgent {
                 name: "other-agent".to_string(),

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1900,12 +1900,22 @@ pub enum McpTransportEntry {
 pub struct A2aConfig {
     /// Whether A2A is enabled.
     pub enabled: bool,
+    /// Service-level display name for the well-known agent card.
+    #[serde(default = "default_a2a_name")]
+    pub name: String,
+    /// Service-level description for the well-known agent card.
+    #[serde(default)]
+    pub description: String,
     /// Path to serve A2A endpoints (default: "/a2a").
     #[serde(default = "default_a2a_path")]
     pub listen_path: String,
     /// External A2A agents to connect to.
     #[serde(default)]
     pub external_agents: Vec<ExternalAgent>,
+}
+
+fn default_a2a_name() -> String {
+    "LibreFang Agent OS".to_string()
 }
 
 fn default_a2a_path() -> String {


### PR DESCRIPTION
## Summary
- `/.well-known/agent.json` was returning a card based on whichever agent happened to be first in the registry (e.g., "lead-hand"), ignoring the `[a2a]` config section
- The `name` and `description` fields from `config.toml` were silently dropped because `A2aConfig` struct lacked them
- Now the service-level agent card correctly uses the configured A2A name/description and aggregates skills from all agents

## Changes
- **`A2aConfig`** (`librefang-types`): Added `name` (default: "LibreFang Agent OS") and `description` fields with `#[serde(default)]`
- **`a2a_agent_card`** handler (`librefang-api`): Uses config name/description, aggregates ALL agents' skills into one card
- Updated test to include new `A2aConfig` fields

## Before/After
**Before:** `/.well-known/agent.json` → `{"name": "lead-hand", "description": "AI lead generation engine..."}`
**After:** `/.well-known/agent.json` → `{"name": "LibreFang Agent OS", "description": "...", "skills": [all agents' skills]}`

## Test plan
- [ ] `curl /.well-known/agent.json` shows configured A2A name/description
- [ ] Skills from all agents are aggregated in the card
- [ ] Existing tests pass with new A2aConfig fields