### PR TITLE
fix: move CLI npm/PyPI publish to Shell workflow and fix Fly.io config path

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@v1
       - name: Deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --config deploy/fly/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -169,52 +169,6 @@ jobs:
             cargo publish --allow-dirty
           fi
 
-  # ── CLI Binary → npm ────────────────────────────────────────────────────
-  cli_npm:
-    name: CLI / npm
-    needs: [wait_for_release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Publish CLI binaries to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          FULL="${GITHUB_REF#refs/tags/v}"
-          export VERSION="${FULL%-*}"
-          bash scripts/publish-npm-binaries.sh
-
-  # ── CLI Binary → PyPI ──────────────────────────────────────────────────
-  cli_pypi:
-    name: CLI / PyPI
-    needs: [wait_for_release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Publish CLI binaries to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          FULL="${GITHUB_REF#refs/tags/v}"
-          export VERSION="${FULL%-*}"
-          bash scripts/publish-pypi-binaries.sh
-
   # ── Go SDK — tag for Go modules ──────────────────────────────────────────
   sdk_go:
     name: SDK / Go (tag)

--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -312,6 +312,52 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}-mini.* --clobber
 
+  # ── CLI Binary → npm ────────────────────────────────────────────────────
+  cli_npm:
+    name: CLI / npm
+    needs: [cli_mac, cli_linux, cli_musl, cli_windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish CLI binaries to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          FULL="${GITHUB_REF#refs/tags/v}"
+          export VERSION="${FULL%-*}"
+          bash scripts/publish-npm-binaries.sh
+
+  # ── CLI Binary → PyPI ──────────────────────────────────────────────────
+  cli_pypi:
+    name: CLI / PyPI
+    needs: [cli_mac, cli_linux, cli_musl, cli_windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Publish CLI binaries to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          FULL="${GITHUB_REF#refs/tags/v}"
+          export VERSION="${FULL%-*}"
+          bash scripts/publish-pypi-binaries.sh
+
   # ── Sync to Homebrew Tap ──────────────────────────────────────────────
   sync_homebrew:
     name: Sync to Homebrew Tap

--- a/scripts/publish-npm-binaries.sh
+++ b/scripts/publish-npm-binaries.sh
@@ -7,6 +7,20 @@ set -euo pipefail
 : "${REPO:?}"
 : "${TAG:?}"
 
+# Retry download (brief retries for GitHub CDN propagation)
+download_asset() {
+  local url=$1 dest=$2
+  for i in $(seq 1 5); do
+    if curl -fsSL -o "$dest" "$url" 2>/dev/null; then
+      return 0
+    fi
+    echo "  Retrying download in 10s... ($i/5)"
+    sleep 10
+  done
+  echo "ERROR: Failed to download $url"
+  return 1
+}
+
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
@@ -60,7 +74,7 @@ for target in "${!TARGETS[@]}"; do
   asset="librefang-${target}.${ext}"
   url="https://github.com/${REPO}/releases/download/${TAG}/${asset}"
   echo "  Downloading $url"
-  curl -fsSL -o "$pkg_dir/$asset" "$url"
+  download_asset "$url" "$pkg_dir/$asset"
 
   # Extract binary
   if [ "$ext" = "tar.gz" ]; then

--- a/scripts/publish-pypi-binaries.sh
+++ b/scripts/publish-pypi-binaries.sh
@@ -7,6 +7,20 @@ set -euo pipefail
 : "${REPO:?}"
 : "${TAG:?}"
 
+# Retry download (brief retries for GitHub CDN propagation)
+download_asset() {
+  local url=$1 dest=$2
+  for i in $(seq 1 5); do
+    if curl -fsSL -o "$dest" "$url" 2>/dev/null; then
+      return 0
+    fi
+    echo "  Retrying download in 10s... ($i/5)"
+    sleep 10
+  done
+  echo "ERROR: Failed to download $url"
+  return 1
+}
+
 WORK=$(mktemp -d)
 DIST="$WORK/dist"
 mkdir -p "$DIST"
@@ -39,7 +53,7 @@ build_wheel() {
   local asset="librefang-${target}.${ext}"
   local url="https://github.com/${REPO}/releases/download/${TAG}/${asset}"
   echo "  Downloading $url"
-  curl -fsSL -o "$wheel_dir/$asset" "$url"
+  download_asset "$url" "$wheel_dir/$asset"
 
   if [ "$ext" = "tar.gz" ]; then
     tar xzf "$wheel_dir/$asset" -C "$wheel_dir/$data_dir"


### PR DESCRIPTION
## Summary
- Move `CLI / npm` and `CLI / PyPI` jobs from `Release / SDK` to `Release / Shell` workflow, with `needs: [cli_mac, cli_linux, cli_musl, cli_windows]` to ensure binaries are uploaded before download
- Fix Fly.io deploy: add `--config deploy/fly/fly.toml` (was looking for fly.toml in repo root)
- Add brief download retry in publish scripts for GitHub CDN propagation

## Why
- CLI binary publish jobs were in SDK workflow which runs in parallel with Shell — binaries not yet uploaded → curl 404
- Fly.io deploy failed every release because `flyctl` couldn't find `fly.toml` in the working directory

## Test plan
- [ ] Next release tag triggers Shell workflow with cli_npm + cli_pypi jobs after all builds complete
- [ ] Fly.io deploy picks up `deploy/fly/fly.toml` correctly
- [ ] SDK workflow still publishes JS/Rust/Python/Go SDKs independently