### PR TITLE
fix: assistant agent model not updated when config changes

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -4354,8 +4354,10 @@ system_prompt = "You are a helpful assistant."
                 manifest.model.provider.is_empty() || manifest.model.provider == "default";
             let is_default_model =
                 manifest.model.model.is_empty() || manifest.model.model == "default";
-            let is_auto_spawned =
-                entry.name == "assistant" && manifest.description == "General-purpose assistant";
+            let is_auto_spawned = entry.name == "assistant"
+                && manifest
+                    .description
+                    .starts_with("General-purpose assistant");
             if (is_default_provider && is_default_model) || is_auto_spawned {
                 let override_guard = self
                     .default_model_override


### PR DESCRIPTION
## Summary
The assistant agent's DB-cached model (e.g. `gpt-5.2`) was never overridden by config.toml changes because the auto-spawned detection used exact string match:

```rust
manifest.description == "General-purpose assistant"
```

But the actual description from AGENT.toml is `"General-purpose assistant agent. The default OpenClaw agent..."` — never matches.

Fix: use `starts_with("General-purpose assistant")` so the override triggers correctly and config changes to `default_model` are applied to the assistant agent.