### PR TITLE
fix: budget PUT accepts GET response field names for read-modify-write

### DIFF
--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -168,15 +168,25 @@ pub async fn update_budget(
     let config_ptr = &state.kernel.config as *const librefang_types::config::KernelConfig
         as *mut librefang_types::config::KernelConfig;
 
-    // Apply updates
+    // Apply updates — accept both config field names (max_hourly_usd) and
+    // GET response field names (hourly_limit) so read-modify-write works.
     unsafe {
-        if let Some(v) = body["max_hourly_usd"].as_f64() {
+        if let Some(v) = body["max_hourly_usd"]
+            .as_f64()
+            .or_else(|| body["hourly_limit"].as_f64())
+        {
             (*config_ptr).budget.max_hourly_usd = v;
         }
-        if let Some(v) = body["max_daily_usd"].as_f64() {
+        if let Some(v) = body["max_daily_usd"]
+            .as_f64()
+            .or_else(|| body["daily_limit"].as_f64())
+        {
             (*config_ptr).budget.max_daily_usd = v;
         }
-        if let Some(v) = body["max_monthly_usd"].as_f64() {
+        if let Some(v) = body["max_monthly_usd"]
+            .as_f64()
+            .or_else(|| body["monthly_limit"].as_f64())
+        {
             (*config_ptr).budget.max_monthly_usd = v;
         }
         if let Some(v) = body["alert_threshold"].as_f64() {


### PR DESCRIPTION
## Summary
- The `GET /api/budget` returns `hourly_limit`, `daily_limit`, `monthly_limit` but `PUT /api/budget` only accepted `max_hourly_usd`, `max_daily_usd`, `max_monthly_usd`
- This meant round-tripping a budget read back as a write silently dropped limit changes
- Now accepts both field name conventions (`hourly_limit` / `max_hourly_usd`, etc.)

## Test plan
- [ ] `PUT /api/budget` with `{"monthly_limit": 100}` — verify `monthly_limit` updates
- [ ] `PUT /api/budget` with `{"max_monthly_usd": 200}` — verify backward compat
- [ ] `cargo test --workspace` passes