### PR TITLE
fix(dashboard): remove count pills from Hands detail tabs to guarantee equal height

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -708,7 +708,7 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
 
   return (
     <div>
-      {/* Tab bar — underline uses a 2px bottom border that overlaps the container's border-b */}
+      {/* Tab bar — all children are text-only so height is determined purely by padding + line-height */}
       <div className="flex border-b border-border-subtle mb-4 overflow-x-auto scrollbar-thin">
         {visibleTabs.map(tab => {
           const isActive = activeTab === tab.id;
@@ -716,19 +716,15 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery, stats, 
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-1.5 h-10 px-3 -mb-px border-b-2 text-xs font-bold whitespace-nowrap transition-colors ${
+              className={`shrink-0 flex items-baseline gap-1.5 px-3 py-3 -mb-px border-b-2 text-xs font-bold leading-none whitespace-nowrap transition-colors ${
                 isActive
                   ? "border-brand text-brand"
                   : "border-transparent text-text-dim/60 hover:text-text"
               }`}
             >
-              {tab.label}
+              <span>{tab.label}</span>
               {tab.count !== undefined && tab.count > 0 && (
-                <span
-                  className={`inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-md text-[10px] font-black ${
-                    isActive ? "bg-brand/15 text-brand" : "bg-main text-text-dim/60"
-                  }`}
-                >
+                <span className={`text-[10px] font-black tabular-nums ${isActive ? "text-brand/70" : "text-text-dim/40"}`}>
                   {tab.count}
                 </span>
               )}


### PR DESCRIPTION
## Summary

Follow-up to #2055. That fix set \`h-10\` on all tab buttons to force a uniform height, but tab heights were still reported as uneven in practice.

The most likely culprit: the 18px count pills inside each button render with a different baseline than plain text. \`flex items-center\` averages this out, but \"same box height\" isn't the same as \"same visual alignment\" — a tab with a pill and a tab without will show a subtle 1-2px offset, which reads as uneven heights in a dense tab bar.

## Fix

Drop the pill and render the count as inline numeric text, same font family as the label. Now every tab button's content is just text, with:

- \`leading-none\` so line-height = font-size exactly
- \`items-baseline\` so the label and count sit on the same baseline
- \`py-3\` giving deterministic vertical padding

Every tab button is exactly 38px tall: 12px text + 24px padding + 2px border. No flex magic, no explicit \`h-10\` needed.

Also adds \`shrink-0\` so Chinese labels can't compress under container width pressure.

## Test plan

- [x] \`tsc --noEmit\` passes
- [x] \`vite build\` succeeds
- [ ] Open detail modal → tab bar is perfectly uniform, no pixel jumps between tabs
- [ ] Counts still readable (just uncolored-pill text now)