### PR TITLE
fix(xtask): stop embedding dashboard artifacts in release commits

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,4 +1,3 @@
-use crate::build_web;
 use crate::changelog;
 use crate::common::repo_root;
 use crate::sync_versions;
@@ -593,17 +592,7 @@ pip install librefang-sdk
         None
     };
 
-    // --- Build dashboard ---
-    println!();
-    println!("Building React dashboard...");
-    let build_result = build_web::run(build_web::BuildWebArgs {
-        dashboard: true,
-        web: false,
-        docs: false,
-    });
-    if let Err(e) = build_result {
-        println!("  Warning: dashboard build failed: {}", e);
-    }
+    // Dashboard is built by CI (dashboard-build.yml), not embedded in release commits.
 
     // --- Git add + commit + tag ---
     println!();
@@ -619,7 +608,6 @@ pip install librefang-sdk
         "sdk/rust/README.md",
         "packages/whatsapp-gateway/package.json",
         "crates/librefang-desktop/tauri.conf.json",
-        "crates/librefang-api/static/react/",
     ];
 
     for file in &files_to_add {


### PR DESCRIPTION
## Summary
- Remove dashboard build step from `cargo xtask release` — CI handles this via `dashboard-build.yml` now (#2032)
- Remove `static/react/` from release commit staging list
- Fixes conflict with the "Reject static/react/ in PR" CI check added in #2032

## Test plan
- [x] `cargo clippy -p xtask -- -D warnings` passes