### PR TITLE
fix(workflow): preserve depends_on when instantiating templates

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -243,7 +243,7 @@ export interface WorkflowStep {
   name: string;
   agent_id?: string;
   agent_name?: string;
-  prompt: string;
+  prompt_template: string;
   timeout_secs?: number;
   inherit_context?: boolean;
   depends_on?: string[];

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -2144,7 +2144,7 @@ impl WorkflowTemplateRegistry {
                     // Use step name as output_var so subsequent steps can reference via {{step_name}}
                     output_var: Some(ts.name.clone()),
                     inherit_context: None,
-                    depends_on: vec![],
+                    depends_on: ts.depends_on.clone(),
                 }
             })
             .collect();


### PR DESCRIPTION
## Summary
- Fix `WorkflowTemplateRegistry::instantiate()` dropping `depends_on` from template steps — was hardcoded to `vec![]`, now clones from the template step
- Fix TypeScript `WorkflowStep` interface field name: `prompt` → `prompt_template` to match backend serialization

## Context
PR #1924 fixed the frontend canvas opening empty when selecting a template. This PR fixes a remaining backend issue where DAG dependency edges were silently lost during template instantiation via API.

Closes #1938