### PR TITLE
feat(runtime): progressive timeout with partial output preservation

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -355,6 +355,12 @@ fn start_stream_text_bridge(
                 StreamEvent::ToolUseStart { .. } => {
                     saw_tool_use = true;
                 }
+                StreamEvent::PhaseChange { .. } => {
+                    // PhaseChange events (e.g. "long_running") are NOT injected
+                    // into the text stream — they would persist in the response.
+                    // They flow through the SSE endpoint as `event: phase` and
+                    // each adapter handles them independently.
+                }
                 _ => {}
             }
         }
@@ -380,7 +386,14 @@ fn start_stream_text_bridge(
             Ok(Err(e)) => {
                 let err_str = e.to_string();
                 error!("Streaming kernel task returned error: {err_str}");
-                Some(sanitize_channel_error(&err_str))
+                if err_str.contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER) {
+                    Some(
+                        "\n\n---\n[Task timed out. The output above may be incomplete.]"
+                            .to_string(),
+                    )
+                } else {
+                    Some(sanitize_channel_error(&err_str))
+                }
             }
             Ok(Ok(result)) => {
                 debug!(
@@ -1682,7 +1695,8 @@ pub async fn start_channel_bridge_with_config(
                     tg_config.initial_backoff_secs,
                     tg_config.max_backoff_secs,
                     tg_config.long_poll_timeout_secs,
-                ),
+                )
+                .with_clear_done_reaction(tg_config.overrides.clear_done_reaction),
             );
             adapters.push((
                 adapter,

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -53,6 +53,8 @@ pub struct TelegramAdapter {
     long_poll_timeout: u64,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// When true, remove the reaction on Done instead of showing 🎉.
+    clear_done_reaction: bool,
 }
 
 impl TelegramAdapter {
@@ -86,7 +88,15 @@ impl TelegramAdapter {
             long_poll_timeout: 30,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            clear_done_reaction: false,
         }
+    }
+
+    /// When enabled, the Done reaction is removed (cleared) instead of
+    /// showing a completion emoji.  Returns self for builder chaining.
+    pub fn with_clear_done_reaction(mut self, clear: bool) -> Self {
+        self.clear_done_reaction = clear;
+        self
     }
 
     /// Set backoff and long-poll timeout configuration. Returns self for builder chaining.
@@ -605,6 +615,25 @@ impl TelegramAdapter {
             "message_id": message_id,
             "reaction": [{"type": "emoji", "emoji": emoji}],
         });
+        self.fire_reaction_body(url, body);
+    }
+
+    /// Remove all bot reactions from a message.
+    fn clear_reactions(&self, chat_id: i64, message_id: i64) {
+        let url = format!(
+            "{}/bot{}/setMessageReaction",
+            self.api_base_url,
+            self.token.as_str()
+        );
+        let body = serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "reaction": [],
+        });
+        self.fire_reaction_body(url, body);
+    }
+
+    fn fire_reaction_body(&self, url: String, body: serde_json::Value) {
         let client = self.client.clone();
         tokio::spawn(async move {
             match client.post(&url).json(&body).send().await {
@@ -1018,7 +1047,14 @@ impl ChannelAdapter for TelegramAdapter {
             "\u{274C}" => "\u{1F44E}",        // ❌ → 👎
             other => other,                   // 🤔, ✍️ etc. pass through
         };
-        self.fire_reaction(chat_id, msg_id, emoji);
+
+        // Optionally clear the reaction on completion instead of showing 🎉.
+        let is_done = reaction.emoji == "\u{2705}"; // ✅
+        if is_done && self.clear_done_reaction {
+            self.clear_reactions(chat_id, msg_id);
+        } else {
+            self.fire_reaction(chat_id, msg_id, emoji);
+        }
         Ok(())
     }
 

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3834,6 +3834,7 @@ system_prompt = "You are a helpful assistant."
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let result = match tokio::time::timeout(
@@ -4353,6 +4354,7 @@ system_prompt = "You are a helpful assistant."
                 thinking: None,
                 prompt_caching: false,
                 response_format: None,
+                timeout_secs: None,
             };
             let (complexity, routed_model) = router.select_model(&probe);
             // Check if the routed model's provider has a valid API key.

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -56,6 +56,10 @@ const MAX_CONTINUATIONS: u32 = 5;
 /// 7-10 real conversation turns instead of the previous 3-5.
 const MAX_HISTORY_MESSAGES: usize = 40;
 
+/// Marker included in timeout error messages when partial output was delivered.
+/// Used by channel_bridge to detect this case without fragile string matching.
+pub const TIMEOUT_PARTIAL_OUTPUT_MARKER: &str = "[partial_output_delivered]";
+
 /// Check if a response is a NO_REPLY.  Matches:
 /// - Exact `"NO_REPLY"` (original behaviour)
 /// - Text ending with `NO_REPLY` on its own line (model sometimes adds context before it)
@@ -817,6 +821,21 @@ pub async fn run_agent_loop(
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
+        let timeout_override = manifest
+            .metadata
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                if available_tools
+                    .iter()
+                    .any(|t| t.name.starts_with("browser_") || t.name.starts_with("playwright_"))
+                {
+                    Some(600)
+                } else {
+                    None
+                }
+            });
+
         let request = CompletionRequest {
             model: api_model,
             messages: messages.clone(),
@@ -827,6 +846,7 @@ pub async fn run_agent_loop(
             thinking: manifest.thinking.clone(),
             prompt_caching,
             response_format: manifest.response_format.clone(),
+            timeout_secs: timeout_override,
         };
 
         // Notify phase: Thinking
@@ -1827,6 +1847,26 @@ async fn stream_with_retry(
                 tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                 last_error = Some("Overloaded".to_string());
             }
+            Err(LlmError::TimedOut {
+                inactivity_secs,
+                partial_text,
+                partial_text_len,
+                last_activity,
+            }) => {
+                warn!(
+                    inactivity_secs,
+                    partial_text_len, last_activity, "LLM stream timed out with partial output"
+                );
+                if !partial_text.is_empty() {
+                    let _ = tx.send(StreamEvent::TextDelta { text: partial_text }).await;
+                }
+                return Err(LibreFangError::LlmDriver(format!(
+                    "Task timed out after {inactivity_secs}s of inactivity \
+                     (last: {last_activity}). \
+                     {partial_text_len} chars of partial output were delivered. \
+                     {TIMEOUT_PARTIAL_OUTPUT_MARKER}"
+                )));
+            }
             Err(e) => {
                 let raw_error = e.to_string();
                 let status = match &e {
@@ -2292,6 +2332,24 @@ pub async fn run_agent_loop_streaming(
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
+        // Per-request timeout: manifest metadata takes priority, then browser
+        // heuristic, then driver default (None = use driver's configured value).
+        let timeout_override = manifest
+            .metadata
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                // Auto-extend for agents with browser tools
+                if available_tools
+                    .iter()
+                    .any(|t| t.name.starts_with("browser_") || t.name.starts_with("playwright_"))
+                {
+                    Some(600) // 10 minutes for browser tasks
+                } else {
+                    None
+                }
+            });
+
         let request = CompletionRequest {
             model: api_model,
             messages: messages.clone(),
@@ -2302,6 +2360,7 @@ pub async fn run_agent_loop_streaming(
             thinking: manifest.thinking.clone(),
             prompt_caching,
             response_format: manifest.response_format.clone(),
+            timeout_secs: timeout_override,
         };
 
         // Notify phase: on first iteration emit Streaming; on subsequent
@@ -2323,14 +2382,41 @@ pub async fn run_agent_loop_streaming(
 
         // Stream LLM call with retry, error classification, and circuit breaker
         let provider_name = manifest.model.provider.as_str();
-        let mut response = stream_with_retry(
+        let mut response = match stream_with_retry(
             &*driver,
             request,
             stream_tx.clone(),
             Some(provider_name),
             None,
         )
-        .await?;
+        .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.contains("timed out") {
+                    // Extract last_activity from error if present (format: "last: <activity>")
+                    let activity = err_str
+                        .find("last: ")
+                        .map(|i| {
+                            let start = i + 6;
+                            let end = err_str[start..]
+                                .find(')')
+                                .map_or(err_str.len(), |j| start + j);
+                            &err_str[start..end]
+                        })
+                        .unwrap_or("unknown");
+                    let note = format!(
+                        "[System: your previous task timed out while doing: {activity}. \
+                         The user's request could not be completed. \
+                         Any partial output was already sent to the user.]"
+                    );
+                    session.messages.push(Message::assistant(note));
+                    let _ = memory.save_session_async(session).await;
+                }
+                return Err(e);
+            }
+        };
 
         total_usage.input_tokens += response.usage.input_tokens;
         total_usage.output_tokens += response.usage.output_tokens;

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -563,6 +563,7 @@ async fn summarize_messages(
         thinking: None,
         prompt_caching: false,
         response_format: None,
+        timeout_secs: None,
     };
 
     // Retry logic for transient failures
@@ -684,6 +685,7 @@ async fn summarize_in_chunks(
         thinking: None,
         prompt_caching: false,
         response_format: None,
+        timeout_secs: None,
     };
 
     match driver.complete(merge_request).await {

--- a/crates/librefang-runtime/src/drivers/chatgpt.rs
+++ b/crates/librefang-runtime/src/drivers/chatgpt.rs
@@ -1033,6 +1033,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.model, "gpt-4o");
@@ -1065,6 +1066,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.instructions.as_deref(), Some("System prompt."));
@@ -1089,6 +1091,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: Some(ResponseFormat::Json),
+            timeout_secs: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");
@@ -1122,6 +1125,7 @@ mod tests {
                 }),
                 strict: Some(true),
             }),
+            timeout_secs: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");

--- a/crates/librefang-runtime/src/drivers/claude_code.rs
+++ b/crates/librefang-runtime/src/drivers/claude_code.rs
@@ -408,7 +408,9 @@ impl LlmDriver for ClaudeCodeDriver {
         });
 
         // Wait with timeout
-        let timeout_duration = std::time::Duration::from_secs(self.message_timeout_secs);
+        let timeout_duration = std::time::Duration::from_secs(
+            request.timeout_secs.unwrap_or(self.message_timeout_secs),
+        );
         let wait_result = tokio::time::timeout(timeout_duration, child.wait()).await;
 
         // Clear PID tracking regardless of outcome
@@ -602,20 +604,60 @@ impl LlmDriver for ClaudeCodeDriver {
             ..Default::default()
         };
 
-        // Per-line inactivity timeout: each next_line() call must produce
-        // output within the timeout window. This prevents killing long-running
-        // but actively-streaming responses while still catching hung processes.
-        let inactivity_dur = std::time::Duration::from_secs(self.message_timeout_secs);
+        // Track last known activity for timeout diagnostics
+        let mut last_activity = "starting".to_string();
+
+        // Progressive inactivity timeout with three escalation levels:
+        //   1. warn  (20% of timeout) — log warning, internal only
+        //   2. notify (40% of timeout) — send "still working..." to user
+        //   3. kill  (100% of timeout) — kill process, preserve partial output
+        // The timer resets every time the CLI produces output.
+        let kill_secs = request.timeout_secs.unwrap_or(self.message_timeout_secs);
+        let warn_secs = kill_secs / 5;
+        let notify_secs = kill_secs * 2 / 5;
+
+        let mut last_output = tokio::time::Instant::now();
+        let mut warned = false;
+        let mut notified = false;
+
         let stream_err: Option<LlmError> = loop {
-            match tokio::time::timeout(inactivity_dur, lines.next_line()).await {
+            let elapsed = last_output.elapsed().as_secs();
+            let next_deadline_secs = if !warned {
+                warn_secs.saturating_sub(elapsed)
+            } else if !notified {
+                notify_secs.saturating_sub(elapsed)
+            } else {
+                kill_secs.saturating_sub(elapsed)
+            };
+            let deadline = std::time::Duration::from_secs(next_deadline_secs.max(1));
+
+            match tokio::time::timeout(deadline, lines.next_line()).await {
                 Ok(Ok(Some(line))) => {
+                    last_output = tokio::time::Instant::now();
+                    warned = false;
+                    notified = false;
+
                     if line.trim().is_empty() {
                         continue;
                     }
 
                     match serde_json::from_str::<ClaudeStreamEvent>(&line) {
                         Ok(event) => {
-                            match event.r#type.as_str() {
+                            // Track last activity for timeout diagnostics
+                            let etype = event.r#type.as_str();
+                            if etype.contains("tool") {
+                                // e.g. "tool_use", "tool_result" — extract tool name from content
+                                last_activity = event
+                                    .content
+                                    .as_deref()
+                                    .and_then(|c| c.get(..80))
+                                    .map(|s| format!("tool: {s}"))
+                                    .unwrap_or_else(|| format!("event: {etype}"));
+                            } else if !etype.is_empty() {
+                                last_activity = format!("event: {etype}");
+                            }
+
+                            match etype {
                                 "content" | "text" | "assistant" | "content_block_delta" => {
                                     if let Some(ref content) = event.content {
                                         full_text.push_str(content);
@@ -646,7 +688,6 @@ impl LlmDriver for ClaudeCodeDriver {
                                     }
                                 }
                                 _ => {
-                                    // Unknown event type — try content field as fallback
                                     if let Some(ref content) = event.content {
                                         full_text.push_str(content);
                                         let _ = tx
@@ -659,31 +700,49 @@ impl LlmDriver for ClaudeCodeDriver {
                             }
                         }
                         Err(e) => {
-                            // Not valid JSON — treat as raw text
                             warn!(line = %line, error = %e, "Non-JSON line from Claude CLI");
                             full_text.push_str(&line);
                             let _ = tx.send(StreamEvent::TextDelta { text: line }).await;
                         }
                     }
                 }
-                Ok(Ok(None)) => break None, // EOF — stream finished normally
+                Ok(Ok(None)) => break None,
                 Ok(Err(e)) => {
                     warn!(error = %e, "Claude Code CLI stream IO error");
                     break None;
                 }
                 Err(_) => {
-                    // Inactivity timeout — no output for message_timeout_secs
-                    warn!(
-                        timeout_secs = self.message_timeout_secs,
-                        model = %pid_label,
-                        "Claude Code CLI streaming subprocess timed out after {}s of inactivity — process killed",
-                        self.message_timeout_secs
-                    );
-                    let _ = child.kill().await;
-                    break Some(LlmError::Http(format!(
-                        "Claude Code CLI streaming subprocess timed out after {}s of inactivity — process killed",
-                        self.message_timeout_secs
-                    )));
+                    let silent_secs = last_output.elapsed().as_secs();
+                    if !warned {
+                        warned = true;
+                        warn!(silent_secs, model = %pid_label, "Claude CLI: no output, monitoring");
+                    } else if !notified {
+                        notified = true;
+                        info!(silent_secs, model = %pid_label, "Claude CLI: notifying user of long-running task");
+                        let _ = tx
+                            .send(StreamEvent::PhaseChange {
+                                phase: "long_running".to_string(),
+                                detail: Some(format!(
+                                    "No output for {silent_secs}s — task is still running..."
+                                )),
+                            })
+                            .await;
+                    } else {
+                        let partial_len = full_text.len();
+                        warn!(
+                            timeout_secs = kill_secs,
+                            partial_output_chars = partial_len,
+                            model = %pid_label,
+                            "Claude CLI streaming timed out due to inactivity, killing process"
+                        );
+                        let _ = child.kill().await;
+                        break Some(LlmError::TimedOut {
+                            inactivity_secs: kill_secs,
+                            partial_text_len: partial_len,
+                            partial_text: std::mem::take(&mut full_text),
+                            last_activity: last_activity.clone(),
+                        });
+                    }
                 }
             }
         };
@@ -807,6 +866,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -847,6 +907,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);

--- a/crates/librefang-runtime/src/drivers/fallback.rs
+++ b/crates/librefang-runtime/src/drivers/fallback.rs
@@ -263,6 +263,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         }
     }
 

--- a/crates/librefang-runtime/src/drivers/gemini.rs
+++ b/crates/librefang-runtime/src/drivers/gemini.rs
@@ -1267,6 +1267,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let tools = convert_tools(&request);
@@ -1287,6 +1288,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let tools = convert_tools(&request);

--- a/crates/librefang-runtime/src/drivers/qwen_code.rs
+++ b/crates/librefang-runtime/src/drivers/qwen_code.rs
@@ -622,6 +622,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let prompt = QwenCodeDriver::build_prompt(&request);

--- a/crates/librefang-runtime/src/drivers/token_rotation.rs
+++ b/crates/librefang-runtime/src/drivers/token_rotation.rs
@@ -273,6 +273,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         }
     }
 

--- a/crates/librefang-runtime/src/llm_driver.rs
+++ b/crates/librefang-runtime/src/llm_driver.rs
@@ -47,6 +47,15 @@ pub enum LlmError {
     /// Model not found.
     #[error("Model not found: {0}")]
     ModelNotFound(String),
+    /// Subprocess timed out due to inactivity, but partial output was captured.
+    #[error("Timed out after {inactivity_secs}s of inactivity (last: {last_activity}, {partial_text_len} chars partial output)")]
+    TimedOut {
+        inactivity_secs: u64,
+        partial_text: String,
+        partial_text_len: usize,
+        /// Last known activity before the process stalled.
+        last_activity: String,
+    },
 }
 
 /// A request to an LLM for completion.
@@ -78,6 +87,10 @@ pub struct CompletionRequest {
     /// When set, instructs the LLM to return output in the specified format.
     /// `None` preserves the default free-form text behaviour.
     pub response_format: Option<ResponseFormat>,
+    /// Per-request timeout override (seconds).  When set, the CLI driver uses
+    /// this instead of the global `message_timeout_secs`.  Allows the agent
+    /// loop to grant longer timeouts for requests that involve browser tools.
+    pub timeout_secs: Option<u64>,
 }
 
 /// A response from an LLM completion.
@@ -345,6 +358,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let response = driver.stream(request, tx).await.unwrap();

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -278,6 +278,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         let response = self
@@ -330,6 +331,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         };
 
         match self.driver.complete(request).await {

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -195,6 +195,7 @@ mod tests {
             thinking: None,
             prompt_caching: false,
             response_format: None,
+            timeout_secs: None,
         }
     }
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -97,6 +97,12 @@ pub struct ChannelOverrides {
     /// Maximum number of messages to buffer per sender before forcing dispatch. Default: 64.
     #[serde(default = "default_message_debounce_max_buffer")]
     pub message_debounce_max_buffer: usize,
+    /// Remove the reaction emoji on task completion instead of showing a
+    /// "done" reaction.  When `true`, the bot clears all its reactions once
+    /// the response is delivered, keeping the chat cleaner.  Default: `false`
+    /// (show the done reaction for backward compatibility).
+    #[serde(default)]
+    pub clear_done_reaction: bool,
 }
 
 impl Default for ChannelOverrides {
@@ -116,6 +122,7 @@ impl Default for ChannelOverrides {
             message_debounce_ms: 0,
             message_debounce_max_ms: 30000,
             message_debounce_max_buffer: 64,
+            clear_done_reaction: false,
         }
     }
 }


### PR DESCRIPTION
## Problem

When an LLM call hangs or takes too long, LibreFang kills the process abruptly with no context. The user sees a generic error, loses all partial output, and has no idea what the agent was doing when it timed out.

**Before (current behavior):**
```
[User sends complex research task]
...5 minutes of silence...
→ "Task failed: Claude Code CLI streaming subprocess timed out — process killed"
```
- No partial output preserved
- No indication of progress during long tasks
- Same timeout for simple chat vs. browser automation
- Raw technical error leaked to channel users

## Solution

A 3-level progressive inactivity timeout that warns, notifies, then kills — preserving partial output and tracking agent activity throughout.

### Architecture

```
                    Time →
    ├──────────────┼──────────────┼──────────────────────┤
    0%          warn(20%)     notify(40%)             kill(100%)
                   │              │                       │
              Internal log   "Still working..."     Kill process
              (no user       (SSE phase event →     Preserve partial text
               impact)        WhatsApp/Telegram)    Record last activity
                                                    Save session context
```

### The three escalation levels

| Level | Trigger | Action | User impact |
|-------|---------|--------|-------------|
| **Warn** | 20% of timeout (e.g. 60s at 300s timeout) | `warn!()` log with `silent_secs` | None — internal only |
| **Notify** | 40% of timeout (e.g. 120s) | Sends `PhaseChange::long_running` SSE event | User sees "Still working..." in chat |
| **Kill** | 100% of timeout (e.g. 300s) | Kills process, captures partial output | User sees partial output + timeout notice |

Timer resets on every meaningful output line — long-running but actively-streaming responses are never killed.

### Per-request timeout configuration

Not all tasks are equal. A simple "hello" shouldn't wait 10 minutes, but a browser automation task needs breathing room:

```rust
// Priority order:
1. Agent manifest metadata: timeout_secs = 600
2. Auto-detection: agents with browser/playwright tools → 600s
3. Driver default: 300s (configurable)
```

### New `LlmError::TimedOut` variant

```rust
LlmError::TimedOut {
    inactivity_secs: 600,
    partial_text_len: 2847,
    partial_text: "Here's what I found so far:\n1. The API supports...",
    last_activity: "tool: browser_navigate https://docs.example.com",
}
```

The agent loop catches this and:
1. Sends partial text to the user (they see what was computed)
2. Saves session with timeout context (agent can resume)
3. Returns a user-friendly error with the `[partial_output_delivered]` marker

### Channel bridge error handling

The bridge detects the marker and shows appropriate messages:
- **With partial output:** `"\n\n---\n[Task timed out. The output above may be incomplete.]"`
- **Timeout without output:** `"Error: task timed out due to inactivity. Try breaking it into smaller steps."`

### Telegram: clear-reaction-on-done

Small UX addition: when `clear_done_reaction: true` in channel config, the bot removes the ✅ reaction on completion instead of changing it to 🎉, keeping group chats cleaner.

## Real-world examples

### Example 1: Long research task
```
User: "Research the top 10 AI frameworks and compare them"

[2 min] ← warn: internal log only
[4 min] ← notify: "No output for 240s — task is still running..."
         → User sees: [Still working...]
[10 min] ← kill: preserves 3 pages of research already written
         → User sees: "Here's what I found so far:
            1. TensorFlow: ...
            2. PyTorch: ...
            3. JAX: ...
            ---
            [Task timed out. The output above may be incomplete.]"
```

### Example 2: Browser automation
```
User: "Check the pricing page at example.com"

[Agent configured with browser tools → timeout auto-extends to 600s]
[60s] Agent navigates, screenshots, reads page
[90s] Agent responds normally — no timeout triggered
```

### Example 3: Simple chat (before vs after)

**Before:** 5 minutes of silence → cryptic error
**After:** Warning at 60s, notification at 120s, graceful timeout at 300s with context

## Changes

| File | Change |
|------|--------|
| `crates/librefang-runtime/src/llm_driver.rs` | `LlmError::TimedOut` variant, `timeout_secs` in `CompletionRequest` |
| `crates/librefang-runtime/src/drivers/claude_code.rs` | Progressive 3-level timeout with activity tracking |
| `crates/librefang-runtime/src/agent_loop.rs` | Per-request timeout logic, partial output forwarding |
| `crates/librefang-api/src/channel_bridge.rs` | Tailored timeout messages with marker detection |
| `crates/librefang-channels/src/telegram.rs` | Clear-reaction-on-done option |
| `crates/librefang-types/src/config/types.rs` | `clear_done_reaction` config field |
| Other driver crates | `timeout_secs: None` field propagation |

## Test plan

- [x] `cargo check --workspace` passes
- [x] Progressive timeout fires warn → notify → kill in correct order
- [x] Partial output is preserved and delivered to user
- [x] Browser-equipped agents get extended timeout (600s)
- [x] `manifest.metadata.timeout_secs` overrides default
- [x] Timer resets on meaningful output (no false kills during active streaming)
- [x] Channel bridge shows appropriate messages for each timeout scenario