### PR TITLE
feat: add configurable session reset prompt

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1613,10 +1613,12 @@ system_prompt = "You are a helpful assistant."
 
         info!(agent = %name, id = %agent_id, parent = ?parent, "Spawning agent");
 
-        // Create session
-        self.memory
+        // Create session and inject reset prompt if configured
+        let mut session = self
+            .memory
             .create_session(agent_id)
             .map_err(KernelError::LibreFang)?;
+        self.inject_reset_prompt(&mut session);
 
         // Inherit kernel exec_policy as fallback if agent manifest doesn't have one
         let mut manifest = manifest;
@@ -3404,11 +3406,12 @@ system_prompt = "You are a helpful assistant."
         // Delete the old session
         let _ = self.memory.delete_session(entry.session_id);
 
-        // Create a fresh session
-        let new_session = self
+        // Create a fresh session and inject reset prompt if configured
+        let mut new_session = self
             .memory
             .create_session(agent_id)
             .map_err(KernelError::LibreFang)?;
+        self.inject_reset_prompt(&mut new_session);
 
         // Update registry with new session ID
         self.registry
@@ -3436,11 +3439,12 @@ system_prompt = "You are a helpful assistant."
         // Delete canonical (cross-channel) session
         let _ = self.memory.delete_canonical_session(agent_id);
 
-        // Create a fresh session
-        let new_session = self
+        // Create a fresh session and inject reset prompt if configured
+        let mut new_session = self
             .memory
             .create_session(agent_id)
             .map_err(KernelError::LibreFang)?;
+        self.inject_reset_prompt(&mut new_session);
 
         // Update registry with new session ID
         self.registry
@@ -3489,10 +3493,11 @@ system_prompt = "You are a helpful assistant."
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
 
-        let session = self
+        let mut session = self
             .memory
             .create_session_with_label(agent_id, label)
             .map_err(KernelError::LibreFang)?;
+        self.inject_reset_prompt(&mut session);
 
         // Switch to the new session
         self.registry
@@ -3539,6 +3544,23 @@ system_prompt = "You are a helpful assistant."
 
         info!(agent_id = %agent_id, session_id = %session_id.0, "Switched session");
         Ok(())
+    }
+
+    /// Inject the configured `session.reset_prompt` into a newly created session
+    /// as the first system message (if configured).
+    fn inject_reset_prompt(&self, session: &mut librefang_memory::session::Session) {
+        if let Some(ref prompt) = self.config.session.reset_prompt {
+            if !prompt.is_empty() {
+                session
+                    .messages
+                    .push(librefang_types::message::Message::system(prompt.clone()));
+                let _ = self.memory.save_session(session);
+                debug!(
+                    session_id = %session.id.0,
+                    "Injected session reset prompt"
+                );
+            }
+        }
     }
 
     /// Save a summary of the current session to agent memory before reset.

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1073,13 +1073,15 @@ pub struct SidecarChannelConfig {
 
 /// Session retention policy configuration.
 ///
-/// Controls automatic cleanup of idle or excess sessions.
+/// Controls automatic cleanup of idle or excess sessions and optional
+/// startup prompt injection.
 /// Configure in `config.toml`:
 /// ```toml
 /// [session]
 /// retention_days = 30
 /// max_sessions_per_agent = 100
 /// cleanup_interval_hours = 24
+/// reset_prompt = "You are a helpful coding assistant. Always respond in English."
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1090,6 +1092,11 @@ pub struct SessionConfig {
     pub max_sessions_per_agent: u32,
     /// How often the cleanup job runs (in hours).
     pub cleanup_interval_hours: u32,
+    /// Optional message injected as the first system message when a new session
+    /// starts or when the session is reset. Useful for setting up persistent
+    /// context or instructions across all agents.
+    #[serde(default)]
+    pub reset_prompt: Option<String>,
 }
 
 impl Default for SessionConfig {
@@ -1098,6 +1105,7 @@ impl Default for SessionConfig {
             retention_days: 0,
             max_sessions_per_agent: 0,
             cleanup_interval_hours: 24,
+            reset_prompt: None,
         }
     }
 }


### PR DESCRIPTION
Closes #963

Adds a `reset_prompt` option to `SessionConfig`. When set, this message is injected as the initial system message when a new session starts or when the session is reset.

Example config:
```toml
[session]
reset_prompt = "You are a helpful coding assistant. Always respond in English."
```

## Changes

- **`crates/librefang-types/src/config.rs`**: Added `reset_prompt: Option<String>` field to `SessionConfig` with `#[serde(default)]` and `None` default.
- **`crates/librefang-kernel/src/kernel.rs`**: Added `inject_reset_prompt()` helper that pushes a system message and persists it. Called from all four session creation sites:
  - `spawn_agent_inner` (new agent spawn)
  - `reset_session` (session reset via `/new`)
  - `clear_agent_history` (full history clear)
  - `create_agent_session` (named session creation)