### PR TITLE
style: fix rustfmt in a2a_agent_card handler

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -157,10 +157,7 @@ pub async fn a2a_agent_card(State(state): State<Arc<AppState>>) -> impl IntoResp
         };
         (name, a2a_cfg.description.clone())
     } else {
-        (
-            "LibreFang Agent OS".to_string(),
-            String::new(),
-        )
+        ("LibreFang Agent OS".to_string(), String::new())
     };
 
     // Aggregate skills from ALL agents.


### PR DESCRIPTION
## Summary
- Fix formatting issue introduced in #1179 merge — `rustfmt` requires the tuple on a single line

One-liner fix: multi-line tuple → single-line tuple in the else branch.