### PR TITLE
fix(ci): don't cancel in-progress runs on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 # Prevent multiple CI runs from competing for runner resources
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Change `cancel-in-progress` from `true` to `${{ github.ref != 'refs/heads/main' }}`
- PR branches still cancel old runs to save resources
- Main branch runs queue instead of cancelling each other

## Root cause
Consecutive merges to main trigger multiple CI runs sharing the same concurrency group (`CI-refs/heads/main`). With `cancel-in-progress: true`, each new run kills the previous one. Ubuntu tests are the slowest (Tauri deps install + `-j 2` build throttle), so they never finish before being cancelled — resulting in persistent SIGTERM failures that look like infrastructure issues but are actually self-inflicted.

Windows and macOS tests are fast enough to complete before the next cancellation.