### PR TITLE
fix(http): always include Mozilla CA roots alongside system certs

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -894,7 +894,11 @@ pub async fn test_provider(
         }
     };
 
-    let api_key = std::env::var(&env_var).ok();
+    // Treat empty-string env vars the same as missing — an env var set to ""
+    // (e.g. `DEEPSEEK_API_KEY=` in secrets.env) should not bypass the guard.
+    let api_key = std::env::var(&env_var)
+        .ok()
+        .filter(|k| !k.trim().is_empty());
     // Only require API key for providers that need one (skip local providers like ollama/vllm/lmstudio)
     if key_required && api_key.is_none() && !env_var.is_empty() {
         return ApiErrorResponse::bad_request("Provider API key not configured").into_json_tuple();

--- a/crates/librefang-runtime/src/http_client.rs
+++ b/crates/librefang-runtime/src/http_client.rs
@@ -25,12 +25,17 @@ static TLS_CONFIG: OnceLock<rustls::ClientConfig> = OnceLock::new();
 fn init_tls_config() -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
 
+    // Always seed with bundled Mozilla CA roots first so common public CAs are
+    // trusted even on systems with incomplete or outdated system cert stores
+    // (minimal Docker images, Termux, corporate Linux with partial CA bundles).
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    // Supplement with system CA certificates (adds org-internal / self-signed CAs
+    // and keeps trust anchors up-to-date without a librefang release).
     let result = rustls_native_certs::load_native_certs();
     let (added, _) = root_store.add_parsable_certificates(result.certs);
-
     if added == 0 {
-        tracing::warn!("No system CA certificates found, using bundled Mozilla CA roots");
-        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        tracing::debug!("No system CA certificates found; relying on bundled Mozilla CA roots");
     }
 
     rustls::ClientConfig::builder_with_provider(


### PR DESCRIPTION
## Summary

Fixes #1915 — "Connection failed: error sending request for url (https://api.deepseek.com/v1/models)" on Linux.

**Root cause (TLS):** `init_tls_config()` in `http_client.rs` only fell back to bundled Mozilla CA roots when *zero* system certs were found. On Linux systems with a partial or outdated CA store (common on minimal Docker images, Termux, and corporate systems with filtered CA bundles), some certs are loaded (`added > 0`) so the fallback never fires — but those certs may not include the root CA used by DeepSeek or other providers, causing the TLS handshake to fail.

**Fix:** Always seed `RootCertStore` with Mozilla/webpki roots first, then supplement with system certs. Both sets are active, so:
- Public provider APIs (OpenAI, DeepSeek, Gemini, …) always work
- Self-signed / org-internal CAs still work (loaded from system store)

**Root cause (empty env var):** `test_provider` checked `api_key.is_none()` but `std::env::var` returns `Ok("")` for an empty-string env var (e.g. `DEEPSEEK_API_KEY=` in secrets.env or shell profile). This caused the "key not configured" guard to be skipped, leading to a keyless request that then failed at the network level. Now filters empty strings: both missing and empty env vars are treated as unconfigured.

## Test plan

- [ ] Configure a provider with a valid key on Linux — test should succeed
- [ ] On a system with partial CA certs (or a minimal Docker container), provider test should no longer fail with "error sending request"
- [ ] With `DEEPSEEK_API_KEY=` (empty) in environment, test should return "Provider API key not configured" instead of attempting a connection