### PR TITLE
fix(hands): update kernel for multi-agent hand architecture

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -5446,9 +5446,12 @@ system_prompt = "You are a helpful assistant."
             .deactivate(instance_id)
             .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
 
-        if let Some(agent_id) = instance.agent_id() {
-            if let Err(e) = self.kill_agent(agent_id) {
-                warn!(agent = %agent_id, error = %e, "Failed to kill hand agent (may already be dead)");
+        // Kill all agents spawned by this hand (multi-agent support)
+        if !instance.agent_ids.is_empty() {
+            for (&ref _role, &agent_id) in &instance.agent_ids {
+                if let Err(e) = self.kill_agent(agent_id) {
+                    warn!(agent = %agent_id, error = %e, "Failed to kill hand agent (may already be dead)");
+                }
             }
         } else {
             // Fallback: if agent_id was never set (incomplete activation), search by hand tag
@@ -5485,9 +5488,9 @@ system_prompt = "You are a helpful assistant."
 
     /// Pause a hand (marks it paused and suspends background loop ticks).
     pub fn pause_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
-        // Pause the background loop for this hand's agent
+        // Pause the background loop for all of this hand's agents
         if let Some(instance) = self.hand_registry.get_instance(instance_id) {
-            if let Some(agent_id) = instance.agent_id() {
+            for &agent_id in instance.agent_ids.values() {
                 self.background.pause_agent(agent_id);
             }
         }
@@ -5503,9 +5506,9 @@ system_prompt = "You are a helpful assistant."
         self.hand_registry
             .resume(instance_id)
             .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
-        // Resume the background loop for this hand's agent
+        // Resume the background loop for all of this hand's agents
         if let Some(instance) = self.hand_registry.get_instance(instance_id) {
-            if let Some(agent_id) = instance.agent_id() {
+            for &agent_id in instance.agent_ids.values() {
                 self.background.resume_agent(agent_id);
             }
         }

--- a/openapi.json
+++ b/openapi.json
@@ -3652,6 +3652,25 @@
         }
       }
     },
+    "/api/hands/reload": {
+      "post": {
+        "tags": [
+          "hands"
+        ],
+        "summary": "POST /api/hands/reload — Reload hand definitions from disk.",
+        "operationId": "reload_hands",
+        "responses": {
+          "200": {
+            "description": "Reload hand definitions from disk",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/hands/{hand_id}": {
       "get": {
         "tags": [
@@ -5093,7 +5112,7 @@
           "system"
         ],
         "summary": "GET /api/metrics — Prometheus text-format metrics.",
-        "description": "Returns counters and gauges for monitoring LibreFang in production:\n- `librefang_agents_active` — number of active agents\n- `librefang_uptime_seconds` — seconds since daemon started\n- `librefang_tokens_total` — total tokens consumed (per agent)\n- `librefang_tool_calls_total` — total tool calls (per agent)\n- `librefang_panics_total` — supervisor panic count\n- `librefang_restarts_total` — supervisor restart count",
+        "description": "Returns counters and gauges for monitoring LibreFang in production:\n- `librefang_agents_active` — number of active agents\n- `librefang_uptime_seconds` — seconds since daemon started\n- `librefang_tokens_total` — total tokens consumed (per agent)\n- `librefang_tool_calls_total` — total tool calls (per agent)\n- `librefang_panics_total` — supervisor panic count\n- `librefang_restarts_total` — supervisor restart count\n- `librefang_http_requests_total` — HTTP request counts (with telemetry feature)\n- `librefang_http_request_duration_ms` — HTTP request latencies (with telemetry feature)",
         "operationId": "prometheus_metrics",
         "responses": {
           "200": {
@@ -6886,6 +6905,39 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/workflows/{id}/save-as-template": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/:id/save-as-template — Convert a workflow into a reusable template.",
+        "operationId": "save_workflow_as_template",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template created",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Update hand deactivation/pause/resume in kernel to iterate over `agent_ids` HashMap instead of single `agent_id()`, supporting multi-agent hands
- Add `/api/hands/reload` and `/api/workflows/{id}/save-as-template` to openapi.json
- Update `/api/metrics` description with telemetry HTTP request metrics