### PR TITLE
feat: add fts_only mode for memory indexing without embedding

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1072,7 +1072,10 @@ impl LibreFangKernel {
         // Auto-detect embedding driver for vector similarity search
         let embedding_driver: Option<
             Arc<dyn librefang_runtime::embedding::EmbeddingDriver + Send + Sync>,
-        > = {
+        > = if config.memory.fts_only == Some(true) {
+            info!("FTS-only memory mode active — skipping embedding driver, using SQLite FTS5 text search");
+            None
+        } else {
             use librefang_runtime::embedding::create_embedding_driver;
             let configured_model = &config.memory.embedding_model;
             if let Some(ref provider) = config.memory.embedding_provider {

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -2266,6 +2266,10 @@ pub struct MemoryConfig {
     /// How often to run memory consolidation (hours). 0 = disabled.
     #[serde(default = "default_consolidation_interval")]
     pub consolidation_interval_hours: u64,
+    /// When true, use SQLite FTS5 full-text search instead of embedding-based
+    /// vector similarity. Eliminates the need for an external embedding provider.
+    #[serde(default)]
+    pub fts_only: Option<bool>,
 }
 
 fn default_consolidation_interval() -> u64 {
@@ -2282,6 +2286,7 @@ impl Default for MemoryConfig {
             embedding_provider: None,
             embedding_api_key_env: None,
             consolidation_interval_hours: default_consolidation_interval(),
+            fts_only: None,
         }
     }
 }


### PR DESCRIPTION
Closes #985

Adds a `fts_only` option to `MemoryConfig`. When set to `true`, the memory system uses SQLite FTS5 full-text search instead of embedding-based vector similarity, eliminating the need for an external embedding provider.

Example config:
```toml
[memory]
fts_only = true
```