### PR TITLE
fix(runtime,kernel): stop stale messages_before index from breaking auto_memorize & append_canonical

### DIFF
--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -39,6 +39,7 @@ pub enum BackendRef {
 // ── AppEvent ────────────────────────────────────────────────────────────────
 
 /// Unified application event.
+#[allow(clippy::large_enum_variant)] // AgentLoopResult is inherently large
 pub enum AppEvent {
     /// A crossterm key press event (filtered to Press only).
     Key(KeyEvent),
@@ -448,6 +449,8 @@ pub fn spawn_daemon_stream(
             provider_not_configured: false,
             experiment_context: None,
             latency_ms: 0,
+            // TUI doesn't use the session-slice index; N/A.
+            new_messages_start: 0,
         })));
     });
 }
@@ -492,6 +495,8 @@ fn daemon_fallback(
             provider_not_configured: false,
             experiment_context: None,
             latency_ms: 0,
+            // TUI doesn't use the session-slice index; N/A.
+            new_messages_start: 0,
         })
     } else {
         Err(body["error"]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3709,7 +3709,6 @@ system_prompt = "You are a helpful assistant."
                 }
             }
 
-            let messages_before = session.messages.len();
             let mut skill_snapshot = kernel_clone
                 .skill_registry
                 .read()
@@ -3799,9 +3798,13 @@ system_prompt = "You are a helpful assistant."
 
             match result {
                 Ok(result) => {
-                    // Append new messages to canonical session for cross-channel memory
-                    if session.messages.len() > messages_before {
-                        let new_messages = session.messages[messages_before..].to_vec();
+                    // Append new messages to canonical session for cross-channel memory.
+                    // Use run_agent_loop_streaming's own start index (post-trim) instead
+                    // of one captured here — the loop may trim session history and make
+                    // a locally-captured index stale (see #2067). Clamp defensively.
+                    let start = result.new_messages_start.min(session.messages.len());
+                    if start < session.messages.len() {
+                        let new_messages = session.messages[start..].to_vec();
                         if let Err(e) = memory.append_canonical(agent_id, &new_messages, None) {
                             warn!(agent_id = %agent_id, "Failed to update canonical session (streaming): {e}");
                         }
@@ -4008,6 +4011,8 @@ system_prompt = "You are a helpful assistant."
             provider_not_configured: false,
             experiment_context: None,
             latency_ms: 0,
+            // WASM agents don't mutate the session; N/A.
+            new_messages_start: 0,
         })
     }
 
@@ -4076,6 +4081,8 @@ system_prompt = "You are a helpful assistant."
             provider_not_configured: false,
             experiment_context: None,
             latency_ms: 0,
+            // Python agents don't mutate the session; N/A.
+            new_messages_start: 0,
         })
     }
 
@@ -4453,8 +4460,6 @@ system_prompt = "You are a helpful assistant."
                 label: None,
             });
 
-        let messages_before = session.messages.len();
-
         let tools = self.available_tools(agent_id);
         let tools = entry.mode.filter_tools((*tools).clone());
 
@@ -4822,9 +4827,13 @@ system_prompt = "You are a helpful assistant."
 
         let latency_ms = start_time.elapsed().as_millis() as u64;
 
-        // Append new messages to canonical session for cross-channel memory
-        if session.messages.len() > messages_before {
-            let new_messages = session.messages[messages_before..].to_vec();
+        // Append new messages to canonical session for cross-channel memory.
+        // Use run_agent_loop's own start index (post-trim) instead of one
+        // captured here — the loop may trim session history and make a
+        // locally-captured index stale (see #2067). Clamp defensively.
+        let start = result.new_messages_start.min(session.messages.len());
+        if start < session.messages.len() {
+            let new_messages = session.messages[start..].to_vec();
             if let Err(e) = self.memory.append_canonical(agent_id, &new_messages, None) {
                 warn!("Failed to update canonical session: {e}");
             }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -356,6 +356,12 @@ pub struct AgentLoopResult {
     pub experiment_context: Option<ExperimentContext>,
     /// Latency in milliseconds for this request.
     pub latency_ms: u64,
+    /// Index in `session.messages` where messages appended during this turn
+    /// begin. Callers use this to slice out the turn's new messages (e.g. for
+    /// writing to a canonical cross-channel session) without tracking their
+    /// own index — which would go stale if the loop trims session history.
+    /// Always in range [0, session.messages.len()] after the loop returns.
+    pub new_messages_start: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -484,11 +490,20 @@ pub async fn run_agent_loop(
 ) -> LibreFangResult<AgentLoopResult> {
     info!(agent = %manifest.name, "Starting agent loop");
 
+    // Start index of new messages added during this turn. Initialized to
+    // current session length so early returns (before the user message is
+    // pushed) expose an empty slice to callers. Updated after
+    // safe_trim_messages to point at the post-trim position of the just-
+    // pushed user message (len-1) so slicing stays in-bounds even when the
+    // trim drains deeper than (len - MAX_HISTORY_MESSAGES). Fixes #2067.
+    let mut new_messages_start = session.messages.len();
+
     // Early return if driver is not configured
     if !driver.is_configured() {
         return Ok(AgentLoopResult {
             silent: true,
             provider_not_configured: true,
+            new_messages_start,
             ..Default::default()
         });
     }
@@ -810,12 +825,10 @@ pub async fn run_agent_loop(
         user_message,
     );
 
-    // Index of the user message just pushed, captured AFTER trim so the slice
-    // `session.messages[messages_before..]` stays in-bounds even when
-    // safe_trim_messages drained more than (len - MAX_HISTORY_MESSAGES) to
-    // land on a safe tool-pair boundary. The trim drains from the front and
+    // Update new_messages_start now that trim has run and the user message
+    // has been pushed. The trim drains only from the front and
     // find_safe_trim_point keeps len >= 1, so the user msg sits at len-1.
-    let messages_before = session.messages.len().saturating_sub(1);
+    new_messages_start = session.messages.len().saturating_sub(1);
 
     // Proactively strip base64 image data from previous turns.  Images that
     // survived from earlier sessions (e.g. after a crash or daemon restart)
@@ -1006,6 +1019,7 @@ pub async fn run_agent_loop(
                         provider_not_configured: false,
                         experiment_context: experiment_context.clone(),
                         latency_ms: 0,
+                        new_messages_start,
                     });
                 }
 
@@ -1188,7 +1202,7 @@ pub async fn run_agent_loop(
                 // Only send new messages from this turn, not the full session history.
                 if let Some(ref pm_store) = proactive_memory {
                     let user_id = session.agent_id.0.to_string();
-                    let new_messages = &session.messages[messages_before..];
+                    let new_messages = &session.messages[new_messages_start..];
                     let messages_json = serialize_session_messages(new_messages);
                     match pm_store
                         .auto_memorize(&user_id, &messages_json, sender_user_id.as_deref())
@@ -1239,6 +1253,7 @@ pub async fn run_agent_loop(
                     provider_not_configured: false,
                     experiment_context: experiment_context.clone(),
                     latency_ms: 0,
+                    new_messages_start,
                 });
             }
             StopReason::ToolUse => {
@@ -1688,6 +1703,7 @@ pub async fn run_agent_loop(
                         provider_not_configured: false,
                         experiment_context: experiment_context.clone(),
                         latency_ms: 0,
+                        new_messages_start,
                     });
                 }
                 // Model hit token limit — add partial response and continue
@@ -2006,6 +2022,11 @@ pub async fn run_agent_loop_streaming(
 ) -> LibreFangResult<AgentLoopResult> {
     info!(agent = %manifest.name, "Starting streaming agent loop");
 
+    // Start index of new messages added during this turn. See the matching
+    // comment in run_agent_loop for details. Initialized to the current
+    // session length, updated post-trim to len-1. Fixes #2067.
+    let mut new_messages_start = session.messages.len();
+
     // Skip streaming agent loop if no LLM provider is configured.
     if !driver.is_configured() {
         info!(agent = %manifest.name, "Skipping streaming agent loop — no LLM provider configured");
@@ -2013,6 +2034,7 @@ pub async fn run_agent_loop_streaming(
             silent: true,
             provider_not_configured: true,
             experiment_context: None,
+            new_messages_start,
             ..Default::default()
         });
     }
@@ -2333,12 +2355,9 @@ pub async fn run_agent_loop_streaming(
         user_message,
     );
 
-    // Index of the user message just pushed, captured AFTER trim so the slice
-    // `session.messages[messages_before..]` stays in-bounds even when
-    // safe_trim_messages drained more than (len - MAX_HISTORY_MESSAGES) to
-    // land on a safe tool-pair boundary. The trim drains from the front and
-    // find_safe_trim_point keeps len >= 1, so the user msg sits at len-1.
-    let messages_before = session.messages.len().saturating_sub(1);
+    // Update new_messages_start now that trim has run and the user message
+    // has been pushed. See iterative-path comment for details.
+    new_messages_start = session.messages.len().saturating_sub(1);
 
     // Proactively strip stale image data from previous turns (streaming path).
     strip_prior_image_data(&mut messages);
@@ -2579,6 +2598,7 @@ pub async fn run_agent_loop_streaming(
                         provider_not_configured: false,
                         experiment_context: experiment_context.clone(),
                         latency_ms: 0,
+                        new_messages_start,
                     });
                 }
 
@@ -2757,7 +2777,7 @@ pub async fn run_agent_loop_streaming(
                 // Only send new messages from this turn, not the full session history.
                 if let Some(ref pm_store) = proactive_memory {
                     let user_id = session.agent_id.0.to_string();
-                    let new_messages = &session.messages[messages_before..];
+                    let new_messages = &session.messages[new_messages_start..];
                     let messages_json = serialize_session_messages(new_messages);
                     match pm_store
                         .auto_memorize(&user_id, &messages_json, sender_user_id.as_deref())
@@ -2811,6 +2831,7 @@ pub async fn run_agent_loop_streaming(
                     provider_not_configured: false,
                     experiment_context,
                     latency_ms: 0,
+                    new_messages_start,
                 });
             }
             StopReason::ToolUse => {
@@ -3262,6 +3283,7 @@ pub async fn run_agent_loop_streaming(
                         provider_not_configured: false,
                         experiment_context: experiment_context.clone(),
                         latency_ms: 0,
+                        new_messages_start,
                     });
                 }
                 let text = response.text();
@@ -4093,13 +4115,16 @@ mod tests {
     /// agent_loop task panicked ("range start index 42 out of range for
     /// slice of length 36").
     ///
-    /// After the fix, `messages_before` is captured POST-trim as
+    /// After the fix, `new_messages_start` is captured POST-trim as
     /// `len.saturating_sub(1)`, pointing at the user message that was just
     /// pushed — which must always be the last message in the session because
     /// safe_trim_messages only drains from the front. This test pins both
     /// halves: it shows the OLD index would have been out of bounds for the
     /// trimmed session, AND that the NEW index yields a valid slice
-    /// containing exactly the just-pushed user message.
+    /// containing exactly the just-pushed user message. The same index is
+    /// exposed via `AgentLoopResult::new_messages_start` so kernel-side
+    /// callers (e.g. canonical-session append) don't need to track their own
+    /// stale index.
     #[test]
     fn test_safe_trim_leaves_user_message_sliceable_after_deep_trim() {
         // Build 42 messages where the tail forms tool-pair chains that
@@ -4169,14 +4194,28 @@ mod tests {
         // site: session is non-empty, the just-pushed user msg is the last
         // element, and slicing at len-1 yields exactly that one message.
         assert!(!session_messages.is_empty());
-        let messages_before = session_messages.len().saturating_sub(1);
-        let tail = &session_messages[messages_before..];
+        let new_messages_start = session_messages.len().saturating_sub(1);
+        let tail = &session_messages[new_messages_start..];
         assert_eq!(tail.len(), 1);
         assert_eq!(tail[0].role, Role::User);
         match &tail[0].content {
             MessageContent::Text(t) => assert_eq!(t, "current turn"),
             other => panic!("expected text user msg, got {other:?}"),
         }
+    }
+
+    /// Verifies that AgentLoopResult exposes a usable `new_messages_start`
+    /// by default so kernel-side callers can always rely on the field
+    /// existing without worrying about uninitialized state.
+    #[test]
+    fn test_agent_loop_result_new_messages_start_default_is_zero() {
+        let result = AgentLoopResult::default();
+        assert_eq!(result.new_messages_start, 0);
+        // Defensively clamping against an empty vec must yield an empty slice.
+        let empty: Vec<Message> = Vec::new();
+        let start = result.new_messages_start.min(empty.len());
+        assert_eq!(start, 0);
+        assert!(empty[start..].is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2067 and one related silent data-corruption bug found by broad-scanning the same stale-index pattern across the codebase.

### Bug 1: `agent_loop` panic (the reported issue)

`run_agent_loop` (and streaming twin) recorded `messages_before = session.messages.len()` **before** pushing the user message and **before** calling `safe_trim_messages`. When the session exceeded `MAX_HISTORY_MESSAGES = 40`, `safe_trim_messages` asked `find_safe_trim_point` for a safe cut — which scans forward past tool-pair boundaries and can trim **deeper** than `len - MAX_HISTORY_MESSAGES`. After that trim, `messages_before` was stale, and the downstream `auto_memorize` slice went out of range:

```
thread 'tokio-rt-worker' panicked at crates/librefang-runtime/src/agent_loop.rs:1169:57:
range start index 42 out of range for slice of length 36
```

### Bug 2: Silent `append_canonical` corruption in `kernel.rs`

`librefang-kernel` used the exact same stale-index pattern at two call sites. A guard (`if session.messages.len() > messages_before`) prevented the panic but masked a correctness bug:

- If `trim_depth > loop_appends`: guard is false, `append_canonical` is silently **skipped** — the turn never reaches the canonical cross-channel session.
- If `trim_depth <= loop_appends`: guard is true but the slice starts at a stale index, **mixing** surviving pre-turn messages in as "new" and **dropping** the leading messages of the turn from the canonical session.

### Fix

`AgentLoopResult` now carries `new_messages_start: usize`, set by the loop itself **after** `safe_trim_messages` runs. The trim only drains from the front and `find_safe_trim_point` keeps at least one message, so the user message we just pushed is always at `len-1`. The kernel uses `result.new_messages_start` instead of a locally-captured index, clamped to `session.messages.len()` defensively.

WASM and Python agent paths (which don't mutate the session) set the field to `0`; the canonical-append slice is a no-op for those. The CLI TUI `AppEvent` gets `#[allow(clippy::large_enum_variant)]` since the new `usize` pushed the already-large `AgentLoopResult` 8 bytes past clippy's default threshold.

### Regression test

`test_safe_trim_leaves_user_message_sliceable_after_deep_trim` builds a session whose tail is a run of `tool_use`/`tool_result` pairs, forcing `find_safe_trim_point` to overshoot the minimum trim depth, and pins:

1. The deep-trim scenario actually reproduces (`post_trim_len < old_messages_before`).
2. After the trim the just-pushed user message is sliceable at `len-1`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p librefang-runtime --lib` — 1189 passed (+1 new), 0 failed
- [x] `cargo test -p librefang-kernel --lib` — 392 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean