### PR TITLE
fix: detect and retry when LLM skips tool execution for action requests

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2796,13 +2796,12 @@ fn looks_like_hallucinated_action(text: &str) -> bool {
 fn user_message_has_action_intent(user_message: &str) -> bool {
     let lower = user_message.to_lowercase();
     let action_keywords = [
-        "send", "execute", "create", "delete", "remove", "update", "write", "post", "publish",
-        "deploy", "run", "install", "upload", "download", "forward", "submit", "trigger", "launch",
-        "notify", "schedule", "move", "copy", "rename", "save", "fetch", "search",
+        "send", "execute", "create", "delete", "remove", "write", "publish", "deploy", "install",
+        "upload", "download", "forward", "submit", "trigger", "launch", "notify", "schedule",
+        "rename", "fetch",
     ];
-    // Require the keyword to appear as a word boundary — avoid false positives
-    // from substrings (e.g. "create" inside "recreate" is fine, but "run" inside
-    // "running" should still match since intent is clear).
+    // Require the keyword to appear as an exact word — uses split_whitespace()
+    // so "running" does NOT match "run", and "recreate" does NOT match "create".
     action_keywords.iter().any(|kw| {
         lower.split_whitespace().any(|word| {
             // Strip common punctuation so "send," or "send!" still match
@@ -5232,7 +5231,7 @@ mod tests {
     #[test]
     fn test_action_intent_combined() {
         assert!(user_message_has_action_intent(
-            "search for news about AI and send to Telegram"
+            "fetch the news about AI and send to Telegram"
         ));
     }
 
@@ -5240,7 +5239,7 @@ mod tests {
     fn test_action_intent_with_punctuation() {
         assert!(user_message_has_action_intent("send, please"));
         assert!(user_message_has_action_intent("can you deploy!"));
-        assert!(user_message_has_action_intent("run?"));
+        assert!(user_message_has_action_intent("execute?"));
     }
 
     #[test]
@@ -5263,15 +5262,15 @@ mod tests {
     fn test_action_intent_case_insensitive() {
         assert!(user_message_has_action_intent("SEND this now"));
         assert!(user_message_has_action_intent("Deploy the app"));
-        assert!(user_message_has_action_intent("RUN the tests"));
+        assert!(user_message_has_action_intent("EXECUTE the tests"));
     }
 
     #[test]
     fn test_action_intent_all_keywords() {
         let keywords = [
-            "send", "execute", "create", "delete", "remove", "update", "write", "post", "publish",
-            "deploy", "run", "install", "upload", "download", "forward", "submit", "trigger",
-            "launch", "notify", "schedule", "move", "copy", "rename", "save", "fetch", "search",
+            "send", "execute", "create", "delete", "remove", "write", "publish", "deploy",
+            "install", "upload", "download", "forward", "submit", "trigger", "launch", "notify",
+            "schedule", "rename", "fetch",
         ];
         for kw in &keywords {
             let msg = format!("please {} the thing", kw);


### PR DESCRIPTION
## Summary

Fixes #910.

When a user sends a message with explicit action intent (e.g. "send to Telegram", "execute the script", "search for news and forward results"), the LLM sometimes responds with only a text summary/plan without actually calling any tools. The agent loop previously treated this as a complete response.

This PR adds a **user-intent action detection** mechanism that complements the existing `looks_like_hallucinated_action` check:

- `looks_like_hallucinated_action` checks the LLM's **response** for claims like "I've created..." (hallucinated completion)
- New `user_message_has_action_intent` checks the **user's message** for action keywords like "send", "execute", "create", "delete", etc.

When the LLM responds without tool calls but the user clearly requested an action and tools are available, the loop now injects a system nudge message and retries once:

> *"You described actions but didn't execute them. Please use the available tools to complete the requested actions."*

### Changes

- Added `user_message_has_action_intent()` function with 26 action keywords and word-boundary matching
- Added `action_nudge_retried` flag to both `run_agent_loop` and `run_agent_loop_streaming` (one-shot retry to avoid infinite loops)
- Added nudge-and-retry block after the existing hallucination check in both loop variants
- Added 10 unit tests covering positive matches, negative cases, punctuation handling, case insensitivity, and exhaustive keyword coverage

## Test plan

- [x] Unit tests for `user_message_has_action_intent` covering all 26 keywords
- [x] Negative tests for plain questions and non-action messages
- [x] Edge cases: punctuation, case insensitivity
- [ ] CI compilation and full test suite