### PR TITLE
fix: wrap channel config payload in fields object

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -765,7 +765,7 @@ export async function testChannel(channelName: string): Promise<ApiActionRespons
 }
 
 export async function configureChannel(channelName: string, config: Record<string, unknown>): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/channels/${encodeURIComponent(channelName)}/configure`, config);
+  return post<ApiActionResponse>(`/api/channels/${encodeURIComponent(channelName)}/configure`, { fields: config });
 }
 
 export async function reloadChannels(): Promise<ApiActionResponse> {


### PR DESCRIPTION
## Summary
- fix dashboard channel configuration request payload shape
- send `{ fields: {...} }` to `/api/channels/{name}/configure` (backend-required format)
- this unblocks saving WeCom configuration from dashboard

Closes #1559

## Testing
- `CARGO_TARGET_DIR=/tmp/librefang-target cargo check -p librefang-api`

## Notes
- I did not run dashboard `npm run typecheck` because `node_modules` is not present in this environment and I kept the change minimal to avoid heavy install/build.

@houko I kept this as a small and focused fix. Please guide me if you want any additional validation.
