### PR TITLE
fix(channels): restore WeCom default output format to Markdown

### DIFF
--- a/crates/librefang-channels/src/formatter.rs
+++ b/crates/librefang-channels/src/formatter.rs
@@ -15,7 +15,7 @@ pub fn default_output_format_for_channel(channel_type: &str) -> OutputFormat {
     match channel_type {
         "telegram" => OutputFormat::TelegramHtml,
         "slack" => OutputFormat::SlackMrkdwn,
-        "wecom" => OutputFormat::PlainText,
+        "wecom" => OutputFormat::Markdown,
         _ => OutputFormat::Markdown,
     }
 }


### PR DESCRIPTION
## Summary

- `6ac2e971` (PR #1877) extracted `default_output_format_for_channel()` into `formatter.rs` but copied the pre-`273f79e2` value (`PlainText`) for WeCom
- `273f79e2` (#1729) intentionally changed WeCom to `Markdown` when the new WebSocket bot adapter was introduced — the bot supports Markdown rendering
- This regression caused `bridge::tests::test_default_output_format_for_channel` to fail on all platforms, **blocking every open PR**

## Fix

One-line change: `"wecom" => OutputFormat::PlainText` → `"wecom" => OutputFormat::Markdown` in `formatter.rs`

## Affected PRs

PRs whose CI is blocked by this: #1879, #1881 (and transitively any new PR until fixed)