### PR TITLE
refactor: extract provider cooldown constants into ProviderCooldownConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -101,6 +101,19 @@ debounce_ms = 500
 # budget_tokens = 10000
 # stream_thinking = false
 
+# ── Provider Cooldown / Circuit Breaker ─────────────────────
+# [provider_cooldown]
+# base_secs = 60              # Base cooldown after provider error
+# max_secs = 3600             # Maximum cooldown (1 hour)
+# multiplier = 5.0            # Backoff multiplier per consecutive error
+# max_exponent = 3            # Cap on escalation exponent
+# billing_base_secs = 18000   # Base cooldown for billing/402 errors (5h)
+# billing_max_secs = 86400    # Max billing cooldown (24h)
+# billing_multiplier = 2.0    # Billing backoff multiplier
+# failure_window_secs = 86400 # Error counting window (24h)
+# probe_enabled = true        # Allow probe requests during cooldown
+# probe_interval_secs = 30    # Seconds between probes
+
 # ── Channels (uncomment to enable) ───────────────────────────
 # [channels.telegram]
 # bot_token_env = "TELEGRAM_BOT_TOKEN"

--- a/crates/librefang-runtime/src/auth_cooldown.rs
+++ b/crates/librefang-runtime/src/auth_cooldown.rs
@@ -56,6 +56,23 @@ impl Default for CooldownConfig {
     }
 }
 
+impl From<librefang_types::config::ProviderCooldownConfig> for CooldownConfig {
+    fn from(c: librefang_types::config::ProviderCooldownConfig) -> Self {
+        Self {
+            base_cooldown_secs: c.base_secs,
+            max_cooldown_secs: c.max_secs,
+            backoff_multiplier: c.multiplier,
+            max_exponent: c.max_exponent,
+            billing_base_cooldown_secs: c.billing_base_secs,
+            billing_max_cooldown_secs: c.billing_max_secs,
+            billing_multiplier: c.billing_multiplier,
+            failure_window_secs: c.failure_window_secs,
+            probe_enabled: c.probe_enabled,
+            probe_interval_secs: c.probe_interval_secs,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Circuit state
 // ---------------------------------------------------------------------------

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1467,6 +1467,9 @@ pub struct KernelConfig {
     /// Auth profiles for key rotation (provider name → profiles).
     #[serde(default)]
     pub auth_profiles: HashMap<String, Vec<AuthProfile>>,
+    /// Provider cooldown / circuit breaker configuration.
+    #[serde(default)]
+    pub provider_cooldown: ProviderCooldownConfig,
     /// Extended thinking configuration.
     #[serde(default)]
     pub thinking: Option<ThinkingConfig>,
@@ -2370,6 +2373,7 @@ impl Default for KernelConfig {
             docker: DockerSandboxConfig::default(),
             pairing: PairingConfig::default(),
             auth_profiles: HashMap::new(),
+            provider_cooldown: ProviderCooldownConfig::default(),
             thinking: None,
             budget: BudgetConfig::default(),
             provider_urls: HashMap::new(),
@@ -4428,6 +4432,111 @@ impl Default for LinkedInConfig {
             account_id: None,
             default_agent: None,
             overrides: ChannelOverrides::default(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provider cooldown / circuit breaker configuration
+// ---------------------------------------------------------------------------
+
+fn default_cooldown_base_secs() -> u64 {
+    60
+}
+fn default_cooldown_max_secs() -> u64 {
+    3600
+}
+fn default_cooldown_multiplier() -> f64 {
+    5.0
+}
+fn default_cooldown_max_exponent() -> u32 {
+    3
+}
+fn default_billing_base_secs() -> u64 {
+    18_000
+}
+fn default_billing_max_secs() -> u64 {
+    86_400
+}
+fn default_billing_multiplier() -> f64 {
+    2.0
+}
+fn default_failure_window_secs() -> u64 {
+    86_400
+}
+fn default_probe_enabled() -> bool {
+    true
+}
+fn default_probe_interval_secs() -> u64 {
+    30
+}
+
+/// Configuration for provider cooldown / circuit breaker behavior.
+///
+/// Controls how long a provider is suspended after errors and how
+/// the cooldown escalates on repeated failures.
+///
+/// ```toml
+/// [provider_cooldown]
+/// base_secs = 60
+/// max_secs = 3600
+/// multiplier = 5.0
+/// max_exponent = 3
+/// billing_base_secs = 18000
+/// billing_max_secs = 86400
+/// billing_multiplier = 2.0
+/// failure_window_secs = 86400
+/// probe_enabled = true
+/// probe_interval_secs = 30
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProviderCooldownConfig {
+    /// Base cooldown duration in seconds after provider error (default: 60).
+    #[serde(default = "default_cooldown_base_secs")]
+    pub base_secs: u64,
+    /// Maximum cooldown duration in seconds (default: 3600).
+    #[serde(default = "default_cooldown_max_secs")]
+    pub max_secs: u64,
+    /// Backoff multiplier for escalation (default: 5.0).
+    #[serde(default = "default_cooldown_multiplier")]
+    pub multiplier: f64,
+    /// Maximum escalation exponent (default: 3).
+    #[serde(default = "default_cooldown_max_exponent")]
+    pub max_exponent: u32,
+    /// Base cooldown for billing errors in seconds (default: 18000).
+    #[serde(default = "default_billing_base_secs")]
+    pub billing_base_secs: u64,
+    /// Maximum cooldown for billing errors in seconds (default: 86400).
+    #[serde(default = "default_billing_max_secs")]
+    pub billing_max_secs: u64,
+    /// Backoff multiplier for billing errors (default: 2.0).
+    #[serde(default = "default_billing_multiplier")]
+    pub billing_multiplier: f64,
+    /// Window for counting failures in seconds (default: 86400).
+    #[serde(default = "default_failure_window_secs")]
+    pub failure_window_secs: u64,
+    /// Enable recovery probes during cooldown (default: true).
+    #[serde(default = "default_probe_enabled")]
+    pub probe_enabled: bool,
+    /// Interval between recovery probes in seconds (default: 30).
+    #[serde(default = "default_probe_interval_secs")]
+    pub probe_interval_secs: u64,
+}
+
+impl Default for ProviderCooldownConfig {
+    fn default() -> Self {
+        Self {
+            base_secs: default_cooldown_base_secs(),
+            max_secs: default_cooldown_max_secs(),
+            multiplier: default_cooldown_multiplier(),
+            max_exponent: default_cooldown_max_exponent(),
+            billing_base_secs: default_billing_base_secs(),
+            billing_max_secs: default_billing_max_secs(),
+            billing_multiplier: default_billing_multiplier(),
+            failure_window_secs: default_failure_window_secs(),
+            probe_enabled: default_probe_enabled(),
+            probe_interval_secs: default_probe_interval_secs(),
         }
     }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -47,6 +47,7 @@ impl KernelConfig {
             "docker",
             "pairing",
             "auth_profiles",
+            "provider_cooldown",
             "thinking",
             "budget",
             "provider_urls",


### PR DESCRIPTION
## Summary
- New `[provider_cooldown]` config section with 10 parameters
- Covers general cooldown (base/max/multiplier), billing cooldown, failure window, recovery probes
- Defaults match previous hardcoded values (60s/3600s/5x, billing 18000s/86400s/2x, probe 30s)

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes