### PR TITLE
release: v2026.3.25-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,19 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 - TUI multi-select provider menu in deploy script (#1618) (@houko)
 - Add publish links to SDK release job summary (#1623) (@houko)
+- Limit-the-degrees-of-freedom-of-agent_spawn (#1624) (@aimlyo)
 
 ### Fixed
 
 - Read from /dev/tty in deploy script for curl-pipe compatibility (#1616) (@houko)
+- TUI arrow key navigation crashes due to set -e (#1620) (@houko)
 - Add -- to grep patterns in release workflows (#1622) (@houko)
+- Use isolated test dir for model_catalog tests (#1627) (@houko)
+- Resolve DMG asset name mismatch in Homebrew Cask sync (#1628) (@houko)
+
+### Maintenance
+
+- Stop marking beta/rc as GitHub prerelease (#1626) (@houko)
 
 
 ## [2026.3.24] - 2026-03-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "aes",
  "async-trait",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "chrono",
  "dashmap",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "async-trait",
  "axum",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10381,7 +10381,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.3.32258",
+  "version": "26.3.32259",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.3.25-rc4",
+  "version": "2026.3.25-rc5",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.3.25-rc4",
+  "version": "2026.3.25-rc5",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.3.25rc4",
+    version="2026.3.25rc5",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.3.25-rc4"
+version = "2026.3.25-rc5"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.3.25-rc5 -->
## Release v2026.3.25-rc5

### Added

- TUI multi-select provider menu in deploy script (#1618) (@houko)
- Add publish links to SDK release job summary (#1623) (@houko)
- Limit-the-degrees-of-freedom-of-agent_spawn (#1624) (@aimlyo)

### Fixed

- Read from /dev/tty in deploy script for curl-pipe compatibility (#1616) (@houko)
- TUI arrow key navigation crashes due to set -e (#1620) (@houko)
- Add -- to grep patterns in release workflows (#1622) (@houko)
- Use isolated test dir for model_catalog tests (#1627) (@houko)
- Resolve DMG asset name mismatch in Homebrew Cask sync (#1628) (@houko)

### Maintenance

- Stop marking beta/rc as GitHub prerelease (#1626) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.3.25-rc3...v2026.3.25-rc5