### PR TITLE
feat: FTS5 full-text session search with API endpoint

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1003,6 +1003,56 @@ pub async fn session_cleanup(
     )
 }
 
+/// GET /api/sessions/search?q=...&agent_id=... — Full-text search across session content.
+#[utoipa::path(
+    get,
+    path = "/api/sessions/search",
+    tag = "sessions",
+    params(
+        ("q" = String, Query, description = "FTS5 search query"),
+        ("agent_id" = Option<String>, Query, description = "Optional agent ID filter"),
+    ),
+    responses(
+        (status = 200, description = "Search results", body = serde_json::Value),
+        (status = 400, description = "Missing query parameter"),
+    )
+)]
+pub async fn search_sessions(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let query = match params.get("q") {
+        Some(q) if !q.is_empty() => q.clone(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "missing or empty 'q' parameter"})),
+            );
+        }
+    };
+
+    let agent_id = params.get("agent_id").and_then(|id| {
+        uuid::Uuid::parse_str(id)
+            .ok()
+            .map(librefang_types::agent::AgentId)
+    });
+
+    match state
+        .kernel
+        .memory
+        .search_sessions(&query, agent_id.as_ref())
+    {
+        Ok(results) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"results": results})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        ),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Execution Approval System — backed by kernel.approval_manager
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -479,6 +479,10 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
         )
         .route("/sessions", axum::routing::get(routes::list_sessions))
         .route(
+            "/sessions/search",
+            axum::routing::get(routes::search_sessions),
+        )
+        .route(
             "/sessions/cleanup",
             axum::routing::post(routes::session_cleanup),
         )

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 11;
+const SCHEMA_VERSION: u32 = 12;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -53,6 +53,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 11 {
         migrate_v11(conn)?;
+    }
+
+    if current_version < 12 {
+        migrate_v12(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -387,6 +391,23 @@ fn migrate_v11(conn: &Connection) -> Result<(), rusqlite::Error> {
 
         INSERT OR IGNORE INTO migrations (version, applied_at, description)
         VALUES (11, datetime('now'), 'Add index on entities.name for knowledge graph queries');
+        ",
+    )?;
+    Ok(())
+}
+
+/// Version 12: Add FTS5 virtual table for full-text session search.
+fn migrate_v12(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "
+        CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
+            session_id UNINDEXED,
+            agent_id UNINDEXED,
+            content
+        );
+
+        INSERT OR IGNORE INTO migrations (version, applied_at, description)
+        VALUES (12, datetime('now'), 'Add FTS5 virtual table for full-text session search');
         ",
     )?;
     Ok(())

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -9,6 +9,19 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+/// Result from a full-text session search.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionSearchResult {
+    /// The session that matched.
+    pub session_id: String,
+    /// The owning agent ID.
+    pub agent_id: String,
+    /// A text snippet showing the matching context.
+    pub snippet: String,
+    /// FTS5 rank score (lower is better match).
+    pub rank: f64,
+}
+
 /// A conversation session with message history.
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -119,7 +132,7 @@ impl SessionStore {
         }
     }
 
-    /// Save a session to the database.
+    /// Save a session to the database and update the FTS5 index.
     pub fn save_session(&self, session: &Session) -> LibreFangResult<()> {
         let conn = self
             .conn
@@ -142,34 +155,72 @@ impl SessionStore {
             ],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+        // Update FTS5 index — extract text from all messages.
+        let content = Self::extract_text_content(&session.messages);
+        let session_id_str = session.id.0.to_string();
+        let agent_id_str = session.agent_id.0.to_string();
+
+        // Delete existing FTS entry, then insert fresh content.
+        let _ = conn.execute(
+            "DELETE FROM sessions_fts WHERE session_id = ?1",
+            rusqlite::params![session_id_str],
+        );
+        if !content.is_empty() {
+            let _ = conn.execute(
+                "INSERT INTO sessions_fts (session_id, agent_id, content) VALUES (?1, ?2, ?3)",
+                rusqlite::params![session_id_str, agent_id_str, content],
+            );
+        }
+
         Ok(())
     }
 
-    /// Delete a session from the database.
+    /// Extract concatenated text content from a list of messages.
+    fn extract_text_content(messages: &[Message]) -> String {
+        messages
+            .iter()
+            .map(|m| m.content.text_content())
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Delete a session from the database and its FTS5 index entry.
     pub fn delete_session(&self, session_id: SessionId) -> LibreFangResult<()> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        let id_str = session_id.0.to_string();
         conn.execute(
             "DELETE FROM sessions WHERE id = ?1",
-            rusqlite::params![session_id.0.to_string()],
+            rusqlite::params![id_str],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        let _ = conn.execute(
+            "DELETE FROM sessions_fts WHERE session_id = ?1",
+            rusqlite::params![id_str],
+        );
         Ok(())
     }
 
-    /// Delete all sessions belonging to an agent.
+    /// Delete all sessions belonging to an agent and their FTS5 index entries.
     pub fn delete_agent_sessions(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        let agent_id_str = agent_id.0.to_string();
         conn.execute(
             "DELETE FROM sessions WHERE agent_id = ?1",
-            rusqlite::params![agent_id.0.to_string()],
+            rusqlite::params![agent_id_str],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        let _ = conn.execute(
+            "DELETE FROM sessions_fts WHERE agent_id = ?1",
+            rusqlite::params![agent_id_str],
+        );
         Ok(())
     }
 
@@ -435,6 +486,88 @@ impl SessionStore {
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         Ok(deleted as u64)
+    }
+}
+
+impl SessionStore {
+    /// Full-text search across session content using FTS5.
+    ///
+    /// Returns matching sessions ranked by relevance. Optionally filter by agent.
+    pub fn search_sessions(
+        &self,
+        query: &str,
+        agent_id: Option<&AgentId>,
+    ) -> LibreFangResult<Vec<SessionSearchResult>> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Sanitize FTS5 query: escape special characters to prevent injection.
+        // FTS5 treats `*`, `"`, `NEAR`, `OR`, `AND`, `NOT` as operators.
+        // Wrap each word in double quotes to treat as literal phrase tokens.
+        let sanitized: String = query
+            .split_whitespace()
+            .map(|word| {
+                let escaped = word.replace('"', "\"\"");
+                format!("\"{escaped}\"")
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+
+        let results = if let Some(aid) = agent_id {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT session_id, agent_id, snippet(sessions_fts, 2, '<b>', '</b>', '...', 32), rank
+                     FROM sessions_fts
+                     WHERE content MATCH ?1 AND agent_id = ?2
+                     ORDER BY rank
+                     LIMIT 50",
+                )
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(rusqlite::params![sanitized, aid.0.to_string()], |row| {
+                    Ok(SessionSearchResult {
+                        session_id: row.get(0)?,
+                        agent_id: row.get(1)?,
+                        snippet: row.get(2)?,
+                        rank: row.get(3)?,
+                    })
+                })
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+            rows.filter_map(|r| r.ok()).collect()
+        } else {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT session_id, agent_id, snippet(sessions_fts, 2, '<b>', '</b>', '...', 32), rank
+                     FROM sessions_fts
+                     WHERE content MATCH ?1
+                     ORDER BY rank
+                     LIMIT 50",
+                )
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(rusqlite::params![sanitized], |row| {
+                    Ok(SessionSearchResult {
+                        session_id: row.get(0)?,
+                        agent_id: row.get(1)?,
+                        snippet: row.get(2)?,
+                        rank: row.get(3)?,
+                    })
+                })
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+            rows.filter_map(|r| r.ok()).collect()
+        };
+
+        Ok(results)
     }
 }
 
@@ -995,5 +1128,85 @@ mod tests {
         assert_eq!(line2["role"], "assistant");
         assert_eq!(line2["content"], "Hi there!");
         assert!(line2.get("tool_use").is_none());
+    }
+
+    #[test]
+    fn test_fts_search_sessions() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        let mut session = store.create_session(agent_id).unwrap();
+        session
+            .messages
+            .push(Message::user("The quick brown fox jumps over the lazy dog"));
+        session
+            .messages
+            .push(Message::assistant("That is a classic pangram!"));
+        store.save_session(&session).unwrap();
+
+        // Search for existing content
+        let results = store.search_sessions("fox", None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].session_id, session.id.0.to_string());
+
+        // Search with agent filter
+        let results = store.search_sessions("pangram", Some(&agent_id)).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Search with wrong agent should return nothing
+        let other_agent = AgentId::new();
+        let results = store.search_sessions("fox", Some(&other_agent)).unwrap();
+        assert!(results.is_empty());
+
+        // Search for non-existent content
+        let results = store.search_sessions("elephant", None).unwrap();
+        assert!(results.is_empty());
+
+        // Empty query should return nothing
+        let results = store.search_sessions("", None).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_fts_updates_on_save() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        let mut session = store.create_session(agent_id).unwrap();
+        session.messages.push(Message::user("alpha beta gamma"));
+        store.save_session(&session).unwrap();
+
+        let results = store.search_sessions("alpha", None).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Update session with different content
+        session.messages.clear();
+        session.messages.push(Message::user("delta epsilon zeta"));
+        store.save_session(&session).unwrap();
+
+        // Old content should no longer match
+        let results = store.search_sessions("alpha", None).unwrap();
+        assert!(results.is_empty());
+
+        // New content should match
+        let results = store.search_sessions("delta", None).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_fts_cleaned_on_delete() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        let mut session = store.create_session(agent_id).unwrap();
+        session
+            .messages
+            .push(Message::user("searchable content here"));
+        store.save_session(&session).unwrap();
+
+        let results = store.search_sessions("searchable", None).unwrap();
+        assert_eq!(results.len(), 1);
+
+        store.delete_session(session.id).unwrap();
+
+        let results = store.search_sessions("searchable", None).unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -241,6 +241,15 @@ impl MemorySubstrate {
         self.sessions.cleanup_excess_sessions(max_per_agent)
     }
 
+    /// Full-text search across session content using FTS5.
+    pub fn search_sessions(
+        &self,
+        query: &str,
+        agent_id: Option<&AgentId>,
+    ) -> LibreFangResult<Vec<crate::session::SessionSearchResult>> {
+        self.sessions.search_sessions(query, agent_id)
+    }
+
     /// Load canonical session context for cross-channel memory.
     ///
     /// Returns the compacted summary (if any) and recent messages from the


### PR DESCRIPTION
## Summary
- SQLite FTS5 virtual table `sessions_fts` via migration v12
- Auto-sync on save/delete — text extracted from messages, indexed
- `GET /api/sessions/search?q=...&agent_id=...` — returns snippets + rank
- `SessionSearchResult` with session_id, agent_id, snippet, rank

## Changes
- `crates/librefang-memory/src/migration.rs` — v12 migration
- `crates/librefang-memory/src/session.rs` — FTS sync + search method
- `crates/librefang-memory/src/substrate.rs` — delegate
- `crates/librefang-api/src/routes/system.rs` — API handler
- `crates/librefang-api/src/server.rs` — route registration

## Test plan
- [x] FTS search finds matching sessions
- [x] FTS updates when session is re-saved
- [x] FTS cleaned when session is deleted

Closes #921