### PR TITLE
fix: models set sends wrong field name to config/set API

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6996,7 +6996,7 @@ fn cmd_models_set(model: Option<String>) {
     let body = daemon_json(
         client
             .post(format!("{base}/api/config/set"))
-            .json(&serde_json::json!({"key": "default_model.model", "value": model}))
+            .json(&serde_json::json!({"path": "default_model.model", "value": model}))
             .send(),
     );
     if body.get("error").is_some() {


### PR DESCRIPTION
## Summary
- `librefang models set <model>` always fails with "missing 'path' field"
- The CLI sends `{"key": "default_model.model", ...}` but the API expects `{"path": "default_model.model", ...}`
- One-character fix: `"key"` → `"path"`

## Test plan
- [ ] `librefang models set gpt-4o` should succeed (currently fails)
- [ ] `cargo test --workspace` passes