### PR TITLE
fix(web): comprehensive website polish and bug fixes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,31 +7,30 @@
     <link rel="apple-touch-icon" href="/fox-mascot.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Librefang is the production-grade Agent Operating System built in Rust. 180ms cold start, 40MB memory, 16 security layers, 40 channel adapters. Run autonomous AI agents 24/7 — not a chatbot framework, a complete OS for AI." />
+    <meta name="description" content="LibreFang is the production-grade Agent Operating System built in Rust. 180ms cold start, 40MB memory, 16 security layers, 40 channel adapters. Run autonomous AI agents 24/7 — not a chatbot framework, a complete OS for AI." />
     <meta name="theme-color" content="#080c10" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://librefang.ai/" />
-    <meta property="og:title" content="Librefang - Production-Grade Agent Operating System" />
+    <meta property="og:title" content="LibreFang - Production-Grade Agent Operating System" />
     <meta property="og:description" content="Run autonomous AI agents 24/7. Built in Rust: 180ms cold start, 40MB memory, 16 security layers, 40 channel adapters." />
-    <meta property="og:image" content="https://librefang.ai/og-image.svg" />
+    <meta property="og:image" content="https://librefang.ai/og-image.png" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://librefang.ai/" />
-    <meta name="twitter:title" content="Librefang - Production-Grade Agent Operating System" />
+    <meta name="twitter:title" content="LibreFang - Production-Grade Agent Operating System" />
     <meta name="twitter:description" content="Run autonomous AI agents 24/7. Built in Rust: 180ms cold start, 40MB memory, 16 security layers, 40 channel adapters." />
-    <meta name="twitter:image" content="https://librefang.ai/og-image.svg" />
+    <meta name="twitter:image" content="https://librefang.ai/og-image.png" />
 
     <!-- Canonical -->
     <link rel="canonical" href="https://librefang.ai/" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="dns-prefetch" href="https://api.github.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    <title>Librefang - Production-Grade Agent Operating System | Rust-Powered, 24/7 Autonomous AI</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="https://api.github.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+    <title>LibreFang - Production-Grade Agent Operating System | Rust-Powered, 24/7 Autonomous AI</title>
     <script>
       (function() {
         var lang = 'en';

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
 import { translations, languages } from './i18n'
-import { ExternalLink, Globe, ChevronDown, Menu, X, ClipboardCheck, Settings, BadgeCheck, Code, Bug, MessageCircle, Copy, Check, Video, UserSearch, Radar, TrendingUp, Activity, Filter, Network, RefreshCw, Shield, Library, Monitor, SearchCheck, Rss } from 'lucide-react'
+import { ExternalLink, Globe, ChevronDown, Menu, X, ClipboardCheck, Settings, BadgeCheck, Code, Bug, MessageCircle, Copy, Check, Video, UserSearch, Radar, TrendingUp, Activity, Filter, Network, RefreshCw, Shield, Library, Monitor, SearchCheck, Rss, Star, GitFork, CircleDot, GitPullRequest } from 'lucide-react'
 
 const queryClient = new QueryClient()
-
 
 const comparisonData = [
   { metric: 'Cold Start', openclaw: '2.5s+', zeroclaw: '4s+', librefang: '180ms' },
@@ -44,22 +43,26 @@ function MaterialIcon({ name, className = '' }) {
     manage_search: SearchCheck,
     rss_feed: Rss,
   }
-  const Icon = icons[name]
-  if (!Icon) return <span className={className}>{name}</span>
-  return <Icon className={className} />
+  const IconComponent = icons[name]
+  if (!IconComponent) return null
+  return <IconComponent className={className} />
+}
+
+function getCurrentLang() {
+  if (typeof window === 'undefined') return 'en'
+  const path = window.location.pathname
+  if (path.startsWith('/zh-TW')) return 'zh-TW'
+  if (path.startsWith('/zh')) return 'zh'
+  if (path.startsWith('/de')) return 'de'
+  if (path.startsWith('/ja')) return 'ja'
+  if (path.startsWith('/ko')) return 'ko'
+  if (path.startsWith('/es')) return 'es'
+  return 'en'
 }
 
 function Header({ t }) {
-  const currentLangName = languages.find(l => {
-    const path = window.location.pathname
-    if (path.startsWith('/zh-TW')) return l.code === 'zh-TW'
-    if (path.startsWith('/zh')) return l.code === 'zh'
-    if (path.startsWith('/de')) return l.code === 'de'
-    if (path.startsWith('/ja')) return l.code === 'ja'
-    if (path.startsWith('/ko')) return l.code === 'ko'
-    if (path.startsWith('/es')) return l.code === 'es'
-    return l.code === 'en'
-  })?.name || 'English'
+  const currentLang = getCurrentLang()
+  const currentLangName = languages.find(l => l.code === currentLang)?.name || 'English'
   const [langOpen, setLangOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
@@ -70,41 +73,50 @@ function Header({ t }) {
         setLangOpen(false)
       }
     }
+    const handleClickOutside = (e) => {
+      if (langOpen && !e.target.closest('[data-lang-menu]')) {
+        setLangOpen(false)
+      }
+    }
     document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [])
+    document.addEventListener('click', handleClickOutside)
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [langOpen])
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-40 px-4 md:px-12 py-4 glass-effect" role="navigation" aria-label="Main navigation">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <a href="/" className="flex items-center gap-3">
           <div className="flex items-center justify-center p-1">
-            <img src="/logo.png" alt="Librefang Logo" width="32" height="32" className="rounded-md" loading="lazy" decoding="async" />
+            <img src="/logo.png" alt="LibreFang Logo" width="32" height="32" className="rounded-md" loading="lazy" decoding="async" />
           </div>
-          <span className="font-extrabold text-2xl tracking-tight">Librefang</span>
+          <span className="font-extrabold text-2xl tracking-tight text-white">LibreFang</span>
         </a>
         <div className="hidden md:flex items-center gap-8 text-sm font-semibold text-gray-400">
           <a className="hover:text-primary transition-colors" href="#features">{t.nav.features}</a>
           <a className="hover:text-primary transition-colors" href="#comparison">{t.nav.comparison}</a>
           <a className="flex items-center gap-1 hover:text-primary transition-colors" href="https://docs.librefang.ai" target="_blank" rel="noopener noreferrer">
             <span>{t.nav.docs}</span>
-            <MaterialIcon name="open_in_new" className="text-sm" />
+            <MaterialIcon name="open_in_new" className="w-3.5 h-3.5" />
           </a>
           <a className="flex items-center gap-1 hover:text-primary transition-colors" href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer">
             <span>{t.nav.github}</span>
-            <MaterialIcon name="open_in_new" className="text-sm" />
+            <MaterialIcon name="open_in_new" className="w-3.5 h-3.5" />
           </a>
         </div>
         <div className="flex items-center gap-4">
-          <div className="relative group">
-            <button className="flex items-center gap-2 p-2 text-gray-400 hover:text-primary transition-colors rounded-lg hover:bg-white/10" aria-label="Switch language" onClick={() => setLangOpen(!langOpen)}>
-              <MaterialIcon name="language" />
+          <div className="relative" data-lang-menu>
+            <button className="flex items-center gap-2 p-2 text-gray-400 hover:text-primary transition-colors rounded-lg hover:bg-white/10" aria-label="Switch language" aria-expanded={langOpen} onClick={() => setLangOpen(!langOpen)}>
+              <MaterialIcon name="language" className="w-5 h-5" />
               <span className="hidden sm:inline text-sm font-bold">{currentLangName}</span>
-              <MaterialIcon name="expand_more" className="text-sm" />
+              <MaterialIcon name="expand_more" className={`w-4 h-4 transition-transform ${langOpen ? 'rotate-180' : ''}`} />
             </button>
-            <div className={`absolute right-0 mt-2 w-40 bg-[#161b22] border border-gray-700/50 rounded-md shadow-2xl ${langOpen ? 'opacity-100 visible' : 'opacity-0 invisible'} transition-all duration-300 z-50`} role="menu">
-              {languages.map((lang, i) => (
-                <a key={lang.code} href={lang.url} role="menuitem" className={`block px-5 py-3 text-sm font-bold transition-colors ${i === 0 ? 'bg-primary/10 text-primary rounded-t-md' : 'text-gray-400 hover:bg-white/10 hover:text-gray-100'} ${i === languages.length - 1 ? 'rounded-b-md' : ''}`}>
+            <div className={`absolute right-0 mt-2 w-40 bg-[#161b22] border border-gray-700/50 rounded-xl shadow-2xl ${langOpen ? 'opacity-100 visible translate-y-0' : 'opacity-0 invisible -translate-y-2'} transition-all duration-200 z-50`} role="menu">
+              {languages.map((lang) => (
+                <a key={lang.code} href={lang.url} role="menuitem" className={`block px-5 py-3 text-sm font-bold transition-colors ${lang.code === currentLang ? 'bg-primary/10 text-primary' : 'text-gray-400 hover:bg-white/10 hover:text-gray-100'} first:rounded-t-xl last:rounded-b-xl`}>
                   {lang.name}
                 </a>
               ))}
@@ -115,16 +127,25 @@ function Header({ t }) {
               <path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68Z"></path>
             </svg>
           </a>
-          <button className="md:hidden" onClick={() => setMobileMenuOpen(!mobileMenuOpen)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setMobileMenuOpen(!mobileMenuOpen) }} aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'} aria-expanded={mobileMenuOpen}>
-            <MaterialIcon name={mobileMenuOpen ? 'close' : 'menu'} />
+          <button className="md:hidden text-gray-300" onClick={() => setMobileMenuOpen(!mobileMenuOpen)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setMobileMenuOpen(!mobileMenuOpen) }} aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'} aria-expanded={mobileMenuOpen}>
+            <MaterialIcon name={mobileMenuOpen ? 'close' : 'menu'} className="w-6 h-6" />
           </button>
         </div>
       </div>
       {mobileMenuOpen && (
-        <div className="md:hidden px-4 pb-4 space-y-2 bg-[#080c10]/95">
-          <a href="#features" className="block py-2 text-gray-400">Features</a>
-          <a href="#comparison" className="block py-2 text-gray-400">Comparison</a>
-          <a href="#install" className="block py-2 text-gray-400">Docs</a>
+        <div className="md:hidden mt-4 px-2 pb-4 space-y-1 border-t border-gray-700/30 pt-4">
+          <a href="#features" onClick={() => setMobileMenuOpen(false)} className="block py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">{t.nav.features}</a>
+          <a href="#comparison" onClick={() => setMobileMenuOpen(false)} className="block py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">{t.nav.comparison}</a>
+          <a href="#install" onClick={() => setMobileMenuOpen(false)} className="block py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">{t.install?.singleBinary || 'Install'}</a>
+          <a href="#faq" onClick={() => setMobileMenuOpen(false)} className="block py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">{t.faq?.title || 'FAQ'}</a>
+          <a href="https://docs.librefang.ai" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">
+            {t.nav.docs}
+            <MaterialIcon name="open_in_new" className="w-3.5 h-3.5" />
+          </a>
+          <a href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 py-3 px-4 text-gray-300 hover:text-primary hover:bg-white/5 rounded-lg transition-colors font-medium">
+            {t.nav.github}
+            <MaterialIcon name="open_in_new" className="w-3.5 h-3.5" />
+          </a>
         </div>
       )}
     </nav>
@@ -157,13 +178,14 @@ function Hero({ t }) {
         <div className="text-center lg:text-left space-y-10">
           <div className="inline-flex items-center gap-2 bg-primary/10 border border-primary/20 px-5 py-2 rounded-full text-sm font-bold text-primary">
             <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-primary"></span>
             </span>
             <span className="min-w-[50px] inline-block">{version || ''}</span> · Rust-Powered · Open Source
           </div>
           <h1 className="text-6xl md:text-8xl font-extrabold tracking-tight leading-[1.05] bg-clip-text text-transparent bg-gradient-to-br from-white via-gray-100 to-primary flex items-center justify-center lg:justify-start gap-4">
-            <img src="/fox-mascot.png" alt="Librefang Mascot" className="w-16 h-16 md:w-20 md:h-20 rounded-xl" />
-            Librefang
+            <img src="/fox-mascot.png" alt="LibreFang Mascot" className="w-16 h-16 md:w-20 md:h-20 rounded-xl" />
+            LibreFang
           </h1>
           <p className="text-gray-400 text-xl md:text-2xl font-light leading-relaxed max-w-xl mx-auto lg:mx-0">
             {t.hero.subtitle}
@@ -172,7 +194,7 @@ function Hero({ t }) {
             <a href="#install" className="bg-primary hover:bg-primary-dark text-white font-extrabold py-5 px-10 rounded-full shadow-2xl shadow-primary/30 transition-all hover:scale-105 active:scale-95">
               {t.hero.getStarted}
             </a>
-            <a href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer" className="bg-white/10 hover:bg-white/5 text-gray-100 font-bold py-5 px-10 rounded-full border border-gray-600/50 backdrop-blur-md transition-all hover:scale-105 active:scale-95 flex items-center gap-2 justify-center">
+            <a href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer" className="bg-white/10 hover:bg-white/15 text-gray-100 font-bold py-5 px-10 rounded-full border border-gray-600/50 backdrop-blur-md transition-all hover:scale-105 active:scale-95 flex items-center gap-2 justify-center">
               <svg fill="currentColor" height="20" width="20" viewBox="0 0 256 256">
                 <path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68Z"></path>
               </svg>
@@ -183,7 +205,7 @@ function Hero({ t }) {
         <div className="relative">
           <div className="rounded-[2.5rem] border border-gray-700/50 bg-[#0d1117] p-4 shadow-3xl backdrop-blur-sm overflow-hidden">
             <div className="w-full aspect-video rounded-[2rem] overflow-hidden relative">
-              <img className="w-full h-full object-cover opacity-80" src="/librefang-vs-claws.png" alt="Librefang Agent OS Interface" width="1920" height="1080" loading="eager" />
+              <img className="w-full h-full object-cover opacity-80" src="/librefang-vs-claws.png" alt="LibreFang Agent OS Interface" width="1920" height="1080" loading="eager" />
               <div className="absolute inset-0 bg-gradient-to-t from-[#080c10]/90 via-transparent to-transparent pointer-events-none"></div>
               <div className="absolute bottom-8 left-8 flex items-center gap-3 pointer-events-none">
                 <div className="h-2 w-2 rounded-full bg-primary animate-pulse"></div>
@@ -223,18 +245,18 @@ function Stats({ t }) {
 function Features({ t }) {
   const featureIcons = ['movie_edit', 'person_search', 'radar', 'trending_up', 'manage_search', 'rss_feed']
   return (
-    <section className="px-6 py-32 bg-[#0d1117] rounded-section mx-4 md:mx-12" id="features">
+    <section className="px-6 py-32 bg-[#0d1117] rounded-section mx-4 md:mx-12 scroll-mt-20" id="features">
       <div className="max-w-7xl mx-auto space-y-20">
         <header className="text-center space-y-6">
           <h2 className="text-4xl md:text-6xl font-extrabold tracking-tight text-white">{t.features.feature1Title}</h2>
           <p className="text-gray-400 text-lg md:text-xl max-w-3xl mx-auto">{t.features.feature1Desc}</p>
-          <div className="h-2 w-32 bg-primary mx-auto rounded-full"></div>
+          <div className="h-1.5 w-24 bg-gradient-to-r from-primary to-cyan-400 mx-auto rounded-full"></div>
         </header>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {t.featureCards.map((feature, i) => (
-            <article key={i} className="bg-[#161b22] p-10 rounded-[2.5rem] border border-gray-700/50 hover:border-primary/50 transition-all duration-500 group hover:-translate-y-3 shadow-sm">
+            <article key={i} className="bg-[#161b22] p-10 rounded-[2.5rem] border border-gray-700/50 hover:border-primary/50 transition-all duration-500 group hover:-translate-y-2 shadow-sm hover:shadow-primary/5 hover:shadow-2xl">
               <div className="size-16 bg-primary/10 rounded-2xl flex items-center justify-center text-primary mb-8 group-hover:bg-primary group-hover:text-white transition-all duration-500">
-                <MaterialIcon name={featureIcons[i]} className="text-4xl font-bold" />
+                <MaterialIcon name={featureIcons[i]} className="w-8 h-8" />
               </div>
               <h3 className="text-2xl font-extrabold mb-5 text-white">{feature.title}</h3>
               <p className="text-gray-400 text-lg leading-relaxed">{feature.description}</p>
@@ -248,15 +270,15 @@ function Features({ t }) {
 
 function Comparison({ t }) {
   return (
-    <section className="px-6 py-32" id="comparison">
+    <section className="px-6 py-32 scroll-mt-20" id="comparison">
       <div className="max-w-6xl mx-auto">
         <header className="text-center mb-20">
           <h2 className="text-4xl md:text-6xl font-extrabold tracking-tight mb-6 text-white">{t.comparison.librefangVs}</h2>
           <p className="text-gray-400 text-xl">{t.comparison.subtitle2}</p>
         </header>
-        <div className="hidden md:block overflow-hidden rounded-[3rem] border border-gray-700/50 bg-white/5 backdrop-blur-xl">
+        <div className="hidden md:block overflow-hidden rounded-[2rem] border border-gray-700/50 bg-white/5 backdrop-blur-xl">
           <table className="w-full text-left">
-            <thead className="bg-gray-800 text-gray-300">
+            <thead className="bg-gray-800/80 text-gray-300">
               <tr>
                 <th scope="col" className="p-8 font-bold text-lg">{t.comparison.metric}</th>
                 <th scope="col" className="p-8 font-bold text-lg text-center border-l border-gray-700/50">{t.comparison.openclaw}</th>
@@ -276,22 +298,23 @@ function Comparison({ t }) {
             </tbody>
           </table>
         </div>
-        <div className="md:hidden space-y-6">
-          {[
-            { title: 'Cold Start', val: '180ms' },
-            { title: 'Security Layers', val: '16' },
-            { title: 'Channel Adapters', val: '40' },
-          ].map((item, i) => (
-            <article key={i} className="bg-white/8 rounded-[2rem] border border-gray-700/50 p-8">
-              <h3 className="text-sm font-black uppercase tracking-widest text-primary mb-6">{item.title}</h3>
-              <dl className="space-y-4">
-                <div className="flex justify-between items-center py-4 border-b border-gray-700/50">
-                  <dt className="text-gray-400 font-medium">{t.comparison.openclaw} / {t.comparison.zeroclaw}</dt>
-                  <dd className="text-gray-400">{i === 0 ? '2.5s – 4s+' : i === 1 ? '2–3 layers' : '8–15'}</dd>
+        {/* Mobile: show all comparison data */}
+        <div className="md:hidden space-y-4">
+          {comparisonData.map((row, i) => (
+            <article key={i} className="bg-white/5 rounded-2xl border border-gray-700/50 p-6">
+              <h3 className="text-sm font-black uppercase tracking-widest text-primary mb-4">{row.metric}</h3>
+              <dl className="space-y-3">
+                <div className="flex justify-between items-center py-2 border-b border-gray-700/30">
+                  <dt className="text-gray-500 text-sm">{t.comparison.openclaw}</dt>
+                  <dd className="text-gray-400 font-medium">{row.openclaw}</dd>
                 </div>
-                <div className="flex justify-between items-center py-4">
-                  <dt className="text-gray-100 font-bold">Librefang</dt>
-                  <dd className="text-primary font-black">{item.val}</dd>
+                <div className="flex justify-between items-center py-2 border-b border-gray-700/30">
+                  <dt className="text-gray-500 text-sm">{t.comparison.zeroclaw}</dt>
+                  <dd className="text-gray-400 font-medium">{row.zeroclaw}</dd>
+                </div>
+                <div className="flex justify-between items-center py-2">
+                  <dt className="text-white font-bold text-sm">LibreFang</dt>
+                  <dd className="text-primary font-black text-lg">{row.librefang}</dd>
                 </div>
               </dl>
             </article>
@@ -305,7 +328,7 @@ function Comparison({ t }) {
 function Workflows({ t }) {
   const workflowIcons = ['video_library', 'filter_alt', 'monitoring', 'hub', 'sync_alt', 'security']
   return (
-    <section className="px-6 py-32">
+    <section className="px-6 py-32 scroll-mt-20" id="workflows">
       <div className="max-w-7xl mx-auto space-y-20">
         <header className="text-center space-y-6">
           <h2 className="text-4xl md:text-6xl font-extrabold tracking-tight text-white">{t.workflows.workflow1Title}</h2>
@@ -313,9 +336,9 @@ function Workflows({ t }) {
         </header>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {t.workflowCards.map((workflow, i) => (
-            <article key={i} className="bg-white/5 rounded-[2.5rem] border border-gray-700/50 p-8 space-y-6 hover:border-primary/50 transition-all group">
+            <article key={i} className="bg-white/5 rounded-[2.5rem] border border-gray-700/50 p-8 space-y-6 hover:border-primary/50 transition-all group hover:-translate-y-1">
               <div className="size-16 bg-primary/10 rounded-2xl flex items-center justify-center group-hover:bg-primary transition-colors">
-                <MaterialIcon name={workflowIcons[i]} className="text-4xl text-primary group-hover:text-white" />
+                <MaterialIcon name={workflowIcons[i]} className="w-8 h-8 text-primary group-hover:text-white" />
               </div>
               <h3 className="text-2xl font-extrabold text-white">{workflow.title}</h3>
               <p className="text-gray-400 text-lg leading-relaxed">{workflow.description}</p>
@@ -336,23 +359,23 @@ function Install({ t }) {
   }
 
   return (
-    <section className="px-6 py-32 bg-[#0d1117] rounded-section mx-4 md:mx-12" id="install">
+    <section className="px-6 py-32 bg-[#0d1117] rounded-section mx-4 md:mx-12 scroll-mt-20" id="install">
       <div className="max-w-5xl mx-auto space-y-16">
         <header className="text-center space-y-6">
           <h2 className="text-4xl md:text-6xl font-extrabold tracking-tight text-white">{t.install.singleBinary}</h2>
           <p className="text-gray-400 text-xl">{t.install.singleBinaryDesc}</p>
         </header>
-        <div className="rounded-[2.5rem] overflow-hidden shadow-3xl bg-[#080c10] border border-gray-700/50">
-          <div className="h-12 flex items-center px-6 justify-between">
-            <div className="flex gap-2.5">
-              <div className="size-3.5 rounded-full bg-gray-50/20"></div>
-              <div className="size-3.5 rounded-full bg-gray-50/20"></div>
-              <div className="size-3.5 rounded-full bg-gray-50/20"></div>
+        <div className="rounded-[2rem] overflow-hidden shadow-3xl bg-[#080c10] border border-gray-700/50">
+          <div className="h-12 flex items-center px-6 justify-between bg-gray-800/30">
+            <div className="flex gap-2">
+              <div className="size-3 rounded-full bg-red-500/60"></div>
+              <div className="size-3 rounded-full bg-yellow-500/60"></div>
+              <div className="size-3 rounded-full bg-green-500/60"></div>
             </div>
-            <span className="text-xs uppercase tracking-[0.2em] font-black text-white/80">{t.install.bashInstall || 'bash — Quick Install'}</span>
+            <span className="text-xs uppercase tracking-[0.2em] font-bold text-white/50">{t.install.bashInstall || 'bash — Quick Install'}</span>
             <div className="w-12"></div>
           </div>
-          <div className="p-6 md:p-10 font-mono text-sm md:text-base lg:text-xl leading-relaxed relative bg-black/40">
+          <div className="p-6 md:p-10 font-mono text-sm md:text-base lg:text-xl leading-relaxed relative">
             <div className="flex items-start gap-3 md:gap-4 overflow-x-auto">
               <span className="text-primary select-none font-bold shrink-0">$</span>
               <code className="flex-1 min-w-0 whitespace-nowrap md:whitespace-normal">
@@ -362,16 +385,16 @@ function Install({ t }) {
                 <span className="text-primary"> sh</span>
               </code>
             </div>
-            <button onClick={copyCommand} className="absolute top-6 right-6 md:top-10 md:right-10 text-primary hover:text-white transition-colors p-2.5 md:p-3 bg-primary/10 rounded-xl md:rounded-2xl hover:bg-primary" aria-label="Copy installation command">
-              <MaterialIcon name={copied ? 'check' : 'content_copy'} className="text-[24px]" />
+            <button onClick={copyCommand} className="absolute top-6 right-6 md:top-10 md:right-10 text-primary hover:text-white transition-colors p-2.5 md:p-3 bg-primary/10 rounded-xl hover:bg-primary" aria-label="Copy installation command">
+              <MaterialIcon name={copied ? 'check' : 'content_copy'} className="w-5 h-5" />
             </button>
           </div>
         </div>
         <div className="grid md:grid-cols-2 gap-8">
-          <article className="bg-white/5 rounded-[2rem] border border-gray-700/50 p-8 space-y-6">
+          <article className="bg-white/5 rounded-[2rem] border border-gray-700/50 p-8 space-y-6 hover:border-gray-600/50 transition-colors">
             <div className="flex items-center gap-4">
               <div className="size-14 bg-primary/10 rounded-xl flex items-center justify-center">
-                <MaterialIcon name="checklist" className="text-primary text-3xl" />
+                <MaterialIcon name="checklist" className="text-primary w-7 h-7" />
               </div>
               <h3 className="text-2xl font-extrabold text-white">{t.install.requirements}</h3>
             </div>
@@ -382,10 +405,10 @@ function Install({ t }) {
               <li className="flex items-center gap-3"><span className="text-primary">•</span> LLM API Key (12 providers supported)</li>
             </ul>
           </article>
-          <article className="bg-white/5 rounded-[2rem] border border-gray-700/50 p-8 space-y-6">
+          <article className="bg-white/5 rounded-[2rem] border border-gray-700/50 p-8 space-y-6 hover:border-gray-600/50 transition-colors">
             <div className="flex items-center gap-4">
               <div className="size-14 bg-primary/10 rounded-xl flex items-center justify-center">
-                <MaterialIcon name="settings_suggest" className="text-primary text-3xl" />
+                <MaterialIcon name="settings_suggest" className="text-primary w-7 h-7" />
               </div>
               <h3 className="text-2xl font-extrabold text-white">{t.install.whatYouGet}</h3>
             </div>
@@ -428,7 +451,7 @@ function Install({ t }) {
         <div className="flex flex-wrap justify-center gap-10 text-sm font-bold text-gray-400">
           {['macOS', 'Linux', 'Windows', 'Raspberry Pi', 'VPS / Cloud'].map((platform, i) => (
             <div key={i} className="flex items-center gap-3">
-              <MaterialIcon name="verified" className="text-primary" />
+              <MaterialIcon name="verified" className="text-primary w-5 h-5" />
               {platform}
             </div>
           ))}
@@ -440,19 +463,19 @@ function Install({ t }) {
 
 function FAQ({ t }) {
   return (
-    <section className="px-6 py-32" id="faq">
+    <section className="px-6 py-32 scroll-mt-20" id="faq">
       <div className="max-w-3xl mx-auto space-y-16">
         <h2 className="text-4xl md:text-6xl font-extrabold tracking-tight text-center text-white">{t.faq.title}</h2>
-        <div className="space-y-6">
+        <div className="space-y-4">
           {t.faq.items.map((faq, i) => (
-            <details key={i} className="group bg-white/5 rounded-[2rem] border border-gray-700/50 overflow-hidden transition-all duration-500" open={i === 0}>
-              <summary className="flex items-center justify-between p-8 cursor-pointer select-none list-none">
-                <h3 className="font-extrabold text-white text-xl">{faq.question}</h3>
-                <div className="bg-primary/10 p-2 rounded-full text-primary group-open:rotate-180 transition-transform">
-                  <MaterialIcon name="expand_more" className="font-bold" />
+            <details key={i} className="group bg-white/5 rounded-2xl border border-gray-700/50 overflow-hidden transition-all duration-300 hover:border-gray-600/50" open={i === 0}>
+              <summary className="flex items-center justify-between p-7 cursor-pointer select-none list-none">
+                <h3 className="font-extrabold text-white text-lg pr-4">{faq.question}</h3>
+                <div className="bg-primary/10 p-2 rounded-full text-primary group-open:rotate-180 transition-transform shrink-0">
+                  <MaterialIcon name="expand_more" className="w-5 h-5" />
                 </div>
               </summary>
-              <div className="px-8 pb-8 text-gray-400 text-lg leading-relaxed pt-2 border-t border-gray-700/30">
+              <div className="px-7 pb-7 text-gray-400 text-lg leading-relaxed pt-2 border-t border-gray-700/30">
                 {faq.answer}
               </div>
             </details>
@@ -463,9 +486,30 @@ function FAQ({ t }) {
   )
 }
 
+function StatCard({ icon, value, label, isLoading }) {
+  return (
+    <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/30 transition-colors">
+      <div className="flex justify-center mb-2 text-primary/60">
+        {icon}
+      </div>
+      <div className="text-2xl md:text-3xl font-black text-primary mb-1">
+        {isLoading ? (
+          <span className="inline-block w-12 h-7 bg-gray-700/50 rounded animate-pulse"></span>
+        ) : value}
+      </div>
+      <div className="text-gray-400 font-semibold text-xs md:text-sm">{label}</div>
+    </div>
+  )
+}
+
+function formatNumber(num) {
+  if (num === null || num === undefined) return '-'
+  if (num >= 1000) return `${(num / 1000).toFixed(1)}k`
+  return num
+}
+
 function GitHubStats({ t }) {
-  // Use worker proxy for GitHub stats (avoids rate limits)
-  const { data: githubData, isError: githubError } = useQuery({
+  const { data: githubData, isLoading: githubLoading, isError: githubError } = useQuery({
     queryKey: ['githubStats'],
     queryFn: async () => {
       try {
@@ -476,12 +520,11 @@ function GitHubStats({ t }) {
         return { stars: 0, forks: 0, issues: 0, prs: 0, lastUpdate: '', downloads: 0, starHistory: [] }
       }
     },
-    initialData: { stars: 0, forks: 0, issues: 0, prs: 0, downloads: 0, lastUpdate: '', starHistory: [] },
     staleTime: 1000 * 60 * 30,
     retry: 1,
   })
 
-  const { data: docsData } = useQuery({
+  const { data: docsData, isLoading: docsLoading } = useQuery({
     queryKey: ['docsVisits'],
     queryFn: async () => {
       try {
@@ -496,6 +539,7 @@ function GitHubStats({ t }) {
     retry: 0,
   })
 
+  const isLoading = githubLoading || docsLoading
   const docsVisits = docsData?.total ?? 0
   const stars = githubError ? null : (githubData?.stars ?? 0)
   const forks = githubData?.forks ?? 0
@@ -504,7 +548,6 @@ function GitHubStats({ t }) {
   const downloads = githubData?.downloads ?? 0
   const lastUpdate = githubData?.lastUpdate ? new Date(githubData.lastUpdate).toLocaleDateString() : ''
 
-  // Use real star history from API, or generate if not available
   const starHistoryData = githubData?.starHistory || []
   const starHistory = starHistoryData.length > 0
     ? starHistoryData.map(d => d.stars)
@@ -525,7 +568,7 @@ function GitHubStats({ t }) {
   const currentValue = historyTab === 'stars' ? stars : historyTab === 'forks' ? forks : historyTab === 'issues' ? issues : prs
 
   return (
-    <section className="px-6 py-20 border-t border-gray-700/50">
+    <section className="px-6 py-24 border-t border-gray-700/50 scroll-mt-20" id="community">
       <div className="max-w-7xl mx-auto">
         <h2 className="text-4xl md:text-5xl font-extrabold text-center mb-4">
           <span className="bg-clip-text text-transparent bg-gradient-to-r from-white to-primary">{t.githubStats?.title || 'Join Our Community'}</span>
@@ -534,83 +577,88 @@ function GitHubStats({ t }) {
           {t.githubStats?.subtitle || 'Help us build the future of autonomous AI agents'}
         </p>
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{stars === null ? '-' : stars >= 1000 ? `${(stars/1000).toFixed(1)}k` : stars}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.stars || 'Stars'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{forks === null ? '-' : forks >= 1000 ? `${(forks/1000).toFixed(1)}k` : forks}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.forks || 'Forks'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{downloads >= 1000 ? `${(downloads/1000).toFixed(1)}k` : downloads}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.downloads || 'Downloads'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{docsVisits >= 1000 ? `${(docsVisits/1000).toFixed(1)}k` : docsVisits}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.docsVisits || 'Docs Visits'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{issues >= 1000 ? `${(issues/1000).toFixed(1)}k` : issues}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.issues || 'Issues'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-3xl font-black text-primary mb-1">{prs >= 1000 ? `${(prs/1000).toFixed(1)}k` : prs}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.prs || 'PRs'}</div>
-          </div>
-          <div className="text-center p-5 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-colors">
-            <div className="text-2xl font-black text-primary mb-1">{lastUpdate || '-'}</div>
-            <div className="text-gray-400 font-semibold text-sm">{t.githubStats?.lastUpdate || 'Last Update'}</div>
-          </div>
+          <StatCard icon={<Star className="w-4 h-4" />} value={formatNumber(stars)} label={t.githubStats?.stars || 'Stars'} isLoading={isLoading} />
+          <StatCard icon={<GitFork className="w-4 h-4" />} value={formatNumber(forks)} label={t.githubStats?.forks || 'Forks'} isLoading={isLoading} />
+          <StatCard icon={<svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>} value={formatNumber(downloads)} label={t.githubStats?.downloads || 'Downloads'} isLoading={isLoading} />
+          <StatCard icon={<svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>} value={formatNumber(docsVisits)} label={t.githubStats?.docsVisits || 'Docs Visits'} isLoading={isLoading} />
+          <StatCard icon={<CircleDot className="w-4 h-4" />} value={formatNumber(issues)} label={t.githubStats?.issues || 'Issues'} isLoading={isLoading} />
+          <StatCard icon={<GitPullRequest className="w-4 h-4" />} value={formatNumber(prs)} label={t.githubStats?.prs || 'PRs'} isLoading={isLoading} />
+          <StatCard icon={<svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/></svg>} value={lastUpdate || '-'} label={t.githubStats?.lastUpdate || 'Last Update'} isLoading={isLoading} />
         </div>
 
-        {/* Star History */}
+        {/* History Chart */}
         <div className="mt-12 p-6 rounded-2xl bg-white/5 border border-gray-700/30">
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-6 gap-4">
             <h3 className="text-lg font-bold text-white">{t.githubStats?.starHistory || 'History'}</h3>
-            <a href="https://star-history.com/#librefang/librefang" target="_blank" rel="noopener noreferrer" className="text-sm text-primary hover:underline">View Full Chart →</a>
+            <div className="flex items-center gap-3">
+              <div className="flex gap-1.5 bg-white/5 rounded-full p-1">
+                {['stars', 'forks', 'issues', 'prs'].map(tab => (
+                  <button
+                    key={tab}
+                    onClick={() => setHistoryTab(tab)}
+                    className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                      historyTab === tab
+                        ? 'bg-primary text-white shadow-sm'
+                        : 'text-gray-400 hover:text-gray-200'
+                    }`}
+                  >
+                    {tab === 'stars' ? (t.githubStats?.stars || 'Stars') : tab === 'forks' ? (t.githubStats?.forks || 'Forks') : tab === 'issues' ? (t.githubStats?.issues || 'Issues') : (t.githubStats?.prs || 'PRs')}
+                  </button>
+                ))}
+              </div>
+              <a href="https://star-history.com/#librefang/librefang" target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-primary transition-colors hidden sm:inline">View Full Chart</a>
+            </div>
           </div>
-          {/* Tabs */}
-          <div className="flex gap-2 mb-4">
-            {['stars', 'forks', 'issues', 'prs'].map(tab => (
-              <button
-                key={tab}
-                onClick={() => setHistoryTab(tab)}
-                className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
-                  historyTab === tab
-                    ? 'bg-primary text-white'
-                    : 'bg-white/10 text-gray-400 hover:bg-white/20'
-                }`}
-              >
-                {tab === 'stars' ? (t.githubStats?.stars || 'Stars') : tab === 'forks' ? (t.githubStats?.forks || 'Forks') : tab === 'issues' ? (t.githubStats?.issues || 'Issues') : (t.githubStats?.prs || 'PRs')}
-              </button>
-            ))}
-          </div>
-          <div className="h-48 flex items-end gap-1 overflow-x-auto">
+          <div className="h-48 flex items-end gap-1">
             {currentHistory.length > 0 ? (
-              Array.from({ length: 12 }, (_, i) => {
-                const idx = Math.floor((i / 12) * currentHistory.length)
+              Array.from({ length: Math.min(24, currentHistory.length || 12) }, (_, i) => {
+                const idx = Math.floor((i / Math.min(24, currentHistory.length || 12)) * currentHistory.length)
                 const value = currentHistory[idx] || 0
                 return (
-                  <div key={i} className="flex-1 bg-primary/60 hover:bg-primary transition-colors rounded-t min-w-4" style={{ height: `${Math.max(5, (value / currentMax) * 100)}%` }} title={`${value} ${historyTab}`}></div>
+                  <div key={i} className="flex-1 bg-primary/40 hover:bg-primary transition-colors rounded-t min-w-1" style={{ height: `${Math.max(4, (value / currentMax) * 100)}%` }} title={`${value} ${historyTab}`}></div>
                 )
               })
             ) : (
-              <div className="w-full h-32 flex items-center justify-center text-gray-500">No data yet</div>
+              <div className="w-full h-32 flex items-center justify-center text-gray-500 text-sm">No data yet</div>
             )}
           </div>
-          <div className="flex justify-between mt-2 text-xs text-gray-500">
+          <div className="flex justify-between mt-3 text-xs text-gray-500">
             <span>12 months ago</span>
-            <span>Now ({currentValue ?? '-'})</span>
+            <span className="text-primary font-semibold">Now ({currentValue ?? '-'})</span>
           </div>
         </div>
-        <div className="flex justify-center gap-6 mt-12">
-          <a href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer" className="bg-white/10 hover:bg-primary text-white font-bold py-4 px-8 rounded-full border border-gray-600/50 transition-all hover:scale-105 flex items-center gap-3">
-            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+
+        {/* Star History & Contributors Images */}
+        <div className="grid md:grid-cols-2 gap-6 mt-8">
+          <a href="https://star-history.com/#librefang/librefang&Date" target="_blank" rel="noopener noreferrer" className="block rounded-2xl overflow-hidden border border-gray-700/30 hover:border-primary/30 transition-colors bg-white/5 p-4">
+            <h4 className="text-sm font-bold text-gray-400 mb-3">{t.githubStats?.starHistory || 'Star History'}</h4>
+            <img
+              src="/assets/star-history.svg"
+              alt="LibreFang Star History Chart"
+              className="w-full h-auto rounded-lg"
+              loading="lazy"
+              onError={(e) => { e.target.style.display = 'none' }}
+            />
+          </a>
+          <a href="https://github.com/librefang/librefang/graphs/contributors" target="_blank" rel="noopener noreferrer" className="block rounded-2xl overflow-hidden border border-gray-700/30 hover:border-primary/30 transition-colors bg-white/5 p-4">
+            <h4 className="text-sm font-bold text-gray-400 mb-3">{t.contributing?.title || 'Contributors'}</h4>
+            <img
+              src="/assets/contributors.svg"
+              alt="LibreFang Contributors"
+              className="w-full h-auto rounded-lg"
+              loading="lazy"
+              onError={(e) => { e.target.style.display = 'none' }}
+            />
+          </a>
+        </div>
+
+        <div className="flex flex-col sm:flex-row justify-center gap-4 mt-12">
+          <a href="https://github.com/librefang/librefang" target="_blank" rel="noopener noreferrer" className="bg-white/10 hover:bg-primary text-white font-bold py-4 px-8 rounded-full border border-gray-600/50 transition-all hover:scale-105 hover:border-primary flex items-center gap-3 justify-center">
+            <Star className="w-5 h-5" />
             {t.githubStats?.starUs || 'Star Us'}
           </a>
-          <a href="https://github.com/librefang/librefang/discussions" target="_blank" rel="noopener noreferrer" className="bg-white/5 hover:bg-white/10 text-gray-100 font-bold py-4 px-8 rounded-full border border-gray-600/30 transition-all hover:scale-105 flex items-center gap-3">
-            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+          <a href="https://github.com/librefang/librefang/discussions" target="_blank" rel="noopener noreferrer" className="bg-white/5 hover:bg-white/10 text-gray-100 font-bold py-4 px-8 rounded-full border border-gray-600/30 transition-all hover:scale-105 flex items-center gap-3 justify-center">
+            <MessageCircle className="w-5 h-5" />
             {t.githubStats?.discuss || 'Discuss'}
           </a>
         </div>
@@ -621,7 +669,7 @@ function GitHubStats({ t }) {
 
 function Contributing({ t }) {
   return (
-    <section className="px-6 py-20 border-t border-gray-700/50 bg-gradient-to-b from-transparent to-primary/5">
+    <section className="px-6 py-24 border-t border-gray-700/50 bg-gradient-to-b from-transparent to-primary/5 scroll-mt-20" id="contributing">
       <div className="max-w-7xl mx-auto">
         <h2 className="text-4xl md:text-5xl font-extrabold text-center mb-4">
           <span className="bg-clip-text text-transparent bg-gradient-to-r from-white to-primary">{t.contributing?.title || 'Contributing'}</span>
@@ -630,30 +678,30 @@ function Contributing({ t }) {
           {t.contributing?.subtitle || 'Help build the future of autonomous AI'}
         </p>
         <div className="grid md:grid-cols-3 gap-8">
-          <div className="p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group">
+          <a href="https://github.com/librefang/librefang/pulls" target="_blank" rel="noopener noreferrer" className="block p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group hover:-translate-y-1">
             <div className="w-14 h-14 rounded-2xl bg-primary/20 flex items-center justify-center mb-6 group-hover:bg-primary/30 transition-colors">
-              <MaterialIcon name="code" className="text-3xl text-primary" />
+              <MaterialIcon name="code" className="w-7 h-7 text-primary" />
             </div>
             <h3 className="text-xl font-bold text-white mb-3">{t.contributing?.code || 'Code'}</h3>
             <p className="text-gray-400 mb-6">{t.contributing?.codeDesc || 'Contribute features, fix bugs, or improve documentation'}</p>
-            <a href="https://github.com/librefang/librefang/pulls" target="_blank" rel="noopener noreferrer" className="text-primary font-semibold hover:underline">{t.contributing?.submitPR || 'Submit PR'} →</a>
-          </div>
-          <div className="p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group">
+            <span className="text-primary font-semibold">{t.contributing?.submitPR || 'Submit PR'} →</span>
+          </a>
+          <a href="https://github.com/librefang/librefang/issues" target="_blank" rel="noopener noreferrer" className="block p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group hover:-translate-y-1">
             <div className="w-14 h-14 rounded-2xl bg-primary/20 flex items-center justify-center mb-6 group-hover:bg-primary/30 transition-colors">
-              <MaterialIcon name="bug_report" className="text-3xl text-primary" />
+              <MaterialIcon name="bug_report" className="w-7 h-7 text-primary" />
             </div>
             <h3 className="text-xl font-bold text-white mb-3">{t.contributing?.report || 'Report Bugs'}</h3>
             <p className="text-gray-400 mb-6">{t.contributing?.reportDesc || 'Found an issue? Help us improve by reporting it'}</p>
-            <a href="https://github.com/librefang/librefang/issues" target="_blank" rel="noopener noreferrer" className="text-primary font-semibold hover:underline">{t.contributing?.openIssue || 'Open Issue'} →</a>
-          </div>
-          <div className="p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group">
+            <span className="text-primary font-semibold">{t.contributing?.openIssue || 'Open Issue'} →</span>
+          </a>
+          <a href="https://github.com/librefang/librefang/discussions" target="_blank" rel="noopener noreferrer" className="block p-8 rounded-2xl bg-white/5 border border-gray-700/30 hover:border-primary/50 transition-all group hover:-translate-y-1">
             <div className="w-14 h-14 rounded-2xl bg-primary/20 flex items-center justify-center mb-6 group-hover:bg-primary/30 transition-colors">
-              <MaterialIcon name="forum" className="text-3xl text-primary" />
+              <MaterialIcon name="forum" className="w-7 h-7 text-primary" />
             </div>
             <h3 className="text-xl font-bold text-white mb-3">{t.contributing?.community || 'Community'}</h3>
             <p className="text-gray-400 mb-6">{t.contributing?.communityDesc || 'Join discussions and help other users'}</p>
-            <a href="https://github.com/librefang/librefang/discussions" target="_blank" rel="noopener noreferrer" className="text-primary font-semibold hover:underline">{t.contributing?.joinDiscuss || 'Join Discussion'} →</a>
-          </div>
+            <span className="text-primary font-semibold">{t.contributing?.joinDiscuss || 'Join Discussion'} →</span>
+          </a>
         </div>
       </div>
     </section>
@@ -662,24 +710,24 @@ function Contributing({ t }) {
 
 function Footer({ t }) {
   return (
-    <footer className="px-6 py-20 border-t border-gray-700/50 bg-white/5">
+    <footer className="px-6 py-20 border-t border-gray-700/50 bg-[#0a0e14]">
       <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-16">
         <div className="flex flex-col items-center md:items-start gap-6">
           <a href="/" className="flex items-center gap-3">
             <div className="flex items-center justify-center">
-              <img src="/logo.png" alt="Librefang Logo" width="32" height="32" className="rounded-md" loading="lazy" decoding="async" />
+              <img src="/logo.png" alt="LibreFang Logo" width="32" height="32" className="rounded-md" loading="lazy" decoding="async" />
             </div>
-            <span className="font-black text-2xl tracking-tight text-white">Librefang</span>
+            <span className="font-black text-2xl tracking-tight text-white">LibreFang</span>
           </a>
           <p className="text-gray-400 text-lg max-w-xs text-center md:text-left leading-relaxed">{t.footer.agentOSDesc}</p>
         </div>
-        <nav className="grid grid-cols-2 sm:grid-cols-3 gap-16 text-sm">
+        <nav className="grid grid-cols-2 sm:grid-cols-3 gap-16 text-sm" aria-label="Footer navigation">
           <div className="space-y-6">
             <h4 className="font-black text-primary uppercase tracking-[0.2em] text-xs">{t.footer.project}</h4>
             <ul className="flex flex-col gap-4 text-gray-400 font-bold">
               <li><a className="hover:text-primary transition-colors" href="#features">{t.nav.features}</a></li>
               <li><a className="hover:text-primary transition-colors" href="#comparison">{t.nav.comparison}</a></li>
-              <li><a className="hover:text-primary transition-colors" href="#install">{t.nav.docs}</a></li>
+              <li><a className="hover:text-primary transition-colors" href="#install">{t.install?.singleBinary || 'Install'}</a></li>
             </ul>
           </div>
           <div className="space-y-6">
@@ -693,15 +741,15 @@ function Footer({ t }) {
           <div className="space-y-6 hidden sm:block">
             <h4 className="font-black text-primary uppercase tracking-[0.2em] text-xs">{t.footer.docs}</h4>
             <ul className="flex flex-col gap-4 text-gray-400 font-bold">
-              <li><a className="hover:text-primary transition-colors" href="https://github.com/librefang/librefang#readme" target="_blank" rel="noopener noreferrer">{t.footer.quickStart}</a></li>
+              <li><a className="hover:text-primary transition-colors" href="https://docs.librefang.ai" target="_blank" rel="noopener noreferrer">{t.footer.quickStart}</a></li>
               <li><a className="hover:text-primary transition-colors" href="https://github.com/librefang/librefang/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">{t.footer.license}</a></li>
               <li><a className="hover:text-primary transition-colors" href="/privacy/">{t.footer.privacy}</a></li>
             </ul>
           </div>
         </nav>
       </div>
-      <div className="max-w-7xl mx-auto mt-20 pt-10 border-t border-gray-700/30 flex flex-col md:flex-row justify-between items-center gap-6 text-xs font-bold text-gray-400">
-        <p>© 2026 Librefang.ai</p>
+      <div className="max-w-7xl mx-auto mt-20 pt-10 border-t border-gray-700/30 flex flex-col md:flex-row justify-between items-center gap-6 text-xs font-bold text-gray-500">
+        <p>&copy; {new Date().getFullYear()} LibreFang.ai</p>
         <div className="flex gap-8">
           <span className="flex items-center gap-2">
             <span className="size-2 bg-primary rounded-full animate-pulse"></span>
@@ -717,15 +765,7 @@ function Footer({ t }) {
 function App() {
   const lang = (() => {
     if (typeof window !== 'undefined' && window.__INITIAL_LANG__) return window.__INITIAL_LANG__
-    if (typeof window === 'undefined') return 'en'
-    const path = window.location.pathname
-    if (path.startsWith('/zh-TW')) return 'zh-TW'
-    if (path.startsWith('/zh')) return 'zh'
-    if (path.startsWith('/de')) return 'de'
-    if (path.startsWith('/ja')) return 'ja'
-    if (path.startsWith('/ko')) return 'ko'
-    if (path.startsWith('/es')) return 'es'
-    return 'en'
+    return getCurrentLang()
   })()
 
   useEffect(() => {
@@ -745,9 +785,10 @@ function App() {
   }, [lang, currentT])
 
   return (
-    <div className="bg-background-light font-display text-slate-900 antialiased overflow-x-hidden" style={{ background: '#080c10', minHeight: '100vh' }}>
+    <div className="font-display antialiased overflow-x-hidden" style={{ background: '#080c10', minHeight: '100vh', color: '#e2e8f0' }}>
+      <a href="#main-content" className="skip-link">Skip to main content</a>
       <Header t={currentT} />
-      <main>
+      <main id="main-content">
         <Hero t={currentT} />
         <Stats t={currentT} />
         <Features t={currentT} />
@@ -755,9 +796,9 @@ function App() {
         <Workflows t={currentT} />
         <Install t={currentT} />
         <FAQ t={currentT} />
+        <GitHubStats t={currentT} />
+        <Contributing t={currentT} />
       </main>
-      <GitHubStats t={currentT} />
-      <Contributing t={currentT} />
       <Footer t={currentT} />
     </div>
   )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -46,10 +44,10 @@
 @layer components {
   .glass-effect {
     @apply fixed top-0 left-0 right-0 z-40 px-4 md:px-12 py-4;
-    background: rgba(8, 12, 16, 0.85);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(8, 12, 16, 0.88);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   }
 
   .rounded-section {
@@ -63,22 +61,26 @@
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #080c10;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
   background: #374151;
-  border-radius: 4px;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #4b5563;
 }
 
 /* Focus visible styles for accessibility */
 :focus-visible {
-  outline: 2px solid #00d4aa;
+  outline: 2px solid #10b981;
   outline-offset: 2px;
 }
 
@@ -91,11 +93,13 @@
   position: absolute;
   top: -40px;
   left: 0;
-  background: #00d4aa;
+  background: #10b981;
   color: #080c10;
   padding: 8px 16px;
   z-index: 100;
   transition: top 0.3s;
+  font-weight: 700;
+  border-radius: 0 0 8px 0;
 }
 
 .skip-link:focus {


### PR DESCRIPTION
## Summary
- Fix GitHub community images (star-history, contributors SVGs) not displaying in bottom section
- Fix mobile navigation: add all nav links with i18n translations, close menu on link click
- Fix language switcher highlighting current language instead of always showing first item
- Fix comparison table mobile view rendering all 6 rows instead of 3 hardcoded items
- Fix invalid Tailwind class `bg-white/8` → `bg-white/5`
- Fix dark text on dark background (`text-slate-900` removed from root)
- Fix OG image format from SVG to PNG for social platform compatibility
- Fix duplicate font preconnect links and CSS imports
- Add semantic structure: `<main>` wrapper, section IDs for deep linking, `scroll-mt-20` for header offset
- Add accessibility: skip-link, aria-labels, focus-visible with brand color
- Add loading skeleton states for GitHub stat cards
- Add macOS-style colored terminal dots in install section
- Polish glass effect, scrollbar, footer, and overall visual consistency
- Normalize brand name to "LibreFang" (capital F) across all meta tags

## Test plan
- [ ] Verify star-history and contributors images load in the community section
- [ ] Test mobile menu: all links present, menu closes on click, language switcher works
- [ ] Test language switching highlights the active language correctly
- [ ] Verify comparison table shows all 6 rows on mobile
- [ ] Check OG meta tags render correctly when sharing on social platforms
- [ ] Test all section deep links (#features, #comparison, #install, #faq, #community, #contributing)
- [ ] Verify accessibility: tab navigation, skip-link, focus-visible styles
- [ ] Cross-browser check: Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)