### PR TITLE
fix(security): replace deterministic session token with random generation

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -11,10 +11,26 @@ use axum::body::Body;
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
 use librefang_types::i18n;
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 use tracing::info;
 
 use librefang_telemetry::metrics;
+
+/// Shared state for the auth middleware.
+///
+/// Combines the static API key(s) with the active session store so the
+/// middleware can validate both legacy deterministic tokens and the new
+/// randomly generated session tokens in a single pass.
+#[derive(Clone)]
+pub struct AuthState {
+    /// Composite key string: multiple valid tokens separated by `\n`.
+    pub api_key_lock: Arc<tokio::sync::RwLock<String>>,
+    /// Active sessions issued by dashboard login, keyed by token string.
+    pub active_sessions:
+        Arc<tokio::sync::RwLock<HashMap<String, crate::password_hash::SessionToken>>>,
+}
 
 /// Request ID header name (standard).
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
@@ -159,14 +175,15 @@ pub async fn api_version_headers(request: Request<Body>, next: Next) -> Response
 /// endpoints must include `Authorization: Bearer <api_key>`.
 /// If the key is empty or whitespace-only, auth is disabled entirely
 /// (public/local development mode).
+///
+/// Also validates randomly generated session tokens from the active
+/// session store, cleaning up expired sessions on each check.
 pub async fn auth(
-    axum::extract::State(api_key_lock): axum::extract::State<
-        std::sync::Arc<tokio::sync::RwLock<String>>,
-    >,
+    axum::extract::State(auth_state): axum::extract::State<AuthState>,
     request: Request<Body>,
     next: Next,
 ) -> Response<Body> {
-    let api_key = api_key_lock.read().await.clone();
+    let api_key = auth_state.api_key_lock.read().await.clone();
     // SECURITY: Capture method early for method-aware public endpoint checks.
     let method = request.method().clone();
 
@@ -299,9 +316,27 @@ pub async fn auth(
     // SECURITY: Use constant-time comparison to prevent timing attacks.
     let query_auth = query_token.map(&matches_any);
 
-    // Accept if either auth method matches
+    // Accept if either auth method matches a static API key or legacy token
     if header_auth == Some(true) || query_auth == Some(true) {
         return next.run(request).await;
+    }
+
+    // Check the active session store for randomly generated dashboard tokens.
+    // Also prune expired sessions opportunistically.
+    let provided_token = api_token.or(query_token);
+    if let Some(token_str) = provided_token {
+        let mut sessions = auth_state.active_sessions.write().await;
+        // Remove expired sessions while we hold the lock
+        sessions.retain(|_, st| {
+            !crate::password_hash::is_token_expired(
+                st,
+                crate::password_hash::DEFAULT_SESSION_TTL_SECS,
+            )
+        });
+        if sessions.contains_key(token_str) {
+            drop(sessions);
+            return next.run(request).await;
+        }
     }
 
     // Determine error message: was a credential provided but wrong, or missing entirely?
@@ -458,13 +493,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_api_version_header_is_added_to_unauthorized_responses() {
-        let _api_key_state = std::sync::Arc::new(tokio::sync::RwLock::new("secret".to_string()));
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+        };
         let app = Router::new()
             .route("/api/private", get(|| async { "ok" }))
-            .layer(axum::middleware::from_fn_with_state(
-                std::sync::Arc::new(tokio::sync::RwLock::new("secret".to_string())),
-                auth,
-            ))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth))
             .layer(axum::middleware::from_fn(api_version_headers));
 
         let response = app

--- a/crates/librefang-api/src/password_hash.rs
+++ b/crates/librefang-api/src/password_hash.rs
@@ -7,11 +7,20 @@
 //! - If `dashboard_pass_hash` is set (Argon2id PHC string), verify against it.
 //! - If only `dashboard_pass` is set (plaintext/vault), fall back to constant-time
 //!   plaintext comparison and return the Argon2id hash for transparent upgrade.
+//!
+//! Session tokens are now generated randomly with expiration support,
+//! replacing the old deterministic HMAC-SHA256-derived tokens that could
+//! not be revoked or expired.
 
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    password_hash::{
+        rand_core::{OsRng, RngCore},
+        PasswordHash, PasswordHasher, PasswordVerifier, SaltString,
+    },
     Algorithm, Argon2, Params, Version,
 };
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Hash a password with Argon2id using recommended parameters.
 ///
@@ -35,11 +44,47 @@ pub fn verify_password(password: &str, hash_str: &str) -> bool {
         .is_ok()
 }
 
+/// A session token with creation metadata for expiration support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionToken {
+    /// The hex-encoded random token string.
+    pub token: String,
+    /// Unix timestamp (seconds) when this token was created.
+    pub created_at: u64,
+}
+
+/// Default session TTL: 24 hours.
+pub const DEFAULT_SESSION_TTL_SECS: u64 = 86400;
+
+/// Generate a cryptographically random session token.
+///
+/// Uses OS-level CSPRNG to produce a 32-byte (256-bit) random token,
+/// paired with a creation timestamp for expiration checks.
+pub fn generate_session_token() -> SessionToken {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    let token = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    SessionToken { token, created_at }
+}
+
+/// Check if a session token has expired based on its creation time and TTL.
+pub fn is_token_expired(token: &SessionToken, ttl_secs: u64) -> bool {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(token.created_at) > ttl_secs
+}
+
 /// Result of a dashboard password verification.
 pub enum VerifyResult {
     /// Password matched (Argon2id or legacy). Contains the session token.
     Ok {
-        token: String,
+        token: SessionToken,
         /// If Some, the caller should persist this Argon2id hash to upgrade
         /// from the legacy plaintext password.
         upgrade_hash: Option<String>,
@@ -60,6 +105,7 @@ fn dashboard_session_secret<'a>(cfg_pass: &'a str, pass_hash: &'a str) -> Option
 }
 
 /// Derive the dashboard session token from the configured credentials.
+#[deprecated(note = "Use generate_session_token() for random tokens with expiration")]
 pub fn derive_dashboard_session_token(
     username: &str,
     cfg_pass: &str,
@@ -69,6 +115,7 @@ pub fn derive_dashboard_session_token(
     if username.is_empty() {
         return None;
     }
+    #[allow(deprecated)]
     Some(derive_session_token(username, secret))
 }
 
@@ -81,6 +128,10 @@ pub fn derive_dashboard_session_token(
 /// **Timing safety**: The password verification path always executes regardless of
 /// whether the username matched. This prevents attackers from enumerating valid
 /// usernames via timing differences (Argon2id is ~tens of ms vs instant return).
+///
+/// Returns a randomly generated `SessionToken` on success instead of a
+/// deterministic HMAC-derived token, preventing token replay and enabling
+/// expiration-based revocation.
 pub fn verify_dashboard_password(
     input_user: &str,
     input_pass: &str,
@@ -110,15 +161,13 @@ pub fn verify_dashboard_password(
 
     // Both matched — build result.
     if !pass_hash.is_empty() {
-        let token =
-            derive_dashboard_session_token(cfg_user, cfg_pass, pass_hash).unwrap_or_default();
+        let token = generate_session_token();
         VerifyResult::Ok {
             token,
             upgrade_hash: None,
         }
     } else {
-        let token =
-            derive_dashboard_session_token(cfg_user, cfg_pass, pass_hash).unwrap_or_default();
+        let token = generate_session_token();
         // Generate an Argon2id hash so the caller can persist it for future logins.
         let upgrade_hash = hash_password(input_pass).ok();
         VerifyResult::Ok {
@@ -132,6 +181,7 @@ pub fn verify_dashboard_password(
 ///
 /// This keeps the same token-derivation logic as before so existing sessions
 /// remain valid across the migration.
+#[deprecated(note = "Use generate_session_token() for random tokens with expiration")]
 pub fn derive_session_token(username: &str, password: &str) -> String {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
@@ -169,7 +219,7 @@ mod tests {
     fn test_same_password_produces_different_salts() {
         let h1 = hash_password("same").unwrap();
         let h2 = hash_password("same").unwrap();
-        // Different salts → different hashes, but both verify.
+        // Different salts -> different hashes, but both verify.
         assert_ne!(h1, h2);
         assert!(verify_password("same", &h1));
         assert!(verify_password("same", &h2));
@@ -182,6 +232,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_derive_session_token_is_deterministic() {
         let t1 = derive_session_token("admin", "secret");
         let t2 = derive_session_token("admin", "secret");
@@ -190,10 +241,42 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_derive_session_token_differs_for_different_creds() {
         let t1 = derive_session_token("admin", "pass1");
         let t2 = derive_session_token("admin", "pass2");
         assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn test_generate_session_token_is_random() {
+        let t1 = generate_session_token();
+        let t2 = generate_session_token();
+        assert_ne!(t1.token, t2.token);
+        assert_eq!(t1.token.len(), 64); // 32 bytes = 64 hex chars
+        assert!(t1.created_at > 0);
+    }
+
+    #[test]
+    fn test_session_token_not_expired() {
+        let token = generate_session_token();
+        assert!(!is_token_expired(&token, DEFAULT_SESSION_TTL_SECS));
+    }
+
+    #[test]
+    fn test_session_token_expired() {
+        let token = SessionToken {
+            token: "deadbeef".to_string(),
+            created_at: 0, // epoch = long ago
+        };
+        assert!(is_token_expired(&token, DEFAULT_SESSION_TTL_SECS));
+    }
+
+    #[test]
+    fn test_session_token_zero_ttl_expires_immediately() {
+        let token = generate_session_token();
+        // A TTL of 0 means the token expires the instant it's created.
+        assert!(is_token_expired(&token, 0));
     }
 
     #[test]
@@ -205,10 +288,27 @@ mod tests {
                 token,
             } => {
                 assert!(upgrade_hash.is_none()); // Already using Argon2id
-                assert!(!token.is_empty());
+                assert!(!token.token.is_empty());
+                assert_eq!(token.token.len(), 64);
+                assert!(!is_token_expired(&token, DEFAULT_SESSION_TTL_SECS));
             }
             VerifyResult::Denied => panic!("should have succeeded"),
         }
+    }
+
+    #[test]
+    fn test_verify_dashboard_argon2id_produces_unique_tokens() {
+        let hash = hash_password("mypass").unwrap();
+        let t1 = match verify_dashboard_password("admin", "mypass", "admin", "", &hash) {
+            VerifyResult::Ok { token, .. } => token,
+            VerifyResult::Denied => panic!("should have succeeded"),
+        };
+        let t2 = match verify_dashboard_password("admin", "mypass", "admin", "", &hash) {
+            VerifyResult::Ok { token, .. } => token,
+            VerifyResult::Denied => panic!("should have succeeded"),
+        };
+        // Each login produces a unique random token.
+        assert_ne!(t1.token, t2.token);
     }
 
     #[test]
@@ -242,7 +342,8 @@ mod tests {
                 assert!(uh.starts_with("$argon2id$"));
                 // The upgrade hash should verify against the password
                 assert!(verify_password("secret", &uh));
-                assert!(!token.is_empty());
+                assert!(!token.token.is_empty());
+                assert_eq!(token.token.len(), 64);
             }
             VerifyResult::Denied => panic!("should have succeeded with legacy plaintext"),
         }
@@ -265,6 +366,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_session_token_matches_legacy_derivation() {
         // Verify our token derivation matches the old HMAC-SHA256 approach
         // so existing sessions are not invalidated.
@@ -284,6 +386,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_dashboard_session_token_uses_hash_when_available() {
         let token =
             derive_dashboard_session_token("admin", "legacy-pass", "stored-hash").expect("token");
@@ -327,5 +430,14 @@ mod tests {
             verify_dashboard_password("wrong-user", "pass", "admin", "", ""),
             VerifyResult::Denied
         ));
+    }
+
+    #[test]
+    fn test_session_token_serialization_roundtrip() {
+        let token = generate_session_token();
+        let json = serde_json::to_string(&token).unwrap();
+        let deserialized: SessionToken = serde_json::from_str(&json).unwrap();
+        assert_eq!(token.token, deserialized.token);
+        assert_eq!(token.created_at, deserialized.created_at);
     }
 }

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4616,6 +4616,7 @@ mod monitoring_tests {
             skillhub_cache: dashmap::DashMap::new(),
             provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
             webhook_store: crate::webhook_store::WebhookStore::load(home_dir.join("webhooks.json")),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
             #[cfg(feature = "telemetry")]
             prometheus_handle: None,
         });

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -55,6 +55,7 @@ use crate::middleware::RequestLanguage;
 use dashmap::DashMap;
 use librefang_kernel::LibreFangKernel;
 use librefang_types::i18n::{self, ErrorTranslator};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -104,6 +105,10 @@ pub struct AppState {
     pub provider_probe_cache: librefang_runtime::provider_health::ProbeCache,
     /// Webhook subscription store for outbound event notifications.
     pub webhook_store: crate::webhook_store::WebhookStore,
+    /// Active session tokens issued by dashboard login.
+    /// Maps token string -> SessionToken (with creation timestamp for expiry checks).
+    pub active_sessions:
+        Arc<tokio::sync::RwLock<HashMap<String, crate::password_hash::SessionToken>>>,
     /// Prometheus metrics handle (only set when `telemetry` feature + config enabled).
     #[cfg(feature = "telemetry")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -127,6 +127,7 @@ fn resolve_dashboard_credential(
     config_value.to_string()
 }
 
+#[allow(deprecated)]
 pub(crate) fn dashboard_session_token(kernel: &LibreFangKernel) -> Option<String> {
     let cfg = kernel.config_ref();
     let username = resolve_dashboard_credential(
@@ -161,7 +162,7 @@ pub(crate) fn valid_api_tokens(kernel: &LibreFangKernel) -> Vec<String> {
 
 /// Dashboard credential login — validates username/password using Argon2id
 /// (with transparent fallback from legacy plaintext passwords) and returns
-/// a session token (HMAC-SHA256-derived from credentials).
+/// a randomly generated session token with expiration metadata.
 async fn dashboard_login(
     axum::extract::State(state): axum::extract::State<Arc<routes::AppState>>,
     axum::Json(body): axum::Json<serde_json::Value>,
@@ -211,9 +212,18 @@ async fn dashboard_login(
                 );
             }
 
+            // Store the session token so the auth middleware can validate it.
+            state
+                .active_sessions
+                .write()
+                .await
+                .insert(token.token.clone(), token.clone());
+
             axum::response::Json(serde_json::json!({
                 "ok": true,
-                "token": token,
+                "token": token.token,
+                "created_at": token.created_at,
+                "expires_at": token.created_at + crate::password_hash::DEFAULT_SESSION_TTL_SECS,
             }))
             .into_response()
         }
@@ -277,6 +287,7 @@ pub async fn build_router(
     };
 
     let channels_config = kernel.config_ref().channels.clone();
+    let active_sessions = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
     let state = Arc::new(AppState {
         kernel: kernel.clone(),
         started_at: Instant::now(),
@@ -290,6 +301,7 @@ pub async fn build_router(
         webhook_store: crate::webhook_store::WebhookStore::load(
             kernel.config_ref().home_dir.join("webhooks.json"),
         ),
+        active_sessions: active_sessions.clone(),
         #[cfg(feature = "telemetry")]
         prometheus_handle: prom_handle,
     });
@@ -330,6 +342,10 @@ pub async fn build_router(
     // Middleware accepts any token in this composite key.
     let api_key = valid_api_tokens(state.kernel.as_ref()).join("\n");
     let api_key_lock = Arc::new(tokio::sync::RwLock::new(api_key));
+    let auth_state = middleware::AuthState {
+        api_key_lock: api_key_lock.clone(),
+        active_sessions: active_sessions.clone(),
+    };
     let gcra_limiter = rate_limiter::create_rate_limiter();
 
     // Build the versioned API routes. All /api/* endpoints are defined once
@@ -379,7 +395,7 @@ pub async fn build_router(
             axum::routing::get(crate::openai_compat::list_models),
         )
         .layer(axum::middleware::from_fn_with_state(
-            api_key_lock,
+            auth_state,
             middleware::auth,
         ))
         .layer(axum::middleware::from_fn(middleware::accept_language))

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -104,6 +104,7 @@ async fn start_test_server_with_provider(
         webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
             format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
         )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         #[cfg(feature = "telemetry")]
         prometheus_handle: None,
     });
@@ -1367,13 +1368,17 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
             format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
         )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         #[cfg(feature = "telemetry")]
         prometheus_handle: None,
     });
 
-    let api_key_state = std::sync::Arc::new(tokio::sync::RwLock::new(
-        state.kernel.config_ref().api_key.clone(),
-    ));
+    let api_key_state = middleware::AuthState {
+        api_key_lock: std::sync::Arc::new(tokio::sync::RwLock::new(
+            state.kernel.config_ref().api_key.clone(),
+        )),
+        active_sessions: state.active_sessions.clone(),
+    };
 
     let app = Router::new()
         .route("/api/health", axum::routing::get(routes::health))

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -119,6 +119,7 @@ async fn test_full_daemon_lifecycle() {
         webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
             format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
         )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         prometheus_handle: None,
     });
 
@@ -251,6 +252,7 @@ async fn test_server_immediate_responsiveness() {
         webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
             format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
         )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         prometheus_handle: None,
     });
 

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -63,6 +63,7 @@ async fn start_test_server() -> TestServer {
         webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
             format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
         )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         prometheus_handle: None,
     });
 


### PR DESCRIPTION
## Summary
- Previous `derive_session_token()` used `HMAC-SHA256(password, username+salt)` producing a deterministic token — same credentials always yielded the same token with no expiration or revocation support.
- Added `SessionToken` struct with random CSPRNG token + creation timestamp
- Added `generate_session_token()` using `OsRng` for 256-bit random tokens
- Added `is_token_expired()` with configurable TTL (default 24h)
- `VerifyResult::Ok` now returns `SessionToken` instead of plain `String`
- Old `derive_session_token()` / `derive_dashboard_session_token()` marked `#[deprecated]` for backward compatibility
- Login response now includes `created_at` and `expires_at` fields

## Test plan
- [ ] `cargo test -p librefang-api --lib password_hash` — all tests pass
- [ ] `cargo check -p librefang-api` — compiles cleanly
- [ ] Verify dashboard login returns new token format with expiration
- [ ] Verify existing sessions still work during migration period