### PR TITLE
fix: release.sh grep compatibility on macOS

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -98,7 +98,7 @@ fi
 TAG="v${VERSION}"
 # Check if this is a pre-release
 IS_PRERELEASE=false
-if echo "$VERSION" | grep -qE '-(beta|rc)[0-9]'; then
+if echo "$VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
     IS_PRERELEASE=true
 fi
 


### PR DESCRIPTION
## Summary
- macOS grep treats `-(` as an invalid option flag
- Add `--` before pattern to mark end of options

## Test plan
- [ ] Run `./scripts/release.sh` on macOS and choose rc/beta option