### PR TITLE
ci: auto-update PR branches on main push

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -1,0 +1,35 @@
+name: Auto Update PR Branches
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            for (const pr of prs) {
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                console.log(`Updated PR #${pr.number}`);
+              } catch (e) {
+                console.log(`Skipped PR #${pr.number}: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically updates all open PR branches whenever main receives a new push.

This eliminates the need to manually run `gh pr update-branch` after each merge.

- Triggers on `push` to `main`
- Iterates all open PRs and calls `updateBranch`
- Skips PRs with merge conflicts (logs and continues)