### PR TITLE
fix(container): resolve MCP server start-up failures by updating base runtime image to official node LTS image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -30,13 +30,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --bin librefang && \
     cp target/release/librefang /usr/local/bin/librefang
 
-FROM debian:bookworm-slim
+FROM node:lts-bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     python3 \
     python3-venv \
-    nodejs \
-    npm \
+    libicu72 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/librefang /usr/local/bin/
 COPY --from=builder /build/packages /opt/librefang/packages


### PR DESCRIPTION
<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

<!-- What does this PR do? Link related issues with "Fixes #123". -->
Current docker image runs node v18.20.4. 
This version is too old for some MCP servers that depend on node version being relatively up to date.
This PR updates base image to be based on current long term support version of node (currently v 24.14.1) but still based on latest debian bookworm.

## Changes

<!-- Brief list of what changed. -->
- Updates base image of runtime docker container to `node:lts-bookworm-slim`
- Installs `libicu72` dependency to prevent a start-up error which occurs without it
- Removes install of nodejs and npm packages as these are now provided by base image.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
