### PR TITLE
fix: remove LibreFang prefix from release title

### DIFF
--- a/.github/actions/wait-for-release/action.yml
+++ b/.github/actions/wait-for-release/action.yml
@@ -34,7 +34,7 @@ runs:
           PRERELEASE_FLAG="--prerelease"
         fi
         gh release create "$TAG" \
-          --title "LibreFang $TAG" \
+          --title "$TAG" \
           --notes "$CHANGES" \
           $PRERELEASE_FLAG \
           --repo "${{ github.repository }}" || true

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -156,7 +156,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "LibreFang ${{ github.ref_name }}"
+          releaseName: "${{ github.ref_name }}"
           releaseDraft: false
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           includeUpdaterJson: true
@@ -176,7 +176,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "LibreFang ${{ github.ref_name }}"
+          releaseName: "${{ github.ref_name }}"
           releaseDraft: false
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           includeUpdaterJson: true


### PR DESCRIPTION
Use tag name directly as release title instead of prefixing with LibreFang.