### PR TITLE
fix: handle re-release in release.sh when no files changed

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -240,11 +240,17 @@ git -C "$REPO_ROOT" add \
     packages/whatsapp-gateway/package.json \
     crates/librefang-desktop/tauri.conf.json
 [ -f "$ARTICLE" ] && git -C "$REPO_ROOT" add "$ARTICLE"
-git -C "$REPO_ROOT" commit -m "chore: bump version to $TAG"
+
+if git -C "$REPO_ROOT" diff --cached --quiet; then
+    echo ""
+    echo "No file changes (re-release). Tagging current HEAD."
+else
+    git -C "$REPO_ROOT" commit -m "chore: bump version to $TAG"
+fi
 git -C "$REPO_ROOT" tag "$TAG"
 
 echo ""
-echo "Created commit and tag $TAG"
+echo "Created tag $TAG"
 
 # --- Create branch and push ---
 


### PR DESCRIPTION
## Summary
- Skip `git commit` when staging area is empty during a re-release (same version tag)
- Tag current HEAD directly instead of failing with "nothing to commit"

## Test plan
- [ ] Run `./scripts/release.sh 0.7.0` on a version that already exists — should succeed without error
- [ ] Run `./scripts/release.sh` with a new version — should still commit + tag normally