### PR TITLE
feat: add push messaging API for agents to send to channels

### DIFF
--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -257,15 +257,6 @@ pub struct PushMessageRequest {
     pub thread_id: Option<String>,
 }
 
-/// Response from a push message operation.
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct PushMessageResponse {
-    /// Whether the message was sent successfully.
-    pub success: bool,
-    /// Human-readable result or error message.
-    pub detail: String,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -542,6 +542,7 @@ impl BridgeManager {
             .send_channel_push(channel_type, recipient, message, thread_id)
             .await
     }
+
     /// Stop all adapters and wait for dispatch tasks to finish.
     pub async fn stop(&mut self) {
         let _ = self.shutdown_tx.send(true);

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -666,24 +666,6 @@ impl TelegramAdapter {
         }
         Ok(())
     }
-
-    /// Send a proactive outbound text message to a Telegram chat.
-    ///
-    /// This is a convenience method for push messaging that takes a raw chat ID
-    /// string and message text, without requiring a `ChannelUser` or `ChannelContent`.
-    /// Useful for the REST push endpoint and the `channel_send` built-in tool.
-    pub async fn send_outbound(
-        &self,
-        chat_id: &str,
-        message: &str,
-        thread_id: Option<&str>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let cid: i64 = chat_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {chat_id}"))?;
-        let tid: Option<i64> = thread_id.and_then(|t| t.parse().ok());
-        self.api_send_message(cid, message, tid).await
-    }
 }
 
 #[async_trait]

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -146,12 +146,12 @@ fn download_and_extract(registry_cache: &Path) -> Result<(), Box<dyn std::error:
 
     // Extract, stripping the `librefang-registry-main/` prefix
     for entry in archive.entries()? {
-        let mut entry: tar::Entry<_> = entry?;
+        let mut entry = entry?;
         let path = entry.path()?;
         let path_str = path.to_string_lossy();
 
         // Strip the tarball prefix
-        let relative: String = match path_str.strip_prefix(TARBALL_PREFIX) {
+        let relative = match path_str.strip_prefix(TARBALL_PREFIX) {
             Some(r) if !r.is_empty() => r.to_string(),
             _ => continue,
         };


### PR DESCRIPTION
## Summary
- `POST /api/agents/:id/push` — send message to a channel proactively
- `BridgeManager::push_message()` routes to channel adapters
- `send_channel_push` added to `ChannelBridgeHandle` trait
- Telegram outbound `send_outbound()` convenience method
- Note: `channel_send` tool already existed in tool_runner.rs for agent self-invocation

## Request format
```json
{"channel": "telegram", "recipient": "chat_id", "message": "Hello!", "thread_id": null}
```

## Test plan
- [ ] POST /api/agents/:id/push with telegram channel
- [ ] Invalid channel returns error
- [ ] Missing fields return 400

Closes #1047