### PR TITLE
refactor: extract API rate limiting constants into RateLimitConfig

### DIFF
--- a/crates/librefang-api/src/rate_limiter.rs
+++ b/crates/librefang-api/src/rate_limiter.rs
@@ -37,10 +37,18 @@ pub fn operation_cost(method: &str, path: &str) -> NonZeroU32 {
 
 pub type KeyedRateLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock>;
 
-/// 500 tokens per minute per IP.
-pub fn create_rate_limiter() -> Arc<KeyedRateLimiter> {
+/// Shared state for the GCRA rate limiting middleware layer.
+#[derive(Clone)]
+pub struct GcraState {
+    pub limiter: Arc<KeyedRateLimiter>,
+    pub retry_after_secs: u64,
+}
+
+/// Create a GCRA rate limiter with the given token budget per minute per IP.
+pub fn create_rate_limiter(tokens_per_minute: u32) -> Arc<KeyedRateLimiter> {
+    let quota = tokens_per_minute.max(1);
     Arc::new(RateLimiter::keyed(Quota::per_minute(
-        NonZeroU32::new(500).unwrap(),
+        NonZeroU32::new(quota).unwrap(),
     )))
 }
 
@@ -50,7 +58,7 @@ pub fn create_rate_limiter() -> Arc<KeyedRateLimiter> {
 /// requested operation, and checks the GCRA limiter. Returns 429 if the
 /// client has exhausted its token budget.
 pub async fn gcra_rate_limit(
-    axum::extract::State(limiter): axum::extract::State<Arc<KeyedRateLimiter>>,
+    axum::extract::State(state): axum::extract::State<GcraState>,
     request: Request<Body>,
     next: Next,
 ) -> Response<Body> {
@@ -64,12 +72,13 @@ pub async fn gcra_rate_limit(
     let path = request.uri().path().to_string();
     let cost = operation_cost(&method, &path);
 
-    if limiter.check_key_n(&ip, cost).is_err() {
+    if state.limiter.check_key_n(&ip, cost).is_err() {
         tracing::warn!(ip = %ip, cost = cost.get(), path = %path, "GCRA rate limit exceeded");
+        let retry_after = state.retry_after_secs.to_string();
         return Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
             .header("content-type", "application/json")
-            .header("retry-after", "60")
+            .header("retry-after", retry_after)
             .body(Body::from(
                 serde_json::json!({"error": "Rate limit exceeded"}).to_string(),
             ))

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -355,7 +355,11 @@ pub async fn build_router(
         api_key_lock: api_key_lock.clone(),
         active_sessions: active_sessions.clone(),
     };
-    let gcra_limiter = rate_limiter::create_rate_limiter();
+    let rl_cfg = &state.kernel.config_ref().rate_limit;
+    let gcra_limiter = rate_limiter::GcraState {
+        limiter: rate_limiter::create_rate_limiter(rl_cfg.api_requests_per_minute),
+        retry_after_secs: rl_cfg.retry_after_secs,
+    };
 
     // Build the versioned API routes. All /api/* endpoints are defined once
     // in api_v1_routes() and mounted at both /api and /api/v1 for backward

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -33,17 +33,6 @@ use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 /// Per-IP WebSocket connection tracker.
-/// Max 5 concurrent WS connections per IP address.
-const MAX_WS_PER_IP: usize = 5;
-
-/// Idle timeout: close WS after 30 minutes of no client messages.
-const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
-
-/// Text delta debounce interval.
-const DEBOUNCE_MS: u64 = 100;
-
-/// Flush text buffer when it exceeds this many characters.
-const DEBOUNCE_CHARS: usize = 200;
 
 // ---------------------------------------------------------------------------
 // Verbose Level
@@ -115,13 +104,13 @@ impl Drop for WsConnectionGuard {
 }
 
 /// Try to acquire a WS connection slot for the given IP.
-/// Returns None if the IP has reached MAX_WS_PER_IP.
-fn try_acquire_ws_slot(ip: IpAddr) -> Option<WsConnectionGuard> {
+/// Returns None if the IP has reached `max_ws_per_ip`.
+fn try_acquire_ws_slot(ip: IpAddr, max_ws_per_ip: usize) -> Option<WsConnectionGuard> {
     let entry = ws_tracker()
         .entry(ip)
         .or_insert_with(|| AtomicUsize::new(0));
     let current = entry.value().fetch_add(1, Ordering::Relaxed);
-    if current >= MAX_WS_PER_IP {
+    if current >= max_ws_per_ip {
         entry.value().fetch_sub(1, Ordering::Relaxed);
         return None;
     }
@@ -177,11 +166,12 @@ pub async fn agent_ws(
 
     // SECURITY: Enforce per-IP WebSocket connection limit
     let ip = addr.ip();
+    let max_ws_per_ip = state.kernel.config_ref().rate_limit.max_ws_per_ip;
 
-    let guard = match try_acquire_ws_slot(ip) {
+    let guard = match try_acquire_ws_slot(ip, max_ws_per_ip) {
         Some(g) => g,
         None => {
-            warn!(ip = %ip, "WebSocket rejected: too many connections from IP (max {MAX_WS_PER_IP})");
+            warn!(ip = %ip, max_ws_per_ip, "WebSocket rejected: too many connections from IP");
             return axum::http::StatusCode::TOO_MANY_REQUESTS.into_response();
         }
     };
@@ -288,10 +278,12 @@ async fn handle_agent_ws(
         }
     });
 
-    // Per-connection rate limiting: max 10 messages per 60 seconds
+    // Per-connection rate limiting (configurable via [rate_limit])
+    let rl_cfg = state.kernel.config_ref().rate_limit.clone();
+    let max_per_min: usize = rl_cfg.ws_messages_per_minute as usize;
+    let ws_idle_timeout = Duration::from_secs(rl_cfg.ws_idle_timeout_secs);
     let mut msg_times: Vec<std::time::Instant> = Vec::new();
-    const MAX_PER_MIN: usize = 10;
-    const WINDOW: Duration = Duration::from_secs(60);
+    let window: Duration = Duration::from_secs(60);
 
     // Track last activity for idle timeout
     let mut last_activity = std::time::Instant::now();
@@ -305,13 +297,14 @@ async fn handle_agent_ws(
                     None => break, // Stream ended
                 }
             }
-            _ = tokio::time::sleep(WS_IDLE_TIMEOUT.saturating_sub(last_activity.elapsed())) => {
-                info!(agent_id = %id_str, "WebSocket idle timeout (30 min)");
+            _ = tokio::time::sleep(ws_idle_timeout.saturating_sub(last_activity.elapsed())) => {
+                let timeout_secs = ws_idle_timeout.as_secs();
+                info!(agent_id = %id_str, timeout_secs, "WebSocket idle timeout");
                 let _ = send_json(
                     &sender,
                     &serde_json::json!({
                         "type": "error",
-                        "content": "Connection closed due to inactivity (30 min timeout)",
+                        "content": format!("Connection closed due to inactivity ({timeout_secs}s timeout)"),
                     }),
                 ).await;
                 break;
@@ -346,13 +339,13 @@ async fn handle_agent_ws(
 
                 // SECURITY: Per-connection rate limiting
                 let now = std::time::Instant::now();
-                msg_times.retain(|t| now.duration_since(*t) < WINDOW);
-                if msg_times.len() >= MAX_PER_MIN {
+                msg_times.retain(|t| now.duration_since(*t) < window);
+                if msg_times.len() >= max_per_min {
                     let _ = send_json(
                         &sender,
                         &serde_json::json!({
                             "type": "error",
-                            "content": "Rate limit exceeded. Max 10 messages per minute.",
+                            "content": format!("Rate limit exceeded. Max {max_per_min} messages per minute."),
                         }),
                     )
                     .await;
@@ -544,6 +537,9 @@ async fn handle_text_message(
                     // Forward stream events to WebSocket with debouncing
                     let sender_stream = Arc::clone(sender);
                     let verbose_clone = Arc::clone(verbose);
+                    let rl = &state.kernel.config_ref().rate_limit;
+                    let debounce_chars = rl.ws_debounce_chars;
+                    let debounce_ms = rl.ws_debounce_ms;
                     let stream_task = tokio::spawn(async move {
                         let mut text_buffer = String::new();
                         let far_future = tokio::time::Instant::now() + Duration::from_secs(86400);
@@ -571,7 +567,7 @@ async fn handle_text_message(
                                         Some(ev) => {
                                             if let StreamEvent::TextDelta { ref text } = ev {
                                                 text_buffer.push_str(text);
-                                                if text_buffer.len() >= DEBOUNCE_CHARS {
+                                                if text_buffer.len() >= debounce_chars {
                                                     let _ = flush_text_buffer(
                                                         &sender_stream,
                                                         &mut text_buffer,
@@ -581,7 +577,7 @@ async fn handle_text_message(
                                                 } else if flush_deadline >= far_future {
                                                     flush_deadline =
                                                         tokio::time::Instant::now()
-                                                            + Duration::from_millis(DEBOUNCE_MS);
+                                                            + Duration::from_millis(debounce_ms);
                                                 }
                                             } else {
                                                 // Flush pending text before non-text events

--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -89,6 +89,16 @@ debounce_ms = 500
 # model = "gpt-4o"
 # api_key_env = "OPENAI_API_KEY"
 
+# ── Rate Limiting ────────────────────────────────────────────
+# [rate_limit]
+# api_requests_per_minute = 500   # GCRA token budget per IP
+# retry_after_secs = 60           # Retry-After header value (429 responses)
+# max_ws_per_ip = 5               # Max concurrent WebSocket connections per IP
+# ws_messages_per_minute = 10     # Max WebSocket messages per minute per connection
+# ws_idle_timeout_secs = 1800     # Close idle WebSocket after 30 min
+# ws_debounce_ms = 100            # Text delta debounce interval
+# ws_debounce_chars = 200         # Flush text buffer at this character count
+
 # ── Budget & Cost Control ────────────────────────────────────
 # [budget]
 # max_hourly_usd = 0.0         # 0 = unlimited

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -381,6 +381,72 @@ impl Default for ReloadConfig {
     }
 }
 
+/// API and WebSocket rate limiting configuration.
+///
+/// Controls GCRA token-bucket rate limiting for HTTP API requests and
+/// per-connection limits for WebSocket connections.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RateLimitConfig {
+    /// API token budget per minute per IP (GCRA algorithm). Default: 500.
+    #[serde(default = "default_api_requests_per_minute")]
+    pub api_requests_per_minute: u32,
+    /// Retry-After header value in seconds when rate limited. Default: 60.
+    #[serde(default = "default_retry_after_secs")]
+    pub retry_after_secs: u64,
+    /// Maximum concurrent WebSocket connections per IP. Default: 5.
+    #[serde(default = "default_max_ws_per_ip")]
+    pub max_ws_per_ip: usize,
+    /// Maximum WebSocket messages per minute per connection. Default: 10.
+    #[serde(default = "default_ws_messages_per_minute")]
+    pub ws_messages_per_minute: u32,
+    /// WebSocket idle timeout in seconds (close after inactivity). Default: 1800.
+    #[serde(default = "default_ws_idle_timeout_secs")]
+    pub ws_idle_timeout_secs: u64,
+    /// Text delta debounce interval in milliseconds. Default: 100.
+    #[serde(default = "default_ws_debounce_ms")]
+    pub ws_debounce_ms: u64,
+    /// Flush text buffer when it exceeds this many characters. Default: 200.
+    #[serde(default = "default_ws_debounce_chars")]
+    pub ws_debounce_chars: usize,
+}
+
+fn default_api_requests_per_minute() -> u32 {
+    500
+}
+fn default_retry_after_secs() -> u64 {
+    60
+}
+fn default_max_ws_per_ip() -> usize {
+    5
+}
+fn default_ws_messages_per_minute() -> u32 {
+    10
+}
+fn default_ws_idle_timeout_secs() -> u64 {
+    1800
+}
+fn default_ws_debounce_ms() -> u64 {
+    100
+}
+fn default_ws_debounce_chars() -> usize {
+    200
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            api_requests_per_minute: default_api_requests_per_minute(),
+            retry_after_secs: default_retry_after_secs(),
+            max_ws_per_ip: default_max_ws_per_ip(),
+            ws_messages_per_minute: default_ws_messages_per_minute(),
+            ws_idle_timeout_secs: default_ws_idle_timeout_secs(),
+            ws_debounce_ms: default_ws_debounce_ms(),
+            ws_debounce_chars: default_ws_debounce_chars(),
+        }
+    }
+}
+
 /// Webhook trigger authentication configuration.
 ///
 /// Controls the `/hooks/wake` and `/hooks/agent` endpoints for external
@@ -1577,6 +1643,9 @@ pub struct KernelConfig {
     /// Controls which releases `librefang update` considers.
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    /// API and WebSocket rate limiting configuration.
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
 }
 
 /// Input sanitization mode for channel messages.
@@ -2400,6 +2469,7 @@ impl Default for KernelConfig {
             telemetry: TelemetryConfig::default(),
             prompt_intelligence: PromptIntelligenceConfig::default(),
             update_channel: UpdateChannel::default(),
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `[rate_limit]` config section: `api_requests_per_minute`, `retry_after_secs`, `max_ws_per_ip`, `ws_messages_per_minute`, `ws_idle_timeout_secs`
- Defaults: 500/60/5/10/1800 matching previous hardcoded values

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes