### PR TITLE
refactor: extract retry policy constants into configurable RetryConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -89,6 +89,13 @@ debounce_ms = 500
 # model = "gpt-4o"
 # api_key_env = "OPENAI_API_KEY"
 
+# ── Retry / Backoff ─────────────────────────────────────────
+# [retry]
+# max_attempts = 3            # Total attempts (including first try)
+# min_delay_ms = 300           # Initial backoff delay
+# max_delay_ms = 30000         # Maximum backoff cap
+# jitter = 0.2                # Jitter factor (0.0–1.0)
+
 # ── Budget & Cost Control ────────────────────────────────────
 # [budget]
 # max_hourly_usd = 0.0         # 0 = unlimited

--- a/crates/librefang-runtime/src/retry.rs
+++ b/crates/librefang-runtime/src/retry.rs
@@ -7,38 +7,8 @@
 //! Jitter uses `std::time::SystemTime` UNIX nanos as a seed to avoid
 //! requiring the `rand` crate as a dependency.
 
+use librefang_types::config::RetryConfig;
 use tracing::{debug, warn};
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/// Configuration for retry behavior.
-#[derive(Debug, Clone)]
-pub struct RetryConfig {
-    /// Maximum number of attempts (including the first try).
-    pub max_attempts: u32,
-    /// Minimum delay between retries in milliseconds.
-    pub min_delay_ms: u64,
-    /// Maximum delay between retries in milliseconds.
-    pub max_delay_ms: u64,
-    /// Jitter factor (0.0 = no jitter, 1.0 = full jitter).
-    ///
-    /// The actual sleep is `delay * (1 + random_fraction * jitter)`, where
-    /// `random_fraction` is in `[0, 1)`.
-    pub jitter: f64,
-}
-
-impl Default for RetryConfig {
-    fn default() -> Self {
-        Self {
-            max_attempts: 3,
-            min_delay_ms: 300,
-            max_delay_ms: 30_000,
-            jitter: 0.2,
-        }
-    }
-}
 
 /// Result of a retry operation.
 #[derive(Debug)]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -381,6 +381,59 @@ impl Default for ReloadConfig {
     }
 }
 
+/// Retry / exponential-backoff defaults.
+///
+/// Controls how many times fallible operations (LLM calls, network requests,
+/// channel delivery) are retried, and the backoff timing between attempts.
+///
+/// ```toml
+/// [retry]
+/// max_attempts = 3
+/// min_delay_ms = 300
+/// max_delay_ms = 30000
+/// jitter = 0.2
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts (including the first try). Default: 3.
+    #[serde(default = "default_retry_max_attempts")]
+    pub max_attempts: u32,
+    /// Minimum delay between retries in milliseconds. Default: 300.
+    #[serde(default = "default_retry_min_delay_ms")]
+    pub min_delay_ms: u64,
+    /// Maximum delay between retries in milliseconds. Default: 30 000.
+    #[serde(default = "default_retry_max_delay_ms")]
+    pub max_delay_ms: u64,
+    /// Jitter factor for retry delays (0.0 = none, 1.0 = full). Default: 0.2.
+    #[serde(default = "default_retry_jitter")]
+    pub jitter: f64,
+}
+
+fn default_retry_max_attempts() -> u32 {
+    3
+}
+fn default_retry_min_delay_ms() -> u64 {
+    300
+}
+fn default_retry_max_delay_ms() -> u64 {
+    30_000
+}
+fn default_retry_jitter() -> f64 {
+    0.2
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_retry_max_attempts(),
+            min_delay_ms: default_retry_min_delay_ms(),
+            max_delay_ms: default_retry_max_delay_ms(),
+            jitter: default_retry_jitter(),
+        }
+    }
+}
+
 /// Webhook trigger authentication configuration.
 ///
 /// Controls the `/hooks/wake` and `/hooks/agent` endpoints for external
@@ -1573,6 +1626,9 @@ pub struct KernelConfig {
     /// Prompt intelligence configuration (versioning + A/B testing).
     #[serde(default)]
     pub prompt_intelligence: PromptIntelligenceConfig,
+    /// Retry / exponential-backoff defaults for fallible operations.
+    #[serde(default)]
+    pub retry: RetryConfig,
     /// CLI update channel (stable, beta, rc).
     /// Controls which releases `librefang update` considers.
     #[serde(default)]
@@ -2399,6 +2455,7 @@ impl Default for KernelConfig {
             inbox: InboxConfig::default(),
             telemetry: TelemetryConfig::default(),
             prompt_intelligence: PromptIntelligenceConfig::default(),
+            retry: RetryConfig::default(),
             update_channel: UpdateChannel::default(),
         }
     }


### PR DESCRIPTION
## Summary
- New `[retry]` config section with `max_attempts`, `min_delay_ms`, `max_delay_ms`, `jitter`
- Defaults match previous hardcoded values (3 attempts, 300ms-30s, 0.2 jitter)
- Existing configs without `[retry]` section continue to work unchanged

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes
- [ ] Config without `[retry]` section uses defaults