### PR TITLE
ci(release): fetch full tag history so diff link is populated

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Extract changelog for this version
         id: changelog


### PR DESCRIPTION
## Problem

The `create_release` job used a default (shallow) checkout with `fetch-depth: 1`. With only the pushed tag's commit present, `git tag --sort=-creatordate` could only see the current tag — `PREV` was always empty, so the `Full diff` line was never written to the release body.

## Fix

Add `fetch-depth: 0` to the `create_release` checkout step, matching what `tag_on_merge` already does. This fetches the full tag history so the previous tag can be resolved.