### PR TITLE
fix: register aliases for custom models

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -677,10 +677,6 @@ pub fn read_codex_credential() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn test_catalog() -> ModelCatalog {
-        ModelCatalog::new()
-    }
     use librefang_types::model_catalog::{LMSTUDIO_BASE_URL, OLLAMA_BASE_URL};
 
     /// Build a catalog for tests.


### PR DESCRIPTION
## Summary
- register aliases when adding custom models to the runtime catalog
- add regression coverage that custom models keep their assigned provider
- add regression coverage that duplicate IDs remain distinct across providers

## Testing
- CARGO_TARGET_DIR=/tmp/librefang-target cargo test -p librefang-runtime custom_model