### PR TITLE
refactor: deduplicate constants and auto-generate user-agent version

### DIFF
--- a/crates/librefang-channels/src/reddit.rs
+++ b/crates/librefang-channels/src/reddit.rs
@@ -36,7 +36,11 @@ const MAX_MESSAGE_LEN: usize = 10000;
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
 
 /// Custom User-Agent required by Reddit API guidelines.
-const USER_AGENT: &str = "librefang:v1.0.0 (by /u/librefang-bot)";
+const USER_AGENT: &str = concat!(
+    "librefang:v",
+    env!("CARGO_PKG_VERSION"),
+    " (by /u/librefang-bot)"
+);
 
 /// Reddit OAuth2 API adapter.
 ///

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -8,7 +8,7 @@ const EN_FTL: &str = include_str!("../locales/en/main.ftl");
 const ZH_CN_FTL: &str = include_str!("../locales/zh-CN/main.ftl");
 
 pub const SUPPORTED_LANGUAGES: &[&str] = &["en", "zh-CN"];
-pub const DEFAULT_LANGUAGE: &str = "en";
+pub use librefang_types::i18n::DEFAULT_LANGUAGE;
 
 thread_local! {
     static I18N: RefCell<Option<I18n>> = const { RefCell::new(None) };

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -150,8 +150,6 @@ impl PromptMetadataCache {
     }
 }
 
-const STABLE_PREFIX_MODE_METADATA_KEY: &str = "stable_prefix_mode";
-
 /// The main LibreFang kernel — coordinates all subsystems.
 /// Stub LLM driver used when no providers are configured.
 /// Returns a helpful error so the dashboard still boots and users can configure providers.

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -18,7 +18,7 @@ use crate::web_search::WebToolsContext;
 use librefang_memory::session::Session;
 use librefang_memory::{MemorySubstrate, ProactiveMemoryHooks};
 use librefang_skills::registry::SkillRegistry;
-use librefang_types::agent::AgentManifest;
+use librefang_types::agent::{AgentManifest, STABLE_PREFIX_MODE_METADATA_KEY};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::memory::{Memory, MemoryFilter, MemorySource};
 use librefang_types::memory::{MemoryFragment, MemoryId};
@@ -52,8 +52,6 @@ const MAX_CONTINUATIONS: u32 = 5;
 
 /// Maximum message history size before auto-trimming to prevent context overflow.
 const MAX_HISTORY_MESSAGES: usize = 20;
-
-const STABLE_PREFIX_MODE_METADATA_KEY: &str = "stable_prefix_mode";
 
 /// Safely trim message history to `MAX_HISTORY_MESSAGES`, cutting at
 /// conversation-turn boundaries so ToolUse/ToolResult pairs are never split.

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -5,7 +5,7 @@
 
 /// Default User-Agent header sent with all outgoing HTTP requests.
 /// Some LLM providers (e.g. Moonshot, Qwen) reject requests without one.
-pub const USER_AGENT: &str = "librefang/0.3.47";
+pub const USER_AGENT: &str = concat!("librefang/", env!("CARGO_PKG_VERSION"));
 
 pub mod a2a;
 pub mod agent_loop;

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use uuid::Uuid;
 
+/// Metadata key for stable prefix mode flag.
+pub const STABLE_PREFIX_MODE_METADATA_KEY: &str = "stable_prefix_mode";
+
 /// Unique identifier for a user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UserId(pub Uuid);


### PR DESCRIPTION
## Summary
- Auto-generate `USER_AGENT` from `CARGO_PKG_VERSION` via `concat!(env!())` so it never goes stale
- Auto-generate Reddit channel User-Agent similarly
- Deduplicate `STABLE_PREFIX_MODE_METADATA_KEY` (was defined in both kernel and runtime)
- Deduplicate `DEFAULT_LANGUAGE` (was defined in both CLI and types)

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes
- [ ] User-Agent header reflects current Cargo.toml version