### PR TITLE
fix: FangHub install and search use local registry

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -403,7 +403,7 @@ pub async fn marketplace_search(
             if let Ok(content) = std::fs::read_to_string(&manifest_path) {
                 if let Ok(manifest) = toml::from_str::<librefang_skills::SkillManifest>(&content) {
                     let name = &manifest.skill.name;
-                    let desc = manifest.skill.description.as_deref().unwrap_or("");
+                    let desc = &manifest.skill.description;
                     if query.is_empty()
                         || name.to_lowercase().contains(&query)
                         || desc.to_lowercase().contains(&query)


### PR DESCRIPTION
## Summary
- FangHub install now copies from `~/.librefang/registry/skills/` instead of calling GitHub API (which returns 404)
- FangHub search now searches local registry instead of GitHub API
- Added `copy_dir_recursive` helper for directory copying

## Test plan
- [ ] Search for a skill in FangHub tab
- [ ] Install a skill from FangHub tab
- [ ] Verify skill appears in installed list

🤖 Generated with [Claude Code](https://claude.com/claude-code)