### PR TITLE
fix: remove dangling doc comment in ws.rs

### DIFF
--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -33,8 +33,6 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
-/// Per-IP WebSocket connection tracker.
-
 // ---------------------------------------------------------------------------
 // Verbose Level
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove orphaned `/// Per-IP WebSocket connection tracker.` doc comment that clippy flags as `empty_lines_after_doc_comment`

## Test plan
- CI clippy check should pass