### PR TITLE
ux: add guided empty state for workflow template library

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -738,7 +738,10 @@
       "organizer_desc": "Categorize and structure",
       "report_writer": "Report Writer",
       "report_writer_desc": "Generate polished report"
-    }
+    },
+    "template_empty_title": "No templates yet",
+    "template_empty_desc": "Templates are synced from the registry when the daemon starts. Restart the daemon or run the command below to populate the library.",
+    "template_empty_cmd": "librefang init"
   },
   "scheduler": {
     "title": "Scheduler",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -742,7 +742,10 @@
       "organizer_desc": "分类和结构化",
       "report_writer": "周报撰写",
       "report_writer_desc": "生成专业周报"
-    }
+    },
+    "template_empty_title": "模板库为空",
+    "template_empty_desc": "模板在守护进程启动时从 registry 同步。重启守护进程，或运行以下命令来初始化模板库。",
+    "template_empty_cmd": "librefang init"
   },
   "scheduler": {
     "title": "调度器",

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -26,7 +26,7 @@ import { ScheduleModal } from "../components/ui/ScheduleModal";
 import {
   Layers, Trash2, FilePlus, Play, Search,
   Calendar, FileText, Activity, Bot, ArrowRight, Loader2, Clock, ChevronRight,
-  ChevronDown, FlaskConical, AlertCircle, CheckCircle2, SkipForward,
+  ChevronDown, FlaskConical, AlertCircle, CheckCircle2, SkipForward, PackageOpen, RefreshCw,
 } from "lucide-react";
 
 const categoryIconMap: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -211,7 +211,23 @@ export function WorkflowsPage() {
             })}
           </div>
         ) : (
-          <div className="py-12 text-center text-text-dim text-sm">{t("common.no_data")}</div>
+          <div className="py-16 flex flex-col items-center gap-4 text-center">
+            <div className="w-14 h-14 rounded-2xl bg-brand/10 flex items-center justify-center">
+              <PackageOpen className="w-7 h-7 text-brand/60" />
+            </div>
+            <div>
+              <p className="text-sm font-bold">{t("workflows.template_empty_title")}</p>
+              <p className="text-xs text-text-dim mt-1 max-w-xs">{t("workflows.template_empty_desc")}</p>
+              <code className="inline-block mt-3 px-3 py-1.5 rounded-lg bg-main text-[11px] font-mono text-text-dim border border-border-subtle">{t("workflows.template_empty_cmd")}</code>
+            </div>
+            <button
+              onClick={() => templatesQuery.refetch()}
+              className="flex items-center gap-1.5 text-xs text-brand hover:underline mt-1"
+            >
+              <RefreshCw className="w-3 h-3" />
+              {t("common.refresh")}
+            </button>
+          </div>
         )
       )}
 


### PR DESCRIPTION
Addresses #1912

The template library is empty by design on a fresh install — templates sync from the registry on daemon startup. The bare "no data" message gave users no guidance.

## Changes
- Replace `t("common.no_data")` with an explanatory empty state
- Shows why it's empty and how templates get populated
- `librefang init` command hint in a code block
- Refresh button to re-query without a page reload
- Added `workflows.template_empty_title/desc/cmd` keys to `en.json` and `zh.json`