### PR TITLE
fix(kernel): auto-wire self handle in streaming path for inter-agent tools

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3364,6 +3364,18 @@ system_prompt = "You are a helpful assistant."
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
     )> {
+        // Auto-wire the self kernel handle when the caller did not supply one.
+        // This mirrors the non-streaming `send_message()` path and is required
+        // for inter-agent tools (memory_store, memory_recall, agent_send, …) to
+        // work in streaming mode — channels like Telegram go through
+        // channel_bridge.rs which historically passes `None` here (#2058).
+        let kernel_handle = kernel_handle.or_else(|| {
+            self.self_handle
+                .get()
+                .and_then(|w| w.upgrade())
+                .map(|arc| arc as Arc<dyn KernelHandle>)
+        });
+
         // Try to acquire config reload barrier (non-blocking — this is a sync fn).
         // If a reload is in progress we proceed without the guard.
         let _config_guard = self.config_reload_lock.try_read();


### PR DESCRIPTION
## Summary

Fixes #2058. In streaming mode, inter-agent tools like `memory_store` / `memory_recall` were failing with:

```
Tool 'memory_store' failed: Error: Kernel handle not available. Inter-agent tools require a running kernel.
```

## Root Cause

`channel_bridge.rs::KernelBridgeAdapter::send_message_streaming_with_sender` calls the kernel with `None` for the kernel handle:

```rust
self.kernel.send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender).await
//                                                                              ^^^^ kernel_handle = None
```

That `None` flows all the way through `run_agent_loop_streaming` → `tool_runner::execute_tool` → `tool_memory_store(..., kernel=None, ...)` → `require_kernel(None)` → returns the "Kernel handle not available" error.

The **non-streaming** sibling methods (`send_message`, `send_message_with_sender_context`, `send_message_with_blocks`, `send_message_with_blocks_and_sender`) all auto-wire the kernel handle from `self_handle` when the caller passes None — so the non-streaming path has worked correctly all along. Only the streaming path was missing this.

The bug became user-visible with #2015 (per-peer memory scoping) because that PR made `memory_store` / `memory_recall` / `memory_list` commonly exercised from streaming Telegram agents, but the underlying defect has existed since the streaming entry points were added. Other KernelHandle-dependent tools (`agent_send`, `agent_spawn`, `task_*`, `event_publish`, `schedule_*`, `knowledge_*`, `cron_*`) were equally affected in streaming mode.

## Fix

In the single private dispatcher `send_message_streaming_with_sender` (kernel.rs:3357), upgrade `self_handle` when `kernel_handle.is_none()`:

```rust
let kernel_handle = kernel_handle.or_else(|| {
    self.self_handle
        .get()
        .and_then(|w| w.upgrade())
        .map(|arc| arc as Arc<dyn KernelHandle>)
});
```

This mirrors the pattern already used in `send_message()` and friends. Because every streaming entry point flows through this one private dispatcher, a single edit fixes all callers: channel_bridge, TUI event loop, ws handler, openai_compat, and `/api/agents/:id/message` streaming route.

No behaviour change for callers that already pass `Some(kernel_handle)` — the `or_else` only fires when the caller supplied None.

## Test plan

Automated:
- [x] `cargo build --workspace --lib` — compiles
- [x] `cargo clippy --package librefang-kernel --lib -- -D warnings` — clean
- [x] `cargo test --package librefang-kernel` — 392 unit tests + 4 workflow + 8 wasm integration tests all pass

Manual (recommended before merge):
- [ ] Configure a Telegram agent with `dmScope = per-channel-peer` and `memory_store` + `memory_recall` in `[capabilities] tools`
- [ ] Send a message via Telegram that causes the agent to call `memory_store` — verify it returns success, not "Kernel handle not available"
- [ ] Send a follow-up message and ask the agent to `memory_recall` the value — verify it comes back peer-scoped
- [ ] Verify the same agent still works via the non-streaming `/api/agents/:id/message` path (shouldn't have regressed)

Closes #2058