### PR TITLE
fix(runtime): detect NO_REPLY token anywhere at end of response

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -62,10 +62,11 @@ pub const TIMEOUT_PARTIAL_OUTPUT_MARKER: &str = "[partial_output_delivered]";
 
 /// Check if a response is a NO_REPLY.  Matches:
 /// - Exact `"NO_REPLY"` (original behaviour)
-/// - Text ending with `NO_REPLY` on its own line (model sometimes adds context before it)
+/// - Text ending with `NO_REPLY` anywhere (model sometimes adds context before it,
+///   either on the same line or on a new line)
 fn is_no_reply(text: &str) -> bool {
     let t = text.trim();
-    t == "NO_REPLY" || t.ends_with("\nNO_REPLY") || t.ends_with("\n\nNO_REPLY")
+    t == "NO_REPLY" || t.ends_with("NO_REPLY")
 }
 
 /// Safely trim message history to `MAX_HISTORY_MESSAGES`, cutting at


### PR DESCRIPTION
## Problem

`is_no_reply()` only matched `NO_REPLY` as the entire response text or preceded by newlines (`\nNO_REPLY`, `\n\nNO_REPLY`). When the LLM appends `NO_REPLY` on the **same line** after other text — e.g. `"No packages tracked. NO_REPLY"` — the token is not detected and the full message (including the `NO_REPLY` marker) leaks to the channel.

## Solution

Simplify to `ends_with("NO_REPLY")` which covers all placement styles: standalone, after newlines, or inline after a sentence.

## Test plan

- [x] `cargo check -p librefang-runtime` passes
- [x] `cargo fmt` clean
- [x] Verified on live deployment: message `"Nessun pacco in tracciamento. NO_REPLY"` was previously leaking to Telegram, now correctly suppressed