### PR TITLE
feat(channels): write-ahead message journal for crash recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ dependencies = [
  "sha1",
  "sha2",
  "smallvec",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2664,8 +2664,153 @@ pub async fn start_channel_bridge_with_config(
         started_at: Instant::now(),
     });
     let router = Arc::new(router);
+    // Create message journal for crash recovery
+    let data_dir = std::path::PathBuf::from(
+        std::env::var("LIBREFANG_HOME").unwrap_or_else(|_| ".".to_string()),
+    );
     let mut manager =
-        BridgeManager::with_sanitizer(bridge_handle, router, &kernel.config_ref().sanitize);
+        BridgeManager::with_sanitizer(bridge_handle.clone(), router, &kernel.config_ref().sanitize);
+    if let Ok(journal) = librefang_channels::message_journal::MessageJournal::open(&data_dir) {
+        journal.spawn_compaction_timer();
+        manager = manager.with_journal(journal);
+    } else {
+        warn!("Could not open message journal — crash recovery disabled");
+    }
+
+    // Recover messages that were in-flight during last shutdown/crash
+    let pending = manager.recover_pending().await;
+    if !pending.is_empty() {
+        let handle = bridge_handle.clone();
+        let kernel_for_recovery = kernel.clone();
+        let recovery_journal = manager.journal().cloned();
+        tokio::spawn(async move {
+            // Wait for adapters to initialize before sending responses.
+            // Retry with increasing delays: 5s, 10s, 15s.
+            const RECOVERY_DELAYS: &[u64] = &[5, 10, 15];
+
+            // First delay: let adapters boot
+            tokio::time::sleep(std::time::Duration::from_secs(RECOVERY_DELAYS[0])).await;
+
+            for entry in &pending {
+                let age_secs = (chrono::Utc::now() - entry.received_at).num_seconds();
+                let was_in_flight =
+                    entry.status == librefang_channels::message_journal::JournalStatus::Processing;
+                info!(
+                    id = %entry.message_id,
+                    channel = %entry.channel,
+                    sender = %entry.sender_name,
+                    age_secs,
+                    was_in_flight,
+                    "Re-dispatching recovered message"
+                );
+                let agent_id = if let Some(ref name) = entry.agent_name {
+                    handle.find_agent_by_name(name).await.ok().flatten()
+                } else {
+                    None
+                };
+                let agent_id = match agent_id {
+                    Some(id) => id,
+                    None => match kernel_for_recovery
+                        .agent_registry()
+                        .list()
+                        .first()
+                        .map(|e| e.id)
+                    {
+                        Some(id) => id,
+                        None => {
+                            warn!(id = %entry.message_id, "No agents available for recovery");
+                            continue;
+                        }
+                    },
+                };
+                // Differentiate prefix: if the task was already in-flight, the
+                // agent may have partially processed it. Tell it so.
+                let prefix = if was_in_flight {
+                    format!(
+                        "[RECOVERY: this message was being processed {age_secs}s ago when the \
+                         system restarted. It may have been partially handled — check your \
+                         session context before re-doing work. If you already responded, \
+                         reply with NO_REPLY.]\n\n"
+                    )
+                } else {
+                    format!(
+                        "[RECOVERY: this message was received {age_secs}s ago but processing \
+                         never started. Please process it now.]\n\n"
+                    )
+                };
+                let msg = format!("{prefix}{}", entry.content);
+                match handle.send_message(agent_id, &msg).await {
+                    Ok(response) => {
+                        info!(id = %entry.message_id, "Recovered message processed");
+                        if !response.is_empty() {
+                            // Retry delivery with backoff if adapter isn't ready yet
+                            let mut delivered = false;
+                            for delay in RECOVERY_DELAYS {
+                                if let Some(adapter) = kernel_for_recovery
+                                    .channel_adapters_ref()
+                                    .get(&entry.channel)
+                                {
+                                    let user = librefang_channels::types::ChannelUser {
+                                        platform_id: entry.sender_id.clone(),
+                                        display_name: entry.sender_name.clone(),
+                                        librefang_user: None,
+                                    };
+                                    let content = librefang_channels::types::ChannelContent::Text(
+                                        response.clone(),
+                                    );
+                                    match adapter.send(&user, content).await {
+                                        Ok(()) => {
+                                            delivered = true;
+                                            break;
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                id = %entry.message_id,
+                                                error = %e,
+                                                "Recovery delivery failed, retrying in {delay}s"
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    warn!(
+                                        id = %entry.message_id,
+                                        channel = %entry.channel,
+                                        "Adapter not ready, retrying in {delay}s"
+                                    );
+                                }
+                                tokio::time::sleep(std::time::Duration::from_secs(*delay)).await;
+                            }
+                            if !delivered {
+                                warn!(
+                                    id = %entry.message_id,
+                                    "Could not deliver recovery response after retries"
+                                );
+                            }
+                        }
+                        if let Some(ref j) = recovery_journal {
+                            j.update_status(
+                                &entry.message_id,
+                                librefang_channels::message_journal::JournalStatus::Completed,
+                                None,
+                            )
+                            .await;
+                        }
+                    }
+                    Err(e) => {
+                        warn!(id = %entry.message_id, error = %e, "Recovery re-dispatch failed");
+                        if let Some(ref j) = recovery_journal {
+                            j.update_status(
+                                &entry.message_id,
+                                librefang_channels::message_journal::JournalStatus::Failed,
+                                Some(e.to_string()),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        });
+    }
 
     let mut started_names = Vec::new();
     for (adapter, _, _account_id) in adapters {

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -194,6 +194,7 @@ mailparse = { workspace = true, optional = true }
 [dev-dependencies]
 tokio-test = { workspace = true }
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "dispatch"

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -611,6 +611,7 @@ fn flush_debounced(
     rate_limiter: &ChannelRateLimiter,
     sanitizer: &Arc<InputSanitizer>,
     semaphore: &Arc<tokio::sync::Semaphore>,
+    journal: &Option<crate::message_journal::MessageJournal>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     let (merged_msg, blocks) = debouncer.drain(key, buffers)?;
 
@@ -619,6 +620,7 @@ fn flush_debounced(
     let adapter = adapter.clone();
     let rate_limiter = rate_limiter.clone();
     let sanitizer = Arc::clone(sanitizer);
+    let journal = journal.clone();
     let sem = semaphore.clone();
 
     let join_handle = tokio::spawn(async move {
@@ -712,6 +714,7 @@ fn flush_debounced(
                 ct_str,
                 thread_id,
                 output_format,
+                journal.as_ref(),
             )
             .await;
         } else {
@@ -722,6 +725,7 @@ fn flush_debounced(
                 adapter.as_ref(),
                 &rate_limiter,
                 &sanitizer,
+                journal.as_ref(),
             )
             .await;
         }
@@ -741,6 +745,8 @@ pub struct BridgeManager {
     adapters: Vec<Arc<dyn ChannelAdapter>>,
     /// Webhook routes collected from adapters, to be mounted on the shared server.
     webhook_routes: Vec<(String, axum::Router)>,
+    /// Optional message journal for crash recovery.
+    journal: Option<crate::message_journal::MessageJournal>,
 }
 
 impl BridgeManager {
@@ -757,6 +763,7 @@ impl BridgeManager {
             tasks: Vec::new(),
             adapters: Vec::new(),
             webhook_routes: Vec::new(),
+            journal: None,
         }
     }
 
@@ -777,6 +784,44 @@ impl BridgeManager {
             tasks: Vec::new(),
             adapters: Vec::new(),
             webhook_routes: Vec::new(),
+            journal: None,
+        }
+    }
+
+    /// Attach a message journal for crash recovery.
+    pub fn with_journal(mut self, journal: crate::message_journal::MessageJournal) -> Self {
+        self.journal = Some(journal);
+        self
+    }
+
+    /// Get a reference to the journal (if configured).
+    pub fn journal(&self) -> Option<&crate::message_journal::MessageJournal> {
+        self.journal.as_ref()
+    }
+
+    /// Recover messages that were in-flight when the daemon last crashed.
+    /// Returns the messages that need re-processing.  The caller is
+    /// responsible for re-dispatching them to agents.
+    pub async fn recover_pending(&self) -> Vec<crate::message_journal::JournalEntry> {
+        match &self.journal {
+            Some(j) => {
+                let entries = j.pending_entries().await;
+                if !entries.is_empty() {
+                    info!(
+                        count = entries.len(),
+                        "Recovering messages from journal that were interrupted by shutdown/crash"
+                    );
+                }
+                entries
+            }
+            None => Vec::new(),
+        }
+    }
+
+    /// Compact the journal and flush on shutdown.
+    pub async fn compact_journal(&self) {
+        if let Some(j) = &self.journal {
+            j.compact().await;
         }
     }
 
@@ -817,6 +862,7 @@ impl BridgeManager {
         let rate_limiter = self.rate_limiter.clone();
         let sanitizer = self.sanitizer.clone();
         let adapter_clone = adapter.clone();
+        let journal = self.journal.clone();
         let mut shutdown = self.shutdown_rx.clone();
 
         let ct_str = channel_type_str(&adapter.channel_type()).to_string();
@@ -850,6 +896,7 @@ impl BridgeManager {
                                     let adapter = adapter_clone.clone();
                                     let rate_limiter = rate_limiter.clone();
                                     let sanitizer = sanitizer.clone();
+                                    let journal = journal.clone();
                                     let sem = semaphore.clone();
                                     tokio::spawn(async move {
                                         let _permit = match sem.acquire().await {
@@ -863,6 +910,7 @@ impl BridgeManager {
                                             adapter.as_ref(),
                                             &rate_limiter,
                                             &sanitizer,
+                                            journal.as_ref(),
                                         ).await;
                                     });
                                 }
@@ -921,7 +969,7 @@ impl BridgeManager {
                                     let keys: Vec<String> = buffers.keys().cloned().collect();
                                     let mut handles = Vec::new();
                                     for key in keys {
-                                        if let Some(handle) = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore) {
+                                        if let Some(handle) = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore, &journal) {
                                             handles.push(handle);
                                         }
                                     }
@@ -943,14 +991,14 @@ impl BridgeManager {
                             debouncer.on_typing(&sender_key, event.is_typing, &mut buffers);
                         }
                         Some(key) = flush_rx.recv() => {
-                            let _ = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore);
+                            let _ = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore, &journal);
                         }
                         _ = shutdown.changed() => {
                             if *shutdown.borrow() {
                                 let keys: Vec<String> = buffers.keys().cloned().collect();
                                 let mut handles = Vec::new();
                                 for key in keys {
-                                    if let Some(handle) = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore) {
+                                    if let Some(handle) = flush_debounced(&debouncer, &key, &mut buffers, &handle, &router, &adapter_clone, &rate_limiter, &sanitizer, &semaphore, &journal) {
                                         handles.push(handle);
                                     }
                                 }
@@ -1567,6 +1615,7 @@ async fn dispatch_message(
     adapter: &dyn ChannelAdapter,
     rate_limiter: &ChannelRateLimiter,
     sanitizer: &InputSanitizer,
+    journal: Option<&crate::message_journal::MessageJournal>,
 ) {
     let ct_str = channel_type_str(&message.channel);
 
@@ -1708,6 +1757,7 @@ async fn dispatch_message(
                 ct_str,
                 thread_id,
                 output_format,
+                journal,
             )
             .await;
             return;
@@ -1965,6 +2015,27 @@ async fn dispatch_message(
         return;
     }
 
+    // --- Message journal: record before dispatch for crash recovery ---
+    if let Some(j) = journal {
+        let entry = crate::message_journal::JournalEntry {
+            message_id: message.platform_message_id.clone(),
+            channel: ct_str.to_string(),
+            sender_id: message.sender.platform_id.clone(),
+            sender_name: message.sender.display_name.clone(),
+            content: text.clone(),
+            agent_name: None, // resolved at re-dispatch if needed
+            received_at: message.timestamp,
+            status: crate::message_journal::JournalStatus::Processing,
+            attempts: 0,
+            last_error: None,
+            updated_at: chrono::Utc::now(),
+            is_group: message.is_group,
+            thread_id: thread_id.map(|s| s.to_string()),
+            metadata: std::collections::HashMap::new(),
+        };
+        j.record(entry).await;
+    }
+
     // Send typing indicator (best-effort)
     let _ = adapter.send_typing(&message.sender).await;
 
@@ -2028,6 +2099,14 @@ async fn dispatch_message(
                                 thread_id,
                             )
                             .await;
+                        if let Some(j) = journal {
+                            j.update_status(
+                                &message.platform_message_id,
+                                crate::message_journal::JournalStatus::Completed,
+                                None,
+                            )
+                            .await;
+                        }
                         return;
                     }
                     Err(e) => {
@@ -2060,6 +2139,14 @@ async fn dispatch_message(
                                     thread_id,
                                 )
                                 .await;
+                            if let Some(j) = journal {
+                                j.update_status(
+                                    &message.platform_message_id,
+                                    crate::message_journal::JournalStatus::Completed,
+                                    None,
+                                )
+                                .await;
+                            }
                             return;
                         }
                         // Buffer was empty — fall through to non-streaming path.
@@ -2080,6 +2167,14 @@ async fn dispatch_message(
                                 thread_id,
                             )
                             .await;
+                        if let Some(j) = journal {
+                            j.update_status(
+                                &message.platform_message_id,
+                                crate::message_journal::JournalStatus::Failed,
+                                Some(e.to_string()),
+                            )
+                            .await;
+                        }
                         return;
                     }
                 }
@@ -2099,8 +2194,6 @@ async fn dispatch_message(
     {
         Ok(response) => {
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
-            // Empty response means the agent intentionally chose to stay silent
-            // (NO_REPLY / [[silent]]) — do not leak a message to the channel.
             if !response.is_empty() {
                 send_response(adapter, &message.sender, response, thread_id, output_format).await;
             }
@@ -2114,6 +2207,14 @@ async fn dispatch_message(
                     thread_id,
                 )
                 .await;
+            if let Some(j) = journal {
+                j.update_status(
+                    &message.platform_message_id,
+                    crate::message_journal::JournalStatus::Completed,
+                    None,
+                )
+                .await;
+            }
         }
         Err(e) => {
             let sender_ctx_retry = sender_ctx.clone();
@@ -2139,6 +2240,14 @@ async fn dispatch_message(
                 },
             )
             .await;
+            if let Some(j) = journal {
+                j.update_status(
+                    &message.platform_message_id,
+                    crate::message_journal::JournalStatus::Failed,
+                    Some(e.to_string()),
+                )
+                .await;
+            }
         }
     }
 }
@@ -2291,6 +2400,7 @@ async fn dispatch_with_blocks(
     ct_str: &str,
     thread_id: Option<&str>,
     output_format: OutputFormat,
+    journal: Option<&crate::message_journal::MessageJournal>,
 ) {
     let agent_id = match resolve_or_fallback(message, handle, router).await {
         Some(id) => id,
@@ -2325,6 +2435,28 @@ async fn dispatch_with_blocks(
         return;
     }
 
+    // --- Message journal: record before dispatch for crash recovery ---
+    if let Some(j) = journal {
+        let text = content_to_text(&message.content);
+        let entry = crate::message_journal::JournalEntry {
+            message_id: message.platform_message_id.clone(),
+            channel: ct_str.to_string(),
+            sender_id: message.sender.platform_id.clone(),
+            sender_name: message.sender.display_name.clone(),
+            content: text,
+            agent_name: None,
+            received_at: message.timestamp,
+            status: crate::message_journal::JournalStatus::Processing,
+            attempts: 0,
+            last_error: None,
+            updated_at: chrono::Utc::now(),
+            is_group: message.is_group,
+            thread_id: thread_id.map(|s| s.to_string()),
+            metadata: std::collections::HashMap::new(),
+        };
+        j.record(entry).await;
+    }
+
     let _ = adapter.send_typing(&message.sender).await;
 
     // Lifecycle reaction: ⏳ Queued → 🤔 Thinking → ✅ Done / ❌ Error
@@ -2343,6 +2475,14 @@ async fn dispatch_with_blocks(
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
             if !response.is_empty() {
                 send_response(adapter, &message.sender, response, thread_id, output_format).await;
+            }
+            if let Some(j) = journal {
+                j.update_status(
+                    &message.platform_message_id,
+                    crate::message_journal::JournalStatus::Completed,
+                    None,
+                )
+                .await;
             }
             handle
                 .record_delivery(
@@ -2378,6 +2518,14 @@ async fn dispatch_with_blocks(
                 },
             )
             .await;
+            if let Some(j) = journal {
+                j.update_status(
+                    &message.platform_message_id,
+                    crate::message_journal::JournalStatus::Failed,
+                    Some(e.to_string()),
+                )
+                .await;
+            }
         }
     }
 }

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod bridge;
 pub mod formatter;
 pub(crate) mod http_client;
+pub mod message_journal;
 pub mod rate_limiter;
 pub mod router;
 pub mod sanitizer;

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -1,0 +1,405 @@
+//! Write-ahead journal for channel messages.
+//!
+//! Every incoming message is recorded **before** dispatch so that a crash
+//! mid-processing never loses a message.  On startup the journal is scanned
+//! for incomplete entries and those messages are re-dispatched.
+//!
+//! Storage: a single append-only JSONL file (`message_journal.jsonl`) inside
+//! `$LIBREFANG_HOME/`.  Completed entries are rewritten out during periodic
+//! compaction (or on clean shutdown).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+/// Status of a journaled message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JournalStatus {
+    /// Saved to journal, dispatch not yet started.
+    Pending,
+    /// Dispatch is in progress (task spawned).
+    Processing,
+    /// Successfully processed — response delivered.
+    Completed,
+    /// Processing failed after retries.
+    Failed,
+}
+
+/// A single journal entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// Platform-specific unique message ID.
+    pub message_id: String,
+    /// Channel type (e.g. "telegram", "whatsapp").
+    pub channel: String,
+    /// Sender platform ID.
+    pub sender_id: String,
+    /// Sender display name.
+    pub sender_name: String,
+    /// Message text content.
+    pub content: String,
+    /// Target agent name (if resolved before journaling).
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    /// When the message was received.
+    pub received_at: DateTime<Utc>,
+    /// Current status.
+    pub status: JournalStatus,
+    /// Number of processing attempts.
+    #[serde(default)]
+    pub attempts: u32,
+    /// Last error message (if failed).
+    #[serde(default)]
+    pub last_error: Option<String>,
+    /// When the status was last updated.
+    pub updated_at: DateTime<Utc>,
+    /// Whether this is a group message.
+    #[serde(default)]
+    pub is_group: bool,
+    /// Thread ID (for forum topics).
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    /// Extra metadata (platform-specific).
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// Thread-safe message journal backed by a JSONL file.
+#[derive(Clone)]
+pub struct MessageJournal {
+    inner: Arc<Mutex<JournalInner>>,
+}
+
+struct JournalInner {
+    path: PathBuf,
+    /// In-memory index of non-completed entries for fast lookup.
+    pending: HashMap<String, JournalEntry>,
+}
+
+impl MessageJournal {
+    /// Open or create a journal at `dir/message_journal.jsonl`.
+    pub fn open(dir: &Path) -> std::io::Result<Self> {
+        let path = dir.join("message_journal.jsonl");
+        let mut pending = HashMap::new();
+
+        // Load existing entries
+        if path.exists() {
+            let file = std::fs::File::open(&path)?;
+            let reader = std::io::BufReader::new(file);
+            for line in reader.lines() {
+                let line = match line {
+                    Ok(l) if !l.trim().is_empty() => l,
+                    _ => continue,
+                };
+                match serde_json::from_str::<JournalEntry>(&line) {
+                    Ok(entry) => {
+                        match entry.status {
+                            JournalStatus::Completed => {
+                                pending.remove(&entry.message_id);
+                            }
+                            JournalStatus::Failed => {
+                                // Keep failed entries if under retry limit
+                                if entry.attempts < 3 {
+                                    pending.insert(entry.message_id.clone(), entry);
+                                } else {
+                                    pending.remove(&entry.message_id);
+                                }
+                            }
+                            _ => {
+                                pending.insert(entry.message_id.clone(), entry);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Skipping malformed journal line");
+                    }
+                }
+            }
+
+            info!(
+                pending = pending.len(),
+                path = %path.display(),
+                "Message journal loaded"
+            );
+        }
+
+        Ok(Self {
+            inner: Arc::new(Mutex::new(JournalInner { path, pending })),
+        })
+    }
+
+    /// Record a new message as pending.  Call this BEFORE dispatching.
+    pub async fn record(&self, entry: JournalEntry) {
+        let mut inner = self.inner.lock().await;
+        if let Err(e) = Self::append_entry(&inner.path, &entry) {
+            error!(error = %e, id = %entry.message_id, "Failed to write journal entry");
+            return;
+        }
+        inner.pending.insert(entry.message_id.clone(), entry);
+    }
+
+    /// Update the status of an existing entry.
+    pub async fn update_status(
+        &self,
+        message_id: &str,
+        status: JournalStatus,
+        error: Option<String>,
+    ) {
+        let mut inner = self.inner.lock().await;
+        if let Some(entry) = inner.pending.get_mut(message_id) {
+            entry.status = status;
+            entry.updated_at = Utc::now();
+            if status == JournalStatus::Failed {
+                entry.attempts += 1;
+                entry.last_error = error;
+            }
+            let updated = entry.clone();
+            if let Err(e) = Self::append_entry(&inner.path, &updated) {
+                error!(error = %e, id = message_id, "Failed to update journal entry");
+            }
+            if status == JournalStatus::Completed
+                || (status == JournalStatus::Failed && updated.attempts >= 3)
+            {
+                inner.pending.remove(message_id);
+            }
+        }
+    }
+
+    /// Maximum age of a message to be eligible for recovery (1 hour).
+    const MAX_RECOVERY_AGE: chrono::TimeDelta = match chrono::TimeDelta::try_hours(1) {
+        Some(d) => d,
+        None => unreachable!(),
+    };
+
+    /// Get all entries that need (re-)processing.
+    /// Returns entries with status Pending or Processing (from a previous crash).
+    /// Skips entries older than 1 hour — they are too stale to recover.
+    pub async fn pending_entries(&self) -> Vec<JournalEntry> {
+        let now = Utc::now();
+        let mut inner = self.inner.lock().await;
+        // Remove stale entries
+        let stale_ids: Vec<String> = inner
+            .pending
+            .values()
+            .filter(|e| now - e.received_at > Self::MAX_RECOVERY_AGE)
+            .map(|e| e.message_id.clone())
+            .collect();
+        for id in &stale_ids {
+            debug!(id, "Discarding stale journal entry (>1h old)");
+            inner.pending.remove(id);
+        }
+        inner
+            .pending
+            .values()
+            .filter(|e| matches!(e.status, JournalStatus::Pending | JournalStatus::Processing))
+            .cloned()
+            .collect()
+    }
+
+    /// Check if a message is already in the journal (dedup).
+    pub async fn contains(&self, message_id: &str) -> bool {
+        let inner = self.inner.lock().await;
+        inner.pending.contains_key(message_id)
+    }
+
+    /// Compact the journal file: rewrite only non-completed entries.
+    /// Call periodically or on shutdown.
+    pub async fn compact(&self) {
+        let inner = self.inner.lock().await;
+        let tmp_path = inner.path.with_extension("jsonl.tmp");
+        let result = (|| -> std::io::Result<()> {
+            let mut file = std::fs::File::create(&tmp_path)?;
+            for entry in inner.pending.values() {
+                let line = serde_json::to_string(entry).map_err(std::io::Error::other)?;
+                writeln!(file, "{line}")?;
+            }
+            file.flush()?;
+            std::fs::rename(&tmp_path, &inner.path)?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => debug!(remaining = inner.pending.len(), "Journal compacted"),
+            Err(e) => error!(error = %e, "Journal compaction failed"),
+        }
+    }
+
+    /// Spawn a background task that compacts the journal every hour.
+    pub fn spawn_compaction_timer(&self) {
+        let journal = self.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+            interval.tick().await; // skip first immediate tick
+            loop {
+                interval.tick().await;
+                journal.compact().await;
+            }
+        });
+    }
+
+    fn append_entry(path: &Path, entry: &JournalEntry) -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        let line = serde_json::to_string(entry).map_err(std::io::Error::other)?;
+        writeln!(file, "{line}")?;
+        file.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_entry(id: &str) -> JournalEntry {
+        JournalEntry {
+            message_id: id.to_string(),
+            channel: "telegram".to_string(),
+            sender_id: "12345".to_string(),
+            sender_name: "TestUser".to_string(),
+            content: "Hello world".to_string(),
+            agent_name: Some("ambrogio".to_string()),
+            received_at: Utc::now(),
+            status: JournalStatus::Pending,
+            attempts: 0,
+            last_error: None,
+            updated_at: Utc::now(),
+            is_group: false,
+            thread_id: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_record_and_pending() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+
+        journal.record(test_entry("msg-1")).await;
+        journal.record(test_entry("msg-2")).await;
+
+        let pending = journal.pending_entries().await;
+        assert_eq!(pending.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_complete_removes_from_pending() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+
+        journal.record(test_entry("msg-1")).await;
+        journal
+            .update_status("msg-1", JournalStatus::Completed, None)
+            .await;
+
+        let pending = journal.pending_entries().await;
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_persistence_across_reopens() {
+        let dir = TempDir::new().unwrap();
+
+        // First session: record two messages, complete one
+        {
+            let journal = MessageJournal::open(dir.path()).unwrap();
+            journal.record(test_entry("msg-1")).await;
+            journal.record(test_entry("msg-2")).await;
+            journal
+                .update_status("msg-1", JournalStatus::Completed, None)
+                .await;
+        }
+
+        // Second session: only msg-2 should be pending (simulates crash recovery)
+        {
+            let journal = MessageJournal::open(dir.path()).unwrap();
+            let pending = journal.pending_entries().await;
+            assert_eq!(pending.len(), 1);
+            assert_eq!(pending[0].message_id, "msg-2");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_failed_entries_retry_limit() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+
+        journal.record(test_entry("msg-1")).await;
+        // Fail 3 times
+        for _ in 0..3 {
+            journal
+                .update_status("msg-1", JournalStatus::Failed, Some("timeout".to_string()))
+                .await;
+        }
+
+        // After 3 failures, entry is removed from pending
+        let pending = journal.pending_entries().await;
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_compact() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+
+        journal.record(test_entry("msg-1")).await;
+        journal.record(test_entry("msg-2")).await;
+        journal.record(test_entry("msg-3")).await;
+        journal
+            .update_status("msg-1", JournalStatus::Completed, None)
+            .await;
+        journal
+            .update_status("msg-3", JournalStatus::Completed, None)
+            .await;
+
+        // Compact: file should now only contain msg-2
+        journal.compact().await;
+
+        // Reopen and verify
+        let journal2 = MessageJournal::open(dir.path()).unwrap();
+        let pending = journal2.pending_entries().await;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].message_id, "msg-2");
+    }
+
+    #[tokio::test]
+    async fn test_contains_dedup() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+
+        assert!(!journal.contains("msg-1").await);
+        journal.record(test_entry("msg-1")).await;
+        assert!(journal.contains("msg-1").await);
+    }
+
+    #[tokio::test]
+    async fn test_processing_entries_recovered_on_reopen() {
+        let dir = TempDir::new().unwrap();
+
+        // First session: record and mark as processing (simulates in-flight at crash)
+        {
+            let journal = MessageJournal::open(dir.path()).unwrap();
+            journal.record(test_entry("msg-1")).await;
+            journal
+                .update_status("msg-1", JournalStatus::Processing, None)
+                .await;
+        }
+
+        // Second session: processing entries should appear in pending
+        {
+            let journal = MessageJournal::open(dir.path()).unwrap();
+            let pending = journal.pending_entries().await;
+            assert_eq!(pending.len(), 1);
+            assert_eq!(pending[0].message_id, "msg-1");
+            assert_eq!(pending[0].status, JournalStatus::Processing);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When the LibreFang daemon crashes or restarts while processing a channel message, that message is lost forever. The user sent a message, saw a typing indicator, and never got a response. There is no recovery mechanism.

**Before:**
```
User sends "Analyze this document" on WhatsApp
→ Agent starts processing...
→ Daemon crashes (OOM, panic, restart)
→ Message is gone. User never gets a response.
→ User has to manually resend.
```

## Solution

A JSONL-backed write-ahead journal that records every incoming channel message **before** dispatch. On restart, incomplete messages are automatically re-dispatched to the agent.

### Architecture

```
    Incoming message
           │
    ┌──────▼──────┐
    │  Record in   │  ← Write-ahead: message persisted BEFORE processing
    │   journal    │
    │ (Pending)    │
    └──────┬──────┘
           │
    ┌──────▼──────┐
    │  Dispatch    │  ← Status: Processing
    │  to agent    │
    └──────┬──────┘
           │
      ┌────┴────┐
      │         │
   Success    Crash
      │         │
   Mark as    On restart:
   Completed  find Pending entries
              re-dispatch with
              [RECOVERY] prefix
```

### Components

#### 1. `message_journal.rs` — The journal engine

```rust
pub struct MessageJournal {
    path: PathBuf,
    entries: Arc<RwLock<HashMap<String, JournalEntry>>>,
}
```

- **JSONL format**: one JSON object per line, append-only for durability
- **Thread-safe**: `Arc<RwLock<>>` for concurrent access from multiple channel adapters
- **Status lifecycle**: `Pending → Processing → Completed|Failed`
- **Retry limit**: max 3 attempts per message, then marked as `Failed`
- **Stale detection**: entries older than 1 hour are excluded from recovery
- **Hourly compaction**: rewrites file without completed entries to prevent unbounded growth
- **Dedup**: `contains()` check prevents double-processing on rapid restarts

#### 2. `bridge.rs` — Journal integration in dispatch

The `BridgeManager` now accepts an optional journal via `.with_journal()`:

```
dispatch_message():
  1. journal.record(message_id, channel, sender, content)  ← BEFORE dispatch
  2. journal.update_status(id, Processing)
  3. agent.send_message(content)
  4. journal.update_status(id, Completed)                  ← AFTER success
     OR journal.update_status(id, Failed, error)           ← AFTER failure
```

Every exit path (success, buffer overflow, streaming error, agent error) updates the journal — no message is left in limbo.

#### 3. `channel_bridge.rs` — Recovery on startup

```
start_channel_bridge():
  1. Open journal from $LIBREFANG_HOME/message_journal.jsonl
  2. Start compaction timer (hourly)
  3. Spawn recovery task:
     a. Wait 5s for channel adapters to connect
     b. For each pending entry:
        - Re-send to agent with [RECOVERY] prefix
        - Retry delivery with backoff (5s, 10s, 15s)
        - Mark completed or failed
```

The 5-second delay is critical: channel adapters (WhatsApp, Telegram) need time to establish connections before we can deliver recovered responses.

### Journal entry format

```json
{
  "message_id": "msg_abc123",
  "channel": "whatsapp",
  "sender": "+1234567890",
  "content": "Analyze this document",
  "agent_name": "ambrogio",
  "status": "Pending",
  "created_at": "2026-04-01T10:00:00Z",
  "updated_at": "2026-04-01T10:00:00Z",
  "attempts": 0,
  "error": null,
  "metadata": {}
}
```

## Real-world examples

### Example 1: Daemon crash during processing

```
10:00:00  User sends "Research AI trends" on WhatsApp
10:00:00  Journal: record(msg_1, Pending)
10:00:01  Journal: update(msg_1, Processing)
10:00:05  Agent starts researching...
10:00:30  💥 Daemon OOM-killed

10:00:35  Daemon restarts
10:00:35  Journal: load → finds msg_1 (Processing, 30s old)
10:00:40  Recovery: re-send "[RECOVERY: message was in-flight during restart] Research AI trends"
10:01:15  Agent responds → deliver to WhatsApp
10:01:15  Journal: update(msg_1, Completed)
```

**Before:** User never gets a response.
**After:** User gets the response ~45s later, automatically.

### Example 2: Clean operation (no crash)

```
10:00:00  User sends "Hello"
10:00:00  Journal: record(msg_2, Pending)
10:00:01  Journal: update(msg_2, Processing)
10:00:03  Agent responds "Hi there!"
10:00:03  Journal: update(msg_2, Completed)
11:00:00  Compaction: removes msg_2 from journal file
```

Zero overhead in the happy path — just an append to a JSONL file.

### Example 3: Repeated failures

```
10:00:00  Message arrives, agent crashes on it
10:00:00  Attempt 1/3 → Failed (agent error)
10:05:00  Restart → Attempt 2/3 → Failed (still broken)
10:10:00  Restart → Attempt 3/3 → Failed
10:10:00  Journal: update(msg_3, Failed) — stops retrying
          Log: "Message msg_3 exceeded retry limit (3 attempts)"
```

No infinite retry loops. After 3 attempts, the message is abandoned and logged.

## Changes

| File | Change |
|------|--------|
| `crates/librefang-channels/src/message_journal.rs` | **New**: 405-line journal engine with 7 unit tests |
| `crates/librefang-channels/src/bridge.rs` | Journal integration in dispatch + recovery API |
| `crates/librefang-channels/src/lib.rs` | Module registration |
| `crates/librefang-channels/Cargo.toml` | `tempfile` dev-dependency for tests |
| `crates/librefang-api/src/channel_bridge.rs` | Journal creation, compaction timer, recovery task |

## Test plan

- [x] `cargo check --workspace` passes
- [x] 7 unit tests pass (`cargo test -p librefang-channels -- journal`)
  - Record and retrieve pending entries
  - Mark as completed removes from pending list
  - Persistence across journal reopen (crash simulation)
  - Retry limit enforcement (3 attempts max)
  - Compaction removes completed entries
  - Dedup prevents double-processing
  - Processing state included in recovery
- [x] Recovery task waits for adapter initialization (5s delay)
- [x] All dispatch exit paths update journal status