### PR TITLE
fix(channels): respect default_agent in channel message routing

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3903,6 +3903,14 @@ system_prompt = "You are a helpful assistant."
         }
         drop(entry);
 
+        // Skip auto-routing for channel messages. When a channel has
+        // `default_agent = "assistant"`, the user explicitly chose the
+        // assistant — keyword/semantic routing must not override that.
+        // Users can still switch agents via `/agent <name>`.
+        if sender_context.is_some() {
+            return Ok(agent_id);
+        }
+
         let route_key = Self::assistant_route_key(agent_id, sender_context);
 
         if Self::should_reuse_cached_route(message) {


### PR DESCRIPTION
## Summary

- When a channel sets `default_agent = "assistant"`, the kernel's `resolve_assistant_target` still applied keyword/semantic routing, redirecting messages to unrelated agents based on content (e.g. "测试" → test-engineer)
- Skip auto-routing when the message comes from a channel (`sender_context.is_some()`)
- Users can still manually switch agents via `/agent <name>`

Fixes #1806

## Test plan

- [ ] Set `default_agent = "assistant"` in WeChat config, send "测试一下" → should go to assistant, not test-engineer
- [ ] `/agent test-engineer` should still work for manual switching