### PR TITLE
fix(kernel): skip disabled agents during background startup

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6716,7 +6716,8 @@ system_prompt = "You are a helpful assistant."
             Vec::new();
 
         for entry in &agents {
-            if matches!(entry.manifest.schedule, ScheduleMode::Reactive) {
+            if matches!(entry.manifest.schedule, ScheduleMode::Reactive) || !entry.manifest.enabled
+            {
                 continue;
             }
             bg_agents.push((


### PR DESCRIPTION
## Summary
- `start_background_agents()` now checks `entry.manifest.enabled` before starting background loops
- Previously, all non-Reactive agents were started unconditionally, ignoring the `enabled` field
- Users can now set `enabled = false` in an agent's TOML to prevent it from auto-starting

## Test plan
- [ ] Set `enabled = false` in an agent's config, restart daemon, verify agent does not start
- [ ] Verify agents with `enabled = true` (default) still start normally

Closes #1769