### PR TITLE
fix: sync workflow templates from registry on boot

### DIFF
--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -58,7 +58,7 @@ pub fn sync_registry(home_dir: &Path) {
 
     // Pre-install core content users need out of the box.
     // Skills and plugins stay in registry — users install via dashboard.
-    for &dir_name in &["providers", "integrations", "channels"] {
+    for &dir_name in &["providers", "integrations", "channels", "workflows"] {
         let src_dir = registry_cache.join(dir_name);
         if src_dir.exists() {
             sync_flat_files(&src_dir, &home_dir.join(dir_name), dir_name);


### PR DESCRIPTION
One-line fix: add `"workflows"` to the sync list in `registry_sync.rs`.

9 workflow templates in librefang-registry will now auto-sync to `~/.librefang/workflows/` on boot.

Closes #1156