### PR TITLE
fix: startup health check respects explicit api_key_env config

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6995,8 +6995,12 @@ system_prompt = "You are a helpful assistant."
         {
             let mut missing: Vec<String> = Vec::new();
 
-            // Default LLM provider
-            let llm_env = cfg.resolve_api_key_env(&cfg.default_model.provider);
+            // Default LLM provider — prefer explicit api_key_env, then resolve
+            let llm_env = if !cfg.default_model.api_key_env.is_empty() {
+                cfg.default_model.api_key_env.clone()
+            } else {
+                cfg.resolve_api_key_env(&cfg.default_model.provider)
+            };
             if std::env::var(&llm_env).unwrap_or_default().is_empty() {
                 missing.push(format!(
                     "LLM ({}): ${}",
@@ -7004,9 +7008,13 @@ system_prompt = "You are a helpful assistant."
                 ));
             }
 
-            // Fallback LLM providers
+            // Fallback LLM providers — prefer explicit api_key_env, then resolve
             for fb in &cfg.fallback_providers {
-                let env_var = cfg.resolve_api_key_env(&fb.provider);
+                let env_var = if !fb.api_key_env.is_empty() {
+                    fb.api_key_env.clone()
+                } else {
+                    cfg.resolve_api_key_env(&fb.provider)
+                };
                 if std::env::var(&env_var).unwrap_or_default().is_empty() {
                     missing.push(format!("LLM fallback ({}): ${}", fb.provider, env_var));
                 }


### PR DESCRIPTION
## Summary
- Startup API key health check now checks the explicit `api_key_env` config field before falling back to `resolve_api_key_env()` inference
- Fixes false missing-key warnings for providers like `zhipu-coding` where users configure a custom env var (e.g. `ZHIPU_API_KEY` instead of inferred `ZHIPU_CODING_API_KEY`)
- Aligns health check logic with the existing LLM driver creation code (kernel.rs L1572, L1717)

Closes #1971