### PR TITLE
fix: replace Pages git integration with GitHub Actions deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,45 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main, feat/*, feature/*]
+    paths:
+      - "docs/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - run: cd docs && pnpm install --frozen-lockfile
+
+      - run: cd docs && pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/out --project-name=librefang-docs --branch=${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,47 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main, feat/*, feature/*]
+    paths:
+      - "web/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: "web/.nvmrc"
+          cache: "pnpm"
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - run: cd web && pnpm install --frozen-lockfile
+
+      - run: cd web && pnpm lint
+
+      - run: cd web && pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy web/dist --project-name=librefang --branch=${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary

- Cloudflare Pages git integration's 1 concurrent build limit causes preview deployments to be constantly skipped for both projects (librefang + librefang-docs) — 48 out of 50 recent deployments were skipped
- Add `deploy-web.yml` and `deploy-docs.yml` workflows using `wrangler pages deploy` to upload build artifacts directly
- Use GitHub Actions `paths:` filters for precise triggering: `web/**` changes only trigger website deploy, `docs/**` changes only trigger docs deploy
- After merge, disconnect git integration from both Pages projects in Cloudflare Dashboard

## TODO after merge

- [ ] Cloudflare Dashboard → librefang → Settings → Builds & deployments → Disconnect git
- [ ] Cloudflare Dashboard → librefang-docs → Settings → Builds & deployments → Disconnect git
- [ ] Optionally delete `web-lint.yml` (lint is now included in `deploy-web.yml`)

## Test plan

- [ ] After merge, push a `web/` change and verify `Deploy Website` workflow triggers and deploys successfully
- [ ] Push a `docs/` change and verify `Deploy Docs` workflow triggers and deploys successfully
- [ ] Push a non-web/docs change (e.g. crate code) and verify no deploy workflow triggers