### PR TITLE
fix: CLI cron list reads nested schedule/action fields

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -7166,14 +7166,18 @@ fn cmd_cron_list(json: bool) {
                 "{:<38} {:<16} {:<20} {:<8} {}",
                 j["id"].as_str().unwrap_or("?"),
                 j["agent_id"].as_str().unwrap_or("?"),
-                j["cron_expr"].as_str().unwrap_or("?"),
+                j["schedule"]["expr"]
+                    .as_str()
+                    .or_else(|| j["cron_expr"].as_str())
+                    .unwrap_or("?"),
                 if j["enabled"].as_bool().unwrap_or(false) {
                     "yes"
                 } else {
                     "no"
                 },
-                j["prompt"]
+                j["action"]["message"]
                     .as_str()
+                    .or_else(|| j["prompt"].as_str())
                     .unwrap_or("")
                     .chars()
                     .take(40)


### PR DESCRIPTION
## Summary
- CLI `cron list` was reading flat `cron_expr` and `prompt` fields, but the API returns nested `schedule.expr` and `action.message`
- Added fallback to read both nested and flat field names so the CLI works with the current API response format
- Includes accumulated `cargo fmt` cleanup across multiple route files and locale files

## Test plan
- [ ] `librefang cron list` displays correct cron expression and prompt columns
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] All existing tests pass