### PR TITLE
fix(xtask): use new tag instead of main in release review URL

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -357,8 +357,8 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
         }
         if let Some(ref pt) = prev_tag {
             println!(
-                "  Review:  https://github.com/librefang/librefang/compare/{}...main",
-                pt
+                "  Review:  https://github.com/librefang/librefang/compare/{}...{}",
+                pt, tag
             );
         }
         println!();


### PR DESCRIPTION
## Summary

- Fix the Review URL in release summary: changed from `...main` to `...v<new-tag>`
- Before: `compare/v2026.3.31-beta4...main` (showed all unreleased commits to HEAD)
- After: `compare/v2026.3.31-beta4...v2026.4.01-beta5` (correct diff between two release tags)

## Test Plan

- [ ] Run `cargo xtask release`, confirm the Review URL contains the new tag instead of `main`