### PR TITLE
refactor: extract compaction constants into CompactionConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -101,6 +101,14 @@ debounce_ms = 500
 # ── Registry Sync ────────────────────────────────────────────
 # [registry]
 # cache_ttl_secs = 86400          # Re-download interval (default: 24 hours)
+# ── Session Compaction (LLM-based history summarization) ─────
+# [compaction]
+# threshold_messages = 30       # Compact when message count exceeds this
+# keep_recent = 10              # Recent messages preserved verbatim
+# max_summary_tokens = 1024     # Max tokens for the LLM summary
+# token_threshold_ratio = 0.7   # Trigger at this fraction of context window
+# max_chunk_chars = 80000       # Max chars per summarization chunk
+# max_retries = 3               # Max LLM summarization retries
 
 # ── Budget & Cost Control ────────────────────────────────────
 # [budget]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1853,6 +1853,7 @@ impl LibreFangKernel {
             context_window_tokens: 200_000, // default, overridden per-agent at call time
             stable_prefix_mode: config.stable_prefix_mode,
             max_recall_results: 5,
+            compaction: Some(config.compaction.clone()),
         };
         let context_engine: Option<Box<dyn librefang_runtime::context_engine::ContextEngine>> = {
             let emb_arc: Option<
@@ -3099,7 +3100,7 @@ system_prompt = "You are a helpful assistant."
                 estimate_token_count, needs_compaction as check_compact,
                 needs_compaction_by_tokens, CompactionConfig,
             };
-            let config = CompactionConfig::default();
+            let config = CompactionConfig::from_toml(&self.config.compaction);
             let by_messages = check_compact(&session, &config);
             let estimated = estimate_token_count(
                 &session.messages,
@@ -3504,7 +3505,7 @@ system_prompt = "You are a helpful assistant."
                         use librefang_runtime::compactor::{
                             estimate_token_count, needs_compaction_by_tokens, CompactionConfig,
                         };
-                        let config = CompactionConfig::default();
+                        let config = CompactionConfig::from_toml(&kernel_clone.config.compaction);
                         let estimated = estimate_token_count(&session.messages, None, None);
                         if needs_compaction_by_tokens(estimated, &config) {
                             let kc = kernel_clone.clone();
@@ -5374,7 +5375,7 @@ system_prompt = "You are a helpful assistant."
                 label: None,
             });
 
-        let config = CompactionConfig::default();
+        let config = CompactionConfig::from_toml(&self.config.compaction);
 
         if !needs_compaction(&session, &config) {
             return Ok(format!(

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -64,6 +64,22 @@ impl Default for CompactionConfig {
     }
 }
 
+impl CompactionConfig {
+    /// Build a `CompactionConfig` from the user-facing TOML config, keeping
+    /// internal algorithmic constants at their defaults.
+    pub fn from_toml(toml: &librefang_types::config::CompactionTomlConfig) -> Self {
+        Self {
+            threshold: toml.threshold_messages,
+            keep_recent: toml.keep_recent,
+            max_summary_tokens: toml.max_summary_tokens as u32,
+            max_chunk_chars: toml.max_chunk_chars,
+            max_retries: toml.max_retries,
+            token_threshold_ratio: toml.token_threshold_ratio,
+            ..Self::default()
+        }
+    }
+}
+
 /// Result of a compaction operation.
 #[derive(Debug)]
 pub struct CompactionResult {

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -61,6 +61,9 @@ pub struct ContextEngineConfig {
     pub stable_prefix_mode: bool,
     /// Maximum number of memories to recall per query.
     pub max_recall_results: usize,
+    /// User-facing compaction configuration (from `[compaction]` TOML section).
+    /// When `None`, runtime defaults are used.
+    pub compaction: Option<librefang_types::config::CompactionTomlConfig>,
 }
 
 impl Default for ContextEngineConfig {
@@ -69,6 +72,7 @@ impl Default for ContextEngineConfig {
             context_window_tokens: 200_000,
             stable_prefix_mode: false,
             max_recall_results: 5,
+            compaction: None,
         }
     }
 }
@@ -204,10 +208,11 @@ impl DefaultContextEngine {
         memory: Arc<MemorySubstrate>,
         embedding_driver: Option<Arc<dyn EmbeddingDriver + Send + Sync>>,
     ) -> Self {
-        let compaction_config = CompactionConfig {
-            context_window_tokens: config.context_window_tokens,
-            ..CompactionConfig::default()
+        let mut compaction_config = match config.compaction {
+            Some(ref toml) => CompactionConfig::from_toml(toml),
+            None => CompactionConfig::default(),
         };
+        compaction_config.context_window_tokens = config.context_window_tokens;
         Self {
             config,
             memory,

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1229,6 +1229,68 @@ impl Default for SessionConfig {
     }
 }
 
+/// Session compaction configuration (exposed in `[compaction]` TOML section).
+///
+/// Controls when and how the LLM-based history compaction runs.
+/// Internal algorithmic ratios (base_chunk_ratio, safety_margin, etc.) are kept
+/// as private constants inside the runtime compactor and are not exposed here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompactionTomlConfig {
+    /// Number of messages that triggers compaction (default: 30).
+    #[serde(default = "default_compaction_threshold")]
+    pub threshold_messages: usize,
+    /// Number of recent messages to preserve verbatim (default: 10).
+    #[serde(default = "default_compaction_keep_recent")]
+    pub keep_recent: usize,
+    /// Maximum tokens for summary output (default: 1024).
+    #[serde(default = "default_compaction_max_summary_tokens")]
+    pub max_summary_tokens: usize,
+    /// Token threshold ratio to trigger compaction (default: 0.7).
+    /// Compaction fires when estimated session tokens exceed this fraction
+    /// of the model's context window.
+    #[serde(default = "default_compaction_token_threshold_ratio")]
+    pub token_threshold_ratio: f64,
+    /// Maximum characters per summarization chunk (default: 80000).
+    #[serde(default = "default_compaction_max_chunk_chars")]
+    pub max_chunk_chars: usize,
+    /// Maximum retries for LLM summarization (default: 3).
+    #[serde(default = "default_compaction_max_retries")]
+    pub max_retries: u32,
+}
+
+fn default_compaction_threshold() -> usize {
+    30
+}
+fn default_compaction_keep_recent() -> usize {
+    10
+}
+fn default_compaction_max_summary_tokens() -> usize {
+    1024
+}
+fn default_compaction_token_threshold_ratio() -> f64 {
+    0.7
+}
+fn default_compaction_max_chunk_chars() -> usize {
+    80_000
+}
+fn default_compaction_max_retries() -> u32 {
+    3
+}
+
+impl Default for CompactionTomlConfig {
+    fn default() -> Self {
+        Self {
+            threshold_messages: default_compaction_threshold(),
+            keep_recent: default_compaction_keep_recent(),
+            max_summary_tokens: default_compaction_max_summary_tokens(),
+            token_threshold_ratio: default_compaction_token_threshold_ratio(),
+            max_chunk_chars: default_compaction_max_chunk_chars(),
+            max_retries: default_compaction_max_retries(),
+        }
+    }
+}
+
 /// Where a context injection should be placed in the session message list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1580,6 +1642,9 @@ pub struct KernelConfig {
     /// Session retention policy (automatic cleanup of old/excess sessions).
     #[serde(default)]
     pub session: SessionConfig,
+    /// Session compaction configuration (LLM-based history summarization).
+    #[serde(default)]
+    pub compaction: CompactionTomlConfig,
     /// Message queue configuration (depth limits, TTL, concurrency).
     #[serde(default)]
     pub queue: QueueConfig,
@@ -2509,6 +2574,7 @@ impl Default for KernelConfig {
             proxy: ProxyConfig::default(),
             prompt_caching: default_prompt_caching(),
             session: SessionConfig::default(),
+            compaction: CompactionTomlConfig::default(),
             queue: QueueConfig::default(),
             external_auth: ExternalAuthConfig::default(),
             tool_policy: crate::tool_policy::ToolPolicy::default(),

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -2775,15 +2775,28 @@ For **web search providers**, the validator checks:
 
 Some subsystems have their own configuration that is not part of `config.toml` but is worth noting:
 
-### Session Compaction (runtime)
+### Session Compaction
 
-Configured internally via `CompactionConfig` (not currently exposed in `config.toml`):
+Configured via the `[compaction]` section in `config.toml`:
+
+```toml
+[compaction]
+threshold_messages = 30       # Compact when message count exceeds this
+keep_recent = 10              # Recent messages preserved verbatim
+max_summary_tokens = 1024     # Max tokens for the LLM summary
+token_threshold_ratio = 0.7   # Trigger at this fraction of context window
+max_chunk_chars = 80000       # Max chars per summarization chunk
+max_retries = 3               # Max LLM summarization retries
+```
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `threshold` | `80` | Compact when session message count exceeds this. |
-| `keep_recent` | `20` | Number of recent messages preserved verbatim after compaction. |
+| `threshold_messages` | `30` | Compact when session message count exceeds this. |
+| `keep_recent` | `10` | Number of recent messages preserved verbatim after compaction. |
 | `max_summary_tokens` | `1024` | Maximum tokens for the LLM summary of compacted messages. |
+| `token_threshold_ratio` | `0.7` | Trigger compaction when estimated tokens exceed this fraction of the context window. |
+| `max_chunk_chars` | `80000` | Maximum characters per summarization chunk. |
+| `max_retries` | `3` | Maximum retries for LLM summarization. |
 
 ### WASM Sandbox (runtime)
 

--- a/docs/src/app/zh/configuration/page.mdx
+++ b/docs/src/app/zh/configuration/page.mdx
@@ -2774,15 +2774,28 @@ max_versions_per_agent = 50
 
 部分子系统有自己的配置，不在 `config.toml` 中，但值得了解：
 
-### 会话压缩（运行时）
+### 会话压缩
 
-通过 `CompactionConfig` 内部配置（目前未在 `config.toml` 中暴露）：
+通过 `config.toml` 中的 `[compaction]` 部分配置：
+
+```toml
+[compaction]
+threshold_messages = 30       # 消息数超过此值时触发压缩
+keep_recent = 10              # 压缩后逐字保留的最近消息数
+max_summary_tokens = 1024     # LLM 摘要的最大 Token 数
+token_threshold_ratio = 0.7   # 估算 Token 超过上下文窗口此比例时触发
+max_chunk_chars = 80000       # 每个摘要分块的最大字符数
+max_retries = 3               # LLM 摘要的最大重试次数
+```
 
 | 字段 | 默认值 | 说明 |
 |------|--------|------|
-| `threshold` | `80` | 会话消息数超过此值时触发压缩。 |
-| `keep_recent` | `20` | 压缩后保留的最近消息数量（逐字保留）。 |
+| `threshold_messages` | `30` | 会话消息数超过此值时触发压缩。 |
+| `keep_recent` | `10` | 压缩后保留的最近消息数量（逐字保留）。 |
 | `max_summary_tokens` | `1024` | LLM 对压缩消息生成摘要的最大 Token 数。 |
+| `token_threshold_ratio` | `0.7` | 估算 Token 超过上下文窗口此比例时触发压缩。 |
+| `max_chunk_chars` | `80000` | 每个摘要分块的最大字符数。 |
+| `max_retries` | `3` | LLM 摘要的最大重试次数。 |
 
 ### WASM 沙箱（运行时）
 


### PR DESCRIPTION
## Summary
- New `[compaction]` config section: threshold_messages, keep_recent, max_summary_tokens, token_threshold_ratio, max_chunk_chars, max_retries
- Defaults: 30 messages/10 recent/1024 tokens/0.7 ratio/80k chars/3 retries

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes