### PR TITLE
fix: resolve compilation errors breaking CI clippy check

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1016,6 +1016,7 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
         display_name: req.sender_name.clone().unwrap_or_else(|| sender_id.clone()),
         is_group: false,
         thread_id: None,
+        account_id: None,
     })
 }
 

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6374,7 +6374,7 @@ pub(crate) fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) {
 fn cmd_integration_add(name: &str, key: Option<&str>) {
     let home = librefang_home();
     let mut registry = librefang_extensions::registry::IntegrationRegistry::new(&home);
-    registry.load_bundled(&librefang_dir);
+    registry.load_bundled(&home);
     let _ = registry.load_installed();
 
     // Check template exists
@@ -6460,7 +6460,7 @@ fn cmd_integration_add(name: &str, key: Option<&str>) {
 fn cmd_integration_remove(name: &str) {
     let home = librefang_home();
     let mut registry = librefang_extensions::registry::IntegrationRegistry::new(&home);
-    registry.load_bundled(&librefang_dir);
+    registry.load_bundled(&home);
     let _ = registry.load_installed();
 
     match librefang_extensions::installer::remove_integration(&mut registry, name) {
@@ -6484,7 +6484,7 @@ fn cmd_integration_remove(name: &str) {
 fn cmd_integrations_list(query: Option<&str>) {
     let home = librefang_home();
     let mut registry = librefang_extensions::registry::IntegrationRegistry::new(&home);
-    registry.load_bundled(&librefang_dir);
+    registry.load_bundled(&home);
     let _ = registry.load_installed();
 
     let dotenv_path = home.join(".env");

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2254,7 +2254,7 @@ system_prompt = "You are a helpful assistant."
                 user_name,
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
-                sender_display_name: sender_context.and_then(|s| s.display_name.clone()),
+                sender_display_name: sender_context.map(|s| s.display_name.clone()),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")
@@ -7758,6 +7758,7 @@ mod tests {
             display_name: "Alice".to_string(),
             is_group: true,
             thread_id: Some("thread-9".to_string()),
+            account_id: None,
         };
 
         let with_sender = LibreFangKernel::assistant_route_key(agent_id, Some(&sender));


### PR DESCRIPTION
## Summary
- Fix type mismatch in `kernel.rs`: `and_then` → `map` for `display_name` which is `String`, not `Option<String>`
- Add missing `account_id` field to `SenderContext` initializers in `routes/agents.rs` and `kernel.rs` test
- Fix undefined `librefang_dir` variable in 3 integration commands in CLI (`cmd_integration_add/remove`, `cmd_integrations_list`) — should reference the local `home` variable

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero errors
- [x] `cargo test --workspace` passes (except pre-existing local env skill count mismatch)
- [ ] CI Quality job should now pass