### PR TITLE
release: v2026.3.2201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DDHH).
 
+## [2026.3.22] - 2026-03-22
+
+### Added
+
+- Add pipeline runner agents + IMAP email reader script (#1307) (@devatsecure)
+- Add ChatGPT device auth flow (#1332) (@poruru-code)
+- Add Qwen International and US provider endpoints (#1370) (@houko)
+- Add custom log directory config (#1379) (@houko)
+- Enrich ClassifiedError with provider/model context (#1380) (@houko)
+- Add rustfmt.toml for consistent code formatting (#1381) (@houko)
+- Display version and git hash in startup logs (#1382) (@houko)
+- Add unfurl_links config option for Slack channel (#1383) (@houko)
+- Add DeepInfra as LLM provider (#1384) (@houko)
+- Add configurable embedding dimensions (#1386) (@houko)
+- Add config validation with tolerant mode (#1387) (@houko)
+- Add Azure OpenAI provider support (#1388) (@houko)
+- Add force_flat_replies config for Slack channels (#1390) (@houko)
+- Add fts_only mode for memory indexing without embedding (#1391) (@houko)
+- Add global workspace directory for cross-session persistence (#1392) (@houko)
+- Add mention_patterns config for Discord channels (#1394) (@houko)
+- Add WorkflowTemplate types and in-memory registry (#1395) (@houko)
+- Add configurable session reset prompt (#1396) (@houko)
+- Add per-agent plugin scoping with allowed_plugins (#1399) (@houko)
+- Add /reboot slash command for graceful context reset (#1401) (@houko)
+- Support arbitrary config keys in skill entries (#1402) (@houko)
+- Add Homebrew Cask CI sync and improve Formula generation (#1404) (@houko)
+- Comprehensive React dashboard UI/UX overhaul (#1419) (@houko)
+- Add refresh param to bypass worker cache for migration (#1426) (@houko)
+- Add Japanese dashboard localization (#1427) (@poruru-code)
+- Add a new Librefang promotional SVG banner and update the corre… (#1429) (@houko)
+- Just api starts dashboard dev server alongside API (#1434) (@houko)
+
+### Fixed
+
+- Register aliases for custom models (#1366) (@TechWizard9999)
+- Knowledge_query JOIN matches entities by name or ID (#1369) (@houko)
+- Browser hand connection failure on Windows (#1371) (@houko)
+- Infinite retry guard, dead branch cleanup, body size limit (#1372) (@houko)
+- Workflow editor save handles nested mode/error_mode from frontend (#1373) (@houko)
+- Scope knowledge JOIN by agent_id and add entities.name index (#1374) (@houko)
+- Replace fragile cmd.len() < 50 heuristic in LoopGuard poll detection (#1378) (@houko)
+- Fix sidebar navigation, broken links, and i18n issues (#1385) (@houko)
+- Comprehensive website polish and bug fixes (#1389) (@houko)
+- Accept [hand] wrapper in HAND.toml format (#1393) (@houko)
+- Fix OG image, brand naming, PWA manifest, and missing i18n keys (#1397) (@houko)
+- Improve Qwen Code CLI path detection (#1398) (@houko)
+- Respect provider field when routing custom models (#1400) (@houko)
+- Remove empty sections overrides and fix mobile nav indicators (#1406) (@houko)
+- Correct Docker compose port binding for admin interface (#944) (#1407) (@houko)
+- Allow hyphens in MCP server names (#947) (#1408) (@houko)
+- Resolve GitHub stats zeros and optimize KV operations (#1409) (@houko)
+- Load .env files in desktop app (#1410) (@houko)
+- Prevent streaming interrupts during multi-tool sequences (#1411) (@houko)
+- Resolve skill file paths for installed skill execution (#1412) (@houko)
+- Cache workspace and skill metadata to reduce per-message overhead (#1414) (@houko)
+- Replace processed images with text placeholders in session history (#911) (#1416) (@houko)
+- Migrate old KV keys to history blob and handle sparse chart data (#1422) (@houko)
+- Complete dashboard i18n coverage for goals and analytics (#1423) (@poruru-code)
+- Correct provider counts, model numbers, and free tier status (#1424) (@houko)
+- Update Hands count to 14 and add deploy/registry links (#1428) (@houko)
+- Release.sh grep compatibility on macOS (#1431) (@houko)
+- Correct Cloudflare Pages _redirects SPA fallback format (#1432) (@houko)
+- Release.sh — macOS grep compat + full diff link (#1433) (@houko)
+- Generate anchor IDs for h3 headings and preserve TOML-style names (#1435) (@houko)
+
+### Changed
+
+- Switch to CalVer (YYYY.M.DDHH) (#1375) (@houko)
+
+### Documentation
+
+- Comprehensive review — fix errors, update numbers, add missing sections (#1368) (@houko)
+
+### Maintenance
+
+- Lock api status version regression (#1363) (@TechWizard9999)
+- Cover hand reactivation runtime profile (#1365) (@TechWizard9999)
+- Cover local model default override routing (#1367) (@TechWizard9999)
+- Auto-update PR branches on main push (#1417) (@houko)
+- Add GitHub Stats Worker to deploy workflow (#1420) (@houko)
+- Remove deploy worker job-level if conditions that fail on squash merges (#1425) (@houko)
+
 ## [2026.3.21] - 2026-03-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "async-trait",
  "axum",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "aes",
  "async-trait",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9957,7 +9957,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-2026.3.22.md
+++ b/articles/release-2026.3.22.md
@@ -1,0 +1,104 @@
+```markdown
+---
+title: "LibreFang 2026.3.22 Released"
+published: true
+description: "LibreFang v2026.3.22 release notes — open-source Agent OS built in Rust"
+tags: rust, ai, opensource, release
+canonical_url: https://github.com/librefang/librefang/releases/tag/v2026.3.2201
+cover_image: https://raw.githubusercontent.com/librefang/librefang/main/public/assets/logo.png
+---
+
+# LibreFang 2026.3.22 Released
+
+We're thrilled to announce **LibreFang v2026.3.22** — a massive release with expanded provider support, powerful new capabilities, and a completely overhauled dashboard. This release marks our evolution to Calendar Versioning and brings 50+ improvements across the entire platform.
+
+## What's New
+
+### 📊 Major Architecture Update: Calendar Versioning
+We've switched to **CalVer (YYYY.M.DDHH)** for more transparent and predictable release cycles. This change makes it easier to track what's fresh and plan your upgrades accordingly.
+
+### 🔌 Expanded Provider Ecosystem
+Connect to virtually any LLM provider now:
+- **New providers**: DeepInfra, Azure OpenAI, Qwen International/US endpoints
+- **ChatGPT device auth flow** for seamless authentication
+- **Custom model support** with proper alias registration and provider routing
+- **Embedding dimensions** configurable per agent — fine-tune costs and quality
+
+### 🤖 Agent & Workflow Superpowers
+- **Pipeline runner agents** let you orchestrate complex multi-step workflows
+- **IMAP email reader script** for email-triggered automation
+- **WorkflowTemplate registry** (in-memory) for reusable workflow definitions
+- **Per-agent plugin scoping** with granular `allowed_plugins` config
+- **Graceful context reset** via `/reboot` slash command
+
+### ⚙️ Configuration & Persistence
+- **Global workspace directory** for cross-session state persistence
+- **Custom log directory config** — store logs anywhere you want
+- **Config validation with tolerant mode** — cleaner error messages, safer defaults
+- **Arbitrary config keys in skills** — unlimited flexibility for custom skill parameters
+- **Configurable session reset prompt** — personalize context resets
+- **Knowledge query improvements** — JOIN matches entities by name or ID, indexed by agent
+
+### 💬 Chat Platform Enhancements
+- **Slack**: Unfurl links option, force-flat replies config for cleaner threads
+- **Discord**: Configurable mention patterns for smarter mentions
+- **HAND.toml format** now accepts flexible [hand] wrappers for better compatibility
+
+### 🚀 Performance & Stability
+- **Infinite retry guard** — prevents runaway loops
+- **Streaming safety** — prevent interrupts during multi-tool sequences
+- **Memory caching** — workspace and skill metadata cached to reduce per-message overhead
+- **Optimized KV operations** — faster, more efficient state management
+- **Migration tools** — refresh param for cache bypassing, sparse chart data handling
+- **Improved polling detection** — replaced fragile heuristics with robust LoopGuard
+
+### 🎨 Dashboard & UX
+- **Complete React UI/UX overhaul** — modern, responsive, beautiful
+- **Japanese localization** + comprehensive i18n coverage for goals/analytics
+- **SVG branding banners** — fresh promotional materials
+- **Fixed navigation** — better link structure and mobile indicators
+- **Dev server integration** — `just api` now starts dashboard + API together
+
+### 🛠️ Developer Experience
+- **Rustfmt.toml** for consistent code formatting across the project
+- **Version & git hash in startup logs** — instant transparency on what's running
+- **Desktop app `.env` support** — easier local configuration
+- **Homebrew Cask CI sync** — streamlined distribution
+- **Improved Qwen Code CLI detection** — smoother integration
+
+### 📚 Documentation
+Comprehensive review — fixed errors, updated all numbers, filled missing gaps.
+
+### 🔧 Infrastructure & CI/CD
+- **GitHub Stats Worker** integration for better analytics
+- **Auto-update PR branches** on main push
+- **Docker Compose fixes** for admin interface port binding
+- **MCP server names** now allow hyphens
+- **Release.sh macOS compatibility** — no more grep headaches
+- **Cloudflare Pages SPA fallback** — corrected _redirects format
+- **PWA manifest & OG image** fixes for better sharing
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v2026.3.2201)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)
+```

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "2026.3.21239",
+  "version": "2026.3.22019",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.3.2123-rc1",
+  "version": "2026.3.2201",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.3.2123-rc1",
+  "version": "2026.3.2201",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.3.2123rc1",
+    version="2026.3.2201",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.3.2123-rc1"
+version = "2026.3.2201"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
## Release v2026.3.2201


### Added

- Add pipeline runner agents + IMAP email reader script (#1307) (@devatsecure)
- Add ChatGPT device auth flow (#1332) (@poruru-code)
- Add Qwen International and US provider endpoints (#1370) (@houko)
- Add custom log directory config (#1379) (@houko)
- Enrich ClassifiedError with provider/model context (#1380) (@houko)
- Add rustfmt.toml for consistent code formatting (#1381) (@houko)
- Display version and git hash in startup logs (#1382) (@houko)
- Add unfurl_links config option for Slack channel (#1383) (@houko)
- Add DeepInfra as LLM provider (#1384) (@houko)
- Add configurable embedding dimensions (#1386) (@houko)
- Add config validation with tolerant mode (#1387) (@houko)
- Add Azure OpenAI provider support (#1388) (@houko)
- Add force_flat_replies config for Slack channels (#1390) (@houko)
- Add fts_only mode for memory indexing without embedding (#1391) (@houko)
- Add global workspace directory for cross-session persistence (#1392) (@houko)
- Add mention_patterns config for Discord channels (#1394) (@houko)
- Add WorkflowTemplate types and in-memory registry (#1395) (@houko)
- Add configurable session reset prompt (#1396) (@houko)
- Add per-agent plugin scoping with allowed_plugins (#1399) (@houko)
- Add /reboot slash command for graceful context reset (#1401) (@houko)
- Support arbitrary config keys in skill entries (#1402) (@houko)
- Add Homebrew Cask CI sync and improve Formula generation (#1404) (@houko)
- Comprehensive React dashboard UI/UX overhaul (#1419) (@houko)
- Add refresh param to bypass worker cache for migration (#1426) (@houko)
- Add Japanese dashboard localization (#1427) (@poruru-code)
- Add a new Librefang promotional SVG banner and update the corre… (#1429) (@houko)
- Just api starts dashboard dev server alongside API (#1434) (@houko)

### Fixed

- Register aliases for custom models (#1366) (@TechWizard9999)
- Knowledge_query JOIN matches entities by name or ID (#1369) (@houko)
- Browser hand connection failure on Windows (#1371) (@houko)
- Infinite retry guard, dead branch cleanup, body size limit (#1372) (@houko)
- Workflow editor save handles nested mode/error_mode from frontend (#1373) (@houko)
- Scope knowledge JOIN by agent_id and add entities.name index (#1374) (@houko)
- Replace fragile cmd.len() < 50 heuristic in LoopGuard poll detection (#1378) (@houko)
- Fix sidebar navigation, broken links, and i18n issues (#1385) (@houko)
- Comprehensive website polish and bug fixes (#1389) (@houko)
- Accept [hand] wrapper in HAND.toml format (#1393) (@houko)
- Fix OG image, brand naming, PWA manifest, and missing i18n keys (#1397) (@houko)
- Improve Qwen Code CLI path detection (#1398) (@houko)
- Respect provider field when routing custom models (#1400) (@houko)
- Remove empty sections overrides and fix mobile nav indicators (#1406) (@houko)
- Correct Docker compose port binding for admin interface (#944) (#1407) (@houko)
- Allow hyphens in MCP server names (#947) (#1408) (@houko)
- Resolve GitHub stats zeros and optimize KV operations (#1409) (@houko)
- Load .env files in desktop app (#1410) (@houko)
- Prevent streaming interrupts during multi-tool sequences (#1411) (@houko)
- Resolve skill file paths for installed skill execution (#1412) (@houko)
- Cache workspace and skill metadata to reduce per-message overhead (#1414) (@houko)
- Replace processed images with text placeholders in session history (#911) (#1416) (@houko)
- Migrate old KV keys to history blob and handle sparse chart data (#1422) (@houko)
- Complete dashboard i18n coverage for goals and analytics (#1423) (@poruru-code)
- Correct provider counts, model numbers, and free tier status (#1424) (@houko)
- Update Hands count to 14 and add deploy/registry links (#1428) (@houko)
- Release.sh grep compatibility on macOS (#1431) (@houko)
- Correct Cloudflare Pages _redirects SPA fallback format (#1432) (@houko)
- Release.sh — macOS grep compat + full diff link (#1433) (@houko)
- Generate anchor IDs for h3 headings and preserve TOML-style names (#1435) (@houko)

### Changed

- Switch to CalVer (YYYY.M.DDHH) (#1375) (@houko)

### Documentation

- Comprehensive review — fix errors, update numbers, add missing sections (#1368) (@houko)

### Maintenance

- Lock api status version regression (#1363) (@TechWizard9999)
- Cover hand reactivation runtime profile (#1365) (@TechWizard9999)
- Cover local model default override routing (#1367) (@TechWizard9999)
- Auto-update PR branches on main push (#1417) (@houko)
- Add GitHub Stats Worker to deploy workflow (#1420) (@houko)
- Remove deploy worker job-level if conditions that fail on squash merges (#1425) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v0.7.0-20260321...v2026.3.2201