### PR TITLE
fix(dashboard): add proxy timeout and WebSocket support for dev server

### DIFF
--- a/crates/librefang-api/dashboard/vite.config.ts
+++ b/crates/librefang-api/dashboard/vite.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
       "/api": {
         target: "http://127.0.0.1:4545",
         changeOrigin: true,
+        ws: true,
         configure: (proxy) => {
+          proxy.options.proxyTimeout = 300_000;
+          proxy.options.timeout = 300_000;
           type Emitter = { on(event: string, fn: (...args: never[]) => void): void };
           const p = proxy as unknown as Emitter;
           p.on("error", () => {});


### PR DESCRIPTION
## Summary
- Vite dev proxy had no explicit timeout — `http-proxy` defaults caused 502 for long-running requests (skill install, LLM calls) when accessed via cloudflared tunnel
- Added `proxyTimeout` and `timeout` of 300s to match the frontend's `LONG_RUNNING_TIMEOUT_MS`
- Enabled `ws: true` for WebSocket proxying (fixes agent chat WS errors through tunnel)

## Test plan
- [ ] Access dashboard via cloudflared tunnel (`dash-macbook.yldm.tech`)
- [ ] Install a skill from Skillhub — should complete without 502
- [ ] Open agent chat — WebSocket should connect without "closed before established" warnings