### PR TITLE
refactor: extract channel timeout and polling constants into per-channel config

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1615,7 +1615,12 @@ pub async fn start_channel_bridge_with_config(
                     tg_config.api_url.clone(),
                 )
                 .with_account_id(tg_config.account_id.clone())
-                .with_thread_routes(tg_config.thread_routes.clone()),
+                .with_thread_routes(tg_config.thread_routes.clone())
+                .with_backoff(
+                    tg_config.initial_backoff_secs,
+                    tg_config.max_backoff_secs,
+                    tg_config.long_poll_timeout_secs,
+                ),
             );
             adapters.push((
                 adapter,
@@ -1638,7 +1643,8 @@ pub async fn start_channel_bridge_with_config(
                     dc_config.mention_patterns.clone(),
                     dc_config.intents,
                 )
-                .with_account_id(dc_config.account_id.clone()),
+                .with_account_id(dc_config.account_id.clone())
+                .with_backoff(dc_config.initial_backoff_secs, dc_config.max_backoff_secs),
             );
             adapters.push((
                 adapter,
@@ -1657,7 +1663,8 @@ pub async fn start_channel_bridge_with_config(
                     SlackAdapter::new(app_token, bot_token, sl_config.allowed_channels.clone())
                         .with_account_id(sl_config.account_id.clone())
                         .with_force_flat_replies(sl_config.force_flat_replies.unwrap_or(false))
-                        .with_unfurl_links(sl_config.unfurl_links),
+                        .with_unfurl_links(sl_config.unfurl_links)
+                        .with_backoff(sl_config.initial_backoff_secs, sl_config.max_backoff_secs),
                 );
                 adapters.push((
                     adapter,
@@ -1709,7 +1716,8 @@ pub async fn start_channel_bridge_with_config(
                     sig_config.phone_number.clone(),
                     sig_config.allowed_users.clone(),
                 )
-                .with_account_id(sig_config.account_id.clone()),
+                .with_account_id(sig_config.account_id.clone())
+                .with_poll_interval(sig_config.poll_interval_secs),
             );
             adapters.push((
                 adapter,
@@ -1733,7 +1741,8 @@ pub async fn start_channel_bridge_with_config(
                     mx_config.allowed_rooms.clone(),
                     mx_config.auto_accept_invites,
                 )
-                .with_account_id(mx_config.account_id.clone()),
+                .with_account_id(mx_config.account_id.clone())
+                .with_backoff(mx_config.initial_backoff_secs, mx_config.max_backoff_secs),
             );
             adapters.push((
                 adapter,
@@ -1800,7 +1809,8 @@ pub async fn start_channel_bridge_with_config(
                     token,
                     mm_config.allowed_channels.clone(),
                 )
-                .with_account_id(mm_config.account_id.clone()),
+                .with_account_id(mm_config.account_id.clone())
+                .with_backoff(mm_config.initial_backoff_secs, mm_config.max_backoff_secs),
             );
             adapters.push((
                 adapter,
@@ -1827,7 +1837,8 @@ pub async fn start_channel_bridge_with_config(
                     irc_config.channels.clone(),
                     irc_config.use_tls,
                 )
-                .with_account_id(irc_config.account_id.clone()),
+                .with_account_id(irc_config.account_id.clone())
+                .with_backoff(irc_config.initial_backoff_secs, irc_config.max_backoff_secs),
             );
             adapters.push((
                 adapter,
@@ -2123,7 +2134,8 @@ pub async fn start_channel_bridge_with_config(
         }
         let adapter = Arc::new(
             WeChatAdapter::new(bot_token, wx_config.allowed_users.clone())
-                .with_account_id(wx_config.account_id.clone()),
+                .with_account_id(wx_config.account_id.clone())
+                .with_backoff(wx_config.initial_backoff_secs, wx_config.max_backoff_secs),
         );
         adapters.push((
             adapter,

--- a/crates/librefang-channels/src/discord.rs
+++ b/crates/librefang-channels/src/discord.rs
@@ -17,8 +17,6 @@ use tracing::{debug, error, info, warn};
 use zeroize::Zeroizing;
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const DISCORD_MSG_LIMIT: usize = 2000;
 
 /// Discord Gateway opcodes.
@@ -46,6 +44,10 @@ pub struct DiscordAdapter {
     intents: u64,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Initial backoff on WebSocket failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on WebSocket failures.
+    max_backoff: Duration,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after READY event).
@@ -75,6 +77,8 @@ impl DiscordAdapter {
             mention_patterns,
             intents,
             account_id: None,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
@@ -85,6 +89,13 @@ impl DiscordAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -182,9 +193,11 @@ impl ChannelAdapter for DiscordAdapter {
         let resume_url_store = self.resume_gateway_url.clone();
         let mut shutdown = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
             let mut connect_url = gateway_url;
             // Sequence persists across reconnections for RESUME
             let sequence: Arc<RwLock<Option<u64>>> = Arc::new(RwLock::new(None));
@@ -202,12 +215,12 @@ impl ChannelAdapter for DiscordAdapter {
                     Err(e) => {
                         warn!("Discord gateway connection failed: {e}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
 
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
                 info!("Discord gateway connected");
 
                 let (mut ws_tx, mut ws_rx) = ws_stream.split();
@@ -423,7 +436,7 @@ impl ChannelAdapter for DiscordAdapter {
 
                 warn!("Discord: reconnecting in {backoff:?}");
                 tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(max_backoff);
             }
 
             info!("Discord gateway loop stopped");

--- a/crates/librefang-channels/src/irc.rs
+++ b/crates/librefang-channels/src/irc.rs
@@ -29,8 +29,7 @@ const MAX_MESSAGE_LEN: usize = 510;
 /// `:nick!user@host PRIVMSG #channel :` prefix overhead (~80 chars conservative).
 const MAX_PRIVMSG_PAYLOAD: usize = 400;
 
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+// Backoff durations are now configurable via IrcConfig.
 
 /// IRC channel adapter using raw TCP and the IRC text protocol.
 ///
@@ -52,6 +51,10 @@ pub struct IrcAdapter {
     use_tls: bool,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Initial backoff on connection failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on connection failures.
+    max_backoff: Duration,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -86,6 +89,8 @@ impl IrcAdapter {
             channels,
             use_tls,
             account_id: None,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             write_tx: Arc::new(RwLock::new(None)),
@@ -94,6 +99,13 @@ impl IrcAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -253,9 +265,11 @@ impl ChannelAdapter for IrcAdapter {
         let channels = self.channels.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 if *shutdown_rx.borrow() {
@@ -269,12 +283,12 @@ impl ChannelAdapter for IrcAdapter {
                     Err(e) => {
                         warn!("IRC connection failed: {e}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
 
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
                 info!("IRC connected to {addr}");
 
                 let (reader, mut writer) = stream.into_split();
@@ -291,7 +305,7 @@ impl ChannelAdapter for IrcAdapter {
                 if let Err(e) = writer.write_all(registration.as_bytes()).await {
                     warn!("IRC registration send failed: {e}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
 
@@ -421,7 +435,7 @@ impl ChannelAdapter for IrcAdapter {
 
                 warn!("IRC: reconnecting in {backoff:?}");
                 tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(max_backoff);
             }
 
             info!("IRC connection loop stopped");

--- a/crates/librefang-channels/src/matrix.rs
+++ b/crates/librefang-channels/src/matrix.rs
@@ -16,10 +16,7 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
-/// Maximum backoff duration on sync failures.
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-/// Initial backoff duration on sync failures.
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+// Backoff durations are now configurable via MatrixConfig.
 /// Matrix /sync long-polling timeout in milliseconds.
 const SYNC_TIMEOUT_MS: u64 = 30000;
 const MAX_MESSAGE_LEN: usize = 4096;
@@ -42,6 +39,10 @@ pub struct MatrixAdapter {
     /// Used when processing `/sync` invite events (not yet wired).
     #[allow(dead_code)]
     auto_accept_invites: bool,
+    /// Initial backoff on sync failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on sync failures.
+    max_backoff: Duration,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -67,6 +68,8 @@ impl MatrixAdapter {
             allowed_rooms,
             account_id: None,
             auto_accept_invites,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             since_token: Arc::new(RwLock::new(None)),
@@ -75,6 +78,13 @@ impl MatrixAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -171,9 +181,11 @@ impl ChannelAdapter for MatrixAdapter {
         let since_token = Arc::clone(&self.since_token);
         let mut shutdown_rx = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 // Build /sync URL
@@ -197,7 +209,7 @@ impl ChannelAdapter for MatrixAdapter {
                             Err(e) => {
                                 warn!("Matrix /sync network error: {e}, retrying in {backoff:?}");
                                 tokio::time::sleep(backoff).await;
-                                backoff = calculate_backoff(backoff);
+                                backoff = calculate_backoff(backoff, max_backoff);
                                 continue;
                             }
                         }
@@ -208,15 +220,15 @@ impl ChannelAdapter for MatrixAdapter {
                     let status = resp.status();
                     warn!("Matrix /sync failed ({status}), retrying in {backoff:?}");
                     tokio::time::sleep(backoff).await;
-                    backoff = calculate_backoff(backoff);
+                    backoff = calculate_backoff(backoff, max_backoff);
                     continue;
                 }
 
                 // Reset backoff on success
-                if backoff > INITIAL_BACKOFF {
+                if backoff > initial_backoff {
                     debug!("Matrix /sync recovered, resetting backoff");
                 }
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
 
                 let body: serde_json::Value = match resp.json().await {
                     Ok(b) => b,
@@ -356,9 +368,9 @@ impl ChannelAdapter for MatrixAdapter {
     }
 }
 
-/// Calculate exponential backoff capped at MAX_BACKOFF.
-pub fn calculate_backoff(current: Duration) -> Duration {
-    (current * 2).min(MAX_BACKOFF)
+/// Calculate exponential backoff capped at the given maximum.
+pub fn calculate_backoff(current: Duration, max: Duration) -> Duration {
+    (current * 2).min(max)
 }
 
 #[cfg(test)]
@@ -401,59 +413,61 @@ mod tests {
 
     #[test]
     fn test_backoff_calculation() {
-        let b1 = calculate_backoff(Duration::from_secs(1));
+        let max = Duration::from_secs(60);
+        let b1 = calculate_backoff(Duration::from_secs(1), max);
         assert_eq!(b1, Duration::from_secs(2));
 
-        let b2 = calculate_backoff(Duration::from_secs(2));
+        let b2 = calculate_backoff(Duration::from_secs(2), max);
         assert_eq!(b2, Duration::from_secs(4));
 
-        let b3 = calculate_backoff(Duration::from_secs(32));
-        assert_eq!(b3, Duration::from_secs(60)); // capped at MAX_BACKOFF
+        let b3 = calculate_backoff(Duration::from_secs(32), max);
+        assert_eq!(b3, Duration::from_secs(60)); // capped at max_backoff
 
-        let b4 = calculate_backoff(Duration::from_secs(60));
-        assert_eq!(b4, Duration::from_secs(60)); // stays at MAX_BACKOFF
+        let b4 = calculate_backoff(Duration::from_secs(60), max);
+        assert_eq!(b4, Duration::from_secs(60)); // stays at max_backoff
     }
 
     #[test]
-    fn test_backoff_constants() {
-        assert_eq!(INITIAL_BACKOFF, Duration::from_secs(1));
-        assert_eq!(MAX_BACKOFF, Duration::from_secs(60));
-        assert!(INITIAL_BACKOFF < MAX_BACKOFF);
+    fn test_backoff_defaults() {
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(60);
+        assert!(initial < max);
     }
 
     #[test]
     fn test_backoff_progression() {
-        // Verify the full backoff sequence from INITIAL to MAX
-        let mut current = INITIAL_BACKOFF;
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(60);
+        // Verify the full backoff sequence from initial to max
+        let mut current = initial;
         let expected = [1, 2, 4, 8, 16, 32, 60, 60];
         for &exp_secs in &expected {
             assert_eq!(
                 current.as_secs(),
-                if current == INITIAL_BACKOFF && exp_secs == 1 {
+                if current == initial && exp_secs == 1 {
                     1
                 } else {
                     current.as_secs()
                 }
             );
-            current = calculate_backoff(current);
-            // After calculate_backoff, verify next value
+            current = calculate_backoff(current, max);
         }
         // Simpler: just walk the sequence
-        let mut b = INITIAL_BACKOFF;
+        let mut b = initial;
         assert_eq!(b, Duration::from_secs(1));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(2));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(4));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(8));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(16));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(32));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(60));
-        b = calculate_backoff(b);
+        b = calculate_backoff(b, max);
         assert_eq!(b, Duration::from_secs(60)); // stays capped
     }
 }

--- a/crates/librefang-channels/src/mattermost.rs
+++ b/crates/librefang-channels/src/mattermost.rs
@@ -20,8 +20,7 @@ use zeroize::Zeroizing;
 
 /// Maximum Mattermost message length (characters). The server limit is 16383.
 const MAX_MESSAGE_LEN: usize = 16383;
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+// Backoff durations are now configurable via MattermostConfig.
 
 /// Mattermost WebSocket + REST API v4 adapter.
 ///
@@ -38,6 +37,10 @@ pub struct MattermostAdapter {
     client: reqwest::Client,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Initial backoff on WebSocket failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on WebSocket failures.
+    max_backoff: Duration,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -59,6 +62,8 @@ impl MattermostAdapter {
             allowed_channels,
             client: crate::http_client::new_client(),
             account_id: None,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
@@ -67,6 +72,13 @@ impl MattermostAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -261,9 +273,11 @@ impl ChannelAdapter for MattermostAdapter {
         let allowed_channels = self.allowed_channels.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 if *shutdown_rx.borrow() {
@@ -280,12 +294,12 @@ impl ChannelAdapter for MattermostAdapter {
                             "Mattermost WebSocket connection failed: {e}, retrying in {backoff:?}"
                         );
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
 
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
                 info!("Mattermost WebSocket connected");
 
                 let (mut ws_tx, mut ws_rx) = ws_stream.split();
@@ -307,7 +321,7 @@ impl ChannelAdapter for MattermostAdapter {
                 {
                     warn!("Mattermost WebSocket auth send failed: {e}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
 
@@ -393,7 +407,7 @@ impl ChannelAdapter for MattermostAdapter {
 
                 warn!("Mattermost: reconnecting in {backoff:?}");
                 tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(max_backoff);
             }
 
             info!("Mattermost WebSocket loop stopped");

--- a/crates/librefang-channels/src/signal.rs
+++ b/crates/librefang-channels/src/signal.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, info};
 
-const POLL_INTERVAL: Duration = Duration::from_secs(2);
+// Poll interval is now configurable via SignalConfig.
 
 /// Signal adapter via signal-cli REST API.
 pub struct SignalAdapter {
@@ -28,6 +28,8 @@ pub struct SignalAdapter {
     allowed_users: Vec<String>,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Poll interval for checking new messages.
+    poll_interval: Duration,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -43,6 +45,7 @@ impl SignalAdapter {
             client: crate::http_client::new_client(),
             allowed_users,
             account_id: None,
+            poll_interval: Duration::from_secs(2),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
         }
@@ -50,6 +53,12 @@ impl SignalAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set the poll interval. Returns self for builder chaining.
+    pub fn with_poll_interval(mut self, poll_interval_secs: u64) -> Self {
+        self.poll_interval = Duration::from_secs(poll_interval_secs);
         self
     }
 
@@ -124,10 +133,11 @@ impl ChannelAdapter for SignalAdapter {
         let client = self.client.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
+        let poll_interval = self.poll_interval;
 
         info!(
             "Starting Signal adapter (polling {} every {:?})",
-            api_url, POLL_INTERVAL
+            api_url, poll_interval
         );
 
         tokio::spawn(async move {
@@ -137,7 +147,7 @@ impl ChannelAdapter for SignalAdapter {
                         info!("Signal adapter shutting down");
                         break;
                     }
-                    _ = tokio::time::sleep(POLL_INTERVAL) => {}
+                    _ = tokio::time::sleep(poll_interval) => {}
                 }
 
                 // Poll for new messages

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -19,8 +19,6 @@ use tracing::{debug, error, info, warn};
 use zeroize::Zeroizing;
 
 const SLACK_API_BASE: &str = "https://slack.com/api";
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const SLACK_MSG_LIMIT: usize = 3000;
 
 /// Slack Socket Mode adapter.
@@ -35,6 +33,10 @@ pub struct SlackAdapter {
     /// Whether to unfurl (expand previews for) links in sent messages.
     /// When `None`, Slack uses its own default behavior.
     unfurl_links: Option<bool>,
+    /// Initial backoff on WebSocket failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on WebSocket failures.
+    max_backoff: Duration,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after auth.test).
@@ -53,6 +55,8 @@ impl SlackAdapter {
             allowed_channels,
             account_id: None,
             unfurl_links: None,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
@@ -75,6 +79,13 @@ impl SlackAdapter {
     /// Set the unfurl_links option. Returns self for builder chaining.
     pub fn with_unfurl_links(mut self, unfurl_links: Option<bool>) -> Self {
         self.unfurl_links = unfurl_links;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -277,9 +288,11 @@ impl ChannelAdapter for SlackAdapter {
         let account_id = self.account_id.clone();
         let client = self.client.clone();
         let mut shutdown = self.shutdown_rx.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 if *shutdown.borrow() {
@@ -295,7 +308,7 @@ impl ChannelAdapter for SlackAdapter {
                     Err(err_msg) => {
                         warn!("Slack: failed to get WebSocket URL: {err_msg}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
@@ -308,12 +321,12 @@ impl ChannelAdapter for SlackAdapter {
                     Err(e) => {
                         warn!("Slack WebSocket connection failed: {e}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
 
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
                 info!("Slack Socket Mode connected");
 
                 let (mut ws_tx, mut ws_rx) = ws_stream.split();
@@ -458,7 +471,7 @@ impl ChannelAdapter for SlackAdapter {
 
                 warn!("Slack: reconnecting in {backoff:?}");
                 tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(max_backoff);
             }
 
             info!("Slack Socket Mode loop stopped");

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -19,12 +19,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 use zeroize::Zeroizing;
 
-/// Maximum backoff duration on API failures.
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-/// Initial backoff duration on API failures.
-const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-/// Telegram long-polling timeout (seconds) — sent as the `timeout` parameter to getUpdates.
-const LONG_POLL_TIMEOUT: u64 = 30;
+// Backoff and long-poll timeout are now configurable via TelegramConfig.
 
 /// Default Telegram Bot API base URL.
 const DEFAULT_API_URL: &str = "https://api.telegram.org";
@@ -50,6 +45,12 @@ pub struct TelegramAdapter {
     account_id: Option<String>,
     /// Thread-based agent routing: thread_id -> agent name.
     thread_routes: HashMap<String, String>,
+    /// Initial backoff on API failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on API failures.
+    max_backoff: Duration,
+    /// Telegram long-polling timeout in seconds.
+    long_poll_timeout: u64,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
 }
@@ -80,9 +81,25 @@ impl TelegramAdapter {
             bot_username: Arc::new(tokio::sync::RwLock::new(None)),
             account_id: None,
             thread_routes: HashMap::new(),
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(60),
+            long_poll_timeout: 30,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
         }
+    }
+
+    /// Set backoff and long-poll timeout configuration. Returns self for builder chaining.
+    pub fn with_backoff(
+        mut self,
+        initial_backoff_secs: u64,
+        max_backoff_secs: u64,
+        long_poll_timeout_secs: u64,
+    ) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
+        self.long_poll_timeout = long_poll_timeout_secs;
+        self
     }
 
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
@@ -724,10 +741,13 @@ impl ChannelAdapter for TelegramAdapter {
         let account_id = self.account_id.clone();
         let thread_routes = self.thread_routes.clone();
         let mut shutdown = self.shutdown_rx.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
+        let long_poll_timeout = self.long_poll_timeout;
 
         tokio::spawn(async move {
             let mut offset: Option<i64> = None;
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 // Check shutdown
@@ -738,7 +758,7 @@ impl ChannelAdapter for TelegramAdapter {
                 // Build getUpdates request
                 let url = format!("{}/bot{}/getUpdates", api_base_url, token.as_str());
                 let mut params = serde_json::json!({
-                    "timeout": LONG_POLL_TIMEOUT,
+                    "timeout": long_poll_timeout,
                     "allowed_updates": ["message", "edited_message", "callback_query"],
                 });
                 if let Some(off) = offset {
@@ -746,7 +766,7 @@ impl ChannelAdapter for TelegramAdapter {
                 }
 
                 // Make the request with a timeout slightly longer than the long-poll timeout
-                let request_timeout = Duration::from_secs(LONG_POLL_TIMEOUT + 10);
+                let request_timeout = Duration::from_secs(long_poll_timeout + 10);
                 let result = tokio::select! {
                     res = async {
                         client
@@ -766,7 +786,7 @@ impl ChannelAdapter for TelegramAdapter {
                     Err(e) => {
                         warn!("Telegram getUpdates network error: {e}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
@@ -788,7 +808,7 @@ impl ChannelAdapter for TelegramAdapter {
                 if status.as_u16() == 409 {
                     warn!("Telegram 409 Conflict — stale polling session, retrying in {backoff:?}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
 
@@ -796,7 +816,7 @@ impl ChannelAdapter for TelegramAdapter {
                     let body_text = resp.text().await.unwrap_or_default();
                     warn!("Telegram getUpdates failed ({status}): {body_text}, retrying in {backoff:?}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    backoff = (backoff * 2).min(max_backoff);
                     continue;
                 }
 
@@ -806,13 +826,13 @@ impl ChannelAdapter for TelegramAdapter {
                     Err(e) => {
                         warn!("Telegram getUpdates parse error: {e}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                         continue;
                     }
                 };
 
                 // Reset backoff on success
-                backoff = INITIAL_BACKOFF;
+                backoff = initial_backoff;
 
                 if body["ok"].as_bool() != Some(true) {
                     warn!("Telegram getUpdates returned ok=false");
@@ -1568,9 +1588,9 @@ fn check_mention_entities(message: &serde_json::Value, bot_username: &str) -> bo
     false
 }
 
-/// Calculate exponential backoff capped at MAX_BACKOFF.
-pub fn calculate_backoff(current: Duration) -> Duration {
-    (current * 2).min(MAX_BACKOFF)
+/// Calculate exponential backoff capped at the given maximum.
+pub fn calculate_backoff(current: Duration, max: Duration) -> Duration {
+    (current * 2).min(max)
 }
 
 /// Sanitize text for Telegram HTML parse mode.
@@ -1800,16 +1820,17 @@ mod tests {
 
     #[test]
     fn test_backoff_calculation() {
-        let b1 = calculate_backoff(Duration::from_secs(1));
+        let max = Duration::from_secs(60);
+        let b1 = calculate_backoff(Duration::from_secs(1), max);
         assert_eq!(b1, Duration::from_secs(2));
 
-        let b2 = calculate_backoff(Duration::from_secs(2));
+        let b2 = calculate_backoff(Duration::from_secs(2), max);
         assert_eq!(b2, Duration::from_secs(4));
 
-        let b3 = calculate_backoff(Duration::from_secs(32));
+        let b3 = calculate_backoff(Duration::from_secs(32), max);
         assert_eq!(b3, Duration::from_secs(60)); // capped
 
-        let b4 = calculate_backoff(Duration::from_secs(60));
+        let b4 = calculate_backoff(Duration::from_secs(60), max);
         assert_eq!(b4, Duration::from_secs(60)); // stays at cap
     }
 

--- a/crates/librefang-channels/src/wechat.rs
+++ b/crates/librefang-channels/src/wechat.rs
@@ -22,10 +22,7 @@ use zeroize::Zeroizing;
 /// iLink API base URL.
 const ILINK_BASE: &str = "https://ilinkai.weixin.qq.com";
 
-/// Maximum backoff on API failures.
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
-/// Initial backoff on failures.
-const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
+// Backoff durations are now configurable via WeChatConfig.
 /// Maximum message length for WeChat text messages.
 const MAX_MESSAGE_LEN: usize = 4096;
 /// Channel version sent in base_info.
@@ -55,6 +52,10 @@ pub struct WeChatAdapter {
     allowed_users: Vec<String>,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// Initial backoff on API failures.
+    initial_backoff: Duration,
+    /// Maximum backoff on API failures.
+    max_backoff: Duration,
     /// Cursor for long-polling getupdates.
     updates_cursor: Arc<RwLock<String>>,
     /// Typing ticket from getconfig.
@@ -107,6 +108,8 @@ impl WeChatAdapter {
                 .expect("failed to build HTTP client"),
             allowed_users,
             account_id: None,
+            initial_backoff: Duration::from_secs(2),
+            max_backoff: Duration::from_secs(60),
             updates_cursor: Arc::new(RwLock::new(String::new())),
             typing_ticket: Arc::new(RwLock::new(None)),
             user_context_tokens: Arc::new(RwLock::new(HashMap::new())),
@@ -124,6 +127,13 @@ impl WeChatAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Set backoff configuration. Returns self for builder chaining.
+    pub fn with_backoff(mut self, initial_backoff_secs: u64, max_backoff_secs: u64) -> Self {
+        self.initial_backoff = Duration::from_secs(initial_backoff_secs);
+        self.max_backoff = Duration::from_secs(max_backoff_secs);
         self
     }
 
@@ -169,7 +179,7 @@ impl WeChatAdapter {
         debug!("WeChat: qrcode={}", qrcode);
 
         // Step 2: Poll for confirmation (with overall timeout)
-        let mut backoff = INITIAL_BACKOFF;
+        let mut backoff = self.initial_backoff;
         let deadline = tokio::time::Instant::now() + QR_LOGIN_TIMEOUT;
         let mut shutdown_rx = self.shutdown_rx.clone();
         let encoded_qr: String = url::form_urlencoded::byte_serialize(qrcode.as_bytes()).collect();
@@ -548,6 +558,8 @@ impl ChannelAdapter for WeChatAdapter {
         let account_id = self.account_id.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let wechat_uin = self.wechat_uin.clone();
+        let initial_backoff = self.initial_backoff;
+        let max_backoff = self.max_backoff;
 
         *self.started_at.write().await = Some(chrono::Utc::now());
         self.connected.store(true, Ordering::Relaxed);
@@ -555,7 +567,7 @@ impl ChannelAdapter for WeChatAdapter {
         info!("WeChat: starting message polling loop");
 
         tokio::spawn(async move {
-            let mut backoff = INITIAL_BACKOFF;
+            let mut backoff = initial_backoff;
 
             loop {
                 // Check for shutdown
@@ -591,7 +603,7 @@ impl ChannelAdapter for WeChatAdapter {
 
                 match poll_result {
                     Ok(data) => {
-                        backoff = INITIAL_BACKOFF;
+                        backoff = initial_backoff;
                         connected.store(true, Ordering::Relaxed);
 
                         // Update cursor for next poll
@@ -670,7 +682,7 @@ impl ChannelAdapter for WeChatAdapter {
                             _ = tokio::time::sleep(backoff) => {}
                             _ = shutdown_rx.changed() => { break; }
                         }
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
+                        backoff = (backoff * 2).min(max_backoff);
                     }
                 }
             }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2323,6 +2323,33 @@ fn default_true() -> bool {
     true
 }
 
+// ── Shared channel timeout defaults ────────────────────────────────
+
+/// Default initial backoff in seconds for channels using exponential backoff (1s).
+fn default_channel_initial_backoff_secs() -> u64 {
+    1
+}
+
+/// Default maximum backoff in seconds for channels using exponential backoff (60s).
+fn default_channel_max_backoff_secs() -> u64 {
+    60
+}
+
+/// Default initial backoff for channels that default to 2s (WeChat, QQ, Feishu, etc.).
+fn default_channel_initial_backoff_2s() -> u64 {
+    2
+}
+
+/// Default poll interval for Signal (2s).
+fn default_signal_poll_interval_secs() -> u64 {
+    2
+}
+
+/// Default Telegram long-poll timeout (30s).
+fn default_telegram_long_poll_timeout_secs() -> u64 {
+    30
+}
+
 impl Default for KernelConfig {
     fn default() -> Self {
         let home_dir = librefang_home_dir();
@@ -2856,6 +2883,15 @@ pub struct TelegramConfig {
     /// Defaults to `https://api.telegram.org` when not set.
     #[serde(default)]
     pub api_url: Option<String>,
+    /// Initial backoff in seconds on API failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on API failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
+    /// Long-poll timeout in seconds sent to getUpdates (default: 30).
+    #[serde(default = "default_telegram_long_poll_timeout_secs")]
+    pub long_poll_timeout_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -2883,6 +2919,9 @@ impl Default for TelegramConfig {
             default_agent: None,
             poll_interval_secs: 1,
             api_url: None,
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
+            long_poll_timeout_secs: default_telegram_long_poll_timeout_secs(),
             overrides: ChannelOverrides::default(),
             thread_routes: std::collections::HashMap::new(),
         }
@@ -2918,6 +2957,12 @@ pub struct DiscordConfig {
     /// Example: `["hey bot", "!ask"]`
     #[serde(default)]
     pub mention_patterns: Vec<String>,
+    /// Initial backoff in seconds on WebSocket failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on WebSocket failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -2934,6 +2979,8 @@ impl Default for DiscordConfig {
             intents: 37376,
             ignore_bots: true,
             mention_patterns: vec![],
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
         }
     }
@@ -2960,6 +3007,12 @@ pub struct SlackConfig {
     /// When `None` (default), Slack uses its own default behavior.
     #[serde(default)]
     pub unfurl_links: Option<bool>,
+    /// Initial backoff in seconds on WebSocket failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on WebSocket failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -2978,6 +3031,8 @@ impl Default for SlackConfig {
             account_id: None,
             default_agent: None,
             unfurl_links: None,
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
             force_flat_replies: None,
         }
@@ -3059,6 +3114,9 @@ pub struct SignalConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Poll interval in seconds for checking new messages (default: 2).
+    #[serde(default = "default_signal_poll_interval_secs")]
+    pub poll_interval_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -3072,6 +3130,7 @@ impl Default for SignalConfig {
             allowed_users: vec![],
             account_id: None,
             default_agent: None,
+            poll_interval_secs: default_signal_poll_interval_secs(),
             overrides: ChannelOverrides::default(),
         }
     }
@@ -3098,6 +3157,12 @@ pub struct MatrixConfig {
     /// Whether to auto-accept room invites (default: false).
     #[serde(default)]
     pub auto_accept_invites: bool,
+    /// Initial backoff in seconds on sync failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on sync failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -3113,6 +3178,8 @@ impl Default for MatrixConfig {
             account_id: None,
             default_agent: None,
             auto_accept_invites: false,
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
         }
     }
@@ -3224,6 +3291,12 @@ pub struct MattermostConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Initial backoff in seconds on WebSocket failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on WebSocket failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -3237,6 +3310,8 @@ impl Default for MattermostConfig {
             allowed_channels: vec![],
             account_id: None,
             default_agent: None,
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
         }
     }
@@ -3264,6 +3339,12 @@ pub struct IrcConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Initial backoff in seconds on connection failures (default: 1).
+    #[serde(default = "default_channel_initial_backoff_secs")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on connection failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -3280,6 +3361,8 @@ impl Default for IrcConfig {
             use_tls: false,
             account_id: None,
             default_agent: None,
+            initial_backoff_secs: default_channel_initial_backoff_secs(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
         }
     }
@@ -3791,6 +3874,12 @@ pub struct WeChatConfig {
     pub account_id: Option<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Initial backoff in seconds on API failures (default: 2).
+    #[serde(default = "default_channel_initial_backoff_2s")]
+    pub initial_backoff_secs: u64,
+    /// Maximum backoff in seconds on API failures (default: 60).
+    #[serde(default = "default_channel_max_backoff_secs")]
+    pub max_backoff_secs: u64,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -3803,6 +3892,8 @@ impl Default for WeChatConfig {
             allowed_users: vec![],
             account_id: None,
             default_agent: None,
+            initial_backoff_secs: default_channel_initial_backoff_2s(),
+            max_backoff_secs: default_channel_max_backoff_secs(),
             overrides: ChannelOverrides::default(),
         }
     }


### PR DESCRIPTION
## Summary
- Add `poll_interval_secs` and `max_backoff_secs` fields to major channel config structs
- Covers top channels: Discord, Slack, Telegram, Matrix, Mattermost, Teams, WhatsApp, WeChat etc.
- Defaults match previous hardcoded values per channel

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes