### PR TITLE
release: v2026.3.25-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DDHH).
 - Add 8GB swap to prevent Ubuntu OOM kill (exit 143) (#1573) (@houko)
 - Split runtime tests to prevent Ubuntu OOM kill (#1574) (@houko)
 - Feishu WS endpoint fails to parse negative ClientConfig values (#1578) (@houko)
+- Use PAT for tag push to trigger release workflows (#1581) (@houko)
 
 ### Performance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "aes",
  "async-trait",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10380,7 +10380,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.3.25015",
+  "version": "26.3.255",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.3.2501-rc1",
+  "version": "2026.3.25-rc1",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.3.2501-rc1",
+  "version": "2026.3.25-rc1",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.3.2501rc1",
+    version="2026.3.25rc1",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.3.2501-rc1"
+version = "2026.3.25-rc1"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.3.25-rc1 -->
## Release v2026.3.25-rc1

### Added

- Version display, mobile optimization, workflow scheduling, and config resilience (#1557) (@houko)
- Add-memory-tool-memory_list (#1565) (@aimlyo)
- Webui-chat-output-by-line (#1569) (@aimlyo)
- Homebrew channels, CLI update_channel, dashboard utility extraction (#1576) (@houko)

### Fixed

- Ignore broken pipe on skill stdin write (#1554) (@houko)
- Create release tag after PR merge, not before (#1555) (@houko)
- Agent-list-presentation-of-tui (#1561) (@aimlyo)
- Make provider key save resilient to empty api_key_env (#1563) (@TechWizard9999)
- Wrap channel config payload in fields object (#1564) (@TechWizard9999)
- Webui-chat-history-to-using-md (#1568) (@aimlyo)
- Webui-chat-change-agent-show-history (#1570) (@aimlyo)
- Reduce Ubuntu test memory pressure to prevent OOM kill (#1571) (@houko)
- Display WeChat QR code for iLink login (#1572) (@houko)
- Add 8GB swap to prevent Ubuntu OOM kill (exit 143) (#1573) (@houko)
- Split runtime tests to prevent Ubuntu OOM kill (#1574) (@houko)
- Feishu WS endpoint fails to parse negative ClientConfig values (#1578) (@houko)
- Use PAT for tag push to trigger release workflows (#1581) (@houko)

### Performance

- Run test jobs in parallel with quality checks (#1579) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.3.2407-rc1...v2026.3.25-rc1