### PR TITLE
fix(dashboard): approval buttons call correct API and hide for resolved items

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -334,6 +334,8 @@
   },
   "approvals": {
     "title": "Approvals", "subtitle": "Review and authorize critical agent actions.", "pending_review": "Pending Review", "approve": "Approve", "reject": "Reject",
+    "approvedToast": "Approved", "rejectedToast": "Rejected",
+    "status": { "pending": "Pending", "approved": "Approved", "rejected": "Rejected", "expired": "Expired" },
     "queue_clear": "Queue Clear", "queue_clear_desc": "No pending actions.",
     "help": "Review approval requests. When agents need human confirmation, requests appear here."
   },

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -322,6 +322,8 @@
   },
   "approvals": {
     "title": "审批", "subtitle": "在执行前审查并授权关键操作。", "pending_review": "等待审查", "approve": "批准", "reject": "拒绝",
+    "approvedToast": "已批准", "rejectedToast": "已拒绝",
+    "status": { "pending": "待审批", "approved": "已批准", "rejected": "已拒绝", "expired": "已过期" },
     "queue_clear": "队列清空", "queue_clear_desc": "没有需要您审批的操作。",
     "help": "审批人工审核请求。当智能体需要人类确认时，请求会出现在这里。"
   },

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -1,16 +1,55 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { approveApproval, listApprovals } from "../api";
+import { approveApproval, rejectApproval, listApprovals } from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { useUIStore } from "../lib/store";
-import { CheckCircle } from "lucide-react";
+import { CheckCircle, XCircle, Clock } from "lucide-react";
 
 const REFRESH_MS = 15000;
+
+function statusBadge(status: string | undefined, t: (key: string) => string) {
+  switch (status) {
+    case "approved":
+      return <Badge variant="success">{t("approvals.status.approved")}</Badge>;
+    case "rejected":
+      return <Badge variant="danger">{t("approvals.status.rejected")}</Badge>;
+    case "expired":
+      return <Badge variant="neutral">{t("approvals.status.expired")}</Badge>;
+    default:
+      return <Badge variant="warning">{t("approvals.pending_review")}</Badge>;
+  }
+}
+
+function statusIcon(status: string | undefined) {
+  switch (status) {
+    case "approved":
+      return <CheckCircle className="w-5 h-5 text-success" />;
+    case "rejected":
+      return <XCircle className="w-5 h-5 text-danger" />;
+    case "expired":
+      return <Clock className="w-5 h-5 text-text-dim" />;
+    default:
+      return <CheckCircle className="w-5 h-5 text-warning" />;
+  }
+}
+
+function statusIconBg(status: string | undefined) {
+  switch (status) {
+    case "approved":
+      return "bg-success/10";
+    case "rejected":
+      return "bg-danger/10";
+    case "expired":
+      return "bg-surface-2";
+    default:
+      return "bg-warning/10";
+  }
+}
 
 export function ApprovalsPage() {
   const { t } = useTranslation();
@@ -19,16 +58,28 @@ export function ApprovalsPage() {
   const addToast = useUIStore((s) => s.addToast);
 
   const approvalsQuery = useQuery({ queryKey: ["approvals", "list"], queryFn: listApprovals, refetchInterval: REFRESH_MS });
-  const approveMutation = useMutation({ mutationFn: ({ id }: any) => approveApproval(id) });
+
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => approveApproval(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["approvals"] }),
+  });
+  const rejectMutation = useMutation({
+    mutationFn: (id: string) => rejectApproval(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["approvals"] }),
+  });
 
   const approvals = approvalsQuery.data ?? [];
 
   async function handleDecision(id: string, decision: "approve" | "reject") {
     setPendingId(id);
     try {
-      await approveMutation.mutateAsync({ id, decision });
-      await queryClient.invalidateQueries({ queryKey: ["approvals"] });
-      addToast(t("common.success"), "success");
+      if (decision === "approve") {
+        await approveMutation.mutateAsync(id);
+        addToast(t("approvals.approvedToast"), "success");
+      } else {
+        await rejectMutation.mutateAsync(id);
+        addToast(t("approvals.rejectedToast"), "success");
+      }
     } catch (e: any) {
       addToast(e.message || t("common.error"), "error");
     } finally {
@@ -63,27 +114,36 @@ export function ApprovalsPage() {
         </div>
       ) : (
         <div className="grid gap-4">
-          {approvals.map((a) => (
-            <Card key={a.id} hover padding="lg">
-              <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center shrink-0">
-                      <CheckCircle className="w-5 h-5 text-warning" />
-                    </div>
-                    <div>
-                      <Badge variant="warning">{t("approvals.pending_review")}</Badge>
-                      <p className="mt-1 text-sm font-medium leading-relaxed">{a.action_summary || a.description || t("common.actions")}</p>
+          {approvals.map((a) => {
+            const isPending = !a.status || a.status === "pending";
+            return (
+              <Card key={a.id} hover padding="lg">
+                <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-3">
+                      <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${statusIconBg(a.status)}`}>
+                        {statusIcon(a.status)}
+                      </div>
+                      <div>
+                        {statusBadge(a.status, t)}
+                        <p className="mt-1 text-sm font-medium leading-relaxed">{a.action_summary || a.description || t("common.actions")}</p>
+                      </div>
                     </div>
                   </div>
+                  {isPending ? (
+                    <div className="flex gap-3 shrink-0">
+                      <Button variant="danger" onClick={() => handleDecision(a.id, "reject")} disabled={pendingId === a.id}>{t("approvals.reject")}</Button>
+                      <Button variant="success" onClick={() => handleDecision(a.id, "approve")} disabled={pendingId === a.id}>{t("approvals.approve")}</Button>
+                    </div>
+                  ) : (
+                    <div className="text-sm text-text-dim shrink-0">
+                      {t(`approvals.status.${a.status}`)}
+                    </div>
+                  )}
                 </div>
-                <div className="flex gap-3 shrink-0">
-                  <Button variant="danger" onClick={() => handleDecision(a.id, "reject")} disabled={pendingId === a.id}>{t("approvals.reject")}</Button>
-                  <Button variant="success" onClick={() => handleDecision(a.id, "approve")} disabled={pendingId === a.id}>{t("approvals.approve")}</Button>
-                </div>
-              </div>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Reject button was calling the approve API — the mutation ignored the `decision` parameter entirely
- Add separate `rejectMutation` using the `rejectApproval` endpoint
- Show status badge instead of action buttons for non-pending (approved/rejected/expired) items
- Add `status.*` and toast locale keys for en and zh

## Test plan
- [ ] Click Approve on a pending approval → should call `/api/approvals/{id}/approve`
- [ ] Click Reject on a pending approval → should call `/api/approvals/{id}/reject`
- [ ] Expired/resolved approvals should show status text, not action buttons

Closes #1797