### PR TITLE
fix(api): ensure static/react dir exists for include_dir!

### DIFF
--- a/crates/librefang-api/build.rs
+++ b/crates/librefang-api/build.rs
@@ -1,6 +1,20 @@
 use std::process::Command;
 
 fn main() {
+    // Ensure the dashboard embed directory exists so `include_dir!` never
+    // fails on fresh clones/worktrees. The directory is gitignored because
+    // it contains build artifacts produced by `npm run build` in the
+    // dashboard subcrate (or downloaded from release assets at runtime).
+    // When empty, `include_dir!` embeds nothing and the runtime directory
+    // `~/.librefang/dashboard/` serves the actual assets.
+    let dashboard_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("static")
+        .join("react");
+    if !dashboard_dir.exists() {
+        std::fs::create_dir_all(&dashboard_dir)
+            .expect("failed to create static/react placeholder directory");
+    }
+
     // Capture git commit hash at build time.
     let git_sha = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])


### PR DESCRIPTION
## Summary

After #2041 removed `static/react/` build artifacts from git tracking, fresh clones and new git worktrees fail to compile:

\`\`\`
error: proc macro panicked
  --> crates/librefang-api/src/webchat.rs:20:30
   |
20 | static REACT_DIST: Dir<'_> = include_dir!(\"\$CARGO_MANIFEST_DIR/static/react\");
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: message: \".../crates/librefang-api/static/react\" is not a directory
\`\`\`

`include_dir!` requires the path to exist at compile time, but the directory is gitignored because its contents are dashboard build artifacts (produced by `npm run build` in `dashboard/` or downloaded from release assets at runtime).

## Fix

`build.rs` now creates an empty `static/react/` directory if it doesn't exist. `include_dir!` accepts empty directories (embeds nothing), and the runtime lookup from `~/.librefang/dashboard/` continues to serve actual assets unchanged.

- Main-worktree users who already ran `npm run build` in `dashboard/`: no behavior change (directory already exists).
- Fresh clones / new worktrees: compile succeeds immediately.
- Release/CI builds: unchanged — dashboard assets are populated before packaging.

## Test plan

- [x] Created a fresh worktree with no `static/react/`, verified `cargo build -p librefang-api --lib` succeeds
- [x] Confirmed directory is created during build
- [ ] Verify release build still embeds correct contents when `npm run build` runs first