### PR TITLE
fix(deps): downgrade hmac from 0.13 to 0.12 to resolve digest version conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,12 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,15 +1540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,7 +1723,6 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
- "ctutils",
 ]
 
 [[package]]
@@ -3002,15 +2986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.2",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,7 +3861,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures",
  "governor",
- "hmac 0.13.0",
+ "hmac",
  "http-body-util",
  "include_dir",
  "jsonwebtoken",
@@ -3943,7 +3918,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "html-escape",
  "imap",
  "k256",
@@ -4185,7 +4160,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http",
  "librefang-channels",
  "librefang-memory",
@@ -4311,7 +4286,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "librefang-types",
  "rand 0.10.0",
  "serde",
@@ -6493,7 +6468,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ sha2 = { version = "0.10", features = ["oid"] }
 sha1 = "0.11"
 aes = "0.8"
 cbc = "0.1"
-hmac = "0.13"
+hmac = "0.12"
 hex = "0.4"
 k256 = { version = "0.13", features = ["schnorr"] }
 subtle = "2"


### PR DESCRIPTION


hmac 0.13 depends on digest 0.11 while sha2 0.10 depends on digest 0.10, causing trait bound errors. Downgrading hmac to 0.12 aligns both on digest 0.10.
