### PR TITLE
fix: correct Docker compose port binding for admin interface (#944)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - librefang-data:/data
     environment:
+      - LIBREFANG_LISTEN=0.0.0.0:4545
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}


### PR DESCRIPTION
## Summary
Add `LIBREFANG_LISTEN=0.0.0.0:4545` to Docker compose environment to ensure the admin interface is accessible from outside the container.

**Problem**: If a user had a pre-existing config volume with `127.0.0.1:4545` (the default), the admin interface would be inaccessible despite the `4545:4545` port mapping.

**Fix**: The `LIBREFANG_LISTEN` env var overrides `api_listen` in config.toml at boot time (kernel.rs:671), ensuring the service always binds to `0.0.0.0` in Docker context.

Closes #944