### PR TITLE
release: v0.6.3-20260319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-03-19
+
+### Added
+
+- Auto-initialize vault during librefang init (#1206) (@houko)
+- Add token consumption metadata and reduce default hands (#1215) (@houko)
+
+### Fixed
+
+- Decrypt encrypted webhook payloads (#1208) (@TechWizard9999)
+- Bootstrap context engine during startup (#1209) (@TechWizard9999)
+- Support target ids in channel test (#1210) (@TechWizard9999)
+- Make shell installer POSIX-compatible for Linux (#1226) (@houko)
+
+### Documentation
+
+- Update contributors (#1214) (@houko)
+
+### Maintenance
+
+- Tidy repo structure (#1211) (@houko)
+
+### Other
+
+- Clean skills (#1212) (@houko)
+
 ## [0.6.2] - 2026-03-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "async-trait",
  "axum",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "aes",
  "async-trait",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "chrono",
  "hex",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9967,7 +9967,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2-20260319"
+version = "0.6.3-20260319"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-0.6.3.md
+++ b/articles/release-0.6.3.md
@@ -1,0 +1,58 @@
+---
+title: "LibreFang 0.6.3 Released"
+published: true
+description: "LibreFang v0.6.3 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v0.6.3-20260319
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 0.6.3 Released
+
+We're excited to announce **LibreFang v0.6.3** — another solid release packed with improvements across the board! This version brings better security, smoother onboarding, and important fixes that make your Agent OS experience more reliable.
+
+## What's New
+
+### 🚀 Better Onboarding & Token Management
+
+The init experience just got smarter. LibreFang now **auto-initializes the vault** during `librefang init`, so you can start building agents right away without extra setup steps. We've also added **token consumption metadata** to help you track usage more precisely, and reduced the default "hands" (concurrent agent slots) to give you more conservative resource allocation out of the box.
+
+### 🔒 Security & Encryption
+
+A big one for webhook users — encrypted webhook payloads are now **properly decrypted** before processing, so your integrations with external services stay secure. The context engine also now bootstraps correctly during startup, ensuring your agent configurations are available from the moment the system comes up.
+
+### 🐛 Bug Fixes
+
+- **Channel tests** now properly support target IDs for more accurate testing scenarios
+- **Linux installer** is now POSIX-compatible, fixing installation issues on various Linux distributions
+- General stability improvements across the board
+
+### 📦 Under the Hood
+
+- Cleaned up the skills subsystem for better maintainability
+- Tidied up the repository structure for a more organized codebase
+- Updated contributor records
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v0.6.3-20260319)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.6.2-20260319",
+  "version": "0.6.3-20260319",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.6.2-20260319",
+  "version": "0.6.3-20260319",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.6.2-20260319",
+  "version": "0.6.3-20260319",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.6.2-20260319",
+    version="0.6.3-20260319",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.6.3-20260319


### Added

- Auto-initialize vault during librefang init (#1206) (@houko)
- Add token consumption metadata and reduce default hands (#1215) (@houko)

### Fixed

- Decrypt encrypted webhook payloads (#1208) (@TechWizard9999)
- Bootstrap context engine during startup (#1209) (@TechWizard9999)
- Support target ids in channel test (#1210) (@TechWizard9999)
- Make shell installer POSIX-compatible for Linux (#1226) (@houko)

### Documentation

- Update contributors (#1214) (@houko)

### Maintenance

- Tidy repo structure (#1211) (@houko)

### Other

- Clean skills (#1212) (@houko)