### PR TITLE
fix: resolve WhatsApp gateway config path from $HOME instead of hardcoded /data/

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -4,6 +4,7 @@
 const http = require('node:http');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 const { randomUUID } = require('node:crypto');
 const toml = require('toml');
 
@@ -165,7 +166,7 @@ function dbUpdateLastSeen(jid, timestamp) {
 // ---------------------------------------------------------------------------
 // Read config.toml — the gateway reads its own config directly
 // ---------------------------------------------------------------------------
-const CONFIG_PATH = process.env.LIBREFANG_CONFIG || '/data/config.toml';
+const CONFIG_PATH = process.env.LIBREFANG_CONFIG || path.join(os.homedir(), '.librefang', 'config.toml');
 
 function readWhatsAppConfig(configPath) {
   const defaults = { default_agent: 'assistant', owner_numbers: [], conversation_ttl_hours: 24 };


### PR DESCRIPTION
## Summary

- Replace hardcoded `/data/config.toml` fallback with `path.join(os.homedir(), '.librefang', 'config.toml')`
- Add `require('node:os')` import
- Consistent with where LibreFang stores its config on all platforms (`~/.librefang/config.toml`)

## Before / After

```diff
-const CONFIG_PATH = process.env.LIBREFANG_CONFIG || '/data/config.toml';
+const CONFIG_PATH = process.env.LIBREFANG_CONFIG || path.join(os.homedir(), '.librefang', 'config.toml');
```

## Test plan

- [x] `cargo check -p librefang-kernel` passes
- [x] `cargo test -p librefang-kernel -- whatsapp` passes
- [ ] Manual test on Termux — gateway should read `~/.librefang/config.toml` without ENOENT

Closes #1634