### PR TITLE
fix(install): add auto-init step to Windows installer

### DIFF
--- a/web/public/install.ps1
+++ b/web/public/install.ps1
@@ -252,6 +252,12 @@ function Install-LibreFang {
     Write-Host "  and configuration."
     Write-Host ""
 
+    # Auto-initialize (sync registry, generate config)
+    Write-Host "  Initializing LibreFang..." -ForegroundColor Cyan
+    try {
+        & $installedExe init 2>&1 | Out-Null
+    } catch {}
+
     $autoStartRaw = if ($env:LIBREFANG_AUTO_START) { $env:LIBREFANG_AUTO_START } else { "1" }
     if (Test-Enabled $autoStartRaw) {
         Write-Host "  Starting daemon in background..." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- Windows `install.ps1` was missing the `librefang init` step that `install.sh` (Unix) already has
- New Windows users got no `config.toml` after installation, causing first-run issues
- Added `& $installedExe init` before the auto-start daemon step, matching the Unix installer behavior

## Test plan
- [ ] Run `install.ps1` on a clean Windows machine and verify `~/.librefang/config.toml` is created
- [ ] Verify daemon auto-start works after init completes