### PR TITLE
feat: add global workspace directory for cross-session persistence

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -486,6 +486,13 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
             .as_ref()
             .map(|p| p.to_string_lossy().to_string())
     );
+    set!(
+        "workspace_dir",
+        config
+            .workspace_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+    );
 
     // ── Default Model ──
     set!("default_model", {
@@ -1220,7 +1227,8 @@ pub async fn config_schema(State(state): State<Arc<AppState>>) -> impl IntoRespo
             "stable_prefix_mode": "boolean",
             "prompt_caching": "boolean",
             "max_cron_jobs": "number",
-            "workspaces_dir": "string"
+            "workspaces_dir": "string",
+            "workspace_dir": "string"
         }
     });
     sec!("default_model", {

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6097,6 +6097,7 @@ fn cmd_config_set(key: &str, value: &str) {
             "max_cron_jobs",
             "usage_footer",
             "workspaces_dir",
+            "workspace_dir",
         ];
         if !known_scalars.contains(&last_key) {
             ui::error_with_fix(

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -701,6 +701,16 @@ impl LibreFangKernel {
         std::fs::create_dir_all(&config.data_dir)
             .map_err(|e| KernelError::BootFailed(format!("Failed to create data dir: {e}")))?;
 
+        // Ensure global shared workspace directory exists
+        let workspace_dir = config.effective_workspace_dir();
+        std::fs::create_dir_all(&workspace_dir).map_err(|e| {
+            KernelError::BootFailed(format!(
+                "Failed to create workspace dir {}: {e}",
+                workspace_dir.display()
+            ))
+        })?;
+        info!("Global workspace dir: {}", workspace_dir.display());
+
         // Initialize memory substrate
         let db_path = config
             .memory

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1306,6 +1306,10 @@ pub struct KernelConfig {
     /// Root directory for agent workspaces. Default: `~/.librefang/workspaces`
     #[serde(default)]
     pub workspaces_dir: Option<PathBuf>,
+    /// Global shared workspace directory for cross-session file persistence.
+    /// Default: `~/.librefang/workspace`
+    #[serde(default)]
+    pub workspace_dir: Option<PathBuf>,
     /// Media understanding configuration.
     #[serde(default)]
     pub media: crate::media::MediaConfig,
@@ -2044,6 +2048,7 @@ impl Default for KernelConfig {
             extensions: ExtensionsConfig::default(),
             vault: VaultConfig::default(),
             workspaces_dir: None,
+            workspace_dir: None,
             media: crate::media::MediaConfig::default(),
             links: crate::media::LinkConfig::default(),
             reload: ReloadConfig::default(),
@@ -2090,6 +2095,13 @@ impl KernelConfig {
         self.workspaces_dir
             .clone()
             .unwrap_or_else(|| self.home_dir.join("workspaces"))
+    }
+
+    /// Resolved global shared workspace directory for cross-session persistence.
+    pub fn effective_workspace_dir(&self) -> PathBuf {
+        self.workspace_dir
+            .clone()
+            .unwrap_or_else(|| self.home_dir.join("workspace"))
     }
 
     /// Resolve the API key env var name for a provider.
@@ -2154,6 +2166,7 @@ impl std::fmt::Debug for KernelConfig {
             .field("extensions", &self.extensions)
             .field("vault", &format!("enabled={}", self.vault.enabled))
             .field("workspaces_dir", &self.workspaces_dir)
+            .field("workspace_dir", &self.workspace_dir)
             .field(
                 "media",
                 &format!(


### PR DESCRIPTION
Closes #1064

Adds a configurable `workspace_dir` to KernelConfig for cross-session file persistence. Defaults to `~/.librefang/workspace/`.

**Changes:**
- `librefang-types/config.rs`: Added `workspace_dir: Option<PathBuf>` field with `#[serde(default)]`, Default impl entry, `effective_workspace_dir()` resolver method, and Debug impl entry
- `librefang-kernel/kernel.rs`: During boot, creates the workspace directory if it doesn't exist and logs the path
- `librefang-api/routes/config.rs`: Exposes `workspace_dir` in the config API response and schema
- `librefang-cli/main.rs`: Registers `workspace_dir` as a known scalar config key for `config set`

**Example config:**
```toml
workspace_dir = "/data/librefang/shared"
```