### PR TITLE
fix(api): make reload_config async to fix panic in async context

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -201,7 +201,7 @@ api_key_env = "{api_key_env}"
     }
 
     // Reload config so kernel picks up new settings
-    let _ = state.kernel.reload_config();
+    let _ = state.kernel.reload_config().await;
 
     Json(serde_json::json!({
         "status": "initialized",
@@ -1374,7 +1374,7 @@ pub async fn config_reload(State(state): State<Arc<AppState>>) -> impl IntoRespo
         "config reload requested via API",
         "pending",
     );
-    match state.kernel.reload_config() {
+    match state.kernel.reload_config().await {
         Ok(plan) => {
             // If channel config changed, the kernel already cleared the adapter
             // registry — but we also need to stop the old BridgeManager and
@@ -1730,7 +1730,7 @@ pub async fn config_set(
     }
 
     // Trigger reload
-    let reload_status = match state.kernel.reload_config() {
+    let reload_status = match state.kernel.reload_config().await {
         Ok(plan) => {
             if plan.restart_required {
                 "applied_partial"

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2653,7 +2653,7 @@ pub async fn add_mcp_server(
     }
 
     // Trigger config reload
-    let reload_status = match state.kernel.reload_config() {
+    let reload_status = match state.kernel.reload_config().await {
         Ok(plan) => {
             if plan.restart_required {
                 "applied_partial"
@@ -2749,8 +2749,11 @@ pub async fn update_mcp_server(
         ))
         .into_json_tuple();
     }
+    // Drop ErrorTranslator before .await — FluentBundle is !Send and cannot
+    // be held across an async suspension point.
+    drop(t);
 
-    let reload_status = match state.kernel.reload_config() {
+    let reload_status = match state.kernel.reload_config().await {
         Ok(plan) => {
             if plan.restart_required {
                 "applied_partial"
@@ -2818,8 +2821,9 @@ pub async fn delete_mcp_server(
         ))
         .into_json_tuple();
     }
+    drop(t);
 
-    let reload_status = match state.kernel.reload_config() {
+    let reload_status = match state.kernel.reload_config().await {
         Ok(plan) => {
             if plan.restart_required {
                 "applied_partial"

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -419,7 +419,7 @@ async fn change_password(
     }
 
     // Trigger config reload so the kernel picks up the new hash
-    if let Err(e) = state.kernel.reload_config() {
+    if let Err(e) = state.kernel.reload_config().await {
         tracing::warn!("Config reload after password change failed: {e}");
     }
 
@@ -705,7 +705,7 @@ pub async fn run_daemon(
                 if current != last_modified && current.is_some() {
                     last_modified = current;
                     tracing::info!("Config file changed, reloading...");
-                    match k.reload_config() {
+                    match k.reload_config().await {
                         Ok(plan) => {
                             if plan.has_changes() {
                                 tracing::info!("Config hot-reload applied: {:?}", plan.hot_actions);

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6095,7 +6095,7 @@ system_prompt = "You are a helpful assistant."
 
     /// Reload configuration: read the config file, diff against current, and
     /// apply hot-reloadable actions. Returns the reload plan for API response.
-    pub fn reload_config(&self) -> Result<crate::config_reload::ReloadPlan, String> {
+    pub async fn reload_config(&self) -> Result<crate::config_reload::ReloadPlan, String> {
         let old_cfg = self.config.load();
         use crate::config_reload::{
             build_reload_plan, should_apply_hot, validate_config_for_reload,
@@ -6127,7 +6127,7 @@ system_prompt = "You are a helpful assistant."
         // In Off / Restart modes the user expects no runtime changes — they
         // must restart to pick up the new config.
         if should_apply_hot(old_cfg.reload.mode, &plan) {
-            let _write_guard = self.config_reload_lock.blocking_write();
+            let _write_guard = self.config_reload_lock.write().await;
             self.apply_hot_actions_inner(&plan, &new_config);
             self.config.store(std::sync::Arc::new(new_config));
         }


### PR DESCRIPTION
## Problem

`reload_config()` called `config_reload_lock.blocking_write()` on a `tokio::sync::RwLock` from within axum async handlers. tokio panics when `blocking_write()` is called from within an async execution context:

```
Cannot block the current thread from within a runtime. This happens because a
function attempted to block the current thread while the thread is being used
to drive asynchronous tasks.
```

This caused `test_config_reload_hot_reloads_proxy_changes` to crash the test server — the HTTP connection was torn down and the test received an `IncompleteMessage` error instead of 200. All PRs with Rust changes were failing CI for this reason.

The bug was introduced in #1846 but was never caught: subsequent main CI runs only contained docs changes, so the `Detect Changes` step skipped Rust test jobs entirely.

## Fix

- Make `reload_config` `async` and replace `blocking_write()` with `write().await`
- Update all call sites in `config.rs`, `skills.rs`, and `server.rs` to `.await` the result
- In `update_mcp_server` and `delete_mcp_server`, `drop(t)` the `ErrorTranslator` before the `.await` point — `FluentBundle` is `!Send` and cannot be held across an async suspension point, which would make the handler future non-`Send` and fail axum's `Handler` bound