### PR TITLE
fix(providers): handle all HTTP error codes in provider test

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1000,7 +1000,16 @@ pub async fn test_provider(
 
     let latency_ms = start.elapsed().as_millis();
 
-    if status_code == 401 || status_code == 403 {
+    if (200..300).contains(&status_code) {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ok",
+                "provider": name,
+                "latency_ms": latency_ms,
+            })),
+        )
+    } else if status_code == 401 || status_code == 403 {
         (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -1009,22 +1018,22 @@ pub async fn test_provider(
                 "error": format!("Authentication failed (HTTP {})", status_code),
             })),
         )
-    } else if status_code >= 500 {
+    } else if status_code == 429 {
         (
             StatusCode::OK,
             Json(serde_json::json!({
                 "status": "error",
                 "provider": name,
-                "error": format!("Server error (HTTP {})", status_code),
+                "error": format!("Rate limited (HTTP 429)"),
             })),
         )
     } else {
         (
             StatusCode::OK,
             Json(serde_json::json!({
-                "status": "ok",
+                "status": "error",
                 "provider": name,
-                "latency_ms": latency_ms,
+                "error": format!("HTTP {}", status_code),
             })),
         )
     }


### PR DESCRIPTION
## Summary
- Fix `test_provider` endpoint to properly handle all HTTP status codes instead of only 401/403 and 500+
- Previously, status codes like 404, 429, 408 were silently treated as "success"
- Now: 200-299 = success, 401/403 = auth error, 429 = rate limited, all other non-2xx = error with HTTP code

## Test plan
- [ ] Test a provider that returns 429 — should show "Rate limited" error
- [ ] Test a provider with unreachable endpoint — should show connection error
- [ ] Test OpenRouter with valid key — should show success
- [ ] Test OpenRouter without key — should show "not configured" error

Closes #1756