### PR TITLE
refactor: extract trigger system constants into TriggersConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -109,6 +109,12 @@ debounce_ms = 500
 # token_threshold_ratio = 0.7   # Trigger at this fraction of context window
 # max_chunk_chars = 80000       # Max chars per summarization chunk
 # max_retries = 3               # Max LLM summarization retries
+# ── Event Triggers ───────────────────────────────────────────
+# [triggers]
+# cooldown_secs = 5             # Default cooldown between trigger firings
+# max_per_event = 10            # Max triggers that can fire per event
+# max_depth = 5                 # Max trigger recursion depth
+# max_workflow_secs = 3600      # Max workflow execution time (1 hour)
 
 # ── Budget & Cost Control ────────────────────────────────────
 # [budget]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1881,7 +1881,7 @@ impl LibreFangKernel {
             supervisor,
             workflows: WorkflowEngine::new_with_persistence(&workflow_home_dir),
             template_registry: WorkflowTemplateRegistry::new(),
-            triggers: TriggerEngine::new(),
+            triggers: TriggerEngine::with_config(&config.triggers),
             background,
             audit_log: Arc::new(AuditLog::with_db(memory.usage_conn())),
             metering,
@@ -6283,14 +6283,14 @@ system_prompt = "You are a helpful assistant."
     ///
     /// Any matching triggers will dispatch messages to the subscribing agents.
     /// Returns the list of (agent_id, message) pairs that were triggered.
-    /// Includes depth limiting to prevent circular trigger chains (max 5 levels).
+    /// Includes depth limiting to prevent circular trigger chains.
     pub async fn publish_event(&self, event: Event) -> Vec<(AgentId, String)> {
         // Depth guard: prevent circular trigger chains
         static TRIGGER_DEPTH: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-        const MAX_TRIGGER_DEPTH: u32 = 5;
+        let max_trigger_depth = self.config.triggers.max_depth as u32;
 
         let depth = TRIGGER_DEPTH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        if depth >= MAX_TRIGGER_DEPTH {
+        if depth >= max_trigger_depth {
             TRIGGER_DEPTH.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
             warn!(
                 depth,
@@ -6448,16 +6448,16 @@ system_prompt = "You are a helpful assistant."
         };
 
         // SECURITY: Global workflow timeout to prevent runaway execution.
-        const MAX_WORKFLOW_SECS: u64 = 3600; // 1 hour
+        let max_workflow_secs = self.config.triggers.max_workflow_secs;
 
         let output = tokio::time::timeout(
-            std::time::Duration::from_secs(MAX_WORKFLOW_SECS),
+            std::time::Duration::from_secs(max_workflow_secs),
             self.workflows.execute_run(run_id, resolver, send_message),
         )
         .await
         .map_err(|_| {
             KernelError::LibreFang(LibreFangError::Internal(format!(
-                "Workflow timed out after {MAX_WORKFLOW_SECS}s"
+                "Workflow timed out after {max_workflow_secs}s"
             )))
         })?
         .map_err(|e| {

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -19,6 +19,10 @@ const DEFAULT_COOLDOWN_SECS: u64 = 5;
 /// Default maximum number of triggers that can fire from a single event.
 const DEFAULT_MAX_TRIGGERS_PER_EVENT: usize = 10;
 
+// Re-export defaults so tests can use TriggerEngine::new() without config.
+// The constants above are kept as fallbacks; production code threads values
+// from TriggersConfig via `TriggerEngine::with_config`.
+
 /// Unique identifier for a trigger.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TriggerId(pub Uuid);
@@ -105,6 +109,8 @@ pub struct TriggerEngine {
     last_fired: DashMap<TriggerId, Instant>,
     /// Maximum number of triggers that can fire from a single event.
     max_triggers_per_event: usize,
+    /// Default cooldown duration (seconds) applied when a trigger has no override.
+    default_cooldown_secs: u64,
 }
 
 impl TriggerEngine {
@@ -115,6 +121,18 @@ impl TriggerEngine {
             agent_triggers: DashMap::new(),
             last_fired: DashMap::new(),
             max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
+            default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
+        }
+    }
+
+    /// Create a trigger engine configured from a `TriggersConfig`.
+    pub fn with_config(config: &librefang_types::config::TriggersConfig) -> Self {
+        Self {
+            triggers: DashMap::new(),
+            agent_triggers: DashMap::new(),
+            last_fired: DashMap::new(),
+            max_triggers_per_event: config.max_per_event.max(1),
+            default_cooldown_secs: config.cooldown_secs,
         }
     }
 
@@ -367,7 +385,7 @@ impl TriggerEngine {
 
             // Check per-trigger cooldown
             let cooldown =
-                Duration::from_secs(trigger.cooldown_secs.unwrap_or(DEFAULT_COOLDOWN_SECS));
+                Duration::from_secs(trigger.cooldown_secs.unwrap_or(self.default_cooldown_secs));
             if !cooldown.is_zero() {
                 if let Some(last) = self.last_fired.get(&trigger.id) {
                     if now.duration_since(*last) < cooldown {

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1448,6 +1448,49 @@ pub fn redact_proxy_url(url: &str) -> String {
     url.to_string()
 }
 
+// ── Trigger system defaults ────────────────────────────────────────────
+
+fn default_trigger_cooldown_secs() -> u64 {
+    5
+}
+fn default_max_triggers_per_event() -> usize {
+    10
+}
+fn default_max_trigger_depth() -> usize {
+    5
+}
+fn default_max_workflow_secs() -> u64 {
+    3600
+}
+
+/// Event-driven trigger system configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggersConfig {
+    /// Default cooldown between trigger firings in seconds (default: 5).
+    #[serde(default = "default_trigger_cooldown_secs")]
+    pub cooldown_secs: u64,
+    /// Maximum triggers that can fire per single event (default: 10).
+    #[serde(default = "default_max_triggers_per_event")]
+    pub max_per_event: usize,
+    /// Maximum trigger recursion depth (default: 5).
+    #[serde(default = "default_max_trigger_depth")]
+    pub max_depth: usize,
+    /// Maximum workflow execution time in seconds (default: 3600).
+    #[serde(default = "default_max_workflow_secs")]
+    pub max_workflow_secs: u64,
+}
+
+impl Default for TriggersConfig {
+    fn default() -> Self {
+        Self {
+            cooldown_secs: default_trigger_cooldown_secs(),
+            max_per_event: default_max_triggers_per_event(),
+            max_depth: default_max_trigger_depth(),
+            max_workflow_secs: default_max_workflow_secs(),
+        }
+    }
+}
+
 /// Top-level kernel configuration.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1557,6 +1600,9 @@ pub struct KernelConfig {
     /// Webhook trigger configuration (external event injection).
     #[serde(default)]
     pub webhook_triggers: Option<WebhookTriggerConfig>,
+    /// Event-driven trigger system configuration (cooldowns, depth limits, etc.).
+    #[serde(default)]
+    pub triggers: TriggersConfig,
     /// Execution approval policy.
     #[serde(default, alias = "approval_policy")]
     pub approval: crate::approval::ApprovalPolicy,
@@ -2550,6 +2596,7 @@ impl Default for KernelConfig {
             links: crate::media::LinkConfig::default(),
             reload: ReloadConfig::default(),
             webhook_triggers: None,
+            triggers: TriggersConfig::default(),
             approval: crate::approval::ApprovalPolicy::default(),
             max_cron_jobs: default_max_cron_jobs(),
             include: Vec::new(),

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -34,6 +34,7 @@ impl KernelConfig {
             "links",
             "reload",
             "webhook_triggers",
+            "triggers",
             "approval",
             "approval_policy", // alias for approval
             "max_cron_jobs",
@@ -654,6 +655,21 @@ impl KernelConfig {
         }
         if self.queue.concurrency.subagent_lane == 0 {
             self.queue.concurrency.subagent_lane = 1;
+        }
+
+        // Triggers: max_per_event must be >= 1 (0 would prevent any trigger from firing)
+        if self.triggers.max_per_event == 0 {
+            self.triggers.max_per_event = 1;
+        }
+        // Triggers: max_depth must be >= 1
+        if self.triggers.max_depth == 0 {
+            self.triggers.max_depth = 1;
+        }
+        // Triggers: max_workflow_secs min 10s, max 86400s (24h)
+        if self.triggers.max_workflow_secs < 10 {
+            self.triggers.max_workflow_secs = 10;
+        } else if self.triggers.max_workflow_secs > 86400 {
+            self.triggers.max_workflow_secs = 86400;
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `[triggers]` config section: cooldown_secs, max_per_event, max_depth, max_workflow_secs
- Defaults: 5s/10/5/3600s matching previous hardcoded values

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes