### PR TITLE
fix: skillhub install via COS direct download

### DIFF
--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -534,6 +534,21 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to read download body: {e}")))?;
 
+        self.install_from_bytes(slug, target_dir, &bytes).await
+    }
+
+    /// Install a skill from raw bytes (zip or SKILL.md).
+    ///
+    /// Shared extraction + security scan logic used by both ClawHub download
+    /// and Skillhub COS download paths.
+    pub async fn install_from_bytes(
+        &self,
+        slug: &str,
+        target_dir: &Path,
+        bytes: &[u8],
+    ) -> Result<ClawHubInstallResult, SkillError> {
+        validate_slug(slug)?;
+
         // Step 1: SHA256 of downloaded content
         let sha256 = {
             let mut hasher = Sha256::new();

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -24,6 +24,9 @@ pub const DEFAULT_SKILLHUB_URL: &str = "https://skillhub.tencent.com/api/v1";
 const SKILLHUB_INDEX_URL: &str =
     "https://skillhub-1388575217.cos.ap-guangzhou.myqcloud.com/skills.json";
 
+/// COS accelerate base URL for skill zip downloads.
+const SKILLHUB_COS_BASE: &str = "https://skillhub-1388575217.cos.accelerate.myqcloud.com";
+
 // ---------------------------------------------------------------------------
 // Browse response types (static index format)
 // ---------------------------------------------------------------------------
@@ -113,16 +116,72 @@ impl SkillhubClient {
 
     /// Install a skill from Skillhub.
     ///
-    /// After download and security scan, patches the source provenance to
-    /// `SkillSource::Skillhub` in the generated `skill.toml`.
+    /// Downloads the skill zip directly from Tencent COS (the static index
+    /// provides slug + version, and the zip lives at a predictable COS path).
+    /// After extraction, delegates to ClawHub's install_from_bytes for security
+    /// scanning and manifest generation, then patches source provenance.
     pub async fn install(
         &self,
         slug: &str,
         target_dir: &Path,
     ) -> Result<ClawHubInstallResult, SkillError> {
-        let result = self.inner.install(slug, target_dir).await?;
+        // Step 1: Look up the version from the static index
+        let index_resp = self
+            .http
+            .get(SKILLHUB_INDEX_URL)
+            .header("User-Agent", "LibreFang/0.1")
+            .send()
+            .await
+            .map_err(|e| SkillError::Network(format!("Skillhub index fetch failed: {e}")))?;
+        if !index_resp.status().is_success() {
+            return Err(SkillError::Network(format!(
+                "Skillhub index returned {}",
+                index_resp.status()
+            )));
+        }
+        let index: SkillhubIndexResponse = index_resp
+            .json()
+            .await
+            .map_err(|e| SkillError::Network(format!("Skillhub index parse error: {e}")))?;
 
-        // Post-install fixup: update source provenance from ClawHub -> Skillhub
+        let entry = index
+            .skills
+            .iter()
+            .find(|s| s.slug == slug)
+            .ok_or_else(|| {
+                SkillError::Network(format!("Skill '{slug}' not found in Skillhub index"))
+            })?;
+        let version = &entry.version;
+
+        // Step 2: Download zip from COS
+        let cos_url = format!("{SKILLHUB_COS_BASE}/skills/{slug}/{version}.zip",);
+        info!(slug, version = %version, "Downloading skill from Skillhub COS");
+
+        let dl_resp = self
+            .http
+            .get(&cos_url)
+            .header("User-Agent", "LibreFang/0.1")
+            .send()
+            .await
+            .map_err(|e| SkillError::Network(format!("Skillhub COS download failed: {e}")))?;
+        if !dl_resp.status().is_success() {
+            return Err(SkillError::Network(format!(
+                "Skillhub COS download returned {}",
+                dl_resp.status()
+            )));
+        }
+        let bytes = dl_resp
+            .bytes()
+            .await
+            .map_err(|e| SkillError::Network(format!("Failed to read download body: {e}")))?;
+
+        // Step 3: Delegate to ClawHub client for extraction + security scan
+        let result = self
+            .inner
+            .install_from_bytes(slug, target_dir, &bytes)
+            .await?;
+
+        // Step 4: Patch source provenance to Skillhub
         let skill_dir = target_dir.join(slug);
         let manifest_path = skill_dir.join("skill.toml");
         if manifest_path.exists() {


### PR DESCRIPTION
## Summary
- `lightmake.site` was wrong URL, changed to `skillhub.tencent.com`
- But `skillhub.tencent.com` is a frontend SPA with no REST download API
- Rewrote install to look up version from COS index, then download zip directly from `skillhub-1388575217.cos.accelerate.myqcloud.com`
- Extracted `install_from_bytes` from `ClawHubClient` to share extraction + security scan logic

## Test plan
- [ ] Install a skill from Skillhub tab (e.g. `xhs`)
- [ ] Verify download succeeds and skill appears in installed list

🤖 Generated with [Claude Code](https://claude.com/claude-code)