### PR TITLE
feat: add WorkflowTemplate types and in-memory registry

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -1024,6 +1024,62 @@ pub fn load_workflow_definitions(dir: &Path) -> Vec<Workflow> {
     workflows
 }
 
+// ---------------------------------------------------------------------------
+// WorkflowTemplateRegistry — in-memory store for workflow templates
+// ---------------------------------------------------------------------------
+
+use librefang_types::workflow_template::WorkflowTemplate;
+
+/// In-memory registry for storing and retrieving [`WorkflowTemplate`]s.
+///
+/// Thread-safe: the registry is designed to be wrapped in an `Arc` and shared
+/// across async tasks. Internal synchronisation uses a `RwLock`.
+pub struct WorkflowTemplateRegistry {
+    templates: RwLock<HashMap<String, WorkflowTemplate>>,
+}
+
+impl WorkflowTemplateRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            templates: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register (insert or update) a template.
+    ///
+    /// If a template with the same `id` already exists it is replaced and the
+    /// old value is returned.
+    pub async fn register(&self, template: WorkflowTemplate) -> Option<WorkflowTemplate> {
+        let mut map = self.templates.write().await;
+        map.insert(template.id.clone(), template)
+    }
+
+    /// Retrieve a template by id, returning a cloned copy.
+    pub async fn get(&self, id: &str) -> Option<WorkflowTemplate> {
+        let map = self.templates.read().await;
+        map.get(id).cloned()
+    }
+
+    /// List all registered templates (order is arbitrary).
+    pub async fn list(&self) -> Vec<WorkflowTemplate> {
+        let map = self.templates.read().await;
+        map.values().cloned().collect()
+    }
+
+    /// Remove a template by id, returning it if it existed.
+    pub async fn remove(&self, id: &str) -> Option<WorkflowTemplate> {
+        let mut map = self.templates.write().await;
+        map.remove(id)
+    }
+}
+
+impl Default for WorkflowTemplateRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1778,5 +1834,91 @@ id = "{id}"
         // created_at should be roughly now (within last 5 seconds)
         let diff = Utc::now() - wf.created_at;
         assert!(diff.num_seconds() < 5);
+    }
+
+    // -- WorkflowTemplateRegistry tests --
+
+    use librefang_types::workflow_template::{
+        ParameterType, TemplateParameter, WorkflowTemplateStep,
+    };
+
+    fn test_template(id: &str) -> WorkflowTemplate {
+        WorkflowTemplate {
+            id: id.to_string(),
+            name: format!("Template {id}"),
+            description: "test".into(),
+            category: None,
+            parameters: vec![TemplateParameter {
+                name: "lang".into(),
+                description: None,
+                param_type: ParameterType::String,
+                default: None,
+                required: true,
+            }],
+            steps: vec![WorkflowTemplateStep {
+                name: "step1".into(),
+                prompt_template: "do {{lang}}".into(),
+                agent: None,
+                depends_on: vec![],
+            }],
+            tags: vec![],
+            created_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_register_and_get() {
+        let reg = WorkflowTemplateRegistry::new();
+        let tpl = test_template("t1");
+
+        assert!(reg.get("t1").await.is_none());
+
+        let prev = reg.register(tpl.clone()).await;
+        assert!(prev.is_none());
+
+        let fetched = reg.get("t1").await.unwrap();
+        assert_eq!(fetched.id, "t1");
+        assert_eq!(fetched.name, "Template t1");
+    }
+
+    #[tokio::test]
+    async fn registry_register_overwrites() {
+        let reg = WorkflowTemplateRegistry::new();
+        reg.register(test_template("t1")).await;
+
+        let mut updated = test_template("t1");
+        updated.name = "Updated".into();
+        let old = reg.register(updated).await;
+        assert!(old.is_some());
+        assert_eq!(old.unwrap().name, "Template t1");
+
+        let fetched = reg.get("t1").await.unwrap();
+        assert_eq!(fetched.name, "Updated");
+    }
+
+    #[tokio::test]
+    async fn registry_list() {
+        let reg = WorkflowTemplateRegistry::new();
+        assert!(reg.list().await.is_empty());
+
+        reg.register(test_template("a")).await;
+        reg.register(test_template("b")).await;
+        reg.register(test_template("c")).await;
+
+        let all = reg.list().await;
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn registry_remove() {
+        let reg = WorkflowTemplateRegistry::new();
+        reg.register(test_template("r1")).await;
+
+        let removed = reg.remove("r1").await;
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().id, "r1");
+
+        assert!(reg.get("r1").await.is_none());
+        assert!(reg.remove("r1").await.is_none());
     }
 }

--- a/crates/librefang-types/src/lib.rs
+++ b/crates/librefang-types/src/lib.rs
@@ -27,6 +27,7 @@ pub mod tool;
 pub mod tool_compat;
 pub mod tool_policy;
 pub mod webhook;
+pub mod workflow_template;
 
 /// Safely truncate a string to at most `max_bytes`, never splitting a UTF-8 char.
 pub fn truncate_str(s: &str, max_bytes: usize) -> &str {

--- a/crates/librefang-types/src/workflow_template.rs
+++ b/crates/librefang-types/src/workflow_template.rs
@@ -1,0 +1,149 @@
+//! Workflow template types — reusable parameterized workflow blueprints.
+//!
+//! A `WorkflowTemplate` is a blueprint that can be instantiated into a
+//! concrete workflow by supplying values for its parameters. Template
+//! steps use `prompt_template` strings with `{{param_name}}` placeholders
+//! that are substituted at instantiation time.
+
+use serde::{Deserialize, Serialize};
+
+/// A reusable workflow blueprint with parameterized steps.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkflowTemplate {
+    /// Unique identifier for this template.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Description of what this template produces.
+    pub description: String,
+    /// Optional category for grouping (e.g. "data-pipeline", "code-review").
+    pub category: Option<String>,
+    /// Parameters that must (or may) be supplied when instantiating.
+    #[serde(default)]
+    pub parameters: Vec<TemplateParameter>,
+    /// The steps that make up the workflow blueprint.
+    pub steps: Vec<WorkflowTemplateStep>,
+    /// Free-form tags for search / filtering.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// ISO-8601 creation timestamp (set by the registry on insert).
+    pub created_at: Option<String>,
+}
+
+/// A single parameter declaration inside a workflow template.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TemplateParameter {
+    /// Parameter name — used as the placeholder key in prompt templates.
+    pub name: String,
+    /// Human-readable description shown to the user.
+    pub description: Option<String>,
+    /// The value type expected for this parameter.
+    pub param_type: ParameterType,
+    /// Optional default value; used when the caller omits this parameter.
+    pub default: Option<serde_json::Value>,
+    /// Whether the caller must supply this parameter (no default fallback).
+    pub required: bool,
+}
+
+/// Supported parameter value types.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParameterType {
+    /// Free-form text.
+    String,
+    /// Numeric value (integer or float).
+    Number,
+    /// True / false flag.
+    Boolean,
+    /// Reference to an existing agent by ID.
+    AgentId,
+}
+
+/// A single step inside a workflow template.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkflowTemplateStep {
+    /// Step name for logging and dependency references.
+    pub name: String,
+    /// Prompt with `{{param}}` placeholders resolved at instantiation.
+    pub prompt_template: String,
+    /// Optional agent selector (name or id); `None` means "use default".
+    pub agent: Option<String>,
+    /// Names of other steps that must complete before this one starts.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_serde() {
+        let tpl = WorkflowTemplate {
+            id: "tpl-1".into(),
+            name: "Summarise & Translate".into(),
+            description: "Summarise text then translate it.".into(),
+            category: Some("text".into()),
+            parameters: vec![TemplateParameter {
+                name: "target_lang".into(),
+                description: Some("Language to translate into".into()),
+                param_type: ParameterType::String,
+                default: Some(serde_json::Value::String("en".into())),
+                required: false,
+            }],
+            steps: vec![
+                WorkflowTemplateStep {
+                    name: "summarise".into(),
+                    prompt_template: "Summarise: {{input}}".into(),
+                    agent: None,
+                    depends_on: vec![],
+                },
+                WorkflowTemplateStep {
+                    name: "translate".into(),
+                    prompt_template: "Translate to {{target_lang}}: {{input}}".into(),
+                    agent: Some("translator-agent".into()),
+                    depends_on: vec!["summarise".into()],
+                },
+            ],
+            tags: vec!["nlp".into(), "translation".into()],
+            created_at: Some("2025-01-01T00:00:00Z".into()),
+        };
+
+        let json = serde_json::to_string(&tpl).expect("serialize");
+        let back: WorkflowTemplate = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.id, "tpl-1");
+        assert_eq!(back.parameters.len(), 1);
+        assert_eq!(back.steps.len(), 2);
+        assert_eq!(back.tags, vec!["nlp", "translation"]);
+    }
+
+    #[test]
+    fn deserialize_minimal() {
+        let json = r#"{
+            "id": "m",
+            "name": "Minimal",
+            "description": "d",
+            "steps": [{"name":"s","prompt_template":"do it"}]
+        }"#;
+        let tpl: WorkflowTemplate = serde_json::from_str(json).expect("deserialize minimal");
+        assert!(tpl.parameters.is_empty());
+        assert!(tpl.tags.is_empty());
+        assert!(tpl.category.is_none());
+        assert!(tpl.created_at.is_none());
+    }
+
+    #[test]
+    fn parameter_type_serde() {
+        let cases = vec![
+            (ParameterType::String, "\"string\""),
+            (ParameterType::Number, "\"number\""),
+            (ParameterType::Boolean, "\"boolean\""),
+            (ParameterType::AgentId, "\"agent_id\""),
+        ];
+        for (variant, expected) in cases {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1155

Adds WorkflowTemplate types for reusable workflow blueprints with parameterized steps, and an in-memory registry for storing/retrieving templates.

New types:
- `WorkflowTemplate` — Blueprint with parameters and steps
- `TemplateParameter` — Parameter definition with type and default
- `WorkflowTemplateStep` — Step with prompt template and dependencies
- `WorkflowTemplateRegistry` — In-memory storage with CRUD operations