### PR TITLE
fix: suppress clippy::manual_clamp in clamp_bounds

### DIFF
--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -617,6 +617,7 @@ impl KernelConfig {
     ///
     /// Called after loading config to prevent zero timeouts, unbounded buffers,
     /// or other misconfigurations that cause silent failures at runtime.
+    #[allow(clippy::manual_clamp)]
     pub fn clamp_bounds(&mut self) {
         // Browser timeout: min 5s, max 300s
         if self.browser.timeout_secs == 0 {


### PR DESCRIPTION
## Summary
- Add `#[allow(clippy::manual_clamp)]` to `clamp_bounds()` — the if-else pattern uses 0 as a "use default" sentinel, not a lower bound, so it's not a simple clamp

## Test plan
- CI clippy check should pass