### PR TITLE
fix(kernel): strip provider prefix from agent fallback_models

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -8022,7 +8022,7 @@ system_prompt = "You are a helpful assistant."
                     message_timeout_secs: cfg.default_model.message_timeout_secs,
                 };
                 match self.driver_cache.get_or_create(&config) {
-                    Ok(d) => chain.push((d, fb.model.clone())),
+                    Ok(d) => chain.push((d, strip_provider_prefix(&fb.model, &fb_provider))),
                     Err(e) => {
                         warn!("Fallback driver '{}' failed to init: {e}", fb_provider);
                     }


### PR DESCRIPTION
## Summary

Fixes #2037.

Agent-level `fallback_models` in `resolve_driver` pushed `fb.model.clone()` directly into the fallback chain without normalizing the model name. This was inconsistent with two other locations in the same file that already call `strip_provider_prefix`:

- `kernel.rs:1781` — global `fallback_providers` during kernel boot
- `kernel.rs:2667` — primary agent model in `normalize_manifest`

As reported in #2037, models written as `provider/model` (e.g. `openai/gpt-4o`) in an agent's `fallback_models` are passed through unchanged, causing upstream API 400 errors.

## Fix

One-line change at `kernel.rs:8025`:
```rust
- Ok(d) => chain.push((d, fb.model.clone())),
+ Ok(d) => chain.push((d, strip_provider_prefix(&fb.model, &fb_provider))),
```

Uses the resolved `fb_provider` (not `fb.provider`) so `provider = "default"` in config is correctly normalized before stripping.

## Test plan

- [x] `cargo build --workspace --lib`
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Live integration: configure an agent with `fallback_models = [{ provider = "openai", model = "openai/gpt-4o" }]`, force primary to fail, verify fallback call no longer 400s