### PR TITLE
fix(runtime): sync streaming fixes

### DIFF
--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1059,8 +1059,9 @@ async fn handle_command(
 fn map_stream_event(event: &StreamEvent, verbose: VerboseLevel) -> Option<serde_json::Value> {
     match event {
         StreamEvent::TextDelta { .. } => None, // Handled by debounce buffer
-        StreamEvent::ToolUseStart { name, .. } => Some(serde_json::json!({
+        StreamEvent::ToolUseStart { id, name } => Some(serde_json::json!({
             "type": "tool_start",
+            "id": id,
             "tool": name,
         })),
         StreamEvent::ToolUseEnd { name, input, .. } if name == "canvas_present" => {
@@ -1076,7 +1077,7 @@ fn map_stream_event(event: &StreamEvent, verbose: VerboseLevel) -> Option<serde_
                 "title": title,
             }))
         }
-        StreamEvent::ToolUseEnd { name, input, .. } => match verbose {
+        StreamEvent::ToolUseEnd { id, name, input } => match verbose {
             VerboseLevel::Off => None,
             VerboseLevel::On => {
                 let input_preview: String = serde_json::to_string(input)
@@ -1086,6 +1087,7 @@ fn map_stream_event(event: &StreamEvent, verbose: VerboseLevel) -> Option<serde_
                     .collect();
                 Some(serde_json::json!({
                     "type": "tool_end",
+                    "id": id,
                     "tool": name,
                     "input": input_preview,
                 }))
@@ -1098,6 +1100,7 @@ fn map_stream_event(event: &StreamEvent, verbose: VerboseLevel) -> Option<serde_
                     .collect();
                 Some(serde_json::json!({
                     "type": "tool_end",
+                    "id": id,
                     "tool": name,
                     "input": input_preview,
                 }))

--- a/crates/librefang-runtime/src/drivers/gemini.rs
+++ b/crates/librefang-runtime/src/drivers/gemini.rs
@@ -562,13 +562,23 @@ pub(crate) async fn stream_gemini_sse(
         let chunk = chunk_result.map_err(|e| LlmError::Http(e.to_string()))?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-        while let Some(pos) = buffer.find("\n\n") {
+        while let Some((pos, delim_len)) = buffer
+            .find("\r\n\r\n")
+            .map(|p| (p, 4usize))
+            .into_iter()
+            .chain(buffer.find("\n\n").map(|p| (p, 2usize)))
+            .min_by_key(|&(p, _)| p)
+        {
             let event_text = buffer[..pos].to_string();
-            buffer = buffer[pos + 2..].to_string();
+            buffer = buffer[pos + delim_len..].to_string();
 
             let data = event_text
                 .lines()
-                .find_map(|line| line.strip_prefix("data:").map(|d| d.trim_start()))
+                .find_map(|line| {
+                    line.trim_end_matches('\r')
+                        .strip_prefix("data:")
+                        .map(|d| d.trim_start())
+                })
                 .unwrap_or("");
 
             if data.is_empty() {
@@ -907,14 +917,24 @@ impl LlmDriver for GeminiDriver {
                 buffer.push_str(&String::from_utf8_lossy(&chunk));
 
                 // Process complete SSE events (delimited by \n\n or \r\n\r\n)
-                while let Some(pos) = buffer.find("\n\n") {
+                while let Some((pos, delim_len)) = buffer
+                    .find("\r\n\r\n")
+                    .map(|p| (p, 4usize))
+                    .into_iter()
+                    .chain(buffer.find("\n\n").map(|p| (p, 2usize)))
+                    .min_by_key(|&(p, _)| p)
+                {
                     let event_text = buffer[..pos].to_string();
-                    buffer = buffer[pos + 2..].to_string();
+                    buffer = buffer[pos + delim_len..].to_string();
 
                     // Extract the data line (handle both "data: " and "data:" formats)
                     let data = event_text
                         .lines()
-                        .find_map(|line| line.strip_prefix("data:").map(|d| d.trim_start()))
+                        .find_map(|line| {
+                            line.trim_end_matches('\r')
+                                .strip_prefix("data:")
+                                .map(|d| d.trim_start())
+                        })
                         .unwrap_or("");
 
                     if data.is_empty() {

--- a/crates/librefang-runtime/src/drivers/openai.rs
+++ b/crates/librefang-runtime/src/drivers/openai.rs
@@ -1109,6 +1109,17 @@ impl LlmDriver for OpenAIDriver {
                                     })
                                     .await;
                             }
+                        } else if let Some(reasoning) = delta["reasoning"].as_str() {
+                            // Fallback: Ollama and some local servers expose the reasoning
+                            // field instead of reasoning_content.
+                            if !reasoning.is_empty() {
+                                reasoning_content.push_str(reasoning);
+                                let _ = tx
+                                    .send(StreamEvent::ThinkingDelta {
+                                        text: reasoning.to_string(),
+                                    })
+                                    .await;
+                            }
                         }
 
                         // Tool call deltas


### PR DESCRIPTION
## Summary

- Gemini SSE parser now correctly handles `\r\n\r\n` event delimiters (was comment-only, code only split on `\n\n`)
- Ollama/OpenAI-compat driver checks `reasoning` field as fallback when `reasoning_content` is absent
- WebSocket `tool_start`/`tool_end` events now include `id` field for concurrent call correlation

## Source

| Fix | Origin | Author |
|-----|--------|--------|
| Gemini SSE `\r\n` | RightNow-AI/openfang#785 | @chahatjaink |
| Ollama `reasoning` fallback | RightNow-AI/openfang#805 | @Bodge-IT |
| WebSocket tool `id` | RightNow-AI/openfang#836 | @9M6 |

## Testing

- `cargo build --workspace --lib` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓