### PR TITLE
fix: detect Qwen Code CLI in test_connection and setup wizard

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -855,6 +855,7 @@ pub async fn test_provider(
     if base_url.is_empty() {
         let cli_ok = match name.as_str() {
             "claude-code" => librefang_runtime::drivers::claude_code::claude_code_available(),
+            "qwen-code" => librefang_runtime::drivers::qwen_code::qwen_code_available(),
             _ => false,
         };
         return if cli_ok {

--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -221,10 +221,10 @@ impl WizardState {
         self.provider_order.clear();
         // Detected providers first
         for (i, p) in PROVIDERS.iter().enumerate() {
-            let detected = if p.name == "claude-code" {
-                librefang_runtime::drivers::claude_code::claude_code_available()
-            } else {
-                !p.env_var.is_empty() && std::env::var(p.env_var).is_ok()
+            let detected = match p.name {
+                "claude-code" => librefang_runtime::drivers::claude_code::claude_code_available(),
+                "qwen-code" => librefang_runtime::drivers::qwen_code::qwen_code_available(),
+                _ => !p.env_var.is_empty() && std::env::var(p.env_var).is_ok(),
             };
             if detected {
                 self.provider_order.push(i);
@@ -232,10 +232,10 @@ impl WizardState {
         }
         // Then the rest
         for (i, p) in PROVIDERS.iter().enumerate() {
-            let detected = if p.name == "claude-code" {
-                librefang_runtime::drivers::claude_code::claude_code_available()
-            } else {
-                !p.env_var.is_empty() && std::env::var(p.env_var).is_ok()
+            let detected = match p.name {
+                "claude-code" => librefang_runtime::drivers::claude_code::claude_code_available(),
+                "qwen-code" => librefang_runtime::drivers::qwen_code::qwen_code_available(),
+                _ => !p.env_var.is_empty() && std::env::var(p.env_var).is_ok(),
             };
             if !detected {
                 self.provider_order.push(i);


### PR DESCRIPTION
## Summary
- Add `qwen-code` to the CLI detection match in `test_provider()` — was falling through to `false`, always returning "CLI not found in PATH"
- Add `qwen-code` to the setup wizard's `build_provider_order()` so it gets properly detected and prioritized when installed

Closes #1329

## Test plan
- [ ] Install `qwen` CLI, run test connection for qwen-code provider — should return `status: ok`
- [ ] Verify setup wizard detects and prioritizes qwen-code when CLI is on PATH