### PR TITLE
fix: usage footer not showing cost when tokens are zero

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -447,7 +447,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter }: { me
             const hasInput = message.tokens?.input !== undefined && message.tokens.input > 0;
             const hasOutput = message.tokens?.output !== undefined && message.tokens.output > 0;
             if (!showTokens && !showCost) return null;
-            if (showTokens && !hasInput && !hasOutput) return null;
+            if (showTokens && !hasInput && !hasOutput && !showCost) return null;
             const parts: string[] = [];
             if (showTokens && (hasInput || hasOutput)) parts.push(`${message.tokens?.input ?? 0} in, ${message.tokens?.output ?? 0} out`);
             if (showCost) parts.push(formatCost(message.cost_usd!));

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4773,6 +4773,7 @@ mod monitoring_tests {
             prometheus_handle: None,
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+            api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
         });
         (state, tmp)
     }

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -711,7 +711,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     set!("language", config.language);
     set!(
         "usage_footer",
-        serde_json::to_value(&config.usage_footer).unwrap_or_default()
+        serde_json::to_value(config.usage_footer).unwrap_or_default()
     );
     set!("stable_prefix_mode", config.stable_prefix_mode);
     set!("prompt_caching", config.prompt_caching);

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -124,6 +124,7 @@ async fn test_full_daemon_lifecycle() {
         prometheus_handle: None,
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+        api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
     });
 
     let app = Router::new()
@@ -260,6 +261,7 @@ async fn test_server_immediate_responsiveness() {
         prometheus_handle: None,
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+        api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -68,6 +68,7 @@ async fn start_test_server() -> TestServer {
         prometheus_handle: None,
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+        api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
     });
 
     let app = Router::new()

--- a/crates/librefang-cli/src/tui/screens/channels.rs
+++ b/crates/librefang-cli/src/tui/screens/channels.rs
@@ -433,7 +433,7 @@ impl ChannelState {
                 .map(|v| {
                     (
                         v.to_string(),
-                        std::env::var(v).map_or(false, |val| !val.trim().is_empty()),
+                        std::env::var(v).is_ok_and(|val| !val.trim().is_empty()),
                     )
                 })
                 .collect();

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -371,7 +371,7 @@ impl State {
     }
 
     fn build_provider_order(&mut self) {
-        let has_key = |var: &str| std::env::var(var).map_or(false, |v| !v.trim().is_empty());
+        let has_key = |var: &str| std::env::var(var).is_ok_and(|v| !v.trim().is_empty());
         self.provider_order.clear();
         let gemini_via_google = has_key("GOOGLE_API_KEY");
         for (i, p) in PROVIDERS.iter().enumerate() {
@@ -441,7 +441,7 @@ impl State {
     }
 
     fn is_provider_detected(&self, prov_idx: usize) -> bool {
-        let has_key = |var: &str| std::env::var(var).map_or(false, |v| !v.trim().is_empty());
+        let has_key = |var: &str| std::env::var(var).is_ok_and(|v| !v.trim().is_empty());
         let p = &PROVIDERS[prov_idx];
         if p.name == "claude-code" {
             return librefang_runtime::drivers::claude_code::claude_code_available();

--- a/crates/librefang-cli/src/tui/screens/welcome.rs
+++ b/crates/librefang-cli/src/tui/screens/welcome.rs
@@ -45,7 +45,7 @@ const PROVIDER_ENV_VARS: &[(&str, &str)] = &[
 /// Returns (provider_name, env_var_name) for the first detected key, or None.
 fn detect_provider() -> Option<(&'static str, &'static str)> {
     for &(var, name) in PROVIDER_ENV_VARS {
-        if std::env::var(var).map_or(false, |v| !v.trim().is_empty()) {
+        if std::env::var(var).is_ok_and(|v| !v.trim().is_empty()) {
             return Some((name, var));
         }
     }

--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -219,7 +219,7 @@ impl WizardState {
     }
 
     fn build_provider_order(&mut self) {
-        let has_key = |var: &str| std::env::var(var).map_or(false, |v| !v.trim().is_empty());
+        let has_key = |var: &str| std::env::var(var).is_ok_and(|v| !v.trim().is_empty());
         self.provider_order.clear();
         // Detected providers first
         for (i, p) in PROVIDERS.iter().enumerate() {

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -117,9 +117,13 @@ impl ModelCatalog {
 
             if !provider.key_required {
                 // Local providers (ollama, vllm, etc.) have their status set by
-                // the async probe at startup. Don't overwrite with NotRequired
-                // here or the probe result gets lost.
-                if !crate::provider_health::is_local_provider(&provider.id) {
+                // the async probe at startup. Only set NotRequired as a fallback
+                // when the probe hasn't run yet (status still Missing).
+                if crate::provider_health::is_local_provider(&provider.id) {
+                    if provider.auth_status == AuthStatus::Missing {
+                        provider.auth_status = AuthStatus::NotRequired;
+                    }
+                } else {
                     provider.auth_status = AuthStatus::NotRequired;
                 }
                 continue;
@@ -1835,6 +1839,7 @@ supports_streaming = true
 /// - `Some(true)`  — HTTP 2xx or 429 (rate-limited = key is valid)
 /// - `Some(false)` — HTTP 401 or 403 (key rejected by provider)
 /// - `None`        — network error, 404, 5xx, etc. (don't update status)
+///
 /// Result of probing a provider's API key.
 #[derive(Debug)]
 pub struct ProbeResult {
@@ -1905,8 +1910,8 @@ pub async fn probe_api_key(provider_id: &str, base_url: &str, api_key: &str) -> 
                                 })
                                 .collect::<Vec<_>>(),
                         )
-                    } else if let Some(arr) = body.get("models").and_then(|d| d.as_array()) {
-                        Some(
+                    } else {
+                        body.get("models").and_then(|d| d.as_array()).map(|arr| {
                             arr.iter()
                                 .filter_map(|m| {
                                     m.get("name")
@@ -1914,10 +1919,8 @@ pub async fn probe_api_key(provider_id: &str, base_url: &str, api_key: &str) -> 
                                         .and_then(|v| v.as_str())
                                         .map(|s| s.strip_prefix("models/").unwrap_or(s).to_string())
                                 })
-                                .collect::<Vec<_>>(),
-                        )
-                    } else {
-                        None
+                                .collect::<Vec<_>>()
+                        })
                     }
                 })
                 .unwrap_or_default();

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -111,6 +111,7 @@ async fn test_mock_llm_driver_recording() {
         thinking: None,
         prompt_caching: false,
         response_format: None,
+        timeout_secs: None,
     };
 
     // First call
@@ -280,6 +281,7 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
         thinking: None,
         prompt_caching: false,
         response_format: None,
+        timeout_secs: None,
     };
 
     let resp = driver.complete(request).await.unwrap();
@@ -318,6 +320,7 @@ async fn test_failing_llm_driver() {
         thinking: None,
         prompt_caching: false,
         response_format: None,
+        timeout_secs: None,
     };
 
     let result = driver.complete(request).await;

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -413,6 +413,7 @@ mod tests {
             signup_url: None,
             regions: HashMap::new(),
             media_capabilities: Vec::new(),
+            available_models: Vec::new(),
         };
         let json = serde_json::to_string(&info).unwrap();
         let parsed: ProviderInfo = serde_json::from_str(&json).unwrap();
@@ -625,6 +626,7 @@ aliases = []
                 ),
             ]),
             media_capabilities: Vec::new(),
+            available_models: Vec::new(),
         };
 
         // Simulate region selection: if user picks "us", use that region's base_url


### PR DESCRIPTION
## Summary
- Fix #1936 — `usage_footer = "full"` 模式下，当 provider 不返回 token 计数时，cost 也不显示。原因是 early return 条件过于激进
- Fix `detect_auth` 对 local provider (ollama/vllm) 的初始状态兜底，解决 probe 未跑时 auth_status 保持 Missing 的问题
- Fix 所有 clippy warnings (`map_or` → `is_ok_and`、needless borrow、`Option::map` 简化)
- Fix 所有测试编译错误（`api_key_lock`、`timeout_secs`、`available_models` 缺失字段）

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all green