### PR TITLE
fix: deploy on RC/beta tags and bind 0.0.0.0 in fly.toml

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -124,7 +124,6 @@ jobs:
     name: Deploy to Fly.io
     runs-on: ubuntu-latest
     needs: [docker-manifest]
-    if: ${{ !contains(github.ref, '-beta') && !contains(github.ref, '-rc') }}
     steps:
       - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@v1
@@ -138,7 +137,6 @@ jobs:
     name: Deploy to Render
     runs-on: ubuntu-latest
     needs: [docker-manifest]
-    if: ${{ !contains(github.ref, '-beta') && !contains(github.ref, '-rc') }}
     steps:
       - name: Trigger Render deploy
         env:

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -6,6 +6,7 @@ image = "ghcr.io/librefang/librefang:latest"
 
 [env]
   LIBREFANG_HOME = "/data"
+  LIBREFANG_LISTEN = "0.0.0.0:4545"
 
 [http_service]
   internal_port = 4545


### PR DESCRIPTION
## Summary
- Remove the `if` condition that skipped Fly.io and Render deploys for `-rc` and `-beta` tags — all `v*` tags now trigger deployment
- Add `LIBREFANG_LISTEN=0.0.0.0:4545` env var in `fly.toml` so the server binds all interfaces (default `127.0.0.1` is unreachable by fly-proxy)

## Test plan
- [x] Manually deployed to Fly.io and verified the server is reachable at https://librefang.fly.dev/
- [ ] Next RC tag push should trigger both Fly.io and Render deploy jobs