### PR TITLE
fix: add 8 missing fields to strict config validation

### DIFF
--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -72,6 +72,14 @@ impl KernelConfig {
             "dashboard_pass_hash",
             "log_dir",
             "inbox",
+            "azure_openai",
+            "heartbeat",
+            "privacy",
+            "prompt_intelligence",
+            "qwen_code_path",
+            "sanitize",
+            "telemetry",
+            "update_channel",
         ]
     }
 


### PR DESCRIPTION
## Summary
Add azure_openai, heartbeat, privacy, prompt_intelligence, qwen_code_path, sanitize, telemetry, update_channel to known_top_level_fields()

## Test plan
- [ ] `strict_config=true` rejects typos in these field names
- [ ] Valid config with these fields loads without warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)