### PR TITLE
fix: validate provider keys and model availability on boot

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/status.ts
+++ b/crates/librefang-api/dashboard/src/lib/status.ts
@@ -14,5 +14,5 @@ export function getStatusVariant(status?: string): BadgeVariant {
 /** Check if a provider auth_status indicates the provider is usable.
  *  Mirrors the Rust AuthStatus::is_available() variants. */
 export function isProviderAvailable(status?: string): boolean {
-  return status === "configured" || status === "not_required" || status === "configured_cli";
+  return status === "configured" || status === "validated_key" || status === "not_required" || status === "configured_cli";
 }

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -16,7 +16,7 @@ import { Typewriter_v2 } from "../components/Typewriter_v2";
 import "katex/dist/katex.min.css";
 
 const isAuthUnavailable = (status?: string) =>
-  !!status && status !== "configured" && status !== "configured_cli" && status !== "not_required";
+  !!status && status !== "configured" && status !== "validated_key" && status !== "configured_cli" && status !== "not_required";
 
 interface ChatMessage {
   id: string;
@@ -815,7 +815,7 @@ export function ChatPage() {
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
                       <p className={`text-sm font-bold truncate ${(agent.state || "").toLowerCase() !== "running" ? "opacity-50" : ""}`}>{t(`agents.builtin.${agent.name}.name`, { defaultValue: agent.name })}</p>
-                      {agent.auth_status === "configured" && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-brand/10 text-brand"}`}>KEY</span>}
+                      {(agent.auth_status === "configured" || agent.auth_status === "validated_key") && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-brand/10 text-brand"}`}>KEY</span>}
                       {agent.auth_status === "configured_cli" && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-accent/10 text-accent"}`}>CLI</span>}
                       {isAuthUnavailable(agent.auth_status) && <AlertCircle className="h-3 w-3 text-warning flex-shrink-0" />}
                     </div>

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -993,7 +993,7 @@ export function ProvidersPage() {
                   {keyTesting ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
                   {t("providers.test")}
                 </Button>
-                {configProvider.auth_status === "configured" && (
+                {(configProvider.auth_status === "configured" || configProvider.auth_status === "validated_key") && (
                   <Button variant="secondary" onClick={handleDeleteKey} disabled={keySaving || keyTesting}>
                     <XCircle className="w-4 h-4 mr-1 text-error" />
                     {t("providers.remove_key")}


### PR DESCRIPTION
## Summary

### 1. Fix validated_key not recognized by frontend
- Frontend auth checks only recognized `configured` / `configured_cli` / `not_required`
- After background validation succeeds, status becomes `validated_key` which the frontend treated as unavailable
- Fixed in `isAuthUnavailable()`, `isProviderAvailable()`, KEY badge, and Remove Key button

### 2. Delete hardcoded provider_default_models.toml
- This file hardcoded default models per provider (e.g. `openai = "gpt-5.2"`)
- `gpt-5.2` doesn't exist on OpenAI, causing all new OpenAI users to fail
- Default models now come from the live model catalog synced from registry

### 3. Add model availability probe
- `probe_api_key` now parses the `/models` response to extract available model IDs
- Stores `available_models` on `ProviderInfo` after successful probe
- Adds `ModelCatalog::is_model_available()` for downstream model existence checks
- Supports both OpenAI-compatible (`data[].id`) and Gemini (`models[].name`) response formats