### PR TITLE
fix(memory): expose cleanup_orphan_sessions on MemorySubstrate

### DIFF
--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -291,6 +291,11 @@ impl MemorySubstrate {
         self.sessions.cleanup_excess_sessions(max_per_agent)
     }
 
+    /// Delete sessions whose agent_id is not in the provided live set. Returns count deleted.
+    pub fn cleanup_orphan_sessions(&self, live_agent_ids: &[AgentId]) -> LibreFangResult<u64> {
+        self.sessions.cleanup_orphan_sessions(live_agent_ids)
+    }
+
     /// Full-text search across session content using FTS5.
     pub fn search_sessions(
         &self,


### PR DESCRIPTION
## Summary
- `SessionStore::cleanup_orphan_sessions` existed but `MemorySubstrate` did not forward it, causing a compile error in kernel GC sweep (`kernel.rs:1423`)
- Added the missing delegation method on `MemorySubstrate`

## Test plan
- [x] `cargo build --workspace --lib` passes