### PR TITLE
docs: fix development guide with just usage and dashboard debugging

### DIFF
--- a/docs/src/app/development/page.mdx
+++ b/docs/src/app/development/page.mdx
@@ -8,9 +8,26 @@ LibreFang development environment setup and contribution guidelines.
 
 ### Prerequisites
 
-- **Rust** 1.75+
-- **Node.js** 18+ (for desktop app)
-- **pnpm** 8+ (for documentation site)
+- **Rust** 1.85+
+- **Node.js** 22+ (for dashboard and desktop app)
+- **pnpm** 10+ (for dashboard, docs, and web site)
+- **just** (command runner, [install guide](https://github.com/casey/just#installation))
+
+Install just:
+
+```bash
+# macOS
+brew install just
+
+# Windows
+winget install Casey.Just        # or: scoop install just
+
+# Linux (Debian/Ubuntu)
+sudo apt install just            # Ubuntu 24.04+, otherwise use cargo
+
+# Any platform with Rust installed
+cargo install just
+```
 
 ### Clone Repository
 
@@ -19,22 +36,84 @@ git clone https://github.com/librefang/librefang.git
 cd librefang
 ```
 
-### Build
+### Build with just (Recommended)
+
+The project uses [just](https://github.com/casey/just) as a command runner.
+Run `just` to list all available recipes.
 
 ```bash
-# Build entire workspace
+# Build + install CLI with dashboard (recommended for first-time setup)
+just install
+
+# Build workspace libraries only
+just build
+
+# Run all tests
+just test
+
+# Lint (must have zero clippy warnings)
+just lint
+
+# Local CI simulation: build + test + clippy + web lint
+just ci
+```
+
+`just install` automatically builds the React dashboard before compiling the CLI binary,
+so the dashboard will be fully functional on `http://127.0.0.1:4545/`.
+
+### Build without just
+
+```bash
+# Build entire workspace (dashboard assets are pre-committed, no extra step needed)
 cargo build --workspace
 
-# Build CLI
+# Build CLI only
 cargo build -p librefang-cli
 
 # Build desktop app
 cargo build -p librefang-desktop
+```
 
-# Build React dashboard (required for web UI)
-cd crates/librefang-api/dashboard-react
-npm install
-npm run build
+### First Run
+
+```bash
+# Initialize config (~/.librefang/config.toml)
+librefang init
+
+# Start the daemon
+librefang start
+
+# Open dashboard: http://127.0.0.1:4545/
+```
+
+### Dashboard Development
+
+The React dashboard build output is pre-committed in `crates/librefang-api/static/react/`.
+If you modify the dashboard source code, rebuild before compiling the Rust binary:
+
+```bash
+# Rebuild dashboard assets
+just dashboard-build
+
+# Or manually:
+cd crates/librefang-api/dashboard
+pnpm install --frozen-lockfile
+pnpm run build
+cd ../../..
+cargo build -p librefang-cli
+```
+
+For active development with hot reload:
+
+```bash
+# Option A: start daemon + dashboard dev server together
+just dev
+
+# Option B: manually
+librefang start                          # Terminal 1: backend daemon
+cd crates/librefang-api/dashboard        # Terminal 2: Vite dev server
+pnpm install && pnpm dev
+# Open http://localhost:5173/dashboard/  # Auto-proxies /api to 127.0.0.1:4545
 ```
 
 ### Test
@@ -387,14 +466,59 @@ RUST_LOG=debug cargo run
 RUST_LOG=librefang_kernel=trace cargo run
 ```
 
+### Dashboard Debugging
+
+The dashboard is a React SPA embedded into the binary at compile time via `include_dir!`.
+Asset files are served at `/dashboard/*`.
+
+**Blank page / assets 404:**
+
+```bash
+# 1. Check that the daemon is running and healthy
+curl -s http://127.0.0.1:4545/api/health
+
+# 2. Verify the HTML is served (should return <!doctype html>...)
+curl -s http://127.0.0.1:4545/ | head -5
+
+# 3. Test a specific asset path (pick from the <script> tag in the HTML)
+curl -sI http://127.0.0.1:4545/dashboard/assets/index-DVRukrPy.js
+# 200 = OK, 404 = assets not embedded
+
+# 4. If assets 404, verify the build output exists before compiling
+ls crates/librefang-api/static/react/index.html
+ls crates/librefang-api/static/react/assets/
+
+# 5. Rebuild: embed fresh assets into the binary
+cargo xtask build-web --dashboard
+cargo build -p librefang-cli --release
+```
+
+**Dashboard shows but data is empty:**
+
+```bash
+# Check API endpoints directly
+curl -s http://127.0.0.1:4545/api/status | python3 -m json.tool
+curl -s http://127.0.0.1:4545/api/agents | python3 -m json.tool
+
+# Check browser console for CORS or auth errors (F12 → Console)
+# Default install has no auth — if api_key is set, pass it:
+curl -s -H "Authorization: Bearer YOUR_KEY" http://127.0.0.1:4545/api/status
+```
+
+**Dashboard dev server can't reach API:**
+
+```bash
+# Vite proxies /api to http://127.0.0.1:4545 — make sure daemon is running
+librefang status
+# If not running:
+librefang start
+```
+
 ### Performance Profiling
 
 ```bash
 # CPU profiling
 cargo flamegraph --bin librefang-cli -- start
-
-# Memory profiling
-cargo leptos --bin librefang-cli -- start
 ```
 
 ---

--- a/docs/src/app/zh/development/page.mdx
+++ b/docs/src/app/zh/development/page.mdx
@@ -8,9 +8,26 @@ LibreFang 开发环境设置和贡献指南。
 
 ### 前置要求
 
-- **Rust** 1.75+
-- **Node.js** 18+ (用于桌面应用)
-- **pnpm** 8+ (用于文档站点)
+- **Rust** 1.85+
+- **Node.js** 22+（用于 Dashboard 和桌面应用）
+- **pnpm** 10+（用于 Dashboard、文档站点和官网）
+- **just**（命令运行器，[安装说明](https://github.com/casey/just#installation)）
+
+安装 just：
+
+```bash
+# macOS
+brew install just
+
+# Windows
+winget install Casey.Just        # 或：scoop install just
+
+# Linux (Debian/Ubuntu)
+sudo apt install just            # Ubuntu 24.04+，否则用 cargo 安装
+
+# 任何已安装 Rust 的平台
+cargo install just
+```
 
 ### 克隆仓库
 
@@ -19,22 +36,84 @@ git clone https://github.com/librefang/librefang.git
 cd librefang
 ```
 
-### 构建
+### 使用 just 构建（推荐）
+
+项目使用 [just](https://github.com/casey/just) 作为命令运行器。
+运行 `just` 可查看所有可用命令。
 
 ```bash
-# 构建整个工作空间
+# 构建 + 安装 CLI 和 Dashboard（首次设置推荐）
+just install
+
+# 仅构建工作空间库
+just build
+
+# 运行所有测试
+just test
+
+# 代码检查（clippy 必须零警告）
+just lint
+
+# 本地 CI 模拟：构建 + 测试 + clippy + web lint
+just ci
+```
+
+`just install` 会自动先构建 React Dashboard，再编译 CLI 二进制，
+确保 Dashboard 在 `http://127.0.0.1:4545/` 上完整可用。
+
+### 不使用 just 构建
+
+```bash
+# 构建整个工作空间（Dashboard 资源已预提交，无需额外步骤）
 cargo build --workspace
 
-# 构建 CLI
+# 仅构建 CLI
 cargo build -p librefang-cli
 
 # 构建桌面应用
 cargo build -p librefang-desktop
+```
 
-# 构建 React Dashboard（Web UI 所需）
-cd crates/librefang-api/dashboard-react
-npm install
-npm run build
+### 首次运行
+
+```bash
+# 初始化配置（~/.librefang/config.toml）
+librefang init
+
+# 启动守护进程
+librefang start
+
+# 打开 Dashboard: http://127.0.0.1:4545/
+```
+
+### Dashboard 开发
+
+React Dashboard 的构建产物已预提交在 `crates/librefang-api/static/react/` 目录中。
+如果你修改了 Dashboard 源码，需要在编译 Rust 二进制之前重新构建：
+
+```bash
+# 重新构建 Dashboard 资源
+just dashboard-build
+
+# 或手动构建：
+cd crates/librefang-api/dashboard
+pnpm install --frozen-lockfile
+pnpm run build
+cd ../../..
+cargo build -p librefang-cli
+```
+
+使用热更新进行开发：
+
+```bash
+# 方式一：同时启动守护进程 + Dashboard 开发服务器
+just dev
+
+# 方式二：手动启动
+librefang start                          # 终端 1：后端守护进程
+cd crates/librefang-api/dashboard        # 终端 2：Vite 开发服务器
+pnpm install && pnpm dev
+# 打开 http://localhost:5173/dashboard/  # 自动代理 /api 到 127.0.0.1:4545
 ```
 
 ### 测试
@@ -387,14 +466,59 @@ RUST_LOG=debug cargo run
 RUST_LOG=librefang_kernel=trace cargo run
 ```
 
+### Dashboard 调试
+
+Dashboard 是一个 React SPA，通过 `include_dir!` 在编译时嵌入到二进制中。
+资源文件通过 `/dashboard/*` 路径提供服务。
+
+**空白页 / 资源 404：**
+
+```bash
+# 1. 确认守护进程正在运行且健康
+curl -s http://127.0.0.1:4545/api/health
+
+# 2. 验证 HTML 是否正常返回（应返回 <!doctype html>...）
+curl -s http://127.0.0.1:4545/ | head -5
+
+# 3. 测试具体资源路径（从 HTML 中的 <script> 标签获取路径）
+curl -sI http://127.0.0.1:4545/dashboard/assets/index-DVRukrPy.js
+# 200 = 正常, 404 = 资源未嵌入
+
+# 4. 如果资源 404，验证编译前构建产物是否存在
+ls crates/librefang-api/static/react/index.html
+ls crates/librefang-api/static/react/assets/
+
+# 5. 重新构建：将新资源嵌入二进制
+cargo xtask build-web --dashboard
+cargo build -p librefang-cli --release
+```
+
+**Dashboard 能显示但数据为空：**
+
+```bash
+# 直接测试 API 端点
+curl -s http://127.0.0.1:4545/api/status | python3 -m json.tool
+curl -s http://127.0.0.1:4545/api/agents | python3 -m json.tool
+
+# 检查浏览器控制台是否有 CORS 或认证错误（F12 → Console）
+# 默认安装无需认证 — 如果设置了 api_key，需要传入：
+curl -s -H "Authorization: Bearer YOUR_KEY" http://127.0.0.1:4545/api/status
+```
+
+**Dashboard 开发服务器无法连接 API：**
+
+```bash
+# Vite 会将 /api 代理到 http://127.0.0.1:4545 — 确保守护进程正在运行
+librefang status
+# 如果未运行：
+librefang start
+```
+
 ### 性能分析
 
 ```bash
-# CPU  profiling
+# CPU profiling
 cargo flamegraph --bin librefang-cli -- start
-
-# 内存分析
-cargo leptos --bin librefang-cli -- start
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fix wrong dashboard build instructions (`dashboard-react` → `dashboard`, `npm` → `pnpm`)
- Add `just` installation guide for macOS/Windows/Linux
- Add `just install` / `just dev` / `just dashboard-build` usage
- Add dashboard debugging section (blank page / 404 / empty data)
- Add first run instructions (`librefang init` + `librefang start`)
- Remove invalid `cargo leptos` profiling command
- Both English and Chinese versions updated