### PR TITLE
fix: clippy warnings and rustfmt from recent merges

### DIFF
--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1140,7 +1140,8 @@ pub async fn get_channel(
     let meta = match find_channel_meta(&name) {
         Some(m) => m,
         None => {
-            return ApiErrorResponse::not_found(format!("Unknown channel: {name}")).into_json_tuple()
+            return ApiErrorResponse::not_found(format!("Unknown channel: {name}"))
+                .into_json_tuple()
         }
     };
 
@@ -1207,16 +1208,12 @@ pub async fn configure_channel(
 ) -> impl IntoResponse {
     let meta = match find_channel_meta(&name) {
         Some(m) => m,
-        None => {
-            return ApiErrorResponse::not_found("Unknown channel").into_json_tuple()
-        }
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
     };
 
     let fields = match body.get("fields").and_then(|v| v.as_object()) {
         Some(f) => f,
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple(),
     };
 
     let home = librefang_kernel::config::librefang_home();
@@ -1240,7 +1237,8 @@ pub async fn configure_channel(
             }
             // Secret field — write to secrets.env and set in process
             if let Err(e) = write_secret_env(&secrets_path, env_var, value) {
-                return ApiErrorResponse::internal(format!("Failed to write secret: {e}")).into_json_tuple();
+                return ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
+                    .into_json_tuple();
             }
             // SAFETY: We are the only writer; this is a single-threaded config operation
             unsafe {
@@ -1263,7 +1261,8 @@ pub async fn configure_channel(
 
     // Write config.toml section
     if let Err(e) = upsert_channel_config(&config_path, &name, &config_fields) {
-        return ApiErrorResponse::internal(format!("Failed to write config: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
+            .into_json_tuple();
     }
 
     // Hot-reload: activate the channel immediately
@@ -1319,9 +1318,7 @@ pub async fn remove_channel(
 ) -> impl IntoResponse {
     let meta = match find_channel_meta(&name) {
         Some(m) => m,
-        None => {
-            return ApiErrorResponse::not_found("Unknown channel").into_json_tuple()
-        }
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
     };
 
     let home = librefang_kernel::config::librefang_home();
@@ -1343,7 +1340,8 @@ pub async fn remove_channel(
 
     // Remove config section
     if let Err(e) = remove_channel_config(&config_path, &name) {
-        return ApiErrorResponse::internal(format!("Failed to remove config: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to remove config: {e}"))
+            .into_json_tuple();
     }
 
     // Hot-reload: deactivate the channel immediately

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1201,7 +1201,10 @@ pub async fn run_migrate(
         "autogpt" => librefang_migrate::MigrateSource::AutoGpt,
         "openfang" => librefang_migrate::MigrateSource::OpenFang,
         other => {
-            return ApiErrorResponse::bad_request(format!("Unknown source: {other}. Use 'openclaw', 'openfang', 'langchain', or 'autogpt'")).into_json_tuple();
+            return ApiErrorResponse::bad_request(format!(
+                "Unknown source: {other}. Use 'openclaw', 'openfang', 'langchain', or 'autogpt'"
+            ))
+            .into_json_tuple();
         }
     };
 

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -123,7 +123,8 @@ pub async fn create_goal(
     let title = match req["title"].as_str() {
         Some(t) if !t.is_empty() => t.to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing or empty 'title' field").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing or empty 'title' field")
+                .into_json_tuple();
         }
     };
 
@@ -133,14 +134,18 @@ pub async fn create_goal(
 
     let description = req["description"].as_str().unwrap_or("").to_string();
     if description.chars().count() > 4096 {
-        return ApiErrorResponse::bad_request("Description too long (max 4096 chars)").into_json_tuple();
+        return ApiErrorResponse::bad_request("Description too long (max 4096 chars)")
+            .into_json_tuple();
     }
 
     let parent_id = req["parent_id"].as_str().map(|s| s.to_string());
 
     let status = req["status"].as_str().unwrap_or("pending").to_string();
     if !["pending", "in_progress", "completed", "cancelled"].contains(&status.as_str()) {
-        return ApiErrorResponse::bad_request("Invalid status. Must be: pending, in_progress, completed, or cancelled").into_json_tuple();
+        return ApiErrorResponse::bad_request(
+            "Invalid status. Must be: pending, in_progress, completed, or cancelled",
+        )
+        .into_json_tuple();
     }
 
     let progress = req["progress"].as_u64().unwrap_or(0);
@@ -184,7 +189,8 @@ pub async fn create_goal(
     if let Some(ref pid) = parent_id {
         let parent_exists = goals.iter().any(|g| g["id"].as_str() == Some(pid.as_str()));
         if !parent_exists {
-            return ApiErrorResponse::not_found(format!("Parent goal '{}' not found", pid)).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Parent goal '{}' not found", pid))
+                .into_json_tuple();
         }
     }
 
@@ -224,13 +230,15 @@ pub async fn update_goal_by_id(
             return ApiErrorResponse::bad_request("Title must not be empty").into_json_tuple();
         }
         if title.chars().count() > 256 {
-            return ApiErrorResponse::bad_request("Title too long (max 256 chars)").into_json_tuple();
+            return ApiErrorResponse::bad_request("Title too long (max 256 chars)")
+                .into_json_tuple();
         }
     }
 
     if let Some(description) = req.get("description").and_then(|v| v.as_str()) {
         if description.chars().count() > 4096 {
-            return ApiErrorResponse::bad_request("Description too long (max 4096 chars)").into_json_tuple();
+            return ApiErrorResponse::bad_request("Description too long (max 4096 chars)")
+                .into_json_tuple();
         }
     }
 
@@ -251,11 +259,13 @@ pub async fn update_goal_by_id(
         if !parent_id.is_null() {
             if let Some(pid) = parent_id.as_str() {
                 if pid == id {
-                    return ApiErrorResponse::bad_request("A goal cannot be its own parent").into_json_tuple();
+                    return ApiErrorResponse::bad_request("A goal cannot be its own parent")
+                        .into_json_tuple();
                 }
                 // Verify the target parent exists
                 if !goals.iter().any(|g| g["id"].as_str() == Some(pid)) {
-                    return ApiErrorResponse::not_found(format!("Parent goal '{}' not found", pid)).into_json_tuple();
+                    return ApiErrorResponse::not_found(format!("Parent goal '{}' not found", pid))
+                        .into_json_tuple();
                 }
                 // Detect indirect cycles: walk ancestor chain from `pid` upward.
                 // Use a seen set to guard against infinite loops on corrupted data.
@@ -275,7 +285,10 @@ pub async fn update_goal_by_id(
                     });
                     match anc_parent {
                         Some(ref ap) if ap == &id => {
-                            return ApiErrorResponse::bad_request("Circular parent reference detected").into_json_tuple();
+                            return ApiErrorResponse::bad_request(
+                                "Circular parent reference detected",
+                            )
+                            .into_json_tuple();
                         }
                         Some(ap) => ancestor = Some(ap),
                         None => break,

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1116,13 +1116,15 @@ pub async fn memory_config_patch(
     let content = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to read config: {e}")).into_json_tuple();
+            return ApiErrorResponse::internal(format!("Failed to read config: {e}"))
+                .into_json_tuple();
         }
     };
     let mut table: toml::Value = match toml::from_str(&content) {
         Ok(t) => t,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to parse config: {e}")).into_json_tuple();
+            return ApiErrorResponse::internal(format!("Failed to parse config: {e}"))
+                .into_json_tuple();
         }
     };
 
@@ -1182,7 +1184,8 @@ pub async fn memory_config_patch(
 
     let new_content = toml::to_string_pretty(&table).unwrap_or_default();
     if let Err(e) = std::fs::write(&config_path, &new_content) {
-        return ApiErrorResponse::internal(format!("Failed to write config: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
+            .into_json_tuple();
     }
 
     tracing::info!("Memory config updated via API");

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -337,7 +337,8 @@ pub async fn a2a_send_task(
                     StatusCode::OK,
                     Json(serde_json::to_value(&completed_task).unwrap_or_default()),
                 ),
-                None => ApiErrorResponse::internal("Task disappeared after completion").into_json_tuple(),
+                None => ApiErrorResponse::internal("Task disappeared after completion")
+                    .into_json_tuple(),
             }
         }
         Err(e) => {
@@ -380,7 +381,9 @@ pub async fn a2a_get_task(
             StatusCode::OK,
             Json(serde_json::to_value(&task).unwrap_or_default()),
         ),
-        None => ApiErrorResponse::not_found(format!("Task '{}' not found", task_id)).into_json_tuple(),
+        None => {
+            ApiErrorResponse::not_found(format!("Task '{}' not found", task_id)).into_json_tuple()
+        }
     }
 }
 
@@ -406,7 +409,9 @@ pub async fn a2a_cancel_task(
                 StatusCode::OK,
                 Json(serde_json::to_value(&task).unwrap_or_default()),
             ),
-            None => ApiErrorResponse::internal("Task disappeared after cancellation").into_json_tuple(),
+            None => {
+                ApiErrorResponse::internal("Task disappeared after cancellation").into_json_tuple()
+            }
         }
     } else {
         ApiErrorResponse::not_found(format!("Task '{}' not found", task_id)).into_json_tuple()
@@ -580,9 +585,7 @@ pub async fn a2a_discover_external(
 ) -> impl IntoResponse {
     let url = match body["url"].as_str() {
         Some(u) => u.to_string(),
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'url' field").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'url' field").into_json_tuple(),
     };
 
     // SSRF protection: validate URL before making any outbound request
@@ -639,15 +642,11 @@ pub async fn a2a_send_external(
 ) -> impl IntoResponse {
     let url = match body["url"].as_str() {
         Some(u) => u.to_string(),
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'url' field").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'url' field").into_json_tuple(),
     };
     let message = match body["message"].as_str() {
         Some(m) => m.to_string(),
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'message' field").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'message' field").into_json_tuple(),
     };
     let session_id = body["session_id"].as_str();
 
@@ -1174,9 +1173,7 @@ pub async fn comms_send(
     // Validate from agent exists
     let from_id: librefang_types::agent::AgentId = match req.from_agent_id.parse() {
         Ok(id) => id,
-        Err(_) => {
-            return ApiErrorResponse::bad_request("Invalid from_agent_id").into_json_tuple()
-        }
+        Err(_) => return ApiErrorResponse::bad_request("Invalid from_agent_id").into_json_tuple(),
     };
     if state.kernel.agent_registry().get(from_id).is_none() {
         return ApiErrorResponse::not_found("Source agent not found").into_json_tuple();
@@ -1185,9 +1182,7 @@ pub async fn comms_send(
     // Validate to agent exists
     let to_id: librefang_types::agent::AgentId = match req.to_agent_id.parse() {
         Ok(id) => id,
-        Err(_) => {
-            return ApiErrorResponse::bad_request("Invalid to_agent_id").into_json_tuple()
-        }
+        Err(_) => return ApiErrorResponse::bad_request("Invalid to_agent_id").into_json_tuple(),
     };
     if state.kernel.agent_registry().get(to_id).is_none() {
         return ApiErrorResponse::not_found("Target agent not found").into_json_tuple();
@@ -1236,7 +1231,9 @@ pub async fn comms_send(
             }
             (StatusCode::OK, Json(resp))
         }
-        Err(e) => ApiErrorResponse::internal(format!("Message delivery failed: {e}")).into_json_tuple(),
+        Err(e) => {
+            ApiErrorResponse::internal(format!("Message delivery failed: {e}")).into_json_tuple()
+        }
     }
 }
 

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -123,7 +123,8 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
             let name = match body.get("name").and_then(|n| n.as_str()) {
                 Some(n) => n.to_string(),
                 None => {
-                    return ApiErrorResponse::bad_request("Missing 'name' for registry install").into_json_tuple()
+                    return ApiErrorResponse::bad_request("Missing 'name' for registry install")
+                        .into_json_tuple()
                 }
             };
             let github_repo = body
@@ -136,7 +137,8 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
             let path = match body.get("path").and_then(|p| p.as_str()) {
                 Some(p) => std::path::PathBuf::from(p),
                 None => {
-                    return ApiErrorResponse::bad_request("Missing 'path' for local install").into_json_tuple()
+                    return ApiErrorResponse::bad_request("Missing 'path' for local install")
+                        .into_json_tuple()
                 }
             };
             librefang_runtime::plugin_manager::PluginSource::Local { path }
@@ -145,7 +147,8 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
             let url = match body.get("url").and_then(|u| u.as_str()) {
                 Some(u) => u.to_string(),
                 None => {
-                    return ApiErrorResponse::bad_request("Missing 'url' for git install").into_json_tuple()
+                    return ApiErrorResponse::bad_request("Missing 'url' for git install")
+                        .into_json_tuple()
                 }
             };
             let branch = body
@@ -155,7 +158,10 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
             librefang_runtime::plugin_manager::PluginSource::Git { url, branch }
         }
         _ => {
-            return ApiErrorResponse::bad_request("Invalid source. Use 'registry', 'local', or 'git'").into_json_tuple()
+            return ApiErrorResponse::bad_request(
+                "Invalid source. Use 'registry', 'local', or 'git'",
+            )
+            .into_json_tuple()
         }
     };
 
@@ -197,9 +203,7 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
 pub async fn uninstall_plugin(Json(body): Json<serde_json::Value>) -> impl IntoResponse {
     let name = match body.get("name").and_then(|n| n.as_str()) {
         Some(n) => n,
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'name'").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'name'").into_json_tuple(),
     };
 
     match librefang_runtime::plugin_manager::remove_plugin(name) {
@@ -234,9 +238,7 @@ pub async fn uninstall_plugin(Json(body): Json<serde_json::Value>) -> impl IntoR
 pub async fn scaffold_plugin(Json(body): Json<serde_json::Value>) -> impl IntoResponse {
     let name = match body.get("name").and_then(|n| n.as_str()) {
         Some(n) => n,
-        None => {
-            return ApiErrorResponse::bad_request("Missing 'name'").into_json_tuple()
-        }
+        None => return ApiErrorResponse::bad_request("Missing 'name'").into_json_tuple(),
     };
     let description = body
         .get("description")

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, post},
     Json, Router,
@@ -57,13 +56,15 @@ async fn list_prompt_versions(
     let agent_id: librefang_types::agent::AgentId = match agent_id.parse() {
         Ok(id) => id,
         Err(e) => {
-            return ApiErrorResponse::bad_request(e.to_string()).into_json_tuple()
+            return ApiErrorResponse::bad_request(e.to_string())
+                .into_json_tuple()
                 .into_response()
         }
     };
     match state.kernel.list_prompt_versions(agent_id) {
         Ok(versions) => Json(versions).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -76,7 +77,8 @@ async fn create_prompt_version(
     let agent_id: librefang_types::agent::AgentId = match agent_id.parse() {
         Ok(id) => id,
         Err(e) => {
-            return ApiErrorResponse::bad_request(e.to_string()).into_json_tuple()
+            return ApiErrorResponse::bad_request(e.to_string())
+                .into_json_tuple()
                 .into_response()
         }
     };
@@ -89,7 +91,8 @@ async fn create_prompt_version(
     version.content_hash = format!("{:x}", hasher.finalize());
     match state.kernel.create_prompt_version(version.clone()) {
         Ok(_) => Json(version).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -100,7 +103,8 @@ async fn get_prompt_version(
 ) -> impl IntoResponse {
     match state.kernel.get_prompt_version(&id) {
         Ok(version) => Json(version).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -111,7 +115,8 @@ async fn delete_prompt_version(
 ) -> impl IntoResponse {
     match state.kernel.delete_prompt_version(&id) {
         Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -124,13 +129,15 @@ async fn activate_prompt_version(
     let agent_id = match body.get("agent_id").and_then(|v| v.as_str()) {
         Some(id) => id,
         None => {
-            return ApiErrorResponse::bad_request("agent_id required in body").into_json_tuple()
+            return ApiErrorResponse::bad_request("agent_id required in body")
+                .into_json_tuple()
                 .into_response()
         }
     };
     match state.kernel.set_active_prompt_version(&id, agent_id) {
         Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -142,13 +149,15 @@ async fn list_experiments(
     let agent_id: librefang_types::agent::AgentId = match agent_id.parse() {
         Ok(id) => id,
         Err(e) => {
-            return ApiErrorResponse::bad_request(e.to_string()).into_json_tuple()
+            return ApiErrorResponse::bad_request(e.to_string())
+                .into_json_tuple()
                 .into_response()
         }
     };
     match state.kernel.list_experiments(agent_id) {
         Ok(experiments) => Json(experiments).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -161,7 +170,8 @@ async fn create_experiment(
     let agent_id: librefang_types::agent::AgentId = match agent_id.parse() {
         Ok(id) => id,
         Err(e) => {
-            return ApiErrorResponse::bad_request(e.to_string()).into_json_tuple()
+            return ApiErrorResponse::bad_request(e.to_string())
+                .into_json_tuple()
                 .into_response()
         }
     };
@@ -174,7 +184,8 @@ async fn create_experiment(
     }
     match state.kernel.create_experiment(experiment.clone()) {
         Ok(_) => Json(experiment).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -185,7 +196,8 @@ async fn get_experiment(
 ) -> impl IntoResponse {
     match state.kernel.get_experiment(&id) {
         Ok(experiment) => Json(experiment).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -199,7 +211,8 @@ async fn start_experiment(
         .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Running)
     {
         Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -213,7 +226,8 @@ async fn pause_experiment(
         .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Paused)
     {
         Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -227,7 +241,8 @@ async fn complete_experiment(
         .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Completed)
     {
         Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -238,7 +253,8 @@ async fn get_experiment_metrics(
 ) -> impl IntoResponse {
     match state.kernel.get_experiment_metrics(&id) {
         Ok(metrics) => Json(metrics).into_response(),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::internal(e)
+            .into_json_tuple()
             .into_response(),
     }
 }

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -203,7 +203,8 @@ pub async fn create_alias(
         .unwrap_or_else(|e| e.into_inner());
 
     if !catalog.add_alias(&alias, &model_id) {
-        return ApiErrorResponse::conflict(format!("Alias '{}' already exists", alias)).into_json_tuple();
+        return ApiErrorResponse::conflict(format!("Alias '{}' already exists", alias))
+            .into_json_tuple();
     }
 
     (
@@ -229,7 +230,8 @@ pub async fn delete_alias(
         .unwrap_or_else(|e| e.into_inner());
 
     if !catalog.remove_alias(&alias) {
-        return ApiErrorResponse::not_found(format!("Alias '{}' not found", alias)).into_json_tuple();
+        return ApiErrorResponse::not_found(format!("Alias '{}' not found", alias))
+            .into_json_tuple();
     }
 
     (
@@ -457,7 +459,8 @@ pub async fn get_provider(
                 (p.clone(), models)
             }
             None => {
-                return ApiErrorResponse::not_found(format!("Provider '{}' not found", name)).into_json_tuple();
+                return ApiErrorResponse::not_found(format!("Provider '{}' not found", name))
+                    .into_json_tuple();
             }
         }
     };
@@ -573,7 +576,11 @@ pub async fn add_custom_model(
         .unwrap_or_else(|e| e.into_inner());
 
     if !catalog.add_custom_model(entry) {
-        return ApiErrorResponse::conflict(format!("Model '{}' already exists for provider '{}'", id, provider)).into_json_tuple();
+        return ApiErrorResponse::conflict(format!(
+            "Model '{}' already exists for provider '{}'",
+            id, provider
+        ))
+        .into_json_tuple();
     }
 
     // Persist to disk
@@ -605,7 +612,8 @@ pub async fn remove_custom_model(
         .unwrap_or_else(|e| e.into_inner());
 
     if !catalog.remove_custom_model(&model_id) {
-        return ApiErrorResponse::not_found(format!("Custom model '{}' not found", model_id)).into_json_tuple();
+        return ApiErrorResponse::not_found(format!("Custom model '{}' not found", model_id))
+            .into_json_tuple();
     }
 
     let custom_path = state.kernel.home_dir().join("custom_models.json");
@@ -654,7 +662,8 @@ pub async fn set_provider_key(
     // Write to secrets.env file
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = write_secret_env(&secrets_path, &env_var, &key) {
-        return ApiErrorResponse::internal(format!("Failed to write secrets.env: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write secrets.env: {e}"))
+            .into_json_tuple();
     }
 
     // Set env var in current process so detect_auth picks it up
@@ -824,13 +833,15 @@ pub async fn delete_provider_key(
     };
 
     if env_var.is_empty() {
-        return ApiErrorResponse::bad_request("Provider does not require an API key").into_json_tuple();
+        return ApiErrorResponse::bad_request("Provider does not require an API key")
+            .into_json_tuple();
     }
 
     // Remove from secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = remove_secret_env(&secrets_path, &env_var) {
-        return ApiErrorResponse::internal(format!("Failed to update secrets.env: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to update secrets.env: {e}"))
+            .into_json_tuple();
     }
 
     // Remove from process environment
@@ -865,7 +876,8 @@ pub async fn test_provider(
         match catalog.get_provider(&name) {
             Some(p) => (p.api_key_env.clone(), p.base_url.clone(), p.key_required),
             None => {
-                return ApiErrorResponse::not_found(format!("Unknown provider '{}'", name)).into_json_tuple();
+                return ApiErrorResponse::not_found(format!("Unknown provider '{}'", name))
+                    .into_json_tuple();
             }
         }
     };
@@ -1037,13 +1049,15 @@ pub async fn set_provider_url(
     let base_url = match body["base_url"].as_str() {
         Some(u) if !u.trim().is_empty() => u.trim().to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing or empty 'base_url' field").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing or empty 'base_url' field")
+                .into_json_tuple();
         }
     };
 
     // Validate URL scheme
     if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
-        return ApiErrorResponse::bad_request("base_url must start with http:// or https://").into_json_tuple();
+        return ApiErrorResponse::bad_request("base_url must start with http:// or https://")
+            .into_json_tuple();
     }
 
     // Update catalog in memory

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -620,7 +620,8 @@ pub async fn clawhub_skill_code(
     }
 
     if code.is_empty() {
-        return ApiErrorResponse::not_found("No source code found for this skill").into_json_tuple();
+        return ApiErrorResponse::not_found("No source code found for this skill")
+            .into_json_tuple();
     }
 
     (
@@ -930,7 +931,8 @@ pub async fn skillhub_skill_detail(
 
 /// GET /api/skillhub/skill/{slug}/code — Source code viewing is not available for Skillhub skills.
 pub async fn skillhub_skill_code(Path(_slug): Path<String>) -> impl IntoResponse {
-    ApiErrorResponse::not_found("Source code viewing is not available for Skillhub skills").into_json_tuple()
+    ApiErrorResponse::not_found("Source code viewing is not available for Skillhub skills")
+        .into_json_tuple()
 }
 
 /// POST /api/skillhub/install — Install a skill from Skillhub.
@@ -1373,7 +1375,8 @@ pub async fn install_hand_deps(
     let def = match state.kernel.hands().get_definition(&hand_id) {
         Some(d) => d.clone(),
         None => {
-            return ApiErrorResponse::not_found(format!("Hand not found: {hand_id}")).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Hand not found: {hand_id}"))
+                .into_json_tuple();
         }
     };
 
@@ -1792,13 +1795,15 @@ pub async fn set_hand_secret(
     let env_key = match body["key"].as_str() {
         Some(k) if !k.trim().is_empty() => k.trim().to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing 'key' field (env var name)").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing 'key' field (env var name)")
+                .into_json_tuple();
         }
     };
     let value = match body["value"].as_str() {
         Some(v) if !v.trim().is_empty() => v.trim().to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing or empty 'value' field").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing or empty 'value' field")
+                .into_json_tuple();
         }
     };
 
@@ -1816,13 +1821,18 @@ pub async fn set_hand_secret(
     };
 
     if !valid {
-        return ApiErrorResponse::bad_request(format!("'{}' is not a requirement of hand '{}'", env_key, hand_id)).into_json_tuple();
+        return ApiErrorResponse::bad_request(format!(
+            "'{}' is not a requirement of hand '{}'",
+            env_key, hand_id
+        ))
+        .into_json_tuple();
     }
 
     // Write to secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = write_secret_env(&secrets_path, &env_key, &value) {
-        return ApiErrorResponse::internal(format!("Failed to write secret: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
+            .into_json_tuple();
     }
 
     // Set in current process
@@ -1866,7 +1876,8 @@ pub async fn get_hand_settings(
     {
         Ok(s) => s,
         Err(_) => {
-            return ApiErrorResponse::not_found(format!("Hand not found: {hand_id}")).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Hand not found: {hand_id}"))
+                .into_json_tuple();
         }
     };
 
@@ -1933,7 +1944,10 @@ pub async fn update_hand_settings(
             }
             Err(e) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
         },
-        None => ApiErrorResponse::not_found(format!("No active instance for hand: {hand_id}. Activate the hand first.")).into_json_tuple(),
+        None => ApiErrorResponse::not_found(format!(
+            "No active instance for hand: {hand_id}. Activate the hand first."
+        ))
+        .into_json_tuple(),
     }
 }
 
@@ -2160,9 +2174,7 @@ fn resolve_hand_agent(
         .kernel
         .hands()
         .get_instance(instance_id)
-        .ok_or_else(|| {
-            ApiErrorResponse::not_found("Hand instance not found").into_json_tuple()
-        })?;
+        .ok_or_else(|| ApiErrorResponse::not_found("Hand instance not found").into_json_tuple())?;
     let agent_id = instance.agent_id().ok_or_else(|| {
         (
             StatusCode::OK,
@@ -2314,7 +2326,9 @@ pub async fn hand_get_session(
             )
         }
         Ok(None) => (StatusCode::OK, Json(serde_json::json!({ "messages": [] }))),
-        Err(e) => ApiErrorResponse::internal(format!("Failed to load session: {e}")).into_json_tuple(),
+        Err(e) => {
+            ApiErrorResponse::internal(format!("Failed to load session: {e}")).into_json_tuple()
+        }
     }
 }
 
@@ -2548,7 +2562,8 @@ pub async fn get_mcp_server(
     let entry = match entry {
         Some(e) => e,
         None => {
-            return ApiErrorResponse::not_found(format!("MCP server '{}' not found", name)).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("MCP server '{}' not found", name))
+                .into_json_tuple();
         }
     };
 
@@ -2606,7 +2621,8 @@ pub async fn add_mcp_server(
     let name = match body.get("name").and_then(|v| v.as_str()) {
         Some(n) if !n.trim().is_empty() => n.trim().to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing or empty 'name' field").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing or empty 'name' field")
+                .into_json_tuple();
         }
     };
 
@@ -2618,7 +2634,8 @@ pub async fn add_mcp_server(
     let entry: librefang_types::config::McpServerConfigEntry = match serde_json::from_value(body) {
         Ok(e) => e,
         Err(e) => {
-            return ApiErrorResponse::bad_request(format!("Invalid MCP server config: {e}")).into_json_tuple();
+            return ApiErrorResponse::bad_request(format!("Invalid MCP server config: {e}"))
+                .into_json_tuple();
         }
     };
 
@@ -2630,13 +2647,15 @@ pub async fn add_mcp_server(
         .iter()
         .any(|s| s.name == name)
     {
-        return ApiErrorResponse::conflict(format!("MCP server '{}' already exists", name)).into_json_tuple();
+        return ApiErrorResponse::conflict(format!("MCP server '{}' already exists", name))
+            .into_json_tuple();
     }
 
     // Persist to config.toml
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        return ApiErrorResponse::internal(format!("Failed to write config: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
+            .into_json_tuple();
     }
 
     // Trigger config reload
@@ -2700,7 +2719,10 @@ pub async fn update_mcp_server(
         .iter()
         .any(|s| s.name == name)
     {
-        return ApiErrorResponse::not_found(t.t_args("api-error-mcp-not-found", &[("name", &name)])).into_json_tuple();
+        return ApiErrorResponse::not_found(
+            t.t_args("api-error-mcp-not-found", &[("name", &name)]),
+        )
+        .into_json_tuple();
     }
 
     // Force the name in body to match the path parameter
@@ -2709,21 +2731,29 @@ pub async fn update_mcp_server(
     }
 
     if body.get("transport").is_none() {
-        return ApiErrorResponse::bad_request(t.t("api-error-mcp-missing-transport")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-mcp-missing-transport"))
+            .into_json_tuple();
     }
 
     // Validate by deserializing
     let entry: librefang_types::config::McpServerConfigEntry = match serde_json::from_value(body) {
         Ok(e) => e,
         Err(e) => {
-            return ApiErrorResponse::bad_request(t.t_args("api-error-mcp-invalid-config", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::bad_request(
+                t.t_args("api-error-mcp-invalid-config", &[("error", &e.to_string())]),
+            )
+            .into_json_tuple();
         }
     };
 
     // Persist — upsert replaces an existing entry with the same name
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        return ApiErrorResponse::internal(t.t_args("api-error-config-write-failed", &[("error", &e.to_string())])).into_json_tuple();
+        return ApiErrorResponse::internal(t.t_args(
+            "api-error-config-write-failed",
+            &[("error", &e.to_string())],
+        ))
+        .into_json_tuple();
     }
 
     let reload_status = match state.kernel.reload_config() {
@@ -2780,12 +2810,19 @@ pub async fn delete_mcp_server(
         .iter()
         .any(|s| s.name == name)
     {
-        return ApiErrorResponse::not_found(t.t_args("api-error-mcp-not-found", &[("name", &name)])).into_json_tuple();
+        return ApiErrorResponse::not_found(
+            t.t_args("api-error-mcp-not-found", &[("name", &name)]),
+        )
+        .into_json_tuple();
     }
 
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = remove_mcp_server_config(&config_path, &name) {
-        return ApiErrorResponse::internal(t.t_args("api-error-config-write-failed", &[("error", &e.to_string())])).into_json_tuple();
+        return ApiErrorResponse::internal(t.t_args(
+            "api-error-config-write-failed",
+            &[("error", &e.to_string())],
+        ))
+        .into_json_tuple();
     }
 
     let reload_status = match state.kernel.reload_config() {
@@ -2936,13 +2973,17 @@ pub async fn create_skill(
     let name = match body["name"].as_str() {
         Some(n) if !n.trim().is_empty() => n.trim().to_string(),
         _ => {
-            return ApiErrorResponse::bad_request("Missing or empty 'name' field").into_json_tuple();
+            return ApiErrorResponse::bad_request("Missing or empty 'name' field")
+                .into_json_tuple();
         }
     };
 
     // Validate name (alphanumeric + hyphens only)
     if !is_safe_component_name(&name) {
-        return ApiErrorResponse::bad_request("Skill name must contain only letters, numbers, hyphens, and underscores").into_json_tuple();
+        return ApiErrorResponse::bad_request(
+            "Skill name must contain only letters, numbers, hyphens, and underscores",
+        )
+        .into_json_tuple();
     }
 
     let description = body["description"].as_str().unwrap_or("").to_string();
@@ -2951,17 +2992,22 @@ pub async fn create_skill(
 
     // Only allow prompt_only skills from the web UI for safety
     if runtime != "prompt_only" {
-        return ApiErrorResponse::bad_request("Only prompt_only skills can be created from the web UI").into_json_tuple();
+        return ApiErrorResponse::bad_request(
+            "Only prompt_only skills can be created from the web UI",
+        )
+        .into_json_tuple();
     }
 
     // Write skill.toml to ~/.librefang/skills/{name}/
     let skill_dir = state.kernel.home_dir().join("skills").join(&name);
     if skill_dir.exists() {
-        return ApiErrorResponse::conflict(format!("Skill '{}' already exists", name)).into_json_tuple();
+        return ApiErrorResponse::conflict(format!("Skill '{}' already exists", name))
+            .into_json_tuple();
     }
 
     if let Err(e) = std::fs::create_dir_all(&skill_dir) {
-        return ApiErrorResponse::internal(format!("Failed to create skill directory: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to create skill directory: {e}"))
+            .into_json_tuple();
     }
 
     let toml_content = format!(
@@ -2973,7 +3019,8 @@ pub async fn create_skill(
 
     let toml_path = skill_dir.join("skill.toml");
     if let Err(e) = std::fs::write(&toml_path, &toml_content) {
-        return ApiErrorResponse::internal(format!("Failed to write skill.toml: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to write skill.toml: {e}"))
+            .into_json_tuple();
     }
 
     (
@@ -3306,7 +3353,8 @@ pub async fn get_integration(
     let template = match registry.get_template(&id) {
         Some(t) => t,
         None => {
-            return ApiErrorResponse::not_found(format!("Integration '{}' not found", id)).into_json_tuple()
+            return ApiErrorResponse::not_found(format!("Integration '{}' not found", id))
+                .into_json_tuple()
                 .into_response();
         }
     };
@@ -3543,7 +3591,8 @@ pub async fn reconnect_integration(
     };
 
     if !is_installed {
-        return ApiErrorResponse::not_found(format!("Integration '{}' not installed", id)).into_json_tuple();
+        return ApiErrorResponse::not_found(format!("Integration '{}' not installed", id))
+            .into_json_tuple();
     }
 
     match state.kernel.reconnect_extension_mcp(&id).await {
@@ -3700,7 +3749,8 @@ pub async fn get_extension(
     let template = match registry.get_template(&name) {
         Some(t) => t.clone(),
         None => {
-            return ApiErrorResponse::not_found(format!("Extension '{}' not found", name)).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Extension '{}' not found", name))
+                .into_json_tuple();
         }
     };
 

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -141,8 +141,8 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::post(test_webhook),
         )
 }
-use crate::types::ApiErrorResponse;
 use crate::middleware::RequestLanguage;
+use crate::types::ApiErrorResponse;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -220,7 +220,10 @@ pub async fn get_profile(
                 "tools": profile.tools(),
             })),
         ),
-        None => ApiErrorResponse::not_found(t.t_args("api-error-profile-not-found", &[("name", &name)])).into_json_tuple(),
+        None => {
+            ApiErrorResponse::not_found(t.t_args("api-error-profile-not-found", &[("name", &name)]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -310,7 +313,8 @@ pub async fn get_agent_template(
             ),
             Err(e) => {
                 tracing::warn!("Invalid template manifest for '{name}': {e}");
-                ApiErrorResponse::internal(t.t("api-error-template-invalid-manifest")).into_json_tuple()
+                ApiErrorResponse::internal(t.t("api-error-template-invalid-manifest"))
+                    .into_json_tuple()
             }
         },
         Err(e) => {
@@ -335,7 +339,8 @@ pub async fn get_agent_kv(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
     match state.kernel.memory_substrate().list_kv(agent_id) {
@@ -364,7 +369,8 @@ pub async fn get_agent_kv_key(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
     match state
@@ -376,7 +382,9 @@ pub async fn get_agent_kv_key(
             StatusCode::OK,
             Json(serde_json::json!({"key": key, "value": val})),
         ),
-        Ok(None) => ApiErrorResponse::not_found(t.t("api-error-kv-key-not-found")).into_json_tuple(),
+        Ok(None) => {
+            ApiErrorResponse::not_found(t.t("api-error-kv-key-not-found")).into_json_tuple()
+        }
         Err(e) => {
             tracing::warn!("Memory get failed for key '{key}': {e}");
             ApiErrorResponse::internal(t.t("api-error-memory-operation-failed")).into_json_tuple()
@@ -396,7 +404,8 @@ pub async fn set_agent_kv_key(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
     let value = body.get("value").cloned().unwrap_or(body);
@@ -428,7 +437,8 @@ pub async fn delete_agent_kv_key(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
     match state
@@ -458,7 +468,8 @@ pub async fn export_agent_memory(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -501,7 +512,8 @@ pub async fn import_agent_memory(
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -513,7 +525,8 @@ pub async fn import_agent_memory(
     let kv = match body.get("kv").and_then(|v| v.as_object()) {
         Some(obj) => obj.clone(),
         None => {
-            return ApiErrorResponse::bad_request(t.t("api-error-kv-missing-kv-object")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-kv-missing-kv-object"))
+                .into_json_tuple();
         }
     };
 
@@ -538,7 +551,8 @@ pub async fn import_agent_memory(
             }
             Err(e) => {
                 tracing::warn!("Failed to list existing KV during import clear: {e}");
-                return ApiErrorResponse::internal(t.t("api-error-kv-import-clear-failed")).into_json_tuple();
+                return ApiErrorResponse::internal(t.t("api-error-kv-import-clear-failed"))
+                    .into_json_tuple();
             }
         }
     }
@@ -840,7 +854,8 @@ pub async fn get_tool(
         }
     }
 
-    ApiErrorResponse::not_found(tr.t_args("api-error-tool-not-found", &[("name", &name)])).into_json_tuple()
+    ApiErrorResponse::not_found(tr.t_args("api-error-tool-not-found", &[("name", &name)]))
+        .into_json_tuple()
 }
 
 // ---------------------------------------------------------------------------
@@ -874,7 +889,8 @@ pub async fn get_session(
     let session_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => librefang_types::agent::SessionId(u),
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -895,8 +911,13 @@ pub async fn get_session(
                 "created_at": created_at,
             })),
         ),
-        Ok(None) => ApiErrorResponse::not_found(t.t("api-error-session-not-found")).into_json_tuple(),
-        Err(e) => ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())])).into_json_tuple(),
+        Ok(None) => {
+            ApiErrorResponse::not_found(t.t("api-error-session-not-found")).into_json_tuple()
+        }
+        Err(e) => {
+            ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -911,7 +932,8 @@ pub async fn delete_session(
     let session_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => librefang_types::agent::SessionId(u),
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -920,7 +942,10 @@ pub async fn delete_session(
             StatusCode::OK,
             Json(serde_json::json!({"status": "deleted", "session_id": id})),
         ),
-        Err(e) => ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())])).into_json_tuple(),
+        Err(e) => {
+            ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -936,7 +961,8 @@ pub async fn set_session_label(
     let session_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => librefang_types::agent::SessionId(u),
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -945,7 +971,10 @@ pub async fn set_session_label(
     // Validate label if present
     if let Some(lbl) = label {
         if let Err(e) = librefang_types::agent::SessionLabel::new(lbl) {
-            return ApiErrorResponse::bad_request(t.t_args("api-error-generic", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::bad_request(
+                t.t_args("api-error-generic", &[("error", &e.to_string())]),
+            )
+            .into_json_tuple();
         }
     }
 
@@ -962,7 +991,10 @@ pub async fn set_session_label(
                 "label": label,
             })),
         ),
-        Err(e) => ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())])).into_json_tuple(),
+        Err(e) => {
+            ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -981,7 +1013,8 @@ pub async fn find_session_by_label(
             match state.kernel.agent_registry().find_by_name(&agent_id_str) {
                 Some(entry) => entry.id,
                 None => {
-                    return ApiErrorResponse::not_found(t.t("api-error-agent-not-found")).into_json_tuple();
+                    return ApiErrorResponse::not_found(t.t("api-error-agent-not-found"))
+                        .into_json_tuple();
                 }
             }
         }
@@ -1001,8 +1034,13 @@ pub async fn find_session_by_label(
                 "message_count": session.messages.len(),
             })),
         ),
-        Ok(None) => ApiErrorResponse::not_found(t.t("api-error-session-no-label")).into_json_tuple(),
-        Err(e) => ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())])).into_json_tuple(),
+        Ok(None) => {
+            ApiErrorResponse::not_found(t.t("api-error-session-no-label")).into_json_tuple()
+        }
+        Err(e) => {
+            ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -1031,7 +1069,11 @@ pub async fn session_cleanup(
         {
             Ok(n) => total += n,
             Err(e) => {
-                return ApiErrorResponse::internal(t.t_args("api-error-session-cleanup-expired-failed", &[("error", &e.to_string())])).into_json_tuple();
+                return ApiErrorResponse::internal(t.t_args(
+                    "api-error-session-cleanup-expired-failed",
+                    &[("error", &e.to_string())],
+                ))
+                .into_json_tuple();
             }
         }
     }
@@ -1044,7 +1086,11 @@ pub async fn session_cleanup(
         {
             Ok(n) => total += n,
             Err(e) => {
-                return ApiErrorResponse::internal(t.t_args("api-error-session-cleanup-excess-failed", &[("error", &e.to_string())])).into_json_tuple();
+                return ApiErrorResponse::internal(t.t_args(
+                    "api-error-session-cleanup-excess-failed",
+                    &[("error", &e.to_string())],
+                ))
+                .into_json_tuple();
             }
         }
     }
@@ -1076,7 +1122,8 @@ pub async fn search_sessions(
     let query = match params.get("q") {
         Some(q) if !q.is_empty() => q.clone(),
         _ => {
-            return ApiErrorResponse::bad_request("missing or empty 'q' parameter").into_json_tuple();
+            return ApiErrorResponse::bad_request("missing or empty 'q' parameter")
+                .into_json_tuple();
         }
     };
 
@@ -1204,7 +1251,8 @@ pub async fn get_approval(
     let uuid = match uuid::Uuid::parse_str(&id) {
         Ok(u) => u,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -1213,7 +1261,10 @@ pub async fn get_approval(
             let registry_agents = state.kernel.agent_registry().list();
             (StatusCode::OK, Json(approval_to_json(&a, &registry_agents)))
         }
-        None => ApiErrorResponse::not_found(t.t_args("api-error-approval-not-found", &[("id", &id)])).into_json_tuple(),
+        None => {
+            ApiErrorResponse::not_found(t.t_args("api-error-approval-not-found", &[("id", &id)]))
+                .into_json_tuple()
+        }
     }
 }
 
@@ -1285,7 +1336,8 @@ pub async fn approve_request(
     let uuid = match uuid::Uuid::parse_str(&id) {
         Ok(u) => u,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -1315,7 +1367,8 @@ pub async fn reject_request(
     let uuid = match uuid::Uuid::parse_str(&id) {
         Ok(u) => u,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-approval-invalid-id"))
+                .into_json_tuple();
         }
     };
 
@@ -1555,7 +1608,8 @@ pub async fn pairing_request(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     if !state.kernel.config_ref().pairing.enabled {
-        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled")).into_json_tuple()
+        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled"))
+            .into_json_tuple()
             .into_response();
     }
     match state.kernel.pairing_ref().create_pairing_request() {
@@ -1568,7 +1622,8 @@ pub async fn pairing_request(
             }))
             .into_response()
         }
-        Err(e) => ApiErrorResponse::bad_request(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::bad_request(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -1582,7 +1637,8 @@ pub async fn pairing_complete(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     if !state.kernel.config_ref().pairing.enabled {
-        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled")).into_json_tuple()
+        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled"))
+            .into_json_tuple()
             .into_response();
     }
     let token = body.get("token").and_then(|v| v.as_str()).unwrap_or("");
@@ -1618,7 +1674,8 @@ pub async fn pairing_complete(
             "paired_at": device.paired_at.to_rfc3339(),
         }))
         .into_response(),
-        Err(e) => ApiErrorResponse::bad_request(e).into_json_tuple()
+        Err(e) => ApiErrorResponse::bad_request(e)
+            .into_json_tuple()
             .into_response(),
     }
 }
@@ -1631,7 +1688,8 @@ pub async fn pairing_devices(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     if !state.kernel.config_ref().pairing.enabled {
-        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled")).into_json_tuple()
+        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled"))
+            .into_json_tuple()
             .into_response();
     }
     let devices: Vec<_> = state
@@ -1661,12 +1719,15 @@ pub async fn pairing_remove_device(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     if !state.kernel.config_ref().pairing.enabled {
-        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled")).into_json_tuple()
+        return ApiErrorResponse::not_found(t.t("api-error-pairing-not-enabled"))
+            .into_json_tuple()
             .into_response();
     }
     match state.kernel.pairing_ref().remove_device(&device_id) {
         Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => ApiErrorResponse::not_found(e).into_json_tuple().into_response(),
+        Err(e) => ApiErrorResponse::not_found(e)
+            .into_json_tuple()
+            .into_response(),
     }
 }
 
@@ -1685,7 +1746,8 @@ pub async fn pairing_notify(
         )
     };
     if !state.kernel.config_ref().pairing.enabled {
-        return ApiErrorResponse::not_found(err_pairing_not_enabled).into_json_tuple()
+        return ApiErrorResponse::not_found(err_pairing_not_enabled)
+            .into_json_tuple()
             .into_response();
     }
     let title = body
@@ -1694,7 +1756,8 @@ pub async fn pairing_notify(
         .unwrap_or("LibreFang");
     let message = body.get("message").and_then(|v| v.as_str()).unwrap_or("");
     if message.is_empty() {
-        return ApiErrorResponse::bad_request(err_message_required).into_json_tuple()
+        return ApiErrorResponse::bad_request(err_message_required)
+            .into_json_tuple()
             .into_response();
     }
     state
@@ -1810,7 +1873,8 @@ pub async fn get_command(
         }
     }
 
-    ApiErrorResponse::not_found(t.t_args("api-error-command-not-found", &[("name", &lookup)])).into_json_tuple()
+    ApiErrorResponse::not_found(t.t_args("api-error-command-not-found", &[("name", &lookup)]))
+        .into_json_tuple()
 }
 
 // ---------------------------------------------------------------------------
@@ -1840,7 +1904,11 @@ pub async fn create_backup(
     let home_dir = &state.kernel.home_dir();
     let backups_dir = home_dir.join("backups");
     if let Err(e) = std::fs::create_dir_all(&backups_dir) {
-        return ApiErrorResponse::internal(t.t_args("api-error-backup-create-dir-failed", &[("error", &e.to_string())])).into_json_tuple();
+        return ApiErrorResponse::internal(t.t_args(
+            "api-error-backup-create-dir-failed",
+            &[("error", &e.to_string())],
+        ))
+        .into_json_tuple();
     }
 
     let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
@@ -1853,7 +1921,11 @@ pub async fn create_backup(
     let file = match std::fs::File::create(&backup_path) {
         Ok(f) => f,
         Err(e) => {
-            return ApiErrorResponse::internal(t.t_args("api-error-backup-create-file-failed", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::internal(t.t_args(
+                "api-error-backup-create-file-failed",
+                &[("error", &e.to_string())],
+            ))
+            .into_json_tuple();
         }
     };
     let mut zip = zip::ZipWriter::new(file);
@@ -2004,7 +2076,11 @@ pub async fn create_backup(
     }
 
     if let Err(e) = zip.finish() {
-        return ApiErrorResponse::internal(t.t_args("api-error-backup-finalize-failed", &[("error", &e.to_string())])).into_json_tuple();
+        return ApiErrorResponse::internal(t.t_args(
+            "api-error-backup-finalize-failed",
+            &[("error", &e.to_string())],
+        ))
+        .into_json_tuple();
     }
 
     let size = std::fs::metadata(&backup_path)
@@ -2131,28 +2207,40 @@ pub async fn delete_backup(
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     // Sanitize filename to prevent path traversal
     if is_invalid_backup_filename(&filename) {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename"))
+            .into_json_tuple();
     }
     if !filename.ends_with(".zip") {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip"))
+            .into_json_tuple();
     }
 
     let backups_dir = state.kernel.home_dir().join("backups");
     let backup_path = match find_backup_path(&backups_dir, &filename) {
         Ok(Some(path)) => path,
         Ok(None) => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found")).into_json_tuple();
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found")).into_json_tuple();
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
         }
         Err(e) => {
-            return ApiErrorResponse::internal(t.t_args("api-error-backup-delete-failed", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::internal(t.t_args(
+                "api-error-backup-delete-failed",
+                &[("error", &e.to_string())],
+            ))
+            .into_json_tuple();
         }
     };
 
     if let Err(e) = std::fs::remove_file(&backup_path) {
-        return ApiErrorResponse::internal(t.t_args("api-error-backup-delete-failed", &[("error", &e.to_string())])).into_json_tuple();
+        return ApiErrorResponse::internal(t.t_args(
+            "api-error-backup-delete-failed",
+            &[("error", &e.to_string())],
+        ))
+        .into_json_tuple();
     }
 
     tracing::info!("Backup deleted: {filename}");
@@ -2179,16 +2267,19 @@ pub async fn restore_backup(
     let filename = match req.get("filename").and_then(|v| v.as_str()) {
         Some(f) => f.to_string(),
         None => {
-            return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-filename")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-filename"))
+                .into_json_tuple();
         }
     };
 
     // Sanitize
     if is_invalid_backup_filename(&filename) {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename"))
+            .into_json_tuple();
     }
     if !filename.ends_with(".zip") {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip"))
+            .into_json_tuple();
     }
 
     let home_dir = &state.kernel.home_dir();
@@ -2196,13 +2287,18 @@ pub async fn restore_backup(
     let backup_path = match find_backup_path(&backups_dir, &filename) {
         Ok(Some(path)) => path,
         Ok(None) => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found")).into_json_tuple();
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found")).into_json_tuple();
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
         }
         Err(e) => {
-            return ApiErrorResponse::internal(t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())]),
+            )
+            .into_json_tuple();
         }
     };
 
@@ -2210,13 +2306,20 @@ pub async fn restore_backup(
     let file = match std::fs::File::open(&backup_path) {
         Ok(f) => f,
         Err(e) => {
-            return ApiErrorResponse::internal(t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())]),
+            )
+            .into_json_tuple();
         }
     };
     let mut archive = match zip::ZipArchive::new(file) {
         Ok(a) => a,
         Err(e) => {
-            return ApiErrorResponse::bad_request(t.t_args("api-error-backup-invalid-archive", &[("error", &e.to_string())])).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t_args(
+                "api-error-backup-invalid-archive",
+                &[("error", &e.to_string())],
+            ))
+            .into_json_tuple();
         }
     };
 
@@ -2236,7 +2339,8 @@ pub async fn restore_backup(
     };
 
     if manifest.is_none() {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-manifest")).into_json_tuple();
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-manifest"))
+            .into_json_tuple();
     }
 
     let mut restored: Vec<String> = Vec::new();
@@ -2472,12 +2576,17 @@ fn validate_event_types(
                 ));
             }
             None => {
-                return Err(ApiErrorResponse::bad_request(t.t("api-error-webhook-event-not-string")).into_json_tuple());
+                return Err(ApiErrorResponse::bad_request(
+                    t.t("api-error-webhook-event-not-string"),
+                )
+                .into_json_tuple());
             }
         }
     }
     if event_list.is_empty() {
-        return Err(ApiErrorResponse::bad_request(t.t("api-error-webhook-events-empty")).into_json_tuple());
+        return Err(
+            ApiErrorResponse::bad_request(t.t("api-error-webhook-events-empty")).into_json_tuple(),
+        );
     }
     Ok(event_list)
 }
@@ -2656,7 +2765,8 @@ pub async fn get_webhook(
     let wh_id = match uuid::Uuid::parse_str(&id) {
         Ok(uuid) => crate::webhook_store::WebhookId(uuid),
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id")).into_json_tuple();
+            return ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id"))
+                .into_json_tuple();
         }
     };
     match state.webhook_store.get(wh_id) {
@@ -2664,7 +2774,8 @@ pub async fn get_webhook(
             let redacted = crate::webhook_store::redact_webhook_secret(&wh);
             match serde_json::to_value(&redacted) {
                 Ok(v) => (StatusCode::OK, Json(v)),
-                Err(_) => ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error")).into_json_tuple(),
+                Err(_) => ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error"))
+                    .into_json_tuple(),
             }
         }
         None => ApiErrorResponse::not_found(t.t("api-error-webhook-not-found")).into_json_tuple(),
@@ -2683,7 +2794,8 @@ pub async fn create_webhook(
             let redacted = crate::webhook_store::redact_webhook_secret(&webhook);
             match serde_json::to_value(&redacted) {
                 Ok(v) => (StatusCode::CREATED, Json(v)),
-                Err(_) => ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error")).into_json_tuple(),
+                Err(_) => ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error"))
+                    .into_json_tuple(),
             }
         }
         Err(e) => ApiErrorResponse::bad_request(e).into_json_tuple(),
@@ -2706,13 +2818,18 @@ pub async fn update_webhook(
                     let redacted = crate::webhook_store::redact_webhook_secret(&webhook);
                     match serde_json::to_value(&redacted) {
                         Ok(v) => (StatusCode::OK, Json(v)),
-                        Err(_) => ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error")).into_json_tuple(),
+                        Err(_) => {
+                            ApiErrorResponse::internal(t.t("api-error-webhook-serialize-error"))
+                                .into_json_tuple()
+                        }
                     }
                 }
                 Err(e) => ApiErrorResponse::not_found(e).into_json_tuple(),
             }
         }
-        Err(_) => ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id")).into_json_tuple(),
+        Err(_) => {
+            ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id")).into_json_tuple()
+        }
     }
 }
 
@@ -2735,7 +2852,9 @@ pub async fn delete_webhook(
                 ApiErrorResponse::not_found(t.t("api-error-webhook-not-found")).into_json_tuple()
             }
         }
-        Err(_) => ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id")).into_json_tuple(),
+        Err(_) => {
+            ApiErrorResponse::bad_request(t.t("api-error-webhook-invalid-id")).into_json_tuple()
+        }
     }
 }
 

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -299,7 +299,11 @@ pub async fn create_workflow(
                 name: name.to_string(),
             }
         } else {
-            return ApiErrorResponse::bad_request(format!("Step '{}' needs 'agent_id' or 'agent_name'", step_name)).into_json_tuple();
+            return ApiErrorResponse::bad_request(format!(
+                "Step '{}' needs 'agent_id' or 'agent_name'",
+                step_name
+            ))
+            .into_json_tuple();
         };
 
         let mode = parse_step_mode(&s["mode"], s);
@@ -454,7 +458,9 @@ pub async fn get_workflow(
                 "layout": w.layout,
             })),
         ),
-        None => ApiErrorResponse::not_found(format!("Workflow '{}' not found", id)).into_json_tuple(),
+        None => {
+            ApiErrorResponse::not_found(format!("Workflow '{}' not found", id)).into_json_tuple()
+        }
     }
 }
 
@@ -519,7 +525,11 @@ pub async fn update_workflow(
                     name: aname.to_string(),
                 }
             } else {
-                return ApiErrorResponse::bad_request(format!("Step '{}' needs 'agent_id' or 'agent_name'", step_name)).into_json_tuple();
+                return ApiErrorResponse::bad_request(format!(
+                    "Step '{}' needs 'agent_id' or 'agent_name'",
+                    step_name
+                ))
+                .into_json_tuple();
             };
 
             let mode = parse_step_mode(&s["mode"], s);
@@ -712,7 +722,8 @@ pub async fn save_workflow_as_template(
     {
         Some(w) => w,
         None => {
-            return ApiErrorResponse::not_found(format!("Workflow '{}' not found", id)).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Workflow '{}' not found", id))
+                .into_json_tuple();
         }
     };
 
@@ -828,7 +839,8 @@ pub async fn create_trigger(
         }
         Err(e) => {
             tracing::warn!("Trigger registration failed: {e}");
-            ApiErrorResponse::not_found("Trigger registration failed (agent not found?)").into_json_tuple()
+            ApiErrorResponse::not_found("Trigger registration failed (agent not found?)")
+                .into_json_tuple()
         }
     }
 }
@@ -990,10 +1002,13 @@ pub async fn get_schedule(
             if let Some(schedule) = arr.iter().find(|s| s["id"].as_str() == Some(&id)) {
                 (StatusCode::OK, Json(schedule.clone()))
             } else {
-                ApiErrorResponse::not_found(format!("Schedule '{}' not found", id)).into_json_tuple()
+                ApiErrorResponse::not_found(format!("Schedule '{}' not found", id))
+                    .into_json_tuple()
             }
         }
-        Ok(_) => ApiErrorResponse::not_found(format!("Schedule '{}' not found", id)).into_json_tuple(),
+        Ok(_) => {
+            ApiErrorResponse::not_found(format!("Schedule '{}' not found", id)).into_json_tuple()
+        }
         Err(e) => {
             tracing::warn!("Failed to load schedules: {e}");
             ApiErrorResponse::internal(format!("Failed to load schedules: {e}")).into_json_tuple()
@@ -1033,7 +1048,10 @@ pub async fn create_schedule(
     // Validate cron expression: must be 5 space-separated fields
     let cron_parts: Vec<&str> = cron.split_whitespace().collect();
     if cron_parts.len() != 5 {
-        return ApiErrorResponse::bad_request("Invalid cron expression: must have 5 fields (min hour dom mon dow)").into_json_tuple();
+        return ApiErrorResponse::bad_request(
+            "Invalid cron expression: must have 5 fields (min hour dom mon dow)",
+        )
+        .into_json_tuple();
     }
 
     let agent_id_str = req["agent_id"].as_str().unwrap_or("").to_string();
@@ -1041,7 +1059,8 @@ pub async fn create_schedule(
 
     // Must have either agent_id or workflow_id
     if agent_id_str.is_empty() && workflow_id_str.is_empty() {
-        return ApiErrorResponse::bad_request("Must provide either agent_id or workflow_id").into_json_tuple();
+        return ApiErrorResponse::bad_request("Must provide either agent_id or workflow_id")
+            .into_json_tuple();
     }
 
     // Validate agent exists if provided
@@ -1057,7 +1076,8 @@ pub async fn create_schedule(
                 .any(|a| a.name == agent_id_str)
         };
         if !agent_exists {
-            return ApiErrorResponse::not_found(format!("Agent not found: {agent_id_str}")).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Agent not found: {agent_id_str}"))
+                .into_json_tuple();
         }
     }
 
@@ -1071,7 +1091,10 @@ pub async fn create_schedule(
                 .await
                 .is_none()
             {
-                return ApiErrorResponse::not_found(format!("Workflow not found: {workflow_id_str}")).into_json_tuple();
+                return ApiErrorResponse::not_found(format!(
+                    "Workflow not found: {workflow_id_str}"
+                ))
+                .into_json_tuple();
             }
         } else {
             return ApiErrorResponse::bad_request("Invalid workflow_id format").into_json_tuple();
@@ -1112,7 +1135,8 @@ pub async fn create_schedule(
         serde_json::Value::Array(schedules),
     ) {
         tracing::warn!("Failed to save schedule: {e}");
-        return ApiErrorResponse::internal(format!("Failed to save schedule: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to save schedule: {e}"))
+            .into_json_tuple();
     }
 
     (StatusCode::CREATED, Json(entry))
@@ -1148,7 +1172,8 @@ pub async fn update_schedule(
             if let Some(cron) = req.get("cron").and_then(|v| v.as_str()) {
                 let cron_parts: Vec<&str> = cron.split_whitespace().collect();
                 if cron_parts.len() != 5 {
-                    return ApiErrorResponse::bad_request("Invalid cron expression").into_json_tuple();
+                    return ApiErrorResponse::bad_request("Invalid cron expression")
+                        .into_json_tuple();
                 }
                 s["cron"] = serde_json::Value::String(cron.to_string());
             }
@@ -1171,7 +1196,8 @@ pub async fn update_schedule(
         SCHEDULES_KEY,
         serde_json::Value::Array(schedules),
     ) {
-        return ApiErrorResponse::internal(format!("Failed to update schedule: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to update schedule: {e}"))
+            .into_json_tuple();
     }
 
     (
@@ -1208,7 +1234,8 @@ pub async fn delete_schedule(
         SCHEDULES_KEY,
         serde_json::Value::Array(schedules),
     ) {
-        return ApiErrorResponse::internal(format!("Failed to delete schedule: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal(format!("Failed to delete schedule: {e}"))
+            .into_json_tuple();
     }
 
     (
@@ -1331,7 +1358,10 @@ pub async fn run_schedule(
         let target_agent = match target_agent {
             Some(a) => a,
             None => {
-                return ApiErrorResponse::not_found("No target agent found. Specify an agent_id or start an agent first.").into_json_tuple();
+                return ApiErrorResponse::not_found(
+                    "No target agent found. Specify an agent_id or start an agent first.",
+                )
+                .into_json_tuple();
             }
         };
 
@@ -1629,7 +1659,9 @@ pub async fn get_workflow_template(
             StatusCode::OK,
             Json(serde_json::to_value(&t).unwrap_or_default()),
         ),
-        None => ApiErrorResponse::not_found(format!("Template '{}' not found", id)).into_json_tuple(),
+        None => {
+            ApiErrorResponse::not_found(format!("Template '{}' not found", id)).into_json_tuple()
+        }
     }
 }
 
@@ -1654,7 +1686,8 @@ pub async fn instantiate_template(
     let template = match state.kernel.templates().get(&id).await {
         Some(t) => t,
         None => {
-            return ApiErrorResponse::not_found(format!("Template '{}' not found", id)).into_json_tuple();
+            return ApiErrorResponse::not_found(format!("Template '{}' not found", id))
+                .into_json_tuple();
         }
     };
 

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -5642,8 +5642,7 @@ system_prompt = "You are a helpful assistant."
                 // Pass `instance_id` (the caller's parameter) so that
                 // `activate_hand()` (None) preserves legacy IDs while
                 // `activate_hand_with_id(_, _, Some(uuid))` uses the new format.
-                let new_id =
-                    AgentId::from_hand_agent(hand_id, &old_role, instance_id);
+                let new_id = AgentId::from_hand_agent(hand_id, &old_role, instance_id);
                 let migrated = self.cron_scheduler.reassign_agent_jobs(old_id, new_id);
                 if migrated > 0 {
                     let _ = self.cron_scheduler.persist();
@@ -5802,8 +5801,7 @@ system_prompt = "You are a helpful assistant."
             // uses the legacy format so existing hands keep their original IDs.
             // When `instance_id` is Some (multi-instance or restart recovery),
             // uses the new format with instance UUID for uniqueness.
-            let deterministic_id =
-                AgentId::from_hand_agent(hand_id, role, instance_id);
+            let deterministic_id = AgentId::from_hand_agent(hand_id, role, instance_id);
             let agent_id = self.spawn_agent_inner(
                 manifest,
                 None,
@@ -6152,8 +6150,7 @@ system_prompt = "You are a helpful assistant."
                     info!(
                         "Hot-reload: web config updated (search_provider={:?}, \
                          cache_ttl={}min) — takes effect on next web tool invocation",
-                        new_config.web.search_provider,
-                        new_config.web.cache_ttl_minutes
+                        new_config.web.search_provider, new_config.web.cache_ttl_minutes
                     );
                 }
                 HotAction::ReloadBrowserConfig => {
@@ -6169,9 +6166,7 @@ system_prompt = "You are a helpful assistant."
                         .as_ref()
                         .map(|w| w.enabled)
                         .unwrap_or(false);
-                    info!(
-                        "Hot-reload: webhook trigger config updated (enabled={enabled})"
-                    );
+                    info!("Hot-reload: webhook trigger config updated (enabled={enabled})");
                 }
                 HotAction::ReloadExtensions => {
                     info!("Hot-reload: reloading extension registry");
@@ -6249,9 +6244,7 @@ system_prompt = "You are a helpful assistant."
                 }
                 HotAction::ReloadFallbackProviders => {
                     let count = new_config.fallback_providers.len();
-                    info!(
-                        "Hot-reload: fallback provider chain updated ({count} provider(s))"
-                    );
+                    info!("Hot-reload: fallback provider chain updated ({count} provider(s))");
                     // Invalidate cached LLM drivers so the new fallback chain
                     // is used when drivers are next constructed.
                     self.driver_cache.clear();

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -831,7 +831,7 @@ impl WorkflowEngine {
         run_id: WorkflowRunId,
         workflow: &Workflow,
         input: &str,
-        agent_resolver: &(impl Fn(&StepAgent) -> Option<(AgentId, String, bool)>),
+        agent_resolver: &impl Fn(&StepAgent) -> Option<(AgentId, String, bool)>,
         send_message: &F,
     ) -> Result<String, String>
     where


### PR DESCRIPTION
- Remove unnecessary parentheses in workflow.rs
- Remove unused StatusCode import in prompts.rs  
- Apply rustfmt formatting to recently merged code