### PR TITLE
fix(ci): use GitHub API to create Go SDK tag

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   packages: write
-  workflows: write
 
 concurrency:
   group: release-sdk-${{ github.ref }}
@@ -185,13 +184,19 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/v}"
           VERSION="${TAG%-*}"
           GO_TAG="sdk/go/v${VERSION}"
+          REPO="${{ github.repository }}"
 
           # Check if tag already exists
-          if git ls-remote --tags origin "refs/tags/$GO_TAG" | grep -q .; then
+          if gh api "repos/$REPO/git/refs/tags/$GO_TAG" &>/dev/null; then
             echo "Tag $GO_TAG already exists, skipping"
             exit 0
           fi
 
-          git tag "$GO_TAG"
-          git push origin "$GO_TAG"
+          # Get the commit SHA for this tag
+          SHA=$(gh api "repos/$REPO/git/ref/tags/${GITHUB_REF#refs/tags/}" --jq '.object.sha')
+
+          # Create tag via API (avoids git push workflow permission issue)
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/$GO_TAG" \
+            -f sha="$SHA"
           echo "✓ Published Go module tag: $GO_TAG"


### PR DESCRIPTION
## Summary

- **Fix Go SDK tag creation failure** — `git push` was rejected because the commit includes workflow files and `GITHUB_TOKEN` can't push refs containing workflow changes (GitHub security restriction). Switched to `gh api` to create the tag via REST API, which bypasses this limitation.
- **Remove unnecessary `workflows: write` permission** — no longer needed since we don't use `git push`.

Error was:
```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/update-contributors.yml` without `workflows` permission
```

This has been failing on every release since v0.6.6.

## Test plan

- [ ] CI passes
- [ ] Next tag push creates the Go module tag successfully