### PR TITLE
fix(ci): add -- to grep patterns in release workflows

### DIFF
--- a/.github/actions/wait-for-release/action.yml
+++ b/.github/actions/wait-for-release/action.yml
@@ -30,7 +30,7 @@ runs:
         fi
         # Detect pre-release tags (-betaN, -rcN)
         PRERELEASE_FLAG=""
-        if echo "$TAG" | grep -qE '-(beta|rc)[0-9]'; then
+        if echo "$TAG" | grep -qE -- '-(beta|rc)[0-9]'; then
           PRERELEASE_FLAG="--prerelease"
         fi
         gh release create "$TAG" \

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -138,12 +138,12 @@ jobs:
 
           # Detect pre-release tags (-betaN, -rcN)
           PRERELEASE_FLAG=""
-          if echo "$TAG" | grep -qE '-(beta|rc)[0-9]'; then
+          if echo "$TAG" | grep -qE -- '-(beta|rc)[0-9]'; then
             PRERELEASE_FLAG="--prerelease"
           fi
 
           # LTS releases get a special label
-          if echo "$TAG" | grep -qE '\-lts$'; then
+          if echo "$TAG" | grep -qE -- '\-lts$'; then
             # v2026.3.0-lts -> release/2026.3
             LTS_BASE="${TAG#v}"
             LTS_BASE="${LTS_BASE%-lts}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -108,11 +108,11 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           TAGS="-t $IMAGE:$VERSION"
           # Only tag :latest for stable releases (not beta/rc)
-          if ! echo "$VERSION" | grep -qE '-(beta|rc)[0-9]'; then
+          if ! echo "$VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
             TAGS="$TAGS -t $IMAGE:latest"
           fi
           # LTS releases also get :lts tag
-          if echo "$VERSION" | grep -qE '\-lts'; then
+          if echo "$VERSION" | grep -qE -- '\-lts'; then
             TAGS="$TAGS -t $IMAGE:lts"
           fi
           docker buildx imagetools create \

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -57,9 +57,9 @@ jobs:
             echo "✓ ${PKG_NAME}@${PKG_VERSION} already published to npm, skipping"
           else
             NPM_TAG=""
-            if echo "$PKG_VERSION" | grep -qE '-(beta|rc)[0-9]'; then
+            if echo "$PKG_VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
               NPM_TAG="--tag next"
-            elif echo "$PKG_VERSION" | grep -qE '\-lts'; then
+            elif echo "$PKG_VERSION" | grep -qE -- '\-lts'; then
               NPM_TAG="--tag lts"
             fi
             npm publish --access public $NPM_TAG


### PR DESCRIPTION
## Summary

- All release workflow `grep -qE` calls with dash-prefixed patterns (e.g. `'-(beta|rc)[0-9]'`) are missing the `--` end-of-options separator
- Newer grep interprets `-(`  as an option flag → `grep: invalid option -- '('`
- **Direct failure**: JS SDK npm publish (rc3) — `--tag next` never set, npm refuses to publish prerelease without `--tag`
- **Silent bug**: Docker workflow's `! grep '-(beta|rc)...'` always "succeeds" because grep errors out → rc/beta images tagged `:latest` and deployed to Fly.io/Render

Adds `--` before every dash-prefixed pattern across 5 release workflows (11 occurrences).

Fixes the ❌ SDK and contributes to fixing ❌ Desktop (the other Desktop failure — Sync Homebrew Cask running for rc tags — was already fixed on main with the `if:` condition guard).

## Affected workflows

| Workflow | Lines fixed |
|----------|------------|
| `release-sdk.yml` | 53, 97, 99 |
| `release-create.yml` | 140, 145 |
| `release-desktop.yml` | 55 |
| `release-docker.yml` | 53, 148, 152 |
| `release-shell.yml` | 55, 462 |

## Test plan

- [ ] Merge and tag `v2026.3.25-rc4` — verify SDK/JS npm publishes with `--tag next`
- [ ] Verify Desktop Cask job is skipped for rc tags (already fixed on main)
- [ ] Spot-check Docker release does NOT tag `:latest` for pre-release