### PR TITLE
fix: local provider status driven by probe, not detect_auth

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -7093,8 +7093,12 @@ system_prompt = "You are a helpful assistant."
                             latency_ms = result.latency_ms,
                             "Local provider online"
                         );
-                        if !result.discovered_models.is_empty() {
-                            if let Ok(mut catalog) = kernel.model_catalog.write() {
+                        if let Ok(mut catalog) = kernel.model_catalog.write() {
+                            catalog.set_provider_auth_status(
+                                provider_id,
+                                librefang_types::model_catalog::AuthStatus::NotRequired,
+                            );
+                            if !result.discovered_models.is_empty() {
                                 catalog.merge_discovered_models(
                                     provider_id,
                                     &result.discovered_models,

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -116,7 +116,12 @@ impl ModelCatalog {
             }
 
             if !provider.key_required {
-                provider.auth_status = AuthStatus::NotRequired;
+                // Local providers (ollama, vllm, etc.) have their status set by
+                // the async probe at startup. Don't overwrite with NotRequired
+                // here or the probe result gets lost.
+                if !crate::provider_health::is_local_provider(&provider.id) {
+                    provider.auth_status = AuthStatus::NotRequired;
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- `detect_auth()` was overwriting probe results for local providers (ollama, vllm, lmstudio, lemonade) with `NotRequired` on every call (boot + catalog sync)
- Now `detect_auth` skips local providers — their status is solely determined by the async startup probe
- Probe online → `NotRequired` (available), probe offline → `Missing` (unavailable)

## Test plan
- [ ] Start daemon without ollama running, check Providers page — ollama should show unavailable
- [ ] Start ollama, restart daemon — ollama should show available

🤖 Generated with [Claude Code](https://claude.com/claude-code)