### PR TITLE
fix(dashboard): skip non-GET requests in service worker cache

### DIFF
--- a/crates/librefang-api/dashboard/public/sw.js
+++ b/crates/librefang-api/dashboard/public/sw.js
@@ -30,6 +30,9 @@ self.addEventListener("fetch", (e) => {
   // API requests: network only
   if (url.pathname.startsWith("/api/")) return;
 
+  // Only cache GET requests (Cache API does not support POST)
+  if (e.request.method !== "GET") return;
+
   // Static assets: stale-while-revalidate
   e.respondWith(
     caches.open(CACHE_NAME).then(async (cache) => {

--- a/crates/librefang-api/static/react/sw.js
+++ b/crates/librefang-api/static/react/sw.js
@@ -30,6 +30,9 @@ self.addEventListener("fetch", (e) => {
   // API requests: network only
   if (url.pathname.startsWith("/api/")) return;
 
+  // Only cache GET requests (Cache API does not support POST)
+  if (e.request.method !== "GET") return;
+
   // Static assets: stale-while-revalidate
   e.respondWith(
     caches.open(CACHE_NAME).then(async (cache) => {


### PR DESCRIPTION
## Summary
- Service worker `cache.put()` fails on POST requests since the Cache API only supports GET
- Dashboard SW was missing the `method !== "GET"` guard that `web/public/sw.js` already had
- Added the check before `respondWith` to let non-GET requests fall through to the network

Fixes: `Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported` at sw.js:39

## Test plan
- [ ] Open dashboard, confirm no more `POST` cache errors in console
- [ ] Verify static assets still cached (check Application > Cache Storage in DevTools)