### PR TITLE
release: v0.6.7-20260320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7] - 2026-03-20
+
+### Added
+
+- Add GitHub Discussions link to dashboard sidebar (#1302) (@TechWizard9999)
+
+### Fixed
+
+- Include user-installed HAND manifests in hand routing (#1205) (@TechWizard9999)
+- Pass raw JSON payloads to context hook scripts (#1207) (@TechWizard9999)
+- Pass GITHUB_TOKEN to contributor/star-history scripts (#1300) (@houko)
+- Self-heal fish config PATH entries (#1303) (@TechWizard9999)
+- Fix 3 release workflow failures from v0.6.6 (#1309) (@houko)
+
 ## [0.6.6] - 2026-03-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "async-trait",
  "axum",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "aes",
  "async-trait",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "chrono",
  "hex",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9930,7 +9930,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6-20260320"
+version = "0.6.7-20260320"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-0.6.7.md
+++ b/articles/release-0.6.7.md
@@ -1,0 +1,60 @@
+```markdown
+---
+title: "LibreFang 0.6.7 Released"
+published: true
+description: "LibreFang v0.6.7 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v0.6.7-20260320
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 0.6.7 Released
+
+We're thrilled to release **LibreFang v0.6.7**—a focused update that strengthens extensibility, improves developer experience, and hardens our release pipeline. If you're building custom agents with HAND manifests or relying on context hooks, this one's for you.
+
+## Extensibility & Scripting Improvements
+
+The foundation of LibreFang's power is its flexibility. This release fixes critical gaps in how your custom code integrates:
+
+- **Include user-installed HAND manifests in hand routing** (#1205) — Custom HAND agent manifests are now properly discovered and included in the routing system, eliminating the friction of manual registration.
+- **Pass raw JSON payloads to context hook scripts** (#1207) — Context hooks now receive unprocessed JSON instead of serialized strings, giving you full control and eliminating unnecessary parsing overhead.
+
+## Better Developer Experience
+
+- **Self-heal fish config PATH entries** (#1303) — Your shell configuration now automatically recovers from corrupted PATH entries in fish, keeping your development environment stable without manual fixes.
+
+## Community & Documentation
+
+- **Add GitHub Discussions link to dashboard sidebar** (#1302) — Find answers and connect with the community without leaving the dashboard. We're making it easier for everyone to share knowledge and get help.
+
+## Release & CI Reliability
+
+Behind the scenes, we've tightened our release process to ensure smooth deployments:
+
+- **Pass GITHUB_TOKEN to contributor/star-history scripts** (#1300) — Improved authentication for release automation, reducing friction in contributor tracking.
+- **Fix 3 release workflow failures from v0.6.6** (#1309) — Resolved critical blockers in the release pipeline for more reliable deployments.
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v0.6.7-20260320)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)
+```

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "0.6.6-20260320",
+  "version": "0.6.7-20260320",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "0.6.6-20260320",
+  "version": "0.6.7-20260320",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.6.6-20260320",
+  "version": "0.6.7-20260320",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="0.6.6-20260320",
+    version="0.6.7-20260320",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",


### PR DESCRIPTION
## Release v0.6.7-20260320


### Added

- Add GitHub Discussions link to dashboard sidebar (#1302) (@TechWizard9999)

### Fixed

- Include user-installed HAND manifests in hand routing (#1205) (@TechWizard9999)
- Pass raw JSON payloads to context hook scripts (#1207) (@TechWizard9999)
- Pass GITHUB_TOKEN to contributor/star-history scripts (#1300) (@houko)
- Self-heal fish config PATH entries (#1303) (@TechWizard9999)
- Fix 3 release workflow failures from v0.6.6 (#1309) (@houko)