### PR TITLE
test: lock api status version regression

### DIFF
--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -165,6 +165,7 @@ async fn test_full_daemon_lifecycle() {
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "ok");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
 
     // --- Verify status endpoint ---
     let resp = client
@@ -175,6 +176,7 @@ async fn test_full_daemon_lifecycle() {
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["status"], "running");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
 
     // --- Shutdown ---
     let resp = client


### PR DESCRIPTION
## Summary
- add regression coverage for daemon lifecycle version responses
- assert /api/health returns the package version
- assert /api/status returns the package version

## Testing
- CARGO_TARGET_DIR=/tmp/librefang-target cargo test -p librefang-api --test daemon_lifecycle_test