### PR TITLE
fix: remove workflows from registry sync (kernel handles this separately)

### DIFF
--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -58,7 +58,7 @@ pub fn sync_registry(home_dir: &Path) {
 
     // Pre-install core content users need out of the box.
     // Skills and plugins stay in registry — users install via dashboard.
-    for &dir_name in &["providers", "integrations", "channels", "workflows"] {
+    for &dir_name in &["providers", "integrations", "channels"] {
         let src_dir = registry_cache.join(dir_name);
         if src_dir.exists() {
             sync_flat_files(&src_dir, &home_dir.join(dir_name), dir_name);


### PR DESCRIPTION
Reverts the workflows addition from #1688. The kernel already copies templates from `registry/workflows/` to `workflows/templates/` at boot (kernel.rs:2228-2250). The sync_flat_files approach would put templates in the wrong location.

Closes #1156 correctly — the feature was already working via the kernel's built-in template sync.