### PR TITLE
feat(dashboard): agent template dropdown + fix resolve path

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -759,6 +759,16 @@ export async function listAgents(): Promise<AgentItem[]> {
   return data.items ?? [];
 }
 
+export interface AgentTemplate {
+  name: string;
+  description: string;
+}
+
+export async function listAgentTemplates(): Promise<AgentTemplate[]> {
+  const data = await get<{ templates: AgentTemplate[] }>("/api/templates");
+  return data.templates ?? [];
+}
+
 export async function loadAgentSession(agentId: string): Promise<AgentSessionResponse> {
   return get<AgentSessionResponse>(`/api/agents/${encodeURIComponent(agentId)}/session`);
 }

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { listAgents, getAgentDetail, AgentDetail, spawnAgent, suspendAgent, resumeAgent, patchAgentConfig,
   listPromptVersions, listExperiments, activatePromptVersion, startExperiment, pauseExperiment, completeExperiment,
   createPromptVersion, createExperiment, deletePromptVersion, PromptVersion, PromptExperiment, ExperimentVariantMetrics, getExperimentMetrics,
-  listModels, listProviders } from "../api";
+  listModels, listProviders, listAgentTemplates } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -36,6 +36,7 @@ export function AgentsPage() {
   const [editingModel, setEditingModel] = useState(false);
   const [modelDraft, setModelDraft] = useState({ provider: "", model: "", max_tokens: "", temperature: "" });
   const queryClient = useQueryClient();
+  const templatesQuery = useQuery({ queryKey: ["agent-templates"], queryFn: listAgentTemplates, enabled: showCreate && createMode === "template" });
   const spawnMutation = useMutation({
     mutationFn: spawnAgent,
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["agents"] }); setShowCreate(false); setTemplateName(""); setManifestToml(""); }
@@ -498,10 +499,13 @@ export function AgentsPage() {
               {createMode === "template" ? (
                 <div>
                   <label className="text-[10px] font-bold text-text-dim uppercase">{t("agents.template_name")}</label>
-                  <input value={templateName} onChange={e => setTemplateName(e.target.value)}
-                    placeholder={t("agents.template_placeholder")}
-                    className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand" />
-                  <p className="text-[9px] text-text-dim/50 mt-1">{t("agents.template_hint")}</p>
+                  <select value={templateName} onChange={e => setTemplateName(e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand">
+                    <option value="">{t("agents.template_placeholder")}</option>
+                    {(templatesQuery.data ?? []).map(tmpl => (
+                      <option key={tmpl.name} value={tmpl.name}>{tmpl.name}</option>
+                    ))}
+                  </select>
                 </div>
               ) : (
                 <div>

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -210,6 +210,7 @@ async fn resolve_manifest(
                 .kernel
                 .config_ref()
                 .home_dir
+                .join("workspaces")
                 .join("agents")
                 .join(&safe_name)
                 .join("agent.toml");


### PR DESCRIPTION
## Summary

Two changes:

1. **Dashboard: template text input → dropdown selector**
   - Agent creation dialog now shows a `<select>` with available templates loaded from `GET /api/templates`
   - No more guessing template names — users pick from a list

2. **Fix: template path mismatch in spawn API**
   - `resolve_manifest` was looking for templates in `{home}/agents/{name}/agent.toml`
   - Templates actually live in `{home}/workspaces/agents/{name}/agent.toml`
   - Now consistent with `load_template_manifest` and `list_agent_templates`

## Test plan

- [x] `cargo check -p librefang-api` — pass
- [ ] Dashboard: open create agent dialog, verify dropdown shows template names
- [ ] Spawn agent from template via dashboard — should work without "template not found" error