### PR TITLE
release: v2026.3.2123-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DDHH).
 
+## [2026.3.21] - 2026-03-21
+
+### Added
+
+- Add pipeline runner agents + IMAP email reader script (#1307) (@devatsecure)
+- Add ChatGPT device auth flow (#1332) (@poruru-code)
+- Add Qwen International and US provider endpoints (#1370) (@houko)
+- Add custom log directory config (#1379) (@houko)
+- Enrich ClassifiedError with provider/model context (#1380) (@houko)
+- Add rustfmt.toml for consistent code formatting (#1381) (@houko)
+- Display version and git hash in startup logs (#1382) (@houko)
+- Add unfurl_links config option for Slack channel (#1383) (@houko)
+- Add DeepInfra as LLM provider (#1384) (@houko)
+- Add configurable embedding dimensions (#1386) (@houko)
+- Add config validation with tolerant mode (#1387) (@houko)
+- Add Azure OpenAI provider support (#1388) (@houko)
+- Add force_flat_replies config for Slack channels (#1390) (@houko)
+- Add fts_only mode for memory indexing without embedding (#1391) (@houko)
+- Add global workspace directory for cross-session persistence (#1392) (@houko)
+- Add mention_patterns config for Discord channels (#1394) (@houko)
+- Add WorkflowTemplate types and in-memory registry (#1395) (@houko)
+- Add configurable session reset prompt (#1396) (@houko)
+- Add per-agent plugin scoping with allowed_plugins (#1399) (@houko)
+- Add /reboot slash command for graceful context reset (#1401) (@houko)
+- Support arbitrary config keys in skill entries (#1402) (@houko)
+- Add Homebrew Cask CI sync and improve Formula generation (#1404) (@houko)
+- Comprehensive React dashboard UI/UX overhaul (#1419) (@houko)
+- Add refresh param to bypass worker cache for migration (#1426) (@houko)
+- Add Japanese dashboard localization (#1427) (@poruru-code)
+- Add a new Librefang promotional SVG banner and update the corre… (#1429) (@houko)
+
+### Fixed
+
+- Register aliases for custom models (#1366) (@TechWizard9999)
+- Knowledge_query JOIN matches entities by name or ID (#1369) (@houko)
+- Browser hand connection failure on Windows (#1371) (@houko)
+- Infinite retry guard, dead branch cleanup, body size limit (#1372) (@houko)
+- Workflow editor save handles nested mode/error_mode from frontend (#1373) (@houko)
+- Scope knowledge JOIN by agent_id and add entities.name index (#1374) (@houko)
+- Replace fragile cmd.len() < 50 heuristic in LoopGuard poll detection (#1378) (@houko)
+- Fix sidebar navigation, broken links, and i18n issues (#1385) (@houko)
+- Comprehensive website polish and bug fixes (#1389) (@houko)
+- Accept [hand] wrapper in HAND.toml format (#1393) (@houko)
+- Fix OG image, brand naming, PWA manifest, and missing i18n keys (#1397) (@houko)
+- Improve Qwen Code CLI path detection (#1398) (@houko)
+- Respect provider field when routing custom models (#1400) (@houko)
+- Remove empty sections overrides and fix mobile nav indicators (#1406) (@houko)
+- Correct Docker compose port binding for admin interface (#944) (#1407) (@houko)
+- Allow hyphens in MCP server names (#947) (#1408) (@houko)
+- Resolve GitHub stats zeros and optimize KV operations (#1409) (@houko)
+- Load .env files in desktop app (#1410) (@houko)
+- Prevent streaming interrupts during multi-tool sequences (#1411) (@houko)
+- Resolve skill file paths for installed skill execution (#1412) (@houko)
+- Cache workspace and skill metadata to reduce per-message overhead (#1414) (@houko)
+- Replace processed images with text placeholders in session history (#911) (#1416) (@houko)
+- Migrate old KV keys to history blob and handle sparse chart data (#1422) (@houko)
+- Complete dashboard i18n coverage for goals and analytics (#1423) (@poruru-code)
+- Correct provider counts, model numbers, and free tier status (#1424) (@houko)
+- Update Hands count to 14 and add deploy/registry links (#1428) (@houko)
+
+### Changed
+
+- Switch to CalVer (YYYY.M.DDHH) (#1375) (@houko)
+
+### Documentation
+
+- Comprehensive review — fix errors, update numbers, add missing sections (#1368) (@houko)
+
+### Maintenance
+
+- Lock api status version regression (#1363) (@TechWizard9999)
+- Cover hand reactivation runtime profile (#1365) (@TechWizard9999)
+- Cover local model default override routing (#1367) (@TechWizard9999)
+- Auto-update PR branches on main push (#1417) (@houko)
+- Add GitHub Stats Worker to deploy workflow (#1420) (@houko)
+- Remove deploy worker job-level if conditions that fail on squash merges (#1425) (@houko)
+
 ## [0.7.0] - 2026-03-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "aes",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9957,7 +9957,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-2026.3.21.md
+++ b/articles/release-2026.3.21.md
@@ -1,0 +1,112 @@
+```markdown
+---
+title: "LibreFang 2026.3.21 Released"
+published: true
+description: "LibreFang v2026.3.21 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v2026.3.2123-rc1
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 2026.3.21 Released
+
+We're thrilled to announce **LibreFang v2026.3.21** — a major release packed with new provider support, a completely redesigned dashboard, granular configuration control, and 30+ stability fixes.
+
+This release also marks our switch to **CalVer** (YYYY.M.DDHH) for clearer versioning. Here's what's new:
+
+## 🚀 Expanded LLM Provider Ecosystem
+
+Connect to more models than ever before:
+- **Azure OpenAI** — Enterprise deployment ready
+- **DeepInfra** — Access a wide range of open-source models
+- **Qwen International & US** — Regional endpoints for lower latency
+- **ChatGPT Device Auth** — New authentication flow for ChatGPT integration
+
+All providers now include enriched error handling with provider/model context baked into `ClassifiedError` for faster debugging.
+
+## ⚙️ Configuration & Control You Demanded
+
+This release delivers fine-grained control over agent behavior:
+- **Config Validation with Tolerant Mode** — Validate configs before startup with graceful fallback options
+- **Per-Agent Plugin Scoping** — Control which plugins each agent can access via `allowed_plugins`
+- **Configurable Embedding Dimensions** — Tune embedding models for your use case
+- **FTS-Only Memory Indexing** — Skip embeddings if you only need full-text search
+- **Custom Log Directory** — Point logs wherever you want
+- **Configurable Session Reset Prompt** — Customize agent context reset behavior
+- **Arbitrary Config Keys in Skills** — Add custom metadata to skill entries
+- **Global Workspace Directory** — Share state across sessions
+
+## 🎨 Dashboard & UI Overhaul
+
+A **comprehensive React redesign** makes agent management delightful:
+- New layout and navigation flow
+- Better mobile responsiveness
+- **Japanese localization** support
+- Expanded i18n coverage for goals and analytics
+- Fixed sidebar navigation and broken links
+- Corrected provider/model counts
+
+Plus a fresh promotional banner! 🎉
+
+## 🤖 Agent Workflows & Automation
+
+Build more sophisticated agents with new tools:
+- **Pipeline Runner Agents** — Execute multi-step workflows with built-in IMAP email reader for email automation
+- **WorkflowTemplate Types** — In-memory registry for reusable workflow definitions
+- **/reboot Slash Command** — Graceful context reset without restarting
+- **Workflow Editor Improvements** — Better handling of nested mode/error_mode definitions from the UI
+
+## 🔌 Slack & Discord Integration Enhancements
+
+More control over how agents interact with chat platforms:
+- `unfurl_links` for Slack — Disable link previews when needed
+- `force_flat_replies` for Slack — Keep messages in flat mode
+- `mention_patterns` for Discord — Define custom mention behavior
+
+## 🐛 Stability & Performance Improvements
+
+30+ bug fixes and optimizations under the hood:
+- **Streaming Reliability** — Prevent interrupts during multi-tool sequences
+- **Infinite Retry Guard** — Dead branch cleanup and body size limits
+- **LoopGuard Improvements** — Replaced fragile heuristics with robust poll detection
+- **Knowledge Queries** — Fixed JOINs to match entities by name/ID with proper agent scoping
+- **GitHub Stats** — Resolved zero values and optimized KV operations
+- **MCP Improvements** — Now supports hyphens in server names
+- **Desktop App** — Properly load .env files at startup
+- **Docker Compose** — Fixed admin interface port binding
+- **Windows Stability** — Fixed browser hand connection issues
+- **Skill Resolution** — Fixed file path resolution for installed skill execution
+- **Cache Performance** — Metadata caching reduces per-message overhead
+- **Session History** — Replace processed images with text placeholders
+
+## 📚 Documentation & Infrastructure
+
+- Comprehensive docs review with updated numbers and new sections
+- Auto-updating PR branches on main push
+- GitHub Stats Worker in deploy workflow
+- Improved Homebrew Cask Formula generation
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v2026.3.2123-rc1)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)
+```

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "2026.3.21019",
+  "version": "2026.3.21239",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.3.2101",
+  "version": "2026.3.2123-rc1",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.3.2101",
+  "version": "2026.3.2123-rc1",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.3.2101",
+    version="2026.3.2123rc1",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.3.2101"
+version = "2026.3.2123-rc1"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
## Release v2026.3.2123-rc1


### Added

- Add pipeline runner agents + IMAP email reader script (#1307) (@devatsecure)
- Add ChatGPT device auth flow (#1332) (@poruru-code)
- Add Qwen International and US provider endpoints (#1370) (@houko)
- Add custom log directory config (#1379) (@houko)
- Enrich ClassifiedError with provider/model context (#1380) (@houko)
- Add rustfmt.toml for consistent code formatting (#1381) (@houko)
- Display version and git hash in startup logs (#1382) (@houko)
- Add unfurl_links config option for Slack channel (#1383) (@houko)
- Add DeepInfra as LLM provider (#1384) (@houko)
- Add configurable embedding dimensions (#1386) (@houko)
- Add config validation with tolerant mode (#1387) (@houko)
- Add Azure OpenAI provider support (#1388) (@houko)
- Add force_flat_replies config for Slack channels (#1390) (@houko)
- Add fts_only mode for memory indexing without embedding (#1391) (@houko)
- Add global workspace directory for cross-session persistence (#1392) (@houko)
- Add mention_patterns config for Discord channels (#1394) (@houko)
- Add WorkflowTemplate types and in-memory registry (#1395) (@houko)
- Add configurable session reset prompt (#1396) (@houko)
- Add per-agent plugin scoping with allowed_plugins (#1399) (@houko)
- Add /reboot slash command for graceful context reset (#1401) (@houko)
- Support arbitrary config keys in skill entries (#1402) (@houko)
- Add Homebrew Cask CI sync and improve Formula generation (#1404) (@houko)
- Comprehensive React dashboard UI/UX overhaul (#1419) (@houko)
- Add refresh param to bypass worker cache for migration (#1426) (@houko)
- Add Japanese dashboard localization (#1427) (@poruru-code)
- Add a new Librefang promotional SVG banner and update the corre… (#1429) (@houko)

### Fixed

- Register aliases for custom models (#1366) (@TechWizard9999)
- Knowledge_query JOIN matches entities by name or ID (#1369) (@houko)
- Browser hand connection failure on Windows (#1371) (@houko)
- Infinite retry guard, dead branch cleanup, body size limit (#1372) (@houko)
- Workflow editor save handles nested mode/error_mode from frontend (#1373) (@houko)
- Scope knowledge JOIN by agent_id and add entities.name index (#1374) (@houko)
- Replace fragile cmd.len() < 50 heuristic in LoopGuard poll detection (#1378) (@houko)
- Fix sidebar navigation, broken links, and i18n issues (#1385) (@houko)
- Comprehensive website polish and bug fixes (#1389) (@houko)
- Accept [hand] wrapper in HAND.toml format (#1393) (@houko)
- Fix OG image, brand naming, PWA manifest, and missing i18n keys (#1397) (@houko)
- Improve Qwen Code CLI path detection (#1398) (@houko)
- Respect provider field when routing custom models (#1400) (@houko)
- Remove empty sections overrides and fix mobile nav indicators (#1406) (@houko)
- Correct Docker compose port binding for admin interface (#944) (#1407) (@houko)
- Allow hyphens in MCP server names (#947) (#1408) (@houko)
- Resolve GitHub stats zeros and optimize KV operations (#1409) (@houko)
- Load .env files in desktop app (#1410) (@houko)
- Prevent streaming interrupts during multi-tool sequences (#1411) (@houko)
- Resolve skill file paths for installed skill execution (#1412) (@houko)
- Cache workspace and skill metadata to reduce per-message overhead (#1414) (@houko)
- Replace processed images with text placeholders in session history (#911) (#1416) (@houko)
- Migrate old KV keys to history blob and handle sparse chart data (#1422) (@houko)
- Complete dashboard i18n coverage for goals and analytics (#1423) (@poruru-code)
- Correct provider counts, model numbers, and free tier status (#1424) (@houko)
- Update Hands count to 14 and add deploy/registry links (#1428) (@houko)

### Changed

- Switch to CalVer (YYYY.M.DDHH) (#1375) (@houko)

### Documentation

- Comprehensive review — fix errors, update numbers, add missing sections (#1368) (@houko)

### Maintenance

- Lock api status version regression (#1363) (@TechWizard9999)
- Cover hand reactivation runtime profile (#1365) (@TechWizard9999)
- Cover local model default override routing (#1367) (@TechWizard9999)
- Auto-update PR branches on main push (#1417) (@houko)
- Add GitHub Stats Worker to deploy workflow (#1420) (@houko)
- Remove deploy worker job-level if conditions that fail on squash merges (#1425) (@houko)