### PR TITLE
fix: cargo fmt formatting corrections

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3744,16 +3744,12 @@ system_prompt = "You are a helpful assistant."
     /// picked up between tool calls and interrupt the remaining sequence.
     /// Returns `Ok(true)` if the message was sent, `Ok(false)` if no active
     /// loop is running for this agent, or `Err` if the agent doesn't exist.
-    pub async fn inject_message(
-        &self,
-        agent_id: AgentId,
-        message: &str,
-    ) -> KernelResult<bool> {
+    pub async fn inject_message(&self, agent_id: AgentId, message: &str) -> KernelResult<bool> {
         // Verify the agent exists
         if self.registry.get(agent_id).is_none() {
-            return Err(KernelError::LibreFang(
-                LibreFangError::AgentNotFound(agent_id.to_string()),
-            ));
+            return Err(KernelError::LibreFang(LibreFangError::AgentNotFound(
+                agent_id.to_string(),
+            )));
         }
         if let Some(tx) = self.injection_senders.get(&agent_id) {
             match tx.try_send(message.to_string()) {
@@ -5165,7 +5161,10 @@ system_prompt = "You are a helpful assistant."
         let depth = TRIGGER_DEPTH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if depth >= MAX_TRIGGER_DEPTH {
             TRIGGER_DEPTH.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-            warn!(depth, "Trigger depth limit reached, skipping evaluation to prevent circular chain");
+            warn!(
+                depth,
+                "Trigger depth limit reached, skipping evaluation to prevent circular chain"
+            );
             return vec![];
         }
 

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1275,9 +1275,7 @@ pub async fn run_agent_loop(
                                 if !tool_result_blocks.is_empty() {
                                     let partial_results = Message {
                                         role: Role::User,
-                                        content: MessageContent::Blocks(
-                                            tool_result_blocks.clone(),
-                                        ),
+                                        content: MessageContent::Blocks(tool_result_blocks.clone()),
                                         pinned: false,
                                     };
                                     session.messages.push(partial_results.clone());
@@ -2657,9 +2655,7 @@ pub async fn run_agent_loop_streaming(
                                 if !tool_result_blocks.is_empty() {
                                     let partial_results = Message {
                                         role: Role::User,
-                                        content: MessageContent::Blocks(
-                                            tool_result_blocks.clone(),
-                                        ),
+                                        content: MessageContent::Blocks(tool_result_blocks.clone()),
                                         pinned: false,
                                     };
                                     session.messages.push(partial_results.clone());

--- a/crates/librefang-runtime/src/drivers/mod.rs
+++ b/crates/librefang-runtime/src/drivers/mod.rs
@@ -19,6 +19,7 @@ pub mod token_rotation;
 pub mod vertex_ai;
 
 use crate::llm_driver::{DriverConfig, LlmDriver, LlmError};
+use dashmap::DashMap;
 use librefang_types::model_catalog::{
     AI21_BASE_URL, ANTHROPIC_BASE_URL, CEREBRAS_BASE_URL, CHATGPT_BASE_URL, CHUTES_BASE_URL,
     COHERE_BASE_URL, DEEPINFRA_BASE_URL, DEEPSEEK_BASE_URL, FIREWORKS_BASE_URL, GEMINI_BASE_URL,
@@ -30,7 +31,6 @@ use librefang_types::model_catalog::{
     VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL, ZAI_BASE_URL, ZAI_CODING_BASE_URL, ZHIPU_BASE_URL,
     ZHIPU_CODING_BASE_URL,
 };
-use dashmap::DashMap;
 use std::sync::Arc;
 
 // ── Driver Cache ────────────────────────────────────────────────
@@ -64,10 +64,7 @@ impl DriverCache {
     ///
     /// The cache key is derived from `(provider, api_key, base_url)` so that
     /// different credentials or endpoints produce distinct drivers.
-    pub fn get_or_create(
-        &self,
-        config: &DriverConfig,
-    ) -> Result<Arc<dyn LlmDriver>, LlmError> {
+    pub fn get_or_create(&self, config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmError> {
         let key = Self::cache_key(config);
         if let Some(driver) = self.cache.get(&key) {
             return Ok(Arc::clone(driver.value()));
@@ -1279,7 +1276,10 @@ mod tests {
         };
         let d_a = cache.get_or_create(&config_a).unwrap();
         let d_b = cache.get_or_create(&config_b).unwrap();
-        assert!(!Arc::ptr_eq(&d_a, &d_b), "Different keys should produce different drivers");
+        assert!(
+            !Arc::ptr_eq(&d_a, &d_b),
+            "Different keys should produce different drivers"
+        );
         assert_eq!(cache.len(), 2);
     }
 

--- a/crates/librefang-skills/src/loader.rs
+++ b/crates/librefang-skills/src/loader.rs
@@ -384,7 +384,10 @@ async fn execute_shell(
             result.map_err(|e| SkillError::ExecutionFailed(format!("Wait for shell: {e}")))?
         }
         Err(_) => {
-            error!("Shell skill timed out after 120s: {}", script_path.display());
+            error!(
+                "Shell skill timed out after 120s: {}",
+                script_path.display()
+            );
             return Ok(SkillToolResult {
                 output: "Shell script timed out after 120 seconds".into(),
                 is_error: true,


### PR DESCRIPTION
## Summary
- Run `cargo fmt` to fix formatting issues caught by CI quality check
- Affects 4 files across kernel, runtime, and skills crates

## Test plan
- [x] CI formatting check should pass