### PR TITLE
fix: dev.to publish fails due to shell expansion in payload

### DIFF
--- a/.github/workflows/devto-publish.yml
+++ b/.github/workflows/devto-publish.yml
@@ -52,8 +52,8 @@ jobs:
                   break
           " 2>/dev/null || true)
 
-            # Build JSON payload
-            PAYLOAD=$(ARTICLE_FILE="$article" ARTICLE_TITLE="$TITLE" ARTICLE_TAGS="$TAGS" \
+            # Build JSON payload to file (avoids shell expansion of $vars in body)
+            ARTICLE_FILE="$article" ARTICLE_TITLE="$TITLE" ARTICLE_TAGS="$TAGS" \
               ARTICLE_DESC="$DESCRIPTION" ARTICLE_COVER="$COVER" ARTICLE_CANONICAL="$CANONICAL" \
               python3 -c "
           import json, os
@@ -78,21 +78,21 @@ jobs:
               article['canonical_url'] = canonical
 
           print(json.dumps({'article': article}))
-          ")
+          " > /tmp/payload.json
 
             if [ -n "$EXISTING" ]; then
               echo "Updating: $TITLE (id=$EXISTING)"
               RESP=$(curl -s -X PUT "https://dev.to/api/articles/$EXISTING" \
                 -H "api-key: $DEVTO_API_KEY" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD")
+                -d @/tmp/payload.json)
               echo "$RESP" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('url',''))" 2>/dev/null || echo "Warning: failed to parse response for '$TITLE'"
             else
               echo "Creating: $TITLE"
               RESP=$(curl -s -X POST "https://dev.to/api/articles" \
                 -H "api-key: $DEVTO_API_KEY" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD")
+                -d @/tmp/payload.json)
               echo "$RESP" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('url',''))" 2>/dev/null || echo "Warning: failed to parse response for '$TITLE'"
             fi
           done


### PR DESCRIPTION
## Summary
- Write JSON payload to `/tmp/payload.json` instead of storing in `$PAYLOAD` shell variable
- Use `curl -d @/tmp/payload.json` to send the file directly
- Fixes articles with `$` characters (e.g. `$5 VPS`) being corrupted by bash variable expansion