### PR TITLE
fix(whatsapp-gateway): prevent NO_REPLY token from leaking in group chats

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -8,6 +8,35 @@ use librefang_channels::router::AgentRouter;
 use librefang_channels::sidecar::SidecarAdapter;
 use librefang_channels::types::{ChannelAdapter, SenderContext};
 
+/// Sanitize LLM/driver errors into user-friendly messages for channel delivery.
+///
+/// Prevents raw technical details (stack traces, driver internals, status codes)
+/// from leaking to end users on WhatsApp, Telegram, etc.
+fn sanitize_channel_error(err: &str) -> String {
+    let lower = err.to_lowercase();
+    if lower.contains("timed out") || lower.contains("inactivity") {
+        "The task timed out due to inactivity. Try breaking it into smaller steps.".to_string()
+    } else if lower.contains("rate limit")
+        || lower.contains("rate_limit")
+        || lower.contains("429")
+        || lower.contains("quota")
+        || lower.contains("rate-limit")
+        || lower.contains("too many requests")
+        || lower.contains("resource exhausted")
+    {
+        "I've hit my usage limit and need to rest. I'll be back soon!".to_string()
+    } else if lower.contains("auth") || lower.contains("not logged in") || lower.contains("401") {
+        "I'm having trouble with my credentials. Please let the admin know.".to_string()
+    } else if lower.contains("exited with code") || lower.contains("llm driver") {
+        "Sorry, something went wrong on my end. Please try again in a moment.".to_string()
+    } else {
+        format!(
+            "Something went wrong: please try again. (ref: {})",
+            &err[..err.len().min(80)]
+        )
+    }
+}
+
 /// Check if text looks like a raw tool call leaked as content.
 ///
 /// Some providers emit tool calls as plain text (recovered by
@@ -343,33 +372,15 @@ fn start_stream_text_bridge(
         let error_msg = match kernel_handle.await {
             Err(e) => {
                 error!("Streaming kernel task panicked: {e}");
-                Some(format!("Task failed: {e}. Please try again."))
+                Some(
+                    "Sorry, something went wrong on my end. Please try again in a moment."
+                        .to_string(),
+                )
             }
             Ok(Err(e)) => {
                 let err_str = e.to_string();
                 error!("Streaming kernel task returned error: {err_str}");
-                if err_str.contains("timed out") {
-                    Some(
-                        "[Error: task timed out due to inactivity. Try breaking it into smaller steps.]"
-                            .to_string(),
-                    )
-                } else if err_str.contains("hit your limit")
-                    || err_str.contains("rate limit")
-                    || err_str.contains("429")
-                    || err_str.contains("quota")
-                {
-                    Some(
-                        "[I've hit my usage limit and need to rest. I'll be back soon!]"
-                            .to_string(),
-                    )
-                } else if err_str.contains("exited with code") || err_str.contains("LLM driver") {
-                    Some(
-                        "[Sorry, something went wrong on my end. Please try again in a moment.]"
-                            .to_string(),
-                    )
-                } else {
-                    Some(format!("Task failed: {e}. Please try again."))
-                }
+                Some(sanitize_channel_error(&err_str))
             }
             Ok(Ok(result)) => {
                 debug!(
@@ -2876,5 +2887,78 @@ mod tests {
         assert!(config.channels.gotify.is_none());
         assert!(config.channels.webhook.is_none());
         assert!(config.channels.linkedin.is_none());
+    }
+
+    #[test]
+    fn test_sanitize_channel_error_rate_limit() {
+        let msg = sanitize_channel_error("LLM driver error: Rate limited — retrying shortly.");
+        assert!(
+            msg.contains("usage limit"),
+            "expected rate-limit msg, got: {msg}"
+        );
+
+        let msg = sanitize_channel_error("API error (429): Too Many Requests");
+        assert!(
+            msg.contains("usage limit"),
+            "expected rate-limit msg, got: {msg}"
+        );
+
+        let msg = sanitize_channel_error("rate_limit_error: Number of request tokens exceeded");
+        assert!(
+            msg.contains("usage limit"),
+            "expected rate-limit msg, got: {msg}"
+        );
+
+        let msg = sanitize_channel_error("Resource exhausted: request rate limit exceeded");
+        assert!(
+            msg.contains("usage limit"),
+            "expected rate-limit msg, got: {msg}"
+        );
+
+        let msg =
+            sanitize_channel_error("All 3 API keys for provider 'anthropic' are rate-limited");
+        assert!(
+            msg.contains("usage limit"),
+            "expected rate-limit msg, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_channel_error_timeout() {
+        let msg = sanitize_channel_error("Task timed out after 600s of inactivity");
+        assert!(
+            msg.contains("timed out"),
+            "expected timeout msg, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_channel_error_driver_crash() {
+        let msg =
+            sanitize_channel_error("LLM driver error: Claude Code CLI exited with code 1: err");
+        assert!(
+            msg.contains("something went wrong"),
+            "expected driver msg, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_channel_error_auth() {
+        let msg = sanitize_channel_error("Auth error: Claude Code CLI is not authenticated");
+        assert!(msg.contains("credentials"), "expected auth msg, got: {msg}");
+    }
+
+    #[test]
+    fn test_sanitize_channel_error_unknown() {
+        let msg = sanitize_channel_error("Something completely unexpected happened");
+        assert!(
+            msg.contains("Something went wrong"),
+            "expected generic msg, got: {msg}"
+        );
+        // Should include a truncated reference, not the full raw error
+        assert!(
+            msg.contains("ref:"),
+            "expected ref in generic msg, got: {msg}"
+        );
     }
 }

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -1532,16 +1532,22 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
               return;
             }
             // The /api/agents/{id}/message endpoint returns { response: "..." }
-            const text = data.response || data.message || data.text || '';
+            const responseText = data.response || data.message || data.text || '';
             // Safety net: strip NO_REPLY token if it leaked through as text
-            const trimmed = text.trim();
+            const trimmed = responseText.trim();
             if (trimmed === 'NO_REPLY' || trimmed.endsWith('\nNO_REPLY')) {
               resolve('');
               return;
             }
-            resolve(text);
+            resolve(responseText);
           } catch {
-            resolve(body.trim() || '');
+            // Non-JSON fallback — still check for NO_REPLY
+            const fallback = body.trim() || '';
+            if (fallback === 'NO_REPLY' || fallback.endsWith('\nNO_REPLY')) {
+              resolve('');
+              return;
+            }
+            resolve(fallback);
           }
         });
       },


### PR DESCRIPTION
## Problem

When the LLM agent decides not to respond to a group message (by outputting `NO_REPLY`), the token leaks through as a visible text message in WhatsApp group chats.

**Root cause — two independent bugs:**

### 1. Gateway ignores `silent` flag from API response

The `/api/agents/{id}/message` endpoint returns `{ "silent": true, "response": "" }` when the agent chooses `NO_REPLY`. However, `forwardToLibreFang()` in the WhatsApp gateway only reads `data.response` and never checks `data.silent`:

```javascript
// Before (packages/whatsapp-gateway/index.js)
resolve(data.response || data.message || data.text || '');
// ↑ If response is "" but data has other fields, may resolve non-empty
```

Additionally, if the `silent` flag is somehow missed (e.g., non-JSON response fallback), the raw `NO_REPLY` token passes through as regular text.

### 2. Channel bridge exposes raw LLM errors to users

When the LLM driver fails (rate limits, timeouts, process crashes), the channel bridge forwards the raw technical error to the channel user:

```
Task failed: LLM driver error: Request failed: Claude Code CLI streaming
exited with code 1: no stderr — raw: API error (1)...
```

This leaks internal implementation details and confuses end users.

## Fix

### Gateway: `forwardToLibreFang()` — check `silent` + safety net

```javascript
// After
if (data.silent) {
  resolve('');
  return;
}
const text = data.response || data.message || data.text || '';
// Safety net: catch NO_REPLY even if silent flag was missed
if (text.trim() === 'NO_REPLY' || text.trim().endsWith('\nNO_REPLY')) {
  resolve('');
  return;
}
resolve(text);
```

**Defense in depth:** The `silent` flag is the primary signal. The text-based `NO_REPLY` check is a safety net for edge cases where the flag might not propagate (e.g., non-JSON fallback parsing).

### Bridge: categorize and sanitize error messages

```
Rate limit errors  → "I've hit my usage limit and need to rest. I'll be back soon!"
Timeout errors     → "Error: task timed out due to inactivity..."
Driver errors      → "Sorry, something went wrong on my end. Please try again."
Other errors       → "Task failed: {e}. Please try again." (unchanged)
```

## Architecture: NO_REPLY flow

```
                    ┌─────────────────┐
                    │   LLM Agent     │
                    │ outputs NO_REPLY│
                    └────────┬────────┘
                             │
                    ┌────────▼────────┐
                    │  agent_loop.rs  │
                    │ is_no_reply()   │──→ silent: true
                    └────────┬────────┘
                             │
                    ┌────────▼────────┐
                    │  API endpoint   │
                    │ returns JSON    │──→ { "silent": true, "response": "" }
                    └────────┬────────┘
                             │
                    ┌────────▼─────────────┐
             ★ FIX  │  forwardToLibreFang()│
                    │ checks data.silent   │──→ resolve('')
                    │ + NO_REPLY safety net│
                    └────────┬─────────────┘
                             │ (empty string)
                    ┌────────▼────────┐
                    │ Gateway handler │
                    │ if (response)   │──→ falsy → skip sending
                    └─────────────────┘
```

## Changes

| File | Change |
|------|--------|
| `packages/whatsapp-gateway/index.js` | Check `data.silent`, filter `NO_REPLY` token as safety net |
| `crates/librefang-api/src/channel_bridge.rs` | Categorize errors: rate-limit, timeout, driver → user-friendly messages |

## Test plan

- [x] Send a message from a non-mentioned user in a WhatsApp group → agent should stay silent (no visible message)
- [x] Trigger a rate limit → user should see friendly message, not raw error
- [x] Send a direct message → agent should respond normally (no regression)
- [x] Verify `data.silent: true` responses return empty string from `forwardToLibreFang()`