### PR TITLE
fix(xtask): use fetch+rebase for dev 'r' hotkey

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -256,8 +256,13 @@ fn run_watch(
             }
             if buf[0] == b'r' {
                 println!("\n\x1b[36m↻ git pull...\x1b[0m");
+                // fetch + rebase instead of pull to avoid tracking branch conflicts
+                let _ = Command::new("git")
+                    .args(["fetch", "origin", "main"])
+                    .current_dir(&root_clone)
+                    .status();
                 let status = Command::new("git")
-                    .args(["pull", "--rebase", "origin", "main"])
+                    .args(["rebase", "origin/main"])
                     .current_dir(&root_clone)
                     .status();
                 match status {


### PR DESCRIPTION
## Summary
- `git pull` fails on feature branches due to tracking config conflicts
- Changed to `git fetch origin main` + `git rebase origin/main` which works on any branch

## Test plan
- [ ] Run `just dev` on a feature branch, press `r`, verify fetch+rebase succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)