### PR TITLE
fix(memory): scope per-turn recall by peer_id to stop cross-user leaks

### DIFF
--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -1163,6 +1163,62 @@ mod tests {
     }
 
     #[test]
+    fn test_recall_with_peer_filter_isolates_users() {
+        // Regression for per-peer memory isolation (#2058 follow-up).
+        // Two users A and B share an agent; recalling with peer_id=Some("A")
+        // must not return B's memories.
+        let store = setup();
+        let agent_id = AgentId::new();
+        let _ = store
+            .remember_with_embedding_and_peer(
+                agent_id,
+                "Alice likes dark roast coffee",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+                None,
+                None,
+                None,
+                Default::default(),
+                Some("user-A"),
+            )
+            .unwrap();
+        let _ = store
+            .remember_with_embedding_and_peer(
+                agent_id,
+                "Bob likes dark roast coffee",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+                None,
+                None,
+                None,
+                Default::default(),
+                Some("user-B"),
+            )
+            .unwrap();
+
+        // Query as user A — should only see Alice's memory.
+        let mut f = MemoryFilter::agent(agent_id);
+        f.peer_id = Some("user-A".into());
+        let results = store.recall("coffee", 10, Some(f)).unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "user-A must not see user-B's memory, got: {:?}",
+            results.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+        assert!(results[0].content.starts_with("Alice"));
+
+        // Query as user B — should only see Bob's memory.
+        let mut f = MemoryFilter::agent(agent_id);
+        f.peer_id = Some("user-B".into());
+        let results = store.recall("coffee", 10, Some(f)).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].content.starts_with("Bob"));
+    }
+
+    #[test]
     fn test_forget() {
         let store = setup();
         let agent_id = AgentId::new();

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -539,9 +539,10 @@ pub async fn run_agent_loop(
 
     // Recall relevant memories — use context engine if available, else fallback to inline logic.
     // In stable_prefix_mode, skip memory recall to keep the system prompt prefix stable for caching.
+    // Scope recall to the current peer so multi-user channels don't leak context across users.
     let mut memories = if let Some(engine) = context_engine {
         engine
-            .ingest(session.agent_id, user_message)
+            .ingest(session.agent_id, user_message, sender_user_id.as_deref())
             .await
             .map(|r| r.recalled_memories)
             .unwrap_or_default()
@@ -557,6 +558,7 @@ pub async fn run_agent_loop(
                         5,
                         Some(MemoryFilter {
                             agent_id: Some(session.agent_id),
+                            peer_id: sender_user_id.clone(),
                             ..Default::default()
                         }),
                         Some(&query_vec),
@@ -572,6 +574,7 @@ pub async fn run_agent_loop(
                         5,
                         Some(MemoryFilter {
                             agent_id: Some(session.agent_id),
+                            peer_id: sender_user_id.clone(),
                             ..Default::default()
                         }),
                     )
@@ -586,6 +589,7 @@ pub async fn run_agent_loop(
                 5,
                 Some(MemoryFilter {
                     agent_id: Some(session.agent_id),
+                    peer_id: sender_user_id.clone(),
                     ..Default::default()
                 }),
             )
@@ -2075,9 +2079,10 @@ pub async fn run_agent_loop_streaming(
 
     // Recall relevant memories — use context engine if available, else fallback to inline logic.
     // In stable_prefix_mode, skip memory recall to keep the system prompt prefix stable for caching.
+    // Scope recall to the current peer so multi-user channels don't leak context across users.
     let mut memories = if let Some(engine) = context_engine {
         engine
-            .ingest(session.agent_id, user_message)
+            .ingest(session.agent_id, user_message, sender_user_id.as_deref())
             .await
             .map(|r| r.recalled_memories)
             .unwrap_or_default()
@@ -2093,6 +2098,7 @@ pub async fn run_agent_loop_streaming(
                         5,
                         Some(MemoryFilter {
                             agent_id: Some(session.agent_id),
+                            peer_id: sender_user_id.clone(),
                             ..Default::default()
                         }),
                         Some(&query_vec),
@@ -2108,6 +2114,7 @@ pub async fn run_agent_loop_streaming(
                         5,
                         Some(MemoryFilter {
                             agent_id: Some(session.agent_id),
+                            peer_id: sender_user_id.clone(),
                             ..Default::default()
                         }),
                     )
@@ -2122,6 +2129,7 @@ pub async fn run_agent_loop_streaming(
                 5,
                 Some(MemoryFilter {
                     agent_id: Some(session.agent_id),
+                    peer_id: sender_user_id.clone(),
                     ..Default::default()
                 }),
             )

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -110,7 +110,16 @@ pub trait ContextEngine: Send + Sync {
     /// Use this to index the message, recall relevant memories, or
     /// update internal state. Returns recalled memories that the
     /// agent loop injects into the system prompt.
-    async fn ingest(&self, agent_id: AgentId, user_message: &str) -> LibreFangResult<IngestResult>;
+    ///
+    /// `peer_id` is the sender's platform user ID when the message arrived
+    /// from a channel (Telegram, Discord, …) — implementors MUST scope
+    /// memory recall to this peer to prevent cross-user context leaks.
+    async fn ingest(
+        &self,
+        agent_id: AgentId,
+        user_message: &str,
+        peer_id: Option<&str>,
+    ) -> LibreFangResult<IngestResult>;
 
     /// Called before each LLM call to assemble the context window.
     ///
@@ -243,7 +252,12 @@ impl ContextEngine for DefaultContextEngine {
         Ok(())
     }
 
-    async fn ingest(&self, agent_id: AgentId, user_message: &str) -> LibreFangResult<IngestResult> {
+    async fn ingest(
+        &self,
+        agent_id: AgentId,
+        user_message: &str,
+        peer_id: Option<&str>,
+    ) -> LibreFangResult<IngestResult> {
         // In stable_prefix_mode, skip memory recall to keep system prompt stable for caching.
         if self.config.stable_prefix_mode {
             return Ok(IngestResult {
@@ -253,6 +267,7 @@ impl ContextEngine for DefaultContextEngine {
 
         let filter = Some(MemoryFilter {
             agent_id: Some(agent_id),
+            peer_id: peer_id.map(String::from),
             ..Default::default()
         });
         let limit = self.config.max_recall_results;
@@ -482,7 +497,12 @@ impl ContextEngine for ScriptableContextEngine {
         self.inner.bootstrap(config).await
     }
 
-    async fn ingest(&self, agent_id: AgentId, user_message: &str) -> LibreFangResult<IngestResult> {
+    async fn ingest(
+        &self,
+        agent_id: AgentId,
+        user_message: &str,
+        peer_id: Option<&str>,
+    ) -> LibreFangResult<IngestResult> {
         // In stable_prefix_mode, skip all recall (including hooks) to keep prompt stable
         if self.inner.config.stable_prefix_mode {
             return Ok(IngestResult {
@@ -492,17 +512,18 @@ impl ContextEngine for ScriptableContextEngine {
 
         // If no ingest script, delegate entirely to default engine
         let Some(ref script) = self.ingest_script else {
-            return self.inner.ingest(agent_id, user_message).await;
+            return self.inner.ingest(agent_id, user_message, peer_id).await;
         };
 
         // Run default recall first (for embedding-based memories)
-        let default_result = self.inner.ingest(agent_id, user_message).await?;
+        let default_result = self.inner.ingest(agent_id, user_message, peer_id).await?;
 
         // Run the Python hook for additional/custom recall
         let input = serde_json::json!({
             "type": "ingest",
             "agent_id": agent_id.0.to_string(),
             "message": user_message,
+            "peer_id": peer_id,
         });
 
         match Self::run_hook(script, input).await {
@@ -827,7 +848,7 @@ mod tests {
             ..Default::default()
         };
         let engine = DefaultContextEngine::new(config, make_memory(), None);
-        let result = engine.ingest(AgentId::new(), "hello").await.unwrap();
+        let result = engine.ingest(AgentId::new(), "hello", None).await.unwrap();
         assert!(result.recalled_memories.is_empty());
     }
 
@@ -860,7 +881,7 @@ mod tests {
 
         let config = ContextEngineConfig::default();
         let engine = DefaultContextEngine::new(config, memory, None);
-        let result = engine.ingest(agent_id, "Rust").await.unwrap();
+        let result = engine.ingest(agent_id, "Rust", None).await.unwrap();
         assert_eq!(result.recalled_memories.len(), 1);
         assert!(result.recalled_memories[0].content.contains("Rust"));
     }

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -1,19 +1,16 @@
 //! Proactive Memory integration for the runtime.
 //!
-//! This module provides:
-//! - `init_proactive_memory`: Create a ProactiveMemoryStore for the kernel
-//! - `build_prompt_context_with_memory`: Format retrieved memories for prompt injection
-//!
-//! The actual auto_retrieve and auto_memorize calls happen directly in `agent_loop.rs`
-//! rather than through fire-and-forget hooks, ensuring results are properly consumed.
+//! Provides `init_proactive_memory` to create a `ProactiveMemoryStore` for the
+//! kernel. The actual `auto_retrieve` and `auto_memorize` calls happen directly
+//! in `agent_loop.rs` rather than through fire-and-forget hooks, ensuring
+//! results are properly consumed and peer-scoped.
 
-use librefang_memory::{ProactiveMemoryConfig, ProactiveMemoryHooks, ProactiveMemoryStore};
+use librefang_memory::{ProactiveMemoryConfig, ProactiveMemoryStore};
 use librefang_types::error::LibreFangError;
 use librefang_types::memory::{
     ExtractionResult, MemoryAction, MemoryExtractor, MemoryFragment, MemoryItem, MemoryLevel,
 };
 use std::sync::Arc;
-use tracing::warn;
 
 // ---------------------------------------------------------------------------
 // EmbeddingDriver → EmbeddingFn bridge
@@ -30,28 +27,6 @@ impl librefang_memory::proactive::EmbeddingFn for EmbeddingBridge {
             .embed_one(text)
             .await
             .map_err(|e| LibreFangError::Internal(format!("Embedding failed: {e}")))
-    }
-}
-
-/// Build a context string with proactive memory for prompt injection.
-///
-/// Includes both semantic memory matches and relevant knowledge graph relations.
-pub async fn build_prompt_context_with_memory(
-    memory: &ProactiveMemoryStore,
-    user_id: &str,
-    user_message: &str,
-) -> Option<String> {
-    let result: Result<Vec<librefang_memory::MemoryItem>, LibreFangError> =
-        memory.auto_retrieve(user_id, user_message, None).await;
-    match result {
-        Ok(memories) if !memories.is_empty() => {
-            Some(memory.format_context_with_query(&memories, user_message))
-        }
-        Ok(_) => None,
-        Err(e) => {
-            warn!("Failed to retrieve proactive memories: {}", e);
-            None
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the per-peer memory isolation shipped in #2015. That PR threaded `peer_id` through `auto_memorize`/`auto_retrieve`, but **missed the per-turn recall path** that fires in every agent loop iteration (both streaming and non-streaming). That recall built `MemoryFilter` with `peer_id: None`, so the SQL in `semantic.rs` did **not** add an `AND peer_id = ?` clause and returned every user's memories for the agent — which then got merged into the prompt.

### Concrete leak (confirmed)

1. User A sends a Telegram message → `sender_user_id = \"A\"`
2. `agent_loop.rs` inline recall at line 558 / 2094 runs with `MemoryFilter { agent_id: …, ..Default::default() }` → `peer_id: None` → SQL returns **all peers' memories** including User B's
3. `auto_retrieve` (correctly scoped) returns only A's memories
4. `memories.extend(pm_fragments)` merges both → A's prompt now contains B's facts

This is a cross-user data exfil, not just admin visibility. Any multi-user Telegram/Discord deployment that stored memories via `auto_memorize` was leaking.

## Fix

- **ContextEngine trait**: `ingest()` now takes `peer_id: Option<&str>`. `DefaultContextEngine` threads it into its `MemoryFilter`; `ScriptableContextEngine` forwards it to both the inner engine and the Python hook input JSON.
- **agent_loop.rs**: all 6 inline recall sites (3 streaming + 3 non-streaming; embedding / text-fallback / no-embedding variants each) now set `MemoryFilter.peer_id = sender_user_id.clone()`. `sender_user_id` was already extracted from `manifest.metadata` a few lines above for the auto_retrieve path — same value, just threaded through the one place it was missed.
- **Dead code removal**: `build_prompt_context_with_memory` in `proactive_memory.rs` had zero callers, hardcoded `peer_id: None`, and was a landmine for future use. Deleted.
- **Regression test**: `semantic::tests::test_recall_with_peer_filter_isolates_users` — inserts memories for peer A and peer B under the same agent, asserts that recall with `peer_id = Some(\"user-A\")` returns exactly A's memory and recall with `peer_id = Some(\"user-B\")` returns exactly B's.

## Scope note

This fixes **cross-user leak** between channel users with distinct `sender_user_id`. It does **not** change the behaviour of `peer_id=None` queries (admin/CLI/API with no sender context still see all memories — that's a separate admin-visibility discussion, tracked separately). Internal queries that intentionally span peers (consolidate, evict, count) also still work because they build `MemoryFilter` with `peer_id: None` on purpose.

## Test plan

Automated (all passing locally):
- [x] `cargo build --workspace --lib` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --lib` — 3268 tests pass, incl. the new regression test
- [x] New test `semantic::tests::test_recall_with_peer_filter_isolates_users` demonstrates the fix

Manual (recommended before merge):
- [ ] Two Telegram users A and B talk to the same agent over several turns each (so `auto_memorize` stores a few facts per user)
- [ ] Verify agent response to A does **not** reference B's facts, and vice versa
- [ ] Verify the single-user case still works — A's earlier facts still show up in A's later turns

Related: #2058 (streaming `memory_store` regression, fixed separately in #2061).