### PR TITLE
feat: add rustfmt.toml for consistent code formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+# LibreFang workspace rustfmt configuration
+# Enforced by CI — run `cargo fmt` before pushing.
+
+edition = "2021"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
## Summary
- Added `rustfmt.toml` with `edition = "2021"`, `max_width = 100`, `use_field_init_shorthand = true`, `use_try_shorthand = true`
- Settings match existing code style — `cargo fmt --check` passes with zero changes

Closes #940