### PR TITLE
fix: update bedrock model count assertion from 8 to 11

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1300,7 +1300,7 @@ mod tests {
     fn test_bedrock_models() {
         let catalog = test_catalog();
         let bedrock = catalog.models_by_provider("bedrock");
-        assert_eq!(bedrock.len(), 8);
+        assert_eq!(bedrock.len(), 11);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bedrock models were expanded to 11 but `test_bedrock_models` still asserts count == 8, causing CI failures on all platforms
- This also blocks PR #1977 which merges against main and inherits the stale assertion

## Test plan
- [x] `cargo test --lib -p librefang-runtime -- model_catalog::tests::test_bedrock_models` passes locally