### PR TITLE
fix(mcp): use mutable default for non-exhaustive config struct

### DIFF
--- a/crates/librefang-runtime/src/mcp.rs
+++ b/crates/librefang-runtime/src/mcp.rs
@@ -435,11 +435,9 @@ impl McpConnection {
             }
         }
 
-        let config = StreamableHttpClientTransportConfig {
-            uri: Arc::from(url),
-            custom_headers,
-            ..Default::default()
-        };
+        let mut config = StreamableHttpClientTransportConfig::default();
+        config.uri = Arc::from(url);
+        config.custom_headers = custom_headers;
 
         let transport = StreamableHttpClientTransport::from_config(config);
 


### PR DESCRIPTION
## Summary

rmcp 1.3 marks `StreamableHttpClientTransportConfig` as `#[non_exhaustive]`, breaking the struct expression used in #1809. Use `Default::default()` + field assignment instead.

## Test plan

- [ ] CI compiles on all platforms