### PR TITLE
docs: update dashboard build references after static/react removal

### DIFF
--- a/docs/src/app/desktop/page.mdx
+++ b/docs/src/app/desktop/page.mdx
@@ -283,7 +283,7 @@ This permits the WebView to load content from the localhost API server while blo
 The embedded web UI served by the axum API server has two implementations that coexist:
 
 - **Legacy Alpine.js dashboard** — served from `crates/librefang-api/static/` as a single HTML file. Always present; no build step required.
-- **React dashboard** — located at `crates/librefang-api/dashboard-react/`. Built with Vite + React + TanStack Router + TanStack Query. Compiled artifacts are committed to `crates/librefang-api/static/react/` and served at `/react/`.
+- **React dashboard** — located at `crates/librefang-api/dashboard/`. Built with Vite + React + TanStack Router + TanStack Query. Build output goes to `crates/librefang-api/static/react/` (gitignored); CI builds and uploads it to release assets automatically.
 
 To rebuild the React dashboard after making frontend changes:
 
@@ -293,7 +293,7 @@ npm install
 npm run build
 ```
 
-The output is written to `../static/react/` and is immediately picked up by the embedded axum server on next launch.
+The output is written to `../static/react/` (gitignored). For local builds, `include_dir!` embeds it into the binary; in production, the daemon downloads dashboard assets from release artifacts at startup.
 
 ### Development
 

--- a/docs/src/app/development/page.mdx
+++ b/docs/src/app/development/page.mdx
@@ -92,8 +92,8 @@ librefang start
 
 ### Dashboard Development
 
-The React dashboard build output is pre-committed in `crates/librefang-api/static/react/`.
-If you modify the dashboard source code, rebuild before compiling the Rust binary:
+The React dashboard is built locally into `crates/librefang-api/static/react/` (gitignored).
+CI builds and uploads it automatically; for local development, rebuild before compiling the Rust binary:
 
 ```bash
 # Rebuild dashboard assets
@@ -488,12 +488,8 @@ curl -s http://127.0.0.1:4545/ | head -5
 curl -sI http://127.0.0.1:4545/dashboard/assets/index-DVRukrPy.js
 # 200 = OK, 404 = assets not embedded
 
-# 4. If assets 404, verify the build output exists before compiling
-ls crates/librefang-api/static/react/index.html
-ls crates/librefang-api/static/react/assets/
-
-# 5. Rebuild: embed fresh assets into the binary
-cargo xtask build-web --dashboard
+# 4. If assets 404, rebuild the dashboard locally and recompile
+just dashboard-build
 cargo build -p librefang-cli --release
 ```
 

--- a/docs/src/app/zh/desktop/page.mdx
+++ b/docs/src/app/zh/desktop/page.mdx
@@ -283,7 +283,7 @@ script-src 'self' 'unsafe-inline'
 内嵌 Web UI 由 axum API 服务器提供服务，包含两套并存的前端实现：
 
 - **旧版 Alpine.js dashboard** -- 从 `crates/librefang-api/static/` 以单个 HTML 文件形式提供。始终可用，无需构建步骤。
-- **React dashboard** -- 位于 `crates/librefang-api/dashboard-react/`。基于 Vite + React + TanStack Router + TanStack Query 构建。编译产物提交至 `crates/librefang-api/static/react/`，通过 `/react/` 路由访问。
+- **React dashboard** -- 位于 `crates/librefang-api/dashboard/`。基于 Vite + React + TanStack Router + TanStack Query 构建。构建产物输出到 `crates/librefang-api/static/react/`（已 gitignore）；CI 自动构建并上传到 release assets。
 
 修改前端代码后，重新构建 React dashboard：
 
@@ -293,7 +293,7 @@ npm install
 npm run build
 ```
 
-输出写入 `../static/react/`，下次启动内嵌 axum 服务器时自动加载。
+输出写入 `../static/react/`（已 gitignore）。本地构建时 `include_dir!` 会嵌入到二进制；生产环境中，daemon 启动时从 release assets 下载 dashboard 资源。
 
 ### 开发模式
 

--- a/docs/src/app/zh/development/page.mdx
+++ b/docs/src/app/zh/development/page.mdx
@@ -92,8 +92,8 @@ librefang start
 
 ### Dashboard 开发
 
-React Dashboard 的构建产物已预提交在 `crates/librefang-api/static/react/` 目录中。
-如果你修改了 Dashboard 源码，需要在编译 Rust 二进制之前重新构建：
+React Dashboard 构建产物输出到 `crates/librefang-api/static/react/`（已 gitignore）。
+CI 会自动构建并上传；本地开发时，需要在编译 Rust 二进制之前手动构建：
 
 ```bash
 # 重新构建 Dashboard 资源
@@ -488,12 +488,8 @@ curl -s http://127.0.0.1:4545/ | head -5
 curl -sI http://127.0.0.1:4545/dashboard/assets/index-DVRukrPy.js
 # 200 = 正常, 404 = 资源未嵌入
 
-# 4. 如果资源 404，验证编译前构建产物是否存在
-ls crates/librefang-api/static/react/index.html
-ls crates/librefang-api/static/react/assets/
-
-# 5. 重新构建：将新资源嵌入二进制
-cargo xtask build-web --dashboard
+# 4. 如果资源 404，本地重新构建 dashboard 并重新编译
+just dashboard-build
 cargo build -p librefang-cli --release
 ```
 


### PR DESCRIPTION
## Summary
- Update 4 docs pages that incorrectly stated dashboard artifacts are "pre-committed" to git
- Reflect new reality: `static/react/` is gitignored, CI builds and uploads to release assets
- Fix stale troubleshooting steps that referenced checking tracked files

Follows up on #2032 (dashboard auto-sync), #2039 (xtask fix), #2041 (remove tracked files).