### PR TITLE
feat(release): show GitHub compare link before version confirmation

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -108,6 +108,9 @@ echo "  Tag:     $TAG"
 if [ "$IS_PRERELEASE" = true ]; then
     echo "  Type:    pre-release"
 fi
+if [ -n "$PREV_TAG" ]; then
+    echo "  Review:  https://github.com/librefang/librefang/compare/${PREV_TAG}...main"
+fi
 echo ""
 read -rp "Confirm? [Y/n]: " confirm
 if [[ "$confirm" =~ ^[Nn] ]]; then


### PR DESCRIPTION
## Summary
- Add a GitHub compare URL (`/compare/<prev-tag>...main`) to the release confirmation prompt
- Allows reviewing all changes since the last release before confirming

## Example output
```
  Version: 2026.3.2201 → 2026.3.2215
  Tag:     v2026.3.2215
  Review:  https://github.com/librefang/librefang/compare/v2026.3.2201...main

Confirm? [Y/n]:
```