### PR TITLE
fix(whatsapp-gateway): send read receipts on incoming messages

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -936,6 +936,9 @@ async function startConnection() {
       });
       dbUpdateLastSeen(sender, msgTimestamp);
 
+      // Send read receipt (blue ticks) immediately
+      await sock.readMessages([msg.key]);
+
       // Forward to LibreFang agent
       try {
         // Track stranger messages


### PR DESCRIPTION
## Summary

The WhatsApp gateway never sent read receipts (blue ticks) for incoming messages. This made the bot appear offline or unresponsive to users, even while it was actively processing their message and preparing a response.

**Before:**
```
User sends message → single grey tick (delivered) → waits 10-30s → reply arrives
User thinks: "Is this thing even working?"
```

**After:**
```
User sends message → blue ticks (read) immediately → waits 10-30s → reply arrives
User sees the bot "read" their message and knows it's processing
```

### Change

One line: `await sock.readMessages([msg.key])` called immediately after the message is saved to the local DB and before forwarding to the LibreFang agent. This uses the Baileys v6 `readMessages` API which sends the read receipt to WhatsApp servers.

## Test plan

- [x] Send a message to the bot on WhatsApp — should see blue ticks immediately
- [x] Verify the read receipt appears before the agent response (not after)
- [ ] Group messages should also get read receipts