### PR TITLE
feat: add custom log directory config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "axum",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "aes",
  "async-trait",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9935,7 +9935,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 
 [[package]]
 name = "yoke"

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1328,6 +1328,7 @@ fn cli_librefang_home() -> std::path::PathBuf {
 struct DaemonConfigContext {
     home_dir: PathBuf,
     api_key: Option<String>,
+    log_dir: Option<PathBuf>,
 }
 
 fn daemon_config_context(config: Option<&std::path::Path>) -> DaemonConfigContext {
@@ -1343,12 +1344,15 @@ fn daemon_config_context(config: Option<&std::path::Path>) -> DaemonConfigContex
     DaemonConfigContext {
         home_dir: config.home_dir,
         api_key,
+        log_dir: config.log_dir,
     }
 }
 
 /// Redirect tracing to a log file so it doesn't corrupt the ratatui TUI.
-fn init_tracing_file(log_level: &str) {
-    let log_dir = cli_librefang_home();
+fn init_tracing_file(log_level: &str, custom_log_dir: Option<&std::path::Path>) {
+    let log_dir = custom_log_dir
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(cli_librefang_home);
     let _ = std::fs::create_dir_all(&log_dir);
     let log_path = log_dir.join("tui.log");
 
@@ -1392,6 +1396,15 @@ fn load_log_level_from_config() -> String {
     level.unwrap_or_else(|| "info".to_string())
 }
 
+/// Load just the `log_dir` field from config.toml without fully deserializing.
+/// Returns the configured custom log directory, or `None` to use the default.
+fn load_log_dir_from_config() -> Option<PathBuf> {
+    let config_path = dirs::home_dir()?.join(".librefang").join("config.toml");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config: toml::Value = toml::from_str(&content).ok()?;
+    config.get("log_dir")?.as_str().map(PathBuf::from)
+}
+
 fn main() {
     // Initialize rustls crypto provider FIRST, before any async/TLS operations
     // This is required because rustls 0.23 needs explicit crypto provider initialization
@@ -1422,9 +1435,10 @@ fn main() {
         );
 
     let log_level = load_log_level_from_config();
+    let custom_log_dir = load_log_dir_from_config();
 
     if is_tui_mode {
-        init_tracing_file(&log_level);
+        init_tracing_file(&log_level, custom_log_dir.as_deref());
     } else {
         // CLI subcommands: install Ctrl+C handler for clean interrupt of
         // blocking read_line calls, and trace to stderr.
@@ -2097,7 +2111,11 @@ fn daemon_log_path_for_home(home_dir: &std::path::Path) -> PathBuf {
 
 fn daemon_log_path_for_config(config: Option<&std::path::Path>) -> PathBuf {
     let daemon = daemon_config_context(config);
-    daemon_log_path_for_home(&daemon.home_dir)
+    if let Some(ref log_dir) = daemon.log_dir {
+        log_dir.join("daemon.log")
+    } else {
+        daemon_log_path_for_home(&daemon.home_dir)
+    }
 }
 
 fn detached_daemon_args(config: Option<&std::path::Path>) -> Vec<OsString> {
@@ -7501,7 +7519,8 @@ fn cmd_logs(config: Option<PathBuf>, lines: usize, follow: bool) {
         return;
     }
 
-    let tui_log = daemon.home_dir.join("tui.log");
+    let tui_log_dir = daemon.log_dir.as_deref().unwrap_or(&daemon.home_dir);
+    let tui_log = tui_log_dir.join("tui.log");
     if tui_log.exists() {
         ui::hint(&format!(
             "Daemon log not found; showing TUI log at {}",

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1318,6 +1318,10 @@ pub struct KernelConfig {
     /// Default: `~/.librefang/workspace`
     #[serde(default)]
     pub workspace_dir: Option<PathBuf>,
+    /// Custom log directory. When set, log files are written here instead of
+    /// the default `~/.librefang/` directory.
+    #[serde(default)]
+    pub log_dir: Option<PathBuf>,
     /// Media understanding configuration.
     #[serde(default)]
     pub media: crate::media::MediaConfig,
@@ -2057,6 +2061,7 @@ impl Default for KernelConfig {
             vault: VaultConfig::default(),
             workspaces_dir: None,
             workspace_dir: None,
+            log_dir: None,
             media: crate::media::MediaConfig::default(),
             links: crate::media::LinkConfig::default(),
             reload: ReloadConfig::default(),
@@ -2175,6 +2180,7 @@ impl std::fmt::Debug for KernelConfig {
             .field("vault", &format!("enabled={}", self.vault.enabled))
             .field("workspaces_dir", &self.workspaces_dir)
             .field("workspace_dir", &self.workspace_dir)
+            .field("log_dir", &self.log_dir)
             .field(
                 "media",
                 &format!(


### PR DESCRIPTION
## Summary
- Added `log_dir: Option<PathBuf>` to `KernelConfig` for custom log directory
- CLI `init_tracing_file()` and daemon log path respect the custom directory
- Falls back to `~/.librefang/` when not set

Closes #984