### PR TITLE
fix(kernel): trigger ReloadSkills on skills config TOML changes

### DIFF
--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -228,6 +228,10 @@ pub fn build_reload_plan(old: &KernelConfig, new: &KernelConfig) -> ReloadPlan {
         plan.hot_actions.push(HotAction::ReloadChannels);
     }
 
+    if field_changed(&old.skills, &new.skills) {
+        plan.hot_actions.push(HotAction::ReloadSkills);
+    }
+
     if old.usage_footer != new.usage_footer {
         plan.hot_actions.push(HotAction::UpdateUsageFooter);
     }
@@ -552,6 +556,45 @@ mod tests {
         let plan = build_reload_plan(&a, &b);
         assert!(!plan.restart_required);
         assert!(plan.hot_actions.contains(&HotAction::ReloadExtensions));
+    }
+
+    #[test]
+    fn test_skills_hot_reload_load_user_toggle() {
+        let a = default_cfg();
+        let mut b = default_cfg();
+        b.skills.load_user = false;
+        let plan = build_reload_plan(&a, &b);
+        assert!(!plan.restart_required);
+        assert!(
+            plan.hot_actions.contains(&HotAction::ReloadSkills),
+            "disabling load_user should trigger ReloadSkills"
+        );
+    }
+
+    #[test]
+    fn test_skills_hot_reload_extra_dirs() {
+        let a = default_cfg();
+        let mut b = default_cfg();
+        b.skills
+            .extra_dirs
+            .push(std::path::PathBuf::from("/tmp/my-skills"));
+        let plan = build_reload_plan(&a, &b);
+        assert!(!plan.restart_required);
+        assert!(
+            plan.hot_actions.contains(&HotAction::ReloadSkills),
+            "adding extra_dirs should trigger ReloadSkills"
+        );
+    }
+
+    #[test]
+    fn test_skills_no_reload_when_unchanged() {
+        let a = default_cfg();
+        let b = default_cfg();
+        let plan = build_reload_plan(&a, &b);
+        assert!(
+            !plan.hot_actions.contains(&HotAction::ReloadSkills),
+            "identical skills config must not push ReloadSkills"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6257,22 +6257,7 @@ system_prompt = "You are a helpful assistant."
                     self.channel_adapters.clear();
                 }
                 HotAction::ReloadSkills => {
-                    info!("Hot-reload: reloading skill registry");
-                    let mut reg = self
-                        .skill_registry
-                        .write()
-                        .unwrap_or_else(|e| e.into_inner());
-                    match reg.load_all() {
-                        Ok(n) => {
-                            info!("Hot-reload: reloaded {n} skill(s)");
-                        }
-                        Err(e) => {
-                            warn!("Hot-reload: failed to reload skills: {e}");
-                        }
-                    }
-                    // Bump skill generation so tool list caches are invalidated
-                    self.skill_generation
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    self.reload_skills();
                 }
                 HotAction::UpdateUsageFooter => {
                     info!(

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -791,6 +791,30 @@ impl Default for PairingConfig {
     }
 }
 
+/// Skills configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SkillsConfig {
+    /// Whether bundled (compile-time embedded) skills are loaded. Default: true.
+    pub load_bundled: bool,
+    /// Whether user-installed skills from the skills directory are loaded. Default: true.
+    pub load_user: bool,
+    /// Extra skill directories to scan in addition to `~/.librefang/skills/`.
+    /// Each entry must be an absolute path.
+    #[serde(default)]
+    pub extra_dirs: Vec<std::path::PathBuf>,
+}
+
+impl Default for SkillsConfig {
+    fn default() -> Self {
+        Self {
+            load_bundled: true,
+            load_user: true,
+            extra_dirs: Vec::new(),
+        }
+    }
+}
+
 /// Extensions & integrations configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1680,6 +1704,9 @@ pub struct KernelConfig {
     /// Extensions & integrations configuration.
     #[serde(default)]
     pub extensions: ExtensionsConfig,
+    /// Skills configuration (bundled + user-installed skills).
+    #[serde(default)]
+    pub skills: SkillsConfig,
     /// Credential vault configuration.
     #[serde(default)]
     pub vault: VaultConfig,
@@ -2758,6 +2785,7 @@ impl Default for KernelConfig {
             fallback_providers: Vec::new(),
             browser: BrowserConfig::default(),
             extensions: ExtensionsConfig::default(),
+            skills: SkillsConfig::default(),
             vault: VaultConfig::default(),
             workspaces_dir: None,
             log_dir: None,


### PR DESCRIPTION
## Summary

`ReloadSkills` was declared but never pushed to the hot-reload plan — config TOML changes to skills had no effect without a daemon restart.

Changes:
- Added `SkillsConfig` struct (`load_bundled`, `load_user`, `extra_dirs`) to `KernelConfig`
- `build_reload_plan` now diffs `old.skills` vs `new.skills` and pushes `HotAction::ReloadSkills` on change
- `ReloadSkills` execution now calls `self.reload_skills()` which fully rebuilds the registry, clears `prompt_metadata_cache.skills`, and bumps `skill_generation`

## Source

| Fix | Origin | Author |
|-----|--------|--------|
| Local skill install + hot-reload | RightNow-AI/openfang#752 | @ezavesky |
| Agent skills hot-reload on TOML | RightNow-AI/openfang#900 | @neo-wanderer |

## Testing

- `cargo build --workspace --lib` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- 3 new unit tests covering toggle/dir change/no-change scenarios