### PR TITLE
fix(ci): use PAT for tag push to trigger release workflows

### DIFF
--- a/.github/actions/wait-for-release/action.yml
+++ b/.github/actions/wait-for-release/action.yml
@@ -22,12 +22,8 @@ runs:
         # Fallback: create a minimal release so builds can proceed
         echo "::warning::Release not found after 60s, creating fallback release"
         VERSION="${TAG#v}"
-        # Strip pre-release suffix then strip hour for CHANGELOG
+        # Strip pre-release suffix for CHANGELOG lookup
         VERSION=$(echo "$VERSION" | sed 's/-.*//')
-        PATCH=$(echo "$VERSION" | cut -d. -f3)
-        if [ ${#PATCH} -eq 4 ]; then
-          VERSION="$(echo "$VERSION" | cut -d. -f1,2).${PATCH:0:2}"
-        fi
         CHANGES=$(awk '/^## \['"$VERSION"'\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md)
         if [ -z "$CHANGES" ]; then
           CHANGES="See [CHANGELOG](https://github.com/librefang/librefang/blob/main/CHANGELOG.md) for details."

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -53,12 +53,8 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
-          # Strip pre-release suffix (-betaN / -rcN) then strip hour for CHANGELOG
+          # Strip pre-release suffix (-betaN / -rcN) for CHANGELOG lookup
           VERSION=$(echo "$VERSION" | sed 's/-.*//')
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-          if [ ${#PATCH} -eq 4 ]; then
-            VERSION="$(echo "$VERSION" | cut -d. -f1,2).${PATCH:0:2}"
-          fi
 
           # Extract this version's changelog section
           CHANGES=$(awk '/^## \['"$VERSION"'\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md)

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -44,12 +44,8 @@ jobs:
           fi
 
           FULL_VERSION="${TAG#v}"
-          # Strip pre-release suffix then strip hour for CHANGELOG lookup
+          # Strip pre-release suffix for CHANGELOG lookup
           CHANGELOG_VERSION=$(echo "$FULL_VERSION" | sed 's/-.*//')
-          PATCH=$(echo "$CHANGELOG_VERSION" | cut -d. -f3)
-          if [ ${#PATCH} -eq 4 ]; then
-            CHANGELOG_VERSION="$(echo "$CHANGELOG_VERSION" | cut -d. -f1,2).${PATCH:0:2}"
-          fi
 
           echo "Checking release workflows for tag $TAG..."
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -205,15 +205,13 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           REPO="${{ github.repository }}"
 
-          # Map CalVer to Go-compatible v0.YYYYMMDD.HH (keeps major=0, no /v2026 import path)
-          # e.g. 2026.3.2114 → v0.20260321.14, 2026.3.2114-rc1 → v0.20260321.14-rc1
+          # Map CalVer to Go-compatible v0.YYYYMMDD.0 (keeps major=0, no /v2026 import path)
+          # e.g. 2026.3.21 → v0.20260321.0, 2026.3.21-rc1 → v0.20260321.0-rc1
           YEAR=$(echo "$VERSION" | cut -d. -f1)
           MONTH=$(printf '%02d' "$(echo "$VERSION" | cut -d. -f2)")
-          DDHH=$(echo "$VERSION" | cut -d. -f3 | sed 's/-.*//')
+          DD=$(echo "$VERSION" | cut -d. -f3 | sed 's/-.*//')
           PRERELEASE=$(echo "$VERSION" | grep -oE '\-.*' || true)
-          DD=${DDHH:0:2}
-          HH=$((10#${DDHH:2:2}))  # strip leading zero (SemVer forbids 01, 02, etc.)
-          GO_VERSION="0.${YEAR}${MONTH}${DD}.${HH}${PRERELEASE}"
+          GO_VERSION="0.${YEAR}${MONTH}${DD}.0${PRERELEASE}"
           GO_TAG="sdk/go/v${GO_VERSION}"
 
           # Check if tag already exists

--- a/crates/librefang-kernel/tests/workflow_integration_test.rs
+++ b/crates/librefang-kernel/tests/workflow_integration_test.rs
@@ -61,7 +61,7 @@ memory_write = ["self.*"]
 // ---------------------------------------------------------------------------
 
 /// Test that workflow registration and agent resolution work at the kernel level.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_workflow_register_and_resolve() {
     let config = test_config("ollama", "test-model", "OLLAMA_API_KEY");
     let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
@@ -181,7 +181,7 @@ memory_write = ["self.*"]
 }
 
 /// Test workflow with agent referenced by ID.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_workflow_agent_by_id() {
     let config = test_config("ollama", "test-model", "OLLAMA_API_KEY");
     let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
@@ -241,7 +241,7 @@ memory_write = ["self.*"]
 }
 
 /// Test trigger registration and listing at kernel level.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trigger_registration_with_kernel() {
     use librefang_kernel::triggers::TriggerPattern;
 
@@ -313,7 +313,7 @@ memory_write = ["self.*"]
 
 /// End-to-end: boot kernel → spawn 2 agents → create 2-step workflow →
 /// run it through the real Groq LLM → verify output flows from step 1 to step 2.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_workflow_e2e_with_groq() {
     if std::env::var("GROQ_API_KEY").is_err() {
         eprintln!("GROQ_API_KEY not set, skipping E2E workflow test");

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -111,11 +111,10 @@ fn prompt(message: &str) -> String {
 fn compute_calver() -> String {
     let now = chrono::Local::now();
     format!(
-        "{}.{}.{}{}",
+        "{}.{}.{}",
         now.format("%Y"),
         now.format("%-m"),
         now.format("%d"),
-        now.format("%H"),
     )
 }
 
@@ -218,7 +217,7 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
             // Default to stable
             base_version
         } else {
-            // Count existing tags to auto-increment
+            // Count existing tags for this day to auto-increment rc/beta numbers
             let beta_count = Command::new("git")
                 .args(["tag", "-l", &format!("v{}-beta*", base_version)])
                 .current_dir(&root)
@@ -293,7 +292,7 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
             .unwrap();
     if !calver_re.is_match(&version) {
         return Err(format!(
-            "'{}' is not a valid CalVer (expected: YYYY.M.DDHH, YYYY.M-lts, etc.)",
+            "'{}' is not a valid CalVer (expected: YYYY.M.DD, YYYY.M-lts, etc.)",
             version
         )
         .into());
@@ -399,16 +398,7 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
     // --- Generate changelog ---
     println!();
     println!("Generating changelog...");
-    let changelog_version = {
-        let base = version.split('-').next().unwrap_or(&version);
-        let parts: Vec<&str> = base.split('.').collect();
-        if parts.len() == 3 && parts[2].len() == 4 {
-            // Strip hour from DDHH -> DD
-            format!("{}.{}.{}", parts[0], parts[1], &parts[2][..2])
-        } else {
-            base.to_string()
-        }
-    };
+    let changelog_version = version.split('-').next().unwrap_or(&version).to_string();
     changelog::run(changelog::ChangelogArgs {
         version: changelog_version.clone(),
         base_tag: prev_tag.clone(),

--- a/xtask/src/sync_versions.rs
+++ b/xtask/src/sync_versions.rs
@@ -24,7 +24,7 @@ fn validate_calver(version: &str) -> Result<(), Box<dyn std::error::Error>> {
     let re = Regex::new(r"^[0-9]{4}\.[0-9]{1,2}\.[0-9]{2,4}(-(beta|rc)[0-9]+)?$")?;
     if !re.is_match(version) {
         return Err(format!(
-            "'{}' is not a valid CalVer (expected: YYYY.M.DDHH e.g. 2026.3.2114)",
+            "'{}' is not a valid CalVer (expected: YYYY.M.DD e.g. 2026.3.21)",
             version
         )
         .into());
@@ -124,7 +124,7 @@ fn update_tauri_conf(path: &Path, version: &str) -> Result<(), Box<dyn std::erro
     let yyyy: u32 = parts[0].parse()?;
     let yy = yyyy % 100;
     let month: u32 = parts[1].parse()?;
-    let ddhh: u32 = parts[2].parse()?;
+    let dd: u32 = parts[2].parse()?;
 
     // Determine pre-release suffix
     let prerelease_re = Regex::new(r"-(beta|rc)([0-9]+)")?;
@@ -132,12 +132,12 @@ fn update_tauri_conf(path: &Path, version: &str) -> Result<(), Box<dyn std::erro
         let kind = caps.get(1).unwrap().as_str();
         let n: u32 = caps.get(2).unwrap().as_str().parse()?;
         match kind {
-            "beta" => ddhh * 10 + n,
-            "rc" => ddhh * 10 + 4 + n,
-            _ => ddhh * 10 + 9,
+            "beta" => dd * 10 + n,
+            "rc" => dd * 10 + 4 + n,
+            _ => dd * 10 + 9,
         }
     } else {
-        ddhh * 10 + 9
+        dd * 10 + 9
     };
 
     let tauri_version = format!("{}.{}.{}", yy, month, tauri_patch);


### PR DESCRIPTION
## Summary
- `tag_on_merge` job pushes tags with the default `GITHUB_TOKEN`, which does not trigger downstream workflows due to GitHub Actions loop prevention
- Switch to the existing `HOMEBREW_TAP_TOKEN` (PAT) for checkout so the tag push properly triggers `release-create`, `release-desktop`, and other release workflows
- This is the root cause of `v2026.3.2501-rc1` release being skipped

## Test plan
- [ ] After merge, delete and re-push `v2026.3.2501-rc1` tag to verify the full release pipeline triggers