### PR TITLE
fix(telegram): add parse_mode and sanitization to streaming initial message

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -500,9 +500,11 @@ impl TelegramAdapter {
             self.api_base_url,
             self.token.as_str()
         );
+        let sanitized = sanitize_telegram_html(text);
         let mut body = serde_json::json!({
             "chat_id": chat_id,
-            "text": text,
+            "text": sanitized,
+            "parse_mode": "HTML",
         });
         if let Some(tid) = thread_id {
             body["message_thread_id"] = serde_json::json!(tid);


### PR DESCRIPTION
## Summary
- `api_send_message_returning_id()` was missing `parse_mode: "HTML"` and `sanitize_telegram_html()`, unlike every other send function in the Telegram adapter
- This caused the first streaming message to display raw HTML tags (`<b>`, `<i>`, etc.) until the next edit applied `parse_mode` correctly
- For short responses with no subsequent edit, the message stayed with raw HTML tags permanently

## Test plan
- [ ] `cargo check -p librefang-channels` passes
- [ ] `cargo test -p librefang-channels` passes (12/12)
- [ ] Send a message via Telegram that triggers a short LLM response with bold/italic — first message should render formatted immediately, not flash raw HTML