### PR TITLE
fix: recognize all available auth statuses for custom providers in WebUI

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/status.ts
+++ b/crates/librefang-api/dashboard/src/lib/status.ts
@@ -10,3 +10,9 @@ export function getStatusVariant(status?: string): BadgeVariant {
   if (value === "error" || value === "crashed") return "error";
   return "default";
 }
+
+/** Check if a provider auth_status indicates the provider is usable.
+ *  Mirrors the Rust AuthStatus::is_available() variants. */
+export function isProviderAvailable(status?: string): boolean {
+  return status === "configured" || status === "not_required" || status === "configured_cli";
+}

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -8,6 +8,7 @@ import { Badge } from "../components/ui/Badge";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { Home, RefreshCw, Users, Layers, Server, Network, Zap, MessageCircle, User, Clock, Shield, Sparkles, Calendar, HardDrive, Activity, Globe } from "lucide-react";
 import { truncateId } from "../lib/string";
+import { isProviderAvailable } from "../lib/status";
 import { getStatusVariant } from "../lib/status";
 
 const REFRESH_MS = 30000;
@@ -33,7 +34,7 @@ export function OverviewPage() {
 
   const agentsActive = snapshot?.status?.active_agent_count ?? 0;
   const agentsTotal = snapshot?.status?.agent_count ?? 0;
-  const providersReady = snapshot?.providers?.filter(p => p.auth_status === "configured" || p.auth_status === "not_required" || p.auth_status === "configured_cli").length ?? 0;
+  const providersReady = snapshot?.providers?.filter(p => isProviderAvailable(p.auth_status)).length ?? 0;
   const providersTotal = snapshot?.providers?.length ?? 0;
   const channelsReady = snapshot?.channels?.filter(c => c.configured).length ?? 0;
   const skillsCount = snapshot?.skillCount ?? 0;

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -3,6 +3,7 @@ import { formatTime, formatDateTime } from "../lib/datetime";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { listProviders, testProvider, setProviderKey, deleteProviderKey, setProviderUrl } from "../api";
+import { isProviderAvailable } from "../lib/status";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -49,11 +50,6 @@ function getLatencyColor(ms?: number) {
   return "text-error";
 }
 
-/** Check if a provider auth_status indicates the provider is usable.
- *  Mirrors the Rust AuthStatus::is_available() variants. */
-function isProviderAvailable(status?: string): boolean {
-  return status === "configured" || status === "not_required" || status === "configured_cli";
-}
 
 type SortField = "name" | "models" | "latency";
 type SortOrder = "asc" | "desc";

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -13,6 +13,7 @@ import {
 } from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
+import { isProviderAvailable } from "../lib/status";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { Button } from "../components/ui/Button";
@@ -609,7 +610,7 @@ export function RuntimePage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 {[
-                  { label: t("runtime.providers"), value: snapshot?.providers?.length ?? 0, sub: `${snapshot?.providers?.filter(p => p.auth_status === "configured" || p.auth_status === "not_required" || p.auth_status === "configured_cli").length ?? 0} ${t("status.configured").toLowerCase()}`, color: "text-brand" },
+                  { label: t("runtime.providers"), value: snapshot?.providers?.length ?? 0, sub: `${snapshot?.providers?.filter(p => isProviderAvailable(p.auth_status)).length ?? 0} ${t("status.configured").toLowerCase()}`, color: "text-brand" },
                   { label: t("runtime.channels"), value: snapshot?.channels?.length ?? 0, sub: `${snapshot?.channels?.filter(c => c.configured).length ?? 0} ${t("status.configured").toLowerCase()}`, color: "text-purple-500" },
                   { label: t("runtime.skills"), value: snapshot?.skillCount ?? 0, sub: t("status.active").toLowerCase(), color: "text-success" },
                   { label: t("runtime.workflows"), value: snapshot?.workflowCount ?? 0, sub: t("common.config").toLowerCase(), color: "text-warning" },


### PR DESCRIPTION
## Summary
- WebUI only checked `auth_status === "configured"` to determine if a provider is available
- Custom providers may report `"not_required"` or `"configured_cli"` which are valid available states (matching Rust `AuthStatus::is_available()`)
- Added `isProviderAvailable()` helper in ProvidersPage and updated all three dashboard pages (OverviewPage, ProvidersPage, RuntimePage)

Closes #1711

## Test plan
- [ ] Configure a custom provider (e.g. ollama) and verify it shows as configured in WebUI
- [ ] Verify provider counts on Overview and Runtime pages include custom providers