### PR TITLE
fix: mark unreachable local providers as unavailable

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -7105,6 +7105,13 @@ system_prompt = "You are a helpful assistant."
                             error = result.error.as_deref().unwrap_or("unknown"),
                             "Local provider offline"
                         );
+                        // Mark unreachable local providers so dashboard doesn't show "configured"
+                        if let Ok(mut catalog) = kernel.model_catalog.write() {
+                            catalog.set_provider_auth_status(
+                                provider_id,
+                                librefang_types::model_catalog::AuthStatus::Missing,
+                            );
+                        }
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- Local providers (ollama, vllm, lmstudio, lemonade) default to `NotRequired` auth status
- `NotRequired` is treated as "available" by `is_available()`, so dashboard shows them as configured
- Startup probe already detects they're offline but only logged a warning without updating status
- Now sets auth_status to `Missing` when probe fails, so dashboard shows accurate state

## Test plan
- [ ] Start daemon without ollama/vllm/lmstudio running
- [ ] Open Providers page, verify local providers show as unavailable not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)