### PR TITLE
fix: 修复chat界面输入框无法换行的问题

### DIFF
--- a/crates/librefang-api/static/index_body.html
+++ b/crates/librefang-api/static/index_body.html
@@ -799,7 +799,7 @@
                   <span class="text-xs" style="color:var(--danger)" x-text="formatRecordingTime()"></span>
                 </div>
                 <textarea id="msg-input" rows="1" :placeholder="composerPlaceholder()"
-                          @keydown.enter.prevent="if(!$event.isComposing && $event.keyCode !== 229 && !$event.shiftKey){if(showModelPicker && filteredModelPicker.length){pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else{sendMessage()}}"
+                          @keydown.enter="if(!$event.isComposing && $event.keyCode !== 229 && !$event.shiftKey){if(showModelPicker && filteredModelPicker.length){preventDefault();pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){preventDefault();executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else if (!$event.shiftKey){preventDefault();sendMessage()}}"
                           @keydown.escape="showSlashMenu = false; showModelPicker = false"
                           @keydown.arrow-up.prevent="if(showModelPicker){modelPickerIdx = Math.max(0, modelPickerIdx - 1)}else if(showSlashMenu){slashIdx = Math.max(0, slashIdx - 1)}"
                           @keydown.arrow-down.prevent="if(showModelPicker){modelPickerIdx = Math.min(filteredModelPicker.length - 1, modelPickerIdx + 1)}else if(showSlashMenu){slashIdx = Math.min(filteredSlashCommands.length - 1, slashIdx + 1)}"


### PR DESCRIPTION
<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary
Fixes the issue where pressing Enter always sent the message even when Shift was held. Now Shift + Enter correctly inserts a newline in the chat input.

## Changes
Modified regular file crates/librefang-api/static/index_body.html:802 :
@keydown.enter.prevent =.... -> @keydown.enter
Manual event control: Implemented manual preventDefault() only when Shift is not pressed. This allows the default newline behavior of textarea to function correctly when Shift+Enter is used.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
