### PR TITLE
fix(xtask): git pull from origin/main in dev hotkey

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -257,7 +257,7 @@ fn run_watch(
             if buf[0] == b'r' {
                 println!("\n\x1b[36m↻ git pull...\x1b[0m");
                 let status = Command::new("git")
-                    .args(["pull", "--rebase"])
+                    .args(["pull", "--rebase", "origin", "main"])
                     .current_dir(&root_clone)
                     .status();
                 match status {


### PR DESCRIPTION
## Summary
- `just dev` runs on feature branches where `git pull --rebase` fails because the remote branch may not exist
- Changed to `git pull --rebase origin main` so the 'r' hotkey always pulls latest main

## Test plan
- [ ] Run `just dev` on a feature branch, press `r`, verify pull succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)