### PR TITLE
fix(channels): apply channel-native formatting in channel_send tool

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1329,12 +1329,7 @@ async fn send_response(
 }
 
 fn default_output_format_for_channel(channel_type: &str) -> OutputFormat {
-    match channel_type {
-        "telegram" => OutputFormat::TelegramHtml,
-        "slack" => OutputFormat::SlackMrkdwn,
-        "wecom" => OutputFormat::Markdown,
-        _ => OutputFormat::Markdown,
-    }
+    formatter::default_output_format_for_channel(channel_type)
 }
 
 /// Send a lifecycle reaction (best-effort, non-blocking for supported adapters).

--- a/crates/librefang-channels/src/formatter.rs
+++ b/crates/librefang-channels/src/formatter.rs
@@ -7,6 +7,19 @@
 
 use librefang_types::config::OutputFormat;
 
+/// Return the default [`OutputFormat`] for a channel type string.
+///
+/// Channels that support rich formatting get their native format;
+/// unknown channel types fall back to raw Markdown (pass-through).
+pub fn default_output_format_for_channel(channel_type: &str) -> OutputFormat {
+    match channel_type {
+        "telegram" => OutputFormat::TelegramHtml,
+        "slack" => OutputFormat::SlackMrkdwn,
+        "wecom" => OutputFormat::PlainText,
+        _ => OutputFormat::Markdown,
+    }
+}
+
 /// Format a message for a specific channel output format.
 #[inline]
 pub fn format_for_channel(text: &str, format: OutputFormat) -> String {

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -32,7 +32,7 @@ use librefang_runtime::sandbox::{SandboxConfig, WasmSandbox};
 use librefang_runtime::tool_runner::builtin_tool_definitions;
 use librefang_types::agent::*;
 use librefang_types::capability::Capability;
-use librefang_types::config::{AuthProfile, KernelConfig, OutputFormat};
+use librefang_types::config::{AuthProfile, KernelConfig};
 use librefang_types::error::LibreFangError;
 use librefang_types::event::*;
 use librefang_types::memory::Memory;
@@ -9505,16 +9505,18 @@ impl KernelHandle for LibreFangKernel {
             librefang_user: None,
         };
 
+        let default_format =
+            librefang_channels::formatter::default_output_format_for_channel(channel);
         let formatted = if channel == "wecom" {
             let output_format = cfg
                 .channels
                 .wecom
                 .as_ref()
                 .and_then(|c| c.overrides.output_format)
-                .unwrap_or(OutputFormat::PlainText);
+                .unwrap_or(default_format);
             librefang_channels::formatter::format_for_wecom(message, output_format)
         } else {
-            message.to_string()
+            librefang_channels::formatter::format_for_channel(message, default_format)
         };
 
         let content = librefang_channels::types::ChannelContent::Text(formatted);


### PR DESCRIPTION
Fixes #1875 — closes #1876 (rebased to resolve conflict with main).

The `channel_send` tool was sending raw Markdown to all channels except WeCom, causing broken formatting on Telegram, Slack, and other platforms.

`Kernel::send_channel_message()` only applied output formatting for WeCom. All other channels received raw Markdown text, which rendered incorrectly because each platform expects its own native format (Telegram HTML, Slack mrkdwn, etc.).

The streaming response path (`bridge.rs` → adapter) correctly applies `format_for_channel()`, but the non-streaming `channel_send` tool path bypassed it entirely.

## Changes

- `formatter.rs`: added public `default_output_format_for_channel()` to centralise the channel → format mapping
- `bridge.rs`: refactored private function to delegate to the new public one, eliminating duplication; resolved conflict where main had incorrectly mapped `wecom → Markdown` (correct value is `PlainText`)
- `kernel.rs`: fixed `send_channel_message()` to call `format_for_channel()` for all channels instead of raw pass-through

Co-authored-by: Federico Liva <federico@federicoliva.dev>