### PR TITLE
fix: correct Cloudflare Pages _redirects SPA fallback format

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,3 +1,2 @@
-# Redirect SPA routes
-/*
-  Index: /index.html
+# SPA fallback — serve index.html for all routes
+/* /index.html 200


### PR DESCRIPTION
## Summary
- Fix `_redirects` file using wrong syntax (`_headers` indented format instead of `_redirects` flat format)
- Before: `/* \n  Index: /index.html` (invalid, Cloudflare skips it)
- After: `/* /index.html 200` (correct SPA fallback)

## Test plan
- [ ] Cloudflare Pages build log should show "Parsed 2 valid redirect rules" instead of the current error
- [ ] SPA client-side routing (e.g. `/zh/`, `/privacy/`) should work without 404