### PR TITLE
release: v0.6.5-20260320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,77 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2026-03-20
+
+### Added
+
+- Auto-initialize vault during librefang init (#1206) (@houko)
+- Add token consumption metadata and reduce default hands (#1215) (@houko)
+- Add image pipeline and subprocess management (#1223) (@f-liva)
+- Add Qwen Code CLI as LLM provider (#1224) (@f-liva)
+- Align init defaults with OpenRouter Stepfun (#1262) (@houko)
+- Replace all icons with new LibreFang branding (#1263) (@f-liva)
+- Fix shell (#1270) (@houko)
+
+### Fixed
+
+- Decrypt encrypted webhook payloads (#1208) (@TechWizard9999)
+- Bootstrap context engine during startup (#1209) (@TechWizard9999)
+- Support target ids in channel test (#1210) (@TechWizard9999)
+- Make shell installer POSIX-compatible for Linux (#1226) (@houko)
+- Web deployment issues (#1236) (@houko)
+- Web deployment issues (#1237) (@houko)
+- Create web/public/assets directory (#1238) (@houko)
+- Web deployment and CI fixes (#1239) (@houko)
+- Web deployment and CI fixes (#1243) (@houko)
+- Repair install smoke script and drop update-star-history workflow (#1255) (@houko)
+- Use web/public installer source and harden curl|sh install flow (#1259) (@houko)
+- Address code-scanning path-injection findings (follow-up) (#1260) (@houko)
+- Initialize rustls crypto provider for TLS connections (#1294) (@houko)
+
+### Documentation
+
+- Update star history (#1197) (@houko)
+- Update star history (#1198) (@houko)
+- Update star history (#1199) (@houko)
+- Update star history (#1200) (@houko)
+- Update star history (#1201) (@houko)
+- Update star history (#1202) (@houko)
+- Update star history (#1203) (@houko)
+- Update star history (#1213) (@houko)
+- Update contributors (#1214) (@houko)
+- Update star history (#1225) (@houko)
+- Update star history (#1228) (@houko)
+- Add SDK usage examples to all README files (#1229) (@houko)
+- Update star history (#1231) (@houko)
+- Update star history (#1232) (@houko)
+- Update star history (#1235) (@houko)
+- Update contributors (#1240) (@app/github-actions)
+- Update star history (#1242) (@app/github-actions)
+
+### Maintenance
+
+- Tidy repo structure (#1211) (@houko)
+- Use .nvmrc for web Node.js version and fix Dockerfile path (#1234) (@houko)
+- Bump actions/setup-node from 4 to 6 (#1280) (@app/dependabot)
+- Bump actions/download-artifact from 4 to 8 (#1281) (@app/dependabot)
+- Bump pnpm/action-setup from 4 to 5 (#1282) (@app/dependabot)
+- Bump actions/labeler from 5 to 6 (#1283) (@app/dependabot)
+- Bump zip from 8.2.0 to 8.3.0 (#1284) (@app/dependabot)
+- Bump jsonwebtoken from 9.3.1 to 10.3.0 (#1285) (@app/dependabot)
+- Bump tracing-subscriber from 0.3.22 to 0.3.23 (#1286) (@app/dependabot)
+- Bump rusqlite from 0.38.0 to 0.39.0 (#1287) (@app/dependabot)
+- Bump rumqttc from 0.24.0 to 0.25.1 (#1288) (@app/dependabot)
+- Bump tokio-tungstenite from 0.28.0 to 0.29.0 (#1289) (@app/dependabot)
+- Bump criterion from 0.5.1 to 0.8.2 (#1290) (@app/dependabot)
+- Bump rand from 0.8.5 to 0.9.2 (#1291) (@app/dependabot)
+- Bump toml_edit from 0.25.4+spec-1.1.0 to 0.25.5+spec-1.1.0 (#1292) (@app/dependabot)
+
+### Other
+
+- Clean skills (#1212) (@houko)
+- Fix/webui chat input line break failed (#1245) (@aimlyo)
+
 ## [v0.6.4-20260320] - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "async-trait",
  "axum",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "aes",
  "async-trait",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "chrono",
  "hex",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9930,7 +9930,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4-20260320"
+version = "0.6.5-20260320"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-0.6.5.md
+++ b/articles/release-0.6.5.md
@@ -1,0 +1,75 @@
+# LibreFang 0.6.5 Released
+
+---
+title: "LibreFang 0.6.5 Released"
+published: true
+description: "LibreFang v0.6.5 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v0.6.5-20260320
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 0.6.5 Released
+
+We're thrilled to announce **LibreFang v0.6.5**! This release focuses on **security hardening**, **multi-provider LLM support**, and **improved deployment reliability**. Whether you're running on Linux, deploying to the web, or integrating with external LLM providers, this update has something for you.
+
+## 🚀 New Features & Improvements
+
+### LLM Provider Expansion & Cost Tracking
+- **Add Qwen Code CLI as LLM provider** (#1224) — expand your model options with Qwen's code-focused offerings
+- **Align init defaults with OpenRouter Stepfun** (#1262) — streamlined configuration for one of the fastest open models
+- **Add token consumption metadata** (#1215) — better visibility into model usage and cost attribution
+
+### Infrastructure & Core Features
+- **Auto-initialize vault during `librefang init`** (#1206) — faster, zero-config setup for secure credential storage
+- **Add image pipeline and subprocess management** (#1223) — enhanced capabilities for task-based workflows
+- **Improved shell compatibility** (#1270) — smoother terminal experience across platforms
+
+### UI & Brand Refresh
+- **Replace all icons with new LibreFang branding** (#1263) — fresh visual identity across the dashboard and CLI
+
+## 🔒 Security & Stability Fixes
+
+### Security Hardening
+- **Harden curl|sh install flow** (#1259) — safer installation from the web with improved source verification
+- **Initialize rustls crypto provider for TLS connections** (#1294) — hardened TLS stack for secure communication
+- **Decrypt encrypted webhook payloads** (#1208) — proper handling of sensitive inbound data
+- **Address code-scanning path-injection findings** (#1260) — proactive security remediation
+
+### Deployment & Reliability
+- **Fix web deployment issues** (#1236, #1237, #1239, #1243) — resolved multiple asset serving and CI/CD blockers
+- **Make shell installer POSIX-compatible for Linux** (#1226) — universal installer support
+- **Bootstrap context engine during startup** (#1209) — more reliable initialization
+- **Repair install smoke script** (#1255) — confidence in installation success
+
+## 📚 Documentation & Maintenance
+
+- **SDK usage examples in all READMEs** (#1229) — get started faster with working code samples
+- **Updated contributor list** — thank you to everyone who made this release possible
+- **Repository structure improvements** (#1211) — cleaner codebase organization
+- **Node.js version standardization** (#1234) — consistent build environments
+- **13 dependency updates** — keep the Rust ecosystem fresh (criterion, rand, tokio, rumqttc, and more)
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v0.6.5-20260320)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.6.4-20260320",
+  "version": "0.6.5-20260320",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.6.4-20260320",
+  "version": "0.6.5-20260320",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.6.4-20260320",
+  "version": "0.6.5-20260320",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.6.4-20260320",
+    version="0.6.5-20260320",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.6.5-20260320


### Added

- Auto-initialize vault during librefang init (#1206) (@houko)
- Add token consumption metadata and reduce default hands (#1215) (@houko)
- Add image pipeline and subprocess management (#1223) (@f-liva)
- Add Qwen Code CLI as LLM provider (#1224) (@f-liva)
- Align init defaults with OpenRouter Stepfun (#1262) (@houko)
- Replace all icons with new LibreFang branding (#1263) (@f-liva)
- Fix shell (#1270) (@houko)

### Fixed

- Decrypt encrypted webhook payloads (#1208) (@TechWizard9999)
- Bootstrap context engine during startup (#1209) (@TechWizard9999)
- Support target ids in channel test (#1210) (@TechWizard9999)
- Make shell installer POSIX-compatible for Linux (#1226) (@houko)
- Web deployment issues (#1236) (@houko)
- Web deployment issues (#1237) (@houko)
- Create web/public/assets directory (#1238) (@houko)
- Web deployment and CI fixes (#1239) (@houko)
- Web deployment and CI fixes (#1243) (@houko)
- Repair install smoke script and drop update-star-history workflow (#1255) (@houko)
- Use web/public installer source and harden curl|sh install flow (#1259) (@houko)
- Address code-scanning path-injection findings (follow-up) (#1260) (@houko)
- Initialize rustls crypto provider for TLS connections (#1294) (@houko)

### Documentation

- Add SDK usage examples to all README files (#1229) (@houko)
- Update contributors (#1240) (@app/github-actions)
- Update star history (#1242) (@app/github-actions)

### Maintenance

- Tidy repo structure (#1211) (@houko)
- Use .nvmrc for web Node.js version and fix Dockerfile path (#1234) (@houko)
- Bump actions/setup-node from 4 to 6 (#1280) (@app/dependabot)
- Bump actions/download-artifact from 4 to 8 (#1281) (@app/dependabot)
- Bump pnpm/action-setup from 4 to 5 (#1282) (@app/dependabot)
- Bump actions/labeler from 5 to 6 (#1283) (@app/dependabot)
- Bump zip from 8.2.0 to 8.3.0 (#1284) (@app/dependabot)
- Bump jsonwebtoken from 9.3.1 to 10.3.0 (#1285) (@app/dependabot)
- Bump tracing-subscriber from 0.3.22 to 0.3.23 (#1286) (@app/dependabot)
- Bump rusqlite from 0.38.0 to 0.39.0 (#1287) (@app/dependabot)
- Bump rumqttc from 0.24.0 to 0.25.1 (#1288) (@app/dependabot)
- Bump tokio-tungstenite from 0.28.0 to 0.29.0 (#1289) (@app/dependabot)
- Bump criterion from 0.5.1 to 0.8.2 (#1290) (@app/dependabot)
- Bump rand from 0.8.5 to 0.9.2 (#1291) (@app/dependabot)
- Bump toml_edit from 0.25.4+spec-1.1.0 to 0.25.5+spec-1.1.0 (#1292) (@app/dependabot)

### Other

- Clean skills (#1212) (@houko)
- Fix/webui chat input line break failed (#1245) (@aimlyo)