### PR TITLE
fix: harden OpenClaw migration inputs

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1017,7 +1017,10 @@ pub async fn migrate_scan(Json(req): Json<MigrateScanRequest>) -> impl IntoRespo
         (status = 200, description = "Run migration from another agent framework", body = serde_json::Value)
     )
 )]
-pub async fn run_migrate(Json(req): Json<MigrateRequest>) -> impl IntoResponse {
+pub async fn run_migrate(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<MigrateRequest>,
+) -> impl IntoResponse {
     let source = match req.source.as_str() {
         "openclaw" => librefang_migrate::MigrateSource::OpenClaw,
         "langchain" => librefang_migrate::MigrateSource::LangChain,
@@ -1032,10 +1035,16 @@ pub async fn run_migrate(Json(req): Json<MigrateRequest>) -> impl IntoResponse {
         }
     };
 
+    let target_dir = if req.target_dir.trim().is_empty() {
+        state.kernel.config.home_dir.clone()
+    } else {
+        std::path::PathBuf::from(req.target_dir.trim())
+    };
+
     let options = librefang_migrate::MigrateOptions {
         source,
-        source_dir: std::path::PathBuf::from(&req.source_dir),
-        target_dir: std::path::PathBuf::from(&req.target_dir),
+        source_dir: std::path::PathBuf::from(req.source_dir.trim()),
+        target_dir,
         dry_run: req.dry_run,
     };
 

--- a/crates/librefang-api/static/js/pages/settings.js
+++ b/crates/librefang-api/static/js/pages/settings.js
@@ -443,8 +443,10 @@ function settingsPage() {
           uptime_seconds: status.uptime_seconds || 0,
           agent_count: status.agent_count || 0,
           default_provider: status.default_provider || '-',
-          default_model: status.default_model || '-'
+          default_model: status.default_model || '-',
+          home_dir: status.home_dir || ''
         };
+        if (!this.targetPath && status.home_dir) this.targetPath = status.home_dir;
       } catch(e) { throw e; }
     },
 

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -432,6 +432,83 @@ async fn test_build_router_unauthorized_responses_include_api_version_header() {
 }
 
 #[tokio::test]
+async fn test_run_migrate_uses_daemon_home_when_target_dir_is_empty() {
+    let harness = start_full_router("").await;
+
+    let source_dir = harness.state.kernel.config.home_dir.join("openclaw-source");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::write(
+        source_dir.join("openclaw.json"),
+        r#"{
+          agents: {
+            list: [
+              { id: "main", name: "Main Agent" }
+            ],
+            defaults: {
+              model: "anthropic/claude-sonnet-4-20250514"
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "source": "openclaw",
+                "source_dir": source_dir.display().to_string(),
+                "target_dir": "",
+                "dry_run": false
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "completed");
+    assert_eq!(json["dry_run"], false);
+
+    let config_path = harness.state.kernel.config.home_dir.join("config.toml");
+    let agent_path = harness
+        .state
+        .kernel
+        .config
+        .home_dir
+        .join("agents")
+        .join("main")
+        .join("agent.toml");
+    let report_path = harness
+        .state
+        .kernel
+        .config
+        .home_dir
+        .join("migration_report.md");
+
+    assert!(
+        config_path.exists(),
+        "config.toml should be written to daemon home"
+    );
+    assert!(
+        agent_path.exists(),
+        "agent.toml should be written to daemon home"
+    );
+    assert!(
+        report_path.exists(),
+        "migration_report.md should be written to daemon home"
+    );
+}
+
+#[tokio::test]
 async fn test_config_reload_reports_proxy_changes_require_restart() {
     let server = start_test_server().await;
     let client = reqwest::Client::new();

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -85,7 +85,7 @@ struct OpenClawAgentDefaults {
     model: Option<OpenClawAgentModel>,
     workspace: Option<String>,
     tools: Option<OpenClawAgentTools>,
-    identity: Option<String>,
+    identity: Option<OpenClawIdentity>,
 }
 
 /// Agent model reference — either `"provider/model"` or `{ primary, fallbacks }`.
@@ -103,6 +103,14 @@ struct OpenClawAgentModelDetailed {
     fallbacks: Vec<String>,
 }
 
+/// Agent identity/system prompt reference — either a raw string or a structured object.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum OpenClawIdentity {
+    Text(String),
+    Structured(serde_json::Value),
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct OpenClawAgentEntry {
@@ -112,7 +120,7 @@ struct OpenClawAgentEntry {
     tools: Option<OpenClawAgentTools>,
     workspace: Option<String>,
     skills: Option<serde_json::Value>,
-    identity: Option<String>,
+    identity: Option<OpenClawIdentity>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -144,6 +152,65 @@ fn extract_string_list(val: &serde_json::Value) -> Vec<String> {
         serde_json::Value::String(s) => vec![s.clone()],
         serde_json::Value::Object(map) => map.keys().cloned().collect(),
         _ => vec![],
+    }
+}
+
+/// Extract a prompt string from OpenClaw's `identity` field.
+///
+/// Recent OpenClaw configs may store identity as a structured object instead of a
+/// raw string. We accept both and look for common prompt-bearing keys without
+/// failing the whole migration when the shape differs.
+fn extract_identity_prompt(identity: &OpenClawIdentity) -> Option<String> {
+    match identity {
+        OpenClawIdentity::Text(s) => {
+            let trimmed = s.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        OpenClawIdentity::Structured(value) => extract_identity_prompt_value(value),
+    }
+}
+
+fn extract_identity_prompt_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => {
+            let trimmed = s.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        serde_json::Value::Array(items) => {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(extract_identity_prompt_value)
+                .collect();
+            (!parts.is_empty()).then(|| parts.join("\n\n"))
+        }
+        serde_json::Value::Object(map) => {
+            for key in [
+                "systemPrompt",
+                "system_prompt",
+                "prompt",
+                "instructions",
+                "instruction",
+                "content",
+                "text",
+                "value",
+                "persona",
+                "identity",
+                "description",
+            ] {
+                if let Some(prompt) = map.get(key).and_then(extract_identity_prompt_value) {
+                    return Some(prompt);
+                }
+            }
+
+            for nested in map.values().filter(|v| v.is_object() || v.is_array()) {
+                if let Some(prompt) = extract_identity_prompt_value(nested) {
+                    return Some(prompt);
+                }
+            }
+
+            None
+        }
+        _ => None,
     }
 }
 
@@ -1849,8 +1916,13 @@ fn convert_agent_from_json(
     // System prompt from identity
     let system_prompt = entry
         .identity
-        .clone()
-        .or_else(|| defaults.and_then(|d| d.identity.clone()))
+        .as_ref()
+        .and_then(extract_identity_prompt)
+        .or_else(|| {
+            defaults
+                .and_then(|d| d.identity.as_ref())
+                .and_then(extract_identity_prompt)
+        })
         .unwrap_or_else(|| {
             format!(
                 "You are {display_name}, an AI agent running on the LibreFang Agent OS. You are helpful, concise, and accurate."
@@ -3842,6 +3914,47 @@ mod tests {
         assert!(agent_toml.contains("provider = \"mycompany\""));
         assert!(agent_toml.contains("model = \"custom-llm-v3\""));
         assert!(agent_toml.contains("api_key_env = \"MYCOMPANY_API_KEY\""));
+    }
+
+    #[test]
+    fn test_json5_identity_object_parsing() {
+        let source = TempDir::new().unwrap();
+        let target = TempDir::new().unwrap();
+
+        let json5_content = r#"{
+  agents: {
+    defaults: {
+      model: "anthropic/claude-sonnet-4-20250514"
+    },
+    list: [
+      {
+        id: "admin",
+        name: "Admin",
+        identity: {
+          prompt: {
+            text: "You are the admin agent. Keep control-plane changes explicit."
+          }
+        }
+      }
+    ]
+  }
+}"#;
+        std::fs::write(source.path().join("openclaw.json"), json5_content).unwrap();
+
+        let options = MigrateOptions {
+            source: crate::MigrateSource::OpenClaw,
+            source_dir: source.path().to_path_buf(),
+            target_dir: target.path().to_path_buf(),
+            dry_run: false,
+        };
+
+        let report = migrate(&options).unwrap();
+        assert!(report.imported.iter().any(|i| i.kind == ItemKind::Agent));
+
+        let agent_toml =
+            std::fs::read_to_string(target.path().join("agents/admin/agent.toml")).unwrap();
+        assert!(agent_toml.contains("You are the admin agent."));
+        assert!(agent_toml.contains("Keep control-plane changes explicit."));
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary
- default an empty Web migration target directory to the daemon home so `/api/migrate` matches CLI/TUI behavior
- accept structured OpenClaw `identity` objects during JSON5 migration instead of failing on string-only deserialization
- add regression coverage for the empty-target API path and structured-identity migration path

## Testing
- cargo test -p librefang-api test_run_migrate_uses_daemon_home_when_target_dir_is_empty -- --nocapture
- cargo test -p librefang-migrate openclaw -- --nocapture

Fixes #1340