### PR TITLE
fix: accept "Failed to resolve" error in Windows capability test

### DIFF
--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -4413,6 +4413,7 @@ mod tests {
         );
         assert!(
             result.content.contains("Failed to read")
+                || result.content.contains("Failed to resolve")
                 || result.content.contains("not found")
                 || result.content.contains("No such file")
                 || result.content.contains("does not exist"),


### PR DESCRIPTION
## Summary
- On Windows, `test_capability_enforcement_allowed` fails because path resolution returns "Failed to resolve parent directory" instead of "No such file"
- Add `"Failed to resolve"` to the accepted error message patterns in the assertion
- Fixes CI failure on main: https://github.com/librefang/librefang/actions/runs/23582745116/job/68668918913