### PR TITLE
feat: add ChatGPT device auth flow

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6632,15 +6632,37 @@ async fn persist_chatgpt_auth(
     std::fs::create_dir_all(&home)
         .map_err(|e| format!("Failed to create LibreFang home directory: {e}"))?;
 
-    let secrets_path = home.join("secrets.env");
     let access_token = auth_result.access_token;
     let refresh_token = auth_result.refresh_token;
+    let secrets_path = write_chatgpt_secrets(
+        &home,
+        access_token.as_str(),
+        refresh_token.as_ref().map(|rt| rt.as_str()),
+    )?;
 
+    println!("\nChatGPT tokens saved to {}", secrets_path.display());
+
+    println!("Detecting best available model...");
+    let best_model = chatgpt_oauth::fetch_best_codex_model(&access_token).await;
+    println!("Selected model: {best_model}");
+
+    update_chatgpt_config(&home, &best_model)?;
+
+    println!("config.toml updated: provider = \"chatgpt\", model = \"{best_model}\"");
+    Ok(())
+}
+
+fn write_chatgpt_secrets(
+    home: &std::path::Path,
+    access_token: &str,
+    refresh_token: Option<&str>,
+) -> Result<std::path::PathBuf, String> {
+    let secrets_path = home.join("secrets.env");
     let mut env_vars: Vec<(String, String)> = vec![(
         "CHATGPT_SESSION_TOKEN".to_string(),
         access_token.to_string(),
     )];
-    if let Some(ref rt) = refresh_token {
+    if let Some(rt) = refresh_token {
         env_vars.push(("CHATGPT_REFRESH_TOKEN".to_string(), rt.to_string()));
     }
 
@@ -6665,12 +6687,10 @@ async fn persist_chatgpt_auth(
     std::fs::write(&secrets_path, updated)
         .map_err(|e| format!("Failed to write secrets.env: {e}"))?;
 
-    println!("\nChatGPT tokens saved to {}", secrets_path.display());
+    Ok(secrets_path)
+}
 
-    println!("Detecting best available model...");
-    let best_model = chatgpt_oauth::fetch_best_codex_model(&access_token).await;
-    println!("Selected model: {best_model}");
-
+fn update_chatgpt_config(home: &std::path::Path, best_model: &str) -> Result<(), String> {
     let config_path = home.join("config.toml");
     let config_str = std::fs::read_to_string(&config_path).unwrap_or_default();
     let mut doc = if config_str.trim().is_empty() {
@@ -6688,16 +6708,15 @@ async fn persist_chatgpt_auth(
         .ok_or("default_model is not a table")?;
     dm.insert("provider", toml_edit::value("chatgpt"));
     dm.insert("api_key_env", toml_edit::value("CHATGPT_SESSION_TOKEN"));
-    dm.insert("model", toml_edit::value(&best_model));
+    dm.insert("model", toml_edit::value(best_model));
     dm.insert(
         "base_url",
-        toml_edit::value(chatgpt_oauth::CHATGPT_BASE_URL),
+        toml_edit::value(librefang_runtime::chatgpt_oauth::CHATGPT_BASE_URL),
     );
 
     std::fs::write(&config_path, doc.to_string())
         .map_err(|e| format!("Failed to write config.toml: {e}"))?;
 
-    println!("config.toml updated: provider = \"chatgpt\", model = \"{best_model}\"");
     Ok(())
 }
 

--- a/crates/librefang-runtime/src/chatgpt_oauth.rs
+++ b/crates/librefang-runtime/src/chatgpt_oauth.rs
@@ -89,21 +89,6 @@ pub enum DeviceAuthFlowError {
     Fatal(String),
 }
 
-impl DeviceAuthFlowError {
-    /// Return true when the caller should fall back to browser auth.
-    pub fn should_fallback_to_browser(&self) -> bool {
-        matches!(self, Self::BrowserFallback { .. })
-    }
-
-    /// Return the user-facing message for logging or CLI output.
-    pub fn message(&self) -> &str {
-        match self {
-            Self::BrowserFallback { message } => message,
-            Self::Fatal(message) => message,
-        }
-    }
-}
-
 #[derive(Debug, Deserialize)]
 struct DeviceAuthPromptEnvelope {
     device_auth_id: String,
@@ -271,7 +256,13 @@ pub async fn poll_device_auth_flow(prompt: &DeviceAuthPrompt) -> Result<ChatGptA
                 )
                 .await;
             }
-            reqwest::StatusCode::FORBIDDEN | reqwest::StatusCode::NOT_FOUND => {}
+            _ if is_device_auth_poll_pending_status(status) => {
+                debug!(
+                    "Device auth still pending (HTTP {}); retrying in {}s",
+                    status,
+                    prompt.interval_secs.max(1)
+                );
+            }
             _ => {
                 return Err(format!(
                     "Device auth polling failed (HTTP {status}): {body}"
@@ -288,14 +279,6 @@ pub async fn poll_device_auth_flow(prompt: &DeviceAuthPrompt) -> Result<ChatGptA
 
         tokio::time::sleep(std::time::Duration::from_secs(prompt.interval_secs.max(1))).await;
     }
-}
-
-/// Run the full device auth flow without any browser automation.
-pub async fn run_device_auth_flow() -> Result<ChatGptAuthResult, DeviceAuthFlowError> {
-    let prompt = start_device_auth_flow().await?;
-    poll_device_auth_flow(&prompt)
-        .await
-        .map_err(DeviceAuthFlowError::Fatal)
 }
 
 /// Run the local callback server, waiting for the OAuth redirect.
@@ -506,6 +489,14 @@ pub fn chatgpt_session_available() -> bool {
 
 fn browser_redirect_uri(port: u16) -> String {
     format!("http://localhost:{port}/auth/callback")
+}
+
+/// Treat 403/404 as "authorization still pending" during device auth polling.
+fn is_device_auth_poll_pending_status(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status,
+        reqwest::StatusCode::FORBIDDEN | reqwest::StatusCode::NOT_FOUND
+    )
 }
 
 fn build_token_exchange_form(
@@ -911,6 +902,19 @@ mod tests {
 
         assert_eq!(parsed.authorization_code, "code-123");
         assert_eq!(parsed.code_verifier, "verifier-456");
+    }
+
+    #[test]
+    fn test_device_auth_poll_pending_statuses() {
+        assert!(is_device_auth_poll_pending_status(
+            reqwest::StatusCode::FORBIDDEN
+        ));
+        assert!(is_device_auth_poll_pending_status(
+            reqwest::StatusCode::NOT_FOUND
+        ));
+        assert!(!is_device_auth_poll_pending_status(
+            reqwest::StatusCode::BAD_REQUEST
+        ));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/drivers/chatgpt.rs
+++ b/crates/librefang-runtime/src/drivers/chatgpt.rs
@@ -255,6 +255,62 @@ impl ChatGptDriver {
         Ok(token)
     }
 
+    async fn post_responses_request(
+        &self,
+        url: &str,
+        api_request: &ResponsesApiRequest,
+        bearer_token: &str,
+    ) -> Result<reqwest::Response, LlmError> {
+        self.client
+            .post(url)
+            .bearer_auth(bearer_token)
+            .json(api_request)
+            .send()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))
+    }
+
+    async fn send_with_auth_retry(
+        &self,
+        url: &str,
+        api_request: &ResponsesApiRequest,
+    ) -> Result<reqwest::Response, LlmError> {
+        let token = self.ensure_token()?;
+        let http_resp = self
+            .post_responses_request(url, api_request, token.token.as_str())
+            .await?;
+        match http_resp.status() {
+            reqwest::StatusCode::UNAUTHORIZED => {}
+            reqwest::StatusCode::FORBIDDEN => {
+                let body = http_resp.text().await.unwrap_or_default();
+                if !should_refresh_after_forbidden(&body) {
+                    return Err(LlmError::Api {
+                        status: reqwest::StatusCode::FORBIDDEN.as_u16(),
+                        message: body,
+                    });
+                }
+            }
+            _ => return Ok(http_resp),
+        }
+
+        let refreshed = self.refresh_token().await?;
+        let http_resp = self
+            .post_responses_request(url, api_request, refreshed.token.as_str())
+            .await?;
+
+        // Preserve post-refresh 403s so higher-level classification can
+        // distinguish quota/model-access/region errors from real auth failures.
+        if should_treat_post_refresh_status_as_auth_failure(http_resp.status()) {
+            let status = http_resp.status();
+            let body = http_resp.text().await.unwrap_or_default();
+            return Err(LlmError::AuthenticationFailed(format!(
+                "ChatGPT API auth failed after refresh ({status}): {body}. Run `librefang auth chatgpt` to re-authenticate."
+            )));
+        }
+
+        Ok(http_resp)
+    }
+
     /// Convert a CompletionRequest (messages-based) to Responses API format.
     fn build_responses_request(request: &CompletionRequest) -> ResponsesApiRequest {
         let mut instructions: Option<String> = request.system.clone();
@@ -466,45 +522,26 @@ fn extract_text_content(content: &MessageContent) -> String {
     }
 }
 
+fn should_treat_post_refresh_status_as_auth_failure(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED
+}
+
+fn should_refresh_after_forbidden(body: &str) -> bool {
+    crate::llm_errors::classify_error(body, Some(reqwest::StatusCode::FORBIDDEN.as_u16())).category
+        == crate::llm_errors::LlmErrorCategory::Auth
+}
+
 #[async_trait::async_trait]
 impl crate::llm_driver::LlmDriver for ChatGptDriver {
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let token = self.ensure_token()?;
         let api_request = Self::build_responses_request(&request);
 
         let base = self.base_url.trim_end_matches('/');
         let url = format!("{base}/codex/responses");
 
         debug!("ChatGPT Responses API POST {url}");
-        let mut http_resp = self
-            .client
-            .post(&url)
-            .bearer_auth(token.token.as_str())
-            .json(&api_request)
-            .send()
-            .await
-            .map_err(|e| LlmError::Http(e.to_string()))?;
-        let mut status = http_resp.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            let refreshed = self.refresh_token().await?;
-            http_resp = self
-                .client
-                .post(&url)
-                .bearer_auth(refreshed.token.as_str())
-                .json(&api_request)
-                .send()
-                .await
-                .map_err(|e| LlmError::Http(e.to_string()))?;
-            status = http_resp.status();
-            if status == reqwest::StatusCode::UNAUTHORIZED
-                || status == reqwest::StatusCode::FORBIDDEN
-            {
-                let body = http_resp.text().await.unwrap_or_default();
-                return Err(LlmError::AuthenticationFailed(format!(
-                    "ChatGPT API auth failed after refresh ({status}): {body}. Run `librefang auth chatgpt` to re-authenticate."
-                )));
-            }
-        }
+        let http_resp = self.send_with_auth_retry(&url, &api_request).await?;
+        let status = http_resp.status();
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(LlmError::RateLimited {
@@ -530,42 +567,14 @@ impl crate::llm_driver::LlmDriver for ChatGptDriver {
         request: CompletionRequest,
         tx: tokio::sync::mpsc::Sender<StreamEvent>,
     ) -> Result<CompletionResponse, LlmError> {
-        let token = self.ensure_token()?;
         let api_request = Self::build_responses_request(&request);
 
         let base = self.base_url.trim_end_matches('/');
         let url = format!("{base}/codex/responses");
 
         debug!("ChatGPT Responses API SSE stream POST {url}");
-        let mut http_resp = self
-            .client
-            .post(&url)
-            .bearer_auth(token.token.as_str())
-            .json(&api_request)
-            .send()
-            .await
-            .map_err(|e| LlmError::Http(e.to_string()))?;
-        let mut status = http_resp.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            let refreshed = self.refresh_token().await?;
-            http_resp = self
-                .client
-                .post(&url)
-                .bearer_auth(refreshed.token.as_str())
-                .json(&api_request)
-                .send()
-                .await
-                .map_err(|e| LlmError::Http(e.to_string()))?;
-            status = http_resp.status();
-            if status == reqwest::StatusCode::UNAUTHORIZED
-                || status == reqwest::StatusCode::FORBIDDEN
-            {
-                let body = http_resp.text().await.unwrap_or_default();
-                return Err(LlmError::AuthenticationFailed(format!(
-                    "ChatGPT API auth failed after refresh ({status}): {body}. Run `librefang auth chatgpt` to re-authenticate."
-                )));
-            }
-        }
+        let http_resp = self.send_with_auth_retry(&url, &api_request).await?;
+        let status = http_resp.status();
 
         if !status.is_success() {
             let body = http_resp.text().await.unwrap_or_default();
@@ -656,12 +665,37 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_token_prefers_session_token_even_with_refresh_token_present() {
-        std::env::set_var("CHATGPT_REFRESH_TOKEN", "refresh-token");
+    fn test_ensure_token_uses_session_token() {
         let driver = ChatGptDriver::new("my-token".to_string(), String::new());
         let token = driver.ensure_token().unwrap();
         assert_eq!(*token.token, "my-token".to_string());
-        std::env::remove_var("CHATGPT_REFRESH_TOKEN");
+    }
+
+    #[test]
+    fn test_post_refresh_only_401_is_auth_failure() {
+        assert!(should_treat_post_refresh_status_as_auth_failure(
+            reqwest::StatusCode::UNAUTHORIZED
+        ));
+        assert!(!should_treat_post_refresh_status_as_auth_failure(
+            reqwest::StatusCode::FORBIDDEN
+        ));
+    }
+
+    #[test]
+    fn test_should_refresh_after_forbidden_for_auth_like_body() {
+        assert!(should_refresh_after_forbidden(
+            "Invalid API key or unauthorized access"
+        ));
+    }
+
+    #[test]
+    fn test_should_not_refresh_after_forbidden_for_model_or_quota_body() {
+        assert!(!should_refresh_after_forbidden(
+            "Model access is not enabled for your account"
+        ));
+        assert!(!should_refresh_after_forbidden(
+            "Quota exceeded for this model"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `librefang auth chatgpt --device-auth` for headless or remote environments
- keep the existing browser-based `librefang auth chatgpt` flow unchanged
- implement ChatGPT device auth request, polling, and token exchange helpers
- share token persistence and post-auth `config.toml` updates across browser and device auth
- add the minimal ChatGPT runtime auth fallback fix so authenticated chats use the stored session token first and only refresh after explicit `401/403` responses
- add CLI and runtime unit tests for the new auth flow and the ChatGPT auth fallback behavior

Scope: this PR is only for the existing `chatgpt` provider (`CHATGPT_SESSION_TOKEN`, `https://chatgpt.com/backend-api`). It does not change the `openai` provider, which remains the Platform API / `OPENAI_API_KEY` provider.

Reference: https://developers.openai.com/codex/auth

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo run -p librefang-cli -- auth chatgpt --device-auth` end to end on WSL
- [x] verified a live dashboard chat returns normally after the minimal ChatGPT auth fallback fix