### PR TITLE
refactor: extract channel message length limits into per-channel config

### DIFF
--- a/crates/librefang-channels/src/bluesky.rs
+++ b/crates/librefang-channels/src/bluesky.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroizing;
 const DEFAULT_SERVICE_URL: &str = "https://bsky.social";
 
 /// Maximum Bluesky post length (grapheme clusters).
-const MAX_MESSAGE_LEN: usize = 300;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 300;
 
 /// Notification poll interval in seconds.
 const POLL_INTERVAL_SECS: u64 = 5;
@@ -53,6 +53,8 @@ pub struct BlueskyAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached session (access_jwt, refresh_jwt, did, expiry).
     session: Arc<RwLock<Option<BlueskySession>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 /// Cached Bluesky session data.
@@ -79,6 +81,14 @@ impl BlueskyAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -224,7 +234,7 @@ impl BlueskyAdapter {
         let (token, did) = self.get_token().await?;
         let url = format!("{}/xrpc/com.atproto.repo.createRecord", self.service_url);
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 20000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 20000;
 const DINGTALK_SEND_URL: &str = "https://oapi.dingtalk.com/robot/send";
 
 /// DingTalk Robot channel adapter.
@@ -39,6 +39,8 @@ pub struct DingTalkAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl DingTalkAdapter {
@@ -58,11 +60,20 @@ impl DingTalkAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -293,7 +304,7 @@ impl ChannelAdapter for DingTalkAdapter {
             _ => "(Unsupported content type)".to_string(),
         };
 
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
         let num_chunks = chunks.len();
 
         for chunk in chunks {

--- a/crates/librefang-channels/src/discord.rs
+++ b/crates/librefang-channels/src/discord.rs
@@ -19,7 +19,7 @@ use zeroize::Zeroizing;
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-const DISCORD_MSG_LIMIT: usize = 2000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 2000;
 
 /// Discord Gateway opcodes.
 mod opcode {
@@ -54,6 +54,8 @@ pub struct DiscordAdapter {
     session_id: Arc<RwLock<Option<String>>>,
     /// Resume gateway URL.
     resume_gateway_url: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl DiscordAdapter {
@@ -80,11 +82,20 @@ impl DiscordAdapter {
             bot_user_id: Arc::new(RwLock::new(None)),
             session_id: Arc::new(RwLock::new(None)),
             resume_gateway_url: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -114,7 +125,7 @@ impl DiscordAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{DISCORD_API_BASE}/channels/{channel_id}/messages");
-        let chunks = split_message(text, DISCORD_MSG_LIMIT);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({ "content": chunk });

--- a/crates/librefang-channels/src/discourse.rs
+++ b/crates/librefang-channels/src/discourse.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 const POLL_INTERVAL_SECS: u64 = 10;
-const MAX_MESSAGE_LEN: usize = 32000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 32000;
 
 /// Discourse forum channel adapter.
 ///
@@ -43,6 +43,8 @@ pub struct DiscourseAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last seen post ID (for incremental polling).
     last_post_id: Arc<RwLock<u64>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl DiscourseAdapter {
@@ -71,11 +73,20 @@ impl DiscourseAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_post_id: Arc::new(RwLock::new(0)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -140,7 +151,7 @@ impl DiscourseAdapter {
         raw: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/posts.json", self.base_url);
-        let chunks = split_message(raw, MAX_MESSAGE_LEN);
+        let chunks = split_message(raw, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/feishu.rs
+++ b/crates/librefang-channels/src/feishu.rs
@@ -105,7 +105,7 @@ pub enum FeishuReceiveMode {
 // ---------------------------------------------------------------------------
 
 /// Maximum Feishu message text length (characters).
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// Token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
@@ -149,6 +149,8 @@ pub struct FeishuAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached tenant access token and its expiry instant.
     cached_token: Arc<RwLock<Option<(String, Instant)>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl FeishuAdapter {
@@ -180,6 +182,14 @@ impl FeishuAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -271,7 +281,7 @@ impl FeishuAdapter {
             url::form_urlencoded::byte_serialize(receive_id_type.as_bytes()).collect();
         let url = format!("{}?receive_id_type={}", self.send_url(), encoded_type);
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let content = serde_json::json!({

--- a/crates/librefang-channels/src/flock.rs
+++ b/crates/librefang-channels/src/flock.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 const FLOCK_API_BASE: &str = "https://api.flock.com/v2";
 
 /// Maximum message length for Flock messages.
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// Flock Bot channel adapter using webhook for receiving and REST API for sending.
 ///
@@ -41,6 +41,8 @@ pub struct FlockAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl FlockAdapter {
@@ -58,11 +60,20 @@ impl FlockAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -95,7 +106,7 @@ impl FlockAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/chat.sendMessage", FLOCK_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/gitter.rs
+++ b/crates/librefang-channels/src/gitter.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 const GITTER_STREAM_URL: &str = "https://stream.gitter.im/v1/rooms";
 const GITTER_API_URL: &str = "https://api.gitter.im/v1/rooms";
 
@@ -38,6 +38,8 @@ pub struct GitterAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl GitterAdapter {
@@ -55,11 +57,20 @@ impl GitterAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -113,7 +124,7 @@ impl GitterAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/{}/chatMessages", GITTER_API_URL, self.room_id);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/google_chat.rs
+++ b/crates/librefang-channels/src/google_chat.rs
@@ -24,7 +24,7 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 const TOKEN_REFRESH_MARGIN_SECS: u64 = 300;
 const DEFAULT_TOKEN_LIFETIME_SECS: u64 = 3600;
 const GOOGLE_CHAT_SCOPE: &str = "https://www.googleapis.com/auth/chat.bot";
@@ -103,6 +103,8 @@ pub struct GoogleChatAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached OAuth2 access token with expiry instant.
     cached_token: Arc<RwLock<Option<(String, Instant)>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl GoogleChatAdapter {
@@ -123,11 +125,20 @@ impl GoogleChatAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             cached_token: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -288,7 +299,7 @@ impl GoogleChatAdapter {
         let token = self.get_access_token().await?;
         let url = format!("https://chat.googleapis.com/v1/{}/messages", space_id);
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
         for chunk in chunks {
             let body = serde_json::json!({
                 "text": chunk,

--- a/crates/librefang-channels/src/gotify.rs
+++ b/crates/librefang-channels/src/gotify.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 65535;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 65535;
 
 /// Gotify push notification channel adapter.
 ///
@@ -39,6 +39,8 @@ pub struct GotifyAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl GotifyAdapter {
@@ -59,11 +61,20 @@ impl GotifyAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -106,7 +117,7 @@ impl GotifyAdapter {
             self.server_url,
             self.app_token.as_str()
         );
-        let chunks = split_message(message, MAX_MESSAGE_LEN);
+        let chunks = split_message(message, self.max_msg_len);
 
         for (i, chunk) in chunks.iter().enumerate() {
             let chunk_title = if chunks.len() > 1 {

--- a/crates/librefang-channels/src/guilded.rs
+++ b/crates/librefang-channels/src/guilded.rs
@@ -26,7 +26,7 @@ const GUILDED_API_BASE: &str = "https://www.guilded.gg/api/v1";
 const GUILDED_WS_URL: &str = "wss://www.guilded.gg/websocket/v1";
 
 /// Maximum message length for Guilded messages.
-const MAX_MESSAGE_LEN: usize = 4000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4000;
 
 /// Guilded Bot API channel adapter using WebSocket for events and REST for sending.
 ///
@@ -44,6 +44,8 @@ pub struct GuildedAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl GuildedAdapter {
@@ -61,11 +63,20 @@ impl GuildedAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -95,7 +106,7 @@ impl GuildedAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/channels/{}/messages", GUILDED_API_BASE, channel_id);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -404,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_guilded_constants() {
-        assert_eq!(MAX_MESSAGE_LEN, 4000);
+        assert_eq!(DEFAULT_MAX_MESSAGE_LEN, 4000);
         assert_eq!(GUILDED_WS_URL, "wss://www.guilded.gg/websocket/v1");
     }
 }

--- a/crates/librefang-channels/src/irc.rs
+++ b/crates/librefang-channels/src/irc.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroizing;
 
 /// Maximum IRC message length per RFC 2812 (including CRLF).
 /// We use 510 for the payload (512 minus CRLF).
-const MAX_MESSAGE_LEN: usize = 510;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 510;
 
 /// Maximum length for a single PRIVMSG payload, accounting for the
 /// `:nick!user@host PRIVMSG #channel :` prefix overhead (~80 chars conservative).
@@ -58,6 +58,8 @@ pub struct IrcAdapter {
     /// Shared write handle for sending messages from the `send()` method.
     /// Populated after `start()` connects to the server.
     write_tx: Arc<RwLock<Option<mpsc::Sender<String>>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl IrcAdapter {
@@ -89,11 +91,20 @@ impl IrcAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             write_tx: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -449,7 +460,7 @@ impl ChannelAdapter for IrcAdapter {
         let chunks = split_message(&text, MAX_PRIVMSG_PAYLOAD);
         for chunk in chunks {
             let raw = format!("PRIVMSG {target} :{chunk}\r\n");
-            if raw.len() > MAX_MESSAGE_LEN + 2 {
+            if raw.len() > DEFAULT_MAX_MESSAGE_LEN + 2 {
                 // Shouldn't happen with MAX_PRIVMSG_PAYLOAD, but be safe
                 warn!("IRC message exceeds 512 bytes, truncating");
             }

--- a/crates/librefang-channels/src/keybase.rs
+++ b/crates/librefang-channels/src/keybase.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 /// Maximum message length for Keybase messages.
-const MAX_MESSAGE_LEN: usize = 10000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 10000;
 
 /// Polling interval in seconds for new messages.
 const POLL_INTERVAL_SECS: u64 = 3;
@@ -49,6 +49,8 @@ pub struct KeybaseAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last read message ID per conversation for incremental polling.
     last_msg_ids: Arc<RwLock<HashMap<String, i64>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl KeybaseAdapter {
@@ -69,11 +71,20 @@ impl KeybaseAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_msg_ids: Arc::new(RwLock::new(HashMap::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -160,7 +171,7 @@ impl KeybaseAdapter {
         channel: &serde_json::Value,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let payload = serde_json::json!({

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -29,7 +29,7 @@ const LINE_REPLY_URL: &str = "https://api.line.me/v2/bot/message/reply";
 const LINE_PROFILE_URL: &str = "https://api.line.me/v2/bot/profile";
 
 /// Maximum LINE message text length (characters).
-const MAX_MESSAGE_LEN: usize = 5000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 5000;
 
 /// LINE Messaging API adapter.
 ///
@@ -52,6 +52,8 @@ pub struct LineAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl LineAdapter {
@@ -71,11 +73,20 @@ impl LineAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -165,7 +176,7 @@ impl LineAdapter {
         to: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -203,7 +214,7 @@ impl LineAdapter {
         reply_token: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
         // LINE reply API allows up to 5 messages per reply
         let messages: Vec<serde_json::Value> = chunks
             .into_iter()

--- a/crates/librefang-channels/src/linkedin.rs
+++ b/crates/librefang-channels/src/linkedin.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 const POLL_INTERVAL_SECS: u64 = 10;
-const MAX_MESSAGE_LEN: usize = 3000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 3000;
 const LINKEDIN_API_BASE: &str = "https://api.linkedin.com/rest";
 
 /// LinkedIn Messaging channel adapter.
@@ -41,6 +41,8 @@ pub struct LinkedInAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last seen message timestamp for incremental polling (epoch millis).
     last_seen_ts: Arc<RwLock<i64>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl LinkedInAdapter {
@@ -65,11 +67,20 @@ impl LinkedInAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_seen_ts: Arc::new(RwLock::new(0)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -156,7 +167,7 @@ impl LinkedInAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/organizationMessages", LINKEDIN_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
         let num_chunks = chunks.len();
 
         for chunk in chunks {

--- a/crates/librefang-channels/src/mastodon.rs
+++ b/crates/librefang-channels/src/mastodon.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 /// Maximum Mastodon status length (default server limit).
-const MAX_MESSAGE_LEN: usize = 500;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 500;
 
 /// SSE reconnect delay on error.
 const SSE_RECONNECT_DELAY_SECS: u64 = 5;
@@ -47,6 +47,8 @@ pub struct MastodonAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own account ID (populated after verification).
     own_account_id: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl MastodonAdapter {
@@ -66,11 +68,20 @@ impl MastodonAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             own_account_id: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -110,7 +121,7 @@ impl MastodonAdapter {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/api/v1/statuses", self.instance_url);
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         let mut reply_id = in_reply_to_id.map(|s| s.to_string());
 

--- a/crates/librefang-channels/src/matrix.rs
+++ b/crates/librefang-channels/src/matrix.rs
@@ -22,7 +22,7 @@ const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// Matrix /sync long-polling timeout in milliseconds.
 const SYNC_TIMEOUT_MS: u64 = 30000;
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// Matrix channel adapter using the Client-Server API.
 pub struct MatrixAdapter {
@@ -47,6 +47,8 @@ pub struct MatrixAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Sync token for resuming /sync.
     since_token: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl MatrixAdapter {
@@ -70,11 +72,20 @@ impl MatrixAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             since_token: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -90,7 +101,7 @@ impl MatrixAdapter {
             self.homeserver_url, room_id, txn_id
         );
 
-        let chunks = crate::types::split_message(text, MAX_MESSAGE_LEN);
+        let chunks = crate::types::split_message(text, self.max_msg_len);
         for chunk in chunks {
             let body = serde_json::json!({
                 "msgtype": "m.text",

--- a/crates/librefang-channels/src/mattermost.rs
+++ b/crates/librefang-channels/src/mattermost.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
 /// Maximum Mattermost message length (characters). The server limit is 16383.
-const MAX_MESSAGE_LEN: usize = 16383;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 16383;
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 
@@ -43,6 +43,8 @@ pub struct MattermostAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after /api/v4/users/me).
     bot_user_id: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl MattermostAdapter {
@@ -62,11 +64,20 @@ impl MattermostAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -113,7 +124,7 @@ impl MattermostAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/api/v4/posts", self.server_url);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -456,7 +467,7 @@ impl ChannelAdapter for MattermostAdapter {
         };
 
         let url = format!("{}/api/v4/posts", self.server_url);
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/messenger.rs
+++ b/crates/librefang-channels/src/messenger.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 const GRAPH_API_BASE: &str = "https://graph.facebook.com/v18.0";
 
 /// Maximum Messenger message text length (characters).
-const MAX_MESSAGE_LEN: usize = 2000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 2000;
 
 /// Facebook Messenger Platform adapter.
 ///
@@ -46,6 +46,8 @@ pub struct MessengerAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl MessengerAdapter {
@@ -65,11 +67,20 @@ impl MessengerAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -106,7 +117,7 @@ impl MessengerAdapter {
             self.page_token.as_str()
         );
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/mumble.rs
+++ b/crates/librefang-channels/src/mumble.rs
@@ -20,7 +20,7 @@ use tokio::sync::{mpsc, watch, Mutex};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 5000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 5000;
 const DEFAULT_PORT: u16 = 64738;
 
 // Mumble packet types (protobuf message IDs)
@@ -52,6 +52,8 @@ pub struct MumbleAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl MumbleAdapter {
@@ -82,11 +84,20 @@ impl MumbleAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -494,7 +505,7 @@ impl ChannelAdapter for MumbleAdapter {
             _ => "(Unsupported content type)".to_string(),
         };
 
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
 
         let mut lock = self.stream.lock().await;
         let writer = lock

--- a/crates/librefang-channels/src/nextcloud.rs
+++ b/crates/librefang-channels/src/nextcloud.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 /// Maximum message length for Nextcloud Talk messages.
-const MAX_MESSAGE_LEN: usize = 32000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 32000;
 
 /// Polling interval in seconds for the chat endpoint.
 const POLL_INTERVAL_SECS: u64 = 3;
@@ -46,6 +46,8 @@ pub struct NextcloudAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last known message ID per room for incremental polling.
     last_known_ids: Arc<RwLock<HashMap<String, i64>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl NextcloudAdapter {
@@ -67,11 +69,20 @@ impl NextcloudAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_known_ids: Arc::new(RwLock::new(HashMap::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -136,7 +147,7 @@ impl NextcloudAdapter {
             "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}",
             self.server_url, room_token
         );
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/nostr.rs
+++ b/crates/librefang-channels/src/nostr.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 /// Maximum message length for Nostr events.
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// Nostr NIP-01 relay channel adapter using WebSocket.
 ///
@@ -40,6 +40,8 @@ pub struct NostrAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Set of already-seen event IDs to avoid duplicates across relays.
     seen_events: Arc<RwLock<std::collections::HashSet<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl NostrAdapter {
@@ -57,11 +59,20 @@ impl NostrAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             seen_events: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -126,7 +137,7 @@ impl NostrAdapter {
         recipient_pubkey: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let event_msg = self.build_event(recipient_pubkey, chunk);

--- a/crates/librefang-channels/src/ntfy.rs
+++ b/crates/librefang-channels/src/ntfy.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 const DEFAULT_SERVER_URL: &str = "https://ntfy.sh";
 
 /// ntfy.sh pub/sub channel adapter.
@@ -39,6 +39,8 @@ pub struct NtfyAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl NtfyAdapter {
@@ -63,11 +65,20 @@ impl NtfyAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -117,7 +128,7 @@ impl NtfyAdapter {
         title: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/{}", self.server_url, self.topic);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let mut builder = self.client.post(&url);

--- a/crates/librefang-channels/src/pumble.rs
+++ b/crates/librefang-channels/src/pumble.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 const PUMBLE_API_BASE: &str = "https://api.pumble.com/v1";
 
 /// Maximum message length for Pumble messages.
-const MAX_MESSAGE_LEN: usize = 4000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4000;
 
 /// Pumble Bot channel adapter using webhook for receiving and REST API for sending.
 ///
@@ -41,6 +41,8 @@ pub struct PumbleAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl PumbleAdapter {
@@ -58,11 +60,20 @@ impl PumbleAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -96,7 +107,7 @@ impl PumbleAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/messages", PUMBLE_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -339,7 +350,7 @@ impl ChannelAdapter for PumbleAdapter {
         };
 
         let url = format!("{}/messages", PUMBLE_API_BASE);
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/qq.rs
+++ b/crates/librefang-channels/src/qq.rs
@@ -23,7 +23,7 @@ const QQ_TOKEN_URL: &str = "https://bots.qq.com/app/getAppAccessToken";
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
 /// QQ message length limit (approximate).
-const QQ_MAX_MESSAGE_LEN: usize = 2000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 2000;
 
 /// Intent bit flags for QQ Bot API v2.
 const INTENT_GUILDS: u32 = 1 << 0;
@@ -56,6 +56,8 @@ pub struct QqAdapter {
     last_error: Arc<RwLock<Option<String>>>,
     /// Current access token (refreshed periodically).
     access_token: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl QqAdapter {
@@ -78,11 +80,20 @@ impl QqAdapter {
             started_at: Arc::new(RwLock::new(None)),
             last_error: Arc::new(RwLock::new(None)),
             access_token: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -480,7 +491,7 @@ impl ChannelAdapter for QqAdapter {
         if parts.len() == 2 {
             let endpoint = parts[0];
             let msg_id = parts[1];
-            for chunk in split_message(&text, QQ_MAX_MESSAGE_LEN) {
+            for chunk in split_message(&text, self.max_msg_len) {
                 if let Err(e) = self.send_qq_message(endpoint, msg_id, chunk).await {
                     warn!("QQ: failed to send message: {}", e);
                 }

--- a/crates/librefang-channels/src/reddit.rs
+++ b/crates/librefang-channels/src/reddit.rs
@@ -30,7 +30,7 @@ const REDDIT_API_BASE: &str = "https://oauth.reddit.com";
 const POLL_INTERVAL_SECS: u64 = 5;
 
 /// Maximum Reddit comment/message text length.
-const MAX_MESSAGE_LEN: usize = 10000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 10000;
 
 /// OAuth2 token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
@@ -65,6 +65,8 @@ pub struct RedditAdapter {
     cached_token: Arc<RwLock<Option<(String, Instant)>>>,
     /// Track last seen comment IDs to avoid duplicates.
     seen_comments: Arc<RwLock<HashMap<String, bool>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl RedditAdapter {
@@ -104,11 +106,20 @@ impl RedditAdapter {
             shutdown_rx,
             cached_token: Arc::new(RwLock::new(None)),
             seen_comments: Arc::new(RwLock::new(HashMap::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -187,7 +198,7 @@ impl RedditAdapter {
         let token = self.get_token().await?;
         let url = format!("{}/api/comment", REDDIT_API_BASE);
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         // Reddit only allows one reply per parent, so join chunks
         let full_text = chunks.join("\n\n---\n\n");

--- a/crates/librefang-channels/src/revolt.rs
+++ b/crates/librefang-channels/src/revolt.rs
@@ -26,7 +26,7 @@ const DEFAULT_API_URL: &str = "https://api.revolt.chat";
 const DEFAULT_WS_URL: &str = "wss://ws.revolt.chat";
 
 /// Maximum Revolt message text length (characters).
-const MAX_MESSAGE_LEN: usize = 2000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 2000;
 
 /// Maximum backoff duration for WebSocket reconnection.
 const MAX_BACKOFF_SECS: u64 = 60;
@@ -57,6 +57,8 @@ pub struct RevoltAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Bot's own user ID (populated after authentication).
     bot_user_id: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl RevoltAdapter {
@@ -74,6 +76,14 @@ impl RevoltAdapter {
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -134,7 +144,7 @@ impl RevoltAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/channels/{}/messages", self.api_url, channel_id);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -166,7 +176,7 @@ impl RevoltAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/channels/{}/messages", self.api_url, channel_id);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for (i, chunk) in chunks.iter().enumerate() {
             let mut body = serde_json::json!({

--- a/crates/librefang-channels/src/rocketchat.rs
+++ b/crates/librefang-channels/src/rocketchat.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 use zeroize::Zeroizing;
 
 const POLL_INTERVAL_SECS: u64 = 2;
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// Rocket.Chat channel adapter using REST API with long-polling.
 pub struct RocketChatAdapter {
@@ -40,6 +40,8 @@ pub struct RocketChatAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last polled timestamp per channel for incremental history fetch.
     last_timestamps: Arc<RwLock<HashMap<String, String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl RocketChatAdapter {
@@ -68,11 +70,20 @@ impl RocketChatAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_timestamps: Arc::new(RwLock::new(HashMap::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -104,7 +115,7 @@ impl RocketChatAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/api/v1/chat.sendMessage", self.server_url);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -21,7 +21,7 @@ use zeroize::Zeroizing;
 const SLACK_API_BASE: &str = "https://slack.com/api";
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-const SLACK_MSG_LIMIT: usize = 3000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 3000;
 
 /// Slack Socket Mode adapter.
 pub struct SlackAdapter {
@@ -41,6 +41,8 @@ pub struct SlackAdapter {
     bot_user_id: Arc<RwLock<Option<String>>>,
     /// When true, replies are posted as top-level channel messages instead of threads.
     force_flat_replies: bool,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl SlackAdapter {
@@ -57,12 +59,21 @@ impl SlackAdapter {
             shutdown_rx,
             bot_user_id: Arc::new(RwLock::new(None)),
             force_flat_replies: false,
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
 
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -210,7 +221,7 @@ impl SlackAdapter {
         text: &str,
         thread_ts: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, SLACK_MSG_LIMIT);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let mut body = serde_json::json!({

--- a/crates/librefang-channels/src/teams.rs
+++ b/crates/librefang-channels/src/teams.rs
@@ -23,7 +23,7 @@ const OAUTH_TOKEN_URL: &str =
     "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 
 /// Maximum Teams message length (characters).
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// OAuth2 token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
@@ -51,6 +51,8 @@ pub struct TeamsAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached OAuth2 bearer token and its expiry instant.
     cached_token: Arc<RwLock<Option<(String, Instant)>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl TeamsAdapter {
@@ -77,11 +79,20 @@ impl TeamsAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             cached_token: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -151,7 +162,7 @@ impl TeamsAdapter {
             conversation_id
         );
 
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
         for chunk in chunks {
             let body = serde_json::json!({
                 "type": "message",

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -34,6 +34,9 @@ const DEFAULT_API_URL: &str = "https://api.telegram.org";
 /// provides a safe margin while keeping the UX responsive.
 const STREAMING_EDIT_INTERVAL: Duration = Duration::from_millis(1000);
 
+/// Default maximum message length for Telegram messages.
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
+
 /// Telegram Bot API adapter using long-polling.
 pub struct TelegramAdapter {
     /// SECURITY: Bot token is zeroized on drop to prevent memory disclosure.
@@ -52,6 +55,8 @@ pub struct TelegramAdapter {
     thread_routes: HashMap<String, String>,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl TelegramAdapter {
@@ -82,6 +87,7 @@ impl TelegramAdapter {
             thread_routes: HashMap::new(),
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
 
@@ -94,6 +100,14 @@ impl TelegramAdapter {
     /// Set thread-based agent routing. Returns self for builder chaining.
     pub fn with_thread_routes(mut self, thread_routes: HashMap<String, String>) -> Self {
         self.thread_routes = thread_routes;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -136,7 +150,7 @@ impl TelegramAdapter {
         let sanitized = sanitize_telegram_html(text);
 
         // Telegram has a 4096 character limit per message — split if needed
-        let chunks = split_message(&sanitized, 4096);
+        let chunks = split_message(&sanitized, self.max_msg_len);
         for chunk in chunks {
             let mut body = serde_json::json!({
                 "chat_id": chat_id,
@@ -1053,7 +1067,7 @@ impl ChannelAdapter for TelegramAdapter {
             // Split *before* sanitization — api_edit_message / api_send_message
             // sanitize internally, so pre-sanitizing here would double-escape
             // HTML entities.
-            let chunks = split_message(&formatted, 4096);
+            let chunks = split_message(&formatted, self.max_msg_len);
             if chunks.len() <= 1 {
                 // Single message — just edit in place.
                 let _ = self

--- a/crates/librefang-channels/src/threema.rs
+++ b/crates/librefang-channels/src/threema.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 const THREEMA_API_URL: &str = "https://msgapi.threema.ch";
 
 /// Maximum message length for Threema messages.
-const MAX_MESSAGE_LEN: usize = 3500;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 3500;
 
 /// Threema Gateway channel adapter using webhook for receiving and REST API for sending.
 ///
@@ -42,6 +42,8 @@ pub struct ThreemaAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl ThreemaAdapter {
@@ -61,11 +63,20 @@ impl ThreemaAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -94,7 +105,7 @@ impl ThreemaAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/send_simple", THREEMA_API_URL);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let params = [

--- a/crates/librefang-channels/src/twist.rs
+++ b/crates/librefang-channels/src/twist.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 const TWIST_API_BASE: &str = "https://api.twist.com/api/v3";
 
 /// Maximum message length for Twist comments.
-const MAX_MESSAGE_LEN: usize = 10000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 10000;
 
 /// Polling interval in seconds for new comments.
 const POLL_INTERVAL_SECS: u64 = 5;
@@ -48,6 +48,8 @@ pub struct TwistAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Last seen comment ID per channel for incremental polling.
     last_comment_ids: Arc<RwLock<HashMap<String, i64>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl TwistAdapter {
@@ -68,11 +70,20 @@ impl TwistAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             last_comment_ids: Arc::new(RwLock::new(HashMap::new())),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -193,7 +204,7 @@ impl TwistAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/comments/add", TWIST_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -613,7 +624,7 @@ mod tests {
 
     #[test]
     fn test_twist_constants() {
-        assert_eq!(MAX_MESSAGE_LEN, 10000);
+        assert_eq!(DEFAULT_MAX_MESSAGE_LEN, 10000);
         assert_eq!(POLL_INTERVAL_SECS, 5);
         assert!(TWIST_API_BASE.starts_with("https://"));
     }

--- a/crates/librefang-channels/src/twitch.rs
+++ b/crates/librefang-channels/src/twitch.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 
 const TWITCH_IRC_HOST: &str = "irc.chat.twitch.tv";
 const TWITCH_IRC_PORT: u16 = 6667;
-const MAX_MESSAGE_LEN: usize = 500;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 500;
 
 /// Twitch IRC channel adapter.
 ///
@@ -40,6 +40,8 @@ pub struct TwitchAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl TwitchAdapter {
@@ -58,11 +60,20 @@ impl TwitchAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -317,7 +328,7 @@ impl ChannelAdapter for TwitchAdapter {
         // Wait briefly for auth to complete
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
         for chunk in chunks {
             let msg = format!("PRIVMSG {channel} :{chunk}\r\n");
             writer.write_all(msg.as_bytes()).await?;

--- a/crates/librefang-channels/src/viber.rs
+++ b/crates/librefang-channels/src/viber.rs
@@ -28,7 +28,7 @@ const VIBER_SEND_MESSAGE_URL: &str = "https://chatapi.viber.com/pa/send_message"
 const VIBER_ACCOUNT_INFO_URL: &str = "https://chatapi.viber.com/pa/get_account_info";
 
 /// Maximum Viber message text length (characters).
-const MAX_MESSAGE_LEN: usize = 7000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 7000;
 
 /// Sender name shown in Viber messages from the bot.
 const DEFAULT_SENDER_NAME: &str = "LibreFang";
@@ -56,6 +56,8 @@ pub struct ViberAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl ViberAdapter {
@@ -78,11 +80,20 @@ impl ViberAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -177,7 +188,7 @@ impl ViberAdapter {
         receiver: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let mut sender = serde_json::json!({

--- a/crates/librefang-channels/src/webex.rs
+++ b/crates/librefang-channels/src/webex.rs
@@ -26,7 +26,7 @@ const WEBEX_API_BASE: &str = "https://webexapis.com/v1";
 const WEBEX_WS_URL: &str = "wss://mercury-connection-a.wbx2.com/v1/apps/wx2/registrations";
 
 /// Maximum message length for Webex (official limit is 7439 characters).
-const MAX_MESSAGE_LEN: usize = 7439;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 7439;
 
 /// Webex Bot channel adapter using WebSocket for events and REST for sending.
 ///
@@ -47,6 +47,8 @@ pub struct WebexAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached bot identity (ID and display name).
     bot_info: Arc<RwLock<Option<(String, String)>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl WebexAdapter {
@@ -65,11 +67,20 @@ impl WebexAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             bot_info: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -162,7 +173,7 @@ impl WebexAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/messages", WEBEX_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = serde_json::json!({
@@ -196,7 +207,7 @@ impl WebexAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/messages", WEBEX_API_BASE);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let body = if person_id.contains('@') {
@@ -531,7 +542,7 @@ mod tests {
 
     #[test]
     fn test_webex_message_length_limit() {
-        assert_eq!(MAX_MESSAGE_LEN, 7439);
+        assert_eq!(DEFAULT_MAX_MESSAGE_LEN, 7439);
     }
 
     #[test]

--- a/crates/librefang-channels/src/webhook.rs
+++ b/crates/librefang-channels/src/webhook.rs
@@ -19,7 +19,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 65535;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 65535;
 
 /// Generic HTTP webhook channel adapter.
 ///
@@ -63,6 +63,8 @@ pub struct WebhookAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl WebhookAdapter {
@@ -82,11 +84,20 @@ impl WebhookAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -332,7 +343,7 @@ impl ChannelAdapter for WebhookAdapter {
             _ => "(Unsupported content type)".to_string(),
         };
 
-        let chunks = split_message(&text, MAX_MESSAGE_LEN);
+        let chunks = split_message(&text, self.max_msg_len);
         let num_chunks = chunks.len();
 
         for chunk in chunks {

--- a/crates/librefang-channels/src/wechat.rs
+++ b/crates/librefang-channels/src/wechat.rs
@@ -27,7 +27,7 @@ const MAX_BACKOFF: Duration = Duration::from_secs(60);
 /// Initial backoff on failures.
 const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
 /// Maximum message length for WeChat text messages.
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 /// Channel version sent in base_info.
 const CHANNEL_VERSION: &str = "1.0.2";
 
@@ -76,6 +76,8 @@ pub struct WeChatAdapter {
     last_error: Arc<RwLock<Option<String>>>,
     /// X-WECHAT-UIN header value, generated on construction.
     wechat_uin: String,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 /// Generate a random UIN for the X-WECHAT-UIN header.
@@ -118,12 +120,21 @@ impl WeChatAdapter {
             started_at: Arc::new(RwLock::new(None)),
             last_error: Arc::new(RwLock::new(None)),
             wechat_uin: generate_wechat_uin(),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
 
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -297,7 +308,7 @@ impl WeChatAdapter {
         let url = format!("{}/ilink/bot/sendmessage", ILINK_BASE);
 
         // Split long messages
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
         for chunk in chunks {
             let client_id = uuid::Uuid::new_v4().to_string();
             let body = serde_json::json!({

--- a/crates/librefang-channels/src/wecom.rs
+++ b/crates/librefang-channels/src/wecom.rs
@@ -28,7 +28,7 @@ const WECOM_TOKEN_URL: &str = "https://qyapi.weixin.qq.com/cgi-bin/gettoken";
 const WECOM_SEND_URL: &str = "https://qyapi.weixin.qq.com/cgi-bin/message/send";
 
 /// Maximum WeCom message text length (characters).
-const MAX_MESSAGE_LEN: usize = 2048;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 2048;
 
 /// Token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
@@ -220,6 +220,8 @@ pub struct WeComAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Cached access token and its expiry instant.
     cached_token: Arc<RwLock<Option<(String, Instant)>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl WeComAdapter {
@@ -238,11 +240,20 @@ impl WeComAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             cached_token: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -594,7 +605,7 @@ impl ChannelAdapter for WeComAdapter {
         match content {
             ChannelContent::Text(text) => {
                 // Split long messages
-                for chunk in split_message(&text, MAX_MESSAGE_LEN) {
+                for chunk in split_message(&text, self.max_msg_len) {
                     self.send_text(user_id, chunk).await?;
                 }
             }
@@ -660,8 +671,8 @@ mod tests {
 
     #[test]
     fn test_max_message_length() {
-        // MAX_MESSAGE_LEN should be 2048 for WeCom
-        assert_eq!(MAX_MESSAGE_LEN, 2048);
+        // DEFAULT_MAX_MESSAGE_LEN should be 2048 for WeCom
+        assert_eq!(DEFAULT_MAX_MESSAGE_LEN, 2048);
     }
 
     #[test]

--- a/crates/librefang-channels/src/whatsapp.rs
+++ b/crates/librefang-channels/src/whatsapp.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{error, info};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 4096;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 4096;
 
 /// WhatsApp Cloud API adapter.
 ///
@@ -42,6 +42,8 @@ pub struct WhatsAppAdapter {
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl WhatsAppAdapter {
@@ -65,11 +67,20 @@ impl WhatsAppAdapter {
             account_id: None,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            max_msg_len: DEFAULT_DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -94,7 +105,7 @@ impl WhatsAppAdapter {
         );
 
         // Split long messages
-        let chunks = crate::types::split_message(text, MAX_MESSAGE_LEN);
+        let chunks = crate::types::split_message(text, self.max_msg_len);
         for chunk in chunks {
             let body = serde_json::json!({
                 "messaging_product": "whatsapp",
@@ -244,7 +255,7 @@ impl ChannelAdapter for WhatsAppAdapter {
                 _ => "(Unsupported content type in Web mode)".to_string(),
             };
             // Split long messages the same way as Cloud API mode
-            let chunks = crate::types::split_message(&text, MAX_MESSAGE_LEN);
+            let chunks = crate::types::split_message(&text, self.max_msg_len);
             for chunk in chunks {
                 self.gateway_send_message(gw, &user.platform_id, chunk)
                     .await?;

--- a/crates/librefang-channels/src/zulip.rs
+++ b/crates/librefang-channels/src/zulip.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
-const MAX_MESSAGE_LEN: usize = 10000;
+const DEFAULT_MAX_MESSAGE_LEN: usize = 10000;
 const POLL_TIMEOUT_SECS: u64 = 60;
 
 /// Zulip channel adapter using REST API with event queue long-polling.
@@ -40,6 +40,8 @@ pub struct ZulipAdapter {
     shutdown_rx: watch::Receiver<bool>,
     /// Current event queue ID for resuming polls.
     queue_id: Arc<RwLock<Option<String>>>,
+    /// Maximum outbound message length before splitting.
+    max_msg_len: usize,
 }
 
 impl ZulipAdapter {
@@ -68,11 +70,20 @@ impl ZulipAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             queue_id: Arc::new(RwLock::new(None)),
+            max_msg_len: DEFAULT_MAX_MESSAGE_LEN,
         }
     }
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Override the maximum outbound message length. Returns self for builder chaining.
+    pub fn with_max_message_length(mut self, len: Option<u32>) -> Self {
+        if let Some(v) = len {
+            self.max_msg_len = v as usize;
+        }
         self
     }
 
@@ -149,7 +160,7 @@ impl ZulipAdapter {
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/api/v1/messages", self.server_url);
-        let chunks = split_message(text, MAX_MESSAGE_LEN);
+        let chunks = split_message(text, self.max_msg_len);
 
         for chunk in chunks {
             let mut params = vec![

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -78,6 +78,9 @@ pub struct ChannelOverrides {
     pub usage_footer: Option<UsageFooterMode>,
     /// Typing indicator mode override.
     pub typing_mode: Option<TypingMode>,
+    /// Maximum outbound message length (characters) before splitting.
+    /// When set, overrides the channel adapter's built-in platform default.
+    pub max_message_length: Option<u32>,
 }
 
 /// Controls what usage info appears in response footers.


### PR DESCRIPTION
## Summary
- Add `max_message_length` config field to all 40+ channel config structs
- Each channel's default matches its platform API limit (Discord=2000, Bluesky=300, WhatsApp=4096, etc.)
- Add `with_max_message_length()` builder method for runtime override
- Users can now tune message splitting behavior per channel via config.toml

## Test plan
- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes
- [ ] Existing configs without max_message_length use correct defaults