### PR TITLE
fix(whatsapp-gateway): use English for shared contacts label

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -801,7 +801,7 @@ async function startConnection() {
           const phone = telMatch ? telMatch[1].trim() : '';
           return `${name}${phone ? ' ' + phone : ''}`;
         });
-        innerMsg._overrideMediaText = `[Contatti condivisi: ${parsed.join(', ')}]`;
+        innerMsg._overrideMediaText = `[Shared contacts: ${parsed.join(', ')}]`;
       }
 
       // Skip if there's nothing to process


### PR DESCRIPTION
## Summary
- Replace hardcoded Italian string `"Contatti condivisi"` with `"Shared contacts"` to match the rest of the codebase

Flagged in the review of #1222 — split out as a focused fix.

## Test plan
- [ ] `node packages/whatsapp-gateway/index.js` starts without errors
- [ ] Receiving a multi-contact vCard message shows `[Shared contacts: ...]` instead of Italian