### PR TITLE
fix(whatsapp): propagate group context and @mention detection

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1241,7 +1241,8 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
             .unwrap_or_else(|| "api".to_string()),
         user_id: sender_id.clone(),
         display_name: req.sender_name.clone().unwrap_or_else(|| sender_id.clone()),
-        is_group: false,
+        is_group: req.is_group,
+        was_mentioned: req.was_mentioned,
         thread_id: None,
         account_id: None,
     })
@@ -4414,6 +4415,8 @@ mod tests {
             sender_id: None,
             sender_name: None,
             channel_type: Some("whatsapp".to_string()),
+            is_group: false,
+            was_mentioned: false,
             ephemeral: false,
         };
         assert!(request_sender_context(&req).is_none());
@@ -4427,12 +4430,31 @@ mod tests {
             sender_id: Some("u-123".to_string()),
             sender_name: None,
             channel_type: None,
+            is_group: false,
+            was_mentioned: false,
             ephemeral: false,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert_eq!(sender.user_id, "u-123");
         assert_eq!(sender.display_name, "u-123");
         assert_eq!(sender.channel, "api");
+    }
+
+    #[test]
+    fn test_request_sender_context_propagates_group_and_mention() {
+        let req = MessageRequest {
+            message: "hello".to_string(),
+            attachments: Vec::new(),
+            sender_id: Some("u-456".to_string()),
+            sender_name: Some("Alice".to_string()),
+            channel_type: Some("whatsapp".to_string()),
+            is_group: true,
+            was_mentioned: true,
+            ephemeral: false,
+        };
+        let sender = request_sender_context(&req).expect("sender context");
+        assert!(sender.is_group);
+        assert!(sender.was_mentioned);
     }
 
     #[test]

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -165,6 +165,12 @@ pub struct MessageRequest {
     /// Optional channel type (e.g. "whatsapp", "telegram").
     #[serde(default)]
     pub channel_type: Option<String>,
+    /// Whether this message originated from a group chat (vs DM).
+    #[serde(default)]
+    pub is_group: bool,
+    /// Whether the bot was @mentioned in a group message.
+    #[serde(default)]
+    pub was_mentioned: bool,
     /// If true, this is an ephemeral "side question" (`/btw`).
     /// The message is answered using the agent's system prompt but WITHOUT
     /// loading or saving session history — the real conversation is untouched.

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -557,6 +557,7 @@ async fn handle_text_message(
                 user_id: client_ip.to_string(),
                 display_name: "Web UI".to_string(),
                 is_group: false,
+                was_mentioned: false,
                 thread_id: None,
                 account_id: None,
             };

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -750,6 +750,11 @@ fn build_sender_context(message: &ChannelMessage) -> SenderContext {
         user_id: sender_user_id(message).to_string(),
         display_name: message.sender.display_name.clone(),
         is_group: message.is_group,
+        was_mentioned: message
+            .metadata
+            .get("was_mentioned")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
         thread_id: message.thread_id.clone(),
         account_id: message
             .metadata

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -176,6 +176,9 @@ pub struct SenderContext {
     /// Whether the message came from a group chat (vs DM).
     #[serde(default)]
     pub is_group: bool,
+    /// Whether the bot was @mentioned in this message.
+    #[serde(default)]
+    pub was_mentioned: bool,
     /// Thread ID for threaded conversations (platform-specific).
     #[serde(default)]
     pub thread_id: Option<String>,

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3285,6 +3285,8 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
+                is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
+                was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")
@@ -4221,6 +4223,8 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
+                is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
+                was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")
@@ -10507,6 +10511,7 @@ mod tests {
             user_id: "user-123".to_string(),
             display_name: "Alice".to_string(),
             is_group: true,
+            was_mentioned: false,
             thread_id: Some("thread-9".to_string()),
             account_id: None,
         };

--- a/crates/librefang-runtime/src/pii_filter.rs
+++ b/crates/librefang-runtime/src/pii_filter.rs
@@ -116,6 +116,7 @@ impl PiiFilter {
                 user_id: REDACTED_PLACEHOLDER.to_string(),
                 display_name: REDACTED_PLACEHOLDER.to_string(),
                 is_group: sender.is_group,
+                was_mentioned: sender.was_mentioned,
                 thread_id: sender.thread_id.clone(),
                 account_id: sender
                     .account_id
@@ -130,6 +131,7 @@ impl PiiFilter {
                     user_id: pseudo_id,
                     display_name: pseudo_name,
                     is_group: sender.is_group,
+                    was_mentioned: sender.was_mentioned,
                     thread_id: sender.thread_id.clone(),
                     account_id: sender
                         .account_id
@@ -349,6 +351,7 @@ mod tests {
             user_id: "12345".to_string(),
             display_name: "Alice Smith".to_string(),
             is_group: false,
+            was_mentioned: false,
             thread_id: None,
             account_id: Some("acct-1".to_string()),
         };
@@ -369,6 +372,7 @@ mod tests {
             user_id: "uid-999".to_string(),
             display_name: "Bob".to_string(),
             is_group: true,
+            was_mentioned: false,
             thread_id: Some("thread-1".to_string()),
             account_id: None,
         };
@@ -389,6 +393,7 @@ mod tests {
             user_id: "U123".to_string(),
             display_name: "Charlie".to_string(),
             is_group: false,
+            was_mentioned: false,
             thread_id: None,
             account_id: None,
         };

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -41,6 +41,10 @@ pub struct PromptContext {
     pub sender_display_name: Option<String>,
     /// Sender's platform user ID (from channel message).
     pub sender_user_id: Option<String>,
+    /// Whether the current message originated from a group chat.
+    pub is_group: bool,
+    /// Whether the bot was @mentioned in a group message.
+    pub was_mentioned: bool,
     /// Whether this agent was spawned as a subagent.
     pub is_subagent: bool,
     /// Whether this agent has autonomous config.
@@ -160,6 +164,8 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
                 channel,
                 ctx.sender_display_name.as_deref(),
                 ctx.sender_user_id.as_deref(),
+                ctx.is_group,
+                ctx.was_mentioned,
             ));
         }
     }
@@ -428,6 +434,8 @@ fn build_channel_section(
     channel: &str,
     sender_name: Option<&str>,
     sender_id: Option<&str>,
+    is_group: bool,
+    was_mentioned: bool,
 ) -> String {
     let (limit, hints) = match channel {
         "telegram" => (
@@ -476,6 +484,12 @@ fn build_channel_section(
             section.push_str(&format!("\nThe current message is from platform ID: {id}."));
         }
         (None, None) => {}
+    }
+    if is_group {
+        section.push_str("\nThis message is from a group chat.");
+        if was_mentioned {
+            section.push_str(" You were @mentioned directly.");
+        }
     }
     section
 }
@@ -935,30 +949,44 @@ mod tests {
 
     #[test]
     fn test_channel_telegram() {
-        let section = build_channel_section("telegram", None, None);
+        let section = build_channel_section("telegram", None, None, false, false);
         assert!(section.contains("4096"));
         assert!(section.contains("Telegram"));
     }
 
     #[test]
     fn test_channel_discord() {
-        let section = build_channel_section("discord", None, None);
+        let section = build_channel_section("discord", None, None, false, false);
         assert!(section.contains("2000"));
         assert!(section.contains("Discord"));
     }
 
     #[test]
     fn test_channel_irc() {
-        let section = build_channel_section("irc", None, None);
+        let section = build_channel_section("irc", None, None, false, false);
         assert!(section.contains("512"));
         assert!(section.contains("plain text"));
     }
 
     #[test]
     fn test_channel_unknown_gets_default() {
-        let section = build_channel_section("smoke_signal", None, None);
+        let section = build_channel_section("smoke_signal", None, None, false, false);
         assert!(section.contains("4096"));
         assert!(section.contains("smoke_signal"));
+    }
+
+    #[test]
+    fn test_channel_group_chat_context() {
+        let section = build_channel_section("whatsapp", Some("Alice"), None, true, false);
+        assert!(section.contains("group chat"));
+        assert!(!section.contains("@mentioned"));
+    }
+
+    #[test]
+    fn test_channel_group_mentioned() {
+        let section = build_channel_section("whatsapp", Some("Bob"), None, true, true);
+        assert!(section.contains("group chat"));
+        assert!(section.contains("@mentioned"));
     }
 
     #[test]

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -875,6 +875,18 @@ async function startConnection() {
       const isOwner = OWNER_JIDS.size > 0 && (OWNER_JIDS.has(sender) || (senderPnJid && OWNER_JIDS.has(senderPnJid)));
       const isStranger = !isGroup && OWNER_JIDS.size > 0 && !isOwner;
 
+      // Detect @mention: check if our JID is in the mentionedJid list
+      let wasMentioned = false;
+      if (isGroup && ownJid) {
+        const mentionedJids = innerMsg.extendedTextMessage?.contextInfo?.mentionedJid
+          || innerMsg.imageMessage?.contextInfo?.mentionedJid
+          || innerMsg.videoMessage?.contextInfo?.mentionedJid
+          || [];
+        // ownJid is normalized like "1234567890@s.whatsapp.net"
+        const ownNumber = ownJid.replace(/@.*$/, '');
+        wasMentioned = mentionedJids.some(jid => jid.replace(/@.*$/, '') === ownNumber);
+      }
+
       // Rate limiting for strangers
       if (isStranger && isRateLimited(sender)) {
         console.log(`[gateway] Rate limited: ${pushName} (${phone}) — dropping message`);
@@ -1014,7 +1026,7 @@ async function startConnection() {
           messageToSend = messageText;
         }
 
-        const response = await forwardToLibreFang(messageToSend, systemPrefix, phone, pushName, isOwner, attachments);
+        const response = await forwardToLibreFang(messageToSend, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned });
 
         if (response && sock) {
           if (isStranger) {
@@ -1421,7 +1433,7 @@ function buildRelaySystemInstruction() {
 // ---------------------------------------------------------------------------
 const MAX_FORWARD_RETRIES = 1;
 
-async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, retryCount = 0) {
+async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup = false, wasMentioned = false } = {}, retryCount = 0) {
   // Resolve agent UUID if not cached (or if invalidated on reconnect)
   if (!cachedAgentId) {
     try {
@@ -1439,6 +1451,8 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
     channel_type: 'whatsapp',
     sender_id: phone,
     sender_name: pushName,
+    is_group: isGroup,
+    was_mentioned: wasMentioned,
   };
 
   // Include attachments if present
@@ -1473,7 +1487,7 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
               console.log('[gateway] Agent UUID stale (404), re-resolving...');
               cachedAgentId = null;
               resolveAgentId()
-                .then(() => forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, retryCount + 1))
+                .then(() => forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned }, retryCount + 1))
                 .then(resolve)
                 .catch(reject);
               return;
@@ -1587,8 +1601,9 @@ async function sendMessage(to, text) {
     throw new Error('WhatsApp not connected');
   }
 
-  // Normalize phone → JID: "+1234567890" → "1234567890@s.whatsapp.net"
-  const jid = to.replace(/^\+/, '').replace(/@.*$/, '') + '@s.whatsapp.net';
+  // Preserve group JIDs (@g.us) as-is; normalize phone → JID for individuals
+  const jid = to.includes('@g.us') ? to
+    : to.replace(/^\+/, '').replace(/@.*$/, '') + '@s.whatsapp.net';
 
   const formatted = markdownToWhatsApp(text);
   const sent = await sock.sendMessage(jid, { text: formatted });
@@ -1612,7 +1627,9 @@ async function sendImage(to, imageUrl, caption) {
     throw new Error('WhatsApp not connected');
   }
 
-  const jid = to.replace(/^\+/, '').replace(/@.*$/, '') + '@s.whatsapp.net';
+  // Preserve group JIDs (@g.us) as-is; normalize phone → JID for individuals
+  const jid = to.includes('@g.us') ? to
+    : to.replace(/^\+/, '').replace(/@.*$/, '') + '@s.whatsapp.net';
 
   // Fetch image into buffer (Baileys needs buffer or local file)
   const buffer = await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Gateway now detects @mentions via `contextInfo.mentionedJid` and sends `is_group` + `was_mentioned` to the API
- API reads these fields into `SenderContext` so the group policy engine works for WhatsApp
- Prompt builder adds sender identity prefix for group messages

Partial fix for #1218 (covers P0 items: group detection + mention detection)

## Test plan

- [ ] Send message in WhatsApp group without @mention → should be filtered by MentionOnly policy (default)
- [ ] Send message in WhatsApp group with @mention → should be processed
- [ ] DM messages → unchanged behavior