### PR TITLE
fix(heartbeat): reset last_active on agent restore

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1555,6 +1555,7 @@ impl LibreFangKernel {
 
                     // Re-register in the in-memory registry
                     let mut restored_entry = entry;
+                    restored_entry.last_active = chrono::Utc::now();
 
                     // Check enabled flag — also do a direct TOML read as fallback
                     let mut is_enabled = restored_entry.manifest.enabled;


### PR DESCRIPTION
## Summary

- Resets `last_active` to `Utc::now()` when restoring agents from persistent storage on daemon startup
- Previously, restored agents kept their old `last_active` timestamp from before shutdown, causing the heartbeat monitor to immediately flag them as unresponsive on the first check

## Changes

- `kernel.rs`: add `restored_entry.last_active = chrono::Utc::now();` after creating the restored entry (1 line)

## Context

Ported from upstream openfang [PR #703](https://github.com/RightNow-AI/openfang/pull/703).