### PR TITLE
fix(docker): remove nonexistent agents/ directory from Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
-COPY agents ./agents
 COPY packages ./packages
 COPY --from=dashboard-builder /build/static/react ./crates/librefang-api/static/react
 
@@ -40,7 +39,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     npm \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/librefang /usr/local/bin/
-COPY --from=builder /build/agents /opt/librefang/agents
 COPY --from=builder /build/packages /opt/librefang/packages
 COPY deploy/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- Remove `COPY agents ./agents` from build stage and `COPY --from=builder /build/agents /opt/librefang/agents` from runtime stage
- The `agents/` directory does not exist in the repository, causing Docker builds to fail with `"/agents": not found`

## Test plan
- [ ] Docker build succeeds on both linux/amd64 and linux/arm64