### PR TITLE
fix(telemetry): make init_prometheus idempotent for parallel test safety

### DIFF
--- a/crates/librefang-api/src/telemetry.rs
+++ b/crates/librefang-api/src/telemetry.rs
@@ -18,13 +18,19 @@ static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 
 /// Initialize the Prometheus metrics recorder.
 ///
-/// Must be called once before any metrics are recorded.
-/// Returns the handle for rendering metrics output.
+/// Safe to call multiple times — the recorder is installed only once via
+/// `OnceLock` and subsequent calls return a clone of the existing handle.
+/// This is important for test environments where multiple tests may build
+/// their own app state in parallel within the same process.
 pub fn init_prometheus() -> PrometheusHandle {
-    let builder = PrometheusBuilder::new();
-    builder
-        .install_recorder()
-        .expect("failed to install prometheus recorder")
+    PROMETHEUS_HANDLE
+        .get_or_init(|| {
+            let builder = PrometheusBuilder::new();
+            builder
+                .install_recorder()
+                .expect("failed to install prometheus recorder")
+        })
+        .clone()
 }
 
 /// Get the global Prometheus handle (if initialized).


### PR DESCRIPTION
## Summary
- `init_prometheus()` panicked when called multiple times in parallel tests because `install_recorder()` sets a global recorder that can only be set once
- Used the existing `PROMETHEUS_HANDLE: OnceLock` to ensure the recorder is installed exactly once; subsequent calls return a cloned handle
- Fixes 5 test failures on CI (test_build_router_* tests)

## Test plan
- [ ] `cargo test -p librefang-api` — all tests pass without panics
- [ ] Verify metrics endpoint still works in single-process daemon mode