### PR TITLE
docs: update channel webhook URLs, add Voice channel docs

### DIFF
--- a/docs/src/app/channels/page.mdx
+++ b/docs/src/app/channels/page.mdx
@@ -409,12 +409,11 @@ mode = "cloud_api"
 phone_number_id_env = "WA_PHONE_ID"
 access_token_env = "WA_ACCESS_TOKEN"
 verify_token_env = "WA_VERIFY_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
 8. Set up a webhook in the Meta dashboard pointing to your server's public URL:
-   - URL: `https://your-domain.com:8443/webhook/whatsapp`
+   - URL: `https://your-domain.com:4545/channels/whatsapp/webhook`
    - Verify Token: the value you chose above
    - Subscribe to: `messages`
 
@@ -422,7 +421,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The WhatsApp adapter runs an HTTP server (on the configured `webhook_port`) that receives incoming webhooks from the WhatsApp Cloud API. It handles webhook verification (GET) and message reception (POST). Responses are sent via the Cloud API's `messages` endpoint.
+The WhatsApp adapter registers webhook routes on the shared API server (default port 4545) to receive incoming webhooks from the WhatsApp Cloud API. It handles webhook verification (GET) and message reception (POST). Responses are sent via the Cloud API's `messages` endpoint.
 
 ---
 
@@ -630,12 +629,12 @@ app_secret_env = "TEAMS_APP_SECRET"
 default_agent = "ops"
 ```
 
-7. Configure the messaging endpoint in Azure to point to your LibreFang instance's public URL (e.g., `https://your-domain.com/webhook/teams`).
+7. Configure the messaging endpoint in Azure to point to your LibreFang instance's public URL (e.g., `https://your-domain.com:4545/channels/teams/webhook`).
 8. Restart the daemon.
 
 ### How It Works
 
-The Teams adapter uses the Microsoft Bot Framework v3 webhook protocol with OAuth2 token exchange. Incoming messages arrive via HTTPS POST webhooks, and the adapter authenticates each request by validating the JWT bearer token against Azure AD. Responses are sent back through the Bot Framework REST API.
+The Teams adapter uses the Microsoft Bot Framework v3 webhook protocol with OAuth2 token exchange. Incoming messages arrive via HTTPS POST to the shared API server at `/channels/teams/webhook`, and the adapter authenticates each request by validating the JWT bearer token against Azure AD. Responses are sent back through the Bot Framework REST API.
 
 ---
 
@@ -689,7 +688,7 @@ The Mattermost adapter connects to the Mattermost server via WebSocket for real-
 
 1. In the [Google Cloud Console](https://console.cloud.google.com/), enable the Google Chat API.
 2. Create a service account and download the JSON key file.
-3. Configure a Chat app in the Google Chat API settings, selecting the **HTTP endpoint** connection type.
+3. Configure a Chat app in the Google Chat API settings, selecting the **HTTP endpoint** connection type. Set the endpoint URL to your LibreFang instance (e.g., `https://your-domain.com:4545/channels/google_chat/webhook`).
 4. Set environment variables:
 
 ```bash
@@ -714,7 +713,7 @@ default_agent = "ops"
 
 ### How It Works
 
-The Google Chat adapter authenticates using a service account and receives messages via webhook callbacks from Google Chat. Responses are sent back through the Google Chat REST API using the space and thread identifiers from the incoming message.
+The Google Chat adapter authenticates using a service account and receives messages via webhook callbacks on the shared API server at `/channels/google_chat/webhook`. Responses are sent back through the Google Chat REST API using the space and thread identifiers from the incoming message.
 
 ---
 
@@ -765,7 +764,7 @@ The Webex adapter registers a webhook with the Webex API to receive message even
 1. Go to the [Feishu Open Platform](https://open.feishu.cn/) and create a custom application.
 2. Enable **Bot** under the app's capabilities.
 3. Note the **App ID** and **App Secret** from the app credentials page.
-4. Configure event subscriptions to point to your LibreFang instance's webhook URL.
+4. Configure event subscriptions to point to your LibreFang instance's webhook URL (e.g., `https://your-domain.com:4545/channels/feishu/webhook`).
 5. Set environment variables:
 
 ```bash
@@ -790,7 +789,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Feishu adapter uses the Open Platform webhook protocol to receive message events. It obtains a tenant access token using the app credentials, then uses the Feishu REST API to send message replies. Event payloads are verified using the app's verification token.
+The Feishu adapter receives message events via webhook callbacks on the shared API server at `/channels/feishu/webhook`. It obtains a tenant access token using the app credentials, then uses the Feishu REST API to send message replies. Event payloads are verified using the app's verification token.
 
 ---
 
@@ -907,7 +906,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Flock adapter receives messages via webhook callbacks from the Flock platform. Responses are sent back through the Flock REST API's `chat.sendMessage` endpoint.
+The Flock adapter receives messages via webhook callbacks on the shared API server at `/channels/flock/webhook`. Responses are sent back through the Flock REST API's `chat.sendMessage` endpoint.
 
 ---
 
@@ -977,7 +976,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Pumble adapter receives messages via webhook callbacks from the Pumble platform. Responses are sent back through the Pumble API.
+The Pumble adapter receives messages via webhook callbacks on the shared API server at `/channels/pumble/webhook`. Responses are sent back through the Pumble API.
 
 ---
 
@@ -1044,16 +1043,15 @@ librefang config set-key line                 # .env file
 [channels.line]
 channel_secret_env = "LINE_CHANNEL_SECRET"
 access_token_env = "LINE_ACCESS_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
-5. In the LINE Developers Console, set the webhook URL to your LibreFang instance (e.g., `https://your-domain.com:8443/webhook/line`).
+5. In the LINE Developers Console, set the webhook URL to your LibreFang instance (e.g., `https://your-domain.com:4545/channels/line/webhook`).
 6. Restart the daemon.
 
 ### How It Works
 
-The LINE adapter runs an HTTP server on the configured `webhook_port` to receive message events from LINE's Messaging API. Each request is verified using the channel secret's HMAC-SHA256 signature. Responses are sent via the LINE Reply API or Push API.
+The LINE adapter registers webhook routes on the shared API server (default port 4545) to receive message events from LINE's Messaging API. Each request is verified using the channel secret's HMAC-SHA256 signature. Responses are sent via the LINE Reply API or Push API.
 
 ---
 
@@ -1082,8 +1080,7 @@ librefang config set-key viber                # .env file
 ```toml
 [channels.viber]
 auth_token_env = "VIBER_AUTH_TOKEN"
-webhook_url = "https://your-domain.com:8443/webhook/viber"
-webhook_port = 8443
+webhook_url = "https://your-domain.com:4545/channels/viber/webhook"
 default_agent = "assistant"
 ```
 
@@ -1091,7 +1088,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Viber adapter registers a webhook with the Viber API on startup and receives message events via HTTPS POST callbacks. Responses are sent via the Viber REST API's `send_message` endpoint.
+The Viber adapter registers a webhook with the Viber API on startup and receives message events via HTTPS POST callbacks on the shared API server at `/channels/viber/webhook`. Responses are sent via the Viber REST API's `send_message` endpoint.
 
 ---
 
@@ -1125,16 +1122,15 @@ librefang config set-key messenger            # .env file
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
-7. In the Meta Developer Dashboard, set the webhook callback URL (e.g., `https://your-domain.com:8443/webhook/messenger`) and enter your verify token. Subscribe to the `messages` event.
+7. In the Meta Developer Dashboard, set the webhook callback URL (e.g., `https://your-domain.com:4545/channels/messenger/webhook`) and enter your verify token. Subscribe to the `messages` event.
 8. Restart the daemon.
 
 ### How It Works
 
-The Messenger adapter runs an HTTP server on the configured `webhook_port` that handles webhook verification (GET) and incoming message events (POST) from the Messenger Platform. Responses are sent via the Send API using the page access token.
+The Messenger adapter registers webhook routes on the shared API server (default port 4545) that handle webhook verification (GET) and incoming message events (POST) from the Messenger Platform. Responses are sent via the Send API using the page access token.
 
 ---
 
@@ -1606,7 +1602,7 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Threema adapter uses the Threema Gateway REST API to send and receive end-to-end encrypted messages. Incoming messages are delivered via webhook callbacks, and responses are sent through the Gateway's message sending endpoint.
+The Threema adapter uses the Threema Gateway REST API to send and receive end-to-end encrypted messages. Incoming messages are delivered via webhook callbacks on the shared API server at `/channels/threema/webhook`, and responses are sent through the Gateway's message sending endpoint.
 
 ---
 
@@ -1715,7 +1711,7 @@ default_agent = "assistant"
 
 In **stream mode**, the adapter registers with the DingTalk gateway API (`/v1.0/gateway/connections/open`) to obtain a WebSocket endpoint and ticket. It then maintains a persistent WebSocket connection, receiving bot message callbacks and responding with ACK frames. Heartbeat ping/pong is handled automatically.
 
-In **webhook mode**, the adapter receives messages via HTTP callback from the DingTalk Robot API. Each request is verified using HMAC-SHA256 signature with the configured secret. Responses are sent back through the DingTalk webhook URL with a signed timestamp.
+In **webhook mode**, the adapter receives messages via HTTP callback on the shared API server at `/channels/dingtalk/webhook`. Each request is verified using HMAC-SHA256 signature with the configured secret. Responses are sent back through the DingTalk webhook URL with a signed timestamp.
 
 ---
 
@@ -2033,7 +2029,73 @@ default_agent = "assistant"
 
 ### How It Works
 
-The Webhook adapter provides a generic bidirectional HTTP integration. Incoming messages are received as HTTP POST requests to the LibreFang webhook endpoint, verified via HMAC-SHA256 using the shared secret. Responses are delivered as HTTP POST payloads to the configured URL, also signed with HMAC-SHA256.
+The Webhook adapter provides a generic bidirectional HTTP integration. Incoming messages are received as HTTP POST requests on the shared API server at `/channels/webhook/webhook`, verified via HMAC-SHA256 using the shared secret. Responses are delivered as HTTP POST payloads to the configured URL, also signed with HMAC-SHA256.
+
+---
+
+## Voice
+
+### Prerequisites
+
+- An API key for an OpenAI-compatible STT/TTS provider (e.g., OpenAI, Groq, or a self-hosted Whisper instance)
+
+### Setup
+
+1. Set your STT/TTS API key:
+
+```bash
+export OPENAI_API_KEY=sk-...
+librefang vault set OPENAI_API_KEY              # Encrypted vault (recommended)
+```
+
+2. Add to config:
+
+```toml
+[channels.voice]
+api_key_env = "OPENAI_API_KEY"
+stt_url = "https://api.openai.com"
+tts_url = "https://api.openai.com"
+tts_voice = "alloy"
+# buffer_threshold = 32768    # Audio buffer size in bytes before triggering STT
+# default_agent = "assistant"
+```
+
+3. Restart the daemon.
+
+### WebSocket Protocol
+
+Clients connect to `ws://your-host:4545/channels/voice/ws` and exchange binary + text frames:
+
+**Client to Server (binary):** Raw audio data (PCM 16-bit LE mono 16kHz, or Opus packets).
+
+**Client to Server (JSON):**
+```json
+{ "type": "config", "format": "pcm", "sample_rate": 16000 }
+{ "type": "end_of_speech" }
+```
+
+**Server to Client (JSON):**
+```json
+{ "type": "ready" }
+{ "type": "transcript", "text": "..." }
+{ "type": "response", "text": "..." }
+{ "type": "error", "message": "..." }
+```
+
+**Server to Client (binary):** Synthesized audio response data.
+
+### How It Works
+
+The Voice adapter accepts real-time audio streams over WebSocket on the shared API server at `/channels/voice/ws`. Audio data is buffered until it reaches the configured threshold (default 32KB), then transcribed via the STT provider (OpenAI Whisper API by default). The transcribed text is routed to an agent through the channel bridge. The agent's text response can be synthesized back into audio via TTS and streamed to the client. Supported audio formats are PCM (16-bit LE mono) and Opus.
+
+| Config field | Type | Default | Description |
+|---|---|---|---|
+| `api_key_env` | string | `"OPENAI_API_KEY"` | Env var name holding the API key for STT/TTS services. |
+| `stt_url` | string | `"https://api.openai.com"` | Base URL for the STT (Speech-to-Text) API. |
+| `tts_url` | string | `"https://api.openai.com"` | Base URL for the TTS (Text-to-Speech) API. |
+| `tts_voice` | string | `"alloy"` | TTS voice name. Options: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`. |
+| `buffer_threshold` | usize | `32768` | Audio buffer size in bytes before triggering STT. |
+| `default_agent` | string | - | Default agent name to route voice messages to. |
 
 ---
 

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -793,7 +793,7 @@ allowed_channels = []
 access_token_env = "WHATSAPP_ACCESS_TOKEN"
 verify_token_env = "WHATSAPP_VERIFY_TOKEN"
 phone_number_id = ""
-webhook_port = 8443
+# webhook_port = 8443  # Deprecated: webhooks now share the API port
 allowed_users = []
 # gateway_url_env = "WHATSAPP_WEB_GATEWAY_URL"  # for QR/Web mode
 # account_id = "my-whatsapp-bot"
@@ -805,7 +805,7 @@ allowed_users = []
 | `access_token_env` | string | `"WHATSAPP_ACCESS_TOKEN"` | Env var holding the WhatsApp Cloud API access token. |
 | `verify_token_env` | string | `"WHATSAPP_VERIFY_TOKEN"` | Env var holding the webhook verification token. |
 | `phone_number_id` | string | `""` | WhatsApp Business phone number ID. |
-| `webhook_port` | u16 | `8443` | Port to listen for incoming webhook callbacks. |
+| `webhook_port` | u16 | `8443` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `gateway_url_env` | string | `"WHATSAPP_WEB_GATEWAY_URL"` | Env var holding the WhatsApp Web gateway URL. When set, outgoing messages are routed through the QR/Web gateway instead of the Cloud API. |
 | `allowed_users` | list of strings | `[]` | Phone numbers allowed. Empty = allow all. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -881,7 +881,7 @@ allowed_senders = []
 [channels.teams]
 app_id = ""
 app_password_env = "TEAMS_APP_PASSWORD"
-webhook_port = 3978
+# webhook_port = 3978  # Deprecated: webhooks now share the API port
 allowed_tenants = []
 ```
 
@@ -889,7 +889,7 @@ allowed_tenants = []
 |-------|------|---------|-------------|
 | `app_id` | string | `""` | Azure Bot App ID. |
 | `app_password_env` | string | `"TEAMS_APP_PASSWORD"` | Env var holding the Azure Bot Framework app password. |
-| `webhook_port` | u16 | `3978` | Port for the Bot Framework incoming webhook. |
+| `webhook_port` | u16 | `3978` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `allowed_tenants` | list of strings | `[]` | Azure AD tenant IDs allowed. Empty = allow all. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
@@ -937,14 +937,14 @@ use_tls = false
 [channels.google_chat]
 service_account_env = "GOOGLE_CHAT_SERVICE_ACCOUNT"
 space_ids = []
-webhook_port = 8444
+# webhook_port = 8444  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `service_account_env` | string | `"GOOGLE_CHAT_SERVICE_ACCOUNT"` | Env var holding the service account JSON key. |
 | `space_ids` | list of strings | `[]` | Google Chat space IDs to listen in. |
-| `webhook_port` | u16 | `8444` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8444` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.twitch]`
@@ -1025,14 +1025,14 @@ rooms = []
 [channels.line]
 channel_secret_env = "LINE_CHANNEL_SECRET"
 access_token_env = "LINE_CHANNEL_ACCESS_TOKEN"
-webhook_port = 8450
+# webhook_port = 8450  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | Env var holding the LINE channel secret. |
 | `access_token_env` | string | `"LINE_CHANNEL_ACCESS_TOKEN"` | Env var holding the LINE channel access token. |
-| `webhook_port` | u16 | `8450` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8450` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.viber]`
@@ -1041,14 +1041,14 @@ webhook_port = 8450
 [channels.viber]
 auth_token_env = "VIBER_AUTH_TOKEN"
 webhook_url = ""
-webhook_port = 8451
+# webhook_port = 8451  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | Env var holding the Viber Bot auth token. |
 | `webhook_url` | string | `""` | Public URL for the Viber webhook endpoint. |
-| `webhook_port` | u16 | `8451` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8451` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.messenger]`
@@ -1057,14 +1057,14 @@ webhook_port = 8451
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
-webhook_port = 8452
+# webhook_port = 8452  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `page_token_env` | string | `"MESSENGER_PAGE_TOKEN"` | Env var holding the Facebook page access token. |
 | `verify_token_env` | string | `"MESSENGER_VERIFY_TOKEN"` | Env var holding the webhook verify token. |
-| `webhook_port` | u16 | `8452` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8452` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.reddit]`
@@ -1123,14 +1123,14 @@ service_url = "https://bsky.social"
 [channels.feishu]
 app_id = ""
 app_secret_env = "FEISHU_APP_SECRET"
-webhook_port = 8453
+# webhook_port = 8453  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `app_id` | string | `""` | Feishu/Lark app ID. |
 | `app_secret_env` | string | `"FEISHU_APP_SECRET"` | Env var holding the Feishu app secret. |
-| `webhook_port` | u16 | `8453` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8453` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.revolt]`
@@ -1199,14 +1199,14 @@ allowed_teams = []
 [channels.threema]
 threema_id = ""
 secret_env = "THREEMA_SECRET"
-webhook_port = 8454
+# webhook_port = 8454  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `threema_id` | string | `""` | Threema Gateway ID. |
 | `secret_env` | string | `"THREEMA_SECRET"` | Env var holding the Threema API secret. |
-| `webhook_port` | u16 | `8454` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8454` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.nostr]`
@@ -1242,13 +1242,13 @@ allowed_rooms = []
 ```toml
 [channels.pumble]
 bot_token_env = "PUMBLE_BOT_TOKEN"
-webhook_port = 8455
+# webhook_port = 8455  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `bot_token_env` | string | `"PUMBLE_BOT_TOKEN"` | Env var holding the Pumble bot token. |
-| `webhook_port` | u16 | `8455` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8455` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.flock]`
@@ -1256,13 +1256,13 @@ webhook_port = 8455
 ```toml
 [channels.flock]
 bot_token_env = "FLOCK_BOT_TOKEN"
-webhook_port = 8456
+# webhook_port = 8456  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `bot_token_env` | string | `"FLOCK_BOT_TOKEN"` | Env var holding the Flock bot token. |
-| `webhook_port` | u16 | `8456` | Port for the incoming webhook. |
+| `webhook_port` | u16 | `8456` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.twist]`
@@ -1317,7 +1317,7 @@ app_secret_env = "DINGTALK_APP_SECRET"
 receive_mode = "webhook"
 access_token_env = "DINGTALK_ACCESS_TOKEN"
 secret_env = "DINGTALK_SECRET"
-webhook_port = 8457
+# webhook_port = 8457  # Deprecated: webhooks now share the API port
 ```
 
 | Field | Type | Default | Description |
@@ -1327,7 +1327,7 @@ webhook_port = 8457
 | `app_secret_env` | string | `"DINGTALK_APP_SECRET"` | Env var holding the DingTalk App Secret (stream mode). |
 | `access_token_env` | string | `"DINGTALK_ACCESS_TOKEN"` | Env var holding the DingTalk webhook access token (webhook mode). |
 | `secret_env` | string | `"DINGTALK_SECRET"` | Env var holding the DingTalk signing secret (webhook mode). |
-| `webhook_port` | u16 | `8457` | Port for the incoming webhook (webhook mode only). |
+| `webhook_port` | u16 | `8457` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `robot_code` | string or null | `null` | Robot code for stream mode replies (defaults to app_key). |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
@@ -1410,6 +1410,29 @@ listen_port = 8460
 | `listen_port` | u16 | `8460` | Port to listen for incoming webhook requests. |
 | `callback_url` | string or null | `null` | URL to POST outgoing messages to. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
+
+#### `[channels.voice]`
+
+WebSocket-based voice channel with STT (Speech-to-Text) and TTS (Text-to-Speech) support.
+
+```toml
+[channels.voice]
+api_key_env = "OPENAI_API_KEY"
+stt_url = "https://api.openai.com"
+tts_url = "https://api.openai.com"
+tts_voice = "alloy"
+# buffer_threshold = 32768
+# default_agent = "assistant"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key_env` | string | `"OPENAI_API_KEY"` | Env var holding the API key for STT/TTS services. |
+| `stt_url` | string | `"https://api.openai.com"` | Base URL for the STT API (OpenAI Whisper-compatible). |
+| `tts_url` | string | `"https://api.openai.com"` | Base URL for the TTS API. |
+| `tts_voice` | string | `"alloy"` | TTS voice name. Options: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`. |
+| `buffer_threshold` | usize | `32768` | Audio buffer size in bytes before triggering STT. |
+| `default_agent` | string or null | `null` | Agent name to route voice messages to. |
 
 #### `[channels.linkedin]`
 

--- a/docs/src/app/zh/channels/page.mdx
+++ b/docs/src/app/zh/channels/page.mdx
@@ -409,12 +409,11 @@ mode = "cloud_api"
 phone_number_id_env = "WA_PHONE_ID"
 access_token_env = "WA_ACCESS_TOKEN"
 verify_token_env = "WA_VERIFY_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
 8. 在 Meta 管理后台设置 Webhook，指向你服务器的公网 URL：
-   - URL：`https://your-domain.com:8443/webhook/whatsapp`
+   - URL：`https://your-domain.com:4545/channels/whatsapp/webhook`
    - Verify Token：你上面选择的值
    - 订阅：`messages`
 
@@ -422,7 +421,7 @@ default_agent = "assistant"
 
 ### 工作原理
 
-WhatsApp 适配器运行一个 HTTP 服务器（监听配置的 `webhook_port`），接收来自 WhatsApp Cloud API 的 Webhook 请求。它处理 Webhook 验证（GET）和消息接收（POST）。响应通过 Cloud API 的 `messages` 端点发送。
+WhatsApp 适配器在主 API 服务器（默认端口 4545）上注册 webhook 路由，接收来自 WhatsApp Cloud API 的 Webhook 请求。它处理 Webhook 验证（GET）和消息接收（POST）。响应通过 Cloud API 的 `messages` 端点发送。
 
 ---
 
@@ -630,7 +629,7 @@ app_secret_env = "TEAMS_APP_SECRET"
 default_agent = "ops"
 ```
 
-7. 在 Azure 中将消息端点配置为指向 LibreFang 实例的公网 URL（例如 `https://your-domain.com/webhook/teams`）。
+7. 在 Azure 中将消息端点配置为指向 LibreFang 实例的公网 URL（例如 `https://your-domain.com:4545/channels/teams/webhook`）。
 8. 重启守护进程。
 
 ### 工作原理
@@ -1044,16 +1043,15 @@ librefang config set-key line                 # .env 文件
 [channels.line]
 channel_secret_env = "LINE_CHANNEL_SECRET"
 access_token_env = "LINE_ACCESS_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
-5. 在 LINE Developers Console 中将 webhook URL 设置为 LibreFang 实例的地址（例如 `https://your-domain.com:8443/webhook/line`）。
+5. 在 LINE Developers Console 中将 webhook URL 设置为 LibreFang 实例的地址（例如 `https://your-domain.com:4545/channels/line/webhook`）。
 6. 重启守护进程。
 
 ### 工作原理
 
-LINE 适配器在配置的 `webhook_port` 上运行 HTTP 服务器，接收来自 LINE Messaging API 的消息事件。每个请求通过 Channel Secret 的 HMAC-SHA256 签名进行验证。响应通过 LINE Reply API 或 Push API 发送。
+LINE 适配器在主 API 服务器（默认端口 4545）上注册 webhook 路由，接收来自 LINE Messaging API 的消息事件。每个请求通过 Channel Secret 的 HMAC-SHA256 签名进行验证。响应通过 LINE Reply API 或 Push API 发送。
 
 ---
 
@@ -1082,8 +1080,7 @@ librefang config set-key viber                # .env 文件
 ```toml
 [channels.viber]
 auth_token_env = "VIBER_AUTH_TOKEN"
-webhook_url = "https://your-domain.com:8443/webhook/viber"
-webhook_port = 8443
+webhook_url = "https://your-domain.com:4545/channels/viber/webhook"
 default_agent = "assistant"
 ```
 
@@ -1125,16 +1122,15 @@ librefang config set-key messenger            # .env 文件
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
-webhook_port = 8443
 default_agent = "assistant"
 ```
 
-7. 在 Meta 开发者面板中设置 webhook 回调 URL（例如 `https://your-domain.com:8443/webhook/messenger`），输入 verify token，并订阅 `messages` 事件。
+7. 在 Meta 开发者面板中设置 webhook 回调 URL（例如 `https://your-domain.com:4545/channels/messenger/webhook`），输入 verify token，并订阅 `messages` 事件。
 8. 重启守护进程。
 
 ### 工作原理
 
-Messenger 适配器在配置的 `webhook_port` 上运行 HTTP 服务器，处理来自 Messenger Platform 的 webhook 验证（GET）和传入消息事件（POST）。响应通过 Send API 使用 page access token 发送。
+Messenger 适配器在主 API 服务器（默认端口 4545）上注册 webhook 路由，处理来自 Messenger Platform 的 webhook 验证（GET）和传入消息事件（POST）。响应通过 Send API 使用 page access token 发送。
 
 ---
 
@@ -2034,6 +2030,72 @@ default_agent = "assistant"
 ### 工作原理
 
 Webhook 适配器提供通用的双向 HTTP 集成。传入消息以 HTTP POST 请求形式发送到 LibreFang 的 webhook 端点，通过共享密钥的 HMAC-SHA256 进行验证。响应以 HTTP POST 负载形式送达配置的 URL，同样使用 HMAC-SHA256 签名。
+
+---
+
+## Voice（语音）
+
+### 前置条件
+
+- 兼容 OpenAI 的 STT/TTS 服务 API key（如 OpenAI、Groq 或自建 Whisper 实例）
+
+### 设置步骤
+
+1. 设置 STT/TTS API key：
+
+```bash
+export OPENAI_API_KEY=sk-...
+librefang vault set OPENAI_API_KEY              # 加密保险库（推荐）
+```
+
+2. 添加配置：
+
+```toml
+[channels.voice]
+api_key_env = "OPENAI_API_KEY"
+stt_url = "https://api.openai.com"
+tts_url = "https://api.openai.com"
+tts_voice = "alloy"
+# buffer_threshold = 32768    # 触发 STT 的音频缓冲区大小（字节）
+# default_agent = "assistant"
+```
+
+3. 重启守护进程。
+
+### WebSocket 协议
+
+客户端连接 `ws://your-host:4545/channels/voice/ws`，通过二进制帧和文本帧交互：
+
+**客户端 -> 服务端（二进制）：** 原始音频数据（PCM 16-bit LE 单声道 16kHz 或 Opus 包）。
+
+**客户端 -> 服务端（JSON）：**
+```json
+{ "type": "config", "format": "pcm", "sample_rate": 16000 }
+{ "type": "end_of_speech" }
+```
+
+**服务端 -> 客户端（JSON）：**
+```json
+{ "type": "ready" }
+{ "type": "transcript", "text": "..." }
+{ "type": "response", "text": "..." }
+{ "type": "error", "message": "..." }
+```
+
+**服务端 -> 客户端（二进制）：** 合成的语音音频数据。
+
+### 工作原理
+
+Voice 适配器通过共享 API 服务器上的 `/channels/voice/ws` 端点接受实时 WebSocket 音频流。音频数据在缓冲区达到阈值（默认 32KB）后，通过 STT 服务（默认 OpenAI Whisper API）进行语音转文字。转写后的文本通过 channel bridge 路由到 Agent，Agent 的文字回复可通过 TTS 合成为语音并流式返回客户端。支持 PCM（16-bit LE 单声道）和 Opus 音频格式。
+
+| 配置字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `api_key_env` | string | `"OPENAI_API_KEY"` | STT/TTS 服务 API key 的环境变量名。 |
+| `stt_url` | string | `"https://api.openai.com"` | STT（语音转文字）API 基础 URL。 |
+| `tts_url` | string | `"https://api.openai.com"` | TTS（文字转语音）API 基础 URL。 |
+| `tts_voice` | string | `"alloy"` | TTS 语音名称。可选：`alloy`、`echo`、`fable`、`onyx`、`nova`、`shimmer`。 |
+| `buffer_threshold` | usize | `32768` | 触发 STT 的音频缓冲区大小（字节）。 |
+| `default_agent` | string | - | 语音消息路由到的默认 Agent 名称。 |
 
 ---
 

--- a/docs/src/app/zh/configuration/page.mdx
+++ b/docs/src/app/zh/configuration/page.mdx
@@ -792,7 +792,7 @@ allowed_channels = []
 access_token_env = "WHATSAPP_ACCESS_TOKEN"
 verify_token_env = "WHATSAPP_VERIFY_TOKEN"
 phone_number_id = ""
-webhook_port = 8443
+# webhook_port = 8443  # 已弃用：Webhook 现共享 API 端口
 allowed_users = []
 # gateway_url_env = "WHATSAPP_WEB_GATEWAY_URL"  # 用于 QR/Web 模式
 # account_id = "my-whatsapp-bot"
@@ -804,7 +804,7 @@ allowed_users = []
 | `access_token_env` | string | `"WHATSAPP_ACCESS_TOKEN"` | 存放 WhatsApp Cloud API 访问令牌的环境变量。 |
 | `verify_token_env` | string | `"WHATSAPP_VERIFY_TOKEN"` | 存放 Webhook 验证令牌的环境变量。 |
 | `phone_number_id` | string | `""` | WhatsApp Business 手机号 ID。 |
-| `webhook_port` | u16 | `8443` | 监听 Webhook 回调的端口。 |
+| `webhook_port` | u16 | `8443` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `gateway_url_env` | string | `"WHATSAPP_WEB_GATEWAY_URL"` | 存放 WhatsApp Web 网关 URL 的环境变量。设置后，发送消息将通过 QR/Web 网关而非 Cloud API 路由。 |
 | `allowed_users` | list of strings | `[]` | 允许的手机号列表。空列表 = 允许所有。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
@@ -880,7 +880,7 @@ allowed_senders = []
 [channels.teams]
 app_id = ""
 app_password_env = "TEAMS_APP_PASSWORD"
-webhook_port = 3978
+# webhook_port = 3978  # 已弃用：Webhook 现共享 API 端口
 allowed_tenants = []
 ```
 
@@ -888,7 +888,7 @@ allowed_tenants = []
 |------|------|--------|------|
 | `app_id` | string | `""` | Azure Bot 应用 ID。 |
 | `app_password_env` | string | `"TEAMS_APP_PASSWORD"` | 存放 Azure Bot Framework 应用密码的环境变量。 |
-| `webhook_port` | u16 | `3978` | Bot Framework 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `3978` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `allowed_tenants` | list of strings | `[]` | 允许的 Azure AD 租户 ID 列表。空列表 = 允许所有。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
@@ -936,14 +936,14 @@ use_tls = false
 [channels.google_chat]
 service_account_env = "GOOGLE_CHAT_SERVICE_ACCOUNT"
 space_ids = []
-webhook_port = 8444
+# webhook_port = 8444  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `service_account_env` | string | `"GOOGLE_CHAT_SERVICE_ACCOUNT"` | 存放服务账号 JSON 密钥的环境变量。 |
 | `space_ids` | list of strings | `[]` | 监听的 Google Chat 聊天室 ID 列表。 |
-| `webhook_port` | u16 | `8444` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8444` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.twitch]`
@@ -1024,14 +1024,14 @@ rooms = []
 [channels.line]
 channel_secret_env = "LINE_CHANNEL_SECRET"
 access_token_env = "LINE_CHANNEL_ACCESS_TOKEN"
-webhook_port = 8450
+# webhook_port = 8450  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | 存放 LINE Channel Secret 的环境变量。 |
 | `access_token_env` | string | `"LINE_CHANNEL_ACCESS_TOKEN"` | 存放 LINE Channel Access Token 的环境变量。 |
-| `webhook_port` | u16 | `8450` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8450` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.viber]`
@@ -1040,14 +1040,14 @@ webhook_port = 8450
 [channels.viber]
 auth_token_env = "VIBER_AUTH_TOKEN"
 webhook_url = ""
-webhook_port = 8451
+# webhook_port = 8451  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | 存放 Viber Bot 认证令牌的环境变量。 |
 | `webhook_url` | string | `""` | Viber Webhook 端点的公网 URL。 |
-| `webhook_port` | u16 | `8451` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8451` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.messenger]`
@@ -1056,14 +1056,14 @@ webhook_port = 8451
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
-webhook_port = 8452
+# webhook_port = 8452  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `page_token_env` | string | `"MESSENGER_PAGE_TOKEN"` | 存放 Facebook 页面访问令牌的环境变量。 |
 | `verify_token_env` | string | `"MESSENGER_VERIFY_TOKEN"` | 存放 Webhook 验证令牌的环境变量。 |
-| `webhook_port` | u16 | `8452` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8452` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.reddit]`
@@ -1122,14 +1122,14 @@ service_url = "https://bsky.social"
 [channels.feishu]
 app_id = ""
 app_secret_env = "FEISHU_APP_SECRET"
-webhook_port = 8453
+# webhook_port = 8453  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `app_id` | string | `""` | 飞书/Lark 应用 ID。 |
 | `app_secret_env` | string | `"FEISHU_APP_SECRET"` | 存放飞书应用密钥的环境变量。 |
-| `webhook_port` | u16 | `8453` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8453` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.revolt]`
@@ -1198,14 +1198,14 @@ allowed_teams = []
 [channels.threema]
 threema_id = ""
 secret_env = "THREEMA_SECRET"
-webhook_port = 8454
+# webhook_port = 8454  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `threema_id` | string | `""` | Threema Gateway ID。 |
 | `secret_env` | string | `"THREEMA_SECRET"` | 存放 Threema API 密钥的环境变量。 |
-| `webhook_port` | u16 | `8454` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8454` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.nostr]`
@@ -1241,13 +1241,13 @@ allowed_rooms = []
 ```toml
 [channels.pumble]
 bot_token_env = "PUMBLE_BOT_TOKEN"
-webhook_port = 8455
+# webhook_port = 8455  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `bot_token_env` | string | `"PUMBLE_BOT_TOKEN"` | 存放 Pumble Bot 令牌的环境变量。 |
-| `webhook_port` | u16 | `8455` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8455` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.flock]`
@@ -1255,13 +1255,13 @@ webhook_port = 8455
 ```toml
 [channels.flock]
 bot_token_env = "FLOCK_BOT_TOKEN"
-webhook_port = 8456
+# webhook_port = 8456  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `bot_token_env` | string | `"FLOCK_BOT_TOKEN"` | 存放 Flock Bot 令牌的环境变量。 |
-| `webhook_port` | u16 | `8456` | 入站 Webhook 端口。 |
+| `webhook_port` | u16 | `8456` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
 #### `[channels.twist]`
@@ -1316,7 +1316,7 @@ app_secret_env = "DINGTALK_APP_SECRET"
 receive_mode = "webhook"
 access_token_env = "DINGTALK_ACCESS_TOKEN"
 secret_env = "DINGTALK_SECRET"
-webhook_port = 8457
+# webhook_port = 8457  # 已弃用：Webhook 现共享 API 端口
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
@@ -1326,7 +1326,7 @@ webhook_port = 8457
 | `app_secret_env` | string | `"DINGTALK_APP_SECRET"` | 存放钉钉 App Secret 的环境变量（stream 模式）。 |
 | `access_token_env` | string | `"DINGTALK_ACCESS_TOKEN"` | 存放钉钉 Webhook 访问令牌的环境变量（webhook 模式）。 |
 | `secret_env` | string | `"DINGTALK_SECRET"` | 存放钉钉签名密钥的环境变量（webhook 模式）。 |
-| `webhook_port` | u16 | `8457` | 入站 Webhook 端口（仅 webhook 模式）。 |
+| `webhook_port` | u16 | `8457` | **已弃用。** 之前用于独立 Webhook 服务器，现已忽略。所有 Webhook 共享 API 端口。 |
 | `robot_code` | string 或 null | `null` | Stream 模式回复使用的机器人编码（默认使用 app_key）。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
 
@@ -1409,6 +1409,29 @@ listen_port = 8460
 | `listen_port` | u16 | `8460` | 监听入站 Webhook 请求的端口。 |
 | `callback_url` | string 或 null | `null` | 发送出站消息的 POST 目标 URL。 |
 | `default_agent` | string 或 null | `null` | 消息路由的目标 Agent 名称。 |
+
+#### `[channels.voice]`
+
+基于 WebSocket 的语音渠道，支持 STT（语音转文字）和 TTS（文字转语音）。
+
+```toml
+[channels.voice]
+api_key_env = "OPENAI_API_KEY"
+stt_url = "https://api.openai.com"
+tts_url = "https://api.openai.com"
+tts_voice = "alloy"
+# buffer_threshold = 32768
+# default_agent = "assistant"
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `api_key_env` | string | `"OPENAI_API_KEY"` | 存放 STT/TTS 服务 API key 的环境变量名。 |
+| `stt_url` | string | `"https://api.openai.com"` | STT API 基础 URL（兼容 OpenAI Whisper）。 |
+| `tts_url` | string | `"https://api.openai.com"` | TTS API 基础 URL。 |
+| `tts_voice` | string | `"alloy"` | TTS 语音名称。可选：`alloy`、`echo`、`fable`、`onyx`、`nova`、`shimmer`。 |
+| `buffer_threshold` | usize | `32768` | 触发 STT 的音频缓冲区大小（字节）。 |
+| `default_agent` | string 或 null | `null` | 语音消息路由到的默认 Agent 名称。 |
 
 #### `[channels.linkedin]`
 


### PR DESCRIPTION
## Summary
- **Webhook URL migration** — All channel docs updated to reflect the new shared server URLs (`/channels/{name}/webhook` on port 4545)
- **Voice channel docs added** — New section in both EN and ZH channels docs with setup guide, WebSocket protocol reference, and config table
- **Configuration reference updated** — `webhook_port` marked as deprecated in all 11 channel config tables, Voice channel config section added

### Files changed
| File | Changes |
|------|---------|
| `docs/src/app/channels/page.mdx` | Updated webhook URLs, added Voice section |
| `docs/src/app/zh/channels/page.mdx` | Same updates in Chinese |
| `docs/src/app/configuration/page.mdx` | webhook_port deprecated, Voice config added |
| `docs/src/app/zh/configuration/page.mdx` | Same updates in Chinese |

## Test plan
- [ ] Docs site builds without errors
- [ ] Voice channel section renders correctly with protocol table
- [ ] All webhook URLs point to `/channels/{name}/webhook` pattern
- [ ] No remaining references to old port-based webhook URLs