### PR TITLE
fix: scope knowledge JOIN by agent_id and add entities.name index

### DIFF
--- a/crates/librefang-memory/src/knowledge.rs
+++ b/crates/librefang-memory/src/knowledge.rs
@@ -116,7 +116,10 @@ impl KnowledgeStore {
             .map_err(|e| LibreFangError::Serialization(e.to_string()))?;
         let count: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM relations WHERE source_entity = ?1 AND relation_type = ?2 AND target_entity = ?3",
+                "SELECT COUNT(*) FROM relations r
+                 WHERE (r.source_entity = ?1 OR EXISTS (SELECT 1 FROM entities e WHERE e.id = ?1 AND e.name = r.source_entity))
+                 AND r.relation_type = ?2
+                 AND (r.target_entity = ?3 OR EXISTS (SELECT 1 FROM entities e WHERE e.id = ?3 AND e.name = r.target_entity))",
                 rusqlite::params![source_id, rel_str, target_id],
                 |row| row.get(0),
             )
@@ -137,8 +140,8 @@ impl KnowledgeStore {
                 r.id, r.source_entity, r.relation_type, r.target_entity, r.properties, r.confidence, r.created_at,
                 t.id, t.entity_type, t.name, t.properties, t.created_at, t.updated_at
              FROM relations r
-             JOIN entities s ON (r.source_entity = s.id OR r.source_entity = s.name)
-             JOIN entities t ON (r.target_entity = t.id OR r.target_entity = t.name)
+             JOIN entities s ON (r.source_entity = s.id OR (r.source_entity = s.name AND s.agent_id = r.agent_id))
+             JOIN entities t ON (r.target_entity = t.id OR (r.target_entity = t.name AND t.agent_id = r.agent_id))
              WHERE 1=1",
         );
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 10;
+const SCHEMA_VERSION: u32 = 11;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -49,6 +49,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 10 {
         migrate_v10(conn)?;
+    }
+
+    if current_version < 11 {
+        migrate_v11(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -370,6 +374,19 @@ fn migrate_v10(conn: &Connection) -> Result<(), rusqlite::Error> {
 
         INSERT OR IGNORE INTO migrations (version, applied_at, description)
         VALUES (10, datetime('now'), 'Add agent_id to entities and relations');
+        ",
+    )?;
+    Ok(())
+}
+
+/// Version 11: Add index on entities.name for name-based JOIN lookups.
+fn migrate_v11(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "
+        CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(name);
+
+        INSERT OR IGNORE INTO migrations (version, applied_at, description)
+        VALUES (11, datetime('now'), 'Add index on entities.name for knowledge graph queries');
         ",
     )?;
     Ok(())


### PR DESCRIPTION
## Summary
Follow-up to #1369 — the original fix widened the JOIN to match by name, but two issues remain:

- **Cross-agent collision**: When two agents have entities with the same name, the JOIN returns results from other agents. Scope the JOIN with `agent_id` to prevent this.
- **Missing index**: `entities.name` is now used in JOIN conditions but has no index, causing full table scans. Add migration v11 with `CREATE INDEX idx_entities_name`.

## Changes
- `knowledge.rs`: Add `AND s.agent_id = r.agent_id` / `AND t.agent_id = r.agent_id` to JOIN conditions; update `has_relation` to also match by entity name
- `migration.rs`: Add migration v11 with `idx_entities_name` index

Closes #1022 (follow-up)