### PR TITLE
fix: use workspace version as floor for RC/beta numbering

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -217,10 +217,23 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
             // Default to stable
             base_version
         } else {
-            // Find max existing rc/beta number for this day and increment
+            // Find max existing rc/beta number for this day and increment.
+            // Also consider the current workspace version (tag may have been
+            // deleted by a previous failed release attempt).
+            let current_beta_num = Regex::new(r"-beta(\d+)$")
+                .unwrap()
+                .captures(&current)
+                .and_then(|c| c.get(1)?.as_str().parse::<u64>().ok())
+                .unwrap_or(0);
+            let current_rc_num = Regex::new(r"-rc(\d+)$")
+                .unwrap()
+                .captures(&current)
+                .and_then(|c| c.get(1)?.as_str().parse::<u64>().ok())
+                .unwrap_or(0);
+
             let beta_re =
                 Regex::new(&format!(r"^v{}-beta(\d+)$", regex::escape(&base_version))).unwrap();
-            let next_beta = Command::new("git")
+            let max_beta_tag = Command::new("git")
                 .args(["tag", "-l", &format!("v{}-beta*", base_version)])
                 .current_dir(&root)
                 .output()
@@ -232,11 +245,12 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
                         .max()
                         .unwrap_or(0)
                 })
-                .unwrap_or(0)
-                + 1;
+                .unwrap_or(0);
+            let next_beta = max_beta_tag.max(current_beta_num) + 1;
+
             let rc_re =
                 Regex::new(&format!(r"^v{}-rc(\d+)$", regex::escape(&base_version))).unwrap();
-            let next_rc = Command::new("git")
+            let max_rc_tag = Command::new("git")
                 .args(["tag", "-l", &format!("v{}-rc*", base_version)])
                 .current_dir(&root)
                 .output()
@@ -248,8 +262,8 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
                         .max()
                         .unwrap_or(0)
                 })
-                .unwrap_or(0)
-                + 1;
+                .unwrap_or(0);
+            let next_rc = max_rc_tag.max(current_rc_num) + 1;
 
             // Compute LTS: YYYY.M.PATCH-lts
             let lts_base = {


### PR DESCRIPTION
## Summary
- When a previous failed release deletes the RC tag, the tag count drops to zero and the next suggestion goes **backwards** (rc2 → rc1 instead of rc3)
- Now parses the RC/beta number from the current workspace version in `Cargo.toml` and uses `max(tag_number, workspace_number) + 1`

## Test plan
- [x] `cargo build -p xtask` compiles
- [x] `cargo clippy -p xtask -- -D warnings` zero warnings
- [x] With workspace version `2026.3.25-rc2` and no rc tags, script should suggest rc3

🤖 Generated with [Claude Code](https://claude.com/claude-code)