### PR TITLE
fix: improve Qwen Code CLI path detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "axum",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "aes",
  "async-trait",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "axum",
  "librefang-api",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9935,7 +9935,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.7.0-20260321"
+version = "2026.3.2101"
 
 [[package]]
 name = "yoke"

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -5572,6 +5572,14 @@ system_prompt = "You are a helpful assistant."
                 }
             }
         }
+        // 3. Dedicated CLI path config fields (more discoverable than provider_urls).
+        if provider == "qwen-code" {
+            if let Some(ref path) = self.config.qwen_code_path {
+                if !path.is_empty() {
+                    return Some(path.clone());
+                }
+            }
+        }
         None
     }
 

--- a/crates/librefang-runtime/src/drivers/qwen_code.rs
+++ b/crates/librefang-runtime/src/drivers/qwen_code.rs
@@ -71,9 +71,38 @@ impl QwenCodeDriver {
         }
     }
 
-    /// Detect if the Qwen Code CLI is available on PATH.
+    /// Detect if the Qwen Code CLI is available.
+    ///
+    /// Tries the bare `qwen` command first (standard PATH lookup), then falls
+    /// back to common install locations that may not be on PATH when LibreFang
+    /// runs as a daemon/service.
     pub fn detect() -> Option<String> {
-        let output = std::process::Command::new("qwen")
+        // 1. Try bare command on PATH.
+        if let Some(version) = Self::try_cli("qwen") {
+            return Some(version);
+        }
+
+        // 2. Try `which qwen` to resolve through shell aliases / env managers.
+        if let Some(path) = Self::which("qwen") {
+            if let Some(version) = Self::try_cli(&path) {
+                return Some(version);
+            }
+        }
+
+        // 3. Try common install locations (npm global, cargo, etc.).
+        let candidates = Self::common_cli_paths("qwen");
+        for candidate in &candidates {
+            if let Some(version) = Self::try_cli(candidate) {
+                return Some(version);
+            }
+        }
+
+        None
+    }
+
+    /// Try to run a CLI binary and return its version string.
+    fn try_cli(path: &str) -> Option<String> {
+        let output = std::process::Command::new(path)
             .arg("--version")
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
@@ -85,6 +114,80 @@ impl QwenCodeDriver {
         } else {
             None
         }
+    }
+
+    /// Use `which` (Unix) or `where` (Windows) to resolve a binary path.
+    fn which(name: &str) -> Option<String> {
+        #[cfg(target_os = "windows")]
+        let cmd = "where";
+        #[cfg(not(target_os = "windows"))]
+        let cmd = "which";
+
+        let output = std::process::Command::new(cmd)
+            .arg(name)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()?
+                .trim()
+                .to_string();
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    /// Return common install locations for a CLI binary.
+    fn common_cli_paths(name: &str) -> Vec<String> {
+        let mut paths = Vec::new();
+        if let Some(home) = home_dir() {
+            // npm global installs (nvm, fnm, volta, etc.)
+            paths.push(
+                home.join(".local")
+                    .join("bin")
+                    .join(name)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+            paths.push(
+                home.join(".nvm")
+                    .join("versions")
+                    .join("node")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+            // Cargo-installed binaries
+            paths.push(
+                home.join(".cargo")
+                    .join("bin")
+                    .join(name)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+
+        // System-wide locations
+        #[cfg(not(target_os = "windows"))]
+        {
+            paths.push(format!("/usr/local/bin/{name}"));
+            paths.push(format!("/usr/bin/{name}"));
+            paths.push(format!("/opt/homebrew/bin/{name}"));
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            if let Ok(appdata) = std::env::var("APPDATA") {
+                paths.push(format!("{appdata}\\npm\\{name}.cmd"));
+            }
+        }
+
+        paths
     }
 
     /// Build the CLI arguments for a given request.
@@ -224,7 +327,10 @@ impl LlmDriver for QwenCodeDriver {
         let output = cmd.output().await.map_err(|e| {
             LlmError::Http(format!(
                 "Qwen Code CLI not found or failed to start ({}). \
-                 Install: npm install -g @qwen-code/qwen-code && qwen auth",
+                 Install: npm install -g @qwen-code/qwen-code && qwen auth. \
+                 If the CLI is installed in a non-standard location, set \
+                 provider_urls.qwen-code in your LibreFang config.toml \
+                 (e.g. provider_urls.qwen-code = \"/path/to/qwen\")",
                 e
             ))
         })?;
@@ -314,7 +420,10 @@ impl LlmDriver for QwenCodeDriver {
         let mut child = cmd.spawn().map_err(|e| {
             LlmError::Http(format!(
                 "Qwen Code CLI not found or failed to start ({}). \
-                 Install: npm install -g @qwen-code/qwen-code && qwen auth",
+                 Install: npm install -g @qwen-code/qwen-code && qwen auth. \
+                 If the CLI is installed in a non-standard location, set \
+                 provider_urls.qwen-code in your LibreFang config.toml \
+                 (e.g. provider_urls.qwen-code = \"/path/to/qwen\")",
                 e
             ))
         })?;
@@ -458,6 +567,9 @@ impl LlmDriver for QwenCodeDriver {
 }
 
 /// Check if the Qwen Code CLI is available.
+///
+/// Returns `true` if the CLI binary is found (via PATH or common install
+/// locations) or if Qwen credentials files exist on disk.
 pub fn qwen_code_available() -> bool {
     QwenCodeDriver::detect().is_some() || qwen_credentials_exist()
 }
@@ -631,5 +743,50 @@ mod tests {
         assert_eq!(event.r#type, "result");
         assert_eq!(event.result.unwrap(), "Final answer");
         assert_eq!(event.usage.unwrap().output_tokens, 10);
+    }
+
+    #[test]
+    fn test_common_cli_paths_contains_standard_locations() {
+        let paths = QwenCodeDriver::common_cli_paths("qwen");
+        assert!(!paths.is_empty(), "should return at least some candidates");
+
+        // On Unix, /usr/local/bin/qwen should be in the list.
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(
+                paths.contains(&"/usr/local/bin/qwen".to_string()),
+                "should include /usr/local/bin/qwen"
+            );
+            assert!(
+                paths.contains(&"/usr/bin/qwen".to_string()),
+                "should include /usr/bin/qwen"
+            );
+        }
+
+        // Should include ~/.local/bin/qwen
+        if let Some(home) = home_dir() {
+            let local_bin = home
+                .join(".local")
+                .join("bin")
+                .join("qwen")
+                .to_string_lossy()
+                .to_string();
+            assert!(
+                paths.contains(&local_bin),
+                "should include ~/.local/bin/qwen"
+            );
+        }
+    }
+
+    #[test]
+    fn test_try_cli_nonexistent_binary() {
+        // A binary that definitely doesn't exist should return None.
+        assert!(QwenCodeDriver::try_cli("__nonexistent_binary_12345__").is_none());
+    }
+
+    #[test]
+    fn test_which_nonexistent_binary() {
+        // `which` for a non-existent binary should return None.
+        assert!(QwenCodeDriver::which("__nonexistent_binary_12345__").is_none());
     }
 }

--- a/crates/librefang-types/src/config.rs
+++ b/crates/librefang-types/src/config.rs
@@ -1442,6 +1442,16 @@ pub struct KernelConfig {
     /// boots normally. This is the "tolerant mode" toggle.
     #[serde(default)]
     pub strict_config: bool,
+    /// Override path to the Qwen Code CLI binary.
+    ///
+    /// When LibreFang runs as a daemon/service the subprocess may not inherit
+    /// the user's full PATH, so the `qwen` binary is not found even though it
+    /// is installed.  Set this to the absolute path of the CLI
+    /// (e.g. `"/home/user/.local/bin/qwen"`).
+    ///
+    /// Alternatively you can set `provider_urls.qwen-code` to the same value.
+    #[serde(default)]
+    pub qwen_code_path: Option<String>,
 }
 
 /// Vertex AI provider configuration.
@@ -2100,6 +2110,7 @@ impl Default for KernelConfig {
             plugins: PluginsConfig::default(),
             cors_origin: Vec::new(),
             strict_config: false,
+            qwen_code_path: None,
         }
     }
 }
@@ -2233,6 +2244,7 @@ impl std::fmt::Debug for KernelConfig {
                 &format!("enabled={}", self.external_auth.enabled),
             )
             .field("strict_config", &self.strict_config)
+            .field("qwen_code_path", &self.qwen_code_path)
             .finish()
     }
 }


### PR DESCRIPTION
Closes #1329

Improves Qwen Code CLI detection by:

- **Fallback path resolution**: When the bare `qwen` command fails (common when LibreFang runs as a daemon/service without the user's full PATH), detection now tries `which qwen` and then checks common install locations (`~/.local/bin/qwen`, `/usr/local/bin/qwen`, `/usr/bin/qwen`, `/opt/homebrew/bin/qwen`, `~/.cargo/bin/qwen`, and Windows npm global path).
- **Configurable CLI path**: Added `qwen_code_path` field to `KernelConfig` so users can specify the full path to the `qwen` binary in `config.toml`. This is also wired into `lookup_provider_url` as a fallback for the `qwen-code` provider (alternatively, `provider_urls.qwen-code` still works).
- **Better error messages**: When the CLI is not found, the error now suggests setting `provider_urls.qwen-code` in config.toml with the full path.
- **Tests**: Added unit tests for `common_cli_paths`, `try_cli`, and `which` helper methods.