### PR TITLE
feat: add Homebrew Cask CI sync and improve Formula generation

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -210,3 +210,137 @@ jobs:
           includeUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}
+
+  # ── Sync Homebrew Cask ──────────────────────────────────────────────────
+  sync_homebrew_cask:
+    name: Sync Homebrew Cask
+    runs-on: ubuntu-latest
+    needs: [desktop]
+    if: ${{ !contains(github.ref, '-beta') && !contains(github.ref, '-rc') }}
+    steps:
+      - name: Check out tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: librefang/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Fetch release metadata (with retry for DMG availability)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 10); do
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG" \
+              > release.json
+
+            VERSION="${TAG#v}"
+
+            ARM_DMG="LibreFang_${VERSION}_aarch64.dmg"
+            X86_DMG="LibreFang_${VERSION}_x64.dmg"
+
+            ARM_OK=$(jq -r --arg name "$ARM_DMG" '.assets[] | select(.name == $name) | .name' release.json)
+            X86_OK=$(jq -r --arg name "$X86_DMG" '.assets[] | select(.name == $name) | .name' release.json)
+
+            if [ -n "$ARM_OK" ] && [ -n "$X86_OK" ]; then
+              echo "✓ Both DMG assets found on attempt $attempt"
+              break
+            fi
+
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::DMG assets not found in release after 10 attempts"
+              echo "  ARM DMG: ${ARM_OK:-MISSING}"
+              echo "  x86 DMG: ${X86_OK:-MISSING}"
+              exit 1
+            fi
+
+            echo "Waiting for DMG assets... ($attempt/10)"
+            sleep 10
+          done
+
+      - name: Generate Cask
+        run: |
+          set -euo pipefail
+
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          asset_sha() {
+            local sha_url
+            sha_url="$(jq -r --arg name "${1}.sha256" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
+            if [ -z "$sha_url" ] || [ "$sha_url" = "null" ]; then
+              # Download asset and compute SHA256 locally
+              local asset_url
+              asset_url="$(jq -r --arg name "$1" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
+              curl -fsSL "$asset_url" | sha256sum | awk '{print $1}'
+            else
+              curl -fsSL "$sha_url" | awk '{print $1}'
+            fi
+          }
+
+          ARM_DMG="LibreFang_${VERSION}_aarch64.dmg"
+          X86_DMG="LibreFang_${VERSION}_x64.dmg"
+
+          ARM_SHA="$(asset_sha "$ARM_DMG")"
+          X86_SHA="$(asset_sha "$X86_DMG")"
+
+          for required in ARM_SHA X86_SHA; do
+            if [ -z "${!required}" ] || [ "${!required}" = "null" ]; then
+              echo "Missing SHA256 for $required" >&2
+              exit 1
+            fi
+          done
+
+          cat > tap/Casks/librefang.rb <<CASK
+          cask "librefang" do
+            arch arm: "aarch64", intel: "x64"
+
+            version "$VERSION"
+
+            on_arm do
+              sha256 "$ARM_SHA"
+            end
+            on_intel do
+              sha256 "$X86_SHA"
+            end
+
+            url "https://github.com/librefang/librefang/releases/download/$TAG/LibreFang_#{version}_#{arch}.dmg",
+                verified: "github.com/librefang/librefang/"
+            name "LibreFang"
+            desc "Community-Maintained Agent Operating System written in Rust"
+            homepage "https://librefang.ai"
+
+            livecheck do
+              url "https://github.com/librefang/librefang/releases/latest"
+              strategy :header_match
+            end
+
+            depends_on macos: ">= :ventura"
+
+            app "LibreFang.app"
+
+            zap trash: [
+              "~/Library/Application Support/ai.librefang.desktop",
+              "~/Library/Caches/ai.librefang.desktop",
+              "~/Library/Preferences/ai.librefang.desktop.plist",
+            ]
+          end
+          CASK
+
+          echo "=== Cask ==="
+          cat tap/Casks/librefang.rb
+
+      - name: Commit and push
+        working-directory: tap
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          mkdir -p Casks
+          git add .
+          git commit -m "chore: update cask to ${{ github.ref_name }}" || echo "No changes"
+          git push

--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -397,23 +397,27 @@ jobs:
 
             jq -e '.tag_name and (.assets | type == "array")' release.json >/dev/null
 
-            # Check that both macOS assets exist
-            ARM_OK=$(jq -r '.assets[] | select(.name == "librefang-aarch64-apple-darwin.tar.gz") | .name' release.json)
-            X86_OK=$(jq -r '.assets[] | select(.name == "librefang-x86_64-apple-darwin.tar.gz") | .name' release.json)
+            # Check that all 4 CLI assets exist (macOS + Linux, arm64 + x86_64)
+            MAC_ARM_OK=$(jq -r '.assets[] | select(.name == "librefang-aarch64-apple-darwin.tar.gz") | .name' release.json)
+            MAC_X86_OK=$(jq -r '.assets[] | select(.name == "librefang-x86_64-apple-darwin.tar.gz") | .name' release.json)
+            LNX_ARM_OK=$(jq -r '.assets[] | select(.name == "librefang-aarch64-unknown-linux-gnu.tar.gz") | .name' release.json)
+            LNX_X86_OK=$(jq -r '.assets[] | select(.name == "librefang-x86_64-unknown-linux-gnu.tar.gz") | .name' release.json)
 
-            if [ -n "$ARM_OK" ] && [ -n "$X86_OK" ]; then
-              echo "✓ Both macOS assets found on attempt $attempt"
+            if [ -n "$MAC_ARM_OK" ] && [ -n "$MAC_X86_OK" ] && [ -n "$LNX_ARM_OK" ] && [ -n "$LNX_X86_OK" ]; then
+              echo "✓ All 4 CLI assets found on attempt $attempt"
               break
             fi
 
             if [ "$attempt" -eq 10 ]; then
-              echo "::error::macOS assets not found in release after 10 attempts"
-              echo "  ARM asset: ${ARM_OK:-MISSING}"
-              echo "  x86 asset: ${X86_OK:-MISSING}"
+              echo "::error::CLI assets not found in release after 10 attempts"
+              echo "  macOS ARM: ${MAC_ARM_OK:-MISSING}"
+              echo "  macOS x86: ${MAC_X86_OK:-MISSING}"
+              echo "  Linux ARM: ${LNX_ARM_OK:-MISSING}"
+              echo "  Linux x86: ${LNX_X86_OK:-MISSING}"
               exit 1
             fi
 
-            echo "Waiting for macOS assets to be uploaded... ($attempt/10)"
+            echo "Waiting for CLI assets to be uploaded... ($attempt/10)"
             sleep 10
           done
 
@@ -439,31 +443,45 @@ jobs:
             local sha_url
             sha_url="$(jq -r --arg name "${1}.sha256" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
             if [ -z "$sha_url" ] || [ "$sha_url" = "null" ]; then
-              echo "" && return
+              # Download asset and compute SHA256 locally
+              local asset_url
+              asset_url="$(jq -r --arg name "$1" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
+              curl -fsSL "$asset_url" | sha256sum | awk '{print $1}'
+            else
+              curl -fsSL "$sha_url" | awk '{print $1}'
             fi
-            curl -fsSL "$sha_url" | awk '{print $1}'
           }
 
           asset_size() {
             jq -r --arg name "$1" '.assets[] | select(.name == $name) | .size' release.json
           }
 
+          # macOS assets
           ARM64_DARWIN_NAME="librefang-aarch64-apple-darwin.tar.gz"
           X86_DARWIN_NAME="librefang-x86_64-apple-darwin.tar.gz"
+          # Linux assets
+          ARM64_LINUX_NAME="librefang-aarch64-unknown-linux-gnu.tar.gz"
+          X86_LINUX_NAME="librefang-x86_64-unknown-linux-gnu.tar.gz"
 
           ARM64_DARWIN_URL="$(asset_url "$ARM64_DARWIN_NAME")"
           X86_DARWIN_URL="$(asset_url "$X86_DARWIN_NAME")"
+          ARM64_LINUX_URL="$(asset_url "$ARM64_LINUX_NAME")"
+          X86_LINUX_URL="$(asset_url "$X86_LINUX_NAME")"
 
           ARM64_DARWIN_SHA="$(asset_sha "$ARM64_DARWIN_NAME")"
           X86_DARWIN_SHA="$(asset_sha "$X86_DARWIN_NAME")"
+          ARM64_LINUX_SHA="$(asset_sha "$ARM64_LINUX_NAME")"
+          X86_LINUX_SHA="$(asset_sha "$X86_LINUX_NAME")"
 
           ARM64_DARWIN_SIZE="$(asset_size "$ARM64_DARWIN_NAME")"
           X86_DARWIN_SIZE="$(asset_size "$X86_DARWIN_NAME")"
+          ARM64_LINUX_SIZE="$(asset_size "$ARM64_LINUX_NAME")"
+          X86_LINUX_SIZE="$(asset_size "$X86_LINUX_NAME")"
 
           for required in \
-            ARM64_DARWIN_URL X86_DARWIN_URL \
-            ARM64_DARWIN_SHA X86_DARWIN_SHA \
-            ARM64_DARWIN_SIZE X86_DARWIN_SIZE
+            ARM64_DARWIN_URL X86_DARWIN_URL ARM64_LINUX_URL X86_LINUX_URL \
+            ARM64_DARWIN_SHA X86_DARWIN_SHA ARM64_LINUX_SHA X86_LINUX_SHA \
+            ARM64_DARWIN_SIZE X86_DARWIN_SIZE ARM64_LINUX_SIZE X86_LINUX_SIZE
           do
             if [ -z "${!required}" ] || [ "${!required}" = "null" ]; then
               echo "Missing release metadata: $required" >&2
@@ -471,7 +489,7 @@ jobs:
             fi
           done
 
-          for size_var in ARM64_DARWIN_SIZE X86_DARWIN_SIZE
+          for size_var in ARM64_DARWIN_SIZE X86_DARWIN_SIZE ARM64_LINUX_SIZE X86_LINUX_SIZE
           do
             if [ "${!size_var}" -le 0 ]; then
               echo "Release asset is empty: $size_var" >&2
@@ -480,21 +498,36 @@ jobs:
           done
 
           # --- Main formula (latest) ---
-          cat > tap/Formula/librefang.rb <<EOF
+          cat > tap/Formula/librefang.rb <<FORMULA
           class Librefang < Formula
             desc "Community-Maintained Agent Operating System written in Rust"
             homepage "https://librefang.ai"
             license "MIT"
             version "$SEMVER"
 
-            depends_on :macos
+            livecheck do
+              url "https://github.com/librefang/librefang/releases/latest"
+              strategy :header_match
+            end
 
-            if Hardware::CPU.arm?
-              url "$ARM64_DARWIN_URL"
-              sha256 "$ARM64_DARWIN_SHA"
-            else
-              url "$X86_DARWIN_URL"
-              sha256 "$X86_DARWIN_SHA"
+            on_macos do
+              if Hardware::CPU.arm?
+                url "$ARM64_DARWIN_URL"
+                sha256 "$ARM64_DARWIN_SHA"
+              else
+                url "$X86_DARWIN_URL"
+                sha256 "$X86_DARWIN_SHA"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "$ARM64_LINUX_URL"
+                sha256 "$ARM64_LINUX_SHA"
+              else
+                url "$X86_LINUX_URL"
+                sha256 "$X86_LINUX_SHA"
+              end
             end
 
             def install
@@ -502,31 +535,46 @@ jobs:
             end
 
             test do
-              system "#{bin}/librefang", "--version"
+              assert_match version.to_s, shell_output("#{bin}/librefang --version")
             end
           end
-          EOF
+          FORMULA
 
           # --- Versioned formula (e.g. librefang@2026.3.2114) ---
           # Class name: LibrefangAT202632114 (@ → AT, dots removed)
           CLASS_SUFFIX=$(echo "$SEMVER" | tr -d '.')
           CLASS_NAME="LibrefangAT${CLASS_SUFFIX}"
 
-          cat > "tap/Formula/librefang@${SEMVER}.rb" <<EOF
+          cat > "tap/Formula/librefang@${SEMVER}.rb" <<FORMULA
           class ${CLASS_NAME} < Formula
             desc "Community-Maintained Agent Operating System written in Rust"
             homepage "https://librefang.ai"
             license "MIT"
             version "$SEMVER"
 
-            depends_on :macos
+            livecheck do
+              url "https://github.com/librefang/librefang/releases/latest"
+              strategy :header_match
+            end
 
-            if Hardware::CPU.arm?
-              url "$ARM64_DARWIN_URL"
-              sha256 "$ARM64_DARWIN_SHA"
-            else
-              url "$X86_DARWIN_URL"
-              sha256 "$X86_DARWIN_SHA"
+            on_macos do
+              if Hardware::CPU.arm?
+                url "$ARM64_DARWIN_URL"
+                sha256 "$ARM64_DARWIN_SHA"
+              else
+                url "$X86_DARWIN_URL"
+                sha256 "$X86_DARWIN_SHA"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "$ARM64_LINUX_URL"
+                sha256 "$ARM64_LINUX_SHA"
+              else
+                url "$X86_LINUX_URL"
+                sha256 "$X86_LINUX_SHA"
+              end
             end
 
             keg_only :versioned_formula
@@ -536,10 +584,10 @@ jobs:
             end
 
             test do
-              system "#{bin}/librefang", "--version"
+              assert_match version.to_s, shell_output("#{bin}/librefang --version")
             end
           end
-          EOF
+          FORMULA
 
           echo "=== Main formula ==="
           cat tap/Formula/librefang.rb


### PR DESCRIPTION
## Summary
- Add `sync_homebrew_cask` job to `release-desktop.yml` — auto-syncs Cask to homebrew-tap on stable release (skips pre-releases)
- Upgrade `release-shell.yml` Formula generation:
  - Use `on_macos`/`on_linux` blocks instead of bare `if Hardware::CPU.arm?`
  - Add `livecheck` for automatic version detection
  - Add Linux binary support (aarch64 + x86_64)
  - Use `assert_match` in test blocks
  - Compute SHA256 locally when `.sha256` sidecar asset is missing

## Context
Companion to librefang/homebrew-tap#1 which adds the Cask file and aligns the tap repo with Homebrew standards.

## Test plan
- [ ] Stable tag triggers `sync_homebrew_cask` job and pushes updated Cask to homebrew-tap
- [ ] Pre-release tag (`-beta1`/`-rc1`) skips Cask sync
- [ ] Generated Formula includes `on_macos`/`on_linux` blocks and `livecheck`
- [ ] Generated versioned formula (`librefang@YYYY.M.DDHH.rb`) matches main formula structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)