### PR TITLE
fix: migrate old KV keys to history blob and handle sparse chart data

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -605,21 +605,31 @@ function GitHubStats({ t }) {
             </div>
           </div>
           <div className="h-48 flex items-end gap-1">
-            {currentHistory.length > 0 ? (
-              Array.from({ length: Math.min(24, currentHistory.length || 12) }, (_, i) => {
-                const idx = Math.floor((i / Math.min(24, currentHistory.length || 12)) * currentHistory.length)
+            {starHistoryData.length >= 3 ? (
+              Array.from({ length: Math.min(24, currentHistory.length) }, (_, i) => {
+                const idx = Math.floor((i / Math.min(24, currentHistory.length)) * currentHistory.length)
                 const value = currentHistory[idx] || 0
                 return (
                   <div key={i} className="flex-1 bg-primary/40 hover:bg-primary transition-colors rounded-t min-w-1" style={{ height: `${Math.max(4, (value / currentMax) * 100)}%` }} title={`${value} ${historyTab}`}></div>
                 )
               })
             ) : (
-              <div className="w-full h-32 flex items-center justify-center text-gray-500 text-sm">No data yet</div>
+              <div className="w-full h-full flex flex-col items-center justify-center text-gray-400 gap-2">
+                <span className="text-4xl font-bold text-primary">{currentValue ?? 0}</span>
+                <span className="text-sm">{historyTab === 'stars' ? (t.githubStats?.stars || 'Stars') : historyTab === 'forks' ? (t.githubStats?.forks || 'Forks') : historyTab === 'issues' ? (t.githubStats?.issues || 'Issues') : (t.githubStats?.prs || 'PRs')}</span>
+                <span className="text-xs text-gray-500">Chart builds as data is collected daily</span>
+              </div>
             )}
           </div>
           <div className="flex justify-between mt-3 text-xs text-gray-500">
-            <span>12 months ago</span>
-            <span className="text-primary font-semibold">Now ({currentValue ?? '-'})</span>
+            {starHistoryData.length >= 3 ? (
+              <>
+                <span>{starHistoryData[0]?.date || ''}</span>
+                <span className="text-primary font-semibold">Now ({currentValue ?? '-'})</span>
+              </>
+            ) : (
+              <span className="mx-auto text-gray-600">Tracking since {starHistoryData[0]?.date || 'today'}</span>
+            )}
           </div>
         </div>
 

--- a/web/workers/github-stats-worker/index.js
+++ b/web/workers/github-stats-worker/index.js
@@ -1,7 +1,6 @@
 // GitHub Stats Worker
 // Optimized: stores history as single JSON blob to minimize KV operations
-// Before: ~128 KV ops per uncached request (120 reads + 8 writes)
-// After: ~6 KV ops per uncached request (2 reads + 4 writes)
+// Includes one-time migration from old individual KV keys (stars_YYYY-MM-DD)
 
 export default {
   async fetch(request, env) {
@@ -11,6 +10,61 @@ export default {
   async scheduled(event, env, ctx) {
     ctx.waitUntil(recordDailyStats(env))
   },
+}
+
+// Migrate old individual KV keys (stars_YYYY-MM-DD, forks_YYYY-MM-DD, etc.)
+// into the stats_history blob. Runs once when blob has < 7 entries.
+async function migrateOldKeys(env, history) {
+  if (history.length >= 7) return history
+
+  const migrated = await env.KV.get('stats_migration_done')
+  if (migrated) return history
+
+  const existingDates = new Set(history.map(h => h.date))
+  const newEntries = []
+
+  // Read old individual keys for last 90 days
+  for (let i = 0; i < 90; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - i)
+    const dateStr = d.toISOString().split('T')[0]
+
+    if (existingDates.has(dateStr)) continue
+
+    const stars = await env.KV.get('stars_' + dateStr)
+    if (stars) {
+      const forks = await env.KV.get('forks_' + dateStr)
+      const issues = await env.KV.get('issues_' + dateStr)
+      const prs = await env.KV.get('prs_' + dateStr)
+      newEntries.push({
+        date: dateStr,
+        stars: parseInt(stars, 10),
+        forks: forks ? parseInt(forks, 10) : 0,
+        issues: issues ? parseInt(issues, 10) : 0,
+        prs: prs ? parseInt(prs, 10) : 0,
+      })
+    }
+  }
+
+  if (newEntries.length > 0) {
+    history = [...history, ...newEntries]
+    history.sort((a, b) => a.date.localeCompare(b.date))
+    // Deduplicate by date (keep latest)
+    const seen = new Map()
+    for (const entry of history) {
+      seen.set(entry.date, entry)
+    }
+    history = Array.from(seen.values())
+    if (history.length > 90) {
+      history = history.slice(-90)
+    }
+    await env.KV.put('stats_history', JSON.stringify(history))
+    console.log('Migration: merged', newEntries.length, 'old entries into blob')
+  }
+
+  // Mark migration done so we don't re-scan
+  await env.KV.put('stats_migration_done', '1')
+  return history
 }
 
 async function recordDailyStats(env) {
@@ -54,6 +108,9 @@ async function recordDailyStats(env) {
         const raw = await env.KV.get('stats_history')
         if (raw) history = JSON.parse(raw)
       } catch {}
+
+      // Run migration if needed
+      history = await migrateOldKeys(env, history)
 
       // Replace or append today's entry
       const idx = history.findIndex(h => h.date === today)
@@ -163,6 +220,9 @@ async function handleGitHubStats(env, cors) {
       const raw = await env.KV.get('stats_history')
       if (raw) history = JSON.parse(raw)
     } catch {}
+
+    // Run migration if needed
+    history = await migrateOldKeys(env, history)
 
     const idx = history.findIndex(h => h.date === today)
     if (idx >= 0) {


### PR DESCRIPTION
## Summary
- **Worker**: Add one-time migration that reads old individual KV keys (`stars_YYYY-MM-DD`, `forks_YYYY-MM-DD`, etc.) and merges them into the `stats_history` JSON blob. Runs automatically when blob has < 7 entries, then marks migration complete.
- **Frontend**: When `starHistory` has < 3 data points, display current metric value with a "chart builds as data is collected daily" message instead of rendering a single invisible bar.

## Context
After PR #1409 switched the worker from individual KV keys to a single blob, the old historical data wasn't migrated. This caused the Star History chart to appear empty (only 1 data point for today).

## Test plan
- [ ] After deploy, verify `stats.librefang.ai/api/github` returns `starHistory` with migrated entries
- [ ] Verify chart shows bars when >= 3 data points, or fallback message when < 3
- [ ] Verify migration flag `stats_migration_done` prevents repeated scans