### PR TITLE
refactor: extract internal resource limits into InternalLimitsConfig

### DIFF
--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -153,6 +153,17 @@ debounce_ms = 500
 # poll_interval_secs = 5
 # default_agent = "assistant"         # Agent to use when no agent: directive
 
+# ── Internal Resource Limits ─────────────────────────────────
+# [internal_limits]
+# max_receipts = 10000              # Total message receipts stored
+# max_receipts_per_agent = 500      # Receipts per agent
+# event_history_size = 1000         # Event bus history buffer
+# max_concurrent_bg_llm = 5         # Concurrent background LLM calls
+# max_consecutive_cron_errors = 5   # Cron failures before auto-disable
+# max_pending_approvals_per_agent = 5  # Pending approval requests per agent
+# max_recent_approvals = 100        # Recent approval records kept
+# max_agent_call_depth = 5          # Nested agent call depth limit
+
 # ── Network (P2P Federation) ─────────────────────────────────
 # network_enabled = false
 # [network]

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -9,16 +9,15 @@ use std::collections::VecDeque;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-/// Max pending requests per agent.
-const MAX_PENDING_PER_AGENT: usize = 5;
-/// Max recent approval records to retain for history and UI visibility.
-const MAX_RECENT_APPROVALS: usize = 100;
-
 /// Manages approval requests with oneshot channels for blocking resolution.
 pub struct ApprovalManager {
     pending: DashMap<Uuid, PendingRequest>,
     recent: std::sync::Mutex<VecDeque<ApprovalRecord>>,
     policy: std::sync::RwLock<ApprovalPolicy>,
+    /// Max pending requests per agent.
+    max_pending_per_agent: usize,
+    /// Max recent approval records to retain.
+    max_recent_approvals: usize,
 }
 
 struct PendingRequest {
@@ -35,11 +34,17 @@ pub struct ApprovalRecord {
 }
 
 impl ApprovalManager {
-    pub fn new(policy: ApprovalPolicy) -> Self {
+    pub fn new(
+        policy: ApprovalPolicy,
+        max_pending_per_agent: usize,
+        max_recent_approvals: usize,
+    ) -> Self {
         Self {
             pending: DashMap::new(),
             recent: std::sync::Mutex::new(VecDeque::new()),
             policy: std::sync::RwLock::new(policy),
+            max_pending_per_agent,
+            max_recent_approvals,
         }
     }
 
@@ -131,7 +136,7 @@ impl ApprovalManager {
             .iter()
             .filter(|r| r.value().request.agent_id == req.agent_id)
             .count();
-        if agent_pending >= MAX_PENDING_PER_AGENT {
+        if agent_pending >= self.max_pending_per_agent {
             warn!(agent_id = %req.agent_id, "Approval request rejected: too many pending");
             return ApprovalDecision::Denied;
         }
@@ -260,7 +265,7 @@ impl ApprovalManager {
             decided_at,
             decided_by,
         });
-        while recent.len() > MAX_RECENT_APPROVALS {
+        while recent.len() > self.max_recent_approvals {
             recent.pop_back();
         }
     }
@@ -276,8 +281,15 @@ mod tests {
     use librefang_types::approval::ApprovalPolicy;
     use std::sync::Arc;
 
+    const TEST_MAX_PENDING_PER_AGENT: usize = 5;
+    const TEST_MAX_RECENT_APPROVALS: usize = 100;
+
     fn default_manager() -> ApprovalManager {
-        ApprovalManager::new(ApprovalPolicy::default())
+        ApprovalManager::new(
+            ApprovalPolicy::default(),
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        )
     }
 
     fn make_request(agent_id: &str, tool_name: &str, timeout_secs: u64) -> ApprovalRequest {
@@ -316,7 +328,11 @@ mod tests {
             trusted_senders: Vec::new(),
             channel_rules: Vec::new(),
         };
-        let mgr = ApprovalManager::new(policy);
+        let mgr = ApprovalManager::new(
+            policy,
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        );
         assert!(mgr.requires_approval("file_write"));
         assert!(mgr.requires_approval("file_delete"));
         assert!(!mgr.requires_approval("shell_exec"));
@@ -502,7 +518,7 @@ mod tests {
 
         // Fill up 5 pending requests for agent-1 (they will all be waiting)
         let mut ids = Vec::new();
-        for _ in 0..MAX_PENDING_PER_AGENT {
+        for _ in 0..TEST_MAX_PENDING_PER_AGENT {
             let req = make_request("agent-1", "shell_exec", 300);
             ids.push(req.id);
             let mgr_clone = Arc::clone(&mgr);
@@ -513,7 +529,7 @@ mod tests {
 
         // Give spawned tasks time to register
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(mgr.pending_count(), MAX_PENDING_PER_AGENT);
+        assert_eq!(mgr.pending_count(), TEST_MAX_PENDING_PER_AGENT);
 
         // 6th request for the same agent should be immediately denied
         let req6 = make_request("agent-1", "shell_exec", 300);
@@ -528,7 +544,7 @@ mod tests {
             mgr2.request_approval(req_other).await;
         });
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        assert_eq!(mgr.pending_count(), MAX_PENDING_PER_AGENT + 1);
+        assert_eq!(mgr.pending_count(), TEST_MAX_PENDING_PER_AGENT + 1);
 
         // Cleanup: resolve all pending to avoid hanging tasks
         for id in &ids {
@@ -591,7 +607,11 @@ mod tests {
             trusted_senders: vec!["admin_123".to_string()],
             ..Default::default()
         };
-        let mgr = ApprovalManager::new(policy);
+        let mgr = ApprovalManager::new(
+            policy,
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        );
 
         // Trusted sender should bypass even for shell_exec
         assert!(!mgr.requires_approval_with_context("shell_exec", Some("admin_123"), None));
@@ -614,7 +634,11 @@ mod tests {
             }],
             ..Default::default()
         };
-        let mgr = ApprovalManager::new(policy);
+        let mgr = ApprovalManager::new(
+            policy,
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        );
 
         // file_write is not in require_approval, but telegram channel denies it
         assert!(mgr.is_tool_denied_with_context("file_write", None, Some("telegram")));
@@ -636,7 +660,11 @@ mod tests {
             }],
             ..Default::default()
         };
-        let mgr = ApprovalManager::new(policy);
+        let mgr = ApprovalManager::new(
+            policy,
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        );
 
         // shell_exec from admin_cli channel is explicitly allowed — bypass approval
         assert!(!mgr.requires_approval_with_context("shell_exec", None, Some("admin_cli")));
@@ -657,7 +685,11 @@ mod tests {
             }],
             ..Default::default()
         };
-        let mgr = ApprovalManager::new(policy);
+        let mgr = ApprovalManager::new(
+            policy,
+            TEST_MAX_PENDING_PER_AGENT,
+            TEST_MAX_RECENT_APPROVALS,
+        );
 
         // Trusted sender bypasses even channel deny rules
         assert!(!mgr.is_tool_denied_with_context(

--- a/crates/librefang-kernel/src/background.rs
+++ b/crates/librefang-kernel/src/background.rs
@@ -14,9 +14,6 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-/// Maximum number of concurrent background LLM calls across all agents.
-const MAX_CONCURRENT_BG_LLM: usize = 5;
-
 /// RAII guard that clears the busy flag on drop, even if the task panics.
 struct BusyGuard {
     flag: Arc<AtomicBool>,
@@ -42,11 +39,11 @@ pub struct BackgroundExecutor {
 
 impl BackgroundExecutor {
     /// Create a new executor bound to the supervisor's shutdown signal.
-    pub fn new(shutdown_rx: watch::Receiver<bool>) -> Self {
+    pub fn new(shutdown_rx: watch::Receiver<bool>, max_concurrent_bg_llm: usize) -> Self {
         Self {
             tasks: DashMap::new(),
             shutdown_rx,
-            llm_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_BG_LLM)),
+            llm_semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent_bg_llm)),
             pause_flags: DashMap::new(),
         }
     }
@@ -451,7 +448,7 @@ mod tests {
     #[tokio::test]
     async fn test_continuous_shutdown() {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let executor = BackgroundExecutor::new(shutdown_rx);
+        let executor = BackgroundExecutor::new(shutdown_rx, 5);
         let agent_id = AgentId::new();
 
         let tick_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -487,7 +484,7 @@ mod tests {
     #[tokio::test]
     async fn test_skip_if_busy() {
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-        let executor = BackgroundExecutor::new(shutdown_rx);
+        let executor = BackgroundExecutor::new(shutdown_rx, 5);
         let agent_id = AgentId::new();
 
         let tick_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -518,7 +515,7 @@ mod tests {
     #[test]
     fn test_executor_active_count() {
         let (_tx, rx) = watch::channel(false);
-        let executor = BackgroundExecutor::new(rx);
+        let executor = BackgroundExecutor::new(rx, 5);
         assert_eq!(executor.active_count(), 0);
 
         // Reactive mode → no background task

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -17,9 +17,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{debug, info, warn};
 
-/// Maximum consecutive errors before a job is auto-disabled.
-const MAX_CONSECUTIVE_ERRORS: u32 = 5;
-
 // ---------------------------------------------------------------------------
 // JobMeta — extra runtime state not stored in CronJob itself
 // ---------------------------------------------------------------------------
@@ -70,6 +67,8 @@ pub struct CronScheduler {
     persist_path: PathBuf,
     /// Global cap on total jobs across all agents (atomic for hot-reload).
     max_total_jobs: AtomicUsize,
+    /// Consecutive failures before auto-disabling a job.
+    max_consecutive_errors: u32,
 }
 
 impl CronScheduler {
@@ -78,11 +77,12 @@ impl CronScheduler {
     /// `home_dir` is the LibreFang data directory; jobs are persisted to
     /// `<home_dir>/cron_jobs.json`. `max_total_jobs` caps the total number
     /// of jobs across all agents.
-    pub fn new(home_dir: &Path, max_total_jobs: usize) -> Self {
+    pub fn new(home_dir: &Path, max_total_jobs: usize, max_consecutive_errors: u32) -> Self {
         Self {
             jobs: DashMap::new(),
             persist_path: home_dir.join("cron_jobs.json"),
             max_total_jobs: AtomicUsize::new(max_total_jobs),
+            max_consecutive_errors,
         }
     }
 
@@ -411,7 +411,7 @@ impl CronScheduler {
     /// Record a failed execution for a job.
     ///
     /// Increments the consecutive error counter. If it reaches
-    /// [`MAX_CONSECUTIVE_ERRORS`], the job is automatically disabled.
+    /// `max_consecutive_errors`, the job is automatically disabled.
     pub fn record_failure(&self, id: CronJobId, error_msg: &str) {
         if let Some(mut meta) = self.jobs.get_mut(&id) {
             meta.job.last_run = Some(Utc::now());
@@ -420,7 +420,7 @@ impl CronScheduler {
                 librefang_types::truncate_str(error_msg, 256)
             ));
             meta.consecutive_errors += 1;
-            if meta.consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+            if meta.consecutive_errors >= self.max_consecutive_errors {
                 warn!(
                     job_id = %id,
                     errors = meta.consecutive_errors,
@@ -546,9 +546,12 @@ mod tests {
     }
 
     /// Create a scheduler backed by a temp directory.
+    /// Default max consecutive errors for tests (matches original hardcoded value).
+    const TEST_MAX_CONSECUTIVE_ERRORS: u32 = 5;
+
     fn make_scheduler(max_total: usize) -> (CronScheduler, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
-        let sched = CronScheduler::new(tmp.path(), max_total);
+        let sched = CronScheduler::new(tmp.path(), max_total, TEST_MAX_CONSECUTIVE_ERRORS);
         (sched, tmp)
     }
 
@@ -690,8 +693,8 @@ mod tests {
         let job = make_job(agent);
         let id = sched.add_job(job, false).unwrap();
 
-        // Fail MAX_CONSECUTIVE_ERRORS - 1 times: should still be enabled
-        for i in 0..(MAX_CONSECUTIVE_ERRORS - 1) {
+        // Fail TEST_MAX_CONSECUTIVE_ERRORS - 1 times: should still be enabled
+        for i in 0..(TEST_MAX_CONSECUTIVE_ERRORS - 1) {
             sched.record_failure(id, &format!("error {i}"));
             let meta = sched.get_meta(id).unwrap();
             assert!(
@@ -707,9 +710,9 @@ mod tests {
         let meta = sched.get_meta(id).unwrap();
         assert!(
             !meta.job.enabled,
-            "Job should be auto-disabled after {MAX_CONSECUTIVE_ERRORS} failures"
+            "Job should be auto-disabled after {TEST_MAX_CONSECUTIVE_ERRORS} failures"
         );
-        assert_eq!(meta.consecutive_errors, MAX_CONSECUTIVE_ERRORS);
+        assert_eq!(meta.consecutive_errors, TEST_MAX_CONSECUTIVE_ERRORS);
         assert!(
             meta.last_status.as_ref().unwrap().starts_with("error:"),
             "last_status should record the error"
@@ -802,7 +805,7 @@ mod tests {
 
         // Create scheduler, add jobs, persist
         {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             let mut j1 = make_job(agent);
             j1.name = "persist-a".into();
             let mut j2 = make_job(agent);
@@ -816,7 +819,7 @@ mod tests {
 
         // Create a new scheduler and load from disk
         {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             let count = sched.load().unwrap();
             assert_eq!(count, 2);
             assert_eq!(sched.total_jobs(), 2);
@@ -838,7 +841,7 @@ mod tests {
     #[test]
     fn test_load_no_file_returns_zero() {
         let tmp = tempfile::tempdir().unwrap();
-        let sched = CronScheduler::new(tmp.path(), 100);
+        let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
         assert_eq!(sched.load().unwrap(), 0);
     }
 
@@ -1166,7 +1169,7 @@ mod tests {
         let id = sched.add_job(job, false).unwrap();
 
         // Simulate enough failures to auto-disable (with "not found" message)
-        for _ in 0..MAX_CONSECUTIVE_ERRORS {
+        for _ in 0..TEST_MAX_CONSECUTIVE_ERRORS {
             sched.record_failure(id, "No such agent");
         }
         let meta = sched.get_meta(id).unwrap();
@@ -1192,7 +1195,7 @@ mod tests {
 
         // Create scheduler, add job, reassign, persist
         let id = {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             let job = make_job(old_agent);
             let id = sched.add_job(job, false).unwrap();
 
@@ -1203,7 +1206,7 @@ mod tests {
 
         // Load from disk and verify the agent_id was persisted
         {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             sched.load().unwrap();
 
             let job = sched.get_job(id).unwrap();
@@ -1265,7 +1268,7 @@ mod tests {
 
         // Add jobs for two agents, remove one agent's jobs, persist
         {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             let mut j1 = make_job(agent);
             j1.name = "doomed".into();
             let mut j2 = make_job(other);
@@ -1280,7 +1283,7 @@ mod tests {
 
         // Reload and verify
         {
-            let sched = CronScheduler::new(tmp.path(), 100);
+            let sched = CronScheduler::new(tmp.path(), 100, TEST_MAX_CONSECUTIVE_ERRORS);
             sched.load().unwrap();
             assert_eq!(sched.total_jobs(), 1);
             assert!(sched.list_jobs(agent).is_empty());

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -9,9 +9,6 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, warn};
 
-/// Maximum events retained in the history ring buffer.
-const HISTORY_SIZE: usize = 1000;
-
 /// The central event bus for inter-agent and system communication.
 pub struct EventBus {
     /// Broadcast channel for all events.
@@ -20,6 +17,8 @@ pub struct EventBus {
     agent_channels: DashMap<AgentId, broadcast::Sender<Event>>,
     /// Event history ring buffer.
     history: Arc<RwLock<VecDeque<Event>>>,
+    /// Maximum events retained in the history ring buffer.
+    history_size: usize,
     /// Count of events dropped due to full channels.
     dropped_count: AtomicU64,
     /// Timestamp of the last drop warning log (for rate-limiting).
@@ -27,13 +26,14 @@ pub struct EventBus {
 }
 
 impl EventBus {
-    /// Create a new event bus.
-    pub fn new() -> Self {
+    /// Create a new event bus with the given history buffer size.
+    pub fn new(history_size: usize) -> Self {
         let (sender, _) = broadcast::channel(1024);
         Self {
             sender,
             agent_channels: DashMap::new(),
-            history: Arc::new(RwLock::new(VecDeque::with_capacity(HISTORY_SIZE))),
+            history: Arc::new(RwLock::new(VecDeque::with_capacity(history_size))),
+            history_size,
             dropped_count: AtomicU64::new(0),
             last_drop_warn: std::sync::Mutex::new(std::time::Instant::now()),
         }
@@ -50,7 +50,7 @@ impl EventBus {
         // Store in history
         {
             let mut history = self.history.write().await;
-            if history.len() >= HISTORY_SIZE {
+            if history.len() >= self.history_size {
                 history.pop_front();
             }
             history.push_back(event.clone());
@@ -149,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_publish_and_history() {
-        let bus = EventBus::new();
+        let bus = EventBus::new(1000);
         let agent_id = AgentId::new();
         let event = Event::new(
             agent_id,
@@ -163,7 +163,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_agent_subscribe() {
-        let bus = EventBus::new();
+        let bus = EventBus::new(1000);
         let agent_id = AgentId::new();
         let mut rx = bus.subscribe_agent(agent_id);
 

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -418,25 +418,27 @@ pub struct LibreFangKernel {
 }
 
 /// Bounded in-memory delivery receipt tracker.
-/// Stores up to `MAX_RECEIPTS` most recent delivery receipts per agent.
 pub struct DeliveryTracker {
     receipts: dashmap::DashMap<AgentId, Vec<librefang_channels::types::DeliveryReceipt>>,
+    /// Maximum total receipts across all agents.
+    max_receipts: usize,
+    /// Maximum receipts per individual agent.
+    max_per_agent: usize,
 }
 
 impl Default for DeliveryTracker {
     fn default() -> Self {
-        Self::new()
+        Self::new(10_000, 500)
     }
 }
 
 impl DeliveryTracker {
-    const MAX_RECEIPTS: usize = 10_000;
-    const MAX_PER_AGENT: usize = 500;
-
-    /// Create a new empty delivery tracker.
-    pub fn new() -> Self {
+    /// Create a new empty delivery tracker with the given capacity limits.
+    pub fn new(max_receipts: usize, max_per_agent: usize) -> Self {
         Self {
             receipts: dashmap::DashMap::new(),
+            max_receipts,
+            max_per_agent,
         }
     }
 
@@ -445,17 +447,17 @@ impl DeliveryTracker {
         let mut entry = self.receipts.entry(agent_id).or_default();
         entry.push(receipt);
         // Per-agent cap
-        if entry.len() > Self::MAX_PER_AGENT {
-            let drain = entry.len() - Self::MAX_PER_AGENT;
+        if entry.len() > self.max_per_agent {
+            let drain = entry.len() - self.max_per_agent;
             entry.drain(..drain);
         }
         // Global cap: evict oldest agents' receipts if total exceeds limit
         drop(entry);
         let total: usize = self.receipts.iter().map(|e| e.value().len()).sum();
-        if total > Self::MAX_RECEIPTS {
+        if total > self.max_receipts {
             // Simple eviction: remove oldest entries from first agent found
             if let Some(mut oldest) = self.receipts.iter_mut().next() {
-                let to_remove = total - Self::MAX_RECEIPTS;
+                let to_remove = total - self.max_receipts;
                 let drain = to_remove.min(oldest.value().len());
                 oldest.value_mut().drain(..drain);
             }
@@ -1486,7 +1488,10 @@ impl LibreFangKernel {
             .map_err(|e| KernelError::BootFailed(format!("Prompt store init failed: {e}")))?;
 
         let supervisor = Supervisor::new();
-        let background = BackgroundExecutor::new(supervisor.subscribe());
+        let background = BackgroundExecutor::new(
+            supervisor.subscribe(),
+            config.internal_limits.max_concurrent_bg_llm,
+        );
 
         // Initialize WASM sandbox engine (shared across all WASM agents)
         let wasm_sandbox = WasmSandbox::new()
@@ -1818,8 +1823,11 @@ impl LibreFangKernel {
         }
 
         // Initialize cron scheduler
-        let cron_scheduler =
-            crate::cron::CronScheduler::new(&config.home_dir, config.max_cron_jobs);
+        let cron_scheduler = crate::cron::CronScheduler::new(
+            &config.home_dir,
+            config.max_cron_jobs,
+            config.internal_limits.max_consecutive_cron_errors,
+        );
         match cron_scheduler.load() {
             Ok(count) => {
                 if count > 0 {
@@ -1832,7 +1840,11 @@ impl LibreFangKernel {
         }
 
         // Initialize execution approval manager
-        let approval_manager = crate::approval::ApprovalManager::new(config.approval.clone());
+        let approval_manager = crate::approval::ApprovalManager::new(
+            config.approval.clone(),
+            config.internal_limits.max_pending_approvals_per_agent,
+            config.internal_limits.max_recent_approvals,
+        );
 
         // Initialize binding/broadcast/auto-reply from config
         let initial_bindings = config.bindings.clone();
@@ -1871,7 +1883,7 @@ impl LibreFangKernel {
             config,
             registry: AgentRegistry::new(),
             capabilities: CapabilityManager::new(),
-            event_bus: EventBus::new(),
+            event_bus: EventBus::new(config.internal_limits.event_history_size),
             scheduler: AgentScheduler::new(),
             memory: memory.clone(),
             proactive_memory: OnceLock::new(),
@@ -1904,7 +1916,10 @@ impl LibreFangKernel {
             extension_registry: std::sync::RwLock::new(extension_registry),
             extension_health,
             effective_mcp_servers: std::sync::RwLock::new(all_mcp_servers),
-            delivery_tracker: DeliveryTracker::new(),
+            delivery_tracker: DeliveryTracker::new(
+                config.internal_limits.max_receipts,
+                config.internal_limits.max_receipts_per_agent,
+            ),
             cron_scheduler,
             approval_manager,
             bindings: std::sync::Mutex::new(initial_bindings),

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, warn};
 
-/// Maximum inter-agent call depth to prevent infinite recursion (A->B->C->...).
-const MAX_AGENT_CALL_DEPTH: u32 = 5;
+/// Default maximum inter-agent call depth to prevent infinite recursion (A->B->C->...).
+const DEFAULT_MAX_AGENT_CALL_DEPTH: u32 = 5;
 
 /// Check if a shell command should be blocked by taint tracking.
 ///
@@ -79,6 +79,8 @@ tokio::task_local! {
     static AGENT_CALL_DEPTH: std::cell::Cell<u32>;
     /// Canvas max HTML size in bytes (set from kernel config at loop start).
     pub static CANVAS_MAX_BYTES: usize;
+    /// Max inter-agent call depth (set from kernel config, default 5).
+    pub static MAX_AGENT_CALL_DEPTH: u32;
 }
 
 /// Get the current inter-agent call depth from the task-local context.
@@ -1724,11 +1726,14 @@ async fn tool_agent_send(
 
     // Check + increment inter-agent call depth
     let current_depth = AGENT_CALL_DEPTH.try_with(|d| d.get()).unwrap_or(0);
-    if current_depth >= MAX_AGENT_CALL_DEPTH {
+    let max_depth = MAX_AGENT_CALL_DEPTH
+        .try_with(|v| *v)
+        .unwrap_or(DEFAULT_MAX_AGENT_CALL_DEPTH);
+    if current_depth >= max_depth {
         return Err(format!(
             "Inter-agent call depth exceeded (max {}). \
              A->B->C chain is too deep. Use the task queue instead.",
-            MAX_AGENT_CALL_DEPTH
+            max_depth
         ));
     }
 
@@ -4688,14 +4693,14 @@ mod tests {
 
     #[test]
     fn test_depth_limit_constant() {
-        assert_eq!(MAX_AGENT_CALL_DEPTH, 5);
+        assert_eq!(DEFAULT_MAX_AGENT_CALL_DEPTH, 5);
     }
 
     #[test]
     fn test_depth_limit_first_call_succeeds() {
-        // Default depth is 0, which is < MAX_AGENT_CALL_DEPTH
+        // Default depth is 0, which is < DEFAULT_MAX_AGENT_CALL_DEPTH
         let default_depth = AGENT_CALL_DEPTH.try_with(|d| d.get()).unwrap_or(0);
-        assert!(default_depth < MAX_AGENT_CALL_DEPTH);
+        assert!(default_depth < DEFAULT_MAX_AGENT_CALL_DEPTH);
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1577,6 +1577,9 @@ pub struct KernelConfig {
     /// Controls which releases `librefang update` considers.
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    /// Internal resource and capacity limits.
+    #[serde(default)]
+    pub internal_limits: InternalLimitsConfig,
 }
 
 /// Input sanitization mode for channel messages.
@@ -2323,6 +2326,81 @@ fn default_true() -> bool {
     true
 }
 
+// ---------------------------------------------------------------------------
+// InternalLimitsConfig — tuneable resource/capacity limits
+// ---------------------------------------------------------------------------
+
+fn default_max_receipts() -> usize {
+    10_000
+}
+fn default_max_receipts_per_agent() -> usize {
+    500
+}
+fn default_event_history_size() -> usize {
+    1000
+}
+fn default_max_concurrent_bg_llm() -> usize {
+    5
+}
+fn default_max_consecutive_cron_errors() -> u32 {
+    5
+}
+fn default_max_pending_approvals_per_agent() -> usize {
+    5
+}
+fn default_max_recent_approvals() -> usize {
+    100
+}
+fn default_max_agent_call_depth() -> u32 {
+    5
+}
+
+/// Internal resource and capacity limits that control bounded data structures
+/// and concurrency ceilings throughout the kernel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InternalLimitsConfig {
+    /// Maximum total message receipts stored (default: 10000).
+    #[serde(default = "default_max_receipts")]
+    pub max_receipts: usize,
+    /// Maximum receipts per agent (default: 500).
+    #[serde(default = "default_max_receipts_per_agent")]
+    pub max_receipts_per_agent: usize,
+    /// Event bus history buffer size (default: 1000).
+    #[serde(default = "default_event_history_size")]
+    pub event_history_size: usize,
+    /// Maximum concurrent background LLM calls (default: 5).
+    #[serde(default = "default_max_concurrent_bg_llm")]
+    pub max_concurrent_bg_llm: usize,
+    /// Consecutive cron errors before auto-disable (default: 5).
+    #[serde(default = "default_max_consecutive_cron_errors")]
+    pub max_consecutive_cron_errors: u32,
+    /// Maximum pending approval requests per agent (default: 5).
+    #[serde(default = "default_max_pending_approvals_per_agent")]
+    pub max_pending_approvals_per_agent: usize,
+    /// Maximum recent approval records to keep (default: 100).
+    #[serde(default = "default_max_recent_approvals")]
+    pub max_recent_approvals: usize,
+    /// Maximum nested agent call depth (default: 5).
+    #[serde(default = "default_max_agent_call_depth")]
+    pub max_agent_call_depth: u32,
+}
+
+impl Default for InternalLimitsConfig {
+    fn default() -> Self {
+        Self {
+            max_receipts: default_max_receipts(),
+            max_receipts_per_agent: default_max_receipts_per_agent(),
+            event_history_size: default_event_history_size(),
+            max_concurrent_bg_llm: default_max_concurrent_bg_llm(),
+            max_consecutive_cron_errors: default_max_consecutive_cron_errors(),
+            max_pending_approvals_per_agent: default_max_pending_approvals_per_agent(),
+            max_recent_approvals: default_max_recent_approvals(),
+            max_agent_call_depth: default_max_agent_call_depth(),
+        }
+    }
+}
+
 impl Default for KernelConfig {
     fn default() -> Self {
         let home_dir = librefang_home_dir();
@@ -2400,6 +2478,7 @@ impl Default for KernelConfig {
             telemetry: TelemetryConfig::default(),
             prompt_intelligence: PromptIntelligenceConfig::default(),
             update_channel: UpdateChannel::default(),
+            internal_limits: InternalLimitsConfig::default(),
         }
     }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -80,6 +80,7 @@ impl KernelConfig {
             "sanitize",
             "telemetry",
             "update_channel",
+            "internal_limits",
         ]
     }
 


### PR DESCRIPTION
## Summary
- New `[internal_limits]` config section for resource tracking caps
- Covers: max_receipts (10000), max_receipts_per_agent (500), event_history_size (1000), max_concurrent_bg_llm (5), max_consecutive_cron_errors (5), approval limits (5/100), max_agent_call_depth (5)

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes