### PR TITLE
fix: sync upstream improvements 

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1452,6 +1452,7 @@ pub async fn start_channel_bridge_with_config(
                     mx_config.user_id.clone(),
                     token,
                     mx_config.allowed_rooms.clone(),
+                    mx_config.auto_accept_invites,
                 )
                 .with_account_id(mx_config.account_id.clone()),
             );

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1035,20 +1035,64 @@ fn approval_to_json(
     })
 }
 
-/// GET /api/approvals — List pending approval requests.
+/// GET /api/approvals — List pending and recent approval requests.
 ///
 /// Transforms field names to match the dashboard template expectations:
 /// `action_summary` → `action`, `agent_id` → `agent_name`, `requested_at` → `created_at`.
-#[utoipa::path(get, path = "/api/approvals", tag = "approvals", responses((status = 200, description = "List pending approvals", body = Vec<serde_json::Value>)))]
+#[utoipa::path(get, path = "/api/approvals", tag = "approvals", responses((status = 200, description = "List pending and recent approvals", body = Vec<serde_json::Value>)))]
 pub async fn list_approvals(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let pending = state.kernel.approval_manager.list_pending();
-    let total = pending.len();
+    let recent = state.kernel.approval_manager.list_recent(50);
 
     let registry_agents = state.kernel.registry.list();
-    let approvals: Vec<serde_json::Value> = pending
+    let agent_name_for = |agent_id: &str| {
+        registry_agents
+            .iter()
+            .find(|ag| ag.id.to_string() == agent_id || ag.name == agent_id)
+            .map(|ag| ag.name.clone())
+            .unwrap_or_else(|| agent_id.to_string())
+    };
+
+    let mut approvals: Vec<serde_json::Value> = pending
         .iter()
         .map(|a| approval_to_json(a, &registry_agents))
         .collect();
+
+    approvals.extend(recent.into_iter().map(|record| {
+        let request = record.request;
+        let agent_name = agent_name_for(&request.agent_id);
+        let status = match record.decision {
+            librefang_types::approval::ApprovalDecision::Approved => "approved",
+            librefang_types::approval::ApprovalDecision::Denied => "rejected",
+            librefang_types::approval::ApprovalDecision::TimedOut => "expired",
+        };
+        serde_json::json!({
+            "id": request.id,
+            "agent_id": request.agent_id,
+            "agent_name": agent_name,
+            "tool_name": request.tool_name,
+            "description": request.description,
+            "action_summary": request.action_summary,
+            "action": request.action_summary,
+            "risk_level": request.risk_level,
+            "requested_at": request.requested_at,
+            "created_at": request.requested_at,
+            "timeout_secs": request.timeout_secs,
+            "status": status,
+            "decided_at": record.decided_at,
+            "decided_by": record.decided_by,
+        })
+    }));
+
+    approvals.sort_by(|a, b| {
+        let a_pending = a["status"].as_str() == Some("pending");
+        let b_pending = b["status"].as_str() == Some("pending");
+        b_pending
+            .cmp(&a_pending)
+            .then_with(|| b["created_at"].as_str().cmp(&a["created_at"].as_str()))
+    });
+
+    let total = approvals.len();
 
     Json(serde_json::json!({"approvals": approvals, "total": total}))
 }

--- a/crates/librefang-api/static/js/pages/approvals.js
+++ b/crates/librefang-api/static/js/pages/approvals.js
@@ -8,6 +8,7 @@ function approvalsPage() {
     filterStatus: 'all',
     loading: true,
     loadError: '',
+    refreshTimer: null,
 
     _updateURL() {
       var params = [];
@@ -27,6 +28,16 @@ function approvalsPage() {
         if (params.get('filter')) self.filterStatus = params.get('filter');
       }
       this.$watch('filterStatus', function() { self._updateURL(); });
+      this.refreshTimer = setInterval(function() {
+        self.loadData();
+      }, 5000);
+    },
+
+    destroy() {
+      if (this.refreshTimer) {
+        clearInterval(this.refreshTimer);
+        this.refreshTimer = null;
+      }
     },
 
     interpolate(text, params) {

--- a/crates/librefang-channels/src/matrix.rs
+++ b/crates/librefang-channels/src/matrix.rs
@@ -38,6 +38,10 @@ pub struct MatrixAdapter {
     allowed_rooms: Vec<String>,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Whether to automatically accept room invites.
+    /// Used when processing `/sync` invite events (not yet wired).
+    #[allow(dead_code)]
+    auto_accept_invites: bool,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -52,6 +56,7 @@ impl MatrixAdapter {
         user_id: String,
         access_token: String,
         allowed_rooms: Vec<String>,
+        auto_accept_invites: bool,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
@@ -61,6 +66,7 @@ impl MatrixAdapter {
             client: crate::http_client::new_client(),
             allowed_rooms,
             account_id: None,
+            auto_accept_invites,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             since_token: Arc::new(RwLock::new(None)),
@@ -366,6 +372,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "access_token".to_string(),
             vec![],
+            false,
         );
         assert_eq!(adapter.name(), "matrix");
     }
@@ -377,6 +384,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "token".to_string(),
             vec!["!room1:matrix.org".to_string()],
+            false,
         );
         assert!(adapter.is_allowed_room("!room1:matrix.org"));
         assert!(!adapter.is_allowed_room("!room2:matrix.org"));
@@ -386,6 +394,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "token".to_string(),
             vec![],
+            false,
         );
         assert!(open.is_allowed_room("!any:matrix.org"));
     }

--- a/crates/librefang-extensions/src/credentials.rs
+++ b/crates/librefang-extensions/src/credentials.rs
@@ -126,6 +126,13 @@ impl CredentialResolver {
             ))
         }
     }
+
+    /// Clear a credential from the in-memory dotenv cache.
+    /// Call this when a key is deleted via the dashboard so the resolver
+    /// doesn't return a stale value from the boot-time snapshot.
+    pub fn clear_dotenv_cache(&mut self, key: &str) {
+        self.dotenv.remove(key);
+    }
 }
 
 /// Load a dotenv file into a HashMap.

--- a/crates/librefang-hands/src/lib.rs
+++ b/crates/librefang-hands/src/lib.rs
@@ -47,6 +47,9 @@ pub enum HandCategory {
     Development,
     Communication,
     Data,
+    Finance,
+    #[serde(other)]
+    Other,
 }
 
 impl std::fmt::Display for HandCategory {
@@ -58,6 +61,8 @@ impl std::fmt::Display for HandCategory {
             Self::Development => write!(f, "Development"),
             Self::Communication => write!(f, "Communication"),
             Self::Data => write!(f, "Data"),
+            Self::Finance => write!(f, "Finance"),
+            Self::Other => write!(f, "Other"),
         }
     }
 }

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -5,15 +5,19 @@ use dashmap::DashMap;
 use librefang_types::approval::{
     ApprovalDecision, ApprovalPolicy, ApprovalRequest, ApprovalResponse, RiskLevel,
 };
+use std::collections::VecDeque;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 /// Max pending requests per agent.
 const MAX_PENDING_PER_AGENT: usize = 5;
+/// Max recent approval records to retain for history and UI visibility.
+const MAX_RECENT_APPROVALS: usize = 100;
 
 /// Manages approval requests with oneshot channels for blocking resolution.
 pub struct ApprovalManager {
     pending: DashMap<Uuid, PendingRequest>,
+    recent: std::sync::Mutex<VecDeque<ApprovalRecord>>,
     policy: std::sync::RwLock<ApprovalPolicy>,
 }
 
@@ -22,10 +26,19 @@ struct PendingRequest {
     sender: tokio::sync::oneshot::Sender<ApprovalDecision>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ApprovalRecord {
+    pub request: ApprovalRequest,
+    pub decision: ApprovalDecision,
+    pub decided_at: chrono::DateTime<Utc>,
+    pub decided_by: Option<String>,
+}
+
 impl ApprovalManager {
     pub fn new(policy: ApprovalPolicy) -> Self {
         Self {
             pending: DashMap::new(),
+            recent: std::sync::Mutex::new(VecDeque::new()),
             policy: std::sync::RwLock::new(policy),
         }
     }
@@ -51,6 +64,7 @@ impl ApprovalManager {
 
         let timeout = std::time::Duration::from_secs(req.timeout_secs);
         let id = req.id;
+        let req_for_timeout = req.clone();
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.pending.insert(
@@ -69,7 +83,12 @@ impl ApprovalManager {
                 decision
             }
             _ => {
-                self.pending.remove(&id);
+                let request = self
+                    .pending
+                    .remove(&id)
+                    .map(|(_, pending)| pending.request)
+                    .unwrap_or(req_for_timeout);
+                self.push_recent(request, ApprovalDecision::TimedOut, None, Utc::now());
                 warn!(request_id = %id, "Approval request timed out");
                 ApprovalDecision::TimedOut
             }
@@ -91,6 +110,12 @@ impl ApprovalManager {
                     decided_at: Utc::now(),
                     decided_by,
                 };
+                self.push_recent(
+                    pending.request.clone(),
+                    decision,
+                    response.decided_by.clone(),
+                    response.decided_at,
+                );
                 // Send decision to waiting agent (ignore error if receiver dropped)
                 let _ = pending.sender.send(decision);
                 info!(request_id = %request_id, ?decision, "Approval request resolved");
@@ -106,6 +131,12 @@ impl ApprovalManager {
             .iter()
             .map(|r| r.value().request.clone())
             .collect()
+    }
+
+    /// List recent non-pending approvals, newest first.
+    pub fn list_recent(&self, limit: usize) -> Vec<ApprovalRecord> {
+        let recent = self.recent.lock().unwrap_or_else(|e| e.into_inner());
+        recent.iter().take(limit).cloned().collect()
     }
 
     /// Get a single pending request by ID.
@@ -138,6 +169,25 @@ impl ApprovalManager {
             "file_write" | "file_delete" => RiskLevel::High,
             "web_fetch" | "browser_navigate" => RiskLevel::Medium,
             _ => RiskLevel::Low,
+        }
+    }
+
+    fn push_recent(
+        &self,
+        request: ApprovalRequest,
+        decision: ApprovalDecision,
+        decided_by: Option<String>,
+        decided_at: chrono::DateTime<Utc>,
+    ) {
+        let mut recent = self.recent.lock().unwrap_or_else(|e| e.into_inner());
+        recent.push_front(ApprovalRecord {
+            request,
+            decision,
+            decided_at,
+            decided_by,
+        });
+        while recent.len() > MAX_RECENT_APPROVALS {
+            recent.pop_back();
         }
     }
 }
@@ -248,6 +298,7 @@ mod tests {
     fn test_list_pending_empty() {
         let mgr = default_manager();
         assert!(mgr.list_pending().is_empty());
+        assert!(mgr.list_recent(10).is_empty());
     }
 
     // -----------------------------------------------------------------------
@@ -298,6 +349,10 @@ mod tests {
         assert_eq!(decision, ApprovalDecision::TimedOut);
         // After timeout, pending map should be cleaned up
         assert_eq!(mgr.pending_count(), 0);
+        let recent = mgr.list_recent(10);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].decision, ApprovalDecision::TimedOut);
+        assert_eq!(recent[0].request.tool_name, "shell_exec");
     }
 
     // -----------------------------------------------------------------------
@@ -327,6 +382,10 @@ mod tests {
 
         let decision = mgr.request_approval(req).await;
         assert_eq!(decision, ApprovalDecision::Approved);
+        let recent = mgr.list_recent(10);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].decision, ApprovalDecision::Approved);
+        assert_eq!(recent[0].decided_by.as_deref(), Some("admin"));
     }
 
     // -----------------------------------------------------------------------
@@ -348,6 +407,9 @@ mod tests {
 
         let decision = mgr.request_approval(req).await;
         assert_eq!(decision, ApprovalDecision::Denied);
+        let recent = mgr.list_recent(10);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].decision, ApprovalDecision::Denied);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -192,6 +192,27 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Update an agent's model, provider, and connection hints together.
+    pub fn update_model_provider_config(
+        &self,
+        id: AgentId,
+        new_model: String,
+        new_provider: String,
+        api_key_env: Option<String>,
+        base_url: Option<String>,
+    ) -> LibreFangResult<()> {
+        let mut entry = self
+            .agents
+            .get_mut(&id)
+            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+        entry.manifest.model.model = new_model;
+        entry.manifest.model.provider = new_provider;
+        entry.manifest.model.api_key_env = api_key_env;
+        entry.manifest.model.base_url = base_url;
+        entry.last_active = chrono::Utc::now();
+        Ok(())
+    }
+
     /// Update an agent's fallback model chain.
     pub fn update_fallback_models(
         &self,

--- a/crates/librefang-memory/src/knowledge.rs
+++ b/crates/librefang-memory/src/knowledge.rs
@@ -145,9 +145,10 @@ impl KnowledgeStore {
         let mut idx = 1;
 
         if let Some(ref source) = pattern.source {
-            sql.push_str(&format!(" AND (s.id = ?{idx} OR s.name = ?{idx})"));
+            sql.push_str(&format!(" AND (s.id = ?{} OR s.name = ?{})", idx, idx + 1));
             params.push(Box::new(source.clone()));
-            idx += 1;
+            params.push(Box::new(source.clone()));
+            idx += 2;
         }
         if let Some(ref relation) = pattern.relation {
             let rel_str = serde_json::to_string(relation)
@@ -157,10 +158,12 @@ impl KnowledgeStore {
             idx += 1;
         }
         if let Some(ref target) = pattern.target {
-            sql.push_str(&format!(" AND (t.id = ?{idx} OR t.name = ?{idx})"));
+            sql.push_str(&format!(" AND (t.id = ?{} OR t.name = ?{})", idx, idx + 1));
             params.push(Box::new(target.clone()));
-            let _ = idx;
+            params.push(Box::new(target.clone()));
+            idx += 2;
         }
+        let _ = idx;
 
         sql.push_str(" LIMIT 100");
 

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -101,11 +101,19 @@ impl ModelCatalog {
         &self.models
     }
 
-    /// Find a model by its canonical ID or by alias.
+    /// Find a model by its canonical ID, display name, or alias.
     pub fn find_model(&self, id_or_alias: &str) -> Option<&ModelCatalogEntry> {
         let lower = id_or_alias.to_lowercase();
         // Direct ID match first
         if let Some(entry) = self.models.iter().find(|m| m.id.to_lowercase() == lower) {
+            return Some(entry);
+        }
+        // Display-name match for dashboard/UI payloads that send labels.
+        if let Some(entry) = self
+            .models
+            .iter()
+            .find(|m| m.display_name.to_lowercase() == lower)
+        {
             return Some(entry);
         }
         // Alias resolution

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -2644,6 +2644,9 @@ pub struct MatrixConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Whether to auto-accept room invites (default: false).
+    #[serde(default)]
+    pub auto_accept_invites: bool,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -2658,6 +2661,7 @@ impl Default for MatrixConfig {
             allowed_rooms: vec![],
             account_id: None,
             default_agent: None,
+            auto_accept_invites: false,
             overrides: ChannelOverrides::default(),
         }
     }

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.6.3-20260319"
+    "version": "0.6.8-20260320"
   },
   "paths": {
     "/.well-known/agent.json": {
@@ -1750,12 +1750,12 @@
         "tags": [
           "approvals"
         ],
-        "summary": "GET /api/approvals — List pending approval requests.",
+        "summary": "GET /api/approvals — List pending and recent approval requests.",
         "description": "Transforms field names to match the dashboard template expectations:\n`action_summary` → `action`, `agent_id` → `agent_name`, `requested_at` → `created_at`.",
         "operationId": "list_approvals",
         "responses": {
           "200": {
-            "description": "List pending approvals",
+            "description": "List pending and recent approvals",
             "content": {
               "application/json": {
                 "schema": {
@@ -7073,8 +7073,29 @@
             },
             "description": "Optional file attachments (uploaded via /upload endpoint)."
           },
+          "channel_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional channel type (e.g. \"whatsapp\", \"telegram\")."
+          },
           "message": {
             "type": "string"
+          },
+          "sender_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional sender ID (platform-specific user ID)."
+          },
+          "sender_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional sender display name."
           }
         }
       },


### PR DESCRIPTION
## Summary

Syncs key bug fixes and improvements

### Bug Fixes
- **Knowledge store SQL param binding** — `query_graph` source/target OR conditions used same bind index `?{idx}` for two placeholders but only pushed one value. Fixed by using separate indices and pushing the value twice.
- **Matrix `auto_accept_invites` default** — Was implicitly true (accepting all room invites). Now configurable via `config.toml`, defaults to `false` for security.

### Features
- **Approval history** — `ApprovalManager` keeps a bounded ring buffer of recent resolved/timed-out approvals. `/api/approvals` now returns both pending and recent records, sorted pending-first. Dashboard polls every 5s.
- **Model catalog display name matching** — `find_model()` now matches by display name (e.g. "Grok 4") in addition to canonical ID and aliases, fixing UI label → model ID resolution.
- **Registry `update_model_provider_config`** — New method to atomically update model + provider + api_key_env + base_url together.
- **Credential resolver `clear_dotenv_cache`** — Allows clearing stale dotenv entries when credentials are deleted via dashboard.
- **HandCategory expansion** — Added `Finance` and `Other` (with `#[serde(other)]` fallback) variants.

### Not ported (not applicable)
- Token detection heuristic (`len() > 80`) — our `read_token` only reads from env vars, doesn't accept raw tokens
- Config schema fields→array format — needs separate dashboard-side changes
- KaTeX lazy loading — needs separate frontend work
- CI dependency bumps (docker actions, zip, roxmltree) — different CI setup

## Test plan
- [x] `cargo build --workspace --lib` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo test --workspace` — 312 passed (1 pre-existing flaky router test)
- [x] `cargo fmt --all` applied