### PR TITLE
fix: remove unused find_latest_stable_tag in release.rs

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -76,10 +76,6 @@ fn read_workspace_version(root: &Path) -> Result<String, Box<dyn std::error::Err
     Ok(version)
 }
 
-fn find_latest_stable_tag(root: &Path) -> Option<String> {
-    find_latest_tag(root, false)
-}
-
 /// Find the latest tag, optionally including pre-releases (rc, beta).
 fn find_latest_tag(root: &Path, include_prerelease: bool) -> Option<String> {
     let output = Command::new("git")


### PR DESCRIPTION
## Summary
- Security audit CI failed: `find_latest_stable_tag` in `xtask/src/release.rs` became dead code after #1547 refactored tag lookup to use `find_latest_tag` with an `include_prerelease` parameter, causing `-D warnings` to reject the build
- Removed the unused function (`changelog.rs` has its own independent copy still in use)

## Test plan
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)