### PR TITLE
fix(channels): use endpoint discovery API for Feishu WebSocket connection

### DIFF
--- a/crates/librefang-channels/src/feishu.rs
+++ b/crates/librefang-channels/src/feishu.rs
@@ -750,7 +750,7 @@ async fn get_ws_endpoint(
     let status = resp.status();
     let text = resp.text().await.map_err(|e| format!("read body: {e}"))?;
     if !status.is_success() {
-        return Err(format!("endpoint returned HTTP {status}: {text}"));
+        return Err(format!("endpoint returned HTTP {status}"));
     }
     let parsed: WsEndpointResp =
         serde_json::from_str(&text).map_err(|e| format!("parse endpoint response: {e}"))?;


### PR DESCRIPTION
## Summary

Fixes #1512 — Feishu WebSocket connection keeps failing with `HTTP error: 200 OK`.

- **Root cause**: The code was connecting directly to `wss://open.feishu.cn/event/ws?app_id=xxx&token=xxx`, but this URL is **not** a WebSocket endpoint — it returns HTTP 200 with JSON instead of the expected 101 Switching Protocols upgrade.
- **Fix**: Implement the correct two-step endpoint discovery protocol (matching the [official Feishu Go SDK](https://github.com/larksuite/oapi-sdk-go/blob/v3_main/ws/client.go)):
  1. `POST /callback/ws/endpoint` with `AppID`/`AppSecret` to obtain the real WebSocket URL
  2. Connect to the returned `wss://` URL via standard WebSocket upgrade
- Use server-provided `PingInterval` from `ClientConfig` (default 120s) instead of hardcoded 30s
- Remove unnecessary tenant token fetch for WebSocket mode (endpoint API takes credentials directly)

## Test plan

- [ ] Configure Feishu `app_id`/`app_secret` and start gateway — WebSocket should connect without `HTTP error: 200 OK`
- [ ] Verify events are received over the WebSocket connection
- [ ] Verify reconnection works after intentional disconnect
- [ ] `cargo test --workspace` passes