### PR TITLE
docs: add Windows exe manual install guide

### DIFF
--- a/docs/src/app/librefang/page.mdx
+++ b/docs/src/app/librefang/page.mdx
@@ -34,14 +34,43 @@ Windows (PowerShell):
 irm https://librefang.ai/install.ps1 | iex
 ```
 
-The script auto-detects platform and architecture, downloads the binary, verifies SHA256 checksums, configures PATH, and starts the daemon.
+The script auto-detects platform and architecture, downloads the binary, verifies SHA256 checksums, configures PATH, runs `librefang init`, and starts the daemon.
 
 Environment variables:
 - `LIBREFANG_INSTALL_DIR` — install directory (default: `~/.librefang/bin`)
 - `LIBREFANG_VERSION` — specific version (default: latest)
 - `LIBREFANG_AUTO_START` — auto-start daemon (default: 1)
 
-**Homebrew**
+**Windows EXE (Manual)**
+
+If you prefer manual installation or the script doesn't work in your environment:
+
+1. Download `librefang-x86_64-pc-windows-msvc.zip` (or `aarch64` for ARM) from [GitHub Releases](https://github.com/librefang/librefang/releases/latest)
+2. Extract `librefang.exe` to a folder, e.g. `C:\Users\<you>\.librefang\bin\`
+3. Add that folder to your system PATH:
+   - Settings → System → About → Advanced system settings → Environment Variables
+   - Edit `Path` under User variables → Add the folder path
+4. Open a **new** terminal and run:
+
+```powershell
+# Initialize configuration
+librefang init
+
+# Start the daemon
+librefang start
+
+# Open dashboard in browser: http://127.0.0.1:4545/
+# Chat with the default agent
+librefang chat
+```
+
+<Note>
+`librefang init` creates `~/.librefang/config.toml` with a setup wizard.
+You must run `init` before `start` — otherwise the daemon has no configuration.
+On first run, if `init` has not been run, `start` and `chat` will auto-initialize.
+</Note>
+
+**Homebrew (macOS / Linux)**
 
 ```bash
 brew tap librefang/tap
@@ -58,17 +87,24 @@ npm install -g @librefang/cli@next             # Latest pre-release (Beta or RC)
 npm install -g @librefang/cli@2026.3.25-rc1    # Specific version
 ```
 
+**pip**
+
+```bash
+pip install librefang-cli                      # Stable
+pip install librefang-cli --pre                # Latest pre-release
+```
+
 **Cargo**
 
 ```bash
 cargo install --git https://github.com/librefang/librefang librefang-cli
 ```
 
-Or build from source:
+Or build from source (requires [just](https://github.com/casey/just)):
 ```bash
 git clone https://github.com/librefang/librefang.git
 cd librefang
-cargo install --path crates/librefang-cli
+just install
 ```
 
 **Docker**

--- a/docs/src/app/zh/librefang/page.mdx
+++ b/docs/src/app/zh/librefang/page.mdx
@@ -66,14 +66,43 @@ Windows (PowerShell):
 irm https://librefang.ai/install.ps1 | iex
 ```
 
-脚本自动检测平台和架构，下载二进制，验证 SHA256 校验和，配置 PATH 并启动守护进程。
+脚本自动检测平台和架构，下载二进制，验证 SHA256 校验和，配置 PATH，运行 `librefang init` 并启动守护进程。
 
 环境变量：
 - `LIBREFANG_INSTALL_DIR` — 安装目录（默认 `~/.librefang/bin`）
 - `LIBREFANG_VERSION` — 指定版本（默认最新）
 - `LIBREFANG_AUTO_START` — 是否自动启动（默认 1）
 
-**Homebrew**
+**Windows EXE（手动安装）**
+
+如果脚本在你的环境中无法使用，可以手动安装：
+
+1. 从 [GitHub Releases](https://github.com/librefang/librefang/releases/latest) 下载 `librefang-x86_64-pc-windows-msvc.zip`（ARM 设备下载 `aarch64` 版本）
+2. 解压 `librefang.exe` 到一个目录，如 `C:\Users\<你的用户名>\.librefang\bin\`
+3. 将该目录添加到系统 PATH：
+   - 设置 → 系统 → 关于 → 高级系统设置 → 环境变量
+   - 编辑用户变量中的 `Path` → 添加该目录路径
+4. 打开**新的**终端运行：
+
+```powershell
+# 初始化配置
+librefang init
+
+# 启动守护进程
+librefang start
+
+# 在浏览器中打开 Dashboard: http://127.0.0.1:4545/
+# 与默认 Agent 对话
+librefang chat
+```
+
+<Note>
+`librefang init` 会通过设置向导创建 `~/.librefang/config.toml` 配置文件。
+必须在 `start` 之前运行 `init`，否则守护进程没有配置。
+首次运行时，如果还没有执行过 `init`，`start` 和 `chat` 命令会自动触发初始化。
+</Note>
+
+**Homebrew (macOS / Linux)**
 
 ```bash
 brew tap librefang/tap
@@ -90,17 +119,24 @@ npm install -g @librefang/cli@next             # 最新预发布版 (Beta 或 RC
 npm install -g @librefang/cli@2026.3.25-rc1    # 指定版本
 ```
 
+**pip**
+
+```bash
+pip install librefang-cli                      # Stable
+pip install librefang-cli --pre                # 最新预发布版
+```
+
 **Cargo**
 
 ```bash
 cargo install --git https://github.com/librefang/librefang librefang-cli
 ```
 
-或从源码构建：
+或从源码构建（需要 [just](https://github.com/casey/just)）：
 ```bash
 git clone https://github.com/librefang/librefang.git
 cd librefang
-cargo install --path crates/librefang-cli
+just install
 ```
 
 **Docker**


### PR DESCRIPTION
## Summary
- Add Windows EXE manual installation guide (download zip, extract, add to PATH, init + start)
- Add `<Note>` explaining `librefang init` requirement and auto-init behavior
- Add `pip` install option
- Update source build to use `just install`
- Both English and Chinese versions updated