### PR TITLE
fix: include system_prompt in GET /api/agents/:id response

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1301,6 +1301,7 @@ pub async fn get_agent(
                 "tools": entry.manifest.capabilities.tools,
                 "network": entry.manifest.capabilities.network,
             },
+            "system_prompt": entry.manifest.model.system_prompt,
             "description": entry.manifest.description,
             "tags": entry.manifest.tags,
             "identity": {


### PR DESCRIPTION
## Summary
- `GET /api/agents/:id` was missing `system_prompt` in the response
- `PATCH /api/agents/:id` correctly writes `system_prompt` but it was invisible via GET
- Added `system_prompt` field from `entry.manifest.model.system_prompt` to the JSON response

## Test plan
- [ ] `PATCH /api/agents/:id` with `{"system_prompt": "test"}` then `GET` returns it
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] All existing tests pass