### PR TITLE
fix: use releases proxy to avoid GitHub API 403

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -781,11 +781,10 @@ function Downloads(_props: SectionProps) {
   const { data: release, isLoading } = useQuery({
     queryKey: ['latestRelease'],
     queryFn: async () => {
-      const res = await fetch('https://api.github.com/repos/librefang/librefang/releases/latest', {
-        headers: { Accept: 'application/vnd.github.v3+json' },
-      })
+      const res = await fetch('https://stats.librefang.ai/api/releases')
       if (!res.ok) throw new Error('Failed')
-      return res.json() as Promise<{ tag_name: string; assets: ReleaseAsset[]; html_url: string }>
+      const releases = await res.json() as { tag_name: string; assets: ReleaseAsset[]; html_url: string }[]
+      return releases[0]
     },
     staleTime: 1000 * 60 * 60,
     retry: 2,

--- a/web/src/pages/DeployPage.tsx
+++ b/web/src/pages/DeployPage.tsx
@@ -174,12 +174,11 @@ export default function DeployPage() {
     }
   }, [])
 
-  // Fetch latest version from GitHub
+  // Fetch latest version from releases proxy
   useEffect(() => {
-    fetch('https://api.github.com/repos/librefang/librefang/releases/latest', {
-      headers: { Accept: 'application/vnd.github.v3+json' },
-    })
-      .then(r => r.ok ? r.json() as Promise<{ tag_name: string }> : null)
+    fetch('https://stats.librefang.ai/api/releases')
+      .then(r => r.ok ? r.json() as Promise<{ tag_name: string }[]> : null)
+      .then(data => data?.[0] ?? null)
       .then(data => { if (data?.tag_name) setVersion(data.tag_name) })
       .catch(() => {})
   }, [])


### PR DESCRIPTION
## Summary
- Replace direct `api.github.com/repos/librefang/librefang/releases/latest` calls with `stats.librefang.ai/api/releases` proxy
- Fixes 403 Forbidden errors due to GitHub API rate limiting on unauthenticated requests
- Affected: Downloads section (App.tsx) and Deploy page (DeployPage.tsx)
- ChangelogPage.tsx already used the proxy, now all three are consistent