### PR TITLE
feat: add Streamable HTTP transport, custom headers, and browser.enabled config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "http",
  "librefang-channels",
  "librefang-memory",
  "librefang-skills",
@@ -6440,10 +6441,13 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "http",
  "pin-project-lite",
  "process-wrap",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -7334,6 +7338,19 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ bytes = "1"
 futures = "0.3"
 
 # MCP SDK
-rmcp = { version = "1.2", default-features = false, features = ["client", "transport-child-process"] }
+rmcp = { version = "1.2", default-features = false, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "reqwest"] }
 
 # WebSocket client (for Discord/Slack gateway)
 tokio-tungstenite = { version = "0.29.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -508,6 +508,9 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
                 Some(librefang_types::config::McpTransportEntry::Sse { url }) => {
                     serde_json::json!({ "type": "sse", "url": url })
                 }
+                Some(librefang_types::config::McpTransportEntry::Http { url }) => {
+                    serde_json::json!({ "type": "http", "url": url })
+                }
                 Some(librefang_types::config::McpTransportEntry::HttpCompat {
                     base_url, ..
                 }) => {

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2452,6 +2452,12 @@ fn serialize_mcp_transport(
                 "url": url,
             })
         }
+        librefang_types::config::McpTransportEntry::Http { url } => {
+            serde_json::json!({
+                "type": "http",
+                "url": url,
+            })
+        }
         librefang_types::config::McpTransportEntry::HttpCompat {
             base_url,
             headers,

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -4098,7 +4098,8 @@ fn cmd_doctor(json: bool, repair: bool) {
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                 }
-                                librefang_types::config::McpTransportEntry::Sse { url } => {
+                                librefang_types::config::McpTransportEntry::Sse { url }
+                                | librefang_types::config::McpTransportEntry::Http { url } => {
                                     if url.is_empty() {
                                         if !json {
                                             ui::check_warn(&format!(

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -89,6 +89,9 @@ pub enum McpTransportTemplate {
     Sse {
         url: String,
     },
+    Http {
+        url: String,
+    },
 }
 
 /// An environment variable required by an integration.

--- a/crates/librefang-extensions/src/registry.rs
+++ b/crates/librefang-extensions/src/registry.rs
@@ -191,6 +191,9 @@ impl IntegrationRegistry {
                     crate::McpTransportTemplate::Sse { url } => {
                         McpTransportEntry::Sse { url: url.clone() }
                     }
+                    crate::McpTransportTemplate::Http { url } => {
+                        McpTransportEntry::Http { url: url.clone() }
+                    }
                 };
                 let env: Vec<String> = template
                     .required_env
@@ -202,6 +205,7 @@ impl IntegrationRegistry {
                     transport: Some(transport),
                     timeout_secs: 30,
                     env,
+                    headers: Vec::new(),
                 })
             })
             .collect()

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -7643,6 +7643,7 @@ system_prompt = "You are a helpful assistant."
                     args: args.clone(),
                 },
                 McpTransportEntry::Sse { url } => McpTransport::Sse { url: url.clone() },
+                McpTransportEntry::Http { url } => McpTransport::Http { url: url.clone() },
                 McpTransportEntry::HttpCompat {
                     base_url,
                     headers,
@@ -7659,6 +7660,7 @@ system_prompt = "You are a helpful assistant."
                 transport,
                 timeout_secs: server_config.timeout_secs,
                 env: server_config.env.clone(),
+                headers: server_config.headers.clone(),
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -7768,6 +7770,7 @@ system_prompt = "You are a helpful assistant."
                     args: args.clone(),
                 },
                 McpTransportEntry::Sse { url } => McpTransport::Sse { url: url.clone() },
+                McpTransportEntry::Http { url } => McpTransport::Http { url: url.clone() },
                 McpTransportEntry::HttpCompat {
                     base_url,
                     headers,
@@ -7784,6 +7787,7 @@ system_prompt = "You are a helpful assistant."
                 transport,
                 timeout_secs: server_config.timeout_secs,
                 env: server_config.env.clone(),
+                headers: server_config.headers.clone(),
             };
 
             self.extension_health.register(&server_config.name);
@@ -7910,6 +7914,7 @@ system_prompt = "You are a helpful assistant."
                 args: args.clone(),
             },
             McpTransportEntry::Sse { url } => McpTransport::Sse { url: url.clone() },
+            McpTransportEntry::Http { url } => McpTransport::Http { url: url.clone() },
             McpTransportEntry::HttpCompat {
                 base_url,
                 headers,
@@ -7926,6 +7931,7 @@ system_prompt = "You are a helpful assistant."
             transport,
             timeout_secs: server_config.timeout_secs,
             env: server_config.env.clone(),
+            headers: server_config.headers.clone(),
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -8012,7 +8018,16 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        let all_builtins = builtin_tool_definitions();
+        let all_builtins = if self.config.browser.enabled {
+            builtin_tool_definitions()
+        } else {
+            // When built-in browser is disabled (replaced by an external
+            // browser MCP server such as CamoFox), filter out browser_* tools.
+            builtin_tool_definitions()
+                .into_iter()
+                .filter(|t| !t.name.starts_with("browser_"))
+                .collect()
+        };
 
         // Look up agent entry for profile, skill/MCP allowlists, and declared tools
         let entry = self.registry.get(agent_id);

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -41,6 +41,7 @@ ureq = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
 rmcp = { workspace = true }
+http = "1"
 shlex = "1"
 toml = { workspace = true }
 url = { workspace = true }

--- a/crates/librefang-runtime/src/mcp.rs
+++ b/crates/librefang-runtime/src/mcp.rs
@@ -6,6 +6,7 @@
 //!
 //! All MCP tools are namespaced with `mcp_{server}_{tool}` to prevent collisions.
 
+use http::{HeaderName, HeaderValue};
 use librefang_types::config::{
     HttpCompatHeaderConfig, HttpCompatMethod, HttpCompatRequestMode, HttpCompatResponseMode,
     HttpCompatToolConfig,
@@ -13,6 +14,7 @@ use librefang_types::config::{
 use librefang_types::tool::ToolDefinition;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{debug, info};
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,12 @@ pub struct McpServerConfig {
     /// the parent environment and pass it through.
     #[serde(default)]
     pub env: Vec<String>,
+    /// Extra HTTP headers to send with every SSE / Streamable-HTTP request.
+    /// Each entry is `"Header-Name: value"`.  Useful for authentication
+    /// (`Authorization: Bearer <token>`), API keys (`X-Api-Key: ...`),
+    /// or any custom headers required by a remote MCP server.
+    #[serde(default)]
+    pub headers: Vec<String>,
 }
 
 fn default_timeout() -> u64 {
@@ -57,6 +65,10 @@ pub enum McpTransport {
     },
     /// HTTP Server-Sent Events (JSON-RPC over HTTP POST).
     Sse { url: String },
+    /// Streamable HTTP transport (MCP 2025-03-26+).
+    /// Single endpoint, client sends Accept: application/json, text/event-stream.
+    /// Supports Mcp-Session-Id for session management.
+    Http { url: String },
     /// Built-in compatibility adapter for plain HTTP/JSON backends.
     HttpCompat {
         base_url: String,
@@ -206,6 +218,9 @@ impl McpConnection {
                 Self::connect_stdio(command, args, &config.env).await?
             }
             McpTransport::Sse { url } => Self::connect_sse(url).await?,
+            McpTransport::Http { url } => {
+                Self::connect_streamable_http(url, &config.headers).await?
+            }
             McpTransport::HttpCompat {
                 base_url,
                 headers,
@@ -386,6 +401,62 @@ impl McpConnection {
             },
             None, // Tools discovered later via sse_initialize + sse_discover_tools
         ))
+    }
+
+    // --- Streamable HTTP transport (rmcp SDK) ---
+
+    /// Connect using Streamable HTTP transport (or SSE fallback via the same endpoint).
+    ///
+    /// The `rmcp` SDK's `StreamableHttpClientTransport` handles the full
+    /// Streamable HTTP protocol: Accept headers, Mcp-Session-Id tracking,
+    /// SSE stream parsing, and content-type negotiation.
+    async fn connect_streamable_http(
+        url: &str,
+        headers: &[String],
+    ) -> Result<(McpInner, Option<Vec<rmcp::model::Tool>>), String> {
+        use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+        use rmcp::transport::StreamableHttpClientTransport;
+        use rmcp::ServiceExt;
+
+        Self::check_ssrf(url, "Streamable HTTP")?;
+
+        // Parse custom headers (e.g., "Authorization: Bearer <token>").
+        let mut custom_headers: HashMap<HeaderName, HeaderValue> = HashMap::new();
+        for header_str in headers {
+            if let Some((name, value)) = header_str.split_once(':') {
+                let name = name.trim();
+                let value = value.trim();
+                if let (Ok(hn), Ok(hv)) = (
+                    HeaderName::from_bytes(name.as_bytes()),
+                    HeaderValue::from_str(value),
+                ) {
+                    custom_headers.insert(hn, hv);
+                }
+            }
+        }
+
+        let config = StreamableHttpClientTransportConfig {
+            uri: Arc::from(url),
+            custom_headers,
+            ..Default::default()
+        };
+
+        let transport = StreamableHttpClientTransport::from_config(config);
+
+        let client = ()
+            .into_dyn()
+            .serve(transport)
+            .await
+            .map_err(|e| format!("MCP Streamable HTTP connection failed: {e}"))?;
+
+        // Discover tools via rmcp (with timeout)
+        let timeout = std::time::Duration::from_secs(60);
+        let tools = tokio::time::timeout(timeout, client.list_all_tools())
+            .await
+            .map_err(|_| "MCP tools/list timed out after 60s for Streamable HTTP".to_string())?
+            .map_err(|e| format!("MCP tools/list failed: {e}"))?;
+
+        Ok((McpInner::Rmcp(client), Some(tools)))
     }
 
     /// Send the MCP `initialize` handshake over SSE transport.
@@ -1227,6 +1298,7 @@ mod tests {
                 "GITHUB_PERSONAL_ACCESS_TOKEN=ghp_test123".to_string(),
                 "LEGACY_NAME_ONLY".to_string(),
             ],
+            headers: vec![],
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1253,6 +1325,7 @@ mod tests {
             },
             timeout_secs: 60,
             env: vec![],
+            headers: vec![],
         };
         let json = serde_json::to_string(&sse_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1283,6 +1356,7 @@ mod tests {
             },
             timeout_secs: 45,
             env: vec![],
+            headers: vec![],
         };
         let json = serde_json::to_string(&http_compat_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1298,6 +1372,27 @@ mod tests {
                 assert_eq!(tools[0].name, "search");
             }
             _ => panic!("Expected HttpCompat transport"),
+        }
+
+        // HTTP (Streamable HTTP) variant
+        let http_config = McpServerConfig {
+            name: "atlassian".to_string(),
+            transport: McpTransport::Http {
+                url: "https://mcp.atlassian.com/v1/mcp".to_string(),
+            },
+            timeout_secs: 120,
+            env: vec![],
+            headers: vec!["Authorization: Bearer test-token-456".to_string()],
+        };
+        let json = serde_json::to_string(&http_config).unwrap();
+        let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.headers.len(), 1);
+        assert_eq!(back.headers[0], "Authorization: Bearer test-token-456");
+        match back.transport {
+            McpTransport::Http { url } => {
+                assert_eq!(url, "https://mcp.atlassian.com/v1/mcp")
+            }
+            _ => panic!("Expected Http transport"),
         }
     }
 
@@ -1329,6 +1424,7 @@ mod tests {
                 },
                 timeout_secs: 30,
                 env: vec![],
+                headers: vec![],
             },
             tools: Vec::new(),
             original_names: HashMap::new(),
@@ -1490,6 +1586,7 @@ mod tests {
             },
             timeout_secs: 5,
             env: vec![],
+            headers: vec![],
         })
         .await
         .unwrap();

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -317,6 +317,10 @@ impl Default for WebFetchConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BrowserConfig {
+    /// Enable the built-in CDP browser tools (browser_navigate, browser_click,
+    /// etc.).  Set to `false` when using an external browser MCP server such as
+    /// CamoFox, which replaces these tools with its own set.
+    pub enabled: bool,
     /// Run browser in headless mode (no visible window).
     pub headless: bool,
     /// Viewport width in pixels.
@@ -336,6 +340,7 @@ pub struct BrowserConfig {
 impl Default for BrowserConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             headless: true,
             viewport_width: 1280,
             viewport_height: 720,
@@ -2444,6 +2449,10 @@ pub struct McpServerConfigEntry {
     /// Environment variables to pass through (e.g., ["GITHUB_PERSONAL_ACCESS_TOKEN"]).
     #[serde(default)]
     pub env: Vec<String>,
+    /// Extra HTTP headers for SSE / Streamable-HTTP transports.
+    /// Each entry is `"Header-Name: value"` (e.g., `"Authorization: Bearer <token>"`).
+    #[serde(default)]
+    pub headers: Vec<String>,
 }
 
 fn default_mcp_timeout() -> u64 {
@@ -2524,6 +2533,8 @@ pub enum McpTransportEntry {
     },
     /// HTTP Server-Sent Events.
     Sse { url: String },
+    /// Streamable HTTP transport (MCP 2025-03-26+).
+    Http { url: String },
     /// Built-in compatibility adapter for plain HTTP/JSON tool backends.
     HttpCompat {
         base_url: String,


### PR DESCRIPTION
## Summary

- Add **Streamable HTTP transport** (`McpTransport::Http`) using the `rmcp` SDK's `StreamableHttpClientTransport`, supporting the MCP 2025-03-26+ protocol with automatic `Mcp-Session-Id` tracking, SSE stream parsing, and content-type negotiation
- Add **configurable custom HTTP headers** for authenticated remote MCP servers (`Authorization`, API keys, etc.) via a new `headers` field on `McpServerConfig` / `McpServerConfigEntry`
- Add **`browser.enabled` config** to disable built-in CDP browser tools when using an external browser MCP server (e.g. CamoFox)

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `transport-streamable-http-client-reqwest` and `reqwest` features to `rmcp` dep |
| `crates/librefang-runtime/Cargo.toml` | Add `http` crate dependency |
| `crates/librefang-runtime/src/mcp.rs` | Add `Http` transport variant, `headers` field, `connect_streamable_http()` method using rmcp SDK |
| `crates/librefang-types/src/config/types.rs` | Add `headers` to `McpServerConfigEntry`, `Http` variant to `McpTransportEntry`, `enabled` to `BrowserConfig` |
| `crates/librefang-kernel/src/kernel.rs` | Wire `Http` transport + `headers` through all 3 MCP connection paths; filter browser tools when `browser.enabled = false` |
| `crates/librefang-extensions/src/lib.rs` | Add `Http` variant to `McpTransportTemplate` |
| `crates/librefang-extensions/src/registry.rs` | Handle `Http` template variant; default `headers` for extension configs |
| `crates/librefang-api/src/routes/config.rs` | Expose `Http` transport in config API |
| `crates/librefang-api/src/routes/skills.rs` | Expose `Http` transport in skills API |
| `crates/librefang-cli/src/main.rs` | Handle `Http` transport in CLI doctor validation |

## Verification

- `cargo build --workspace --lib` — compiles clean
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings

Ported from [RightNow-AI/openfang#778](https://github.com/RightNow-AI/openfang/pull/778), adapted for the librefang crate structure and existing rmcp integration.