### PR TITLE
fix: re-land SSRF DNS pinning to prevent TOCTOU rebinding attacks

### DIFF
--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -120,9 +120,16 @@ fn safe_resolve_parent(path: &str) -> Result<std::path::PathBuf, serde_json::Val
 // SSRF protection
 // ---------------------------------------------------------------------------
 
+/// SSRF-validated DNS resolution result for the WASM host function path.
+struct SsrfResolved {
+    hostname: String,
+    resolved: Vec<std::net::SocketAddr>,
+}
+
 /// SSRF protection: check if a hostname resolves to a private/internal IP.
-/// This defeats DNS rebinding by checking the RESOLVED address, not the hostname.
-fn is_ssrf_target(url: &str) -> Result<(), serde_json::Value> {
+/// Returns the resolved addresses on success so the caller can pin DNS and
+/// prevent TOCTOU / DNS-rebinding attacks.
+fn is_ssrf_target(url: &str) -> Result<SsrfResolved, serde_json::Value> {
     // Only allow http:// and https:// schemes (block file://, gopher://, ftp://)
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(json!({"error": "Only http:// and https:// URLs are allowed"}));
@@ -146,17 +153,34 @@ fn is_ssrf_target(url: &str) -> Result<(), serde_json::Value> {
     // Resolve DNS and check every returned IP
     let port = if url.starts_with("https") { 443 } else { 80 };
     let socket_addr = format!("{hostname}:{port}");
-    if let Ok(addrs) = socket_addr.to_socket_addrs() {
-        for addr in addrs {
-            let ip = addr.ip();
-            if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
-                return Err(json!({"error": format!(
-                    "SSRF blocked: {hostname} resolves to private IP {ip}"
-                )}));
+    let mut resolved = Vec::new();
+    match socket_addr.to_socket_addrs() {
+        Ok(addrs) => {
+            for addr in addrs {
+                let ip = addr.ip();
+                if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
+                    return Err(json!({"error": format!(
+                        "SSRF blocked: {hostname} resolves to private IP {ip}"
+                    )}));
+                }
+                resolved.push(addr);
             }
         }
+        Err(e) => {
+            return Err(json!({"error": format!(
+                "SSRF blocked: DNS resolution failed for {hostname}: {e}"
+            )}));
+        }
     }
-    Ok(())
+    if resolved.is_empty() {
+        return Err(json!({"error": format!(
+            "SSRF blocked: DNS resolution returned no addresses for {hostname}"
+        )}));
+    }
+    Ok(SsrfResolved {
+        hostname: hostname.to_string(),
+        resolved,
+    })
 }
 
 fn is_private_ip(ip: &std::net::IpAddr) -> bool {
@@ -279,10 +303,11 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
         .unwrap_or("GET");
     let body = params.get("body").and_then(|b| b.as_str()).unwrap_or("");
 
-    // SECURITY: SSRF protection — check resolved IP against private ranges
-    if let Err(e) = is_ssrf_target(url) {
-        return e;
-    }
+    // SECURITY: SSRF protection — resolve DNS once and validate IPs
+    let ssrf_result = match is_ssrf_target(url) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
 
     // Extract host:port from URL for capability check
     let host = extract_host_from_url(url);
@@ -291,7 +316,13 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
     }
 
     state.tokio_handle.block_on(async {
-        let client = crate::http_client::proxied_client();
+        // Build a DNS-pinned client so the HTTP request connects to the
+        // same IPs we already validated (prevents DNS-rebinding TOCTOU).
+        let mut builder = crate::http_client::proxied_client_builder();
+        for addr in &ssrf_result.resolved {
+            builder = builder.resolve(&ssrf_result.hostname, *addr);
+        }
+        let client = builder.build().expect("HTTP client build");
         let request = match method.to_uppercase().as_str() {
             "POST" => client.post(url).body(body.to_string()),
             "PUT" => client.put(url).body(body.to_string()),

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -15,25 +15,26 @@ use tracing::debug;
 /// Enhanced web fetch engine with SSRF protection and readability extraction.
 pub struct WebFetchEngine {
     config: WebFetchConfig,
-    client: reqwest::Client,
     cache: Arc<WebCache>,
 }
 
 impl WebFetchEngine {
     /// Create a new fetch engine from config with a shared cache.
     pub fn new(config: WebFetchConfig, cache: Arc<WebCache>) -> Self {
-        let client = crate::http_client::proxied_client_builder()
-            .timeout(std::time::Duration::from_secs(config.timeout_secs))
+        Self { config, cache }
+    }
+
+    /// Build a per-request client with DNS pinned to the SSRF-validated IPs.
+    fn pinned_client(&self, resolution: SsrfResolution) -> reqwest::Client {
+        let builder = crate::http_client::proxied_client_builder()
+            .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
             .gzip(true)
             .deflate(true)
-            .brotli(true)
+            .brotli(true);
+        resolution
+            .pin_dns(builder)
             .build()
-            .expect("HTTP client build");
-        Self {
-            config,
-            client,
-            cache,
-        }
+            .expect("HTTP client build")
     }
 
     /// Fetch a URL with full security pipeline (GET only, for backwards compat).
@@ -51,8 +52,8 @@ impl WebFetchEngine {
     ) -> Result<String, String> {
         let method_upper = method.to_uppercase();
 
-        // Step 1: SSRF protection — BEFORE any network I/O
-        check_ssrf(url)?;
+        // Step 1: SSRF protection — resolve DNS once and validate IPs
+        let resolution = check_ssrf(url)?;
 
         // Step 2: Cache lookup (only for GET)
         let cache_key = format!("fetch:{}:{}", method_upper, url);
@@ -63,13 +64,16 @@ impl WebFetchEngine {
             }
         }
 
-        // Step 3: Build request with configured method
+        // Step 3: Build request using a DNS-pinned client to prevent
+        // TOCTOU / DNS-rebinding attacks (the resolved IPs from step 1
+        // are the only ones the HTTP stack will connect to).
+        let pinned_client = self.pinned_client(resolution);
         let mut req = match method_upper.as_str() {
-            "POST" => self.client.post(url),
-            "PUT" => self.client.put(url),
-            "PATCH" => self.client.patch(url),
-            "DELETE" => self.client.delete(url),
-            _ => self.client.get(url),
+            "POST" => pinned_client.post(url),
+            "PUT" => pinned_client.put(url),
+            "PATCH" => pinned_client.patch(url),
+            "DELETE" => pinned_client.delete(url),
+            _ => pinned_client.get(url),
         };
         req = req.header(
             "User-Agent",
@@ -181,10 +185,35 @@ fn is_html(content_type: &str, body: &str) -> bool {
 // SSRF Protection (replicates host_functions.rs logic for builtin tools)
 // ---------------------------------------------------------------------------
 
+/// Result of a successful SSRF check: the hostname and its resolved socket
+/// addresses.  Callers should use [`SsrfResolution::pin_dns`] to build an
+/// HTTP client that connects to the *already-validated* IPs, preventing
+/// DNS-rebinding TOCTOU attacks.
+pub struct SsrfResolution {
+    /// The hostname extracted from the URL (without port).
+    pub hostname: String,
+    /// All resolved socket addresses (guaranteed to be non-private).
+    pub resolved: Vec<std::net::SocketAddr>,
+}
+
+impl SsrfResolution {
+    /// Apply the pinned DNS resolution to a [`reqwest::ClientBuilder`] so
+    /// the actual HTTP request connects to the IPs we already validated.
+    pub fn pin_dns(self, mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+        for addr in &self.resolved {
+            builder = builder.resolve(&self.hostname, *addr);
+        }
+        builder
+    }
+}
+
 /// Check if a URL targets a private/internal network resource.
 /// Blocks localhost, metadata endpoints, and private IPs.
 /// Must run BEFORE any network I/O.
-pub(crate) fn check_ssrf(url: &str) -> Result<(), String> {
+///
+/// Returns the resolved addresses on success so that callers can pin DNS
+/// and avoid TOCTOU / DNS-rebinding attacks.
+pub(crate) fn check_ssrf(url: &str) -> Result<SsrfResolution, String> {
     // Only allow http:// and https:// schemes
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err("Only http:// and https:// URLs are allowed".to_string());
@@ -219,18 +248,35 @@ pub(crate) fn check_ssrf(url: &str) -> Result<(), String> {
     // Resolve DNS and check every returned IP
     let port = if url.starts_with("https") { 443 } else { 80 };
     let socket_addr = format!("{hostname}:{port}");
-    if let Ok(addrs) = socket_addr.to_socket_addrs() {
-        for addr in addrs {
-            let ip = addr.ip();
-            if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
-                return Err(format!(
-                    "SSRF blocked: {hostname} resolves to private IP {ip}"
-                ));
+    let mut resolved = Vec::new();
+    match socket_addr.to_socket_addrs() {
+        Ok(addrs) => {
+            for addr in addrs {
+                let ip = addr.ip();
+                if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
+                    return Err(format!(
+                        "SSRF blocked: {hostname} resolves to private IP {ip}"
+                    ));
+                }
+                resolved.push(addr);
             }
         }
+        Err(e) => {
+            return Err(format!(
+                "SSRF blocked: DNS resolution failed for {hostname}: {e}"
+            ));
+        }
+    }
+    if resolved.is_empty() {
+        return Err(format!(
+            "SSRF blocked: DNS resolution returned no addresses for {hostname}"
+        ));
     }
 
-    Ok(())
+    Ok(SsrfResolution {
+        hostname: hostname.to_string(),
+        resolved,
+    })
 }
 
 /// Check if an IP address is in a private range.


### PR DESCRIPTION
## Summary
PR #1653 was merged but the code never landed on main. This re-implements:
- `check_ssrf()` returns resolved IPs, caller pins DNS via reqwest `.resolve()`
- `is_ssrf_target()` in host_functions.rs does the same for WASM sandbox path
- DNS resolution failure → BLOCKED (fixes silent pass-through)
- Remove dead `client` field from WebFetchEngine

## Test plan
- [ ] Web fetch to public URLs works
- [ ] Private/loopback IPs blocked even with DNS rebinding
- [ ] DNS failure blocks request instead of passing through