### PR TITLE
fix(api): serialize usage_footer with serde instead of Debug format

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -709,7 +709,10 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     set!("network_enabled", config.network_enabled);
     set!("mode", format!("{:?}", config.mode));
     set!("language", config.language);
-    set!("usage_footer", format!("{:?}", config.usage_footer));
+    set!(
+        "usage_footer",
+        serde_json::to_value(&config.usage_footer).unwrap_or_default()
+    );
     set!("stable_prefix_mode", config.stable_prefix_mode);
     set!("prompt_caching", config.prompt_caching);
     set!("max_cron_jobs", config.max_cron_jobs);


### PR DESCRIPTION
## Summary
- Config endpoint used `format!("{:?}", config.usage_footer)` which outputs `"Full"` (Rust Debug format)
- `UsageFooterMode` has `#[serde(rename_all = "snake_case")]` so frontend expects `"full"`
- Changed to `serde_json::to_value()` for consistent serialization
- This is the actual backend root cause for #1948 — PR #1956 fixed the frontend side

## Test plan
- [ ] `curl /api/config | jq .usage_footer` returns `"full"` not `"Full"`
- [ ] Usage footer renders in chat after sending a message