### PR TITLE
fix(channels): apply channel-native formatting in channel_send tool

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -780,12 +780,7 @@ async fn send_response(
 }
 
 fn default_output_format_for_channel(channel_type: &str) -> OutputFormat {
-    match channel_type {
-        "telegram" => OutputFormat::TelegramHtml,
-        "slack" => OutputFormat::SlackMrkdwn,
-        "wecom" => OutputFormat::PlainText,
-        _ => OutputFormat::Markdown,
-    }
+    formatter::default_output_format_for_channel(channel_type)
 }
 
 /// Send a lifecycle reaction (best-effort, non-blocking for supported adapters).

--- a/crates/librefang-channels/src/formatter.rs
+++ b/crates/librefang-channels/src/formatter.rs
@@ -7,6 +7,19 @@
 
 use librefang_types::config::OutputFormat;
 
+/// Return the default [`OutputFormat`] for a channel type string.
+///
+/// Channels that support rich formatting get their native format;
+/// unknown channel types fall back to raw Markdown (pass-through).
+pub fn default_output_format_for_channel(channel_type: &str) -> OutputFormat {
+    match channel_type {
+        "telegram" => OutputFormat::TelegramHtml,
+        "slack" => OutputFormat::SlackMrkdwn,
+        "wecom" => OutputFormat::PlainText,
+        _ => OutputFormat::Markdown,
+    }
+}
+
 /// Format a message for a specific channel output format.
 #[inline]
 pub fn format_for_channel(text: &str, format: OutputFormat) -> String {

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -32,7 +32,7 @@ use librefang_runtime::sandbox::{SandboxConfig, WasmSandbox};
 use librefang_runtime::tool_runner::builtin_tool_definitions;
 use librefang_types::agent::*;
 use librefang_types::capability::Capability;
-use librefang_types::config::{AuthProfile, KernelConfig, OutputFormat};
+use librefang_types::config::{AuthProfile, KernelConfig};
 use librefang_types::error::LibreFangError;
 use librefang_types::event::*;
 use librefang_types::memory::Memory;
@@ -8837,6 +8837,8 @@ impl KernelHandle for LibreFangKernel {
             librefang_user: None,
         };
 
+        let default_format =
+            librefang_channels::formatter::default_output_format_for_channel(channel);
         let formatted = if channel == "wecom" {
             let output_format = self
                 .config
@@ -8844,10 +8846,10 @@ impl KernelHandle for LibreFangKernel {
                 .wecom
                 .as_ref()
                 .and_then(|c| c.overrides.output_format)
-                .unwrap_or(OutputFormat::PlainText);
+                .unwrap_or(default_format);
             librefang_channels::formatter::format_for_wecom(message, output_format)
         } else {
-            message.to_string()
+            librefang_channels::formatter::format_for_channel(message, default_format)
         };
 
         let content = librefang_channels::types::ChannelContent::Text(formatted);


### PR DESCRIPTION
## Summary

Fixes #1875 — the `channel_send` tool was sending raw Markdown to all channels except WeCom, causing broken formatting on Telegram, Slack, and other platforms.

## Problem

`Kernel::send_channel_message()` only applied output formatting for WeCom. All other channels received raw Markdown text, which rendered incorrectly because each platform expects its own native format (Telegram HTML, Slack mrkdwn, etc.).

The streaming response path (`bridge.rs` → adapter) correctly applies `format_for_channel()`, but the non-streaming `channel_send` tool path bypassed it entirely.

### Before (Telegram)
```
**Age of Money**: 142 giorni ✅
**Prossime scadenze**:
- 💳 Iconto: €2.00 (domani, 01/04)
```
Literal asterisks displayed as text.

### After (Telegram)
```html
<b>Age of Money</b>: 142 giorni ✅
<b>Prossime scadenze</b>:
- 💳 Iconto: €2.00 (domani, 01/04)
```
Properly formatted bold text.

## Changes

### `crates/librefang-channels/src/formatter.rs`
- **Added** `pub fn default_output_format_for_channel()` — returns the default `OutputFormat` for a channel type string (Telegram → `TelegramHtml`, Slack → `SlackMrkdwn`, WeCom → `PlainText`, others → `Markdown`)

### `crates/librefang-channels/src/bridge.rs`
- **Refactored** private `default_output_format_for_channel()` to delegate to the new public function in `formatter.rs`, eliminating duplication

### `crates/librefang-kernel/src/kernel.rs`
- **Fixed** `send_channel_message()` to call `format_for_channel()` for non-WeCom channels instead of passing raw Markdown
- Removed unused `OutputFormat` import (now resolved inside `formatter.rs`)

## How It Works

```
channel_send("telegram", user, "**bold** text")
                │
                ▼
default_output_format_for_channel("telegram") → TelegramHtml
                │
                ▼
format_for_channel("**bold** text", TelegramHtml) → "<b>bold</b> text"
                │
                ▼
adapter.send(ChannelContent::Text("<b>bold</b> text"))
```

WeCom retains its special path through `format_for_wecom()` with config-based override support.

## Testing

- All 16 existing `formatter` tests pass
- `test_default_output_format_for_channel` (bridge) passes — now delegates to the shared public function
- `cargo clippy --workspace` clean (zero warnings on affected crates)