### PR TITLE
fix: webui-chat-change-agent-show-history 

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -149,8 +149,11 @@ function useChatMessages(agentId: string | null, agents: any[] = []) {
   const { ws, wsConnected } = useWebSocket(agentId);
   const addSkillOutput = useUIStore((s) => s.addSkillOutput);
 
-  // Load history
+  // Load history - clear messages when agent changes
   useEffect(() => {
+    // Clear messages when switching agents
+    setMessages([]);
+
     if (!agentId) return;
     loadAgentSession(agentId)
       .then(session => {


### PR DESCRIPTION
<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary
webui切换agent时只展示对应的对话历史

## Changes
crates/librefang-api/dashboard/src/pages/ChatPage.tsx:152
agent更改时清空当前展示的消息

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
