### PR TITLE
feat(dashboard): wire up channel test/reload and session labels

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -398,7 +398,12 @@
     "no_results": "No matching channels",
     "no_configured": "No configured channels",
     "no_unconfigured": "No unconfigured channels",
-    "help": "Configure messaging adapters and integration gateways. Set up channels like Slack, Discord, Telegram, and more."
+    "help": "Configure messaging adapters and integration gateways. Set up channels like Slack, Discord, Telegram, and more.",
+    "test": "Test",
+    "test_success": "Channel test passed",
+    "test_failed": "Channel test failed",
+    "reload": "Reload",
+    "reload_success": "Channels reloaded"
   },
   "skills": {
     "title": "Skills",
@@ -1093,7 +1098,10 @@
     "empty_desc": "Sessions will appear when agents start conversations.",
     "unknown_agent": "Unknown Agent",
     "just_now": "just now",
-    "help": "View and manage agent conversation sessions. Switch active sessions, delete old ones, and monitor session activity."
+    "help": "View and manage agent conversation sessions. Switch active sessions, delete old ones, and monitor session activity.",
+    "set_label": "Set label",
+    "no_label": "add label",
+    "label_placeholder": "Label..."
   },
   "approvals": {
     "title": "Approvals",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -398,7 +398,12 @@
     "no_results": "没有匹配的通道",
     "no_configured": "暂无已配置的通道",
     "no_unconfigured": "暂无未配置的通道",
-    "help": "配置消息通道适配器和集成网关。设置 Slack、Discord、Telegram 等通道。"
+    "help": "配置消息通道适配器和集成网关。设置 Slack、Discord、Telegram 等通道。",
+    "test": "测试",
+    "test_success": "通道测试通过",
+    "test_failed": "通道测试失败",
+    "reload": "重新加载",
+    "reload_success": "通道已重新加载"
   },
   "skills": {
     "title": "技能",
@@ -1068,7 +1073,10 @@
     "empty_desc": "智能体开始对话时会话将出现在这里。",
     "unknown_agent": "未知智能体",
     "just_now": "刚刚",
-    "help": "查看和管理智能体对话会话。切换活跃会话、删除旧会话，监控会话活动。"
+    "help": "查看和管理智能体对话会话。切换活跃会话、删除旧会话，监控会话活动。",
+    "set_label": "设置标签",
+    "no_label": "添加标签",
+    "label_placeholder": "标签..."
   },
   "approvals": {
     "title": "审批",

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { listChannels, configureChannel, wechatQrStart, wechatQrStatus, whatsappQrStart, whatsappQrStatus, type ChannelItem } from "../api";
+import { listChannels, configureChannel, testChannel, reloadChannels, wechatQrStart, wechatQrStatus, whatsappQrStart, whatsappQrStatus, type ChannelItem } from "../api";
+import { useUIStore } from "../lib/store";
 import QRCode from "qrcode";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -167,10 +168,11 @@ function ChannelCard({ channel: c, isSelected, viewMode, onSelect, onConfigure, 
 }
 
 // Details Modal
-function DetailsModal({ channel, onClose, onConfigure, t }: {
+function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
   channel: Channel;
   onClose: () => void;
   onConfigure: () => void;
+  onTest: () => void;
   t: (key: string) => string
 }) {
   return (
@@ -295,6 +297,11 @@ function DetailsModal({ channel, onClose, onConfigure, t }: {
             <Button variant="primary" className="flex-1" onClick={onConfigure} leftIcon={<Settings className="w-4 h-4" />}>
               {channel.configured ? t("channels.update_config") : t("channels.setup_adapter")}
             </Button>
+            {channel.configured && (
+              <Button variant="secondary" onClick={onTest} leftIcon={<CheckCircle2 className="w-4 h-4" />}>
+                {t("channels.test") || "Test"}
+              </Button>
+            )}
           </div>
         </div>
 
@@ -593,7 +600,26 @@ export function ChannelsPage() {
   const [configuringChannel, setConfiguringChannel] = useState<Channel | null>(null);
   const [qrLoginChannel, setQrLoginChannel] = useState<Channel | null>(null);
 
+  const queryClient = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
+
   const channelsQuery = useQuery({ queryKey: ["channels", "list"], queryFn: listChannels, refetchInterval: REFRESH_MS });
+  const testMut = useMutation({
+    mutationFn: (name: string) => testChannel(name),
+    onSuccess: (_data, name) => {
+      addToast(t("channels.test_success", { defaultValue: `Channel "${name}" test passed` }), "success");
+      queryClient.invalidateQueries({ queryKey: ["channels"] });
+    },
+    onError: (err: any, name) => addToast(err.message || t("channels.test_failed", { defaultValue: `Channel "${name}" test failed` }), "error"),
+  });
+  const reloadMut = useMutation({
+    mutationFn: reloadChannels,
+    onSuccess: () => {
+      addToast(t("channels.reload_success", { defaultValue: "Channels reloaded" }), "success");
+      queryClient.invalidateQueries({ queryKey: ["channels"] });
+    },
+    onError: (err: any) => addToast(err.message || t("common.error"), "error"),
+  });
 
   const channels = channelsQuery.data ?? [];
   const configuredCount = useMemo(() => channels.filter(c => c.configured).length, [channels]);
@@ -662,8 +688,13 @@ export function ChannelsPage() {
         icon={<Network className="h-4 w-4" />}
         helpText={t("channels.help")}
         actions={
-          <div className="hidden rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-[10px] font-bold uppercase text-text-dim sm:block">
-            {t("channels.configured_count", { count: configuredCount })}
+          <div className="flex items-center gap-2">
+            <Button variant="secondary" size="sm" onClick={() => reloadMut.mutate()} disabled={reloadMut.isPending}>
+              {t("channels.reload", { defaultValue: "Reload" })}
+            </Button>
+            <div className="hidden rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-[10px] font-bold uppercase text-text-dim sm:block">
+              {t("channels.configured_count", { count: configuredCount })}
+            </div>
           </div>
         }
       />
@@ -804,6 +835,7 @@ export function ChannelsPage() {
               setConfiguringChannel(ch);
             }
           }}
+          onTest={() => testMut.mutate(detailsChannel.name)}
           t={t}
         />
       )}

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -2,14 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatRelativeTime } from "../lib/datetime";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { deleteSession, listAgents, listSessions, switchAgentSession } from "../api";
+import { deleteSession, listAgents, listSessions, switchAgentSession, setSessionLabel } from "../api";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { useUIStore } from "../lib/store";
-import { Clock, Search, MessageCircle, Trash2, Play, Users } from "lucide-react";
+import { Clock, Search, MessageCircle, Trash2, Play, Users, Tag, Check, X } from "lucide-react";
 import { truncateId } from "../lib/string";
 
 const REFRESH_MS = 30000;
@@ -20,6 +20,8 @@ export function SessionsPage() {
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+  const [labelValue, setLabelValue] = useState("");
   const addToast = useUIStore((s) => s.addToast);
 
   const sessionsQuery = useQuery({ queryKey: ["sessions", "list"], queryFn: listSessions, refetchInterval: REFRESH_MS });
@@ -27,6 +29,13 @@ export function SessionsPage() {
 
   const switchMutation = useMutation({ mutationFn: ({ agentId, sessionId }: any) => switchAgentSession(agentId, sessionId) });
   const deleteMutation = useMutation({ mutationFn: (id: string) => deleteSession(id) });
+  const labelMutation = useMutation({
+    mutationFn: ({ sessionId, label }: { sessionId: string; label: string }) => setSessionLabel(sessionId, label),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      setEditingLabelId(null);
+    },
+  });
 
   const agents = agentsQuery.data ?? [];
   const agentMap = useMemo(() => new Map(agents.map(a => [a.id, a])), [agents]);
@@ -49,7 +58,7 @@ export function SessionsPage() {
       });
   }, [sessionsQuery.data, search, agentMap]);
 
-  const activeCount = sessions.filter(s => (s as any).active).length;
+  const activeCount = sessions.filter(s => s.active).length;
 
   async function handleSwitch(agentId: string, sessionId: string) {
     setPendingId(sessionId);
@@ -132,36 +141,59 @@ export function SessionsPage() {
             return (
               <div key={s.session_id}
                 className={`flex items-center gap-3 p-3 sm:p-4 rounded-xl sm:rounded-2xl border transition-all duration-300 card-glow cursor-pointer ${
-                  (s as any).active ? "border-success/30 bg-success/5" : "border-border-subtle hover:border-brand/30 hover:-translate-y-0.5"
+                  s.active ? "border-success/30 bg-success/5" : "border-border-subtle hover:border-brand/30 hover:-translate-y-0.5"
                 }`}>
                 {/* Agent avatar */}
                 <div className={`relative w-9 h-9 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl flex items-center justify-center text-base sm:text-lg font-bold shrink-0 ${
-                  (s as any).active ? "bg-success/20 text-success" : "bg-main text-text-dim/40"
+                  s.active ? "bg-success/20 text-success" : "bg-main text-text-dim/40"
                 }`}>
                   {agent?.name?.charAt(0).toUpperCase() || <Users className="w-4 h-4 sm:w-5 sm:h-5" />}
-                  {(s as any).active && <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-success border-2 border-white dark:border-surface animate-pulse" />}
+                  {s.active && <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full bg-success border-2 border-white dark:border-surface animate-pulse" />}
                 </div>
 
                 {/* Info */}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5 sm:gap-2">
                     <h3 className="text-xs sm:text-sm font-bold truncate">{agent?.name || t("sessions.unknown_agent")}</h3>
-                    <Badge variant={(s as any).active ? "success" : "default"}>
-                      {(s as any).active ? t("common.active") : t("common.idle")}
+                    <Badge variant={s.active ? "success" : "default"}>
+                      {s.active ? t("common.active") : t("common.idle")}
                     </Badge>
                   </div>
-                  <div className="flex items-center gap-2 sm:gap-3 mt-0.5 sm:mt-1 text-[9px] sm:text-[10px] text-text-dim/60">
+                  <div className="flex items-center gap-2 sm:gap-3 mt-0.5 sm:mt-1 text-[9px] sm:text-[10px] text-text-dim/60 flex-wrap">
                     <span className="font-mono">{truncateId(s.session_id)}</span>
                     <span className="flex items-center gap-1"><Clock className="w-3 h-3" /> {formatTime(s.created_at || "")}</span>
                     {s.message_count !== undefined && (
                       <span className="flex items-center gap-1 hidden sm:flex"><MessageCircle className="w-3 h-3" /> {s.message_count}</span>
+                    )}
+                    {editingLabelId === s.session_id ? (
+                      <span className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
+                        <input
+                          autoFocus
+                          value={labelValue}
+                          onChange={e => setLabelValue(e.target.value)}
+                          onKeyDown={e => { if (e.key === "Enter") labelMutation.mutate({ sessionId: s.session_id, label: labelValue }); if (e.key === "Escape") setEditingLabelId(null); }}
+                          className="px-1.5 py-0.5 rounded border border-brand bg-main text-[10px] w-24 outline-none"
+                          placeholder={t("sessions.label_placeholder", { defaultValue: "Label..." })}
+                        />
+                        <button onClick={() => labelMutation.mutate({ sessionId: s.session_id, label: labelValue })} className="text-success"><Check className="w-3 h-3" /></button>
+                        <button onClick={() => setEditingLabelId(null)} className="text-text-dim"><X className="w-3 h-3" /></button>
+                      </span>
+                    ) : (
+                      <button
+                        onClick={e => { e.stopPropagation(); setEditingLabelId(s.session_id); setLabelValue(s.label || ""); }}
+                        className="flex items-center gap-0.5 hover:text-brand transition-colors"
+                        title={t("sessions.set_label", { defaultValue: "Set label" })}
+                      >
+                        <Tag className="w-3 h-3" />
+                        {s.label ? <span className="text-brand font-bold">{s.label}</span> : <span className="italic">{t("sessions.no_label", { defaultValue: "add label" })}</span>}
+                      </button>
                     )}
                   </div>
                 </div>
 
                 {/* Actions */}
                 <div className="flex items-center gap-1 shrink-0">
-                  {!(s as any).active && s.agent_id && (
+                  {!s.active && s.agent_id && (
                     <Button variant="secondary" size="sm" onClick={() => handleSwitch(s.agent_id!, s.session_id)} disabled={pendingId === s.session_id}>
                       <Play className="w-3.5 h-3.5" />
                     </Button>


### PR DESCRIPTION
## Summary

Connects existing but unused backend API endpoints to dashboard UI:

### ChannelsPage
- **Reload button** in header — calls `POST /api/channels/reload` to hot-reload channel configs without daemon restart
- **Test button** in channel detail panel — calls `POST /api/channels/{name}/test` for configured channels, shows success/error toast

### SessionsPage
- **Inline label editing** — click the tag icon on any session to set/edit a label via `PUT /api/sessions/{id}/label`
- Labels display inline with session metadata (ID, timestamp, message count)

### i18n
- Added channel test/reload keys and session label keys to both en.json and zh.json

## Context

Audit found 19 API client functions defined in `api.ts` but never imported by any page. This PR wires up the highest-value ones: `testChannel`, `reloadChannels`, and `setSessionLabel`.

## Test plan
- [x] `npm run build` clean
- [x] TypeScript — no new errors