### PR TITLE
feat: add force_flat_replies config for Slack channels

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1587,7 +1587,8 @@ pub async fn start_channel_bridge_with_config(
             if let Some(bot_token) = read_token(&sl_config.bot_token_env, "Slack (bot)") {
                 let adapter = Arc::new(
                     SlackAdapter::new(app_token, bot_token, sl_config.allowed_channels.clone())
-                        .with_account_id(sl_config.account_id.clone()),
+                        .with_account_id(sl_config.account_id.clone())
+                        .with_force_flat_replies(sl_config.force_flat_replies.unwrap_or(false)),
                 );
                 adapters.push((
                     adapter,

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -35,6 +35,8 @@ pub struct SlackAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after auth.test).
     bot_user_id: Arc<RwLock<Option<String>>>,
+    /// When true, replies are posted as top-level channel messages instead of threads.
+    force_flat_replies: bool,
 }
 
 impl SlackAdapter {
@@ -49,12 +51,19 @@ impl SlackAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
+            force_flat_replies: false,
         }
     }
 
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Force replies to be posted as top-level channel messages instead of threads.
+    pub fn with_force_flat_replies(mut self, force: bool) -> Self {
+        self.force_flat_replies = force;
         self
     }
 
@@ -346,7 +355,15 @@ impl ChannelAdapter for SlackAdapter {
             _ => "(Unsupported content type)".to_string(),
         };
 
-        self.api_send_message_opts(&user.platform_id, &text, Some(thread_id))
+        // When force_flat_replies is enabled, skip threading so the message
+        // appears as a top-level channel message instead of a thread reply.
+        let ts = if self.force_flat_replies {
+            None
+        } else {
+            Some(thread_id)
+        };
+
+        self.api_send_message_opts(&user.platform_id, &text, ts)
             .await?;
         Ok(())
     }

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -2533,6 +2533,10 @@ pub struct SlackConfig {
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
+    /// When true, bot replies are posted as top-level channel messages instead
+    /// of threaded replies. Defaults to `None` (i.e. use normal threading).
+    #[serde(default)]
+    pub force_flat_replies: Option<bool>,
 }
 
 impl Default for SlackConfig {
@@ -2544,6 +2548,7 @@ impl Default for SlackConfig {
             account_id: None,
             default_agent: None,
             overrides: ChannelOverrides::default(),
+            force_flat_replies: None,
         }
     }
 }


### PR DESCRIPTION
Closes #960

Adds a `force_flat_replies` option to SlackConfig. When set to `true`, the bot posts messages directly in the channel instead of replying in threads.

Example config:
```toml
[channels.slack]
force_flat_replies = true
```