### PR TITLE
fix(ci): reduce Ubuntu test memory pressure to prevent OOM kill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,4 +154,9 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
-      - run: cargo test --workspace
+      - name: Build tests
+        run: cargo test --workspace --no-run
+      - name: Run tests
+        env:
+          RUST_TEST_THREADS: "2"
+        run: cargo test --workspace


### PR DESCRIPTION
## Summary
- Split Ubuntu test step into separate build (`--no-run`) and run phases so linker memory is freed before test execution
- Limit `RUST_TEST_THREADS=2` on Ubuntu to reduce peak memory during the 1110-test `librefang-runtime` binary

## Problem
All open PRs consistently fail `Test / Ubuntu` with exit code 143 (SIGTERM). Analysis shows:
- Every run dies at exactly **789/1110** tests in `librefang-runtime` (~0.8s into execution)
- All 789 completed tests pass with `ok` — no actual test failures
- The test binary is **374MB** in debug mode
- macOS and Windows pass fine; only Ubuntu is affected
- Runner logs confirm: `The runner has received a shutdown signal`

## Test plan
- [ ] This PR's own `Test / Ubuntu` job should pass (currently 100% fail rate on all open PRs)
- [ ] No impact on macOS/Windows test jobs (unchanged)