### PR TITLE
refactor: extract size limit constants into configurable LimitsConfig

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1451,6 +1451,10 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .send_channel_message(channel_type, recipient, message, thread_id)
             .await
     }
+
+    fn max_channel_image_bytes(&self) -> usize {
+        self.kernel.config_ref().limits.max_channel_image_bytes
+    }
 }
 
 /// Parse a trigger pattern string from chat into a `TriggerPattern`.

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -174,9 +174,6 @@ use std::sync::{Arc, LazyLock};
 // Shared manifest resolution helper
 // ---------------------------------------------------------------------------
 
-/// Maximum manifest size (1MB) to prevent parser memory exhaustion.
-const MAX_MANIFEST_SIZE: usize = 1024 * 1024;
-
 /// Resolved manifest ready for spawning.
 struct ResolvedManifest {
     manifest: AgentManifest,
@@ -238,7 +235,8 @@ async fn resolve_manifest(
     };
 
     // Size guard
-    if manifest_toml.len() > MAX_MANIFEST_SIZE {
+    let max_manifest = state.kernel.config_ref().limits.max_manifest_size;
+    if manifest_toml.len() > max_manifest {
         let t = ErrorTranslator::new(lang);
         return Err(ManifestError {
             message: t.t("api-error-manifest-too-large"),
@@ -1059,8 +1057,8 @@ pub async fn send_message(
     };
 
     // SECURITY: Reject oversized messages to prevent OOM / LLM token abuse.
-    const MAX_MESSAGE_SIZE: usize = 64 * 1024; // 64KB
-    if req.message.len() > MAX_MESSAGE_SIZE {
+    let max_msg = state.kernel.config_ref().limits.max_message_size;
+    if req.message.len() > max_msg {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({"error": err_too_large})),
@@ -1687,8 +1685,8 @@ pub async fn send_message_stream(
     };
 
     // SECURITY: Reject oversized messages to prevent OOM / LLM token abuse.
-    const MAX_MESSAGE_SIZE: usize = 64 * 1024; // 64KB
-    if req.message.len() > MAX_MESSAGE_SIZE {
+    let max_msg = state.kernel.config_ref().limits.max_message_size;
+    if req.message.len() > max_msg {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({"error": err_too_large})),
@@ -3621,9 +3619,9 @@ pub async fn set_agent_file(
         );
     }
 
-    // Max 32KB content
-    const MAX_FILE_SIZE: usize = 32_768;
-    if req.content.len() > MAX_FILE_SIZE {
+    // Max workspace file content
+    let max_file = state.kernel.config_ref().limits.max_workspace_file_size;
+    if req.content.len() > max_file {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({"error": t.t("api-error-file-too-large")})),
@@ -3843,9 +3841,6 @@ pub(crate) struct UploadMeta {
 pub(crate) static UPLOAD_REGISTRY: LazyLock<DashMap<String, UploadMeta>> =
     LazyLock::new(DashMap::new);
 
-/// Maximum upload size: 10 MB.
-const MAX_UPLOAD_SIZE: usize = 10 * 1024 * 1024;
-
 /// Allowed content type prefixes for upload.
 const ALLOWED_CONTENT_TYPES: &[&str] = &["image/", "text/", "application/pdf", "audio/"];
 
@@ -3929,7 +3924,8 @@ pub async fn upload_file(
         .to_string();
 
     // Validate size
-    if body.len() > MAX_UPLOAD_SIZE {
+    let max_upload = state.kernel.config_ref().limits.max_upload_size;
+    if body.len() > max_upload {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({"error": err_too_large_upload})),

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2199,8 +2199,8 @@ pub async fn hand_send_message(
     };
 
     // Reject oversized messages
-    const MAX_MESSAGE_SIZE: usize = 64 * 1024;
-    if req.message.len() > MAX_MESSAGE_SIZE {
+    let max_msg = state.kernel.config_ref().limits.max_message_size;
+    if req.message.len() > max_msg {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({"error": "Message too large (max 64KB)"})),

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -32,10 +32,6 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
-/// Per-IP WebSocket connection tracker.
-/// Max 5 concurrent WS connections per IP address.
-const MAX_WS_PER_IP: usize = 5;
-
 /// Idle timeout: close WS after 30 minutes of no client messages.
 const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
@@ -115,13 +111,13 @@ impl Drop for WsConnectionGuard {
 }
 
 /// Try to acquire a WS connection slot for the given IP.
-/// Returns None if the IP has reached MAX_WS_PER_IP.
-fn try_acquire_ws_slot(ip: IpAddr) -> Option<WsConnectionGuard> {
+/// Returns None if the IP has reached the per-IP limit.
+fn try_acquire_ws_slot(ip: IpAddr, max_ws_per_ip: usize) -> Option<WsConnectionGuard> {
     let entry = ws_tracker()
         .entry(ip)
         .or_insert_with(|| AtomicUsize::new(0));
     let current = entry.value().fetch_add(1, Ordering::Relaxed);
-    if current >= MAX_WS_PER_IP {
+    if current >= max_ws_per_ip {
         entry.value().fetch_sub(1, Ordering::Relaxed);
         return None;
     }
@@ -177,11 +173,12 @@ pub async fn agent_ws(
 
     // SECURITY: Enforce per-IP WebSocket connection limit
     let ip = addr.ip();
+    let max_ws_per_ip = state.kernel.config_ref().limits.max_ws_per_ip;
 
-    let guard = match try_acquire_ws_slot(ip) {
+    let guard = match try_acquire_ws_slot(ip, max_ws_per_ip) {
         Some(g) => g,
         None => {
-            warn!(ip = %ip, "WebSocket rejected: too many connections from IP (max {MAX_WS_PER_IP})");
+            warn!(ip = %ip, max = max_ws_per_ip, "WebSocket rejected: too many connections from IP");
             return axum::http::StatusCode::TOO_MANY_REQUESTS.into_response();
         }
     };

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -330,6 +330,13 @@ pub trait ChannelBridgeHandle: Send + Sync {
     ) -> Result<String, String> {
         Err("Channel push not available".to_string())
     }
+
+    /// Maximum size in bytes for images downloaded from channels (default: 5 MB).
+    ///
+    /// Override in concrete implementations to read from `LimitsConfig`.
+    fn max_channel_image_bytes(&self) -> usize {
+        5 * 1024 * 1024
+    }
 }
 
 /// Owns all running channel adapters and dispatches messages to agents.
@@ -1064,7 +1071,9 @@ async fn dispatch_message(
         ref mime_type,
     } = message.content
     {
-        let blocks = download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await;
+        let max_img = handle.max_channel_image_bytes();
+        let blocks =
+            download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref(), max_img).await;
         if blocks
             .iter()
             .any(|b| matches!(b, ContentBlock::Image { .. }))
@@ -1627,11 +1636,9 @@ async fn download_image_to_blocks(
     url: &str,
     caption: Option<&str>,
     mime_type_hint: Option<&str>,
+    max_channel_image_bytes: usize,
 ) -> Vec<ContentBlock> {
     use base64::Engine;
-
-    // 5 MB limit to prevent memory abuse from oversized images
-    const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
 
     let client = crate::http_client::new_client();
     let resp = match client.get(url).send().await {
@@ -1677,7 +1684,7 @@ async fn download_image_to_blocks(
         .or(header_type)
         .unwrap_or_else(|| detect_image_magic(&bytes).unwrap_or_else(|| media_type_from_url(url)));
 
-    if bytes.len() > MAX_IMAGE_BYTES {
+    if bytes.len() > max_channel_image_bytes {
         warn!(
             "Image too large ({} bytes), skipping vision — sending as text",
             bytes.len()

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -8259,8 +8259,10 @@ system_prompt = "You are a helpful assistant."
 
         let metadata = CachedWorkspaceMetadata {
             workspace_context: {
-                let mut ws_ctx =
-                    librefang_runtime::workspace_context::WorkspaceContext::detect(workspace);
+                let mut ws_ctx = librefang_runtime::workspace_context::WorkspaceContext::detect(
+                    workspace,
+                    self.config.limits.max_workspace_file_size as u64,
+                );
                 Some(ws_ctx.build_context_section())
             },
             soul_md: read_identity_file(workspace, "SOUL.md"),

--- a/crates/librefang-runtime/src/workspace_context.rs
+++ b/crates/librefang-runtime/src/workspace_context.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tracing::debug;
 
-/// Maximum file size to read for context files (32KB).
-const MAX_FILE_SIZE: u64 = 32_768;
+/// Default maximum file size to read for context files (32KB).
+const DEFAULT_MAX_FILE_SIZE: u64 = 32_768;
 
 /// Known context file names scanned in the workspace root.
 const CONTEXT_FILES: &[&str] = &[
@@ -69,11 +69,21 @@ pub struct WorkspaceContext {
     pub has_librefang_dir: bool,
     /// Cached context files.
     cache: HashMap<String, CachedFile>,
+    /// Maximum file size for context files.
+    max_file_size: u64,
 }
 
 impl WorkspaceContext {
     /// Detect workspace context from the given root directory.
-    pub fn detect(root: &Path) -> Self {
+    ///
+    /// `max_file_size` controls the upper bound for context files.
+    /// Pass `0` to use the compiled-in default (32 KB).
+    pub fn detect(root: &Path, max_file_size: u64) -> Self {
+        let max_file_size = if max_file_size == 0 {
+            DEFAULT_MAX_FILE_SIZE
+        } else {
+            max_file_size
+        };
         let project_type = detect_project_type(root);
         let is_git_repo = root.join(".git").exists();
         let has_librefang_dir = root.join(".librefang").exists();
@@ -81,7 +91,7 @@ impl WorkspaceContext {
         let mut cache = HashMap::new();
         for &name in CONTEXT_FILES {
             let file_path = root.join(name);
-            if let Some(cached) = read_cached_file(&file_path) {
+            if let Some(cached) = read_cached_file(&file_path, max_file_size) {
                 debug!(file = name, "Loaded workspace context file");
                 cache.insert(name.to_string(), cached);
             }
@@ -93,6 +103,7 @@ impl WorkspaceContext {
             is_git_repo,
             has_librefang_dir,
             cache,
+            max_file_size,
         }
     }
 
@@ -113,7 +124,7 @@ impl WorkspaceContext {
         }
 
         // Cache miss or mtime changed — re-read
-        if let Some(new_cached) = read_cached_file(&file_path) {
+        if let Some(new_cached) = read_cached_file(&file_path, self.max_file_size) {
             self.cache.insert(name.to_string(), new_cached);
             return self.cache.get(name).map(|c| c.content.as_str());
         }
@@ -159,9 +170,9 @@ impl WorkspaceContext {
 }
 
 /// Read a file into the cache if it exists and is under the size limit.
-fn read_cached_file(path: &Path) -> Option<CachedFile> {
+fn read_cached_file(path: &Path, max_file_size: u64) -> Option<CachedFile> {
     let meta = std::fs::metadata(path).ok()?;
-    if meta.len() > MAX_FILE_SIZE {
+    if meta.len() > max_file_size {
         debug!(
             path = %path.display(),
             size = meta.len(),
@@ -317,7 +328,7 @@ mod tests {
         std::fs::create_dir_all(dir.join(".git")).unwrap();
         std::fs::write(dir.join("AGENTS.md"), "# Agent Guidelines\nBe helpful.").unwrap();
 
-        let ctx = WorkspaceContext::detect(&dir);
+        let ctx = WorkspaceContext::detect(&dir, 0);
         assert_eq!(ctx.project_type, ProjectType::Rust);
         assert!(ctx.is_git_repo);
         assert!(ctx.cache.contains_key("AGENTS.md"));
@@ -332,7 +343,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("SOUL.md"), "I am a helpful agent.").unwrap();
 
-        let mut ctx = WorkspaceContext::detect(&dir);
+        let mut ctx = WorkspaceContext::detect(&dir, 0);
         let content1 = ctx.get_file("SOUL.md").map(|s| s.to_string());
         let content2 = ctx.get_file("SOUL.md").map(|s| s.to_string());
         assert_eq!(content1, content2);
@@ -351,7 +362,7 @@ mod tests {
         let big = "x".repeat(40_000);
         std::fs::write(dir.join("AGENTS.md"), &big).unwrap();
 
-        let ctx = WorkspaceContext::detect(&dir);
+        let ctx = WorkspaceContext::detect(&dir, 0);
         assert!(!ctx.cache.contains_key("AGENTS.md"));
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -366,7 +377,7 @@ mod tests {
         std::fs::create_dir_all(dir.join(".git")).unwrap();
         std::fs::write(dir.join("SOUL.md"), "Be nice").unwrap();
 
-        let mut ctx = WorkspaceContext::detect(&dir);
+        let mut ctx = WorkspaceContext::detect(&dir, 0);
         let section = ctx.build_context_section();
         assert!(section.contains("Rust"));
         assert!(section.contains("Git repository: yes"));

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1320,6 +1320,107 @@ pub fn redact_proxy_url(url: &str) -> String {
     url.to_string()
 }
 
+// ---------------------------------------------------------------------------
+// Size & rate limits
+// ---------------------------------------------------------------------------
+
+/// Default: 5 MB (message-level image validation).
+const fn default_max_message_image_bytes() -> usize {
+    5 * 1024 * 1024
+}
+/// Default: 10 MB (media attachment image).
+const fn default_max_image_bytes() -> usize {
+    10 * 1024 * 1024
+}
+/// Default: 20 MB (media attachment audio).
+const fn default_max_audio_bytes() -> usize {
+    20 * 1024 * 1024
+}
+/// Default: 50 MB (media attachment video).
+const fn default_max_video_bytes() -> usize {
+    50 * 1024 * 1024
+}
+/// Default: 1 MB (agent manifest upload).
+const fn default_max_manifest_size() -> usize {
+    1024 * 1024
+}
+/// Default: 10 MB (file upload).
+const fn default_max_upload_size() -> usize {
+    10 * 1024 * 1024
+}
+/// Default: 64 KB (API message body).
+const fn default_max_message_size() -> usize {
+    64 * 1024
+}
+/// Default: 5 (WebSocket connections per IP).
+const fn default_max_ws_per_ip() -> usize {
+    5
+}
+/// Default: 32 KB (workspace context file).
+const fn default_max_workspace_file_size() -> usize {
+    32_768
+}
+/// Default: 5 MB (channel bridge downloaded image).
+const fn default_max_channel_image_bytes() -> usize {
+    5 * 1024 * 1024
+}
+
+/// Configurable size and rate limits.
+///
+/// All limits default to the same values that were previously hardcoded.
+/// Override in `[limits]` section of `config.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LimitsConfig {
+    /// Maximum image size in message validation — base64-decoded (default: 5 MB).
+    #[serde(default = "default_max_message_image_bytes")]
+    pub max_message_image_bytes: usize,
+    /// Maximum image attachment size in bytes (default: 10 MB).
+    #[serde(default = "default_max_image_bytes")]
+    pub max_image_bytes: usize,
+    /// Maximum audio attachment size in bytes (default: 20 MB).
+    #[serde(default = "default_max_audio_bytes")]
+    pub max_audio_bytes: usize,
+    /// Maximum video attachment size in bytes (default: 50 MB).
+    #[serde(default = "default_max_video_bytes")]
+    pub max_video_bytes: usize,
+    /// Maximum manifest upload size in bytes (default: 1 MB).
+    #[serde(default = "default_max_manifest_size")]
+    pub max_manifest_size: usize,
+    /// Maximum file upload size in bytes (default: 10 MB).
+    #[serde(default = "default_max_upload_size")]
+    pub max_upload_size: usize,
+    /// Maximum API/WS message body size in bytes (default: 64 KB).
+    #[serde(default = "default_max_message_size")]
+    pub max_message_size: usize,
+    /// Maximum concurrent WebSocket connections per IP (default: 5).
+    #[serde(default = "default_max_ws_per_ip")]
+    pub max_ws_per_ip: usize,
+    /// Maximum workspace context file size in bytes (default: 32 KB).
+    #[serde(default = "default_max_workspace_file_size")]
+    pub max_workspace_file_size: usize,
+    /// Maximum channel-bridge downloaded image size in bytes (default: 5 MB).
+    #[serde(default = "default_max_channel_image_bytes")]
+    pub max_channel_image_bytes: usize,
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        Self {
+            max_message_image_bytes: default_max_message_image_bytes(),
+            max_image_bytes: default_max_image_bytes(),
+            max_audio_bytes: default_max_audio_bytes(),
+            max_video_bytes: default_max_video_bytes(),
+            max_manifest_size: default_max_manifest_size(),
+            max_upload_size: default_max_upload_size(),
+            max_message_size: default_max_message_size(),
+            max_ws_per_ip: default_max_ws_per_ip(),
+            max_workspace_file_size: default_max_workspace_file_size(),
+            max_channel_image_bytes: default_max_channel_image_bytes(),
+        }
+    }
+}
+
 /// Top-level kernel configuration.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1577,6 +1678,9 @@ pub struct KernelConfig {
     /// Controls which releases `librefang update` considers.
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    /// Size and rate limits (image upload, message body, WS connections, etc.).
+    #[serde(default)]
+    pub limits: LimitsConfig,
 }
 
 /// Input sanitization mode for channel messages.
@@ -2400,6 +2504,7 @@ impl Default for KernelConfig {
             telemetry: TelemetryConfig::default(),
             prompt_intelligence: PromptIntelligenceConfig::default(),
             update_channel: UpdateChannel::default(),
+            limits: LimitsConfig::default(),
         }
     }
 }
@@ -2538,6 +2643,7 @@ impl std::fmt::Debug for KernelConfig {
             .field("privacy", &format!("{:?}", self.privacy.mode))
             .field("strict_config", &self.strict_config)
             .field("qwen_code_path", &self.qwen_code_path)
+            .field("limits", &self.limits)
             .finish()
     }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -80,6 +80,7 @@ impl KernelConfig {
             "sanitize",
             "telemetry",
             "update_channel",
+            "limits",
         ]
     }
 

--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -146,8 +146,20 @@ pub const ALLOWED_AUDIO_TYPES: &[&str] = &[
 pub const ALLOWED_VIDEO_TYPES: &[&str] = &["video/mp4", "video/quicktime", "video/webm"];
 
 impl MediaAttachment {
-    /// Validate the attachment against security constraints.
+    /// Validate the attachment against security constraints using the default
+    /// compiled-in limits.  Prefer [`validate_with_limits`] when a
+    /// [`LimitsConfig`](crate::config::LimitsConfig) is available.
     pub fn validate(&self) -> Result<(), String> {
+        self.validate_with_limits(MAX_IMAGE_BYTES, MAX_AUDIO_BYTES, MAX_VIDEO_BYTES)
+    }
+
+    /// Validate the attachment with caller-supplied size limits.
+    pub fn validate_with_limits(
+        &self,
+        max_image: u64,
+        max_audio: u64,
+        max_video: u64,
+    ) -> Result<(), String> {
         // Check MIME type allowlist
         let allowed = match self.media_type {
             MediaType::Image => ALLOWED_IMAGE_TYPES.contains(&self.mime_type.as_str()),
@@ -163,9 +175,9 @@ impl MediaAttachment {
 
         // Check size limits
         let max_bytes = match self.media_type {
-            MediaType::Image => MAX_IMAGE_BYTES,
-            MediaType::Audio => MAX_AUDIO_BYTES,
-            MediaType::Video => MAX_VIDEO_BYTES,
+            MediaType::Image => max_image,
+            MediaType::Audio => max_audio,
+            MediaType::Video => max_video,
         };
         if self.size_bytes > max_bytes {
             return Err(format!(

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -110,14 +110,26 @@ pub enum ContentBlock {
 /// Allowed image media types.
 const ALLOWED_IMAGE_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif", "image/webp"];
 
-/// Maximum decoded image size (5 MB).
+/// Default maximum decoded image size for message-level validation (5 MB).
 const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
 
-/// Validate an image content block.
+/// Validate an image content block using the compiled-in 5 MB default.
+///
+/// Prefer [`validate_image_with_limit`] when a
+/// [`LimitsConfig`](crate::config::LimitsConfig) is available.
+pub fn validate_image(media_type: &str, data: &str) -> Result<(), String> {
+    validate_image_with_limit(media_type, data, MAX_IMAGE_BYTES)
+}
+
+/// Validate an image content block with a caller-supplied decoded-size limit.
 ///
 /// Checks that the media type is an allowed image format and the
-/// base64 data doesn't exceed 5 MB when decoded (~7 MB base64).
-pub fn validate_image(media_type: &str, data: &str) -> Result<(), String> {
+/// base64 data doesn't exceed the limit when decoded.
+pub fn validate_image_with_limit(
+    media_type: &str,
+    data: &str,
+    max_image_bytes: usize,
+) -> Result<(), String> {
     if !ALLOWED_IMAGE_TYPES.contains(&media_type) {
         return Err(format!(
             "Unsupported image type '{}'. Allowed: {}",
@@ -125,14 +137,14 @@ pub fn validate_image(media_type: &str, data: &str) -> Result<(), String> {
             ALLOWED_IMAGE_TYPES.join(", ")
         ));
     }
-    // Base64 encodes 3 bytes into 4 chars, so max base64 len ≈ MAX_IMAGE_BYTES * 4/3
-    let max_b64_len = MAX_IMAGE_BYTES * 4 / 3 + 4; // small padding allowance
+    // Base64 encodes 3 bytes into 4 chars, so max base64 len ≈ max_image_bytes * 4/3
+    let max_b64_len = max_image_bytes * 4 / 3 + 4; // small padding allowance
     if data.len() > max_b64_len {
         return Err(format!(
             "Image too large: {} bytes base64 (max ~{} bytes for {} MB decoded)",
             data.len(),
             max_b64_len,
-            MAX_IMAGE_BYTES / (1024 * 1024)
+            max_image_bytes / (1024 * 1024)
         ));
     }
     Ok(())


### PR DESCRIPTION
## Summary
- New `[limits]` config section for file/message/upload size limits
- Covers: max_image_bytes, max_audio_bytes, max_video_bytes, max_upload_size, max_message_size, max_ws_message_size, max_ws_per_ip, max_workspace_file_size
- Defaults match previous hardcoded values
- Allows enterprise deployments to tune resource limits

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes