### PR TITLE
chore(ci): stop marking beta/rc as GitHub prerelease

### DIFF
--- a/.github/actions/wait-for-release/action.yml
+++ b/.github/actions/wait-for-release/action.yml
@@ -28,13 +28,7 @@ runs:
         if [ -z "$CHANGES" ]; then
           CHANGES="See [CHANGELOG](https://github.com/librefang/librefang/blob/main/CHANGELOG.md) for details."
         fi
-        # Detect pre-release tags (-betaN, -rcN)
-        PRERELEASE_FLAG=""
-        if echo "$TAG" | grep -qE -- '-(beta|rc)[0-9]'; then
-          PRERELEASE_FLAG="--prerelease"
-        fi
         gh release create "$TAG" \
           --title "$TAG" \
           --notes "$CHANGES" \
-          $PRERELEASE_FLAG \
           --repo "${{ github.repository }}" || true

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -136,12 +136,6 @@ jobs:
             fi
           } > /tmp/release-body.md
 
-          # Detect pre-release tags (-betaN, -rcN)
-          PRERELEASE_FLAG=""
-          if echo "$TAG" | grep -qE -- '-(beta|rc)[0-9]'; then
-            PRERELEASE_FLAG="--prerelease"
-          fi
-
           # LTS releases get a special label
           if echo "$TAG" | grep -qE -- '\-lts$'; then
             # v2026.3.0-lts -> release/2026.3
@@ -156,11 +150,9 @@ jobs:
             echo "Release $TAG already exists, updating..."
             gh release edit "$TAG" \
               --title "$TAG" \
-              --notes-file /tmp/release-body.md \
-              $PRERELEASE_FLAG
+              --notes-file /tmp/release-body.md
           else
             gh release create "$TAG" \
               --title "$TAG" \
-              --notes-file /tmp/release-body.md \
-              $PRERELEASE_FLAG
+              --notes-file /tmp/release-body.md
           fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -158,7 +158,7 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ github.ref_name }}"
           releaseDraft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          prerelease: false
           includeUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}
@@ -178,7 +178,7 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ github.ref_name }}"
           releaseDraft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          prerelease: false
           includeUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}


### PR DESCRIPTION
## Summary

- 移除所有 release workflow 中的 `--prerelease` 标记逻辑
- beta/rc 版本和 stable 版本在 GitHub Releases 上同等对待
- rc/beta 发布后会自动成为 Latest，用户默认下载最新版

## 改动

- `release-create.yml`: 删除 PRERELEASE_FLAG 检测和传递
- `wait-for-release/action.yml`: 同上
- `release-desktop.yml`: `prerelease: false`（两处 tauri-action）

已手动将 rc4 设为 Latest，历史 rc 版本取消 Latest 标记。