### PR TITLE
feat: add /reboot slash command for graceful context reset

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1078,6 +1078,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Ok("Session reset. Chat history cleared.".to_string())
     }
 
+    async fn reboot_session(&self, agent_id: AgentId) -> Result<String, String> {
+        self.kernel
+            .reboot_session(agent_id)
+            .map_err(|e| format!("{e}"))?;
+        Ok("Session rebooted. Context cleared.".to_string())
+    }
+
     async fn compact_session(&self, agent_id: AgentId) -> Result<String, String> {
         self.kernel
             .compact_agent_session(agent_id)

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -59,6 +59,7 @@ use crate::types;
         routes::create_agent_session,
         routes::switch_agent_session,
         routes::reset_session,
+        routes::reboot_session,
         routes::clear_agent_history,
         routes::compact_session,
         routes::stop_agent,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1683,6 +1683,47 @@ pub async fn reset_session(
     }
 }
 
+/// POST /api/agents/{id}/session/reboot — Hard-reboot an agent's session (full clear, no summary).
+#[utoipa::path(
+    post,
+    path = "/api/agents/{id}/session/reboot",
+    tag = "agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses(
+        (status = 200, description = "Hard-reboot an agent's session without saving summary", body = serde_json::Value)
+    )
+)]
+pub async fn reboot_session(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let agent_id: AgentId = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+            )
+        }
+    };
+    match state.kernel.reboot_session(agent_id) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(
+                serde_json::json!({"status": "ok", "message": "Session rebooted. Context cleared."}),
+            ),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(
+                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+            ),
+        ),
+    }
+}
+
 /// DELETE /api/agents/{id}/history — Clear ALL conversation history for an agent.
 #[utoipa::path(
     delete,

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1674,6 +1674,7 @@ pub async fn list_commands(State(state): State<Arc<AppState>>) -> impl IntoRespo
     let mut commands = vec![
         serde_json::json!({"cmd": "/help", "desc": "Show available commands"}),
         serde_json::json!({"cmd": "/new", "desc": "Reset session (clear history)"}),
+        serde_json::json!({"cmd": "/reboot", "desc": "Hard reset session (full context clear, no summary)"}),
         serde_json::json!({"cmd": "/compact", "desc": "Trigger LLM session compaction"}),
         serde_json::json!({"cmd": "/model", "desc": "Show or switch model (/model [name])"}),
         serde_json::json!({"cmd": "/stop", "desc": "Cancel current agent run"}),
@@ -1721,6 +1722,10 @@ pub async fn get_command(
     let builtins = [
         ("/help", "Show available commands"),
         ("/new", "Reset session (clear history)"),
+        (
+            "/reboot",
+            "Hard reset session (full context clear, no summary)",
+        ),
         ("/compact", "Trigger LLM session compaction"),
         ("/model", "Show or switch model (/model [name])"),
         ("/stop", "Cancel current agent run"),

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -102,6 +102,10 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
             axum::routing::post(routes::reset_session),
         )
         .route(
+            "/agents/{id}/session/reboot",
+            axum::routing::post(routes::reboot_session),
+        )
+        .route(
             "/agents/{id}/history",
             axum::routing::delete(routes::clear_agent_history),
         )

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -794,6 +794,14 @@ async fn handle_command(
             }
             Err(e) => serde_json::json!({"type": "error", "content": format!("Reset failed: {e}")}),
         },
+        "reboot" => match state.kernel.reboot_session(agent_id) {
+            Ok(()) => {
+                serde_json::json!({"type": "command_result", "command": "reboot", "message": "Session rebooted. Context cleared."})
+            }
+            Err(e) => {
+                serde_json::json!({"type": "error", "content": format!("Reboot failed: {e}")})
+            }
+        },
         "compact" => match state.kernel.compact_agent_session(agent_id).await {
             Ok(msg) => {
                 serde_json::json!({"type": "command_result", "command": cmd, "message": msg})

--- a/crates/librefang-api/static/js/pages/chat.js
+++ b/crates/librefang-api/static/js/pages/chat.js
@@ -48,6 +48,7 @@ function chatPage() {
       { cmd: '/help', descKey: 'agentChat.cmd.help', descFallback: 'Show available commands' },
       { cmd: '/agents', descKey: 'agentChat.cmd.agents', descFallback: 'Switch to Agents page' },
       { cmd: '/new', descKey: 'agentChat.cmd.new', descFallback: 'Reset session (clear history)' },
+      { cmd: '/reboot', descKey: 'agentChat.cmd.reboot', descFallback: 'Hard reset session (full context clear, no summary)' },
       { cmd: '/compact', descKey: 'agentChat.cmd.compact', descFallback: 'Trigger LLM session compaction' },
       { cmd: '/model', descKey: 'agentChat.cmd.model', descFallback: 'Show or switch model (/model [name])' },
       { cmd: '/stop', descKey: 'agentChat.cmd.stop', descFallback: 'Cancel current agent run' },
@@ -533,6 +534,14 @@ function chatPage() {
               self.messages = [];
               LibreFangToast.success(self.t('agentChat.toast.sessionReset', 'Session reset'));
             }).catch(function(e) { LibreFangToast.error(self.t('agentChat.toast.resetFailed', 'Reset failed: {message}', { message: e.message })); });
+          }
+          break;
+        case '/reboot':
+          if (self.currentAgent) {
+            LibreFangAPI.post('/api/agents/' + self.currentAgent.id + '/session/reboot', {}).then(function() {
+              self.messages = [];
+              LibreFangToast.success(self.t('agentChat.toast.sessionRebooted', 'Session rebooted. Context cleared.'));
+            }).catch(function(e) { LibreFangToast.error(self.t('agentChat.toast.rebootFailed', 'Reboot failed: {message}', { message: e.message })); });
           }
           break;
         case '/compact':

--- a/crates/librefang-api/static/locales/en.json
+++ b/crates/librefang-api/static/locales/en.json
@@ -419,6 +419,7 @@
       "help": "Show available commands",
       "agents": "Switch to Agents page",
       "new": "Reset session (clear history)",
+      "reboot": "Hard reset session (full context clear, no summary)",
       "compact": "Trigger LLM session compaction",
       "model": "Show or switch model (/model [name])",
       "stop": "Cancel current agent run",
@@ -438,7 +439,9 @@
       "modelSwitched": "Switched to {model}",
       "switchFailed": "Switch failed: {message}",
       "sessionReset": "Session reset",
+      "sessionRebooted": "Session rebooted. Context cleared.",
       "resetFailed": "Reset failed: {message}",
+      "rebootFailed": "Reboot failed: {message}",
       "compactFailed": "Compaction failed: {message}",
       "stopFailed": "Stop failed: {message}",
       "modelSwitchFailed": "Model switch failed: {message}"

--- a/crates/librefang-api/static/locales/zh-CN.json
+++ b/crates/librefang-api/static/locales/zh-CN.json
@@ -419,6 +419,7 @@
       "help": "显示可用命令",
       "agents": "切换到代理页面",
       "new": "重置会话（清除历史）",
+      "reboot": "硬重置会话（完全清除上下文，不保存摘要）",
       "compact": "触发LLM会话压缩",
       "model": "显示或切换模型（/model [名称]）",
       "stop": "取消当前代理运行",
@@ -438,7 +439,9 @@
       "modelSwitched": "已切换到 {model}",
       "switchFailed": "切换失败：{message}",
       "sessionReset": "会话已重置",
+      "sessionRebooted": "会话已重启，上下文已清除。",
       "resetFailed": "重置失败：{message}",
+      "rebootFailed": "重启失败：{message}",
       "compactFailed": "压缩失败：{message}",
       "stopFailed": "停止失败：{message}",
       "modelSwitchFailed": "模型切换失败：{message}"

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -89,6 +89,10 @@ async fn start_test_server() -> TestServer {
             axum::routing::post(routes::reset_session),
         )
         .route(
+            "/api/agents/{id}/session/reboot",
+            axum::routing::post(routes::reboot_session),
+        )
+        .route(
             "/api/agents/{id}/sessions",
             axum::routing::get(routes::list_agent_sessions).post(routes::create_agent_session),
         )

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -105,6 +105,11 @@ pub trait ChannelBridgeHandle: Send + Sync {
         Err("Not implemented".to_string())
     }
 
+    /// Hard-reboot an agent's session — full context clear without saving summary.
+    async fn reboot_session(&self, _agent_id: AgentId) -> Result<String, String> {
+        Err("Not implemented".to_string())
+    }
+
     /// Trigger LLM-based session compaction for an agent.
     async fn compact_session(&self, _agent_id: AgentId) -> Result<String, String> {
         Err("Not implemented".to_string())
@@ -817,6 +822,7 @@ async fn dispatch_message(
                 | "models"
                 | "providers"
                 | "new"
+                | "reboot"
                 | "compact"
                 | "model"
                 | "stop"
@@ -1497,6 +1503,7 @@ async fn handle_command(
              /agents - list running agents\n\
              /agent <name> - select which agent to talk to\n\
              /new - reset session (clear messages)\n\
+             /reboot - hard reset session (full context clear, no summary)\n\
              /compact - trigger LLM session compaction\n\
              /model [name] - show or switch agent model\n\
              /stop - cancel current agent run\n\
@@ -1580,6 +1587,20 @@ async fn handle_command(
             match agent_id {
                 Some(aid) => handle
                     .reset_session(aid)
+                    .await
+                    .unwrap_or_else(|e| format!("Error: {e}")),
+                None => "No agent selected. Use /agent <name> first.".to_string(),
+            }
+        }
+        "reboot" => {
+            let agent_id = router.resolve(
+                &crate::types::ChannelType::CLI,
+                &sender.platform_id,
+                sender.librefang_user.as_deref(),
+            );
+            match agent_id {
+                Some(aid) => handle
+                    .reboot_session(aid)
                     .await
                     .unwrap_or_else(|e| format!("Error: {e}")),
                 None => "No agent selected. Use /agent <name> first.".to_string(),

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3422,6 +3422,36 @@ system_prompt = "You are a helpful assistant."
         Ok(())
     }
 
+    /// Hard-reboot an agent's session — clears conversation history WITHOUT saving
+    /// a summary to memory.  Keeps agent config, system prompt, and tools intact.
+    /// More aggressive than `reset_session` (which auto-saves a summary) but less
+    /// destructive than `clear_agent_history` (which wipes ALL sessions).
+    pub fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()> {
+        let entry = self.registry.get(agent_id).ok_or_else(|| {
+            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
+        })?;
+
+        // Delete the old session WITHOUT saving a summary
+        let _ = self.memory.delete_session(entry.session_id);
+
+        // Create a fresh session
+        let new_session = self
+            .memory
+            .create_session(agent_id)
+            .map_err(KernelError::LibreFang)?;
+
+        // Update registry with new session ID
+        self.registry
+            .update_session_id(agent_id, new_session.id)
+            .map_err(KernelError::LibreFang)?;
+
+        // Reset quota tracking
+        self.scheduler.reset_usage(agent_id);
+
+        info!(agent_id = %agent_id, "Session rebooted (no summary saved)");
+        Ok(())
+    }
+
     /// Clear ALL conversation history for an agent (sessions + canonical).
     ///
     /// Creates a fresh empty session afterward so the agent is still usable.


### PR DESCRIPTION
Closes #980

Adds a `/reboot` slash command that clears the current session's conversation history while preserving the agent's configuration, system prompt, and tools. Unlike `/new` (which saves a session summary to memory before clearing) and `/compact` (which summarizes context), `/reboot` performs a full hard reset with no summary saved.

## Changes

- **Kernel** (`kernel.rs`): New `reboot_session()` method — deletes session without saving summary, creates fresh session, resets quota
- **Channel bridge** (`bridge.rs`): Added `reboot_session` to `ChannelBridgeHandle` trait, registered `/reboot` in slash command dispatch and help text
- **API bridge** (`channel_bridge.rs`): Implemented `reboot_session` on the API bridge impl
- **WebSocket** (`ws.rs`): Added `reboot` command handler
- **REST API** (`routes/agents.rs`): New `POST /api/agents/{id}/session/reboot` endpoint
- **Server** (`server.rs`): Registered the new route
- **OpenAPI** (`openapi.rs`): Registered for API docs
- **Dashboard** (`chat.js`): Added `/reboot` to slash command list and handler
- **Locales** (`en.json`, `zh-CN.json`): Added command description and toast translations
- **Load test** (`load_test.rs`): Registered route in test router

## Command comparison

| Command | Behavior |
|---------|----------|
| `/new` | Saves session summary to memory, then clears and creates fresh session |
| `/reboot` | Full context clear — no summary saved, fresh session, quota reset |
| `/compact` | LLM-based summarization to reduce context window pressure |