### PR TITLE
release: v2026.4.5-beta14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.5] - 2026-04-05
+
+### Added
+
+- Add inline tool use display to chat UI (#2031) (@neo-wanderer)
+- Support username and @username in allowed_users filter (#2036) (@leszek3737)
+- Add alibaba coding plan as provider (#2040) (@joshuachong)
+- Add hidden models — hide/unhide models from selectors (#2045) (@leszek3737)
+- HITL notification engine, batch ops, modify-and-retry, audit log (#2046) (@houko)
+- Add media generation page (#2051) (@houko)
+- Redesign Hands page with running strip and richer cards (#2052) (@houko)
+- Redesign Hands detail modal with hero, action bar, metrics strip (#2053) (@houko)
+- Polish Hands list — grid skeleton, empty states, degraded (#2054) (@houko)
+- Per-channel command policy for public-facing bots (#2063) (@houko)
+
+### Fixed
+
+- Stop embedding dashboard artifacts in release commits (#2039) (@houko)
+- Remove tracked static/react/ build artifacts from git (#2041) (@houko)
+- Trigger dashboard build on release publish (#2043) (@houko)
+- Strip provider prefix from agent fallback_models (#2047) (@houko)
+- Ensure static/react dir exists for include_dir! (#2048) (@houko)
+- Defer WebSocket close until connection is established (#2050) (@houko)
+- Hands detail modal tab bar height, underline, and schedules label (#2055) (@houko)
+- Remove count pills from Hands detail tabs to guarantee equal height (#2056) (@houko)
+- Auto-wire self handle in streaming path for inter-agent tools (#2061) (@houko)
+- Scope per-turn recall by peer_id to stop cross-user leaks (#2062) (@houko)
+
+### Documentation
+
+- Update dashboard build references after static/react removal (#2042) (@houko)
+- Clarify routing lives in agent manifest, not config.toml (#2060) (@houko)
+
+### Maintenance
+
+- Fix 20 pre-existing TypeScript errors (#2049) (@houko)
+
+
 ## [2026.4.4] - 2026-04-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "aes",
  "async-trait",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "async-trait",
  "axum",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10593,7 +10593,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32053",
+  "version": "26.4.32064",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.4-beta13",
+  "version": "2026.4.5-beta14",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.4-beta13",
+  "version": "2026.4.5-beta14",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.4b13",
+    version="2026.4.5b14",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.4-beta13"
+version = "2026.4.5-beta14"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.5-beta14 -->
## Release v2026.4.5-beta14

### Added

- Add inline tool use display to chat UI (#2031) (@neo-wanderer)
- Support username and @username in allowed_users filter (#2036) (@leszek3737)
- Add alibaba coding plan as provider (#2040) (@joshuachong)
- Add hidden models — hide/unhide models from selectors (#2045) (@leszek3737)
- HITL notification engine, batch ops, modify-and-retry, audit log (#2046) (@houko)
- Add media generation page (#2051) (@houko)
- Redesign Hands page with running strip and richer cards (#2052) (@houko)
- Redesign Hands detail modal with hero, action bar, metrics strip (#2053) (@houko)
- Polish Hands list — grid skeleton, empty states, degraded (#2054) (@houko)
- Per-channel command policy for public-facing bots (#2063) (@houko)

### Fixed

- Stop embedding dashboard artifacts in release commits (#2039) (@houko)
- Remove tracked static/react/ build artifacts from git (#2041) (@houko)
- Trigger dashboard build on release publish (#2043) (@houko)
- Strip provider prefix from agent fallback_models (#2047) (@houko)
- Ensure static/react dir exists for include_dir! (#2048) (@houko)
- Defer WebSocket close until connection is established (#2050) (@houko)
- Hands detail modal tab bar height, underline, and schedules label (#2055) (@houko)
- Remove count pills from Hands detail tabs to guarantee equal height (#2056) (@houko)
- Auto-wire self handle in streaming path for inter-agent tools (#2061) (@houko)
- Scope per-turn recall by peer_id to stop cross-user leaks (#2062) (@houko)

### Documentation

- Update dashboard build references after static/react removal (#2042) (@houko)
- Clarify routing lives in agent manifest, not config.toml (#2060) (@houko)

### Maintenance

- Fix 20 pre-existing TypeScript errors (#2049) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.4-beta13...v2026.4.5-beta14