### PR TITLE
fix(ci): pass GITHUB_TOKEN to contributor/star-history scripts

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -32,9 +32,13 @@ jobs:
           python-version: "3.x"
 
       - name: Generate contributors SVG
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: python3 scripts/generate_contributors.py librefang/librefang web/public/assets/contributors.svg
 
       - name: Generate star history SVG
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: python3 scripts/generate_star_history.py librefang/librefang web/public/assets/star-history.svg
 
       - name: Create PR with updated SVGs

--- a/scripts/generate_contributors.py
+++ b/scripts/generate_contributors.py
@@ -8,6 +8,7 @@ import base64
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -30,7 +31,7 @@ class Contributor:
     contributions: int
 
 
-def github_request(url: str) -> list[dict]:
+def github_request(url: str, retries: int = 3) -> list[dict]:
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "librefang-contributors-generator",
@@ -38,9 +39,18 @@ def github_request(url: str) -> list[dict]:
     token = os.environ.get("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read())
+    for attempt in range(retries):
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 403 and attempt < retries - 1:
+                wait = 2 ** attempt * 5
+                print(f"Rate limited, retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
 
 
 def fetch_contributors(repo: str) -> list[Contributor]:

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -24,7 +25,7 @@ class Point:
     stars: int
 
 
-def github_request(url: str) -> list[dict]:
+def github_request(url: str, retries: int = 3) -> list[dict]:
     headers = {
         "Accept": "application/vnd.github.star+json",
         "User-Agent": "librefang-star-history-generator",
@@ -34,9 +35,18 @@ def github_request(url: str) -> list[dict]:
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    request = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(request) as response:
-        return json.load(response)
+    for attempt in range(retries):
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as e:
+            if e.code == 403 and attempt < retries - 1:
+                wait = 2 ** attempt * 5
+                print(f"Rate limited, retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
 
 
 def fetch_stargazers(repo: str) -> list[datetime]:


### PR DESCRIPTION
## Summary
- Pass `GITHUB_TOKEN` env var to both Python scripts in the update-contributors workflow — root cause of the 403 rate limit error
- Add retry with exponential backoff (5s/10s/20s) on 403 errors in both `generate_contributors.py` and `generate_star_history.py`

Fixes https://github.com/librefang/librefang/actions/runs/23327953845/job/67853134951