### PR TITLE
feat(dashboard): redesign Hands detail modal with hero, action bar, metrics strip

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -33,6 +33,7 @@ import {
   Search,
   Power,
   PowerOff,
+  Pause as PauseIcon,
   Loader2,
   X,
   CheckCircle2,
@@ -428,82 +429,162 @@ function HandDetailPanel({
   const settings: HandSettingsResponse = settingsQuery.data ?? {};
   const stats: HandStatsResponse = statsQuery.data ?? {};
 
+  // Primary metric keys to pull out for the hero strip (best-effort — falls back to any available)
+  const metricEntries = stats.metrics
+    ? Object.entries(stats.metrics)
+        .filter(([, m]) => m.value != null && String(m.value) !== "-" && String(m.value) !== "")
+        .slice(0, 4)
+    : [];
+
+  const heroIconClass = isActive
+    ? isPaused
+      ? "bg-warning/15 text-warning"
+      : "bg-success/15 text-success"
+    : hand.requirements_met
+      ? "bg-brand/10 text-brand"
+      : "bg-warning/10 text-warning";
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
       onClick={onClose}
     >
       <div
-        className="bg-surface w-full max-w-lg h-[70vh] rounded-2xl shadow-2xl border border-border-subtle flex flex-col overflow-hidden"
+        className="bg-surface rounded-t-2xl sm:rounded-2xl shadow-2xl border border-border-subtle w-full sm:w-[640px] sm:max-w-[90vw] max-h-[90vh] sm:max-h-[85vh] flex flex-col overflow-hidden animate-fade-in-scale"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Title bar */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
-          <h2 className="text-sm font-bold truncate">{hand.name || hand.id}</h2>
-          <button onClick={onClose} className="p-1 rounded-lg text-text-dim/40 hover:text-text hover:bg-main transition-colors">
-            <X className="w-4 h-4" />
-          </button>
+        {/* Hero header */}
+        <div className="px-6 py-5 border-b border-border-subtle shrink-0">
+          <div className="flex items-start gap-4">
+            <div className={`w-12 h-12 rounded-2xl flex items-center justify-center shrink-0 ${heroIconClass}`}>
+              <Hand className="w-5 h-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <h2 className="text-lg font-black tracking-tight truncate">{hand.name || hand.id}</h2>
+                {isActive && !isPaused && (
+                  <span className="w-1.5 h-1.5 rounded-full bg-success animate-pulse shrink-0" />
+                )}
+                {isActive && isPaused && (
+                  <span className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />
+                )}
+              </div>
+              <div className="flex items-center gap-1.5 flex-wrap">
+                {isActive ? (
+                  isPaused
+                    ? <Badge variant="warning" dot>{t("hands.paused")}</Badge>
+                    : <Badge variant="success" dot>{t("hands.active_label")}</Badge>
+                ) : hand.requirements_met ? (
+                  <Badge variant="default">{t("hands.ready")}</Badge>
+                ) : (
+                  <Badge variant="warning">{t("hands.missing_req")}</Badge>
+                )}
+                {hand.category && (
+                  <Badge variant="info">{t(`hands.cat_${hand.category}`, { defaultValue: hand.category })}</Badge>
+                )}
+                {instance?.instance_id && (
+                  <span className="text-[10px] text-text-dim/50 font-mono">
+                    {truncateId(instance.instance_id, 12)}
+                  </span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-xl text-text-dim/60 hover:text-text hover:bg-main transition-colors shrink-0"
+              aria-label="Close"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
         {/* Scrollable body */}
         <div className="flex-1 overflow-y-auto scrollbar-thin">
-          <div className="px-5 py-4 space-y-4">
-            {/* Status + actions */}
+          <div className="px-6 py-5 space-y-5">
+            {/* Description */}
+            {hand.description && (
+              <p className="text-sm text-text-dim leading-relaxed">{hand.description}</p>
+            )}
+
+            {/* Primary action bar */}
             <div className="flex items-center gap-2">
-              {isActive ? (
-                isPaused
-                  ? <Badge variant="warning" dot>{t("hands.paused")}</Badge>
-                  : <Badge variant="success" dot>{t("hands.active_label")}</Badge>
-              ) : hand.requirements_met ? (
-                <Badge variant="default">{t("hands.ready")}</Badge>
-              ) : (
-                <Badge variant="warning">{t("hands.missing_req")}</Badge>
-              )}
-              {hand.category && (
-                <Badge variant="info">{t(`hands.cat_${hand.category}`, { defaultValue: hand.category })}</Badge>
-              )}
-              <div className="flex-1" />
               {isActive && instance ? (
-                <div className="flex items-center gap-1">
-                  <button onClick={() => onChat(instance.instance_id, hand.name || hand.id)} disabled={isPaused}
-                    className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-brand hover:bg-brand/10 transition-colors disabled:opacity-30">
+                <>
+                  <button
+                    onClick={() => onChat(instance.instance_id, hand.name || hand.id)}
+                    disabled={isPaused}
+                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold text-white bg-brand hover:brightness-110 shadow-md shadow-brand/20 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none"
+                  >
+                    <MessageCircle className="w-4 h-4" />
                     {t("chat.title")}
                   </button>
                   {isPaused ? (
-                    <button onClick={() => onResume(instance.instance_id)} disabled={isPending}
-                      className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-success hover:bg-success/10 transition-colors disabled:opacity-30">
-                      {isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : t("hands.resume")}
+                    <button
+                      onClick={() => onResume(instance.instance_id)}
+                      disabled={isPending}
+                      className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-bold text-success bg-success/10 hover:bg-success/20 transition-colors disabled:opacity-40"
+                    >
+                      {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Power className="w-4 h-4" />}
+                      {t("hands.resume")}
                     </button>
                   ) : (
-                    <button onClick={() => onPause(instance.instance_id)} disabled={isPending}
-                      className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-text-dim hover:bg-main transition-colors disabled:opacity-30">
-                      {isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : t("hands.pause")}
+                    <button
+                      onClick={() => onPause(instance.instance_id)}
+                      disabled={isPending}
+                      className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-bold text-text-dim bg-main hover:bg-main/70 transition-colors disabled:opacity-40"
+                    >
+                      {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <PauseIcon className="w-4 h-4" />}
+                      {t("hands.pause")}
                     </button>
                   )}
-                  <button onClick={() => onDeactivate(instance.instance_id)} disabled={isPending}
-                    className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-error hover:bg-error/10 transition-colors disabled:opacity-30">
-                    {isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : t("hands.deactivate")}
+                  <button
+                    onClick={() => onDeactivate(instance.instance_id)}
+                    disabled={isPending}
+                    className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-bold text-error bg-error/10 hover:bg-error/20 transition-colors disabled:opacity-40"
+                  >
+                    {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <PowerOff className="w-4 h-4" />}
+                    {t("hands.deactivate")}
                   </button>
-                </div>
+                </>
               ) : (
-                <button onClick={() => onActivate(hand.id)} disabled={isPending || !hand.requirements_met}
-                  className="px-3 py-1 rounded-lg text-[11px] font-medium text-white bg-brand hover:bg-brand/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                  {isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : t("hands.activate")}
+                <button
+                  onClick={() => onActivate(hand.id)}
+                  disabled={isPending || !hand.requirements_met}
+                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold text-white bg-brand hover:brightness-110 shadow-md shadow-brand/20 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none disabled:bg-main disabled:text-text-dim"
+                >
+                  {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Power className="w-4 h-4" />}
+                  {!hand.requirements_met ? t("hands.missing_req") : t("hands.activate")}
                 </button>
               )}
             </div>
 
-            {/* Description */}
-            {hand.description && (
-              <p className="text-[13px] text-text-dim leading-relaxed">{hand.description}</p>
+            {/* Live metrics strip — only when active with data */}
+            {isActive && metricEntries.length > 0 && (
+              <div className={`grid gap-2 ${metricEntries.length >= 4 ? "grid-cols-4" : metricEntries.length === 3 ? "grid-cols-3" : "grid-cols-2"}`}>
+                {metricEntries.map(([label, m]) => (
+                  <div key={label} className="p-3 rounded-xl bg-main/50 border border-border-subtle/50">
+                    <p className="text-[9px] uppercase tracking-wider font-bold text-text-dim/50 truncate mb-1">{label}</p>
+                    <p className="text-base font-black text-brand tabular-nums truncate">{String(m.value)}</p>
+                  </div>
+                ))}
+              </div>
             )}
 
-            {/* Sections */}
-            <DetailTabs key={hand.id} hand={hand} instance={instance} isActive={isActive} settings={settings} settingsQuery={settingsQuery} stats={stats} statsQuery={statsQuery} />
+            {/* Detail sections */}
+            <DetailTabs
+              key={hand.id}
+              hand={hand}
+              instance={instance}
+              isActive={isActive}
+              settings={settings}
+              settingsQuery={settingsQuery}
+              stats={stats}
+              statsQuery={statsQuery}
+            />
           </div>
         </div>
       </div>
-
     </div>
   );
 }
@@ -543,16 +624,20 @@ function RequirementsForm({ handId, requirements }: { handId: string; requiremen
   };
 
   return (
-    <div className="space-y-2.5">
+    <div className="space-y-3">
       {requirements.map((r) => (
-        <div key={r.key}>
-          <div className="flex items-center gap-2 mb-1">
-            {r.satisfied ? <CheckCircle2 className="w-3.5 h-3.5 text-success shrink-0" /> : <XCircle className="w-3.5 h-3.5 text-error shrink-0" />}
-            <span className={`text-[11px] font-medium ${r.satisfied ? "text-text-dim" : "text-text"}`}>{r.label || r.key}</span>
-            {r.optional && <span className="text-[9px] text-text-dim/40">(optional)</span>}
+        <div key={r.key} className="rounded-xl border border-border-subtle bg-main/30 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            {r.satisfied
+              ? <CheckCircle2 className="w-4 h-4 text-success shrink-0" />
+              : <XCircle className="w-4 h-4 text-error shrink-0" />}
+            <span className="text-xs font-bold">{r.label || r.key}</span>
+            {r.optional && (
+              <span className="text-[10px] text-text-dim/50 font-bold uppercase tracking-wide">optional</span>
+            )}
           </div>
           {r.key && (
-            <div className="flex gap-1.5 ml-5">
+            <div className="flex gap-2">
               <input
                 type="text"
                 autoComplete="off"
@@ -560,17 +645,17 @@ function RequirementsForm({ handId, requirements }: { handId: string; requiremen
                 value={values[r.key!] ?? ""}
                 onChange={(e) => { setValues(prev => ({ ...prev, [r.key!]: e.target.value })); }}
                 onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleSave(r.key!); } }}
-                className={`flex-1 px-2.5 py-1.5 rounded-lg border text-[11px] font-mono outline-none focus:border-brand placeholder:text-text-dim/30 ${
-                  r.satisfied ? "border-success/20 bg-success/5" : "border-border-subtle bg-main"
+                className={`flex-1 px-3 py-2 rounded-lg border text-xs font-mono outline-none focus:border-brand placeholder:text-text-dim/30 transition-colors ${
+                  r.satisfied ? "border-success/30 bg-success/5 focus:border-success/60" : "border-border-subtle bg-surface"
                 }`}
               />
               <button
                 type="button"
                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleSave(r.key!); }}
                 disabled={!values[r.key!]?.trim() || saving === r.key}
-                className="px-2.5 py-1.5 rounded-lg text-[11px] font-medium text-white bg-brand hover:bg-brand/90 transition-colors disabled:opacity-40"
+                className="px-3 py-2 rounded-lg text-xs font-bold text-white bg-brand hover:brightness-110 shadow-sm shadow-brand/20 transition-all disabled:opacity-40 disabled:shadow-none"
               >
-                {saving === r.key ? <Loader2 className="w-3 h-3 animate-spin" /> : t("common.save")}
+                {saving === r.key ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : t("common.save")}
               </button>
             </div>
           )}
@@ -607,75 +692,80 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
   });
   const cronJobs = cronJobsQuery.data ?? [];
 
-  type Tab = "agents" | "settings" | "requirements" | "tools" | "metrics" | "schedules";
+  type Tab = "agents" | "settings" | "requirements" | "tools" | "schedules";
   const tabs: { id: Tab; label: string; count?: number; show: boolean }[] = [
     { id: "agents", label: t("nav.agents"), count: workspaceAgents.length, show: workspaceAgents.length > 0 },
     { id: "schedules", label: t("scheduler.schedules", { defaultValue: "Schedules" }), count: cronJobs.length, show: isActive && !!agentId },
     { id: "settings", label: t("hands.settings"), count: settings.settings?.length, show: true },
     { id: "requirements", label: t("hands.requirements"), count: hand.requirements?.length, show: !!(hand.requirements && hand.requirements.length > 0) },
     { id: "tools", label: t("hands.tools"), count: hand.tools?.length, show: !!(hand.tools && hand.tools.length > 0) },
-    { id: "metrics", label: t("hands.metrics"), show: !!hasMetrics },
   ];
+  // Silence unused — hasMetrics is now surfaced via the hero metrics strip in HandDetailPanel
+  void hasMetrics;
   const visibleTabs = tabs.filter(t => t.show);
   const [activeTab, setActiveTab] = useState<Tab>(visibleTabs[0]?.id ?? "settings");
 
   return (
     <div>
       {/* Tab bar */}
-      <div className="flex border-b border-border-subtle">
-        {visibleTabs.map(tab => (
-          <button key={tab.id} onClick={() => setActiveTab(tab.id)}
-            className={`px-3 py-2 text-[11px] font-semibold transition-colors relative ${
-              activeTab === tab.id
-                ? "text-brand"
-                : "text-text-dim/50 hover:text-text-dim"
-            }`}>
-            {tab.label}
-            {tab.count !== undefined && <span className="ml-1 text-[9px] opacity-50">{tab.count}</span>}
-            {activeTab === tab.id && <span className="absolute bottom-0 left-1 right-1 h-0.5 bg-brand rounded-full" />}
-          </button>
-        ))}
+      <div className="flex gap-0.5 border-b border-border-subtle mb-4 overflow-x-auto scrollbar-thin">
+        {visibleTabs.map(tab => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`relative flex items-center gap-1.5 px-3 py-2.5 text-xs font-bold whitespace-nowrap transition-colors ${
+                isActive ? "text-brand" : "text-text-dim/60 hover:text-text"
+              }`}
+            >
+              {tab.label}
+              {tab.count !== undefined && tab.count > 0 && (
+                <span
+                  className={`inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-md text-[10px] font-black ${
+                    isActive ? "bg-brand/15 text-brand" : "bg-main text-text-dim/60"
+                  }`}
+                >
+                  {tab.count}
+                </span>
+              )}
+              {isActive && (
+                <span className="absolute -bottom-px left-0 right-0 h-0.5 bg-brand rounded-full" />
+              )}
+            </button>
+          );
+        })}
       </div>
 
       {/* Tab content */}
-      <div className="py-3">
-        {activeTab === "metrics" && hasMetrics && (
-          <div className="grid grid-cols-2 gap-2">
-            {Object.entries(stats.metrics!).filter(([, m]) => m.value != null && String(m.value) !== "-" && String(m.value) !== "").map(([label, m]) => (
-              <div key={label} className="p-2.5 rounded-lg bg-main border border-border-subtle">
-                <p className="text-[10px] text-text-dim/60 truncate">{label}</p>
-                <p className="text-sm font-bold text-brand">{String(m.value)}</p>
-              </div>
-            ))}
-          </div>
-        )}
+      <div>
 
         {activeTab === "agents" && (
-          <div className="space-y-3">
+          <div className="space-y-2">
             {workspaceAgents.map((a) => (
-              <div key={a.role} className="rounded-lg border border-border-subtle bg-main/30 overflow-hidden">
-                <div className="flex items-center gap-3 p-2.5">
-                  <div className={`w-7 h-7 rounded-lg flex items-center justify-center text-[11px] font-bold shrink-0 ${
-                    a.coordinator ? "bg-brand/10 text-brand" : "bg-main text-text-dim/50"
+              <div key={a.role} className="rounded-xl border border-border-subtle bg-main/40 overflow-hidden">
+                <div className="flex items-center gap-3 p-3">
+                  <div className={`w-9 h-9 rounded-xl flex items-center justify-center text-sm font-black shrink-0 ${
+                    a.coordinator ? "bg-brand/15 text-brand" : "bg-surface text-text-dim/60"
                   }`}>
                     {a.role.charAt(0).toUpperCase()}
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
-                      <p className="text-[11px] font-semibold truncate">{a.role}</p>
+                      <p className="text-xs font-extrabold truncate">{a.role}</p>
                       {a.coordinator && <Badge variant="brand">coordinator</Badge>}
                     </div>
-                    <p className="text-[10px] text-text-dim/50 truncate">{a.model}</p>
+                    <p className="text-[10px] text-text-dim/60 font-mono truncate mt-0.5">{a.model}</p>
                   </div>
                   <Badge variant="info">{a.provider}</Badge>
                 </div>
                 {a.description && (
-                  <p className="px-2.5 pb-2 text-[10px] text-text-dim/60 leading-relaxed line-clamp-2">{a.description}</p>
+                  <p className="px-3 pb-2 text-[11px] text-text-dim/70 leading-relaxed line-clamp-2">{a.description}</p>
                 )}
                 {a.steps && a.steps.length > 0 && (
-                  <div className="px-2.5 pb-2.5 flex flex-wrap gap-1">
+                  <div className="px-3 pb-3 flex flex-wrap gap-1">
                     {a.steps.map((s, i) => (
-                      <span key={i} className="text-[9px] px-1.5 py-0.5 rounded bg-brand/5 text-brand/70 font-medium">{s}</span>
+                      <span key={i} className="text-[10px] px-2 py-0.5 rounded-md bg-brand/5 text-brand/80 font-semibold border border-brand/10">{s}</span>
                     ))}
                   </div>
                 )}
@@ -686,20 +776,25 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
 
         {activeTab === "settings" && (
           settingsQuery.isLoading ? (
-            <div className="flex items-center gap-2 text-text-dim/50 text-[10px]">
-              <Loader2 className="w-3 h-3 animate-spin" /> {t("common.loading")}
+            <div className="flex items-center gap-2 text-text-dim/60 text-xs py-4">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" /> {t("common.loading")}
             </div>
           ) : settings.settings && settings.settings.length > 0 ? (
-            <div className="space-y-0.5">
+            <div className="rounded-xl border border-border-subtle bg-main/30 divide-y divide-border-subtle/50">
               {settings.settings.map((s) => {
                 const currentVal = settings.current_values?.[s.key ?? ""];
                 const displayVal = currentVal !== undefined ? String(currentVal) : (s.default !== undefined ? String(s.default) : undefined);
                 const isDefault = currentVal === undefined;
                 return (
-                  <div key={s.key} className="flex items-center justify-between gap-2 py-1.5">
-                    <span className="text-[11px] font-medium truncate">{s.label || s.key}</span>
+                  <div key={s.key} className="flex items-center justify-between gap-3 px-3 py-2.5">
+                    <div className="min-w-0 flex-1">
+                      <span className="text-xs font-bold truncate block">{s.label || s.key}</span>
+                      {s.label && s.key !== s.label && (
+                        <span className="text-[10px] text-text-dim/40 font-mono">{s.key}</span>
+                      )}
+                    </div>
                     {displayVal !== undefined && (
-                      <span className={`text-[10px] font-mono shrink-0 px-1.5 py-0.5 rounded ${isDefault ? "text-text-dim/50 bg-main" : "text-brand bg-brand/8"}`}>
+                      <span className={`text-[11px] font-mono shrink-0 px-2 py-0.5 rounded-md ${isDefault ? "text-text-dim/60 bg-surface" : "text-brand bg-brand/10"}`}>
                         {displayVal || "-"}
                       </span>
                     )}
@@ -708,7 +803,7 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
               })}
             </div>
           ) : (
-            <p className="text-[10px] text-text-dim/50">{t("hands.settings_empty")}</p>
+            <p className="text-xs text-text-dim/50 py-4 text-center">{t("hands.settings_empty")}</p>
           )
         )}
 
@@ -719,7 +814,9 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
         {activeTab === "tools" && hand.tools && (
           <div className="flex flex-wrap gap-1.5">
             {hand.tools.map((tool) => (
-              <span key={tool} className="text-[10px] font-mono text-text-dim px-2 py-1 rounded-md bg-main/50 border border-border-subtle/50">{tool}</span>
+              <span key={tool} className="text-[11px] font-mono text-text-dim px-2.5 py-1 rounded-lg bg-main/60 border border-border-subtle/60">
+                {tool}
+              </span>
             ))}
           </div>
         )}
@@ -765,9 +862,9 @@ function HandSchedulesTab({ cronJobs, isLoading, onRefresh }: {
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
 
-  if (isLoading) return <div className="flex items-center gap-2 text-text-dim/50 text-[10px]"><Loader2 className="w-3 h-3 animate-spin" /> {t("common.loading")}</div>;
+  if (isLoading) return <div className="flex items-center gap-2 text-text-dim/60 text-xs py-4"><Loader2 className="w-3.5 h-3.5 animate-spin" /> {t("common.loading")}</div>;
 
-  if (cronJobs.length === 0) return <p className="text-[10px] text-text-dim/50">{t("scheduler.no_schedules", { defaultValue: "No scheduled tasks" })}</p>;
+  if (cronJobs.length === 0) return <p className="text-xs text-text-dim/50 py-4 text-center">{t("scheduler.no_schedules", { defaultValue: "No scheduled tasks" })}</p>;
 
   return (
     <div className="space-y-2">
@@ -775,26 +872,28 @@ function HandSchedulesTab({ cronJobs, isLoading, onRefresh }: {
         const isEnabled = job.enabled !== false;
         const schedule = typeof job.schedule === "string" ? job.schedule : (job.schedule as any)?.expr || (job.schedule as any)?.every_secs ? `every ${(job.schedule as any).every_secs}s` : "-";
         return (
-          <div key={job.id} className={`flex items-center gap-2.5 p-2.5 rounded-lg border transition-colors ${isEnabled ? "border-border-subtle" : "border-border-subtle/50 opacity-50"}`}>
-            <Activity className={`w-3.5 h-3.5 shrink-0 ${isEnabled ? "text-brand" : "text-text-dim/30"}`} />
+          <div key={job.id} className={`flex items-center gap-3 p-3 rounded-xl border transition-colors ${isEnabled ? "border-border-subtle bg-main/30" : "border-border-subtle/50 bg-main/10 opacity-60"}`}>
+            <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${isEnabled ? "bg-brand/10 text-brand" : "bg-main text-text-dim/40"}`}>
+              <Activity className="w-4 h-4" />
+            </div>
             <div className="min-w-0 flex-1">
-              <p className="text-[11px] font-semibold truncate">{job.name || "Unnamed"}</p>
-              <p className="text-[9px] font-mono text-text-dim/50">{schedule}</p>
+              <p className="text-xs font-bold truncate">{job.name || "Unnamed"}</p>
+              <p className="text-[10px] font-mono text-text-dim/60 truncate">{schedule}</p>
             </div>
             <button
               onClick={() => handleToggle(job)}
-              className={`px-1.5 py-0.5 rounded-full text-[9px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
+              className={`px-2 py-0.5 rounded-md text-[10px] font-black tracking-wide transition-colors ${isEnabled ? "bg-success/15 text-success hover:bg-success/25" : "bg-main text-text-dim/50 hover:text-text-dim"}`}
             >
               {isEnabled ? "ON" : "OFF"}
             </button>
             {confirmDeleteId === job.id ? (
               <div className="flex items-center gap-1">
-                <button onClick={() => handleDelete(job.id!)} className="px-1.5 py-0.5 rounded-md bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
-                <button onClick={() => setConfirmDeleteId(null)} className="px-1.5 py-0.5 rounded-md bg-main text-text-dim text-[9px] font-bold">{t("common.cancel")}</button>
+                <button onClick={() => handleDelete(job.id!)} className="px-2 py-1 rounded-md bg-error text-white text-[10px] font-bold">{t("common.confirm")}</button>
+                <button onClick={() => setConfirmDeleteId(null)} className="px-2 py-1 rounded-md bg-main text-text-dim text-[10px] font-bold">{t("common.cancel")}</button>
               </div>
             ) : (
-              <button onClick={() => handleDelete(job.id!)} className="p-1 rounded text-text-dim/30 hover:text-error hover:bg-error/10 transition-colors">
-                <XCircle className="w-3 h-3" />
+              <button onClick={() => handleDelete(job.id!)} className="p-1.5 rounded-lg text-text-dim/40 hover:text-error hover:bg-error/10 transition-colors" title="Delete schedule">
+                <XCircle className="w-3.5 h-3.5" />
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary

Follow-up to #2052. The grid/running-strip redesign shipped, but the detail modal was still the old compact dialog — small (max-w-lg, 70vh), status and all actions crammed into one inline row with 11px text-only buttons, metrics hidden behind a tab, and each tab using a different mix of 9-11px fonts.

This PR redesigns the modal shell and all tab content to match the rest of the dashboard.

## Changes

**Modal shell**
- Widens to 640px with max-h 85vh, fade-in-scale animation, slides up from the bottom on mobile (matches the AgentsPage modal).
- New hero header: 48px colored icon, name, pulsing status dot, status + category badges, and a short instance id.

**Primary action bar**
- Chat / Pause / Resume / Stop as full 44px pill buttons with semantic colors (brand for Chat/Activate, success for Resume, error tint for Stop).
- Activate button shows *'Missing Requirements'* label when the hand is blocked.

**Live metrics strip**
- Surfaces the first 4 metric values from \`getHandStats\` as large headline cards below the actions, visible whenever the hand is active.
- Removes the now-redundant *'metrics'* tab.

**Tabs and content**
- Tab bar: 12px bold labels with pill-shaped count badges that invert color on the active tab.
- Agents tab: bigger initials disc, 12px role name, bullet-style step chips.
- Settings tab: single bordered card with divide-y rows.
- Requirements tab: each requirement in its own card, wider inputs, shadowed Save button.
- Schedules tab: row rebuilt with Activity icon in a tinted tile, consistent 12px typography.

## Test plan

- [x] \`tsc --noEmit\` passes with 0 errors
- [x] \`vite build\` succeeds (HandsPage chunk 28.8 kB / 7.43 kB gzipped, +2 kB vs previous)
- [ ] Open modal for an **inactive** hand → hero shows Ready/Missing Req, primary CTA is Activate
- [ ] Open modal for a **running** hand → hero shows pulsing dot + active badge, action bar shows Chat/Pause/Stop, metrics strip visible at top
- [ ] Pause a hand → action bar swaps to Chat/Resume/Stop
- [ ] Switch tabs → active tab's count badge turns brand-colored
- [ ] Mobile viewport → modal slides up from bottom