### PR TITLE
fix(dashboard): match usage_footer values to backend snake_case

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -441,9 +441,9 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter }: { me
         {/* Meta info */}
         <div className="flex items-center gap-2 mt-1.5 text-[10px] text-text-dim/50">
           <span>{message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
-          {!message.isStreaming && usageFooter !== "Off" && (() => {
-            const showTokens = usageFooter === "Full" || usageFooter === "Tokens";
-            const showCost = (usageFooter === "Full" || usageFooter === "Cost") && message.cost_usd !== undefined && message.cost_usd > 0;
+          {!message.isStreaming && usageFooter !== "off" && (() => {
+            const showTokens = usageFooter === "full" || usageFooter === "tokens";
+            const showCost = (usageFooter === "full" || usageFooter === "cost") && message.cost_usd !== undefined && message.cost_usd > 0;
             const hasInput = message.tokens?.input !== undefined && message.tokens.input > 0;
             const hasOutput = message.tokens?.output !== undefined && message.tokens.output > 0;
             if (!showTokens && !showCost) return null;
@@ -823,7 +823,7 @@ export function ChatPage() {
   }, [navigate]);
 
   const configQuery = useQuery({ queryKey: ["config"], queryFn: getFullConfig, staleTime: 60000 });
-  const usageFooter = (configQuery.data as Record<string, unknown>)?.usage_footer as string | undefined ?? "Full";
+  const usageFooter = (configQuery.data as Record<string, unknown>)?.usage_footer as string | undefined ?? "full";
   const agentsQuery = useQuery({ queryKey: ["agents", "list", "chat"], queryFn: listAgents, staleTime: 30000 });
   const agents = useMemo(() => [...(agentsQuery.data ?? [])].filter(a => !a.is_hand).sort((a, b) => {
     // Auth missing → sort to bottom


### PR DESCRIPTION
## Summary
- `UsageFooterMode` enum uses `#[serde(rename_all = "snake_case")]`, so the API returns `"off"` / `"tokens"` / `"cost"` / `"full"`
- Frontend compared against `"Off"` / `"Tokens"` / `"Cost"` / `"Full"` — none matched, so the usage footer never rendered
- Fixed all comparisons and the default fallback to use lowercase

Fixes the regression from #1948.

## Test plan
- [ ] Send a message, verify token/cost footer appears below assistant replies
- [ ] Set `usage_footer = "off"` in config, verify footer disappears
- [ ] Set `usage_footer = "tokens"`, verify only token counts shown (no cost)