### PR TITLE
feat: pluggable VectorStore backend with HTTP implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4033,6 +4033,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "librefang-types",
+ "reqwest 0.13.2",
  "rmp-serde",
  "rusqlite",
  "serde",

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1277,14 +1277,37 @@ impl LibreFangKernel {
             .sqlite_path
             .clone()
             .unwrap_or_else(|| config.data_dir.join("librefang.db"));
-        let memory = Arc::new(
-            MemorySubstrate::open_with_chunking(
-                &db_path,
-                config.memory.decay_rate,
-                config.memory.chunking.clone(),
-            )
-            .map_err(|e| KernelError::BootFailed(format!("Memory init failed: {e}")))?,
-        );
+        let mut substrate = MemorySubstrate::open_with_chunking(
+            &db_path,
+            config.memory.decay_rate,
+            config.memory.chunking.clone(),
+        )
+        .map_err(|e| KernelError::BootFailed(format!("Memory init failed: {e}")))?;
+
+        // Optionally attach an external vector store backend.
+        if let Some(ref backend) = config.memory.vector_backend {
+            match backend.as_str() {
+                "http" => {
+                    let url = config.memory.vector_store_url.as_deref().ok_or_else(|| {
+                        KernelError::BootFailed(
+                            "vector_backend = \"http\" requires vector_store_url".into(),
+                        )
+                    })?;
+                    let store =
+                        std::sync::Arc::new(librefang_memory::HttpVectorStore::new(url));
+                    substrate.set_vector_store(store);
+                    tracing::info!("Vector store backend: http ({})", url);
+                }
+                "sqlite" | "" => { /* default — no external backend */ }
+                other => {
+                    return Err(KernelError::BootFailed(format!(
+                        "Unknown vector_backend: {other:?}"
+                    )));
+                }
+            }
+        }
+
+        let memory = Arc::new(substrate);
 
         // Create LLM driver.
         // For the API key, try: 1) explicit api_key_env from config, 2) provider_api_keys

--- a/crates/librefang-memory/Cargo.toml
+++ b/crates/librefang-memory/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/librefang-memory/src/http_vector_store.rs
+++ b/crates/librefang-memory/src/http_vector_store.rs
@@ -1,0 +1,237 @@
+//! HTTP-backed vector store implementation.
+//!
+//! Delegates all vector operations to a remote service over HTTP/JSON,
+//! allowing LibreFang to use external vector databases (Qdrant, Weaviate,
+//! a custom microservice, etc.) without linking their native clients.
+//!
+//! ## Expected API contract
+//!
+//! | Method | Path               | Body (JSON)                                     | Response (JSON)                |
+//! |--------|--------------------|------------------------------------------------|--------------------------------|
+//! | POST   | `/insert`          | `{ id, embedding, payload, metadata }`         | `{}`                           |
+//! | POST   | `/search`          | `{ query_embedding, limit, filter? }`          | `[{ id, payload, score, metadata }]` |
+//! | DELETE | `/delete`          | `{ id }`                                       | `{}`                           |
+//! | POST   | `/get_embeddings`  | `{ ids }`                                      | `{ "<id>": [f32, ...], ... }` |
+
+use async_trait::async_trait;
+use librefang_types::error::{LibreFangError, LibreFangResult};
+use librefang_types::memory::{MemoryFilter, VectorSearchResult, VectorStore};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A [`VectorStore`] that talks to a remote HTTP service.
+#[derive(Clone)]
+pub struct HttpVectorStore {
+    client: Client,
+    base_url: String,
+}
+
+impl HttpVectorStore {
+    /// Create a new HTTP vector store pointing at `base_url`.
+    ///
+    /// `base_url` should include the scheme and host, e.g.
+    /// `http://localhost:6333/collections/memories`.  No trailing slash.
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+        }
+    }
+
+    /// Build the full URL for an endpoint.
+    fn url(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url, path.trim_start_matches('/'))
+    }
+}
+
+// ── Request / response DTOs ──────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct InsertRequest<'a> {
+    id: &'a str,
+    embedding: &'a [f32],
+    payload: &'a str,
+    metadata: &'a HashMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct SearchRequest<'a> {
+    query_embedding: &'a [f32],
+    limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filter: Option<&'a MemoryFilter>,
+}
+
+#[derive(Deserialize)]
+struct SearchResponseItem {
+    id: String,
+    payload: String,
+    score: f32,
+    #[serde(default)]
+    metadata: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct DeleteRequest<'a> {
+    id: &'a str,
+}
+
+#[derive(Serialize)]
+struct GetEmbeddingsRequest<'a> {
+    ids: &'a [&'a str],
+}
+
+// ── VectorStore implementation ───────────────────────────────────────────
+
+#[async_trait]
+impl VectorStore for HttpVectorStore {
+    async fn insert(
+        &self,
+        id: &str,
+        embedding: &[f32],
+        payload: &str,
+        metadata: HashMap<String, serde_json::Value>,
+    ) -> LibreFangResult<()> {
+        let body = InsertRequest {
+            id,
+            embedding,
+            payload,
+            metadata: &metadata,
+        };
+        let resp = self
+            .client
+            .post(self.url("insert"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LibreFangError::Internal(format!("HTTP vector insert: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(LibreFangError::Internal(format!(
+                "HTTP vector insert returned {status}: {text}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+        filter: Option<MemoryFilter>,
+    ) -> LibreFangResult<Vec<VectorSearchResult>> {
+        let body = SearchRequest {
+            query_embedding,
+            limit,
+            filter: filter.as_ref(),
+        };
+        let resp = self
+            .client
+            .post(self.url("search"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LibreFangError::Internal(format!("HTTP vector search: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(LibreFangError::Internal(format!(
+                "HTTP vector search returned {status}: {text}"
+            )));
+        }
+
+        let items: Vec<SearchResponseItem> = resp
+            .json()
+            .await
+            .map_err(|e| LibreFangError::Internal(format!("HTTP vector search parse: {e}")))?;
+
+        Ok(items
+            .into_iter()
+            .map(|i| VectorSearchResult {
+                id: i.id,
+                payload: i.payload,
+                score: i.score,
+                metadata: i.metadata,
+            })
+            .collect())
+    }
+
+    async fn delete(&self, id: &str) -> LibreFangResult<()> {
+        let body = DeleteRequest { id };
+        let resp = self
+            .client
+            .delete(self.url("delete"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LibreFangError::Internal(format!("HTTP vector delete: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(LibreFangError::Internal(format!(
+                "HTTP vector delete returned {status}: {text}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn get_embeddings(
+        &self,
+        ids: &[&str],
+    ) -> LibreFangResult<HashMap<String, Vec<f32>>> {
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let body = GetEmbeddingsRequest { ids };
+        let resp = self
+            .client
+            .post(self.url("get_embeddings"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LibreFangError::Internal(format!("HTTP vector get_embeddings: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(LibreFangError::Internal(format!(
+                "HTTP vector get_embeddings returned {status}: {text}"
+            )));
+        }
+
+        let map: HashMap<String, Vec<f32>> = resp
+            .json()
+            .await
+            .map_err(|e| {
+                LibreFangError::Internal(format!("HTTP vector get_embeddings parse: {e}"))
+            })?;
+        Ok(map)
+    }
+
+    fn backend_name(&self) -> &str {
+        "http"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_building() {
+        let store = HttpVectorStore::new("http://localhost:6333/v1");
+        assert_eq!(store.url("search"), "http://localhost:6333/v1/search");
+        assert_eq!(store.url("/insert"), "http://localhost:6333/v1/insert");
+    }
+
+    #[test]
+    fn test_trailing_slash_stripped() {
+        let store = HttpVectorStore::new("http://localhost:6333/v1/");
+        assert_eq!(store.url("search"), "http://localhost:6333/v1/search");
+    }
+}

--- a/crates/librefang-memory/src/lib.rs
+++ b/crates/librefang-memory/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod chunker;
 pub mod consolidation;
 pub mod decay;
+pub mod http_vector_store;
 pub mod knowledge;
 pub mod migration;
 pub mod proactive;
@@ -41,4 +42,5 @@ pub use proactive::{MemoryExportItem, MemoryStats, ProactiveMemoryStore};
 pub use prompt::PromptStore;
 
 // Re-export vector store implementations
+pub use http_vector_store::HttpVectorStore;
 pub use semantic::SqliteVectorStore;

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use librefang_types::agent::AgentId;
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::memory::{
-    MemoryFilter, MemoryFragment, MemoryId, MemoryModality, MemorySource,
+    MemoryFilter, MemoryFragment, MemoryId, MemoryModality, MemorySource, VectorStore,
 };
 use rusqlite::Connection;
 use std::collections::HashMap;
@@ -19,15 +19,40 @@ use std::sync::{Arc, Mutex};
 use tracing::debug;
 
 /// Semantic store backed by SQLite with optional vector search.
+///
+/// When a [`VectorStore`] backend is provided, vector similarity search in
+/// [`recall_with_embedding`](Self::recall_with_embedding) is delegated to that
+/// backend instead of doing in-process cosine similarity over SQLite BLOBs.
+/// When no backend is set (the default), the original SQLite path is used.
 #[derive(Clone)]
 pub struct SemanticStore {
     conn: Arc<Mutex<Connection>>,
+    vector_store: Option<Arc<dyn VectorStore>>,
 }
 
 impl SemanticStore {
     /// Create a new semantic store wrapping the given connection.
     pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
-        Self { conn }
+        Self {
+            conn,
+            vector_store: None,
+        }
+    }
+
+    /// Create a new semantic store with an external vector backend.
+    pub fn new_with_vector_store(
+        conn: Arc<Mutex<Connection>>,
+        vector_store: Arc<dyn VectorStore>,
+    ) -> Self {
+        Self {
+            conn,
+            vector_store: Some(vector_store),
+        }
+    }
+
+    /// Set or replace the vector store backend at runtime.
+    pub fn set_vector_store(&mut self, store: Arc<dyn VectorStore>) {
+        self.vector_store = Some(store);
     }
 
     /// Get a reference to the underlying connection for advanced operations.
@@ -121,6 +146,11 @@ impl SemanticStore {
 
     /// Search for memories using vector similarity when a query embedding is provided,
     /// falling back to LIKE matching otherwise.
+    ///
+    /// When an external [`VectorStore`] is configured **and** a `query_embedding`
+    /// is supplied, the search is delegated to that backend.  The returned IDs
+    /// are then hydrated into full [`MemoryFragment`]s from SQLite so the caller
+    /// always gets the same rich result type.
     pub fn recall_with_embedding(
         &self,
         query: &str,
@@ -128,6 +158,11 @@ impl SemanticStore {
         filter: Option<MemoryFilter>,
         query_embedding: Option<&[f32]>,
     ) -> LibreFangResult<Vec<MemoryFragment>> {
+        // ── Delegate to external vector store when available ──────────
+        if let (Some(vs), Some(qe)) = (&self.vector_store, query_embedding) {
+            return self.recall_via_vector_store(vs, qe, limit, filter.clone());
+        }
+
         let conn = self
             .conn
             .lock()
@@ -337,6 +372,57 @@ impl SemanticStore {
         }
 
         // Update access counts for returned memories
+        for frag in &fragments {
+            let _ = conn.execute(
+                "UPDATE memories SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2",
+                rusqlite::params![Utc::now().to_rfc3339(), frag.id.0.to_string()],
+            );
+        }
+
+        Ok(fragments)
+    }
+
+    /// Delegate vector search to an external [`VectorStore`] backend, then
+    /// hydrate the returned IDs into full [`MemoryFragment`]s from SQLite.
+    fn recall_via_vector_store(
+        &self,
+        vs: &Arc<dyn VectorStore>,
+        query_embedding: &[f32],
+        limit: usize,
+        filter: Option<MemoryFilter>,
+    ) -> LibreFangResult<Vec<MemoryFragment>> {
+        // VectorStore is async — run inside a small blocking-compatible context.
+        let vs = Arc::clone(vs);
+        let qe = query_embedding.to_vec();
+        let filter_clone = filter.clone();
+        let results: Vec<librefang_types::memory::VectorSearchResult> =
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current()
+                    .block_on(vs.search(&qe, limit, filter_clone))
+            })?;
+
+        debug!(
+            "VectorStore ({}) recall: {} results",
+            vs.backend_name(),
+            results.len()
+        );
+
+        // Hydrate full MemoryFragments from SQLite by ID
+        let mut fragments = Vec::with_capacity(results.len());
+        for r in &results {
+            let mem_id = uuid::Uuid::parse_str(&r.id)
+                .map(MemoryId)
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+            if let Some(frag) = self.get_by_id(mem_id, false)? {
+                fragments.push(frag);
+            }
+        }
+
+        // Update access counts
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         for frag in &fragments {
             let _ = conn.execute(
                 "UPDATE memories SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2",
@@ -822,7 +908,7 @@ fn embedding_from_bytes(bytes: &[u8]) -> Vec<f32> {
 // ---------------------------------------------------------------------------
 
 use async_trait::async_trait;
-use librefang_types::memory::{VectorSearchResult, VectorStore};
+use librefang_types::memory::VectorSearchResult;
 
 /// SQLite-backed vector store (the default backend).
 ///

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -105,6 +105,15 @@ impl MemorySubstrate {
         &self.knowledge
     }
 
+    /// Attach an external vector store backend to the semantic store.
+    ///
+    /// When set, [`SemanticStore::recall_with_embedding`] will delegate vector
+    /// similarity search to this backend instead of doing in-process cosine
+    /// similarity over SQLite BLOBs.
+    pub fn set_vector_store(&mut self, store: Arc<dyn librefang_types::memory::VectorStore>) {
+        self.semantic.set_vector_store(store);
+    }
+
     /// Get the shared database connection (for constructing stores from outside).
     pub fn usage_conn(&self) -> Arc<Mutex<Connection>> {
         Arc::clone(&self.conn)

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2907,6 +2907,12 @@ pub struct MemoryConfig {
     /// Chunking configuration for long documents.
     #[serde(default)]
     pub chunking: ChunkConfig,
+    /// Vector store backend: `"sqlite"` (default) or `"http"`.
+    #[serde(default)]
+    pub vector_backend: Option<String>,
+    /// Base URL for the HTTP vector store (used when `vector_backend = "http"`).
+    #[serde(default)]
+    pub vector_store_url: Option<String>,
 }
 
 /// Configuration for splitting long documents into overlapping chunks.
@@ -2949,6 +2955,8 @@ impl Default for MemoryConfig {
             fts_only: None,
             decay: MemoryDecayConfig::default(),
             chunking: ChunkConfig::default(),
+            vector_backend: None,
+            vector_store_url: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refactor SemanticStore to use VectorStore trait instead of hardcoded SQLite queries
- Add HttpVectorStore for remote vector DB support (Qdrant/Pinecone/etc.)
- Config: `memory.vector_backend = "http"` + `memory.vector_store_url = "..."`
- Backward compatible: default behavior unchanged (SQLite)

Closes #1497