### PR TITLE
fix(heartbeat): stamp last_active before LLM call

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -7638,6 +7638,12 @@ impl KernelHandle for LibreFangKernel {
             .collect()
     }
 
+    fn touch_heartbeat(&self, agent_id: &str) {
+        if let Ok(id) = agent_id.parse::<AgentId>() {
+            self.registry.touch(id);
+        }
+    }
+
     fn kill_agent(&self, agent_id: &str) -> Result<(), String> {
         let id: AgentId = agent_id
             .parse()

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -50,6 +50,14 @@ impl AgentRegistry {
             .and_then(|id| self.agents.get(id.value()).map(|e| e.value().clone()))
     }
 
+    /// Touch the agent's `last_active` timestamp without changing any other field.
+    /// Used to prevent heartbeat false-positives during long-running operations.
+    pub fn touch(&self, id: AgentId) {
+        if let Some(mut entry) = self.agents.get_mut(&id) {
+            entry.last_active = chrono::Utc::now();
+        }
+    }
+
     /// Update agent state.
     pub fn set_state(&self, id: AgentId, state: AgentState) -> LibreFangResult<()> {
         let mut entry = self

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -718,6 +718,12 @@ pub async fn run_agent_loop(
             cb(LoopPhase::Thinking);
         }
 
+        // Stamp last_active before LLM call to prevent heartbeat false-positives
+        // during long-running completions.
+        if let Some(ref k) = kernel {
+            k.touch_heartbeat(&agent_id_str);
+        }
+
         // Call LLM with retry, error classification, and circuit breaker
         let provider_name = manifest.model.provider.as_str();
         let mut response = call_with_retry(&*driver, request, Some(provider_name), None).await?;
@@ -2090,6 +2096,12 @@ pub async fn run_agent_loop_streaming(
             } else {
                 cb(LoopPhase::Thinking);
             }
+        }
+
+        // Stamp last_active before LLM call to prevent heartbeat false-positives
+        // during long-running completions.
+        if let Some(ref k) = kernel {
+            k.touch_heartbeat(&agent_id_str);
         }
 
         // Stream LLM call with retry, error classification, and circuit breaker

--- a/crates/librefang-runtime/src/kernel_handle.rs
+++ b/crates/librefang-runtime/src/kernel_handle.rs
@@ -238,6 +238,12 @@ pub trait KernelHandle: Send + Sync {
         Err("Channel file data send not available".to_string())
     }
 
+    /// Touch the agent's `last_active` timestamp to prevent heartbeat false-positives
+    /// during long-running operations (e.g., LLM calls).
+    fn touch_heartbeat(&self, agent_id: &str) {
+        let _ = agent_id;
+    }
+
     /// Spawn an agent with capability inheritance enforcement.
     /// `parent_caps` are the parent's granted capabilities. The kernel MUST verify
     /// that every capability in the child manifest is covered by `parent_caps`.


### PR DESCRIPTION
## Summary

- Stamps `last_active` on the agent registry entry before each LLM call (both non-streaming and streaming paths)
- Prevents heartbeat from falsely flagging agents as unresponsive during long-running LLM completions (e.g., complex reasoning 30s+)

## Changes

- `kernel_handle.rs`: add `touch_heartbeat(&self, agent_id: &str)` method with default no-op
- `registry.rs`: add `touch(&self, id: AgentId)` method that only updates `last_active`
- `kernel.rs`: implement `touch_heartbeat` for `LibreFangKernel`
- `agent_loop.rs`: call `touch_heartbeat` before `call_with_retry` and `stream_with_retry`

## Context

Ported from upstream openfang [PR #709](https://github.com/RightNow-AI/openfang/pull/709).