### PR TITLE
fix(ci): always tag Docker image as :latest

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -106,11 +106,7 @@ jobs:
         run: |
           IMAGE=ghcr.io/librefang/librefang
           VERSION=${{ steps.version.outputs.version }}
-          TAGS="-t $IMAGE:$VERSION"
-          # Only tag :latest for stable releases (not beta/rc)
-          if ! echo "$VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
-            TAGS="$TAGS -t $IMAGE:latest"
-          fi
+          TAGS="-t $IMAGE:$VERSION -t $IMAGE:latest"
           # LTS releases also get :lts tag
           if echo "$VERSION" | grep -qE -- '\-lts'; then
             TAGS="$TAGS -t $IMAGE:lts"


### PR DESCRIPTION
fly.toml 用 :latest 拉镜像，但 rc/beta 版本不打 :latest 标签，导致 Fly.io 部署成功但拉到旧镜像。