### PR TITLE
fix: add missing message_timeout_secs in test DefaultModelConfig

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -10332,6 +10332,7 @@ mod tests {
             model: "Qwen3.5-4B-MLX-4bit".to_string(),
             api_key_env: String::new(),
             base_url: Some("http://127.0.0.1:11434/v1".to_string()),
+            message_timeout_secs: 300,
         });
 
         let agent_id = kernel


### PR DESCRIPTION
CI fix: test code at kernel.rs:10330 constructs DefaultModelConfig manually but was missing the new `message_timeout_secs` field added in #1834.