### PR TITLE
fix: remove needless borrow for clippy (Rust 1.94)

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -160,7 +160,7 @@ pub async fn quick_init(State(state): State<Arc<AppState>>) -> impl IntoResponse
     }
 
     // Ensure directories exist
-    let _ = std::fs::create_dir_all(&home);
+    let _ = std::fs::create_dir_all(home);
     let _ = std::fs::create_dir_all(home.join("data"));
 
     // Detect best available provider


### PR DESCRIPTION
## Summary
Fixes clippy error `needless_borrows_for_generic_args` in Rust 1.94.1.

The lint detects unnecessary borrows in function calls. Changed `&home` to `home` in `create_dir_all`.

## Test plan
- [ ] CI passes (clippy check)