### PR TITLE
refactor: extract registry cache TTL into configurable RegistryConfig

### DIFF
--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -192,7 +192,10 @@ async fn start_full_router(api_key: &str) -> FullRouterHarness {
 
     // Sync registry content into the temp home_dir so the kernel boots
     // with a populated model catalog.
-    librefang_runtime::registry_sync::sync_registry(tmp.path());
+    librefang_runtime::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_runtime::registry_sync::DEFAULT_CACHE_TTL_SECS,
+    );
 
     let config = KernelConfig {
         home_dir: tmp.path().to_path_buf(),

--- a/crates/librefang-cli/src/bundled_agents.rs
+++ b/crates/librefang-cli/src/bundled_agents.rs
@@ -7,5 +7,8 @@ use std::path::Path;
 
 /// Sync all content from the registry to the local librefang home directory.
 pub fn sync_registry_agents(home_dir: &Path) {
-    librefang_runtime::registry_sync::sync_registry(home_dir);
+    librefang_runtime::registry_sync::sync_registry(
+        home_dir,
+        librefang_runtime::registry_sync::DEFAULT_CACHE_TTL_SECS,
+    );
 }

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1903,7 +1903,10 @@ fn cmd_init(quick: bool) {
     }
 
     // Sync registry content (downloads to registry/, pre-installs providers/integrations/assistant)
-    librefang_runtime::registry_sync::sync_registry(&librefang_dir);
+    librefang_runtime::registry_sync::sync_registry(
+        &librefang_dir,
+        librefang_runtime::registry_sync::DEFAULT_CACHE_TTL_SECS,
+    );
 
     // Initialize vault if not already initialized
     init_vault_if_missing(&librefang_dir);

--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -98,6 +98,9 @@ debounce_ms = 500
 # ws_idle_timeout_secs = 1800     # Close idle WebSocket after 30 min
 # ws_debounce_ms = 100            # Text delta debounce interval
 # ws_debounce_chars = 200         # Flush text buffer at this character count
+# ── Registry Sync ────────────────────────────────────────────
+# [registry]
+# cache_ttl_secs = 86400          # Re-download interval (default: 24 hours)
 
 # ── Budget & Cost Control ────────────────────────────────────
 # [budget]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1502,7 +1502,10 @@ impl LibreFangKernel {
         // Auto-sync registry content on first boot or after upgrade when
         // Sync registry: downloads if cache is stale, pre-installs providers/agents/integrations.
         // Skips download if cache is fresh; skips copy if files already exist.
-        librefang_runtime::registry_sync::sync_registry(&config.home_dir);
+        librefang_runtime::registry_sync::sync_registry(
+            &config.home_dir,
+            config.registry.cache_ttl_secs,
+        );
 
         // Initialize model catalog, detect provider auth, and apply URL overrides
         let mut model_catalog =

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -21,8 +21,9 @@ const REGISTRY_REPO: &str = "https://github.com/librefang/librefang-registry.git
 /// Prefix inside the tarball (GitHub convention: `{repo}-{branch}/`).
 const TARBALL_PREFIX: &str = "librefang-registry-main/";
 
-/// How long (in seconds) before we re-download the registry.
-const CACHE_MAX_AGE_SECS: u64 = 24 * 60 * 60; // 24 hours
+/// Default cache TTL: how long (in seconds) before we re-download the registry.
+/// Callers without access to `KernelConfig` can use this value directly.
+pub const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 
 /// Sync all content from the registry to the local librefang home directory.
 ///
@@ -30,10 +31,14 @@ const CACHE_MAX_AGE_SECS: u64 = 24 * 60 * 60; // 24 hours
 /// that don't already exist on disk (preserves user customization).
 /// Tries git first (incremental pull, supports private forks), falls back to
 /// HTTP tarball download when git is unavailable (Docker, minimal VMs).
-pub fn sync_registry(home_dir: &Path) {
+///
+/// `cache_ttl_secs` controls how long the local cache is considered fresh
+/// before triggering a re-download. Pass [`DEFAULT_CACHE_TTL_SECS`] when
+/// no user-configured value is available.
+pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64) {
     let registry_cache = home_dir.join("registry");
 
-    if !should_refresh(&registry_cache) {
+    if !should_refresh(&registry_cache, cache_ttl_secs) {
         tracing::debug!("Registry cache is fresh, skipping download");
     } else {
         // Try git first (faster incremental updates, private fork support)
@@ -104,8 +109,8 @@ pub fn sync_registry(home_dir: &Path) {
 /// Check whether we should re-download the registry.
 ///
 /// Returns `false` if the cache exists and the marker file is younger than
-/// [`CACHE_MAX_AGE_SECS`].
-fn should_refresh(registry_cache: &Path) -> bool {
+/// `cache_ttl_secs`.
+fn should_refresh(registry_cache: &Path, cache_ttl_secs: u64) -> bool {
     let marker = registry_cache.join(".sync_marker");
     if !marker.exists() {
         return true;
@@ -119,7 +124,7 @@ fn should_refresh(registry_cache: &Path) -> bool {
     let Ok(age) = modified.elapsed() else {
         return true;
     };
-    age.as_secs() > CACHE_MAX_AGE_SECS
+    age.as_secs() > cache_ttl_secs
 }
 
 /// Touch (create/update) the sync marker file.
@@ -256,7 +261,7 @@ pub fn resolve_home_dir_for_tests() -> std::path::PathBuf {
                 .map(|d| d.count() == 0)
                 .unwrap_or(true)
         {
-            sync_registry(&home);
+            sync_registry(&home, DEFAULT_CACHE_TTL_SECS);
         }
         home
     })
@@ -484,7 +489,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cache = tmp.path().join("registry");
         std::fs::create_dir_all(&cache).unwrap();
-        assert!(super::should_refresh(&cache));
+        assert!(super::should_refresh(&cache, super::DEFAULT_CACHE_TTL_SECS));
     }
 
     #[test]
@@ -493,7 +498,10 @@ mod tests {
         let cache = tmp.path().join("registry");
         std::fs::create_dir_all(&cache).unwrap();
         super::touch_marker(&cache);
-        assert!(!super::should_refresh(&cache));
+        assert!(!super::should_refresh(
+            &cache,
+            super::DEFAULT_CACHE_TTL_SECS
+        ));
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1607,6 +1607,9 @@ pub struct KernelConfig {
     /// Plugin registry configuration.
     #[serde(default)]
     pub plugins: PluginsConfig,
+    /// Registry sync configuration (cache TTL, etc.).
+    #[serde(default)]
+    pub registry: RegistryConfig,
     /// PII privacy controls for LLM context filtering.
     #[serde(default)]
     pub privacy: PrivacyConfig,
@@ -2222,6 +2225,34 @@ impl Default for HeartbeatTomlConfig {
     }
 }
 
+/// Registry sync configuration.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [registry]
+/// cache_ttl_secs = 86400
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RegistryConfig {
+    /// Cache TTL for registry sync in seconds (default: 86400 = 24 hours).
+    /// The registry is re-downloaded when the local cache is older than this.
+    #[serde(default = "default_registry_cache_ttl_secs")]
+    pub cache_ttl_secs: u64,
+}
+
+fn default_registry_cache_ttl_secs() -> u64 {
+    86400
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            cache_ttl_secs: default_registry_cache_ttl_secs(),
+        }
+    }
+}
+
 /// Plugin registry configuration.
 ///
 /// Configure in config.toml:
@@ -2487,6 +2518,7 @@ impl Default for KernelConfig {
             health_check: HealthCheckConfig::default(),
             heartbeat: HeartbeatTomlConfig::default(),
             plugins: PluginsConfig::default(),
+            registry: RegistryConfig::default(),
             cors_origin: Vec::new(),
             privacy: PrivacyConfig::default(),
             strict_config: false,


### PR DESCRIPTION
## Summary
- New `[registry]` config section with `cache_ttl_secs` field
- Default: 86400 (24 hours), matching previous hardcoded value
- Allows operators to tune sync frequency

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes