### PR TITLE
fix: remove duplicate is_group/was_mentioned in PromptContext

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3307,8 +3307,6 @@ system_prompt = "You are a helpful assistant."
                         .to_string(),
                 ),
                 active_goals: self.active_goals_for_prompt(Some(agent_id)),
-                is_group: false,
-                was_mentioned: false,
             };
             manifest.model.system_prompt =
                 librefang_runtime::prompt_builder::build_system_prompt(&prompt_ctx);
@@ -4255,8 +4253,6 @@ system_prompt = "You are a helpful assistant."
                         .to_string(),
                 ),
                 active_goals: self.active_goals_for_prompt(Some(agent_id)),
-                is_group: false,
-                was_mentioned: false,
             };
             manifest.model.system_prompt =
                 librefang_runtime::prompt_builder::build_system_prompt(&prompt_ctx);


### PR DESCRIPTION
PR #1816 added is_group/was_mentioned to PromptContext constructions that #1811 had already populated from sender_context. This caused E0062 (field specified more than once) on all platforms.