### PR TITLE
fix(dashboard): Hands detail modal tab bar height, underline, and schedules label

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -470,6 +470,7 @@
     "metrics_no_data": "No metrics data yet.",
     "settings": "Settings",
     "settings_empty": "No settings available.",
+    "tab_schedules": "Schedules",
     "requirements": "Requirements",
     "tools": "Tools",
     "cat_content": "Content",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -470,6 +470,7 @@
     "metrics_no_data": "暂无指标数据。",
     "settings": "设置",
     "settings_empty": "暂无可用设置。",
+    "tab_schedules": "定时任务",
     "requirements": "依赖项",
     "tools": "工具",
     "cat_communication": "通信",

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -696,7 +696,7 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
   type Tab = "agents" | "settings" | "requirements" | "tools" | "schedules";
   const tabs: { id: Tab; label: string; count?: number; show: boolean }[] = [
     { id: "agents", label: t("nav.agents"), count: workspaceAgents.length, show: workspaceAgents.length > 0 },
-    { id: "schedules", label: t("scheduler.schedules", { defaultValue: "Schedules" }), count: cronJobs.length, show: isActive && !!agentId },
+    { id: "schedules", label: t("hands.tab_schedules"), count: cronJobs.length, show: isActive && !!agentId },
     { id: "settings", label: t("hands.settings"), count: settings.settings?.length, show: true },
     { id: "requirements", label: t("hands.requirements"), count: hand.requirements?.length, show: !!(hand.requirements && hand.requirements.length > 0) },
     { id: "tools", label: t("hands.tools"), count: hand.tools?.length, show: !!(hand.tools && hand.tools.length > 0) },
@@ -708,16 +708,18 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
 
   return (
     <div>
-      {/* Tab bar */}
-      <div className="flex gap-0.5 border-b border-border-subtle mb-4 overflow-x-auto scrollbar-thin">
+      {/* Tab bar — underline uses a 2px bottom border that overlaps the container's border-b */}
+      <div className="flex border-b border-border-subtle mb-4 overflow-x-auto scrollbar-thin">
         {visibleTabs.map(tab => {
           const isActive = activeTab === tab.id;
           return (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`relative flex items-center gap-1.5 px-3 py-2.5 text-xs font-bold whitespace-nowrap transition-colors ${
-                isActive ? "text-brand" : "text-text-dim/60 hover:text-text"
+              className={`flex items-center gap-1.5 h-10 px-3 -mb-px border-b-2 text-xs font-bold whitespace-nowrap transition-colors ${
+                isActive
+                  ? "border-brand text-brand"
+                  : "border-transparent text-text-dim/60 hover:text-text"
               }`}
             >
               {tab.label}
@@ -729,9 +731,6 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
                 >
                   {tab.count}
                 </span>
-              )}
-              {isActive && (
-                <span className="absolute -bottom-px left-0 right-0 h-0.5 bg-brand rounded-full" />
               )}
             </button>
           );


### PR DESCRIPTION
## Summary

Three issues reported on the tab bar inside the Hands detail modal after #2053 shipped:

1. **Underline looked wrong** — the active tab's indicator was an absolutely-positioned \`<span>\` at \`bottom: -1px\` with \`h-0.5\`, which floated a couple pixels above the container's \`border-b\` instead of fusing with it. Rendered as a short line slicing through the bottom of the label.
2. **Tab heights jumped** — tabs with a count pill (\`h-[18px]\`) were 2px taller than tabs without, so the whole bar shifted when switching tabs.
3. **Mistranslated Schedules label** — the tab used \`scheduler.schedules\` as its label, but that i18n key is a **counter suffix** ('个调度' / lowercase 'schedules') meant to be concatenated after a number ('3 schedules'). Shown standalone in Chinese it read as *'个调度'* which is gibberish.

## Changes

- Each tab button now has a fixed \`h-10\` plus \`border-b-2\` (transparent for inactive, brand for active) with \`-mb-px\` so the active border overlaps the container's \`border-b\`. Consistent height, clean underline fused with the baseline, no absolute positioning.
- Add dedicated \`hands.tab_schedules\` i18n key ('Schedules' / '定时任务') and switch the tab to use it.

## Test plan

- [x] \`tsc --noEmit\` passes
- [x] \`vite build\` succeeds
- [ ] Open detail modal → all tabs are same height regardless of count pill
- [ ] Click through tabs → underline sits on the baseline, no jump
- [ ] Chinese locale → Schedules tab reads *'定时任务'* instead of *'个调度'*