### PR TITLE
ci: skip Cloudflare deploy for fork PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,6 +42,7 @@ jobs:
       - run: cd docs && pnpm build
 
       - name: Deploy to Cloudflare Pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Fork `pull_request` events do not receive repository secrets (GitHub security policy)
- `CLOUDFLARE_API_TOKEN` is empty → wrangler exits with code 1 → CI fails
- Add `if` condition to the Deploy step to skip it for fork PRs

This unblocks PR #1926 and any future external contributor PRs that touch docs.

## Test plan

- [ ] Fork PRs touching `docs/**`: deploy step is skipped, CI passes
- [ ] Same-repo PRs touching `docs/**`: deploy step runs normally
- [ ] Push to `main`/`feat/*` touching `docs/**`: deploy step runs normally