### PR TITLE
refactor: extract context budget constants into ContextBudgetConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -96,6 +96,17 @@ debounce_ms = 500
 # max_monthly_usd = 0.0
 # alert_threshold = 0.8        # Alert at 80% of limit
 
+# ── Context Budget Tuning ───────────────────────────────────
+# [context_budget]
+# tool_chars_per_token = 2.0       # Char density for tool output estimation
+# general_chars_per_token = 4.0    # Char density for general text
+# per_result_cap = 0.30            # Max fraction of context per tool result
+# single_result_max = 0.50         # Absolute max fraction for one result
+# tool_headroom = 0.75             # Fraction reserved for all tool results
+# default_context_window = 200000  # Fallback context window (tokens)
+# overflow_stage1_threshold = 0.70 # Triggers moderate trim
+# overflow_stage2_threshold = 0.90 # Triggers aggressive trim
+
 # ── Extended Thinking (Claude models) ────────────────────────
 # [thinking]
 # budget_tokens = 10000

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1859,6 +1859,7 @@ impl LibreFangKernel {
             > = embedding_driver.as_ref().map(Arc::clone);
             let engine = librefang_runtime::context_engine::build_context_engine(
                 &config.context_engine,
+                &config.context_budget,
                 context_engine_config.clone(),
                 memory.clone(),
                 emb_arc,

--- a/crates/librefang-runtime/src/context_budget.rs
+++ b/crates/librefang-runtime/src/context_budget.rs
@@ -5,6 +5,7 @@
 //! - Layer 2: Context guard that scans all tool results before LLM calls
 //!   and compacts oldest results when total exceeds 75% headroom.
 
+use librefang_types::config::ContextBudgetConfig;
 use librefang_types::message::{ContentBlock, Message, MessageContent};
 use librefang_types::tool::ToolDefinition;
 use tracing::debug;
@@ -18,33 +19,48 @@ pub struct ContextBudget {
     pub tool_chars_per_token: f64,
     /// Estimated characters per token for general content.
     pub general_chars_per_token: f64,
+    /// Fraction of context window for per-result cap.
+    per_result_cap_frac: f64,
+    /// Fraction of context window for single result max.
+    single_result_max_frac: f64,
+    /// Fraction of context window for tool headroom.
+    tool_headroom_frac: f64,
 }
 
 impl ContextBudget {
-    /// Create a new budget from a context window size.
+    /// Create a new budget from a context window size using built-in defaults.
     pub fn new(context_window_tokens: usize) -> Self {
+        Self::from_config(context_window_tokens, &ContextBudgetConfig::default())
+    }
+
+    /// Create a budget from a context window size and external configuration.
+    pub fn from_config(context_window_tokens: usize, cfg: &ContextBudgetConfig) -> Self {
         Self {
             context_window_tokens,
-            tool_chars_per_token: 2.0,
-            general_chars_per_token: 4.0,
+            tool_chars_per_token: cfg.tool_chars_per_token,
+            general_chars_per_token: cfg.general_chars_per_token,
+            per_result_cap_frac: cfg.per_result_cap,
+            single_result_max_frac: cfg.single_result_max,
+            tool_headroom_frac: cfg.tool_headroom,
         }
     }
 
-    /// Per-result character cap: 30% of context window converted to chars.
+    /// Per-result character cap based on configured fraction of context window.
     pub fn per_result_cap(&self) -> usize {
-        let tokens_for_tool = (self.context_window_tokens as f64 * 0.30) as usize;
+        let tokens_for_tool =
+            (self.context_window_tokens as f64 * self.per_result_cap_frac) as usize;
         (tokens_for_tool as f64 * self.tool_chars_per_token) as usize
     }
 
-    /// Single result absolute max: 50% of context window.
+    /// Single result absolute max based on configured fraction.
     pub fn single_result_max(&self) -> usize {
-        let tokens = (self.context_window_tokens as f64 * 0.50) as usize;
+        let tokens = (self.context_window_tokens as f64 * self.single_result_max_frac) as usize;
         (tokens as f64 * self.tool_chars_per_token) as usize
     }
 
-    /// Total tool result headroom: 75% of context window in chars.
+    /// Total tool result headroom based on configured fraction in chars.
     pub fn total_tool_headroom_chars(&self) -> usize {
-        let tokens = (self.context_window_tokens as f64 * 0.75) as usize;
+        let tokens = (self.context_window_tokens as f64 * self.tool_headroom_frac) as usize;
         (tokens as f64 * self.tool_chars_per_token) as usize
     }
 }
@@ -99,24 +115,24 @@ pub fn truncate_tool_result_dynamic(content: &str, budget: &ContextBudget) -> St
         let cap_bytes = (cap.saturating_sub(summary_reserve) as f64 * bytes_per_char) as usize;
         let break_point = find_safe_break_before(content, cap_bytes);
         return format!(
-            "{}\n\n[TRUNCATED: result was {} chars, showing first {} (budget: {}% of {}K context window)]",
+            "{}\n\n[TRUNCATED: result was {} chars, showing first {} (budget: {:.0}% of {}K context window)]",
             &content[..break_point],
             char_count,
             content[..break_point].chars().count(),
-            30,
+            budget.per_result_cap_frac * 100.0,
             budget.context_window_tokens / 1000
         );
     }
 
     format!(
-        "{}{}{}\n\n[TRUNCATED: result was {} chars, showing first {} + last {} (budget: {}% of {}K context window)]",
+        "{}{}{}\n\n[TRUNCATED: result was {} chars, showing first {} + last {} (budget: {:.0}% of {}K context window)]",
         &content[..head_end],
         TRUNCATION_MARKER,
         &content[tail_start..],
         char_count,
         content[..head_end].chars().count(),
         content[tail_start..].chars().count(),
-        30,
+        budget.per_result_cap_frac * 100.0,
         budget.context_window_tokens / 1000
     )
 }

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -48,7 +48,7 @@ use tracing::{debug, warn};
 
 use crate::compactor::{self, CompactionConfig, CompactionResult};
 use crate::context_budget::{apply_context_guard, ContextBudget};
-use crate::context_overflow::{recover_from_overflow, RecoveryStage};
+use crate::context_overflow::{recover_from_overflow_with_thresholds, RecoveryStage};
 use crate::embedding::EmbeddingDriver;
 use crate::llm_driver::LlmDriver;
 
@@ -192,6 +192,7 @@ pub trait ContextEngine: Send + Sync {
 /// - Embedding-based semantic memory recall with LIKE fallback
 pub struct DefaultContextEngine {
     config: ContextEngineConfig,
+    budget_config: librefang_types::config::ContextBudgetConfig,
     memory: Arc<MemorySubstrate>,
     embedding_driver: Option<Arc<dyn EmbeddingDriver + Send + Sync>>,
     compaction_config: CompactionConfig,
@@ -201,6 +202,7 @@ impl DefaultContextEngine {
     /// Create a new default context engine.
     pub fn new(
         config: ContextEngineConfig,
+        budget_config: librefang_types::config::ContextBudgetConfig,
         memory: Arc<MemorySubstrate>,
         embedding_driver: Option<Arc<dyn EmbeddingDriver + Send + Sync>>,
     ) -> Self {
@@ -210,6 +212,7 @@ impl DefaultContextEngine {
         };
         Self {
             config,
+            budget_config,
             memory,
             embedding_driver,
             compaction_config,
@@ -300,7 +303,14 @@ impl ContextEngine for DefaultContextEngine {
     ) -> LibreFangResult<AssembleResult> {
         // Stage 1: Overflow recovery pipeline (4-stage cascade, respects pinned messages)
         // Uses the per-agent context window size, not the boot-time default.
-        let recovery = recover_from_overflow(messages, system_prompt, tools, context_window_tokens);
+        let recovery = recover_from_overflow_with_thresholds(
+            messages,
+            system_prompt,
+            tools,
+            context_window_tokens,
+            self.budget_config.overflow_stage1_threshold,
+            self.budget_config.overflow_stage2_threshold,
+        );
 
         if recovery == RecoveryStage::FinalError {
             warn!("ContextEngine: overflow unrecoverable — suggest /reset or /compact");
@@ -313,7 +323,7 @@ impl ContextEngine for DefaultContextEngine {
 
         // Stage 2: Context guard — compact oversized tool results
         // Build a per-agent budget so tool result caps match the actual context window.
-        let agent_budget = ContextBudget::new(context_window_tokens);
+        let agent_budget = ContextBudget::from_config(context_window_tokens, &self.budget_config);
         apply_context_guard(messages, &agent_budget, tools);
 
         Ok(AssembleResult { recovery })
@@ -355,7 +365,7 @@ impl ContextEngine for DefaultContextEngine {
     }
 
     fn truncate_tool_result(&self, content: &str, context_window_tokens: usize) -> String {
-        let budget = ContextBudget::new(context_window_tokens);
+        let budget = ContextBudget::from_config(context_window_tokens, &self.budget_config);
         crate::context_budget::truncate_tool_result_dynamic(content, &budget)
     }
 }
@@ -746,11 +756,17 @@ pub fn list_installed_plugins() -> Vec<librefang_types::config::PluginManifest> 
 /// 3. Otherwise, return a plain `DefaultContextEngine`
 pub fn build_context_engine(
     toml_config: &librefang_types::config::ContextEngineTomlConfig,
+    budget_config: &librefang_types::config::ContextBudgetConfig,
     runtime_config: ContextEngineConfig,
     memory: Arc<MemorySubstrate>,
     embedding_driver: Option<Arc<dyn EmbeddingDriver + Send + Sync>>,
 ) -> Box<dyn ContextEngine> {
-    let default = DefaultContextEngine::new(runtime_config, memory, embedding_driver);
+    let default = DefaultContextEngine::new(
+        runtime_config,
+        budget_config.clone(),
+        memory,
+        embedding_driver,
+    );
 
     // Warn if an unknown engine name is configured
     if toml_config.engine != "default" {
@@ -808,7 +824,8 @@ mod tests {
     #[tokio::test]
     async fn test_bootstrap_default() {
         let config = ContextEngineConfig::default();
-        let engine = DefaultContextEngine::new(config.clone(), make_memory(), None);
+        let engine =
+            DefaultContextEngine::new(config.clone(), Default::default(), make_memory(), None);
         assert!(engine.bootstrap(&config).await.is_ok());
     }
 
@@ -818,7 +835,7 @@ mod tests {
             stable_prefix_mode: true,
             ..Default::default()
         };
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
         let result = engine.ingest(AgentId::new(), "hello").await.unwrap();
         assert!(result.recalled_memories.is_empty());
     }
@@ -851,7 +868,7 @@ mod tests {
             .unwrap();
 
         let config = ContextEngineConfig::default();
-        let engine = DefaultContextEngine::new(config, memory, None);
+        let engine = DefaultContextEngine::new(config, Default::default(), memory, None);
         let result = engine.ingest(agent_id, "Rust").await.unwrap();
         assert_eq!(result.recalled_memories.len(), 1);
         assert!(result.recalled_memories[0].content.contains("Rust"));
@@ -860,7 +877,7 @@ mod tests {
     #[tokio::test]
     async fn test_assemble_no_overflow() {
         let config = ContextEngineConfig::default();
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
         let mut messages = vec![Message::user("hi"), Message::assistant("hello")];
         let result = engine
             .assemble(&mut messages, "system", &[], 200_000)
@@ -875,7 +892,7 @@ mod tests {
             context_window_tokens: 100, // tiny window
             ..Default::default()
         };
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
 
         // Create messages that exceed the tiny context window
         let mut messages: Vec<Message> = (0..20)
@@ -901,7 +918,7 @@ mod tests {
             context_window_tokens: 500,
             ..Default::default()
         };
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
         let big_content = "x".repeat(10_000);
         let truncated = engine.truncate_tool_result(&big_content, 500);
         assert!(truncated.len() < big_content.len());
@@ -911,7 +928,7 @@ mod tests {
     #[tokio::test]
     async fn test_after_turn_noop() {
         let config = ContextEngineConfig::default();
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
         assert!(engine
             .after_turn(AgentId::new(), &[Message::user("hi")])
             .await
@@ -921,7 +938,7 @@ mod tests {
     #[tokio::test]
     async fn test_subagent_hooks_noop() {
         let config = ContextEngineConfig::default();
-        let engine = DefaultContextEngine::new(config, make_memory(), None);
+        let engine = DefaultContextEngine::new(config, Default::default(), make_memory(), None);
         let parent = AgentId::new();
         let child = AgentId::new();
         assert!(engine.prepare_subagent_context(parent, child).await.is_ok());
@@ -1034,7 +1051,13 @@ ingest = "hooks/ingest.py"
     fn test_build_context_engine_default() {
         let toml_config = librefang_types::config::ContextEngineTomlConfig::default();
         let runtime_config = ContextEngineConfig::default();
-        let engine = build_context_engine(&toml_config, runtime_config, make_memory(), None);
+        let engine = build_context_engine(
+            &toml_config,
+            &Default::default(),
+            runtime_config,
+            make_memory(),
+            None,
+        );
         // Should not panic — returns DefaultContextEngine
         let _ = engine;
     }
@@ -1047,7 +1070,13 @@ ingest = "hooks/ingest.py"
         };
         let runtime_config = ContextEngineConfig::default();
         // Should fall back to default engine, not panic
-        let engine = build_context_engine(&toml_config, runtime_config, make_memory(), None);
+        let engine = build_context_engine(
+            &toml_config,
+            &Default::default(),
+            runtime_config,
+            make_memory(),
+            None,
+        );
         let _ = engine;
     }
 }

--- a/crates/librefang-runtime/src/context_overflow.rs
+++ b/crates/librefang-runtime/src/context_overflow.rs
@@ -68,15 +68,37 @@ fn drain_unpinned_from_front(messages: &mut Vec<Message>, target: usize) -> usiz
 /// Run the 4-stage overflow recovery pipeline.
 ///
 /// Returns the recovery stage applied and the number of messages/results affected.
+///
+/// `stage1_threshold` and `stage2_threshold` are fractions of `context_window`
+/// (e.g. 0.70 and 0.90). Pass `None` to use the built-in defaults (0.70 / 0.90).
 pub fn recover_from_overflow(
     messages: &mut Vec<Message>,
     system_prompt: &str,
     tools: &[ToolDefinition],
     context_window: usize,
 ) -> RecoveryStage {
+    recover_from_overflow_with_thresholds(
+        messages,
+        system_prompt,
+        tools,
+        context_window,
+        0.70,
+        0.90,
+    )
+}
+
+/// Like [`recover_from_overflow`] but with explicit stage thresholds.
+pub fn recover_from_overflow_with_thresholds(
+    messages: &mut Vec<Message>,
+    system_prompt: &str,
+    tools: &[ToolDefinition],
+    context_window: usize,
+    stage1_threshold: f64,
+    stage2_threshold: f64,
+) -> RecoveryStage {
     let estimated = estimate_tokens(messages, system_prompt, tools);
-    let threshold_70 = (context_window as f64 * 0.70) as usize;
-    let threshold_90 = (context_window as f64 * 0.90) as usize;
+    let threshold_70 = (context_window as f64 * stage1_threshold) as usize;
+    let threshold_90 = (context_window as f64 * stage2_threshold) as usize;
 
     // No recovery needed
     if estimated <= threshold_70 {

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1526,6 +1526,9 @@ pub struct KernelConfig {
     /// Proactive memory (mem0-style) configuration.
     #[serde(default)]
     pub proactive_memory: crate::memory::ProactiveMemoryConfig,
+    /// Context budget and overflow recovery tuning.
+    #[serde(default)]
+    pub context_budget: ContextBudgetConfig,
     /// Pluggable context engine configuration.
     #[serde(default)]
     pub context_engine: ContextEngineTomlConfig,
@@ -1718,6 +1721,93 @@ pub struct VertexAiConfig {
 /// token_url = "https://github.com/login/oauth/access_token"
 /// userinfo_url = "https://api.github.com/user"
 /// client_id = "your-github-client-id"
+// -- Context budget default value functions ----------------------------------
+
+fn default_tool_chars_per_token() -> f64 {
+    2.0
+}
+fn default_general_chars_per_token() -> f64 {
+    4.0
+}
+fn default_per_result_cap() -> f64 {
+    0.30
+}
+fn default_single_result_max() -> f64 {
+    0.50
+}
+fn default_tool_headroom() -> f64 {
+    0.75
+}
+fn default_context_window_tokens() -> usize {
+    200_000
+}
+fn default_overflow_stage1_threshold() -> f64 {
+    0.70
+}
+fn default_overflow_stage2_threshold() -> f64 {
+    0.90
+}
+
+/// Tuning knobs for the context budget and overflow recovery pipeline.
+///
+/// All fraction fields are expressed as values between 0.0 and 1.0 relative to
+/// the model's context window size. Configure in `config.toml`:
+///
+/// ```toml
+/// [context_budget]
+/// tool_chars_per_token = 2.0
+/// general_chars_per_token = 4.0
+/// per_result_cap = 0.30
+/// single_result_max = 0.50
+/// tool_headroom = 0.75
+/// default_context_window = 200000
+/// overflow_stage1_threshold = 0.70
+/// overflow_stage2_threshold = 0.90
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ContextBudgetConfig {
+    /// Characters per token for tool output estimation (default: 2.0).
+    #[serde(default = "default_tool_chars_per_token")]
+    pub tool_chars_per_token: f64,
+    /// Characters per token for general text estimation (default: 4.0).
+    #[serde(default = "default_general_chars_per_token")]
+    pub general_chars_per_token: f64,
+    /// Max fraction of context window for a single tool result (default: 0.30).
+    #[serde(default = "default_per_result_cap")]
+    pub per_result_cap: f64,
+    /// Max fraction of context window for single large result (default: 0.50).
+    #[serde(default = "default_single_result_max")]
+    pub single_result_max: f64,
+    /// Fraction of context window reserved for tool results (default: 0.75).
+    #[serde(default = "default_tool_headroom")]
+    pub tool_headroom: f64,
+    /// Default context window size in tokens (default: 200000).
+    #[serde(default = "default_context_window_tokens")]
+    pub default_context_window: usize,
+    /// Context usage fraction that triggers stage 1 recovery (default: 0.70).
+    #[serde(default = "default_overflow_stage1_threshold")]
+    pub overflow_stage1_threshold: f64,
+    /// Context usage fraction that triggers stage 2 recovery (default: 0.90).
+    #[serde(default = "default_overflow_stage2_threshold")]
+    pub overflow_stage2_threshold: f64,
+}
+
+impl Default for ContextBudgetConfig {
+    fn default() -> Self {
+        Self {
+            tool_chars_per_token: default_tool_chars_per_token(),
+            general_chars_per_token: default_general_chars_per_token(),
+            per_result_cap: default_per_result_cap(),
+            single_result_max: default_single_result_max(),
+            tool_headroom: default_tool_headroom(),
+            default_context_window: default_context_window_tokens(),
+            overflow_stage1_threshold: default_overflow_stage1_threshold(),
+            overflow_stage2_threshold: default_overflow_stage2_threshold(),
+        }
+    }
+}
+
 /// Pluggable context engine configuration.
 ///
 /// Configure in config.toml:
@@ -2386,6 +2476,7 @@ impl Default for KernelConfig {
             external_auth: ExternalAuthConfig::default(),
             tool_policy: crate::tool_policy::ToolPolicy::default(),
             proactive_memory: crate::memory::ProactiveMemoryConfig::default(),
+            context_budget: ContextBudgetConfig::default(),
             context_engine: ContextEngineTomlConfig::default(),
             audit: AuditConfig::default(),
             health_check: HealthCheckConfig::default(),


### PR DESCRIPTION
## Summary
- New `[context_budget]` config section: token density estimates, per-result cap, headroom, overflow thresholds
- Covers both `context_budget.rs` and `context_overflow.rs` constants
- Defaults: 2.0/4.0 chars/token, 30%/50%/75% caps, 70%/90% overflow stages, 200k window

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes