### PR TITLE
feat(hands): multi-agent hand architecture

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -5446,12 +5446,15 @@ system_prompt = "You are a helpful assistant."
             .deactivate(instance_id)
             .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
 
-        if let Some(agent_id) = instance.agent_id() {
-            if let Err(e) = self.kill_agent(agent_id) {
-                warn!(agent = %agent_id, error = %e, "Failed to kill hand agent (may already be dead)");
+        // Kill all agents spawned by this hand (multi-agent support)
+        if !instance.agent_ids.is_empty() {
+            for &agent_id in instance.agent_ids.values() {
+                if let Err(e) = self.kill_agent(agent_id) {
+                    warn!(agent = %agent_id, error = %e, "Failed to kill hand agent (may already be dead)");
+                }
             }
         } else {
-            // Fallback: if agent_id was never set (incomplete activation), search by hand tag
+            // Fallback: if agent_ids was never set (incomplete activation), search by hand tag
             let hand_tag = format!("hand:{}", instance.hand_id);
             for entry in self.registry.list() {
                 if entry.tags.contains(&hand_tag) {
@@ -5485,9 +5488,9 @@ system_prompt = "You are a helpful assistant."
 
     /// Pause a hand (marks it paused and suspends background loop ticks).
     pub fn pause_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
-        // Pause the background loop for this hand's agent
+        // Pause the background loop for all of this hand's agents
         if let Some(instance) = self.hand_registry.get_instance(instance_id) {
-            if let Some(agent_id) = instance.agent_id() {
+            for &agent_id in instance.agent_ids.values() {
                 self.background.pause_agent(agent_id);
             }
         }
@@ -5503,9 +5506,9 @@ system_prompt = "You are a helpful assistant."
         self.hand_registry
             .resume(instance_id)
             .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
-        // Resume the background loop for this hand's agent
+        // Resume the background loop for all of this hand's agents
         if let Some(instance) = self.hand_registry.get_instance(instance_id) {
-            if let Some(agent_id) = instance.agent_id() {
+            for &agent_id in instance.agent_ids.values() {
                 self.background.resume_agent(agent_id);
             }
         }


### PR DESCRIPTION
## Summary
- Evolve Hand system from single-agent to multi-agent: each Hand can now define multiple named agent roles via `[agents.*]` TOML sections
- Coordinator pattern: one agent per hand receives user messages (marked `coordinator = true`), others are specialists reachable via `agent_send`
- Deterministic agent IDs: `AgentId::from_hand_agent(hand_id, role)` using UUID v5
- Peer info injection: each agent's system prompt includes a "Your Team" block listing teammates
- State persistence v3: `agent_ids` BTreeMap with v2/v1 backward compatibility
- Full backward compatibility: existing `[agent]` single-agent TOML format auto-converts to `{"main": HandAgentManifest}` with coordinator=true

### Key Changes
- **librefang-types**: Add `AgentId::from_hand_agent(hand_id, role)` for deterministic multi-agent IDs
- **librefang-hands**: Add `HandAgentManifest` struct, restructure `HandDefinition` (custom Deserialize for both formats), restructure `HandInstance` (field→method, `agent_ids` BTreeMap), registry v3 state
- **librefang-kernel**: Rewrite `activate_hand` to spawn agents per role with peer info injection and `agent_send` tool, update `deactivate/pause/resume` to iterate all agents, update boot restoration for multi-agent
- **librefang-api**: Update skills routes, channel_bridge, TUI event handler for new method-based API
- **Tests**: 20 comprehensive hand lifecycle tests (activation, deactivation, pause/resume, deterministic IDs, tagging, tool inheritance, state persistence, coexistence, error cases, live LLM fleet test)

## Test plan
- [x] All 20 multi_agent_test.rs tests pass
- [x] All 33 librefang-hands tests pass  
- [x] Full workspace: 357 passed, 4 failed (pre-existing router test failures, unrelated)
- [ ] Live integration test with multi-agent HAND.toml from registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)