### PR TITLE
feat(ci): add publish links to SDK release job summary

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -64,6 +64,7 @@ jobs:
             fi
             npm publish --access public $NPM_TAG
           fi
+          echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${PKG_VERSION}" >> $GITHUB_STEP_SUMMARY
 
       - name: Publish to GitHub Packages
         env:
@@ -116,6 +117,7 @@ jobs:
             fi
             npm publish --access public $NPM_TAG
           fi
+          echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${PKG_VERSION}" >> $GITHUB_STEP_SUMMARY
 
   # ── Python SDK → PyPI ─────────────────────────────────────────────────────
   sdk_python:
@@ -154,6 +156,11 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
+      - name: Output publish link
+        run: |
+          PYPI_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "- **PyPI**: https://pypi.org/project/librefang-sdk/${PYPI_VERSION}/" >> $GITHUB_STEP_SUMMARY
+
   # ── Rust SDK → crates.io ──────────────────────────────────────────────────
   sdk_rust:
     name: SDK / Rust (crates.io)
@@ -189,6 +196,7 @@ jobs:
           else
             cargo publish --allow-dirty
           fi
+          echo "- **crates.io**: https://crates.io/crates/librefang/${VERSION}" >> $GITHUB_STEP_SUMMARY
 
   # ── Go SDK — tag for Go modules ──────────────────────────────────────────
   sdk_go:
@@ -228,3 +236,4 @@ jobs:
             -f ref="refs/tags/$GO_TAG" \
             -f sha="$SHA"
           echo "✓ Published Go module tag: $GO_TAG (from $VERSION)"
+          echo "- **Go**: https://pkg.go.dev/github.com/librefang/librefang/sdk/go@v${GO_VERSION}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- SDK 发布完成后，在 GitHub Actions Job Summary 页面输出各包的链接
- 覆盖所有 5 个 SDK job：npm SDK、npm CLI、PyPI、crates.io、Go pkg.go.dev

Stacked on #1622.

## Links output example

- **npm**: https://www.npmjs.com/package/@librefang/sdk/v/2026.3.25-rc4
- **npm**: https://www.npmjs.com/package/@librefang/cli/v/2026.3.25-rc4
- **PyPI**: https://pypi.org/project/librefang-sdk/2026.3.25rc4/
- **crates.io**: https://crates.io/crates/librefang/2026.3.25-rc4
- **Go**: https://pkg.go.dev/github.com/librefang/librefang/sdk/go@v0.20260325.4-rc4

## Test plan

- [ ] Merge #1622 first, then merge this PR
- [ ] Tag rc4, verify job summary shows clickable links