### PR TITLE
feat: configurable CORS, channel rate limits, audit pruning, and media gates

### DIFF
--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -300,6 +300,16 @@ pub async fn install_plugin_deps(Path(name): Path<String>) -> impl IntoResponse 
 pub async fn list_plugin_registries(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     // Ensure the official registry is always present.
     let mut registries = state.kernel.config.context_engine.plugin_registries.clone();
+
+    // Merge registries from [plugins].plugin_registries (URL strings treated as github repos)
+    for url in &state.kernel.config.plugins.plugin_registries {
+        if !registries.iter().any(|r| r.github_repo == *url) {
+            registries.push(librefang_types::config::PluginRegistrySource {
+                name: url.clone(),
+                github_repo: url.clone(),
+            });
+        }
+    }
     if !registries
         .iter()
         .any(|r| r.github_repo == "librefang/plugin-registry")

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -8,7 +8,6 @@ use crate::webchat;
 use crate::ws;
 use axum::Router;
 use librefang_kernel::LibreFangKernel;
-use librefang_types::config::DEFAULT_API_PORT;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -800,14 +799,13 @@ pub async fn build_router(
         ),
     });
 
-    // CORS: allow localhost origins by default. If API key is set, the API
-    // is protected anyway. For development, permissive CORS is convenient.
-    let cors = if state.kernel.config.api_key.trim().is_empty() {
-        // No auth -> restrict CORS to localhost origins (include both 127.0.0.1 and localhost)
+    // CORS: allow localhost origins by default, plus any configured in cors_origin.
+    let cors = {
         let port = listen_addr.port();
         let mut origins: Vec<axum::http::HeaderValue> = vec![
             format!("http://{listen_addr}").parse().unwrap(),
             format!("http://localhost:{port}").parse().unwrap(),
+            format!("http://127.0.0.1:{port}").parse().unwrap(),
         ];
         // Also allow common dev ports
         for p in [3000u16, 8080] {
@@ -820,32 +818,12 @@ pub async fn build_router(
                 }
             }
         }
-        CorsLayer::new()
-            .allow_origin(origins)
-            .allow_methods(tower_http::cors::Any)
-            .allow_headers(tower_http::cors::Any)
-    } else {
-        // Auth enabled -> restrict CORS to localhost + configured origins.
-        // SECURITY: CorsLayer::permissive() is dangerous - any website could
-        // make cross-origin requests. Restrict to known origins instead.
-        let mut origins: Vec<axum::http::HeaderValue> = vec![
-            format!("http://{listen_addr}").parse().unwrap(),
-            format!("http://localhost:{DEFAULT_API_PORT}")
-                .parse()
-                .unwrap(),
-            format!("http://127.0.0.1:{DEFAULT_API_PORT}")
-                .parse()
-                .unwrap(),
-            "http://localhost:8080".parse().unwrap(),
-            "http://127.0.0.1:8080".parse().unwrap(),
-        ];
-        // Add the actual listen address variants
-        if listen_addr.port() != DEFAULT_API_PORT && listen_addr.port() != 8080 {
-            if let Ok(v) = format!("http://localhost:{}", listen_addr.port()).parse() {
+        // Add explicitly configured CORS origins from config.toml
+        for origin in &state.kernel.config.cors_origin {
+            if let Ok(v) = origin.parse::<axum::http::HeaderValue>() {
                 origins.push(v);
-            }
-            if let Ok(v) = format!("http://127.0.0.1:{}", listen_addr.port()).parse() {
-                origins.push(v);
+            } else {
+                tracing::warn!("Invalid CORS origin in config, skipping: {origin}");
             }
         }
         CorsLayer::new()

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -679,6 +679,14 @@ async fn dispatch_message(
 
     // --- Rate limiting ---
     if let Some(ref ov) = overrides {
+        // Global per-channel rate limit (all users combined)
+        if ov.rate_limit_per_minute > 0 {
+            if let Err(msg) = rate_limiter.check(ct_str, "__global__", ov.rate_limit_per_minute) {
+                send_response(adapter, &message.sender, msg, thread_id, output_format).await;
+                return;
+            }
+        }
+        // Per-user rate limit
         if ov.rate_limit_per_user > 0 {
             if let Err(msg) =
                 rate_limiter.check(ct_str, sender_user_id(message), ov.rate_limit_per_user)

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1004,12 +1004,18 @@ impl LibreFangKernel {
             }
         }
 
-        // Initialize integration health monitor
+        // Initialize integration health monitor.
+        // [health_check] section overrides [extensions] when explicitly set (non-default).
+        let hc_interval = if config.health_check.health_check_interval_secs != 60 {
+            config.health_check.health_check_interval_secs
+        } else {
+            config.extensions.health_check_interval_secs
+        };
         let health_config = librefang_extensions::health::HealthMonitorConfig {
             auto_reconnect: config.extensions.auto_reconnect,
             max_reconnect_attempts: config.extensions.reconnect_max_attempts,
             max_backoff_secs: config.extensions.reconnect_max_backoff_secs,
-            check_interval_secs: config.extensions.health_check_interval_secs,
+            check_interval_secs: hc_interval,
         };
         let extension_health = librefang_extensions::health::HealthMonitor::new(health_config);
         // Register all installed integrations for health monitoring
@@ -4925,6 +4931,30 @@ impl LibreFangKernel {
                     }
                 }
             });
+        }
+
+        // Periodic audit log pruning (daily, respects audit.retention_days)
+        {
+            let kernel = Arc::clone(self);
+            let retention = self.config.audit.retention_days;
+            if retention > 0 {
+                tokio::spawn(async move {
+                    let mut interval =
+                        tokio::time::interval(std::time::Duration::from_secs(24 * 3600));
+                    interval.tick().await; // Skip first immediate tick
+                    loop {
+                        interval.tick().await;
+                        if kernel.supervisor.is_shutting_down() {
+                            break;
+                        }
+                        let pruned = kernel.audit_log.prune(retention);
+                        if pruned > 0 {
+                            info!("Audit log pruning: removed {pruned} entries older than {retention} days");
+                        }
+                    }
+                });
+                info!("Audit log pruning scheduled daily (retention_days={retention})");
+            }
         }
 
         // Periodic session retention cleanup (prune expired / excess sessions)

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -2174,6 +2174,26 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
         let mut stored_memories = Vec::new();
         let mut conflicts = Vec::new();
         for item in &extraction_result.memories {
+            // Filter by configured extract_categories (if non-empty)
+            if !cfg.extract_categories.is_empty() {
+                let cat = item.category.as_deref().unwrap_or("");
+                if !cat.is_empty() && !cfg.extract_categories.iter().any(|c| c == cat) {
+                    continue;
+                }
+            }
+
+            // Filter by extraction_threshold: skip low-confidence extractions.
+            // Confidence is stored in metadata by the LLM extractor; rule-based
+            // extractor defaults to 1.0 (always passes).
+            let confidence = item
+                .metadata
+                .get("confidence")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(1.0) as f32;
+            if confidence < cfg.extraction_threshold {
+                continue;
+            }
+
             // Tag with auto_memorize metadata
             let mut enriched = item.clone();
             enriched

--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -301,6 +301,45 @@ impl AuditLog {
         let start = entries.len().saturating_sub(n);
         entries[start..].to_vec()
     }
+
+    /// Remove audit entries older than `retention_days` days.
+    ///
+    /// Returns the number of entries pruned. When `retention_days` is 0 the
+    /// call is a no-op (unlimited retention).
+    pub fn prune(&self, retention_days: u32) -> usize {
+        if retention_days == 0 {
+            return 0;
+        }
+
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
+        let cutoff_str = cutoff.to_rfc3339();
+        let mut pruned = 0;
+
+        // Prune from database
+        if let Some(ref db) = self.db {
+            if let Ok(conn) = db.lock() {
+                if let Ok(n) = conn.execute(
+                    "DELETE FROM audit_entries WHERE timestamp < ?1",
+                    rusqlite::params![cutoff_str],
+                ) {
+                    pruned = n;
+                }
+            }
+        }
+
+        // Prune from in-memory list
+        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let before = entries.len();
+        entries.retain(|e| e.timestamp >= cutoff_str);
+        let mem_pruned = before - entries.len();
+
+        // Prefer DB count (authoritative), fall back to in-memory count
+        if pruned > 0 {
+            pruned
+        } else {
+            mem_pruned
+        }
+    }
 }
 
 impl Default for AuditLog {

--- a/crates/librefang-runtime/src/media_understanding.rs
+++ b/crates/librefang-runtime/src/media_understanding.rs
@@ -209,6 +209,20 @@ impl MediaEngine {
         let mut handles = Vec::new();
 
         for attachment in attachments {
+            // Skip media types that are disabled in config
+            match attachment.media_type {
+                MediaType::Image if !self.config.image_description => {
+                    continue;
+                }
+                MediaType::Audio if !self.config.audio_transcription => {
+                    continue;
+                }
+                MediaType::Video if !self.config.video_description => {
+                    continue;
+                }
+                _ => {}
+            }
+
             let sem = self.semaphore.clone();
             let config = self.config.clone();
             let handle = tokio::spawn(async move {

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -180,6 +180,8 @@ pub struct ChannelOverrides {
     pub dm_policy: DmPolicy,
     /// Group message policy.
     pub group_policy: GroupPolicy,
+    /// Global rate limit for this channel (messages per minute, 0 = unlimited).
+    pub rate_limit_per_minute: u32,
     /// Per-user rate limit (messages per minute, 0 = unlimited).
     pub rate_limit_per_user: u32,
     /// Enable thread replies.
@@ -1241,6 +1243,11 @@ pub struct KernelConfig {
     /// API listen address (e.g., "0.0.0.0:4545").
     #[serde(alias = "listen_addr")]
     pub api_listen: String,
+    /// Allowed CORS origins. When non-empty, these origins are added to the
+    /// CORS allow list (in addition to localhost). Accepts exact origin strings
+    /// like `"https://dash.example.com"`.
+    #[serde(default)]
+    pub cors_origin: Vec<String>,
     /// Whether to enable the OFP network layer.
     pub network_enabled: bool,
     /// Default LLM provider configuration.
@@ -1403,6 +1410,15 @@ pub struct KernelConfig {
     /// Pluggable context engine configuration.
     #[serde(default)]
     pub context_engine: ContextEngineTomlConfig,
+    /// Audit log configuration.
+    #[serde(default)]
+    pub audit: AuditConfig,
+    /// Health check configuration.
+    #[serde(default)]
+    pub health_check: HealthCheckConfig,
+    /// Plugin registry configuration.
+    #[serde(default)]
+    pub plugins: PluginsConfig,
 }
 
 /// Vertex AI provider configuration.
@@ -1784,6 +1800,63 @@ fn default_max_cron_jobs() -> usize {
     500
 }
 
+/// Audit log configuration.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [audit]
+/// retention_days = 90
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AuditConfig {
+    /// How many days to retain audit log entries. Default: 90. Set to 0 for unlimited.
+    pub retention_days: u32,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self { retention_days: 90 }
+    }
+}
+
+/// Health check configuration.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [health_check]
+/// health_check_interval_secs = 60
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HealthCheckConfig {
+    /// Interval in seconds between periodic health checks of LLM providers. Default: 60.
+    pub health_check_interval_secs: u64,
+}
+
+impl Default for HealthCheckConfig {
+    fn default() -> Self {
+        Self {
+            health_check_interval_secs: 60,
+        }
+    }
+}
+
+/// Plugin registry configuration.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [plugins]
+/// plugin_registries = ["librefang/plugin-registry"]
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PluginsConfig {
+    /// Additional GitHub `owner/repo` plugin registries to search.
+    /// Merged with `context_engine.plugin_registries`.
+    pub plugin_registries: Vec<String>,
+}
+
 fn default_prompt_caching() -> bool {
     true
 }
@@ -1997,6 +2070,10 @@ impl Default for KernelConfig {
             tool_policy: crate::tool_policy::ToolPolicy::default(),
             proactive_memory: crate::memory::ProactiveMemoryConfig::default(),
             context_engine: ContextEngineTomlConfig::default(),
+            audit: AuditConfig::default(),
+            health_check: HealthCheckConfig::default(),
+            plugins: PluginsConfig::default(),
+            cors_origin: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **CORS**: Add `cors_origin` field to `KernelConfig` so allowed origins are configurable in `config.toml` instead of hardcoded. Simplify CORS logic into a single unified branch.
- **Channel rate limiting**: Add `rate_limit_per_minute` to `ChannelOverrides` for global per-channel throttling, checked before per-user limits.
- **Audit pruning**: Add `AuditConfig` with `retention_days`; kernel spawns a daily background task to prune old entries from both SQLite and in-memory store.
- **Media gates**: Wire `image_description`, `audio_transcription`, `video_description` config flags to actually skip disabled media types in `process_attachments`.
- **Proactive memory**: Wire `extraction_threshold` (skip low-confidence extractions) and `extract_categories` (filter by allowed categories) in `auto_memorize`.
- **Health check**: Add `HealthCheckConfig` struct; `[health_check]` section overrides `[extensions]` interval when explicitly set.
- **Plugins**: Add `PluginsConfig` struct; `[plugins].plugin_registries` entries are merged into the plugin registry listing endpoint.

## Changed files

| File | Change |
|------|--------|
| `librefang-types/config.rs` | +`cors_origin`, +`rate_limit_per_minute`, +`AuditConfig`, +`HealthCheckConfig`, +`PluginsConfig` |
| `librefang-api/server.rs` | CORS reads `cors_origin` from config; unified single-branch logic |
| `librefang-api/routes/plugins.rs` | Merge `plugins.plugin_registries` into registry list |
| `librefang-channels/bridge.rs` | Global `rate_limit_per_minute` check before per-user check |
| `librefang-kernel/kernel.rs` | Daily audit prune job; health check interval override |
| `librefang-memory/proactive.rs` | Filter by `extract_categories` and `extraction_threshold` |
| `librefang-runtime/audit.rs` | New `AuditLog::prune(retention_days)` method |
| `librefang-runtime/media_understanding.rs` | Skip disabled media types in `process_attachments` |

## Config example

```toml
cors_origin = ["https://dash.example.com"]

[audit]
retention_days = 90

[health_check]
health_check_interval_secs = 60

[plugins]
plugin_registries = ["librefang/plugin-registry"]

[channels.telegram.overrides]
rate_limit_per_minute = 20
rate_limit_per_user = 5

[media]
image_description = true
audio_transcription = true
video_description = false

[proactive_memory]
extraction_threshold = 0.6
extract_categories = ["fact", "preference", "decision", "context"]
```

## Test plan

- [x] `cargo check` passes all modified crates (0 errors, 0 new warnings)
- [x] 2122 tests pass, 0 failures
- [x] `cargo fmt` clean
- [ ] Manual: restart daemon, verify CORS header includes configured origin
- [ ] Manual: verify channel `rate_limit_per_minute` blocks after threshold
- [ ] Manual: verify audit entries pruned after `retention_days`
- [ ] Manual: set `audio_transcription = false`, send audio, confirm it is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)