### PR TITLE
chore: translate all Chinese comments to English

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -361,7 +361,7 @@ export function App() {
             {navGroups.map((group) => (
               <div key={group.key} className="flex flex-col gap-1">
                 {navLayout === "collapsible" ? (
-                  // 二级菜单布局 - 可折叠
+                  // Collapsible sub-menu layout
                   <>
                     <button
                       onClick={() => toggleNavGroup(group.key)}
@@ -386,7 +386,7 @@ export function App() {
                     </div>
                   </>
                 ) : (
-                  // 分组布局 - 全部显示
+                  // Grouped layout — all items visible
                   <>
                     <h3 className={`px-3 text-[11px] font-bold uppercase tracking-[0.1em] text-text-dim/80 ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:!p-0 lg:!m-0 lg:!mb-0" : "lg:max-h-20 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
                       {group.label}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -50,7 +50,7 @@ export function AgentsPage() {
   const filteredAgents = agents
     .filter(a => a.name.toLowerCase().includes(search.toLowerCase()) || a.id.toLowerCase().includes(search.toLowerCase()))
     .sort((a, b) => {
-      // 1. Suspended last
+      // 1. Suspended agents last
       const aSusp = (a.state || "").toLowerCase() === "suspended" ? 1 : 0;
       const bSusp = (b.state || "").toLowerCase() === "suspended" ? 1 : 0;
       if (aSusp !== bSusp) return aSusp - bSusp;
@@ -62,7 +62,7 @@ export function AgentsPage() {
       return a.name.localeCompare(b.name);
     });
 
-  // 分组：core agents 和 hands
+  // Group: core agents and hands
   const coreAgents = filteredAgents.filter(a => !a.name.includes("-hand"));
   const handAgents = filteredAgents.filter(a => a.name.includes("-hand"));
 

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -35,29 +35,29 @@ import {
   Download, Upload, HelpCircle, Scan, Check, LayoutTemplate, Search, Tag
 } from "lucide-react";
 
-// 节点类型配置 — n8n 风格配色
+// Node type configuration — n8n-style color scheme
 const NODE_TYPES = [
-  // 触发器（视觉标记）
+  // Triggers (visual markers)
   { type: "start", labelKey: "canvas.node_types.start", color: "#10b981", bg: "#ecfdf5", icon: "S", descKey: "canvas.node_types.start_desc" },
   { type: "end", labelKey: "canvas.node_types.end", color: "#ef4444", bg: "#fef2f2", icon: "E", descKey: "canvas.node_types.end_desc" },
   { type: "schedule", labelKey: "canvas.node_types.schedule", color: "#f59e0b", bg: "#fffbeb", icon: "C", descKey: "canvas.node_types.schedule_desc" },
   { type: "webhook", labelKey: "canvas.node_types.webhook", color: "#6366f1", bg: "#eef2ff", icon: "W", descKey: "canvas.node_types.webhook_desc" },
   { type: "channel", labelKey: "canvas.node_types.channel", color: "#8b5cf6", bg: "#f5f3ff", icon: "M", descKey: "canvas.node_types.channel_desc" },
-  // 逻辑控制
+  // Logic control
   { type: "condition", labelKey: "canvas.node_types.condition", color: "#f59e0b", bg: "#fffbeb", icon: "?", descKey: "canvas.node_types.condition_desc" },
   { type: "loop", labelKey: "canvas.node_types.loop", color: "#8b5cf6", bg: "#f5f3ff", icon: "L", descKey: "canvas.node_types.loop_desc" },
   { type: "parallel", labelKey: "canvas.node_types.parallel", color: "#f59e0b", bg: "#fffbeb", icon: "P", descKey: "canvas.node_types.parallel_desc" },
   { type: "collect", labelKey: "canvas.node_types.collect", color: "#10b981", bg: "#ecfdf5", icon: "C", descKey: "canvas.node_types.collect_desc" },
   { type: "wait", labelKey: "canvas.node_types.wait", color: "#6b7280", bg: "#f9fafb", icon: "T", descKey: "canvas.node_types.wait_desc" },
-  // 动作
+  // Actions
   { type: "respond", labelKey: "canvas.node_types.respond", color: "#10b981", bg: "#ecfdf5", icon: "R", descKey: "canvas.node_types.respond_desc" },
   { type: "agent", labelKey: "canvas.node_types.agent", color: "#3b82f6", bg: "#eff6ff", icon: "A", descKey: "canvas.node_types.agent_desc" },
 ];
 
-// 需要绑定 agent 的节点类型
+// Node types that require an agent binding
 const AGENT_NODE_TYPES_SET = new Set(["agent", "channel", "respond", "condition", "loop", "parallel", "collect"]);
 
-// 自定义节点组件 — n8n 风格
+// Custom node component — n8n style
 function CustomNode({ data, type: nodeTypeKey, t }: { data: any; type: string; t: (key: string) => string }) {
   const config = NODE_TYPES.find(n => n.type === (data.nodeType || nodeTypeKey)) || NODE_TYPES[11];
   const isStart = data.nodeType === "start";
@@ -136,7 +136,7 @@ function CustomNode({ data, type: nodeTypeKey, t }: { data: any; type: string; t
   );
 }
 
-// 分组节点组件
+// Group node component
 function GroupNodeComponent({ data, id }: { data: any; id: string }) {
   const expanded = data._expanded !== false;
   return (
@@ -163,13 +163,13 @@ function GroupNodeComponent({ data, id }: { data: any; id: string }) {
             <span className="text-[9px] text-brand/50">{data._childCount}</span>
           )}
         </div>
-        {/* 解散分组（保留子节点） */}
+        {/* Ungroup (keep child nodes) */}
         <button onClick={(e) => { e.stopPropagation(); data._onUngroup?.(id); }}
           title="Ungroup"
           className="p-0.5 rounded hover:bg-brand/20 text-brand/50 hover:text-brand shrink-0">
           <X className="w-3 h-3" />
         </button>
-        {/* 删除分组+子节点 */}
+        {/* Delete group + child nodes */}
         <button onClick={(e) => { e.stopPropagation(); data._onDeleteGroup?.(id); }}
           title="Delete group and children"
           className="p-0.5 rounded hover:bg-error/20 text-text-dim/30 hover:text-error shrink-0">
@@ -186,7 +186,7 @@ function GroupNodeComponent({ data, id }: { data: any; id: string }) {
   );
 }
 
-// 工作流列表侧边栏
+// Workflow list sidebar
 function WorkflowList({
   workflows, selectedId, onSelect, onDelete, onRun, isRunning, t
 }: {
@@ -246,7 +246,7 @@ function WorkflowList({
   );
 }
 
-// 模板浏览器
+// Template browser
 function TemplateBrowser({
   onInstantiate, onClose, t
 }: {
@@ -417,7 +417,7 @@ function TemplateBrowser({
   );
 }
 
-// 节点配置面板
+// Node configuration panel
 const inputClass = "mt-1 w-full rounded-lg border border-border-subtle bg-main px-2 py-1.5 text-xs outline-none focus:border-brand";
 const labelClass = "text-[10px] font-bold text-text-dim uppercase";
 
@@ -479,7 +479,7 @@ function NodeConfigPanel({
         </div>
       </div>
       <div className="p-3 space-y-2.5 overflow-y-auto flex-1">
-        {/* 基础信息 */}
+        {/* Basic info */}
         <div>
           <label className={labelClass}>{t("canvas.node_label")}</label>
           <input type="text" value={label} onChange={e => setLabel(e.target.value)} className={inputClass} />
@@ -489,7 +489,7 @@ function NodeConfigPanel({
           <input type="text" value={description} onChange={e => setDescription(e.target.value)} className={inputClass} />
         </div>
 
-        {/* Agent 绑定 */}
+        {/* Agent binding */}
         <div>
           <label className={labelClass}>{t("canvas.assign_agent")}</label>
           <select value={agentId} onChange={e => setAgentId(e.target.value)} className={inputClass}>
@@ -511,7 +511,7 @@ function NodeConfigPanel({
           </div>
         )}
 
-        {/* 执行模式 */}
+        {/* Execution mode */}
         {hasAgent && (
           <div>
             <label className={labelClass}>{t("canvas.step_mode")}</label>
@@ -525,7 +525,7 @@ function NodeConfigPanel({
           </div>
         )}
 
-        {/* Conditional 专属字段 */}
+        {/* Conditional-specific fields */}
         {hasAgent && mode === "conditional" && (
           <div>
             <label className={labelClass}>{t("canvas.condition_text")}</label>
@@ -534,7 +534,7 @@ function NodeConfigPanel({
           </div>
         )}
 
-        {/* Loop 专属字段 */}
+        {/* Loop-specific fields */}
         {hasAgent && mode === "loop" && (
           <>
             <div>
@@ -550,7 +550,7 @@ function NodeConfigPanel({
           </>
         )}
 
-        {/* 错误处理 */}
+        {/* Error handling */}
         {hasAgent && (
           <div>
             <label className={labelClass}>{t("canvas.error_mode")}</label>
@@ -569,7 +569,7 @@ function NodeConfigPanel({
           </div>
         )}
 
-        {/* 高级选项 */}
+        {/* Advanced options */}
         {hasAgent && (
           <>
             <div>
@@ -661,7 +661,7 @@ function CanvasPageInner() {
   const [showHelp, setShowHelp] = useState(false);
   const [showTemplateBrowser, setShowTemplateBrowser] = useState(false);
 
-  // 撤销/重做历史
+  // Undo/redo history
   const historyRef = useRef<{ nodes: Node[]; edges: Edge[] }[]>([]);
   const historyIndexRef = useRef(-1);
   const clipboardRef = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null);
@@ -676,7 +676,7 @@ function CanvasPageInner() {
 
   const undo = useCallback(() => {
     if (historyIndexRef.current <= 0) return;
-    // 先保存当前状态到历史末尾（如果还没保存）
+    // Save current state to end of history (if not already saved)
     if (historyIndexRef.current === historyRef.current.length - 1) pushHistory();
     historyIndexRef.current--;
     const s = historyRef.current[historyIndexRef.current];
@@ -690,9 +690,9 @@ function CanvasPageInner() {
     if (s) { setNodes(s.nodes); setEdges(s.edges); }
   }, [setNodes, setEdges]);
 
-  // 记录关键操作前的快照
+  // Record snapshot before key operations
   const onNodesChangeWithHistory = useCallback((changes: any) => {
-    // 拖拽结束/删除时记录
+    // Record on drag end / delete
     const hasEnd = changes.some((c: any) => c.type === "position" && c.dragging === false);
     const hasRemove = changes.some((c: any) => c.type === "remove");
     if (hasEnd || hasRemove) pushHistory();
@@ -705,7 +705,7 @@ function CanvasPageInner() {
     onEdgesChange(changes);
   }, [onEdgesChange, pushHistory]);
 
-  // 复制选中节点
+  // Copy selected nodes
   const copySelected = useCallback(() => {
     const selNodes = nodes.filter(n => selectedNodeIds.has(n.id));
     if (selNodes.length === 0) return;
@@ -714,7 +714,7 @@ function CanvasPageInner() {
     clipboardRef.current = { nodes: JSON.parse(JSON.stringify(selNodes)), edges: JSON.parse(JSON.stringify(selEdges)) };
   }, [nodes, edges, selectedNodeIds]);
 
-  // 粘贴
+  // Paste
   const paste = useCallback(() => {
     if (!clipboardRef.current) return;
     pushHistory();
@@ -731,12 +731,12 @@ function CanvasPageInner() {
       source: idMap.get(e.source) || e.source,
       target: idMap.get(e.target) || e.target,
     }));
-    // 取消选择旧节点
+    // Deselect old nodes
     setNodes(nds => [...nds.map(n => ({ ...n, selected: false })), ...newNodes]);
     setEdges(eds => [...eds, ...newEdges]);
   }, [pushHistory, setNodes, setEdges]);
 
-  // 复制选中节点（Cmd+D）
+  // Duplicate selected nodes (Cmd+D)
   const duplicate = useCallback(() => {
     copySelected();
     paste();
@@ -747,7 +747,7 @@ function CanvasPageInner() {
     setTimeout(() => setErrorMsg(null), 5000);
   }, []);
 
-  // 重新计算分组边框以包含所有子节点（提前声明，autoLayout 需要）
+  // Recalculate group bounds to contain all child nodes (declared early, needed by autoLayout)
   const NODE_W = 200;
   const NODE_H = 80;
   const GROUP_PAD = 30;
@@ -778,12 +778,12 @@ function CanvasPageInner() {
     } : n);
   }, []);
 
-  // 全选
+  // Select all
   const selectAll = useCallback(() => {
     setNodes(nds => nds.map(n => ({ ...n, selected: true })));
   }, [setNodes]);
 
-  // 自动布局（简单的纵向排列）
+  // Auto layout (simple vertical arrangement)
   const autoLayout = useCallback(() => {
     pushHistory();
     const agentNodes = nodes.filter(n => n.type === "custom" && !n.hidden);
@@ -800,19 +800,19 @@ function CanvasPageInner() {
       const pos = positioned.get(n.id);
       return pos ? { ...n, position: pos } : n;
     }));
-    // 重新计算分组边框
+    // Recalculate group bounds
     groupNodes.forEach(g => {
       setNodes(nds => recalcGroupBounds(nds, g.id));
     });
   }, [nodes, pushHistory, setNodes, recalcGroupBounds]);
 
-  // Toast 提示
+  // Toast notification
   const showToast = useCallback((msg: string) => {
     setToast(msg);
     setTimeout(() => setToast(null), 2000);
   }, []);
 
-  // 导出工作流 JSON
+  // Export workflow JSON
   const exportWorkflow = useCallback(() => {
     const data = { nodes, edges, name: workflowName, description: workflowDescription };
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
@@ -825,7 +825,7 @@ function CanvasPageInner() {
     showToast(t("canvas.exported"));
   }, [nodes, edges, workflowName, workflowDescription, showToast, t]);
 
-  // 导入工作流 JSON
+  // Import workflow JSON
   const importWorkflow = useCallback(() => {
     const input = document.createElement("input");
     input.type = "file";
@@ -849,12 +849,12 @@ function CanvasPageInner() {
     input.click();
   }, [pushHistory, setNodes, setEdges, showToast, showError, t]);
 
-  // 连线验证：阻止 source→source 或 target→target
+  // Connection validation: prevent source->source or target->target
   const isValidConnection = useCallback((connection: Edge | Connection) => {
     return connection.source !== connection.target;
   }, []);
 
-  // 快捷键 refs
+  // Shortcut key refs
   const createGroupRef = useRef<() => void>(() => {});
   const ungroupRef = useRef<(id: string) => void>(() => {});
 
@@ -870,37 +870,37 @@ function CanvasPageInner() {
       return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
     };
     const down = (e: KeyboardEvent) => {
-      if (isInput()) return; // 不在输入框中才处理
+      if (isInput()) return; // Only handle when not in an input field
       const mod = e.metaKey || e.ctrlKey;
-      // 空格：平移模式
+      // Space: pan mode
       if (e.code === "Space" && !e.repeat) { e.preventDefault(); setSpacePressed(true); }
-      // Cmd+Z：撤销
+      // Cmd+Z: undo
       if (e.code === "KeyZ" && mod && !e.shiftKey) { e.preventDefault(); undo(); }
-      // Cmd+Shift+Z：重做
+      // Cmd+Shift+Z: redo
       if (e.code === "KeyZ" && mod && e.shiftKey) { e.preventDefault(); redo(); }
-      // Cmd+C：复制
+      // Cmd+C: copy
       if (e.code === "KeyC" && mod) { e.preventDefault(); copySelected(); }
-      // Cmd+V：粘贴
+      // Cmd+V: paste
       if (e.code === "KeyV" && mod) { e.preventDefault(); paste(); }
-      // Cmd+D：复制
+      // Cmd+D: duplicate
       if (e.code === "KeyD" && mod) { e.preventDefault(); duplicate(); }
-      // Cmd+A：全选
+      // Cmd+A: select all
       if (e.code === "KeyA" && mod) { e.preventDefault(); selectAll(); }
-      // Cmd+B：创建分组
+      // Cmd+B: create group
       if (e.code === "KeyB" && mod && !e.shiftKey) { e.preventDefault(); createGroupRef.current(); }
-      // Shift+Cmd+B：解散分组
+      // Shift+Cmd+B: ungroup
       if (e.code === "KeyB" && mod && e.shiftKey) {
         e.preventDefault();
         const groupNode = nodes.find(n => selectedNodeIds.has(n.id) && n.type === "groupNode");
         if (groupNode) ungroupRef.current(groupNode.id);
       }
-      // Cmd+1：适配视口
+      // Cmd+1: fit viewport
       if (e.code === "Digit1" && mod) { e.preventDefault(); fitView({ padding: 0.2, duration: 300 }); }
-      // Cmd+E：导出
+      // Cmd+E: export
       if (e.code === "KeyE" && mod) { e.preventDefault(); exportWorkflow(); }
-      // Cmd+I：导入
+      // Cmd+I: import
       if (e.code === "KeyI" && mod) { e.preventDefault(); importWorkflow(); }
-      // ?：快捷键帮助
+      // ?: shortcut help
       if (e.code === "Slash" && e.shiftKey && !mod) { e.preventDefault(); setShowHelp(h => !h); }
     };
     const up = (e: KeyboardEvent) => { if (e.code === "Space") setSpacePressed(false); };
@@ -909,7 +909,7 @@ function CanvasPageInner() {
     return () => { window.removeEventListener("keydown", down); window.removeEventListener("keyup", up); };
   }, [nodes, selectedNodeIds, undo, redo, copySelected, paste, duplicate, selectAll, fitView, exportWorkflow, importWorkflow]);
 
-  // 折叠/展开分组
+  // Collapse/expand group
   const toggleGroup = useCallback((groupId: string) => {
     setNodes(nds => {
       const groupNode = nds.find(n => n.id === groupId);
@@ -919,7 +919,7 @@ function CanvasPageInner() {
       const willCollapse = isExpanded;
       const childIds = new Set<string>(gd._childIds || []);
 
-      // 折叠时记录当前尺寸，展开时恢复
+      // Record current dimensions on collapse, restore on expand
       const origStyle = willCollapse
         ? { _origWidth: groupNode.style?.width, _origHeight: groupNode.style?.height }
         : {};
@@ -941,7 +941,7 @@ function CanvasPageInner() {
       });
     });
 
-    // 处理边
+    // Handle edges
     setEdges(eds => {
       const groupNode = nodes.find(n => n.id === groupId);
       const gd = groupNode?.data as any;
@@ -953,20 +953,20 @@ function CanvasPageInner() {
         const srcChild = childIds.has(e.source);
         const tgtChild = childIds.has(e.target);
 
-        // 内部边：折叠时隐藏
+        // Internal edges: hide on collapse
         if (srcChild && tgtChild) {
           return { ...e, hidden: willCollapse };
         }
         if (willCollapse) {
-          // 外部边：重定向到 group 节点，保存原始端点
+          // External edges: redirect to group node, save original endpoints
           if (srcChild) return { ...e, data: { ...e.data, _origSource: e.source }, source: groupId };
           if (tgtChild) return { ...e, data: { ...e.data, _origTarget: e.target }, target: groupId };
         } else {
-          // 展开：恢复原始端点
+          // Expand: restore original endpoints
           const ed = e.data as any;
           if (ed?._origSource) return { ...e, source: ed._origSource, data: { ...e.data, _origSource: undefined }, hidden: false };
           if (ed?._origTarget) return { ...e, target: ed._origTarget, data: { ...e.data, _origTarget: undefined }, hidden: false };
-          // 恢复内部边可见
+          // Restore internal edge visibility
           if (srcChild && tgtChild) return { ...e, hidden: false };
         }
         return e;
@@ -974,7 +974,7 @@ function CanvasPageInner() {
     });
   }, [nodes, setNodes, setEdges]);
 
-  // 解散分组：删掉 group 节点，子节点保留并清除 _groupId
+  // Ungroup: remove group node, keep child nodes and clear _groupId
   const ungroupNodes = useCallback((groupId: string) => {
     setNodes(nds => {
       const group = nds.find(n => n.id === groupId);
@@ -986,7 +986,7 @@ function CanvasPageInner() {
           : n
         );
     });
-    // 恢复被重定向的边
+    // Restore redirected edges
     setEdges(eds => eds.map(e => {
       const ed = e.data as any;
       if (ed?._origSource) return { ...e, source: ed._origSource, data: { ...e.data, _origSource: undefined }, hidden: false };
@@ -995,7 +995,7 @@ function CanvasPageInner() {
     }));
   }, [setNodes, setEdges]);
 
-  // 删除分组 + 所有子节点
+  // Delete group + all child nodes
   const deleteGroupAndChildren = useCallback((groupId: string) => {
     setNodes(nds => {
       const group = nds.find(n => n.id === groupId);
@@ -1003,7 +1003,7 @@ function CanvasPageInner() {
       childIds.add(groupId);
       return nds.filter(n => !childIds.has(n.id));
     });
-    // 删除涉及子节点的边
+    // Delete edges involving child nodes
     setEdges(eds => {
       const group = nodes.find(n => n.id === groupId);
       const childIds = new Set<string>((group?.data as any)?._childIds || []);
@@ -1026,18 +1026,18 @@ function CanvasPageInner() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), []);
 
-  // 需要 agent 的节点类型（后端所有 step 都需要 agent）
+  // Node types that require an agent (all backend steps need an agent)
   const AGENT_NODE_TYPES = AGENT_NODE_TYPES_SET;
 
-  // 加载模板数据（传入 agents 列表以便自动分配）
+  // Load template data (agents list passed in for auto-assignment)
   const loadTemplate = useCallback((availableAgents: AgentItem[]) => {
     const templateData = sessionStorage.getItem("workflowTemplate");
     if (templateData) {
       try {
         const { nodes: templateNodes, edges: templateEdges, name, description, workflowId } = JSON.parse(templateData);
-        // 找一个可用的 agent 作为默认分配
+        // Find an available agent as default assignment
         const defaultAgent = availableAgents.find(a => a.state === "Running") || availableAgents[0];
-        // 根据界面语言决定输出语言指令
+        // Determine output language instruction based on UI language
         const lang = t("_lang", { defaultValue: "en" });
         const langSuffix = lang === "zh" ? "\n\nIMPORTANT: You MUST respond entirely in Chinese (中文)." : "";
         const newNodes = templateNodes.map((n: any, idx: number) => {
@@ -1054,7 +1054,7 @@ function CanvasPageInner() {
               nodeType,
               labelKey: n.data?.label,
               descKey: n.data?.description,
-              // 保留已有 agent 绑定（按 ID 查名字），或自动分配默认 agent
+              // Keep existing agent binding (look up name by ID), or auto-assign default agent
               ...(n.data?.agentId ? {
                 agentId: n.data.agentId,
                 agentName: n.data.agentName || availableAgents.find(a => a.id === n.data.agentId)?.name || n.data.agentId,
@@ -1078,7 +1078,7 @@ function CanvasPageInner() {
         }
         if (name) setWorkflowName(name.startsWith("workflows.") ? t(name) : name);
         if (description) setWorkflowDescription(description.startsWith("workflows.") ? t(description) : description);
-        // 如果是编辑已有工作流，恢复 selectedWorkflow 以便保存时走更新逻辑
+        // If editing an existing workflow, restore selectedWorkflow so save uses update logic
         if (workflowId) setSelectedWorkflow({ id: workflowId, name: name || "", description: description || "" } as WorkflowItem);
         sessionStorage.removeItem("workflowTemplate");
         return true;
@@ -1087,13 +1087,13 @@ function CanvasPageInner() {
     return false;
   }, [t, setNodes, setEdges]);
 
-  // 加载智能体、工作流，然后加载模板
+  // Load agents, workflows, then load template
   useEffect(() => {
     Promise.all([listAgents(), listWorkflows()])
       .then(([a, w]) => {
         setAgents(a);
         setWorkflows(w);
-        // agents 就绪后再加载模板
+        // Load template after agents are ready
         if (!loadTemplate(a)) {
           const savedNodes = sessionStorage.getItem("canvasNodes");
           if (savedNodes) {
@@ -1104,12 +1104,12 @@ function CanvasPageInner() {
       .catch(() => {});
   }, [routeTimestamp, loadTemplate]);
 
-  // 保存节点到 sessionStorage
+  // Save nodes to sessionStorage
   useEffect(() => {
     if (nodes.length > 0) sessionStorage.setItem("canvasNodes", JSON.stringify(nodes));
   }, [nodes]);
 
-  // nodeType → 默认 stepMode 映射
+  // nodeType -> default stepMode mapping
   const NODE_MODE_MAP: Record<string, string> = {
     condition: "conditional",
     loop: "loop",
@@ -1117,11 +1117,11 @@ function CanvasPageInner() {
     collect: "collect",
   };
 
-  // 添加节点
+  // Add node
   const addNode = useCallback((type: string) => {
     const config = NODE_TYPES.find(n => n.type === type) || NODE_TYPES[10];
     const defaultMode = NODE_MODE_MAP[type];
-    // 用函数式更新读最新 nodes，避免闭包过期
+    // Use functional update to read latest nodes, avoiding stale closures
     setNodes(nds => {
       const existing = nds.filter(n => n.type === "custom" && !n.hidden);
       let maxY = 0;
@@ -1144,7 +1144,7 @@ function CanvasPageInner() {
     });
   }, [setNodes, t]);
 
-  // 连线
+  // Edge connections
   const edgeColor = theme === "dark" ? "#6b7280" : "#94a3b8";
   const edgeColorActive = theme === "dark" ? "#818cf8" : "#6366f1";
 
@@ -1164,19 +1164,19 @@ function CanvasPageInner() {
     }, eds));
   }, [setEdges, edgeColorActive]);
 
-  // 节点点击 → 打开配置面板
+  // Node click -> open config panel
   const onNodeClick = useCallback((_: any, node: Node) => {
     setEditingNode(node);
   }, []);
 
-  // 节点被删除时清理编辑面板
+  // Clean up editing panel when nodes are deleted
   const onNodesDelete = useCallback((deleted: Node[]) => {
     if (editingNode && deleted.some(n => n.id === editingNode.id)) {
       setEditingNode(null);
     }
   }, [editingNode]);
 
-  // group 拖拽时带动子节点
+  // Group drag moves child nodes along
   const groupDragStart = useRef<{ id: string; x: number; y: number } | null>(null);
 
   const onNodeDragStart = useCallback((_: any, node: Node) => {
@@ -1187,7 +1187,7 @@ function CanvasPageInner() {
 
   const onNodeDrag = useCallback((_: any, node: Node) => {
     if (node.type === "groupNode" && groupDragStart.current?.id === node.id) {
-      // 拖拽分组 → 带动子节点
+      // Dragging group -> move child nodes along
       const dx = node.position.x - groupDragStart.current.x;
       const dy = node.position.y - groupDragStart.current.y;
       if (dx === 0 && dy === 0) return;
@@ -1199,7 +1199,7 @@ function CanvasPageInner() {
           : n
       ));
     } else {
-      // 拖拽子节点 → 扩展所属分组边框
+      // Dragging child node -> expand parent group bounds
       const groupId = (node.data as any)?._groupId;
       if (groupId) {
         setNodes(nds => recalcGroupBounds(nds, groupId));
@@ -1207,21 +1207,21 @@ function CanvasPageInner() {
     }
   }, [setNodes, recalcGroupBounds]);
 
-  // 跟踪选中的节点
+  // Track selected nodes
   const onSelectionChange = useCallback(({ nodes: selected }: OnSelectionChangeParams) => {
     setSelectedNodeIds(new Set(selected.map(n => n.id)));
   }, []);
 
-  // 创建分组：不改变子节点位置，只在底层加一个背景框 + 标记归属
+  // Create group: keep child node positions, just add a background frame underneath + mark ownership
   const createGroup = useCallback(() => {
     if (selectedNodeIds.size < 2) return;
 
     const selected = nodes.filter(n => selectedNodeIds.has(n.id) && n.type !== "groupNode");
     if (selected.length < 2) return;
 
-    // 手动计算包围盒（考虑节点自身宽高，getNodesBounds 不一定准）
-    const NODE_W = 200; // 节点最大宽度
-    const NODE_H = 80;  // 节点估算高度
+    // Manually calculate bounding box (considering node dimensions, getNodesBounds may not be accurate)
+    const NODE_W = 200; // Max node width
+    const NODE_H = 80;  // Estimated node height
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     for (const n of selected) {
       const w = (n.measured?.width ?? n.width ?? NODE_W);
@@ -1254,8 +1254,8 @@ function CanvasPageInner() {
       },
     };
 
-    // 用函数式更新：在现有节点前面插入 group，修改子节点 data 标记归属
-    // 不替换整个数组，保留 ReactFlow 内部节点状态（measured 等）
+    // Use functional update: insert group before existing nodes, update child node data to mark ownership
+    // Don't replace the entire array, preserve ReactFlow internal node state (measured, etc.)
     setNodes(nds => [
       groupNode,
       ...nds.map(n => childIds.includes(n.id)
@@ -1266,7 +1266,7 @@ function CanvasPageInner() {
     setSelectedNodeIds(new Set());
   }, [selectedNodeIds, nodes, setNodes, t]);
 
-  // 同步快捷键 refs
+  // Sync shortcut key refs
   createGroupRef.current = createGroup;
   ungroupRef.current = ungroupNodes;
 
@@ -1276,12 +1276,12 @@ function CanvasPageInner() {
   deleteGroupAndChildrenRef.current = deleteGroupAndChildren;
   tRef.current = t;
 
-  // 更新节点数据
+  // Update node data
   const handleNodeUpdate = useCallback((id: string, newData: any) => {
     setNodes(nds => nds.map(n => n.id === id ? { ...n, data: newData } : n));
   }, [setNodes]);
 
-  // 从节点构建后端 steps：只有绑定了真实 agent 的节点才是 step
+  // Build backend steps from nodes: only nodes bound to a real agent are steps
   const buildSteps = useCallback((nodeList: Node[]) => {
     return nodeList
       .filter(n => {
@@ -1297,7 +1297,7 @@ function CanvasPageInner() {
           prompt: d.prompt || d.description || "",
           timeout_secs: d.timeoutSecs || 120,
         };
-        // 执行模式
+        // Execution mode
         const mode = d.stepMode || "sequential";
         if (mode === "conditional") {
           step.mode = { conditional: { condition: d.condition || "" } };
@@ -1306,22 +1306,22 @@ function CanvasPageInner() {
         } else {
           step.mode = mode;
         }
-        // 错误模式
+        // Error mode
         const errMode = d.errorMode || "fail";
         if (errMode === "retry") {
           step.error_mode = { retry: { max_retries: d.maxRetries || 3 } };
         } else {
           step.error_mode = errMode;
         }
-        // 输出变量
+        // Output variable
         if (d.outputVar) step.output_var = d.outputVar;
-        // DAG 依赖
+        // DAG dependencies
         if (d.dependsOn && d.dependsOn.length > 0) step.depends_on = d.dependsOn;
         return step;
       });
   }, []);
 
-  // 保存工作流
+  // Save workflow
   const handleSave = useCallback(async () => {
     if (!workflowName.trim()) {
       showError(t("canvas.name_required"));
@@ -1352,10 +1352,10 @@ function CanvasPageInner() {
     }
   }, [workflowName, workflowDescription, selectedWorkflow, nodes, edges, buildSteps, t, showError, showToast]);
 
-  // 点击运行 → 弹出输入框
+  // Click run -> show input dialog
   const handleRunClick = useCallback((id?: string) => {
     if (id) {
-      // 从侧边栏直接运行已保存的工作流
+      // Run saved workflow directly from sidebar
       setRunInput("");
       setShowRunInput(true);
     } else if (selectedWorkflow?.id || nodes.length > 0) {
@@ -1364,12 +1364,12 @@ function CanvasPageInner() {
     }
   }, [selectedWorkflow, nodes]);
 
-  // 确认运行
+  // Confirm run
   const handleRunConfirm = useCallback(async (id?: string) => {
     setShowRunInput(false);
     let workflowId = id || selectedWorkflow?.id;
 
-    // 没有已保存的工作流 → 先保存
+    // No saved workflow -> save first
     if (!workflowId && nodes.length > 0) {
       const steps = buildSteps(nodes);
       if (steps.length === 0) {
@@ -1399,10 +1399,10 @@ function CanvasPageInner() {
     setRunningWorkflowId(workflowId);
     setErrorMsg(null);
     setRunResult(null);
-    // 运行时边动画
+    // Edge animation during run
     setEdges(eds => eds.map(e => ({ ...e, animated: true })));
 
-    // 逐步点亮节点动画
+    // Progressively highlight node animation
     const agentNodeIds = nodes.filter(n => (n.data as any).agentId).map(n => n.id);
     const allNodeIds = nodes.map(n => n.id);
     let stepTimer: ReturnType<typeof setInterval> | null = null;
@@ -1418,19 +1418,19 @@ function CanvasPageInner() {
       })));
     };
 
-    // 逐步推进动画，最后一个节点保持 running 直到 API 返回
+    // Step through animation, last node stays running until API returns
     const doneSet = new Set<string>();
     if (agentNodeIds.length > 0) {
       updateRunState(agentNodeIds[0], doneSet);
       if (agentNodeIds.length > 1) {
         stepTimer = setInterval(() => {
           if (currentStep < agentNodeIds.length - 1) {
-            // 标记当前为 done，推进到下一个
+            // Mark current as done, advance to next
             doneSet.add(agentNodeIds[currentStep]);
             currentStep++;
             updateRunState(agentNodeIds[currentStep], doneSet);
           }
-          // 到最后一个节点就停止 timer，保持 running 等 API 返回
+          // Stop timer at last node, keep running until API returns
           if (currentStep >= agentNodeIds.length - 1) {
             if (stepTimer) clearInterval(stepTimer);
             stepTimer = null;
@@ -1441,7 +1441,7 @@ function CanvasPageInner() {
 
     try {
       const resp = await runWorkflow(workflowId, runInput);
-      // 完成：所有节点标记 done
+      // Complete: mark all nodes as done
       if (stepTimer) clearInterval(stepTimer);
       setNodes(nds => nds.map(n => ({
         ...n,
@@ -1452,14 +1452,14 @@ function CanvasPageInner() {
         status: (resp as any).status || "completed",
         run_id: (resp as any).run_id || "",
       });
-      // 3秒后清除 done 状态和边动画
+      // Clear done state and edge animation after 3 seconds
       setTimeout(() => {
         setNodes(nds => nds.map(n => ({ ...n, data: { ...(n.data as any), _runState: undefined } })));
         setEdges(eds => eds.map(e => ({ ...e, animated: false })));
       }, 3000);
     } catch (e: any) {
       if (stepTimer) clearInterval(stepTimer);
-      // 错误：清除所有状态和边动画
+      // Error: clear all state and edge animation
       setNodes(nds => nds.map(n => ({ ...n, data: { ...(n.data as any), _runState: undefined } })));
       setEdges(eds => eds.map(e => ({ ...e, animated: false })));
       showError(e?.message || String(e));
@@ -1468,7 +1468,7 @@ function CanvasPageInner() {
     }
   }, [selectedWorkflow, nodes, edges, workflowName, workflowDescription, buildSteps, runInput, t, showError]);
 
-  // 删除工作流
+  // Delete workflow
   const handleDeleteConfirmed = useCallback(async (id: string) => {
     try {
       await deleteWorkflow(id);
@@ -1481,7 +1481,7 @@ function CanvasPageInner() {
     } catch (e) { console.error(e); }
   }, [selectedWorkflow, setNodes, setEdges]);
 
-  // 选择已保存的工作流
+  // Select saved workflow
   const handleSelectWorkflow = useCallback((w: WorkflowItem) => {
     setSelectedWorkflow(w);
     setWorkflowName(w.name);
@@ -1544,7 +1544,7 @@ function CanvasPageInner() {
     setEdges(newEdges);
   }, [setNodes, setEdges]);
 
-  // 新建工作流
+  // Create new workflow
   const handleNewWorkflow = useCallback(() => {
     setSelectedWorkflow(null);
     setNodes([]); setEdges([]);
@@ -1552,7 +1552,7 @@ function CanvasPageInner() {
     setEditingNode(null);
   }, [setNodes, setEdges]);
 
-  // 模板实例化回调：关闭浏览器，刷新工作流列表，选中新工作流
+  // Template instantiation callback: close browser, refresh workflow list, select new workflow
   const handleTemplateInstantiate = useCallback(async (workflowId: string) => {
     setShowTemplateBrowser(false);
     try {
@@ -1565,7 +1565,7 @@ function CanvasPageInner() {
     } catch { /* ignore */ }
   }, [handleSelectWorkflow]);
 
-  // 有效 agent 步骤数量
+  // Valid agent step count
   const agentStepCount = useMemo(() => buildSteps(nodes).length, [nodes, buildSteps]);
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -1595,7 +1595,7 @@ function CanvasPageInner() {
           )}
         </div>
         <div className="flex items-center gap-1 flex-wrap">
-          {/* 状态信息 */}
+          {/* Status info */}
           {selectedNodeIds.size >= 2 && (
             <Button variant="secondary" size="sm" onClick={createGroup}>
               <Group className="w-3.5 h-3.5 mr-1" />
@@ -1608,7 +1608,7 @@ function CanvasPageInner() {
             </span>
           )}
 
-          {/* 视图工具 */}
+          {/* View tools */}
           <div className="flex items-center gap-0.5 px-0.5 sm:px-1">
             <Button variant="secondary" onClick={() => setIsFullscreen(!isFullscreen)} title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}>
               {isFullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
@@ -1620,7 +1620,7 @@ function CanvasPageInner() {
 
           <div className="w-px h-5 bg-border-subtle hidden sm:block" />
 
-          {/* 文件操作 */}
+          {/* File operations */}
           <div className="flex items-center gap-0.5 px-0.5 sm:px-1">
             <Button variant="secondary" onClick={() => setShowWorkflowPanel(!showWorkflowPanel)} title={t("workflows.open_workflows")}>
               <FolderOpen className="w-4 h-4" />
@@ -1638,7 +1638,7 @@ function CanvasPageInner() {
 
           <div className="w-px h-5 bg-border-subtle hidden sm:block" />
 
-          {/* 画布操作 */}
+          {/* Canvas operations */}
           <div className="flex items-center gap-0.5 px-0.5 sm:px-1">
             <Button variant="secondary" onClick={() => { setNodes([]); setEdges([]); setEditingNode(null); }} title={t("common.clear")}>
               <Trash2 className="w-4 h-4" />
@@ -1650,7 +1650,7 @@ function CanvasPageInner() {
 
           <div className="w-px h-5 bg-border-subtle hidden sm:block" />
 
-          {/* 主操作 */}
+          {/* Primary actions */}
           <div className="flex items-center gap-1 sm:gap-1.5 pl-0.5 sm:pl-1">
             <Button variant="primary" onClick={handleSave} disabled={!workflowName.trim() || agentStepCount === 0}>
               <Save className="w-4 h-4" />
@@ -1679,7 +1679,7 @@ function CanvasPageInner() {
             isRunning={runningWorkflowId} t={t} />
         )}
 
-        {/* 节点库（可折叠） */}
+        {/* Node library (collapsible) */}
         <div className={`border-r border-border-subtle bg-surface/50 backdrop-blur overflow-y-auto transition-all duration-200 hidden sm:block ${
           sidebarCollapsed ? "w-10 px-1 py-2" : "w-52 p-3 space-y-4"
         }`}>
@@ -1717,7 +1717,7 @@ function CanvasPageInner() {
           )}
         </div>
 
-        {/* 画布 */}
+        {/* Canvas */}
         <main className="flex-1 relative">
           <div className="absolute top-3 left-3 right-3 z-10 flex gap-2">
             <input type="text" value={workflowName} onChange={(e) => setWorkflowName(e.target.value)}
@@ -1728,7 +1728,7 @@ function CanvasPageInner() {
               className="flex-1 max-w-sm rounded-xl border border-border-subtle bg-surface/90 backdrop-blur px-3 py-2 text-sm text-text-dim focus:border-brand focus:ring-2 focus:ring-brand/20 outline-none shadow-sm" />
           </div>
 
-          {/* 节点配置面板 */}
+          {/* Node configuration panel */}
           {editingNode && !showRunInput && (
             <NodeConfigPanel node={{
               ...editingNode,
@@ -1741,7 +1741,7 @@ function CanvasPageInner() {
               t={t} />
           )}
 
-          {/* 运行输入弹窗 */}
+          {/* Run input dialog */}
           {showRunInput && (
             <div className="absolute top-3 right-3 z-20 w-80 rounded-xl border border-border-subtle bg-surface shadow-2xl overflow-hidden">
               <div className="flex items-center justify-between px-3 py-2 bg-success/10 border-b border-border-subtle">
@@ -1794,7 +1794,7 @@ function CanvasPageInner() {
             defaultViewport={{ x: 50, y: 80, zoom: 1 }}
             minZoom={0.1} maxZoom={2}
             snapToGrid snapGrid={[12, 12]}
-            // 交互：默认拖拽=框选，空格+拖拽=平移
+            // Interaction: default drag = box select, space + drag = pan
             panOnDrag={spacePressed}
             selectionOnDrag={!spacePressed}
             panOnScroll
@@ -1818,7 +1818,7 @@ function CanvasPageInner() {
               maskColor={theme === "dark" ? "rgba(0,0,0,0.3)" : "rgba(0,0,0,0.08)"} />
           </ReactFlow>
 
-          {/* 空画布引导 */}
+          {/* Empty canvas guide */}
           {nodes.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
               <div className="text-center pointer-events-auto">
@@ -1831,7 +1831,7 @@ function CanvasPageInner() {
             </div>
           )}
 
-          {/* 右键上下文菜单 */}
+          {/* Right-click context menu */}
           {contextMenu && (
             <div className="fixed z-50 rounded-xl border border-border-subtle bg-surface shadow-2xl py-1 min-w-[160px]"
               style={{ left: contextMenu.x, top: contextMenu.y }}>
@@ -1881,7 +1881,7 @@ function CanvasPageInner() {
             </div>
           )}
 
-          {/* 运行结果面板 */}
+          {/* Run result panel */}
           {runResult && (
             <div className="absolute bottom-3 left-3 right-3 z-20 max-h-48 rounded-xl border border-border-subtle bg-surface shadow-2xl overflow-hidden flex flex-col">
               <div className="flex items-center justify-between px-3 py-2 bg-success/10 border-b border-border-subtle shrink-0">
@@ -1898,7 +1898,7 @@ function CanvasPageInner() {
         </main>
       </div>
 
-      {/* 模板浏览器 */}
+      {/* Template browser */}
       {showTemplateBrowser && (
         <TemplateBrowser
           onInstantiate={handleTemplateInstantiate}
@@ -1914,7 +1914,7 @@ function CanvasPageInner() {
         </div>
       )}
 
-      {/* 快捷键帮助面板 */}
+      {/* Shortcut help panel */}
       {showHelp && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-xl backdrop-saturate-150" onClick={() => setShowHelp(false)}>
           <div className="bg-surface rounded-2xl shadow-2xl border border-border-subtle w-[420px] max-w-[90vw] max-h-[80vh] overflow-y-auto animate-fade-in-scale" onClick={e => e.stopPropagation()}>

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -366,7 +366,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
         <div className="p-6">
         <p className="text-xs text-text-dim mb-5">{channel.description}</p>
 
-        {/* 已添加的配置 */}
+        {/* Added Configurations */}
         {Object.keys(configs).length > 0 && (
           <div className="space-y-2 mb-4">
             {Object.entries(configs).map(([key, value]) => (
@@ -384,7 +384,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
           </div>
         )}
 
-        {/* 配置字段 */}
+        {/* Configuration Fields */}
         {channel.fields && channel.fields.length > 0 ? (
           <div className="space-y-3 mb-6 max-h-60 overflow-y-auto">
             {channel.fields.filter(f => !f.advanced).map((field, idx) => (
@@ -408,7 +408,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
           </div>
         )}
 
-        {/* 按钮 */}
+        {/* Buttons */}
         <div className="flex gap-3">
           <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
           <Button variant="primary" className="flex-1" onClick={() => configMutation.mutate()} disabled={configMutation.isPending}>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -27,7 +27,7 @@ interface ChatMessage {
   memories_used?: string[];
 }
 
-// Slash 命令
+// Slash commands
 const SLASH_COMMANDS = [
   { cmd: "/help", desc: "Show available commands" },
   { cmd: "/clear", desc: "Clear chat history" },
@@ -35,7 +35,7 @@ const SLASH_COMMANDS = [
   { cmd: "/info", desc: "Show current agent info" },
 ];
 
-// Markdown 样式
+// Markdown styles
 const mdComponents = {
   p: ({ children }: any) => <p className="mb-2 last:mb-0">{children}</p>,
   h1: ({ children }: any) => <h1 className="text-lg font-bold mb-2">{children}</h1>,
@@ -59,7 +59,7 @@ const mdComponents = {
   a: ({ href, children }: any) => <a href={href} className="text-brand underline" target="_blank" rel="noopener noreferrer">{children}</a>,
 };
 
-// 流式打字机效果 + Markdown
+// Streaming typewriter effect + Markdown
 function Typewriter({ text, speed = 15 }: { text: string; speed?: number }) {
   const [displayed, setDisplayed] = useState("");
   const done = displayed.length >= text.length;
@@ -142,14 +142,14 @@ function useWebSocket(agentId: string | null) {
   return { ws: wsRef, wsConnected };
 }
 
-// 聊天消息管理 - 包含历史加载和发送 (with WS streaming)
+// Chat message management - includes history loading and sending (with WS streaming)
 function useChatMessages(agentId: string | null, agents: any[] = []) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { ws, wsConnected } = useWebSocket(agentId);
   const addSkillOutput = useUIStore((s) => s.addSkillOutput);
 
-  // 加载历史记录
+  // Load history
   useEffect(() => {
     if (!agentId) return;
     loadAgentSession(agentId)
@@ -167,12 +167,12 @@ function useChatMessages(agentId: string | null, agents: any[] = []) {
       .catch(() => {});
   }, [agentId]);
 
-  // 发送消息 - WS优先，HTTP回退
+  // Send message - WS first, HTTP fallback
   const sendMessage = useCallback(async (content: string) => {
     if (!content.trim()) return;
     const trimmed = content.trim();
 
-    // Slash 命令处理
+    // Slash command handling
     if (trimmed.startsWith("/")) {
       const sysMsg = (text: string) => {
         setMessages(prev => [...prev,
@@ -352,7 +352,7 @@ function useChatMessages(agentId: string | null, agents: any[] = []) {
   return { messages, isLoading, sendMessage, clearHistory, wsConnected };
 }
 
-// 消息气泡组件
+// Message bubble component
 function MessageBubble({ message }: { message: ChatMessage }) {
   const { t } = useTranslation();
   const isUser = message.role === "user";
@@ -372,7 +372,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} animate-fade-in-up`}>
       <div className={`flex flex-col max-w-[90%] sm:max-w-[75%] ${isUser ? "items-end" : "items-start"}`}>
-        {/* 头像 + 名字 */}
+        {/* Avatar + name */}
         <div className={`flex items-center gap-2 mb-1.5 ${isUser ? "self-end flex-row-reverse" : "self-start"}`}>
           <div className={`h-7 w-7 rounded-lg flex items-center justify-center ${
             isUser ? "bg-gradient-to-br from-brand to-accent text-white shadow-md" : "bg-surface border border-border-subtle"
@@ -384,7 +384,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           </span>
         </div>
 
-        {/* 消息内容 */}
+        {/* Message content */}
         <div className={`relative px-4 py-3 rounded-2xl text-sm leading-relaxed shadow-sm transition-all ${
           isUser
             ? "bg-gradient-to-br from-brand to-brand/90 text-white rounded-tr-md"
@@ -408,7 +408,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           )}
         </div>
 
-        {/* 元信息 */}
+        {/* Meta info */}
         <div className="flex items-center gap-2 mt-1.5 text-[10px] text-text-dim/50">
           <span>{message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
           {message.tokens?.output && !message.isStreaming && (
@@ -436,7 +436,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   );
 }
 
-// 输入框 - 带快捷键提示
+// Input box - with shortcut hints
 function ChatInput({ onSend, disabled, placeholder }: { onSend: (msg: string) => void; disabled: boolean; placeholder: string }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
@@ -462,7 +462,7 @@ function ChatInput({ onSend, disabled, placeholder }: { onSend: (msg: string) =>
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2">
-      {/* Slash 命令补全 */}
+      {/* Slash command autocomplete */}
       {showingSlash && filteredCmds.length > 0 && (
         <div className="rounded-xl border border-border-subtle bg-surface shadow-lg p-1 mb-1">
           {filteredCmds.map(c => (
@@ -508,7 +508,7 @@ function ChatInput({ onSend, disabled, placeholder }: { onSend: (msg: string) =>
   );
 }
 
-// 连接状态栏
+// Connection status bar
 function ConnectionBar({ agentName, isLoading, messageCount, onClear, wsConnected }: { agentName: string; isLoading: boolean; messageCount: number; onClear: () => void; wsConnected?: boolean }) {
   const { t } = useTranslation();
   return (
@@ -710,7 +710,7 @@ export function ChatPage() {
     }
   }, [agents, selectedAgentId]);
 
-  // 滚动到最新消息
+  // Scroll to latest message
   useEffect(() => {
     if (messages.length > 0) {
       setTimeout(() => {
@@ -721,7 +721,7 @@ export function ChatPage() {
 
   return (
     <div className="flex h-[calc(100vh-100px)] sm:h-[calc(100vh-140px)] flex-col">
-      {/* 头部 */}
+      {/* Header */}
       <header className="pb-2 sm:pb-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 sm:gap-3">
@@ -741,9 +741,9 @@ export function ChatPage() {
         </div>
       </header>
 
-      {/* 主内容区 */}
+      {/* Main content area */}
       <div className="flex flex-1 overflow-hidden rounded-2xl border border-border-subtle bg-surface shadow-xl ring-1 ring-black/5 dark:ring-white/5">
-        {/* 左侧 Agent 列表 */}
+        {/* Left sidebar - Agent list */}
         <aside className="hidden md:flex w-64 flex-shrink-0 border-r border-border-subtle bg-main/30 backdrop-blur-md flex-col">
           <div className="p-4 border-b border-border-subtle">
             <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-text-dim/60">{t("nav.agents")}</h3>
@@ -787,9 +787,9 @@ export function ChatPage() {
           </div>
         </aside>
 
-        {/* 右侧聊天区域 */}
+        {/* Right side - Chat area */}
         <main className="flex-1 flex flex-col overflow-hidden bg-main/10 relative">
-          {/* 背景装饰 */}
+          {/* Background decoration */}
           <div className="absolute inset-0 pointer-events-none opacity-30">
             <div className="absolute top-0 left-0 w-64 h-64 bg-brand/5 rounded-full blur-3xl" />
             <div className="absolute bottom-0 right-0 w-48 h-48 bg-accent/5 rounded-full blur-3xl" />
@@ -821,7 +821,7 @@ export function ChatPage() {
             />
           )}
 
-          {/* 消息区域 */}
+          {/* Message area */}
           <div className="flex-1 overflow-y-auto p-3 sm:p-6 space-y-4 sm:space-y-6 scrollbar-thin">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
@@ -855,7 +855,7 @@ export function ChatPage() {
             )}
           </div>
 
-          {/* 输入区域 */}
+          {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface/90 backdrop-blur-md transition-all ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
               onSend={sendMessage}

--- a/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
@@ -61,7 +61,7 @@ export function LogsPage() {
       />
 
       <Card padding="none" className="flex-1 overflow-hidden">
-        {/* 搜索和筛选 */}
+        {/* Search and Filter */}
         <div className="bg-main border-b border-border-subtle px-3 sm:px-6 py-3 flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-4">
           <div className="flex-1">
             <Input

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -57,7 +57,7 @@ export function OverviewPage() {
     }
   };
 
-  // 统计卡片数据
+  // Stats card data
   const statsCards = [
     {
       title: t("overview.active_agents"),
@@ -95,7 +95,7 @@ export function OverviewPage() {
     },
   ];
 
-  // 快捷操作
+  // Quick actions
   const quickActions = [
     { label: t("overview.new_workflow"), to: "/canvas", icon: Zap, primary: true },
     { label: t("overview.deploy_agent"), to: "/agents", icon: Users },

--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
@@ -64,7 +64,7 @@ export function SettingsPage() {
       />
 
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
-        {/* 外观设置 */}
+        {/* Appearance Settings */}
         <Card padding="lg" hover>
           <h2 className="text-lg font-black tracking-tight mb-6">{t("settings.appearance")}</h2>
           <div className="space-y-8">
@@ -104,7 +104,7 @@ export function SettingsPage() {
           </div>
         </Card>
 
-        {/* Tools 管理 */}
+        {/* Tools Management */}
         <Card padding="lg" hover>
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-black tracking-tight flex items-center gap-2">

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -136,7 +136,7 @@ export function WorkflowsPage() {
         }
       />
 
-      {/* 模板推荐区 — 从 API 加载 */}
+      {/* Template Recommendations — loaded from API */}
       {apiTemplates.length > 0 && (
       <div>
         <h2 className="text-xs font-bold uppercase tracking-widest text-text-dim/50 mb-3">{t("workflows.templates")}</h2>
@@ -168,22 +168,22 @@ export function WorkflowsPage() {
       </div>
       )}
 
-      {/* 搜索栏 */}
+      {/* Search Bar */}
       {hasWorkflows && (
         <Input value={searchQuery} onChange={e => setSearchQuery(e.target.value)}
           placeholder={t("workflows.search_placeholder")}
           leftIcon={<Search className="h-4 w-4" />} />
       )}
 
-      {/* 加载骨架 */}
+      {/* Loading Skeleton */}
       {workflowsQuery.isLoading && (
         <ListSkeleton rows={3} />
       )}
 
-      {/* 主内容区 */}
+      {/* Main Content Area */}
       {hasWorkflows ? (
         <div className="grid gap-6 lg:grid-cols-[1fr_300px] xl:grid-cols-[1fr_340px]">
-          {/* 工作流列表 */}
+          {/* Workflow List */}
           <div className="space-y-2">
             <h2 className="text-xs font-bold uppercase tracking-widest text-text-dim/50 mb-1">
               {t("workflows.all_workflows")} ({workflows.length})
@@ -197,13 +197,13 @@ export function WorkflowsPage() {
                     ? "border-brand bg-brand/5 shadow-sm"
                     : "border-border-subtle bg-surface hover:border-brand/30 hover:shadow-sm"
                 }`}>
-                {/* 图标 */}
+                {/* Icon */}
                 <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${
                   selectedWorkflowId === wf.id ? "bg-brand text-white" : "bg-main text-brand"
                 }`}>
                   <Layers className="w-5 h-5" />
                 </div>
-                {/* 信息 */}
+                {/* Info */}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <h3 className="text-sm font-bold truncate">{wf.name}</h3>
@@ -217,7 +217,7 @@ export function WorkflowsPage() {
                     <span>{new Date(wf.created_at || "").toLocaleDateString()}</span>
                   </div>
                 </div>
-                {/* 操作 */}
+                {/* Actions */}
                 <div className="flex items-center gap-1 shrink-0" onClick={e => e.stopPropagation()}>
                   <button onClick={() => openWorkflow(wf.id)}
                     className="p-2 rounded-lg text-text-dim/40 hover:text-brand hover:bg-brand/10 transition-all"
@@ -240,7 +240,7 @@ export function WorkflowsPage() {
             ))}
           </div>
 
-          {/* 右侧面板：选中工作流后显示 */}
+          {/* Right Panel: shown when a workflow is selected */}
           {selectedWorkflowId && (
             <div className="space-y-4">
               <Card padding="lg" className="sticky top-4">
@@ -253,7 +253,7 @@ export function WorkflowsPage() {
                   {t("canvas.run_now")}
                 </Button>
 
-                {/* 运行结果 */}
+                {/* Run Result */}
                 {runMutation.data && (
                   <div className="mt-4 p-3 rounded-xl bg-success/5 border border-success/20">
                     <p className="text-[10px] font-bold text-success mb-1">{t("canvas.run_result")}</p>
@@ -272,7 +272,7 @@ export function WorkflowsPage() {
           )}
         </div>
       ) : (
-        /* 空状态 */
+        /* Empty State */
         !workflowsQuery.isLoading && (
           <div className="text-center py-16">
             <div className="w-16 h-16 rounded-2xl bg-brand/10 flex items-center justify-center mx-auto mb-4">

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2,14 +2,14 @@
 
 use super::AppState;
 
-/// 构建 Agent 领域的所有路由。
+/// Build all routes for the Agent domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route(
             "/agents",
             axum::routing::get(list_agents).post(spawn_agent),
         )
-        // 批量 agent 操作（放在 /agents/{id} 之前避免路径冲突）
+        // Bulk agent operations (placed before /agents/{id} to avoid path conflicts)
         .route(
             "/agents/bulk",
             axum::routing::post(bulk_create_agents).delete(bulk_delete_agents),
@@ -213,7 +213,7 @@ async fn resolve_manifest(
                 .join("agents")
                 .join(&safe_name)
                 .join("agent.toml");
-            // 使用 tokio::fs 避免在异步上下文中阻塞
+            // Use tokio::fs to avoid blocking in an async context
             match tokio::fs::read_to_string(&tmpl_path).await {
                 Ok(content) => content,
                 Err(_) => {

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -2,7 +2,7 @@
 
 use super::AppState;
 
-/// 构建预算和用量领域的路由。
+/// Build routes for the budget and usage domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route("/usage", axum::routing::get(usage_stats))

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1,6 +1,6 @@
 //! Channel configuration, status, and WhatsApp QR flow handlers.
 
-/// 构建 Channel 领域的路由。
+/// Build routes for the Channel domain.
 pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
     axum::Router::new()
         .route("/channels", axum::routing::get(list_channels))

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2,7 +2,7 @@
 
 use super::AppState;
 
-/// 构建配置/健康/安全/迁移领域的路由。
+/// Build routes for the config/health/security/migration domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route("/metrics", axum::routing::get(prometheus_metrics))

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -2,7 +2,7 @@
 
 use super::AppState;
 
-/// 构建目标管理领域的路由。
+/// Build routes for the goal management domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route("/goals", axum::routing::get(list_goals).post(create_goal))

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use super::AppState;
 
-/// 构建内存/KV 领域的路由。
+/// Build routes for the memory/KV domain.
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        // 全局 proactive memory 端点
+        // Global proactive memory endpoints
         .route(
             "/memory",
             axum::routing::get(memory_list).post(memory_add),
@@ -32,7 +32,7 @@ pub fn router() -> axum::Router<Arc<AppState>> {
             "/memory/user/{user_id}",
             axum::routing::get(memory_get_user),
         )
-        // 每个 agent 的 proactive memory 端点
+        // Per-agent proactive memory endpoints
         .route(
             "/memory/agents/{id}",
             axum::routing::get(memory_list_agent).delete(memory_reset_agent),

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -1,13 +1,16 @@
 //! Route handlers for the LibreFang API.
 //!
-//! 每个领域子模块导出一个 `router()` 函数来构建自己的路由树。
-//! `server.rs` 通过 `.merge()` 组合所有子路由器，避免在单一函数中维护数百行路由注册。
+//! Each domain sub-module exports a `router()` function that builds its own route tree.
+//! `server.rs` combines all sub-routers via `.merge()`, avoiding hundreds of route
+//! registrations in a single function.
 //!
-//! 处理函数仍通过 glob re-export 暴露，以保持 `routes::handler_name` 的向后兼容性
-//! （特别是 openapi.rs 的 utoipa 宏需要此路径格式）。
+//! Handler functions are still exposed via glob re-export to maintain
+//! `routes::handler_name` backward compatibility (in particular, the utoipa macros
+//! in openapi.rs require this path format).
 
-// 各模块都导出 `router()` 函数，glob re-export 会产生同名歧义，
-// 但 `router()` 只通过限定路径访问（如 `routes::agents::router()`），不会实际冲突。
+// All modules export a `router()` function; glob re-export causes a name ambiguity
+// warning, but `router()` is only accessed via qualified paths (e.g.
+// `routes::agents::router()`), so there is no actual conflict.
 #![allow(ambiguous_glob_reexports)]
 
 pub mod agents;
@@ -23,15 +26,16 @@ pub mod skills;
 pub mod system;
 pub mod workflows;
 
-// 通过 glob re-export 保持 `routes::handler_name` 向后兼容
-// （openapi.rs 的 utoipa 宏、ws.rs 等都依赖此路径格式）。
+// Glob re-export to keep `routes::handler_name` backward compatible
+// (utoipa macros in openapi.rs, ws.rs, etc. all depend on this path format).
 //
-// 原先 system.rs 和 workflows.rs 都导出了 `list_templates` / `get_template`，
-// 导致 E0659 名称歧义。已将 workflows.rs 中的版本重命名为
-// `list_workflow_templates` / `get_workflow_template` 以消除冲突。
+// Previously both system.rs and workflows.rs exported `list_templates` / `get_template`,
+// causing E0659 name ambiguity. The workflows.rs versions have been renamed to
+// `list_workflow_templates` / `get_workflow_template` to resolve the conflict.
 //
-// 各模块都导出了 `router()` 函数，glob re-export 会产生歧义警告，
-// 但 `router()` 只通过限定路径（如 `routes::agents::router()`）访问，不会实际冲突。
+// All modules export a `router()` function; glob re-export produces an ambiguity
+// warning, but `router()` is only accessed via qualified paths (e.g.
+// `routes::agents::router()`), so there is no actual conflict.
 pub use agents::*;
 pub use budget::*;
 pub use channels::*;

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -2,7 +2,7 @@
 
 use super::AppState;
 
-/// 构建网络/对等节点/A2A/通信领域的路由。
+/// Build routes for the network/peer/A2A/communication domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route("/peers", axum::routing::get(list_peers))
@@ -16,7 +16,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         )
         .route("/comms/send", axum::routing::post(comms_send))
         .route("/comms/task", axum::routing::post(comms_task))
-        // 内部管理用 A2A 端点（版本化 API）
+        // Internal management A2A endpoints (versioned API)
         .route(
             "/a2a/agents",
             axum::routing::get(a2a_list_external_agents),
@@ -36,7 +36,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         )
 }
 
-/// 构建协议级 A2A 路由（不受版本管理，挂载在根路径）。
+/// Build protocol-level A2A routes (not versioned, mounted at the root path).
 pub fn protocol_router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
         .route(

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use super::AppState;
 
-/// 构建上下文引擎插件领域的路由。
+/// Build routes for the context engine plugin domain.
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
         .route(

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1,6 +1,6 @@
 //! Model catalog, provider management, and Copilot OAuth handlers.
 
-/// 构建模型/提供者领域的路由。
+/// Build routes for the model/provider domain.
 pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
     axum::Router::new()
         .route("/models", axum::routing::get(list_models))

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -1,14 +1,14 @@
 //! Skills, marketplace, ClawHub, hands, and extension handlers.
 
-/// 构建技能/市场/Hands/MCP/集成/扩展领域的路由。
+/// Build routes for the skills/marketplace/hands/MCP/integrations/extensions domain.
 pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
     axum::Router::new()
-        // 技能
+        // Skills
         .route("/skills", axum::routing::get(list_skills))
         .route("/skills/install", axum::routing::post(install_skill))
         .route("/skills/uninstall", axum::routing::post(uninstall_skill))
         .route("/skills/create", axum::routing::post(create_skill))
-        // 市场 / ClawHub
+        // Marketplace / ClawHub
         .route(
             "/marketplace/search",
             axum::routing::get(marketplace_search),
@@ -45,7 +45,7 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
             "/skillhub/install",
             axum::routing::post(skillhub_install),
         )
-        // Hands（浏览器自动化引擎）
+        // Hands (browser automation engine)
         .route("/hands", axum::routing::get(list_hands))
         .route("/hands/install", axum::routing::post(install_hand))
         .route("/hands/active", axum::routing::get(list_active_hands))
@@ -86,7 +86,7 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
             "/hands/instances/{id}/browser",
             axum::routing::get(hand_instance_browser),
         )
-        // MCP 服务器管理
+        // MCP server management
         .route(
             "/mcp/servers",
             axum::routing::get(list_mcp_servers).post(add_mcp_server),
@@ -97,7 +97,7 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
                 .put(update_mcp_server)
                 .delete(delete_mcp_server),
         )
-        // 集成
+        // Integrations
         .route("/integrations", axum::routing::get(list_integrations))
         .route(
             "/integrations/available",
@@ -120,7 +120,7 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
             "/integrations/reload",
             axum::routing::post(reload_integrations),
         )
-        // 扩展
+        // Extensions
         .route("/extensions", axum::routing::get(list_extensions))
         .route(
             "/extensions/install",

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -3,15 +3,15 @@
 
 use super::AppState;
 
-/// 构建系统杂项领域的路由（审计、日志、工具、会话、审批、配对等）。
+/// Build routes for the system miscellaneous domain (audit, logs, tools, sessions, approvals, pairing, etc.).
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
-        // 配置文件与模板
+        // Profiles and templates
         .route("/profiles", axum::routing::get(list_profiles))
         .route("/profiles/{name}", axum::routing::get(get_profile))
         .route("/templates", axum::routing::get(list_agent_templates))
         .route("/templates/{name}", axum::routing::get(get_agent_template))
-        // Agent KV 存储
+        // Agent KV storage
         .route(
             "/memory/agents/{id}/kv",
             axum::routing::get(get_agent_kv),
@@ -30,15 +30,15 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/agents/{id}/memory/import",
             axum::routing::post(import_agent_memory),
         )
-        // 审计
+        // Audit
         .route("/audit/recent", axum::routing::get(audit_recent))
         .route("/audit/verify", axum::routing::get(audit_verify))
-        // 日志流
+        // Log streaming
         .route("/logs/stream", axum::routing::get(logs_stream))
-        // 工具
+        // Tools
         .route("/tools", axum::routing::get(list_tools))
         .route("/tools/{name}", axum::routing::get(get_tool))
-        // 会话管理
+        // Session management
         .route("/sessions", axum::routing::get(list_sessions))
         .route("/sessions/search", axum::routing::get(search_sessions))
         .route("/sessions/cleanup", axum::routing::post(session_cleanup))
@@ -54,7 +54,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/agents/{id}/sessions/by-label/{label}",
             axum::routing::get(find_session_by_label),
         )
-        // 审批
+        // Approvals
         .route(
             "/approvals",
             axum::routing::get(list_approvals).post(create_approval),
@@ -68,13 +68,13 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/approvals/{id}/reject",
             axum::routing::post(reject_request),
         )
-        // Webhook 触发（外部事件注入）
+        // Webhook triggers (external event injection)
         .route("/hooks/wake", axum::routing::post(webhook_wake))
         .route("/hooks/agent", axum::routing::post(webhook_agent))
-        // 聊天命令端点
+        // Chat command endpoints
         .route("/commands", axum::routing::get(list_commands))
         .route("/commands/{name}", axum::routing::get(get_command))
-        // 绑定
+        // Bindings
         .route(
             "/bindings",
             axum::routing::get(list_bindings).post(add_binding),
@@ -83,7 +83,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/bindings/{index}",
             axum::routing::delete(remove_binding),
         )
-        // 配对
+        // Pairing
         .route("/pairing/request", axum::routing::post(pairing_request))
         .route(
             "/pairing/complete",
@@ -95,7 +95,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::delete(pairing_remove_device),
         )
         .route("/pairing/notify", axum::routing::post(pairing_notify))
-        // 备份 / 恢复
+        // Backup / restore
         .route("/backup", axum::routing::post(create_backup))
         .route("/backups", axum::routing::get(list_backups))
         .route(
@@ -103,9 +103,9 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::delete(delete_backup),
         )
         .route("/restore", axum::routing::post(restore_backup))
-        // 队列状态
+        // Queue status
         .route("/queue/status", axum::routing::get(queue_status))
-        // 任务队列管理
+        // Task queue management
         .route("/tasks/status", axum::routing::get(task_queue_status))
         .route("/tasks/list", axum::routing::get(task_queue_list))
         .route(
@@ -116,7 +116,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/tasks/{id}/retry",
             axum::routing::post(task_queue_retry),
         )
-        // 事件 Webhook 订阅
+        // Event webhook subscriptions
         .route(
             "/webhooks/events",
             axum::routing::get(list_event_webhooks).post(create_event_webhook),
@@ -125,7 +125,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/webhooks/events/{id}",
             axum::routing::put(update_event_webhook).delete(delete_event_webhook),
         )
-        // 出站 Webhook 管理
+        // Outbound webhook management
         .route(
             "/webhooks",
             axum::routing::get(list_webhooks).post(create_webhook),

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -2,10 +2,10 @@
 
 use super::AppState;
 
-/// 构建工作流/触发器/调度/Cron 领域的路由。
+/// Build routes for the workflow/trigger/schedule/cron domain.
 pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
     axum::Router::new()
-        // 触发器
+        // Triggers
         .route(
             "/triggers",
             axum::routing::get(list_triggers).post(create_trigger),
@@ -14,7 +14,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/triggers/{id}",
             axum::routing::delete(delete_trigger).put(update_trigger),
         )
-        // 调度
+        // Schedules
         .route(
             "/schedules",
             axum::routing::get(list_schedules).post(create_schedule),
@@ -29,7 +29,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/schedules/{id}/run",
             axum::routing::post(run_schedule),
         )
-        // 工作流
+        // Workflows
         .route(
             "/workflows",
             axum::routing::get(list_workflows).post(create_workflow),
@@ -48,7 +48,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/workflows/{id}/runs",
             axum::routing::get(list_workflow_runs),
         )
-        // 工作流模板（与 system.rs 的 agent 模板不同）
+        // Workflow templates (distinct from the agent templates in system.rs)
         .route(
             "/workflow-templates",
             axum::routing::get(list_workflow_templates),
@@ -61,7 +61,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/workflow-templates/{id}/instantiate",
             axum::routing::post(instantiate_template),
         )
-        // Cron 作业
+        // Cron jobs
         .route(
             "/cron/jobs",
             axum::routing::get(list_cron_jobs).post(create_cron_job),

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -34,12 +34,14 @@ pub const API_VERSION_LATEST: &str = crate::versioning::CURRENT_VERSION;
 /// All available API versions with their status.
 pub const API_VERSIONS: &[(&str, &str)] = &[("v1", "stable")];
 
-/// 构建 v1 API 路由树。
+/// Build the v1 API route tree.
 ///
-/// 每个领域子模块提供自己的 `router()` 方法，此处通过 `.merge()` 组合。
-/// 路径相对于挂载点（如 `/health`、`/agents` 等），调用方将其嵌套在 `/api` 和 `/api/v1` 下。
+/// Each domain sub-module provides its own `router()` method, combined here via `.merge()`.
+/// Paths are relative to the mount point (e.g. `/health`, `/agents`, etc.); the caller
+/// nests them under `/api` and `/api/v1`.
 ///
-/// 未来添加 v2 时只需新建 `api_v2_routes()`，挂载到 `/api/v2`，然后更新 `API_VERSION_LATEST`。
+/// To add v2 in the future, just create `api_v2_routes()`, mount it at `/api/v2`,
+/// and update `API_VERSION_LATEST`.
 fn api_v1_routes() -> Router<Arc<AppState>> {
     Router::new()
         .merge(routes::config::router())
@@ -54,7 +56,7 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
         .merge(routes::providers::router())
         .merge(routes::budget::router())
         .merge(routes::goals::router())
-        // Dashboard 凭证登录（handler 定义在 server.rs 本地）
+        // Dashboard credential login (handler defined locally in server.rs)
         .route(
             "/auth/dashboard-login",
             axum::routing::post(dashboard_login),
@@ -63,7 +65,7 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
             "/auth/dashboard-check",
             axum::routing::get(dashboard_auth_check),
         )
-        // OAuth/OIDC 外部认证端点
+        // OAuth/OIDC external authentication endpoints
         .route(
             "/auth/providers",
             axum::routing::get(crate::oauth::auth_providers),
@@ -350,12 +352,12 @@ pub async fn build_router(
         .nest("/api/v1", v1_routes.clone())
         // Mount the same routes at /api (latest version alias for backward compat)
         .nest("/api", v1_routes)
-        // Webhook 触发端点（不受版本管理 — 外部调用方使用固定 URL）
+        // Webhook trigger endpoints (not versioned — external callers use fixed URLs)
         .route("/hooks/wake", axum::routing::post(routes::webhook_wake))
         .route("/hooks/agent", axum::routing::post(routes::webhook_agent))
-        // A2A 协议端点 + MCP HTTP（协议级别，不受版本管理）
+        // A2A protocol endpoints + MCP HTTP (protocol-level, not versioned)
         .merge(routes::network::protocol_router())
-        // MCP HTTP 端点（协议级别，不受版本管理）
+        // MCP HTTP endpoint (protocol-level, not versioned)
         .route("/mcp", axum::routing::post(routes::mcp_http))
         // OpenAI-compatible API (follows OpenAI versioning, not ours)
         .route(

--- a/crates/librefang-testing/Cargo.toml
+++ b/crates/librefang-testing/Cargo.toml
@@ -3,7 +3,7 @@ name = "librefang-testing"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "测试基础设施：提供 mock kernel、mock LLM driver 和 API 路由测试工具"
+description = "Test infrastructure: mock kernel, mock LLM driver and API route test utilities"
 
 [dependencies]
 librefang-types = { path = "../librefang-types" }

--- a/crates/librefang-testing/src/helpers.rs
+++ b/crates/librefang-testing/src/helpers.rs
@@ -1,16 +1,16 @@
-//! 测试辅助函数 — HTTP 请求构建和响应断言。
+//! Test helper functions — HTTP request building and response assertions.
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 
-/// 构建一个测试用的 HTTP 请求。
+/// Builds a test HTTP request.
 ///
-/// # 参数
-/// - `method` — HTTP 方法（GET、POST 等）
-/// - `path` — 请求路径（例如 "/api/health"）
-/// - `body` — 请求体（None 表示空 body）
+/// # Parameters
+/// - `method` — HTTP method (GET, POST, etc.)
+/// - `path` — Request path (e.g. "/api/health")
+/// - `body` — Request body (None for empty body)
 ///
-/// # 示例
+/// # Example
 ///
 /// ```rust
 /// use librefang_testing::test_request;
@@ -35,16 +35,16 @@ pub fn test_request(method: Method, path: &str, body: Option<&str>) -> Request<B
         None => Body::empty(),
     };
 
-    builder.body(body).expect("构建测试请求失败")
+    builder.body(body).expect("failed to build test request")
 }
 
-/// 断言响应状态码为 200 且 body 是有效的 JSON。
+/// Asserts the response status is 200 and the body is valid JSON.
 ///
-/// 返回解析后的 `serde_json::Value`。
+/// Returns the parsed `serde_json::Value`.
 ///
 /// # Panics
 ///
-/// 如果状态码不是 200 或 body 不是有效 JSON，则 panic。
+/// Panics if the status code is not 200 or the body is not valid JSON.
 pub async fn assert_json_ok(response: axum::http::Response<Body>) -> serde_json::Value {
     let status = response.status();
     let body = read_body(response).await;
@@ -52,21 +52,21 @@ pub async fn assert_json_ok(response: axum::http::Response<Body>) -> serde_json:
     assert_eq!(
         status,
         StatusCode::OK,
-        "期望状态码 200，实际为 {status}。响应体: {body}"
+        "expected status 200, got {status}. Response body: {body}"
     );
 
     serde_json::from_str(&body).unwrap_or_else(|e| {
-        panic!("响应体不是有效的 JSON: {e}。原始内容: {body}");
+        panic!("response body is not valid JSON: {e}. Raw content: {body}");
     })
 }
 
-/// 断言响应状态码为指定的错误码且 body 是有效的 JSON。
+/// Asserts the response status matches the expected error code and the body is valid JSON.
 ///
-/// 返回解析后的 `serde_json::Value`。
+/// Returns the parsed `serde_json::Value`.
 ///
 /// # Panics
 ///
-/// 如果状态码不匹配或 body 不是有效 JSON，则 panic。
+/// Panics if the status code does not match or the body is not valid JSON.
 pub async fn assert_json_error(
     response: axum::http::Response<Body>,
     expected_status: StatusCode,
@@ -76,22 +76,22 @@ pub async fn assert_json_error(
 
     assert_eq!(
         status, expected_status,
-        "期望状态码 {expected_status}，实际为 {status}。响应体: {body}"
+        "expected status {expected_status}, got {status}. Response body: {body}"
     );
 
     serde_json::from_str(&body).unwrap_or_else(|e| {
-        panic!("响应体不是有效的 JSON: {e}。原始内容: {body}");
+        panic!("response body is not valid JSON: {e}. Raw content: {body}");
     })
 }
 
-/// 读取 response body 为字符串。
+/// Reads the response body as a string.
 async fn read_body(response: axum::http::Response<Body>) -> String {
     use http_body_util::BodyExt;
     let bytes = response
         .into_body()
         .collect()
         .await
-        .expect("读取响应体失败")
+        .expect("failed to read response body")
         .to_bytes();
-    String::from_utf8(bytes.to_vec()).expect("响应体不是有效的 UTF-8")
+    String::from_utf8(bytes.to_vec()).expect("response body is not valid UTF-8")
 }

--- a/crates/librefang-testing/src/lib.rs
+++ b/crates/librefang-testing/src/lib.rs
@@ -1,13 +1,13 @@
-//! # librefang-testing — 测试基础设施
+//! # librefang-testing — Test Infrastructure
 //!
-//! 提供用于单元测试 API 路由的 mock 基础设施，无需启动完整的 daemon。
+//! Provides mock infrastructure for unit testing API routes without starting a full daemon.
 //!
-//! ## 主要组件
+//! ## Main Components
 //!
-//! - [`MockKernelBuilder`] — 构建最小化的 `LibreFangKernel`（内存 SQLite，临时目录）
-//! - [`MockLlmDriver`] — 可配置的 LLM 驱动 mock，支持录制调用和固定回复
-//! - [`TestAppState`] — 构建适用于 axum 测试的 `AppState`
-//! - 辅助函数 — `test_request`、`assert_json_ok`、`assert_json_error`
+//! - [`MockKernelBuilder`] — Builds a minimal `LibreFangKernel` (in-memory SQLite, temp directory)
+//! - [`MockLlmDriver`] — Configurable LLM driver mock with call recording and canned responses
+//! - [`TestAppState`] — Builds an `AppState` suitable for axum testing
+//! - Helper functions — `test_request`, `assert_json_ok`, `assert_json_error`
 
 pub mod helpers;
 pub mod mock_driver;

--- a/crates/librefang-testing/src/mock_driver.rs
+++ b/crates/librefang-testing/src/mock_driver.rs
@@ -1,9 +1,9 @@
-//! Mock LLM 驱动 — 用于测试的可配置假 LLM 提供程序。
+//! Mock LLM driver — a configurable fake LLM provider for testing.
 //!
-//! 支持：
-//! - 返回固定回复（canned responses）
-//! - 记录所有请求以便断言
-//! - 模拟流式响应
+//! Supports:
+//! - Returning canned responses
+//! - Recording all requests for assertions
+//! - Simulating streaming responses
 
 use async_trait::async_trait;
 use librefang_runtime::llm_driver::{
@@ -12,45 +12,48 @@ use librefang_runtime::llm_driver::{
 use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
 use std::sync::{Arc, Mutex};
 
-/// 记录的 LLM 调用信息。
+/// Recorded LLM call information.
 #[derive(Debug, Clone)]
 pub struct RecordedCall {
-    /// 请求中的模型名称。
+    /// Model name from the request.
     pub model: String,
-    /// 消息数量。
+    /// Number of messages.
     pub message_count: usize,
-    /// 工具定义数量。
+    /// Number of tool definitions.
     pub tool_count: usize,
-    /// 系统提示（如有）。
+    /// System prompt (if any).
     pub system: Option<String>,
 }
 
-/// Mock LLM 驱动 — 返回可配置的固定回复，并记录所有调用。
+/// Mock LLM driver — returns configurable canned responses and records all calls.
 pub struct MockLlmDriver {
-    /// 固定回复文本列表，按顺序返回。用完后循环使用最后一个。
+    /// List of canned response texts, returned in order. Wraps around to the last one when exhausted.
     responses: Vec<String>,
-    /// 已记录的调用。
+    /// Recorded calls.
     calls: Arc<Mutex<Vec<RecordedCall>>>,
-    /// 当前回复索引。
+    /// Current response index.
     index: Arc<Mutex<usize>>,
-    /// 自定义输入 token 数（默认 10）。
+    /// Custom input token count (default 10).
     input_tokens: u64,
-    /// 自定义输出 token 数（默认 5）。
+    /// Custom output token count (default 5).
     output_tokens: u64,
-    /// 自定义停止原因（默认 EndTurn）。
+    /// Custom stop reason (default EndTurn).
     stop_reason: StopReason,
 }
 
 impl MockLlmDriver {
-    /// 创建一个返回固定回复的 mock driver。
+    /// Creates a mock driver that returns canned responses.
     ///
     /// ```rust
     /// use librefang_testing::MockLlmDriver;
     ///
-    /// let driver = MockLlmDriver::new(vec!["你好！".into()]);
+    /// let driver = MockLlmDriver::new(vec!["Hello!".into()]);
     /// ```
     pub fn new(responses: Vec<String>) -> Self {
-        assert!(!responses.is_empty(), "MockLlmDriver 需要至少一个固定回复");
+        assert!(
+            !responses.is_empty(),
+            "MockLlmDriver requires at least one canned response"
+        );
         Self {
             responses,
             calls: Arc::new(Mutex::new(Vec::new())),
@@ -61,12 +64,12 @@ impl MockLlmDriver {
         }
     }
 
-    /// 创建始终返回同一回复的 mock driver。
+    /// Creates a mock driver that always returns the same response.
     pub fn with_response(response: impl Into<String>) -> Self {
         Self::new(vec![response.into()])
     }
 
-    /// 设置自定义 token 用量（覆盖默认的 input=10, output=5）。
+    /// Sets custom token usage (overrides the default input=10, output=5).
     ///
     /// ```rust
     /// use librefang_testing::MockLlmDriver;
@@ -79,7 +82,7 @@ impl MockLlmDriver {
         self
     }
 
-    /// 设置自定义停止原因（覆盖默认的 EndTurn）。
+    /// Sets a custom stop reason (overrides the default EndTurn).
     ///
     /// ```rust
     /// use librefang_testing::MockLlmDriver;
@@ -92,23 +95,23 @@ impl MockLlmDriver {
         self
     }
 
-    /// 返回已记录的所有调用。
+    /// Returns all recorded calls.
     pub fn recorded_calls(&self) -> Vec<RecordedCall> {
         self.calls.lock().unwrap().clone()
     }
 
-    /// 返回调用次数。
+    /// Returns the number of calls made.
     pub fn call_count(&self) -> usize {
         self.calls.lock().unwrap().len()
     }
 
-    /// 获取下一个回复文本。
+    /// Gets the next response text.
     fn next_response(&self) -> String {
         let mut idx = self.index.lock().unwrap();
         let response = if *idx < self.responses.len() {
             self.responses[*idx].clone()
         } else {
-            // 用完后循环使用最后一个
+            // Wrap around to the last response when exhausted
             self.responses.last().unwrap().clone()
         };
         *idx += 1;
@@ -119,7 +122,7 @@ impl MockLlmDriver {
 #[async_trait]
 impl LlmDriver for MockLlmDriver {
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        // 记录调用
+        // Record the call
         {
             let call = RecordedCall {
                 model: request.model.clone(),
@@ -152,7 +155,7 @@ impl LlmDriver for MockLlmDriver {
         request: CompletionRequest,
         tx: tokio::sync::mpsc::Sender<StreamEvent>,
     ) -> Result<CompletionResponse, LlmError> {
-        // 模拟流式：先发送 TextDelta，再发送 ContentComplete
+        // Simulate streaming: send TextDelta first, then ContentComplete
         let response = self.complete(request).await?;
         let text = response.text();
         if !text.is_empty() {
@@ -172,13 +175,13 @@ impl LlmDriver for MockLlmDriver {
     }
 }
 
-/// 始终返回错误的 mock driver，用于测试错误处理。
+/// A mock driver that always returns errors, used for testing error handling.
 pub struct FailingLlmDriver {
     error_message: String,
 }
 
 impl FailingLlmDriver {
-    /// 创建一个始终返回指定错误的 driver。
+    /// Creates a driver that always returns the specified error.
     pub fn new(error_message: impl Into<String>) -> Self {
         Self {
             error_message: error_message.into(),

--- a/crates/librefang-testing/src/mock_kernel.rs
+++ b/crates/librefang-testing/src/mock_kernel.rs
@@ -1,21 +1,22 @@
-//! MockKernelBuilder — 构建最小化的 `LibreFangKernel` 用于测试。
+//! MockKernelBuilder — Builds a minimal `LibreFangKernel` for testing.
 //!
-//! 使用内存 SQLite、临时目录，跳过网络/OFP/cron 等重量级初始化。
-//! 底层通过 `LibreFangKernel::boot_with_config` 构建真实 kernel 实例。
+//! Uses in-memory SQLite and a temp directory, skipping heavy initialization
+//! like networking/OFP/cron. Internally uses `LibreFangKernel::boot_with_config`
+//! to construct a real kernel instance.
 
 use librefang_kernel::LibreFangKernel;
 use librefang_types::config::KernelConfig;
 use tempfile::TempDir;
 
-/// 测试用 kernel 构建器。
+/// Test kernel builder.
 ///
-/// 通过 builder 模式配置 kernel，然后调用 `.build()` 生成一个
-/// 真实的 `LibreFangKernel` 实例（使用临时目录和内存数据库）。
+/// Configures the kernel via the builder pattern, then call `.build()` to produce
+/// a real `LibreFangKernel` instance (using a temp directory and in-memory database).
 ///
-/// # 示例
+/// # Example
 ///
 /// ```rust,ignore
-/// // ignore: 需要完整 kernel 启动环境（临时目录、SQLite），详见 tests.rs 中的集成测试
+/// // ignore: requires full kernel boot environment (temp directory, SQLite), see integration tests in tests.rs
 /// use librefang_testing::MockKernelBuilder;
 ///
 /// let (kernel, _tmp) = MockKernelBuilder::new().build();
@@ -25,12 +26,12 @@ type ConfigFn = Box<dyn FnOnce(&mut KernelConfig)>;
 
 pub struct MockKernelBuilder {
     config: KernelConfig,
-    /// 自定义 config 修改函数。
+    /// Custom config modification function.
     config_fn: Option<ConfigFn>,
 }
 
 impl MockKernelBuilder {
-    /// 创建一个使用默认最小配置的 builder。
+    /// Creates a builder with the default minimal configuration.
     pub fn new() -> Self {
         Self {
             config: KernelConfig::default(),
@@ -38,10 +39,10 @@ impl MockKernelBuilder {
         }
     }
 
-    /// 设置自定义的 config 修改函数。
+    /// Sets a custom config modification function.
     ///
     /// ```rust,ignore
-    /// // ignore: 需要完整 kernel 启动环境（临时目录、SQLite），详见 tests.rs 中的集成测试
+    /// // ignore: requires full kernel boot environment (temp directory, SQLite), see integration tests in tests.rs
     /// use librefang_testing::MockKernelBuilder;
     ///
     /// let (kernel, _tmp) = MockKernelBuilder::new()
@@ -55,34 +56,37 @@ impl MockKernelBuilder {
         self
     }
 
-    /// 构建 kernel 实例。
+    /// Builds the kernel instance.
     ///
-    /// 返回 `(LibreFangKernel, TempDir)` — 调用方必须持有 `TempDir`，
-    /// 否则临时目录会在 drop 时被删除，导致 kernel 文件路径失效。
+    /// Returns `(LibreFangKernel, TempDir)` — the caller must hold onto `TempDir`,
+    /// otherwise the temp directory will be deleted on drop, invalidating kernel file paths.
     pub fn build(mut self) -> (LibreFangKernel, TempDir) {
-        let tmp = tempfile::tempdir().expect("无法创建临时目录");
+        let tmp = tempfile::tempdir().expect("failed to create temp directory");
         let home_dir = tmp.path().to_path_buf();
         let data_dir = home_dir.join("data");
 
-        // 确保必要目录存在
-        std::fs::create_dir_all(&data_dir).expect("无法创建 data 目录");
-        std::fs::create_dir_all(home_dir.join("skills")).expect("无法创建 skills 目录");
-        std::fs::create_dir_all(home_dir.join("workspaces")).expect("无法创建 workspaces 目录");
+        // Ensure required directories exist
+        std::fs::create_dir_all(&data_dir).expect("failed to create data directory");
+        std::fs::create_dir_all(home_dir.join("skills"))
+            .expect("failed to create skills directory");
+        std::fs::create_dir_all(home_dir.join("workspaces"))
+            .expect("failed to create workspaces directory");
 
-        // 配置最小化 kernel
+        // Configure minimal kernel
         self.config.home_dir = home_dir;
         self.config.data_dir = data_dir;
         self.config.network_enabled = false;
-        // 使用内存 SQLite（设置路径为 :memory: 无效，boot_with_config 会用文件路径）
-        // 因此使用临时目录下的文件路径即可
+        // Use in-memory SQLite (setting path to :memory: doesn't work; boot_with_config uses file paths)
+        // So we use a file path under the temp directory instead
         self.config.memory.sqlite_path = Some(self.config.data_dir.join("test.db"));
 
-        // 应用自定义配置
+        // Apply custom configuration
         if let Some(f) = self.config_fn.take() {
             f(&mut self.config);
         }
 
-        let kernel = LibreFangKernel::boot_with_config(self.config).expect("测试 kernel 启动失败");
+        let kernel =
+            LibreFangKernel::boot_with_config(self.config).expect("failed to boot test kernel");
 
         (kernel, tmp)
     }
@@ -94,9 +98,9 @@ impl Default for MockKernelBuilder {
     }
 }
 
-/// 快速构建一个默认的测试 kernel（便捷函数）。
+/// Quickly builds a default test kernel (convenience function).
 ///
-/// 等价于 `MockKernelBuilder::new().build()`。
+/// Equivalent to `MockKernelBuilder::new().build()`.
 pub fn test_kernel() -> (LibreFangKernel, TempDir) {
     MockKernelBuilder::new().build()
 }

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -1,6 +1,6 @@
-//! TestAppState — 构建适用于 axum 路由测试的 `AppState` 和 `Router`。
+//! TestAppState — Builds an `AppState` and `Router` suitable for axum route testing.
 //!
-//! 封装了 `MockKernelBuilder` 的输出，提供快速构建测试路由器的方法。
+//! Wraps the output of `MockKernelBuilder` and provides quick construction of test routers.
 
 use crate::mock_kernel::MockKernelBuilder;
 use axum::Router;
@@ -10,60 +10,60 @@ use std::sync::Arc;
 use std::time::Instant;
 use tempfile::TempDir;
 
-/// 测试用 AppState 构建器。
+/// Test AppState builder.
 ///
-/// # 示例
+/// # Example
 ///
 /// ```rust,ignore
-/// // ignore: 需要完整 kernel 启动环境（临时目录、SQLite），详见 tests.rs 中的集成测试
+/// // ignore: requires full kernel boot environment (temp directory, SQLite), see integration tests in tests.rs
 /// use librefang_testing::TestAppState;
 ///
 /// let test = TestAppState::new();
 /// let router = test.router();
-/// // 现在可以使用 tower::ServiceExt 发送测试请求
+/// // Now you can use tower::ServiceExt to send test requests
 /// ```
 pub struct TestAppState {
-    /// 共享的 AppState（和生产环境相同的类型）。
+    /// Shared AppState (same type as production).
     pub state: Arc<AppState>,
-    /// 临时目录 — 必须持有引用，否则目录会被删除。
+    /// Temp directory — must hold the reference, otherwise the directory will be deleted.
     _tmp: TempDir,
 }
 
 impl TestAppState {
-    /// 使用默认 mock kernel 创建 TestAppState。
+    /// Creates a TestAppState using the default mock kernel.
     pub fn new() -> Self {
         Self::with_builder(MockKernelBuilder::new())
     }
 
-    /// 使用自定义 MockKernelBuilder 创建 TestAppState。
+    /// Creates a TestAppState using a custom MockKernelBuilder.
     pub fn with_builder(builder: MockKernelBuilder) -> Self {
         let (kernel, tmp) = builder.build();
         let state = Self::build_state(kernel, &tmp);
         Self { state, _tmp: tmp }
     }
 
-    /// 从已有的 kernel 构建（调用方负责持有 TempDir）。
+    /// Builds from an existing kernel (caller is responsible for holding TempDir).
     pub fn from_kernel(kernel: LibreFangKernel, tmp: TempDir) -> Self {
         let state = Self::build_state(kernel, &tmp);
         Self { state, _tmp: tmp }
     }
 
-    /// 构建一个包含常用 API 路由的 axum Router（适合测试）。
+    /// Builds an axum Router with common API routes (suitable for testing).
     ///
-    /// 返回的 Router 已嵌套在 `/api` 路径下，和生产环境一致。
-    /// 涵盖 agents CRUD、skills、config、memory、budget、system 等主要端点。
+    /// The returned Router is nested under the `/api` path, matching the production setup.
+    /// Covers agents CRUD, skills, config, memory, budget, system, and other main endpoints.
     pub fn router(&self) -> Router {
         use axum::routing::{get, post, put};
         use librefang_api::routes;
 
         let api = Router::new()
-            // ── 系统端点 ──
+            // -- System endpoints --
             .route("/health", get(routes::health))
             .route("/health/detail", get(routes::health_detail))
             .route("/status", get(routes::status))
             .route("/version", get(routes::version))
             .route("/metrics", get(routes::prometheus_metrics))
-            // ── Agents CRUD ──
+            // -- Agents CRUD --
             .route("/agents", get(routes::list_agents).post(routes::spawn_agent))
             .route(
                 "/agents/{id}",
@@ -84,31 +84,31 @@ impl TestAppState {
             .route("/agents/{id}/tools", get(routes::get_agent_tools).put(routes::set_agent_tools))
             .route("/agents/{id}/skills", get(routes::get_agent_skills).put(routes::set_agent_skills))
             .route("/agents/{id}/logs", get(routes::agent_logs))
-            // ── Profiles ──
+            // -- Profiles --
             .route("/profiles", get(routes::list_profiles))
             .route("/profiles/{name}", get(routes::get_profile))
-            // ── Skills ──
+            // -- Skills --
             .route("/skills", get(routes::list_skills))
             .route("/skills/create", post(routes::create_skill))
-            // ── Config ──
+            // -- Config --
             .route("/config", get(routes::get_config))
             .route("/config/schema", get(routes::config_schema))
             .route("/config/set", post(routes::config_set))
             .route("/config/reload", post(routes::config_reload))
-            // ── Memory ──
+            // -- Memory --
             .route("/memory/search", get(routes::memory_search))
             .route("/memory/stats", get(routes::memory_stats))
-            // ── Budget / Usage ──
+            // -- Budget / Usage --
             .route("/usage", get(routes::usage_stats))
             .route("/usage/summary", get(routes::usage_summary))
-            // ── Tools & Commands ──
+            // -- Tools & Commands --
             .route("/tools", get(routes::list_tools))
             .route("/tools/{name}", get(routes::get_tool))
             .route("/commands", get(routes::list_commands))
-            // ── Models & Providers ──
+            // -- Models & Providers --
             .route("/models", get(routes::list_models))
             .route("/providers", get(routes::list_providers))
-            // ── Sessions ──
+            // -- Sessions --
             .route("/sessions", get(routes::list_sessions));
 
         Router::new()
@@ -116,12 +116,12 @@ impl TestAppState {
             .with_state(self.state.clone())
     }
 
-    /// 获取 AppState 的 Arc 引用。
+    /// Returns an Arc reference to the AppState.
     pub fn app_state(&self) -> Arc<AppState> {
         self.state.clone()
     }
 
-    /// 内部：从 kernel 构建 AppState。
+    /// Internal: builds AppState from a kernel.
     fn build_state(kernel: LibreFangKernel, tmp: &TempDir) -> Arc<AppState> {
         let kernel = Arc::new(kernel);
         let channels_config = kernel.config_ref().channels.clone();

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -1,99 +1,99 @@
-//! 示例测试 — 演示如何使用测试基础设施。
+//! Example tests — demonstrates how to use the test infrastructure.
 
 use crate::{assert_json_error, assert_json_ok, test_request, MockKernelBuilder, TestAppState};
 use axum::http::{Method, StatusCode};
 use tower::ServiceExt;
 
-/// 测试 GET /api/health 端点返回 200 且包含 status 字段。
+/// Tests that GET /api/health returns 200 and contains a status field.
 #[tokio::test]
 async fn test_health_endpoint() {
     let app = TestAppState::new();
     let router = app.router();
 
     let req = test_request(Method::GET, "/api/health", None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let json = assert_json_ok(resp).await;
 
-    // health 端点应该返回 status 字段
+    // Health endpoint should return a status field
     assert!(
         json.get("status").is_some(),
-        "健康检查应包含 status 字段，实际返回: {json}"
+        "health check should contain a status field, got: {json}"
     );
     let status = json["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "degraded",
-        "status 应为 ok 或 degraded，实际: {status}"
+        "status should be ok or degraded, got: {status}"
     );
 }
 
-/// 测试 GET /api/agents 端点 — 返回 items 数组和 total 字段。
+/// Tests that GET /api/agents returns an items array and a total field.
 #[tokio::test]
 async fn test_list_agents() {
     let app = TestAppState::new();
     let router = app.router();
 
     let req = test_request(Method::GET, "/api/agents", None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let json = assert_json_ok(resp).await;
 
-    // list_agents 返回 {"items": [...], "total": N, "offset": 0}
+    // list_agents returns {"items": [...], "total": N, "offset": 0}
     assert!(
         json.get("items").is_some(),
-        "list_agents 应返回 items 字段，实际: {json}"
+        "list_agents should return an items field, got: {json}"
     );
     assert!(
         json["items"].is_array(),
-        "items 应为数组，实际: {}",
+        "items should be an array, got: {}",
         json["items"]
     );
     assert!(
         json.get("total").is_some(),
-        "list_agents 应返回 total 字段，实际: {json}"
+        "list_agents should return a total field, got: {json}"
     );
-    // 验证 total 是一个合法的无符号整数
+    // Verify total is a valid unsigned integer
     assert!(
         json["total"].is_u64(),
-        "total 应为无符号整数，实际: {}",
+        "total should be an unsigned integer, got: {}",
         json["total"]
     );
 }
 
-/// 测试 GET /api/agents/{id} — 使用无效 ID 应返回 400。
+/// Tests that GET /api/agents/{id} with an invalid ID returns 400.
 #[tokio::test]
 async fn test_get_agent_invalid_id() {
     let app = TestAppState::new();
     let router = app.router();
 
     let req = test_request(Method::GET, "/api/agents/not-a-valid-uuid", None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let json = assert_json_error(resp, StatusCode::BAD_REQUEST).await;
 
     assert!(
         json.get("error").is_some(),
-        "错误响应应包含 error 字段，实际: {json}"
+        "error response should contain an error field, got: {json}"
     );
 }
 
-/// 测试 GET /api/agents/{id} — 使用有效但不存在的 UUID 应返回 404。
+/// Tests that GET /api/agents/{id} with a valid but nonexistent UUID returns 404.
 #[tokio::test]
 async fn test_get_agent_not_found() {
     let app = TestAppState::new();
     let router = app.router();
 
-    // 使用一个有效的 UUID 但不存在于 registry 中
+    // Use a valid UUID that does not exist in the registry
     let fake_id = uuid::Uuid::new_v4();
     let path = format!("/api/agents/{fake_id}");
     let req = test_request(Method::GET, &path, None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let json = assert_json_error(resp, StatusCode::NOT_FOUND).await;
 
     assert!(
         json.get("error").is_some(),
-        "404 响应应包含 error 字段，实际: {json}"
+        "404 response should contain an error field, got: {json}"
     );
 }
 
-/// 测试 MockLlmDriver 的调用记录功能。
+/// Tests MockLlmDriver call recording functionality.
 #[tokio::test]
 async fn test_mock_llm_driver_recording() {
     use crate::MockLlmDriver;
@@ -112,51 +112,51 @@ async fn test_mock_llm_driver_recording() {
         prompt_caching: false,
     };
 
-    // 第一次调用
+    // First call
     let resp1 = driver.complete(request.clone()).await.unwrap();
     assert_eq!(resp1.text(), "回复1");
 
-    // 第二次调用
+    // Second call
     let resp2 = driver.complete(request).await.unwrap();
     assert_eq!(resp2.text(), "回复2");
 
-    // 验证调用记录
+    // Verify call recording
     assert_eq!(driver.call_count(), 2);
     let calls = driver.recorded_calls();
     assert_eq!(calls[0].model, "test-model");
     assert_eq!(calls[0].system, Some("test system prompt".into()));
 }
 
-/// 测试使用自定义 config 构建 kernel。
+/// Tests building a kernel with custom config.
 #[tokio::test]
 async fn test_custom_config_kernel() {
     let app = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
         cfg.language = "zh".into();
     }));
 
-    // 验证自定义配置生效
+    // Verify that the custom configuration took effect
     assert_eq!(app.state.kernel.config_ref().language, "zh");
 }
 
-/// 测试 GET /api/version 端点。
+/// Tests the GET /api/version endpoint.
 #[tokio::test]
 async fn test_version_endpoint() {
     let app = TestAppState::new();
     let router = app.router();
 
     let req = test_request(Method::GET, "/api/version", None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let json = assert_json_ok(resp).await;
 
     assert!(
         json.get("version").is_some(),
-        "version 端点应包含 version 字段，实际: {json}"
+        "version endpoint should contain a version field, got: {json}"
     );
 }
 
-// ── POST / PUT / DELETE 测试 ──────────────────────────────────────────
+// -- POST / PUT / DELETE tests ------------------------------------------------
 
-/// 测试 POST /api/agents — 使用 manifest_toml 创建 agent。
+/// Tests POST /api/agents — creates an agent using manifest_toml.
 #[tokio::test]
 async fn test_spawn_agent_post() {
     let app = TestAppState::new();
@@ -169,17 +169,17 @@ system_prompt = "You are a test bot."
 "#;
     let body = serde_json::json!({ "manifest_toml": manifest }).to_string();
     let req = test_request(Method::POST, "/api/agents", Some(&body));
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
     let status = resp.status();
 
-    // spawn 应返回 200 或 201（包含 agent id）
+    // spawn should return 200 or 201 (with agent id)
     assert!(
         status == StatusCode::OK || status == StatusCode::CREATED,
-        "spawn_agent 应返回 200/201，实际: {status}"
+        "spawn_agent should return 200/201, got: {status}"
     );
 }
 
-/// 测试 DELETE /api/agents/{id} — 删除不存在的 agent 应返回错误。
+/// Tests DELETE /api/agents/{id} — deleting a nonexistent agent should return an error.
 #[tokio::test]
 async fn test_delete_agent_not_found() {
     let app = TestAppState::new();
@@ -188,17 +188,17 @@ async fn test_delete_agent_not_found() {
     let fake_id = uuid::Uuid::new_v4();
     let path = format!("/api/agents/{fake_id}");
     let req = test_request(Method::DELETE, &path, None);
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
 
-    // 删除不存在的 agent 应返回 404
+    // Deleting a nonexistent agent should return 404
     let json = assert_json_error(resp, StatusCode::NOT_FOUND).await;
     assert!(
         json.get("error").is_some(),
-        "DELETE 404 响应应包含 error 字段，实际: {json}"
+        "DELETE 404 response should contain an error field, got: {json}"
     );
 }
 
-/// 测试 PUT /api/agents/{id}/model — 为不存在的 agent 设置模型应返回错误。
+/// Tests PUT /api/agents/{id}/model — setting model for a nonexistent agent should return an error.
 #[tokio::test]
 async fn test_set_model_not_found() {
     let app = TestAppState::new();
@@ -208,17 +208,17 @@ async fn test_set_model_not_found() {
     let path = format!("/api/agents/{fake_id}/model");
     let body = serde_json::json!({ "model": "gpt-4" }).to_string();
     let req = test_request(Method::PUT, &path, Some(&body));
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
 
-    // 不存在的 agent 应返回非 200 的错误状态码
+    // Nonexistent agent should return a non-200 error status code
     let status = resp.status();
     assert!(
         status.is_client_error() || status.is_server_error(),
-        "set_model 对不存在的 agent 应返回错误状态码，实际: {status}"
+        "set_model for a nonexistent agent should return an error status code, got: {status}"
     );
 }
 
-/// 测试 POST /api/agents/{id}/message — 向不存在的 agent 发消息应返回错误。
+/// Tests POST /api/agents/{id}/message — sending a message to a nonexistent agent should return an error.
 #[tokio::test]
 async fn test_send_message_agent_not_found() {
     let app = TestAppState::new();
@@ -228,16 +228,16 @@ async fn test_send_message_agent_not_found() {
     let path = format!("/api/agents/{fake_id}/message");
     let body = serde_json::json!({ "message": "hello" }).to_string();
     let req = test_request(Method::POST, &path, Some(&body));
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
 
     let status = resp.status();
     assert!(
         status == StatusCode::NOT_FOUND || status == StatusCode::BAD_REQUEST,
-        "send_message 对不存在的 agent 应返回 404/400，实际: {status}"
+        "send_message for a nonexistent agent should return 404/400, got: {status}"
     );
 }
 
-/// 测试 PATCH /api/agents/{id} — 更新不存在的 agent 应返回错误。
+/// Tests PATCH /api/agents/{id} — updating a nonexistent agent should return an error.
 #[tokio::test]
 async fn test_patch_agent_not_found() {
     let app = TestAppState::new();
@@ -247,18 +247,18 @@ async fn test_patch_agent_not_found() {
     let path = format!("/api/agents/{fake_id}");
     let body = serde_json::json!({ "name": "new-name" }).to_string();
     let req = test_request(Method::PATCH, &path, Some(&body));
-    let resp = router.oneshot(req).await.expect("请求失败");
+    let resp = router.oneshot(req).await.expect("request failed");
 
     let status = resp.status();
     assert!(
         status == StatusCode::NOT_FOUND || status == StatusCode::BAD_REQUEST,
-        "patch_agent 对不存在的 agent 应返回 404/400，实际: {status}"
+        "patch_agent for a nonexistent agent should return 404/400, got: {status}"
     );
 }
 
-// ── MockLlmDriver builder 方法测试 ──────────────────────────────────
+// -- MockLlmDriver builder method tests ---------------------------------------
 
-/// 测试 MockLlmDriver 的 with_tokens 和 with_stop_reason 自定义设置。
+/// Tests MockLlmDriver's with_tokens and with_stop_reason custom settings.
 #[tokio::test]
 async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
     use crate::MockLlmDriver;
@@ -283,22 +283,22 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
     let resp = driver.complete(request).await.unwrap();
     assert_eq!(
         resp.usage.input_tokens, 200,
-        "input_tokens 应为自定义值 200"
+        "input_tokens should be the custom value 200"
     );
     assert_eq!(
         resp.usage.output_tokens, 100,
-        "output_tokens 应为自定义值 100"
+        "output_tokens should be the custom value 100"
     );
     assert_eq!(
         resp.stop_reason,
         StopReason::MaxTokens,
-        "stop_reason 应为 MaxTokens"
+        "stop_reason should be MaxTokens"
     );
 }
 
-// ── FailingLlmDriver 测试 ──────────────────────────────────────────
+// -- FailingLlmDriver tests ---------------------------------------------------
 
-/// 测试 FailingLlmDriver 始终返回错误（用于错误处理场景）。
+/// Tests that FailingLlmDriver always returns errors (for error handling scenarios).
 #[tokio::test]
 async fn test_failing_llm_driver() {
     use crate::FailingLlmDriver;
@@ -318,18 +318,21 @@ async fn test_failing_llm_driver() {
     };
 
     let result = driver.complete(request).await;
-    assert!(result.is_err(), "FailingLlmDriver 应始终返回错误");
+    assert!(
+        result.is_err(),
+        "FailingLlmDriver should always return an error"
+    );
 
     let err = result.unwrap_err();
     let err_msg = format!("{err}");
     assert!(
         err_msg.contains("模拟的 API 错误"),
-        "错误消息应包含自定义内容，实际: {err_msg}"
+        "error message should contain the custom content, got: {err_msg}"
     );
 
-    // FailingLlmDriver 的 is_configured 应返回 false
+    // FailingLlmDriver's is_configured should return false
     assert!(
         !driver.is_configured(),
-        "FailingLlmDriver.is_configured() 应返回 false"
+        "FailingLlmDriver.is_configured() should return false"
     );
 }

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1,17 +1,17 @@
 //! Configuration types for the LibreFang kernel.
 //!
-//! 此模块将配置相关代码按职责拆分为多个子模块：
-//! - `types`: 所有配置 struct 与 enum 定义
-//! - `serde_helpers`: 自定义序列化/反序列化辅助函数
-//! - `validation`: 配置验证与安全边界约束
-//! - `version`: 配置版本追踪
+//! This module splits configuration-related code into submodules by responsibility:
+//! - `types`: All configuration struct and enum definitions
+//! - `serde_helpers`: Custom serialization/deserialization helper functions
+//! - `validation`: Configuration validation and safety boundary constraints
+//! - `version`: Configuration version tracking
 
 mod serde_helpers;
 mod types;
 mod validation;
 mod version;
 
-// 保持向后兼容性：重新导出所有公共类型
+// Maintain backward compatibility: re-export all public types
 pub use serde_helpers::*;
 pub use types::*;
 pub use version::*;

--- a/crates/librefang-types/src/config/serde_helpers.rs
+++ b/crates/librefang-types/src/config/serde_helpers.rs
@@ -1,4 +1,4 @@
-//! 自定义序列化/反序列化辅助函数。
+//! Custom serialization/deserialization helper functions.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1,4 +1,4 @@
-//! 所有配置 struct 与 enum 类型定义，包含 Default impl 和关联 helper 函数。
+//! All configuration struct and enum type definitions, including Default impls and associated helper functions.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -1,4 +1,4 @@
-//! 配置验证逻辑：未知字段检测、结构验证和安全边界约束。
+//! Configuration validation logic: unknown field detection, structural validation, and safety boundary constraints.
 
 use super::types::*;
 

--- a/crates/librefang-types/src/config/version.rs
+++ b/crates/librefang-types/src/config/version.rs
@@ -1,7 +1,7 @@
-//! 配置版本追踪，为未来的配置迁移提供基础。
+//! Configuration version tracking, providing the foundation for future config migrations.
 
-/// 配置文件版本号，用于未来的配置迁移支持。
+/// Configuration file version number, used for future config migration support.
 ///
-/// TODO: 当配置格式发生不兼容变更时，递增此版本号，
-/// 并在 loader 中实现自动迁移逻辑（旧版本 → 新版本）。
+/// TODO: When an incompatible change is made to the config format, increment this version
+/// and implement automatic migration logic in the loader (old version -> new version).
 pub const CONFIG_VERSION: u32 = 1;

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -10,7 +10,7 @@
 //! use librefang_types::i18n::ErrorTranslator;
 //!
 //! let translator = ErrorTranslator::new("zh-CN");
-//! assert_eq!(translator.t("api-error-agent-not-found"), "未找到智能体");
+//! assert_eq!(translator.t("api-error-agent-not-found"), "Agent not found (in Chinese)");
 //! ```
 
 use fluent::{FluentArgs, FluentBundle, FluentResource, FluentValue};

--- a/docs/src/components/Code.tsx
+++ b/docs/src/components/Code.tsx
@@ -161,7 +161,7 @@ function CodePanel({
 	}
 
 	if (!code) {
-		// 尝试从子元素中提取代码内容
+		// Try to extract code content from child elements
 		if (child && isValidElement(child) && child.type === "pre") {
 			const childProps = child.props as { children?: React.ReactNode };
 			const codeChild = childProps.children;
@@ -170,7 +170,7 @@ function CodePanel({
 				code = codeProps.children || "";
 			}
 		}
-		// 如果仍然没有代码使用空字符串
+		// If still no code found, use an empty string
 		if (!code) {
 			code = "";
 		}

--- a/docs/src/components/ErrorBoundary.tsx
+++ b/docs/src/components/ErrorBoundary.tsx
@@ -19,27 +19,27 @@ interface ErrorFallbackProps {
 	resetError?: () => void;
 }
 
-// 文档站点专用的错误回退组件
+// Error fallback component for the docs site
 function DocsErrorFallback({ error, resetError }: ErrorFallbackProps) {
 	return (
 		<div className="flex min-h-[60vh] flex-col items-center justify-center p-8">
 			<div className="text-center">
 				<div className="mb-6 text-8xl"></div>
 				<h1 className="mb-3 text-3xl font-bold text-zinc-900 dark:text-white">
-					页面加载失败
+					Page Failed to Load
 				</h1>
 				<p className="mb-8 max-w-md text-lg text-zinc-600 dark:text-zinc-400">
-					文档页面遇到了问题这可能是 MDX 解析错误或组件渲染异常
+					The docs page encountered a problem. This may be an MDX parsing error or a component rendering issue.
 				</p>
 
 				{process.env.NODE_ENV === "development" && error && (
 					<div className="mb-8 max-w-2xl rounded-lg bg-red-50 p-4 dark:bg-red-950/20">
 						<h3 className="mb-2 font-semibold text-red-800 dark:text-red-200">
-							开发模式错误信息
+							Development Mode Error Info
 						</h3>
 						<details className="text-left">
 							<summary className="cursor-pointer text-sm text-red-600 dark:text-red-400">
-								点击查看详细错误
+								Click to view error details
 							</summary>
 							<pre className="mt-2 overflow-auto text-xs text-red-600 dark:text-red-400">
 								{error.name}: {error.message}
@@ -56,7 +56,7 @@ function DocsErrorFallback({ error, resetError }: ErrorFallbackProps) {
 							onClick={resetError}
 							className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
 						>
-							重新尝试
+							Try Again
 						</button>
 					)}
 					<button
@@ -66,14 +66,14 @@ function DocsErrorFallback({ error, resetError }: ErrorFallbackProps) {
 						}}
 						className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
 					>
-						返回首页
+						Back to Home
 					</button>
 					<button
 						type="button"
 						onClick={() => window.location.reload()}
 						className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
 					>
-						刷新页面
+						Refresh Page
 					</button>
 				</div>
 			</div>
@@ -81,7 +81,7 @@ function DocsErrorFallback({ error, resetError }: ErrorFallbackProps) {
 	);
 }
 
-// MDX 错误边界组件
+// MDX error boundary component
 export class MDXErrorBoundary extends React.Component<
 	ErrorBoundaryProps,
 	ErrorBoundaryState
@@ -101,7 +101,7 @@ export class MDXErrorBoundary extends React.Component<
 	override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
 		console.error("MDX ErrorBoundary caught an error:", error, errorInfo);
 
-		// 记录 MDX 相关错误
+		// Log MDX-related errors
 		this.reportMDXError(error, errorInfo);
 
 		this.props.onError?.(error, errorInfo);
@@ -118,12 +118,12 @@ export class MDXErrorBoundary extends React.Component<
 				typeof window !== "undefined" ? navigator.userAgent : undefined,
 			url: typeof window !== "undefined" ? window.location.href : undefined,
 
-			// MDX 特定信息
+			// MDX-specific information
 			isDevelopment: process.env.NODE_ENV === "development",
 			errorType: this.classifyMDXError(error),
 		};
 
-		// 开发环境下详细输出
+		// Verbose output in development
 		if (process.env.NODE_ENV === "development") {
 			console.group(" MDX Error Details");
 			console.error("Error:", error);
@@ -132,7 +132,7 @@ export class MDXErrorBoundary extends React.Component<
 			console.groupEnd();
 		}
 
-		// 生产环境发送错误报告
+		// Send error report in production
 		if (
 			typeof window !== "undefined" &&
 			process.env.NODE_ENV === "production"
@@ -184,7 +184,7 @@ export class MDXErrorBoundary extends React.Component<
 	}
 }
 
-// MDX 组件包装器用于捕获单个组件的错误
+// MDX component wrapper for catching errors in individual components
 export function MDXComponentWrapper({
 	children,
 	componentName,
@@ -197,15 +197,15 @@ export function MDXComponentWrapper({
 			fallback={({ error, resetError }) => (
 				<div className="my-4 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/20">
 					<h4 className="mb-2 font-semibold text-red-800 dark:text-red-200">
-						组件渲染错误 {componentName && `(${componentName})`}
+						Component Render Error {componentName && `(${componentName})`}
 					</h4>
 					<p className="mb-3 text-sm text-red-600 dark:text-red-400">
-						这个组件无法正常显示可能是由于属性错误或组件代码问题
+						This component could not render properly. This may be due to incorrect props or a component code issue.
 					</p>
 					{process.env.NODE_ENV === "development" && error && (
 						<details className="mb-3">
 							<summary className="cursor-pointer text-sm text-red-600 dark:text-red-400">
-								查看错误详情
+								View error details
 							</summary>
 							<pre className="mt-1 text-xs text-red-500">{error.message}</pre>
 						</details>
@@ -215,7 +215,7 @@ export function MDXComponentWrapper({
 						onClick={resetError}
 						className="text-sm text-red-600 underline dark:text-red-400"
 					>
-						重试
+						Retry
 					</button>
 				</div>
 			)}
@@ -225,15 +225,15 @@ export function MDXComponentWrapper({
 	);
 }
 
-// 搜索错误处理
+// Search error handling
 export function useSearchErrorHandler() {
 	const [error, setError] = React.useState<string | null>(null);
 
 	const handleSearchError = React.useCallback((error: Error) => {
 		console.error("Search error:", error);
-		setError("搜索功能暂时不可用请稍后重试");
+		setError("Search is temporarily unavailable. Please try again later.");
 
-		// 5秒后自动清除错误
+		// Auto-clear the error after 5 seconds
 		setTimeout(() => setError(null), 5000);
 	}, []);
 
@@ -244,18 +244,18 @@ export function useSearchErrorHandler() {
 	return { searchError: error, handleSearchError, clearError };
 }
 
-// 导航错误处理
+// Navigation error handling
 export function useNavigationErrorHandler() {
 	const handleNavigationError = React.useCallback(
 		(href: string, error: Error) => {
 			console.error(`Navigation error for ${href}:`, error);
 
-			// 尝试使用原生导航作为后备
+			// Fall back to native navigation
 			try {
 				window.location.href = href;
 			} catch (fallbackError) {
 				console.error("Fallback navigation also failed:", fallbackError);
-				alert("页面跳转失败请检查链接是否正确");
+				alert("Navigation failed. Please check that the link is correct.");
 			}
 		},
 		[],
@@ -264,7 +264,7 @@ export function useNavigationErrorHandler() {
 	return { handleNavigationError };
 }
 
-// 内容加载错误处理
+// Content loading error handling
 export function useContentErrorHandler() {
 	const [loadingErrors, setLoadingErrors] = React.useState<Set<string>>(
 		new Set(),
@@ -296,15 +296,15 @@ export function useContentErrorHandler() {
 	return { handleContentError, retryContent, hasError };
 }
 
-// 全局错误处理器
+// Global error handler
 export const globalErrorHandler = {
-	// 处理未捕获的 Promise 拒绝
+	// Handle uncaught Promise rejections
 	setupGlobalHandlers: () => {
 		if (typeof window !== "undefined") {
 			window.addEventListener("unhandledrejection", (event) => {
 				console.error("Unhandled promise rejection:", event.reason);
 
-				// 发送错误报告
+				// Send error report
 				if (process.env.NODE_ENV === "production") {
 					fetch("/api/errors", {
 						method: "POST",
@@ -319,7 +319,7 @@ export const globalErrorHandler = {
 				}
 			});
 
-			// 处理全局错误
+			// Handle global errors
 			window.addEventListener("error", (event) => {
 				console.error("Global error:", event.error);
 
@@ -344,5 +344,5 @@ export const globalErrorHandler = {
 	},
 };
 
-// 默认导出主要的错误边界组件
+// Default export for the main error boundary component
 export { MDXErrorBoundary as ErrorBoundary };

--- a/docs/src/mdx/search.d.ts
+++ b/docs/src/mdx/search.d.ts
@@ -11,7 +11,7 @@ export interface SearchOptions {
 
 export function search(query: string, options?: SearchOptions): Result[];
 
-// 为.mjs文件声明模块类型
+// Declare module types for .mjs files
 declare module "@/mdx/search.mjs" {
 	export interface Result {
 		url: string;

--- a/docs/src/types/index.ts
+++ b/docs/src/types/index.ts
@@ -1,2 +1,2 @@
-// 所有文档类型已移至 @web/shared
-// 请从 @web/shared 中导入需要的文档类型
+// All document types have been moved to @web/shared
+// Please import the required document types from @web/shared

--- a/web/workers/github-stats-worker/wrangler.toml
+++ b/web/workers/github-stats-worker/wrangler.toml
@@ -7,6 +7,6 @@ account_id = "3ee9bb524a4fb2a9d685ce1f82b52581"
 binding = "KV"
 id = "5d12c668469a4dd39f3b2b378cc20036"
 
-# 每天 UTC 0点执行
+# Runs daily at UTC 00:00
 [triggers]
 crons = ["0 0 * * *"]


### PR DESCRIPTION
## Summary
- Translate all Chinese comments, doc comments, and assertion messages to English across 41 files
- Covers `librefang-api` (server + routes + dashboard), `librefang-testing`, `librefang-types`, and `docs/`
- Intentional i18n content preserved unchanged: locale files, router intent patterns, multilingual UI labels (`labelZh`), test data strings, and language toggle elements

## Test plan
- [ ] `cargo build --workspace --lib` compiles successfully
- [ ] `cargo test --workspace` all tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [ ] Verify no functional Chinese content was accidentally modified (i18n, router patterns)