### PR TITLE
fix: resolve clippy errors blocking all PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,6 +4031,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures",
  "hex",
+ "librefang-channels",
  "librefang-memory",
  "librefang-skills",
  "librefang-types",

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -412,6 +412,7 @@ impl TelegramAdapter {
     ///
     /// Telegram shows a progress spinner on the button until the bot calls
     /// `answerCallbackQuery`. Fire-and-forget.
+    #[allow(dead_code)]
     fn fire_answer_callback_query(&self, callback_query_id: &str, notification_text: Option<&str>) {
         let url = format!(
             "{}/bot{}/answerCallbackQuery",

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3744,16 +3744,12 @@ system_prompt = "You are a helpful assistant."
     /// picked up between tool calls and interrupt the remaining sequence.
     /// Returns `Ok(true)` if the message was sent, `Ok(false)` if no active
     /// loop is running for this agent, or `Err` if the agent doesn't exist.
-    pub async fn inject_message(
-        &self,
-        agent_id: AgentId,
-        message: &str,
-    ) -> KernelResult<bool> {
+    pub async fn inject_message(&self, agent_id: AgentId, message: &str) -> KernelResult<bool> {
         // Verify the agent exists
         if self.registry.get(agent_id).is_none() {
-            return Err(KernelError::LibreFang(
-                LibreFangError::AgentNotFound(agent_id.to_string()),
-            ));
+            return Err(KernelError::LibreFang(LibreFangError::AgentNotFound(
+                agent_id.to_string(),
+            )));
         }
         if let Some(tx) = self.injection_senders.get(&agent_id) {
             match tx.try_send(message.to_string()) {
@@ -5165,7 +5161,10 @@ system_prompt = "You are a helpful assistant."
         let depth = TRIGGER_DEPTH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if depth >= MAX_TRIGGER_DEPTH {
             TRIGGER_DEPTH.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-            warn!(depth, "Trigger depth limit reached, skipping evaluation to prevent circular chain");
+            warn!(
+                depth,
+                "Trigger depth limit reached, skipping evaluation to prevent circular chain"
+            );
             return vec![];
         }
 

--- a/crates/librefang-memory/src/decay.rs
+++ b/crates/librefang-memory/src/decay.rs
@@ -104,7 +104,7 @@ mod tests {
         conn.query_row(
             "SELECT COUNT(*) FROM memories WHERE deleted = 0",
             [],
-            |row| row.get::<_, usize>(0),
+            |row| row.get::<_, i64>(0).map(|v| v as usize),
         )
         .unwrap()
     }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1275,9 +1275,7 @@ pub async fn run_agent_loop(
                                 if !tool_result_blocks.is_empty() {
                                     let partial_results = Message {
                                         role: Role::User,
-                                        content: MessageContent::Blocks(
-                                            tool_result_blocks.clone(),
-                                        ),
+                                        content: MessageContent::Blocks(tool_result_blocks.clone()),
                                         pinned: false,
                                     };
                                     session.messages.push(partial_results.clone());
@@ -2657,9 +2655,7 @@ pub async fn run_agent_loop_streaming(
                                 if !tool_result_blocks.is_empty() {
                                     let partial_results = Message {
                                         role: Role::User,
-                                        content: MessageContent::Blocks(
-                                            tool_result_blocks.clone(),
-                                        ),
+                                        content: MessageContent::Blocks(tool_result_blocks.clone()),
                                         pinned: false,
                                     };
                                     session.messages.push(partial_results.clone());

--- a/crates/librefang-runtime/src/drivers/mod.rs
+++ b/crates/librefang-runtime/src/drivers/mod.rs
@@ -19,6 +19,7 @@ pub mod token_rotation;
 pub mod vertex_ai;
 
 use crate::llm_driver::{DriverConfig, LlmDriver, LlmError};
+use dashmap::DashMap;
 use librefang_types::model_catalog::{
     AI21_BASE_URL, ANTHROPIC_BASE_URL, CEREBRAS_BASE_URL, CHATGPT_BASE_URL, CHUTES_BASE_URL,
     COHERE_BASE_URL, DEEPINFRA_BASE_URL, DEEPSEEK_BASE_URL, FIREWORKS_BASE_URL, GEMINI_BASE_URL,
@@ -30,7 +31,6 @@ use librefang_types::model_catalog::{
     VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL, ZAI_BASE_URL, ZAI_CODING_BASE_URL, ZHIPU_BASE_URL,
     ZHIPU_CODING_BASE_URL,
 };
-use dashmap::DashMap;
 use std::sync::Arc;
 
 // ── Driver Cache ────────────────────────────────────────────────
@@ -64,10 +64,7 @@ impl DriverCache {
     ///
     /// The cache key is derived from `(provider, api_key, base_url)` so that
     /// different credentials or endpoints produce distinct drivers.
-    pub fn get_or_create(
-        &self,
-        config: &DriverConfig,
-    ) -> Result<Arc<dyn LlmDriver>, LlmError> {
+    pub fn get_or_create(&self, config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmError> {
         let key = Self::cache_key(config);
         if let Some(driver) = self.cache.get(&key) {
             return Ok(Arc::clone(driver.value()));
@@ -1279,7 +1276,10 @@ mod tests {
         };
         let d_a = cache.get_or_create(&config_a).unwrap();
         let d_b = cache.get_or_create(&config_b).unwrap();
-        assert!(!Arc::ptr_eq(&d_a, &d_b), "Different keys should produce different drivers");
+        assert!(
+            !Arc::ptr_eq(&d_a, &d_b),
+            "Different keys should produce different drivers"
+        );
         assert_eq!(cache.len(), 2);
     }
 

--- a/crates/librefang-skills/src/loader.rs
+++ b/crates/librefang-skills/src/loader.rs
@@ -384,7 +384,10 @@ async fn execute_shell(
             result.map_err(|e| SkillError::ExecutionFailed(format!("Wait for shell: {e}")))?
         }
         Err(_) => {
-            error!("Shell skill timed out after 120s: {}", script_path.display());
+            error!(
+                "Shell skill timed out after 120s: {}",
+                script_path.display()
+            );
             return Ok(SkillToolResult {
                 output: "Shell script timed out after 120 seconds".into(),
                 is_error: true,


### PR DESCRIPTION
## Summary
Fix compilation errors on main that cause all PR CI to fail:

1. **`usize: FromSql` not satisfied** — `decay.rs:107` test uses `row.get::<_, usize>()` but rusqlite doesn't impl `FromSql` for `usize`. Fixed: `row.get::<_, i64>().map(|v| v as usize)`
2. **`fire_answer_callback_query` never used** — method defined but not called yet (will be used by #1457 interactive messages). Fixed: `#[allow(dead_code)]`
3. **`cargo fmt`** — several files had formatting drift

## Priority
This blocks all open PRs — should merge ASAP.