### PR TITLE
feat: support arbitrary config keys in skill entries

### DIFF
--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -125,8 +125,7 @@ pub struct SkillManifest {
     pub source: Option<SkillSource>,
     /// Arbitrary user-defined configuration keys.
     ///
-    /// Any keys in the skill TOML that don't match a known field are
-    /// captured here, allowing skills to define custom configuration:
+    /// Skill authors place custom config under a `[config]` table:
     ///
     /// ```toml
     /// [skill]
@@ -137,8 +136,8 @@ pub struct SkillManifest {
     /// custom_endpoint = "https://api.example.com"
     /// max_retries = 3
     /// ```
-    #[serde(default, flatten)]
-    pub extra: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub config: HashMap<String, serde_json::Value>,
 }
 
 /// Skill metadata section.
@@ -283,6 +282,7 @@ description = "A skill with custom config"
 type = "python"
 entry = "main.py"
 
+[config]
 apiKey = "sk-test-123"
 custom_endpoint = "https://api.example.com"
 max_retries = 3
@@ -291,23 +291,23 @@ nested_config = { timeout = 30, retries = 5 }
 
         let manifest: SkillManifest = toml::from_str(toml_str).unwrap();
         assert_eq!(manifest.skill.name, "my-custom-skill");
-        assert_eq!(manifest.extra.len(), 4);
+        assert_eq!(manifest.config.len(), 4);
         assert_eq!(
-            manifest.extra.get("apiKey").and_then(|v| v.as_str()),
+            manifest.config.get("apiKey").and_then(|v| v.as_str()),
             Some("sk-test-123")
         );
         assert_eq!(
             manifest
-                .extra
+                .config
                 .get("custom_endpoint")
                 .and_then(|v| v.as_str()),
             Some("https://api.example.com")
         );
         assert_eq!(
-            manifest.extra.get("max_retries").and_then(|v| v.as_i64()),
+            manifest.config.get("max_retries").and_then(|v| v.as_i64()),
             Some(3)
         );
-        assert!(manifest.extra.get("nested_config").unwrap().is_object());
+        assert!(manifest.config.get("nested_config").unwrap().is_object());
     }
 
     #[test]
@@ -321,7 +321,7 @@ description = "No extra config"
 
         let manifest: SkillManifest = toml::from_str(toml_str).unwrap();
         assert_eq!(manifest.skill.name, "plain-skill");
-        assert!(manifest.extra.is_empty());
+        assert!(manifest.config.is_empty());
     }
 
     #[test]
@@ -332,17 +332,18 @@ name = "roundtrip-skill"
 version = "1.0.0"
 description = "Test serialization roundtrip"
 
+[config]
 custom_key = "custom_value"
 "#;
 
         let manifest: SkillManifest = toml::from_str(toml_str).unwrap();
-        assert_eq!(manifest.extra.len(), 1);
+        assert_eq!(manifest.config.len(), 1);
 
         // Serialize back and verify the extra key is preserved
         let serialized = toml::to_string(&manifest).unwrap();
         let reparsed: SkillManifest = toml::from_str(&serialized).unwrap();
         assert_eq!(
-            reparsed.extra.get("custom_key").and_then(|v| v.as_str()),
+            reparsed.config.get("custom_key").and_then(|v| v.as_str()),
             Some("custom_value")
         );
     }

--- a/crates/librefang-skills/src/loader.rs
+++ b/crates/librefang-skills/src/loader.rs
@@ -28,7 +28,7 @@ pub async fn execute_skill_tool(
                 &manifest.runtime.entry,
                 tool_name,
                 input,
-                &manifest.extra,
+                &manifest.config,
             )
             .await
         }
@@ -38,7 +38,7 @@ pub async fn execute_skill_tool(
                 &manifest.runtime.entry,
                 tool_name,
                 input,
-                &manifest.extra,
+                &manifest.config,
             )
             .await
         }
@@ -67,7 +67,7 @@ async fn execute_python(
     entry: &str,
     tool_name: &str,
     input: &serde_json::Value,
-    extra: &std::collections::HashMap<String, serde_json::Value>,
+    config: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<SkillToolResult, SkillError> {
     let script_path = skill_dir.join(entry);
     if !script_path.exists() {
@@ -77,8 +77,8 @@ async fn execute_python(
         )));
     }
 
-    // Build the JSON payload to send via stdin, including any extra config
-    let payload = if extra.is_empty() {
+    // Build the JSON payload to send via stdin, including any skill config
+    let payload = if config.is_empty() {
         serde_json::json!({
             "tool": tool_name,
             "input": input,
@@ -87,7 +87,7 @@ async fn execute_python(
         serde_json::json!({
             "tool": tool_name,
             "input": input,
-            "config": extra,
+            "config": config,
         })
     };
 
@@ -182,7 +182,7 @@ async fn execute_node(
     entry: &str,
     tool_name: &str,
     input: &serde_json::Value,
-    extra: &std::collections::HashMap<String, serde_json::Value>,
+    config: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<SkillToolResult, SkillError> {
     let script_path = skill_dir.join(entry);
     if !script_path.exists() {
@@ -198,8 +198,8 @@ async fn execute_node(
         )
     })?;
 
-    // Build the JSON payload to send via stdin, including any extra config
-    let payload = if extra.is_empty() {
+    // Build the JSON payload to send via stdin, including any skill config
+    let payload = if config.is_empty() {
         serde_json::json!({
             "tool": tool_name,
             "input": input,
@@ -208,7 +208,7 @@ async fn execute_node(
         serde_json::json!({
             "tool": tool_name,
             "input": input,
-            "config": extra,
+            "config": config,
         })
     };
 
@@ -362,7 +362,7 @@ mod tests {
             requirements: SkillRequirements::default(),
             prompt_context: Some("You are a helpful assistant.".to_string()),
             source: None,
-            extra: std::collections::HashMap::new(),
+            config: std::collections::HashMap::new(),
         };
 
         let result = execute_skill_tool(&manifest, dir.path(), "test_tool", &serde_json::json!({}))

--- a/crates/librefang-skills/src/openclaw_compat.rs
+++ b/crates/librefang-skills/src/openclaw_compat.rs
@@ -257,7 +257,7 @@ pub fn convert_skillmd(dir: &Path) -> Result<ConvertedSkillMd, SkillError> {
         requirements: SkillRequirements::default(),
         prompt_context: Some(body.clone()),
         source: Some(SkillSource::OpenClaw),
-        extra: std::collections::HashMap::new(),
+        config: std::collections::HashMap::new(),
     };
 
     info!(
@@ -350,7 +350,7 @@ pub fn convert_skillmd_str(name_hint: &str, content: &str) -> Result<ConvertedSk
         requirements: SkillRequirements::default(),
         prompt_context: Some(body.clone()),
         source: Some(SkillSource::Bundled),
-        extra: std::collections::HashMap::new(),
+        config: std::collections::HashMap::new(),
     };
 
     Ok(ConvertedSkillMd {
@@ -468,7 +468,7 @@ pub fn convert_openclaw_skill(dir: &Path) -> Result<SkillManifest, SkillError> {
         requirements: SkillRequirements::default(),
         prompt_context: None,
         source: Some(SkillSource::OpenClaw),
-        extra: std::collections::HashMap::new(),
+        config: std::collections::HashMap::new(),
     })
 }
 


### PR DESCRIPTION
Closes #931

Adds support for arbitrary key-value pairs in skill configuration using `#[serde(flatten)]`. Skills can now define custom configuration keys beyond the predefined fields.

Example:
```toml
[skill]
name = "my-skill"

apiKey = "sk-..."
custom_endpoint = "https://api.example.com"
max_retries = 3
```

## Changes

- Added `extra: HashMap<String, serde_json::Value>` field with `#[serde(flatten)]` to `SkillManifest` so unknown TOML keys are captured instead of rejected
- Updated `execute_python` and `execute_node` in the skill loader to pass extra config as a `"config"` key in the JSON payload sent to skill scripts via stdin
- Updated all `SkillManifest` construction sites (openclaw_compat, loader tests) to include the new field
- Added tests for extra config parsing, empty config, and serialization roundtrip