### PR TITLE
fix(dashboard): defer WebSocket close until connection is established

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -118,9 +118,16 @@ function useWebSocket(agentId: string | null) {
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
       retriesRef.current = 0;
       onDropRef.current = null;
-      if (wsRef.current) {
-        wsRef.current.onclose = null; // prevent reconnect on intentional close
-        wsRef.current.close();
+      const ws = wsRef.current;
+      if (ws) {
+        ws.onclose = null; // prevent reconnect on intentional close
+        if (ws.readyState === WebSocket.CONNECTING) {
+          // Closing a CONNECTING socket triggers a noisy browser warning;
+          // defer the close until it actually opens.
+          ws.onopen = () => ws.close();
+        } else if (ws.readyState === WebSocket.OPEN) {
+          ws.close();
+        }
         wsRef.current = null;
       }
     };


### PR DESCRIPTION
## Summary

- When StrictMode or rapid navigation triggered the \`useWebSocket\` cleanup while the socket was still in the \`CONNECTING\` state, calling \`close()\` logged a *WebSocket is closed before the connection is established* warning in Chrome DevTools.
- Cleanup now checks \`readyState\` first. For \`CONNECTING\` sockets, the cleanup hooks \`ws.onopen\` to defer the close until the handshake completes, avoiding the browser warning.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [ ] Hot-navigate between chat agents rapidly → no more \`WebSocket is closed before the connection is established\` noise in DevTools
- [ ] Normal chat flow still works (open, receive messages, close, reconnect)