### PR TITLE
fix(dashboard): respect usage_footer config in chat message footer

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -721,7 +721,7 @@ export function ChatPage() {
   }, [navigate]);
 
   const configQuery = useQuery({ queryKey: ["config"], queryFn: getFullConfig, staleTime: 60000 });
-  const usageFooter = (configQuery.data as Record<string, unknown>)?.usage_footer as string | undefined ?? "Tokens";
+  const usageFooter = (configQuery.data as Record<string, unknown>)?.usage_footer as string | undefined ?? "Full";
   const agentsQuery = useQuery({ queryKey: ["agents", "list", "chat"], queryFn: listAgents, staleTime: 30000 });
   const agents = useMemo(() => [...(agentsQuery.data ?? [])].filter(a => !a.is_hand).sort((a, b) => {
     // Auth missing → sort to bottom

--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -21,7 +21,7 @@ dashboard_pass = "librefang"
 # ── Performance ──────────────────────────────────────────────
 prompt_caching = true           # Reduce LLM costs (Anthropic/OpenAI)
 stable_prefix_mode = true       # Improve prompt cache hit rate
-usage_footer = "tokens"         # off | tokens | cost | full
+usage_footer = "full"           # off | tokens | cost | full
 
 # ── Default LLM ──────────────────────────────────────────────
 [default_model]


### PR DESCRIPTION
## Summary

### 1. Usage footer respects config mode
- Chat page now fetches `usage_footer` config and renders the message footer accordingly
- **Full**: `5 in, 12 out | $0.0003` (tokens + cost)
- **Tokens**: `5 in, 12 out` (token count only)
- **Cost**: `$0.0003` (cost only)
- **Off**: nothing shown
- Previously the footer always displayed `{output} tok` regardless of config

### 2. Default usage_footer aligned to Full
- `init_default_config.toml` now defaults to `full` (was `tokens`), matching the Rust enum `#[default]`

### 3. Fix validated_key treated as unavailable
- Frontend auth checks only recognized `configured` / `configured_cli` / `not_required`
- After background key validation succeeds, status becomes `validated_key` — which the frontend treated as unavailable, blocking chat and hiding the KEY badge
- Fixed in `isAuthUnavailable()`, `isProviderAvailable()`, KEY badge, and "Remove Key" button

Closes #1936