### PR TITLE
fix: release.sh — macOS grep compat + full diff link

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -321,6 +321,12 @@ if command -v gh &>/dev/null; then
 
 $RELEASE_BODY"
     fi
+    if [ -n "$PREV_TAG" ]; then
+        PR_BODY="$PR_BODY
+
+---
+**Full diff:** https://github.com/librefang/librefang/compare/${PREV_TAG}...${TAG}"
+    fi
 
     PR_URL=$(gh pr create \
         --repo librefang/librefang \


### PR DESCRIPTION
## Summary
- Fix `grep: invalid option -- (` on macOS by adding `--` before pattern
- Fix duplicate catch blocks from merge conflict in github-stats-worker
- Add **Homebrew** install commands (tap + install + cask) to release notes
- Add **Full diff** link at bottom of release notes
- Remove "LibreFang" prefix from release title (just use tag name)

## Existing releases updated
- All 20 release titles: removed "LibreFang " prefix
- All 20 release notes: added full diff link
- v2026.3.2123-rc1: added brew install commands

## Test plan
- [ ] Run `./scripts/release.sh` on macOS, choose rc/beta
- [ ] Verify release notes include brew tap + install + cask
- [ ] Verify full diff link at bottom
- [ ] Verify title is just the tag name