### PR TITLE
fix(ci): use per-SHA concurrency group on main to prevent SIGTERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
 permissions:
   contents: read
 
-# Prevent multiple CI runs from competing for runner resources
+# On PRs: only one run per branch, cancel stale runs.
+# On main: each push gets its own group (by SHA) so parallel runs never interfere.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.workflow, github.sha) || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:


### PR DESCRIPTION
## Summary
- Main branch CI has failed 3 consecutive times (all Ubuntu-only) due to SIGTERM killing the test runner mid-execution
- Root cause: rapid-fire merges create multiple CI runs in the same concurrency group; even with `cancel-in-progress: false`, GitHub's queue mechanism sends SIGTERM to the Ubuntu runner
- Fix: give each main push a unique concurrency group keyed by commit SHA, so runs never interact. PR branches keep the existing cancel-stale behavior

## Failed runs
- `fix(ci): don't cancel in-progress runs on main branch (#1788)` — [run](https://github.com/librefang/librefang/actions/runs/23709212058)
- `feat(config): add registry_mirror` — [run](https://github.com/librefang/librefang/actions/runs/23708811650)
- `feat(dashboard): add WeCom callback mode UI` — [run](https://github.com/librefang/librefang/actions/runs/23702463926)

## Test plan
- [ ] Merge this PR and verify CI passes on the resulting main push
- [ ] Merge another PR shortly after and verify both CI runs complete independently