### PR TITLE
fix(docs): escape < in MDX troubleshooting page

### DIFF
--- a/docs/src/app/troubleshooting/page.mdx
+++ b/docs/src/app/troubleshooting/page.mdx
@@ -425,7 +425,7 @@ cors_origins = ["http://localhost:5173", "https://your-app.com"]
 
 ### Slow startup
 
-**Normal startup**: `<200ms` for the kernel, `~1-2s` with channel adapters.
+**Normal startup**: `&lt;200ms` for the kernel, `~1-2s` with channel adapters.
 
 If slower:
 - Check database size (`~/.librefang/data/librefang.db`)
@@ -519,7 +519,7 @@ model = "llama3.2"
 | Providers | 20 | 3 |
 | Security | 16 systems | Config-based |
 | Binary size | ~30 MB | ~200 MB |
-| Startup | `<200 ms` | `~3 s` |
+| Startup | `&lt;200 ms` | `~3 s` |
 
 LibreFang can import OpenClaw configs: `librefang migrate --from openclaw`
 


### PR DESCRIPTION
## Summary
- Escape `<` to `&lt;` in two places in `troubleshooting/page.mdx` where `<200ms` was breaking the MDX parser (same issue as #1350)

## Test plan
- [x] `pnpm run build` passes with all 55 pages generated