### PR TITLE
fix: add elevenlabs support to API key test endpoints

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1043,6 +1043,7 @@ pub async fn test_provider(
         ),
         "chatgpt" => format!("{}/me", base_url.trim_end_matches('/')),
         "github-copilot" => format!("{}/models", base_url.trim_end_matches('/')),
+        "elevenlabs" => format!("{}/user", base_url.trim_end_matches('/')),
         _ => format!("{}/models", base_url.trim_end_matches('/')),
     };
 
@@ -1058,6 +1059,9 @@ pub async fn test_provider(
         }
         "github-copilot" => {
             req = req.header("Authorization", format!("token {}", api_key_val));
+        }
+        "elevenlabs" => {
+            req = req.header("xi-api-key", &api_key_val);
         }
         _ => {
             if !api_key_val.is_empty() {

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6476,6 +6476,10 @@ pub(crate) fn test_api_key(provider: &str, key: &str) -> bool {
             .get("https://openrouter.ai/api/v1/models")
             .bearer_auth(key)
             .send(),
+        "elevenlabs" => client
+            .get("https://api.elevenlabs.io/v1/user")
+            .header("xi-api-key", key)
+            .send(),
         _ => return true, // unknown provider — skip test
     };
 


### PR DESCRIPTION
## Type
- [x] Bug fix
## Summary
Fixes #2002 — ElevenLabs API key validation was failing with "Authorization failed" because the test endpoints used the wrong authentication header and URL. ElevenLabs requires the `xi-api-key` header and `/v1/user` endpoint for key validation, not the default `Bearer` auth and `/v1/models` endpoint used by other providers.
## Changes
- Added `elevenlabs` case to `test_api_key()` in `librefang-cli/src/main.rs` — tests against `https://api.elevenlabs.io/v1/user` with `xi-api-key` header
- Added `elevenlabs` case to `test_provider()` in `librefang-api/src/routes/providers.rs` — uses `/v1/user` endpoint and `xi-api-key` header instead of default `/v1/models` with `Bearer` auth
## Attribution
- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)
## Testing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)
## Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries