### PR TITLE
fix(xtask): wait for port release before restarting daemon in dev mode

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -212,7 +212,10 @@ fn run_watch(
         "{binary} stop 2>/dev/null; \
          for pid in $(lsof -ti :{port} -sTCP:LISTEN 2>/dev/null); do kill -9 $pid 2>/dev/null; done; \
          rm -f {home}/daemon.json; \
-         sleep 0.5",
+         for _i in 1 2 3 4 5 6 7 8 9 10; do \
+           lsof -ti :{port} -sTCP:LISTEN >/dev/null 2>&1 || break; \
+           sleep 0.3; \
+         done",
         binary = binary_str,
         port = port,
         home = home_dir,


### PR DESCRIPTION
## Summary

Replace fixed `sleep 0.5` in the dev mode stop script with a polling loop that checks if the port is actually free before starting the new daemon. Waits up to 3 seconds with 300ms intervals.

Fixes the spurious "Daemon already running" message during `just dev` restarts caused by the old daemon not releasing the port in time.