### PR TITLE
feat(ui): add GitHub Discussions link to dashboard sidebar

### DIFF
--- a/crates/librefang-api/static/index_body.html
+++ b/crates/librefang-api/static/index_body.html
@@ -185,6 +185,10 @@
               <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3"/><path d="M1 14h6M9 8h6M17 16h6"/></svg></span>
               <span class="nav-label" data-i18n="nav.settings">Settings</span>
             </a>
+            <a class="nav-item" href="https://github.com/librefang/librefang/discussions" target="_blank" rel="noopener noreferrer">
+              <span class="nav-icon"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+              <span class="nav-label">Discussions</span>
+            </a>
           </div>
         </template>
       </div>


### PR DESCRIPTION
## Summary
Adds a direct GitHub Discussions link in the dashboard sidebar (System section) so users can quickly access community Q&A and feedback.

## Changes
- Added a new sidebar item in crates/librefang-api/static/index_body.html
- Link target: https://github.com/librefang/librefang/discussions

Closes #1028