### PR TITLE
fix(ci): add 8GB swap to prevent Ubuntu OOM kill (exit 143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: test-ubuntu-${{ hashFiles('**/Cargo.lock') }}
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
       - name: Install Tauri system deps
         run: |
           sudo apt-get update
@@ -158,5 +164,5 @@ jobs:
         run: cargo test --workspace --no-run
       - name: Run tests
         env:
-          RUST_TEST_THREADS: "2"
+          RUST_TEST_THREADS: "1"
         run: cargo test --workspace


### PR DESCRIPTION
## Summary
- Add 8GB swap space on Ubuntu runner before building/running tests
- Reduce `RUST_TEST_THREADS` from 2 to 1

## Problem
Every PR fails `Test / Ubuntu` with exit code 143 (SIGTERM/OOM kill). The runner has 7GB RAM, the debug test binary is 374MB, and running 1110+ tests OOMs at ~789/1110. PR #1571 (`RUST_TEST_THREADS=2`) did not fix this.

## Why this works
- 8GB swap gives the OS a safety net when physical RAM runs out
- `RUST_TEST_THREADS=1` ensures only one test runs at a time, keeping peak RSS predictable
- macOS/Windows unaffected (unchanged)

## Test plan
- [ ] This PR's `Test / Ubuntu` job passes
- [ ] macOS and Windows jobs still pass