### PR TITLE
fix: resolve all open issues (#1827 #1828 #1829 #1830 #1832)

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -68,6 +68,8 @@
     "default_set": "Default provider updated",
     "is_default": "Default",
     "add": "Add Provider",
+    "delete_confirm_title": "Remove Provider Key",
+    "delete_confirm_message": "Are you sure you want to remove the API key for this provider? The provider will become unconfigured.",
     "help": "Manage LLM provider connections. Test connectivity, configure API keys, and monitor provider health status."
   },
   "channels": {

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -68,6 +68,8 @@
     "default_set": "默认供应商已更新",
     "is_default": "默认",
     "add": "添加供应商",
+    "delete_confirm_title": "移除供应商密钥",
+    "delete_confirm_message": "确定要移除此供应商的 API Key 吗？移除后该供应商将变为未配置状态。",
     "help": "管理大模型供应商连接。测试连通性、配置 API Key，监控供应商健康状态。"
   },
   "channels": {

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -17,7 +17,7 @@ import { useUIStore } from "../lib/store";
 import {
   Server, Zap, Clock, Key, Globe, CheckCircle2, XCircle, Loader2, AlertCircle, Search,
   SortAsc, SortDesc, CheckSquare, Square, ChevronRight, X, Grid3X3, List, Filter,
-  ExternalLink, Activity, Cpu, Cloud, Bot, Globe2, Sparkles, Plus, Star
+  ExternalLink, Activity, Cpu, Cloud, Bot, Globe2, Sparkles, Plus, Star, Pencil, Trash2
 } from "lucide-react";
 
 const REFRESH_MS = 30000;
@@ -84,10 +84,12 @@ interface ProviderCardProps {
   onSetDefault: (id: string) => void;
   onViewDetails: (provider: Provider) => void;
   onQuickConfig: (provider: Provider) => void;
+  onEdit: (provider: Provider) => void;
+  onDelete: (provider: Provider) => void;
   t: (key: string) => string;
 }
 
-function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onQuickConfig, t }: ProviderCardProps) {
+function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onQuickConfig, onEdit, onDelete, t }: ProviderCardProps) {
   const isConfigured = isProviderAvailable(p.auth_status);
 
   if (viewMode === "list") {
@@ -160,6 +162,16 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
           {isConfigured && !isDefault && (
             <Button variant="ghost" size="sm" onClick={() => onSetDefault(p.id)} leftIcon={<Star className="w-3 h-3" />}>
               <span className="hidden sm:inline">{t("providers.set_as_default")}</span>
+            </Button>
+          )}
+          {isConfigured && (
+            <Button variant="ghost" size="sm" onClick={() => onEdit(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+              <span className="hidden sm:inline">{t("common.edit")}</span>
+            </Button>
+          )}
+          {isConfigured && (
+            <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+              <span className="hidden sm:inline text-error">{t("common.delete")}</span>
             </Button>
           )}
           <Button
@@ -312,6 +324,16 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
           {isConfigured && !isDefault && (
             <Button variant="ghost" size="sm" onClick={() => onSetDefault(p.id)} leftIcon={<Star className="w-3 h-3" />} className="flex-1">
               {t("providers.set_as_default")}
+            </Button>
+          )}
+          {isConfigured && (
+            <Button variant="ghost" size="sm" onClick={() => onEdit(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+              {t("common.edit")}
+            </Button>
+          )}
+          {isConfigured && (
+            <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+              {t("common.delete")}
             </Button>
           )}
           <Button
@@ -506,6 +528,9 @@ export function ProvidersPage() {
   const [urlInput, setUrlInput] = useState("");
   const [keySaving, setKeySaving] = useState(false);
   const [keyError, setKeyError] = useState<string | null>(null);
+  const [keyTesting, setKeyTesting] = useState(false);
+  const [keyTestResult, setKeyTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [deleteConfirmProvider, setDeleteConfirmProvider] = useState<Provider | null>(null);
   const addToast = useUIStore((s) => s.addToast);
 
   const providersQuery = useQuery({ queryKey: ["providers", "list"], queryFn: listProviders, refetchInterval: REFRESH_MS });
@@ -631,6 +656,7 @@ export function ProvidersPage() {
     setKeyInput("");
     setUrlInput(provider.base_url || "");
     setKeyError(null);
+    setKeyTestResult(null);
   };
 
   const handleSaveKey = async () => {
@@ -666,6 +692,48 @@ export function ProvidersPage() {
       setKeyError(e?.message || String(e));
     } finally {
       setKeySaving(false);
+    }
+  };
+
+  const handleEdit = (provider: Provider) => {
+    setConfigProvider(provider);
+    setKeyInput("");
+    setUrlInput(provider.base_url || "");
+    setKeyError(null);
+    setKeyTestResult(null);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteConfirmProvider) return;
+    setKeySaving(true);
+    try {
+      await deleteProviderKey(deleteConfirmProvider.id);
+      await providersQuery.refetch();
+      setDeleteConfirmProvider(null);
+      addToast(t("providers.key_removed"), "success");
+    } catch (e: any) {
+      addToast(e?.message || t("common.error"), "error");
+    } finally {
+      setKeySaving(false);
+    }
+  };
+
+  const handleTestKey = async () => {
+    if (!configProvider) return;
+    setKeyTesting(true);
+    setKeyTestResult(null);
+    try {
+      const result = await testMutation.mutateAsync(configProvider.id);
+      if (result.status === "error") {
+        setKeyTestResult({ ok: false, message: String(result.error_message || result.error || t("providers.unreachable")) });
+      } else {
+        setKeyTestResult({ ok: true, message: t("providers.reachable") });
+      }
+      await providersQuery.refetch();
+    } catch (e: any) {
+      setKeyTestResult({ ok: false, message: e?.message || t("common.error") });
+    } finally {
+      setKeyTesting(false);
     }
   };
 
@@ -851,6 +919,8 @@ export function ProvidersPage() {
                 onSetDefault={handleSetDefault}
                 onViewDetails={setDetailsProvider}
                 onQuickConfig={handleQuickConfig}
+                onEdit={handleEdit}
+                onDelete={setDeleteConfirmProvider}
                 t={t}
               />
             ))}
@@ -918,17 +988,64 @@ export function ProvidersPage() {
                 </div>
               )}
 
+              {keyTestResult && (
+                <div className={`flex items-center gap-2 text-xs p-3 rounded-xl ${keyTestResult.ok ? "bg-success/10 border border-success/20 text-success" : "bg-error/10 border border-error/20 text-error"}`}>
+                  {keyTestResult.ok ? <CheckCircle2 className="w-4 h-4 shrink-0" /> : <XCircle className="w-4 h-4 shrink-0" />}
+                  {keyTestResult.message}
+                </div>
+              )}
+
               <div className="flex gap-2 pt-2">
-                <Button variant="primary" className="flex-1" onClick={handleSaveKey} disabled={keySaving || (!keyInput.trim() && urlInput === (configProvider.base_url || ""))}>
+                <Button variant="primary" className="flex-1" onClick={handleSaveKey} disabled={keySaving || keyTesting || (!keyInput.trim() && urlInput === (configProvider.base_url || ""))}>
                   {keySaving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Key className="w-4 h-4 mr-1" />}
                   {t("common.save")}
                 </Button>
+                <Button variant="secondary" onClick={handleTestKey} disabled={keySaving || keyTesting || !isProviderAvailable(configProvider.auth_status)}>
+                  {keyTesting ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
+                  {t("providers.test")}
+                </Button>
                 {configProvider.auth_status === "configured" && (
-                  <Button variant="secondary" onClick={handleDeleteKey} disabled={keySaving}>
+                  <Button variant="secondary" onClick={handleDeleteKey} disabled={keySaving || keyTesting}>
                     <XCircle className="w-4 h-4 mr-1 text-error" />
                     {t("providers.remove_key")}
                   </Button>
                 )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteConfirmProvider && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm" onClick={() => setDeleteConfirmProvider(null)}>
+          <div className="bg-surface rounded-2xl shadow-2xl border border-border-subtle w-[400px] max-w-[90vw] animate-fade-in-scale" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle">
+              <div className="flex items-center gap-2">
+                <Trash2 className="w-4 h-4 text-error" />
+                <h3 className="text-sm font-bold">{t("providers.delete_confirm_title")}</h3>
+              </div>
+              <button onClick={() => setDeleteConfirmProvider(null)} className="p-1 rounded hover:bg-main"><X className="w-4 h-4" /></button>
+            </div>
+            <div className="p-5 space-y-4">
+              <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
+                <div className="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
+                  {providerIcons[deleteConfirmProvider.id] || <Server className="w-5 h-5 text-error" />}
+                </div>
+                <div>
+                  <p className="text-sm font-bold">{deleteConfirmProvider.display_name || deleteConfirmProvider.id}</p>
+                  <p className="text-[10px] text-text-dim font-mono">{deleteConfirmProvider.id}</p>
+                </div>
+              </div>
+              <p className="text-sm text-text-dim">{t("providers.delete_confirm_message")}</p>
+              <div className="flex gap-2 pt-2">
+                <Button variant="ghost" className="flex-1" onClick={() => setDeleteConfirmProvider(null)}>
+                  {t("common.cancel")}
+                </Button>
+                <Button variant="primary" className="flex-1 !bg-error hover:!bg-error/80" onClick={handleDeleteConfirm} disabled={keySaving}>
+                  {keySaving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Trash2 className="w-4 h-4 mr-1" />}
+                  {t("common.delete")}
+                </Button>
               </div>
             </div>
           </div>

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -292,6 +292,7 @@ fn start_stream_text_bridge(
     >,
 ) -> mpsc::Receiver<String> {
     let (tx, rx) = mpsc::channel::<String>(64);
+    let error_tx = tx.clone();
 
     let bridge_handle = tokio::spawn(async move {
         // Buffer text per iteration. Some providers emit tool call syntax
@@ -339,9 +340,15 @@ fn start_stream_text_bridge(
     });
 
     tokio::spawn(async move {
-        match kernel_handle.await {
-            Err(e) => error!("Streaming kernel task panicked: {e}"),
-            Ok(Err(e)) => error!("Streaming kernel task returned error: {e}"),
+        let error_msg = match kernel_handle.await {
+            Err(e) => {
+                error!("Streaming kernel task panicked: {e}");
+                Some(format!("Task failed: {e}. Please try again."))
+            }
+            Ok(Err(e)) => {
+                error!("Streaming kernel task returned error: {e}");
+                Some(format!("Task failed: {e}. Please try again."))
+            }
             Ok(Ok(result)) => {
                 debug!(
                     input_tokens = result.total_usage.input_tokens,
@@ -349,8 +356,18 @@ fn start_stream_text_bridge(
                     iterations = result.iterations,
                     "Streaming kernel task completed"
                 );
+                None
             }
+        };
+        // Send error notification to the user through the channel before
+        // awaiting bridge_handle (which drops the original tx). The rx end
+        // stays open as long as at least one sender exists, so error_tx can
+        // still deliver here even if the bridge task already finished.
+        if let Some(msg) = error_msg {
+            let _ = error_tx.send(msg).await;
         }
+        // Drop error_tx so rx will close once bridge_handle also finishes.
+        drop(error_tx);
         if let Err(e) = bridge_handle.await {
             error!("Streaming bridge task panicked: {e}");
         }

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -1374,6 +1374,7 @@ impl LibreFangKernel {
             vertex_ai: config.vertex_ai.clone(),
             azure_openai: config.azure_openai.clone(),
             skip_permissions: true,
+            message_timeout_secs: config.default_model.message_timeout_secs,
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -1407,6 +1408,7 @@ impl LibreFangKernel {
                     vertex_ai: config.vertex_ai.clone(),
                     azure_openai: config.azure_openai.clone(),
                     skip_permissions: true,
+                    message_timeout_secs: config.default_model.message_timeout_secs,
                 };
                 match drivers::create_driver(&profile_config) {
                     Ok(profile_driver) => {
@@ -1465,6 +1467,7 @@ impl LibreFangKernel {
                             vertex_ai: config.vertex_ai.clone(),
                             azure_openai: config.azure_openai.clone(),
                             skip_permissions: true,
+                            message_timeout_secs: config.default_model.message_timeout_secs,
                         };
                         match drivers::create_driver(&auto_config) {
                             Ok(d) => {
@@ -1513,6 +1516,7 @@ impl LibreFangKernel {
                 vertex_ai: config.vertex_ai.clone(),
                 azure_openai: config.azure_openai.clone(),
                 skip_permissions: true,
+                message_timeout_secs: config.default_model.message_timeout_secs,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -7563,6 +7567,7 @@ system_prompt = "You are a helpful assistant."
                 vertex_ai: self.config.vertex_ai.clone(),
                 azure_openai: self.config.azure_openai.clone(),
                 skip_permissions: true,
+                message_timeout_secs: self.config.default_model.message_timeout_secs,
             };
 
             match self.driver_cache.get_or_create(&driver_config) {
@@ -7641,6 +7646,7 @@ system_prompt = "You are a helpful assistant."
                     vertex_ai: self.config.vertex_ai.clone(),
                     azure_openai: self.config.azure_openai.clone(),
                     skip_permissions: true,
+                    message_timeout_secs: self.config.default_model.message_timeout_secs,
                 };
                 match self.driver_cache.get_or_create(&config) {
                     Ok(d) => chain.push((d, fb.model.clone())),

--- a/crates/librefang-runtime/src/drivers/claude_code.rs
+++ b/crates/librefang-runtime/src/drivers/claude_code.rs
@@ -602,84 +602,98 @@ impl LlmDriver for ClaudeCodeDriver {
             ..Default::default()
         };
 
-        let timeout_duration = std::time::Duration::from_secs(self.message_timeout_secs);
-        let stream_result = tokio::time::timeout(timeout_duration, async {
-            while let Ok(Some(line)) = lines.next_line().await {
-                if line.trim().is_empty() {
-                    continue;
-                }
+        // Per-line inactivity timeout: each next_line() call must produce
+        // output within the timeout window. This prevents killing long-running
+        // but actively-streaming responses while still catching hung processes.
+        let inactivity_dur = std::time::Duration::from_secs(self.message_timeout_secs);
+        let stream_err: Option<LlmError> = loop {
+            match tokio::time::timeout(inactivity_dur, lines.next_line()).await {
+                Ok(Ok(Some(line))) => {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
 
-                match serde_json::from_str::<ClaudeStreamEvent>(&line) {
-                    Ok(event) => {
-                        match event.r#type.as_str() {
-                            "content" | "text" | "assistant" | "content_block_delta" => {
-                                if let Some(ref content) = event.content {
-                                    full_text.push_str(content);
-                                    let _ = tx
-                                        .send(StreamEvent::TextDelta {
-                                            text: content.clone(),
-                                        })
-                                        .await;
-                                }
-                            }
-                            "result" | "done" | "complete" => {
-                                if let Some(ref result) = event.result {
-                                    if full_text.is_empty() {
-                                        full_text = result.clone();
+                    match serde_json::from_str::<ClaudeStreamEvent>(&line) {
+                        Ok(event) => {
+                            match event.r#type.as_str() {
+                                "content" | "text" | "assistant" | "content_block_delta" => {
+                                    if let Some(ref content) = event.content {
+                                        full_text.push_str(content);
                                         let _ = tx
                                             .send(StreamEvent::TextDelta {
-                                                text: result.clone(),
+                                                text: content.clone(),
                                             })
                                             .await;
                                     }
                                 }
-                                if let Some(usage) = event.usage {
-                                    final_usage = TokenUsage {
-                                        input_tokens: usage.input_tokens,
-                                        output_tokens: usage.output_tokens,
-                                        ..Default::default()
-                                    };
+                                "result" | "done" | "complete" => {
+                                    if let Some(ref result) = event.result {
+                                        if full_text.is_empty() {
+                                            full_text = result.clone();
+                                            let _ = tx
+                                                .send(StreamEvent::TextDelta {
+                                                    text: result.clone(),
+                                                })
+                                                .await;
+                                        }
+                                    }
+                                    if let Some(usage) = event.usage {
+                                        final_usage = TokenUsage {
+                                            input_tokens: usage.input_tokens,
+                                            output_tokens: usage.output_tokens,
+                                            ..Default::default()
+                                        };
+                                    }
                                 }
-                            }
-                            _ => {
-                                // Unknown event type — try content field as fallback
-                                if let Some(ref content) = event.content {
-                                    full_text.push_str(content);
-                                    let _ = tx
-                                        .send(StreamEvent::TextDelta {
-                                            text: content.clone(),
-                                        })
-                                        .await;
+                                _ => {
+                                    // Unknown event type — try content field as fallback
+                                    if let Some(ref content) = event.content {
+                                        full_text.push_str(content);
+                                        let _ = tx
+                                            .send(StreamEvent::TextDelta {
+                                                text: content.clone(),
+                                            })
+                                            .await;
+                                    }
                                 }
                             }
                         }
-                    }
-                    Err(e) => {
-                        // Not valid JSON — treat as raw text
-                        warn!(line = %line, error = %e, "Non-JSON line from Claude CLI");
-                        full_text.push_str(&line);
-                        let _ = tx.send(StreamEvent::TextDelta { text: line }).await;
+                        Err(e) => {
+                            // Not valid JSON — treat as raw text
+                            warn!(line = %line, error = %e, "Non-JSON line from Claude CLI");
+                            full_text.push_str(&line);
+                            let _ = tx.send(StreamEvent::TextDelta { text: line }).await;
+                        }
                     }
                 }
+                Ok(Ok(None)) => break None, // EOF — stream finished normally
+                Ok(Err(e)) => {
+                    warn!(error = %e, "Claude Code CLI stream IO error");
+                    break None;
+                }
+                Err(_) => {
+                    // Inactivity timeout — no output for message_timeout_secs
+                    warn!(
+                        timeout_secs = self.message_timeout_secs,
+                        model = %pid_label,
+                        "Claude Code CLI streaming subprocess timed out after {}s of inactivity — process killed",
+                        self.message_timeout_secs
+                    );
+                    let _ = child.kill().await;
+                    break Some(LlmError::Http(format!(
+                        "Claude Code CLI streaming subprocess timed out after {}s of inactivity — process killed",
+                        self.message_timeout_secs
+                    )));
+                }
             }
-        })
-        .await;
+        };
 
         // Clear PID tracking
         self.active_pids.remove(&pid_label);
 
-        if stream_result.is_err() {
-            warn!(
-                timeout_secs = self.message_timeout_secs,
-                model = %pid_label,
-                "Claude Code CLI streaming subprocess timed out, killing process"
-            );
-            let _ = child.kill().await;
+        if let Some(err) = stream_err {
             prepared.cleanup();
-            return Err(LlmError::Http(format!(
-                "Claude Code CLI streaming subprocess timed out after {}s — process killed",
-                self.message_timeout_secs
-            )));
+            return Err(err);
         }
 
         // Clean up temp images now that the CLI has finished reading them

--- a/crates/librefang-runtime/src/drivers/mod.rs
+++ b/crates/librefang-runtime/src/drivers/mod.rs
@@ -675,9 +675,10 @@ fn create_driver_from_entry(
         ApiFormat::OpenAI => Ok(Arc::new(openai::OpenAIDriver::new(api_key, base_url))),
         ApiFormat::Anthropic => Ok(Arc::new(anthropic::AnthropicDriver::new(api_key, base_url))),
         ApiFormat::Gemini => Ok(Arc::new(gemini::GeminiDriver::new(api_key, base_url))),
-        ApiFormat::ClaudeCode => Ok(Arc::new(claude_code::ClaudeCodeDriver::new(
+        ApiFormat::ClaudeCode => Ok(Arc::new(claude_code::ClaudeCodeDriver::with_timeout(
             config.base_url.clone(),
             config.skip_permissions,
+            config.message_timeout_secs,
         ))),
         ApiFormat::QwenCode => Ok(Arc::new(qwen_code::QwenCodeDriver::new(
             config.base_url.clone(),
@@ -949,6 +950,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -963,6 +965,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1074,6 +1077,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1093,6 +1097,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1114,6 +1119,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let result = create_driver(&config);
         assert!(result.is_err());
@@ -1144,6 +1150,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -1168,6 +1175,7 @@ mod tests {
             },
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
 
         let driver = create_driver(&config);
@@ -1204,6 +1212,7 @@ mod tests {
                 api_version: Some("2024-02-01".to_string()),
             },
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1221,6 +1230,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         // Clear any env var that might interfere
         std::env::remove_var("AZURE_OPENAI_ENDPOINT");
@@ -1247,6 +1257,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let d1 = cache.get_or_create(&config).unwrap();
         let d2 = cache.get_or_create(&config).unwrap();
@@ -1264,6 +1275,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let config_b = DriverConfig {
             provider: "ollama".to_string(),
@@ -1272,6 +1284,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let d_a = cache.get_or_create(&config_a).unwrap();
         let d_b = cache.get_or_create(&config_b).unwrap();
@@ -1292,6 +1305,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         cache.get_or_create(&config).unwrap();
         assert_eq!(cache.len(), 1);

--- a/crates/librefang-runtime/src/drivers/vertex_ai.rs
+++ b/crates/librefang-runtime/src/drivers/vertex_ai.rs
@@ -954,6 +954,7 @@ mod tests {
             vertex_ai: librefang_types::config::VertexAiConfig::default(),
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "us-central1");
@@ -971,6 +972,7 @@ mod tests {
             },
             azure_openai: librefang_types::config::AzureOpenAiConfig::default(),
             skip_permissions: true,
+            message_timeout_secs: 300,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "europe-west4");

--- a/crates/librefang-runtime/src/llm_driver.rs
+++ b/crates/librefang-runtime/src/llm_driver.rs
@@ -201,10 +201,19 @@ pub struct DriverConfig {
     /// restricts what agents can do, making this safe.
     #[serde(default = "default_skip_permissions")]
     pub skip_permissions: bool,
+    /// Message timeout in seconds for CLI-based providers (e.g. Claude Code).
+    /// Inactivity-based: the process is killed after this many seconds of
+    /// silence on stdout, not wall-clock time.
+    #[serde(default = "default_message_timeout_secs")]
+    pub message_timeout_secs: u64,
 }
 
 fn default_skip_permissions() -> bool {
     true
+}
+
+fn default_message_timeout_secs() -> u64 {
+    300
 }
 
 /// SECURITY: Custom Debug impl redacts the API key.
@@ -228,6 +237,7 @@ impl std::fmt::Debug for DriverConfig {
             .field("azure_openai.deployment", &self.azure_openai.deployment)
             .field("azure_openai.api_version", &self.azure_openai.api_version)
             .field("skip_permissions", &self.skip_permissions)
+            .field("message_timeout_secs", &self.message_timeout_secs)
             .finish()
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2939,6 +2939,15 @@ pub struct DefaultModelConfig {
     pub api_key_env: String,
     /// Optional base URL override.
     pub base_url: Option<String>,
+    /// Message timeout in seconds for CLI-based providers (e.g. Claude Code).
+    /// The timeout is inactivity-based: the process is killed only after this
+    /// many seconds of silence on stdout, not wall-clock time.
+    #[serde(default = "default_message_timeout_secs")]
+    pub message_timeout_secs: u64,
+}
+
+fn default_message_timeout_secs() -> u64 {
+    300
 }
 
 impl Default for DefaultModelConfig {
@@ -2948,6 +2957,7 @@ impl Default for DefaultModelConfig {
             model: String::new(),
             api_key_env: String::new(),
             base_url: None,
+            message_timeout_secs: default_message_timeout_secs(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves all 5 open issues in a single PR.

### #1830 — Claude Code CLI timeout kills active tasks silently
- Add `message_timeout_secs` config field to `[default_model]` section (default: 300s)
- Wire timeout through `DriverConfig` → `ClaudeCodeDriver::with_timeout()`
- **Replace wall-clock timeout with per-line inactivity timeout** for streaming — long-running tasks that continuously produce output no longer get killed
- Send error notification to user through channel (Telegram/WhatsApp) on task failure instead of silent logging

### #1827 — Configure suppliers to add testing functionality
- Add "Test" button in provider key configuration dialog
- Tests connection before/after saving via `POST /api/providers/{name}/test`
- Shows inline success/failure status

### #1828 — Configured suppliers can modify their configurations
- Add "Edit" (pencil icon) button on configured provider cards
- Opens config form pre-filled with current base URL

### #1829 — Configured suppliers can be removed
- Add "Delete" (trash icon) button on configured provider cards
- Confirmation dialog before deletion
- Calls `DELETE /api/providers/{name}/key` and auto-refreshes

### #1832 — Set default supplier to take effect without restarting
- Already supported by existing hot-reload mechanism (`config_reload.rs` detects `default_model` changes → `UpdateDefaultModel` hot action)
- `POST /api/providers/{name}/default` endpoint already hot-updates `default_model_override` in memory
- No code changes needed — issue can be closed

## Changed files (10)
| File | Changes |
|------|---------|
| `types.rs` | Add `message_timeout_secs` to `DefaultModelConfig` |
| `llm_driver.rs` | Add `message_timeout_secs` to `DriverConfig` |
| `drivers/mod.rs` | Use `with_timeout()` for Claude Code driver |
| `drivers/claude_code.rs` | Inactivity-based streaming timeout |
| `drivers/vertex_ai.rs` | Add field to test configs |
| `kernel.rs` | Propagate timeout config to all driver sites |
| `channel_bridge.rs` | Send error to user on task failure |
| `ProvidersPage.tsx` | Edit/Delete/Test UI for providers |
| `en.json` / `zh.json` | i18n keys for delete confirmation |

## Test plan
- [ ] Configure `message_timeout_secs = 600` in config.toml, verify Claude Code uses it
- [ ] Stream a long Claude Code task — verify it runs beyond 5min if active
- [ ] Trigger a timeout — verify user receives error message in channel
- [ ] Test provider key from dashboard config dialog
- [ ] Edit an existing provider's base URL from dashboard
- [ ] Delete a configured provider from dashboard with confirmation
- [ ] Change default provider via API — verify it takes effect without restart

Closes #1827 Closes #1828 Closes #1829 Closes #1830 Closes #1832