### PR TITLE
fix(ci): add retry logic to release asset upload steps

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -137,8 +137,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          # List assets and delete any matching this target
-          gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | while read -r name; do
+          # Fetch asset list with retry (GitHub API can be transiently unavailable)
+          ASSETS=""
+          for attempt in $(seq 1 5); do
+            if ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null); then
+              break
+            fi
+            echo "Failed to fetch release assets (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          # Delete any matching this target
+          echo "$ASSETS" | while read -r name; do
+            [ -z "$name" ] && continue
             case "$name" in
               *${{ matrix.platform.rust_target }}*|*latest.json)
                 echo "Deleting existing asset: $name"

--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -59,7 +59,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Linux) ──────────────────────────────────────────────────
   cli_linux:
@@ -104,7 +115,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Android / Termux) ───────────────────────────────────────
   cli_android:
@@ -131,7 +153,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-aarch64-linux-android.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-aarch64-linux-android.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Linux) - Mini (12 channels) ───────────────────────────────
   cli_linux_mini:
@@ -165,7 +198,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}-mini.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Linux, musl — fully static) ─────────────────────────────
   cli_musl:
@@ -208,7 +252,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Windows) ────────────────────────────────────────────────
   cli_windows:
@@ -242,7 +297,18 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (macOS) - Mini ─────────────────────────────────────────────
   cli_mac_mini:
@@ -278,7 +344,18 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}-mini.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary (Windows) - Mini ───────────────────────────────────────────
   cli_windows_mini:
@@ -311,7 +388,18 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" librefang-${{ matrix.target }}-mini.* --clobber
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for attempt in $(seq 1 5); do
+            if gh release upload "$TAG" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
 
   # ── CLI Binary → npm ────────────────────────────────────────────────────
   cli_npm:


### PR DESCRIPTION
## Summary
- Release builds for beta9/beta10 compiled successfully but `gh release upload` returned `release not found` due to transient GitHub API issues, resulting in incomplete release assets
- Added 5-attempt retry with 10s backoff to all 8 upload steps in `release-shell.yml`
- Fixed `release-desktop.yml` `delete-assets` step failing due to `pipefail` propagating `gh release view` transient errors

## Test plan
- [x] YAML syntax validated (python3 yaml.safe_load)
- [ ] Verify all CI jobs pass on next release tag push
- [ ] Confirm complete assets across all platforms (Linux/macOS/Windows + mini variants)