### PR TITLE
feat: add unfurl_links config option for Slack channel

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1596,7 +1596,8 @@ pub async fn start_channel_bridge_with_config(
                 let adapter = Arc::new(
                     SlackAdapter::new(app_token, bot_token, sl_config.allowed_channels.clone())
                         .with_account_id(sl_config.account_id.clone())
-                        .with_force_flat_replies(sl_config.force_flat_replies.unwrap_or(false)),
+                        .with_force_flat_replies(sl_config.force_flat_replies.unwrap_or(false))
+                        .with_unfurl_links(sl_config.unfurl_links),
                 );
                 adapters.push((
                     adapter,

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -31,6 +31,9 @@ pub struct SlackAdapter {
     allowed_channels: Vec<String>,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Whether to unfurl (expand previews for) links in sent messages.
+    /// When `None`, Slack uses its own default behavior.
+    unfurl_links: Option<bool>,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after auth.test).
@@ -48,6 +51,7 @@ impl SlackAdapter {
             client: crate::http_client::new_client(),
             allowed_channels,
             account_id: None,
+            unfurl_links: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
@@ -64,6 +68,12 @@ impl SlackAdapter {
     /// Force replies to be posted as top-level channel messages instead of threads.
     pub fn with_force_flat_replies(mut self, force: bool) -> Self {
         self.force_flat_replies = force;
+        self
+    }
+
+    /// Set the unfurl_links option. Returns self for builder chaining.
+    pub fn with_unfurl_links(mut self, unfurl_links: Option<bool>) -> Self {
+        self.unfurl_links = unfurl_links;
         self
     }
 
@@ -120,6 +130,10 @@ impl SlackAdapter {
 
             if let Some(ts) = thread_ts {
                 body["thread_ts"] = serde_json::json!(ts);
+            }
+
+            if let Some(unfurl) = self.unfurl_links {
+                body["unfurl_links"] = serde_json::json!(unfurl);
             }
 
             let resp: serde_json::Value = self

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -2566,6 +2566,11 @@ pub struct SlackConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Whether to disable link unfurling (preview expansion) in sent messages.
+    /// When set to `false`, Slack will not expand link previews.
+    /// When `None` (default), Slack uses its own default behavior.
+    #[serde(default)]
+    pub unfurl_links: Option<bool>,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -2583,6 +2588,7 @@ impl Default for SlackConfig {
             allowed_channels: vec![],
             account_id: None,
             default_agent: None,
+            unfurl_links: None,
             overrides: ChannelOverrides::default(),
             force_flat_replies: None,
         }
@@ -4538,6 +4544,34 @@ mod tests {
         assert_eq!(sl.app_token_env, "SLACK_APP_TOKEN");
         assert_eq!(sl.bot_token_env, "SLACK_BOT_TOKEN");
         assert!(sl.allowed_channels.is_empty());
+        assert!(sl.unfurl_links.is_none());
+    }
+
+    #[test]
+    fn test_slack_config_unfurl_links_deserialization() {
+        let toml_str = r#"
+            app_token_env = "SLACK_APP_TOKEN"
+            bot_token_env = "SLACK_BOT_TOKEN"
+            unfurl_links = false
+        "#;
+        let sl: SlackConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(sl.unfurl_links, Some(false));
+
+        let toml_str2 = r#"
+            app_token_env = "SLACK_APP_TOKEN"
+            bot_token_env = "SLACK_BOT_TOKEN"
+            unfurl_links = true
+        "#;
+        let sl2: SlackConfig = toml::from_str(toml_str2).unwrap();
+        assert_eq!(sl2.unfurl_links, Some(true));
+
+        // Default (field omitted) should be None
+        let toml_str3 = r#"
+            app_token_env = "SLACK_APP_TOKEN"
+            bot_token_env = "SLACK_BOT_TOKEN"
+        "#;
+        let sl3: SlackConfig = toml::from_str(toml_str3).unwrap();
+        assert!(sl3.unfurl_links.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added `unfurl_links: Option<bool>` to `SlackConfig` with `#[serde(default)]`
- `SlackAdapter` passes the value through to `chat.postMessage` API payload
- Wired in `channel_bridge.rs` via `.with_unfurl_links()`
- Tests for default, true, and false deserialization

Closes #915