### PR TITLE
fix(api): providers.rs persistence failures + expect() panic

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -609,10 +609,15 @@ pub async fn add_custom_model(
         .into_json_tuple();
     }
 
-    // Persist to disk
+    // Persist to disk. If save fails, roll back the in-memory add so the
+    // catalog stays consistent with what's on disk — otherwise the caller
+    // sees "added" now but the model vanishes on the next daemon restart.
     let custom_path = state.kernel.home_dir().join("custom_models.json");
     if let Err(e) = catalog.save_custom_models(&custom_path) {
         tracing::warn!("Failed to persist custom models: {e}");
+        catalog.remove_custom_model(&id);
+        return ApiErrorResponse::internal(format!("Failed to persist custom model: {e}"))
+            .into_json_tuple();
     }
 
     (
@@ -637,6 +642,10 @@ pub async fn remove_custom_model(
         .write()
         .unwrap_or_else(|e| e.into_inner());
 
+    // Snapshot the entry before removing so we can restore it if the
+    // subsequent persist fails — keeps the in-memory catalog consistent
+    // with disk across failure paths.
+    let snapshot = catalog.find_model(&model_id).cloned();
     if !catalog.remove_custom_model(&model_id) {
         return ApiErrorResponse::not_found(format!("Custom model '{}' not found", model_id))
             .into_json_tuple();
@@ -645,6 +654,11 @@ pub async fn remove_custom_model(
     let custom_path = state.kernel.home_dir().join("custom_models.json");
     if let Err(e) = catalog.save_custom_models(&custom_path) {
         tracing::warn!("Failed to persist custom models: {e}");
+        if let Some(entry) = snapshot {
+            catalog.add_custom_model(entry);
+        }
+        return ApiErrorResponse::internal(format!("Failed to persist custom model: {e}"))
+            .into_json_tuple();
     }
 
     (
@@ -1011,10 +1025,18 @@ pub async fn test_provider(
 
     let start = std::time::Instant::now();
     let api_key_val = api_key.unwrap_or_default();
-    let client = librefang_runtime::http_client::proxied_client_builder()
+    let client = match librefang_runtime::http_client::proxied_client_builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
-        .expect("HTTP client build");
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return ApiErrorResponse::internal(format!(
+                "Failed to build HTTP client for provider test: {e}"
+            ))
+            .into_json_tuple();
+        }
+    };
 
     // ── Bedrock: AWS Signature auth — can't test with simple HTTP ──
     if name == "bedrock" || name == "aws-bedrock" {


### PR DESCRIPTION
## Problems

Three related defects in the custom-models and provider-test endpoints:

### 1. \`POST /api/models/custom\` — silent write failure

\`\`\`rust
if !catalog.add_custom_model(entry) { return Conflict; }
if let Err(e) = catalog.save_custom_models(&path) {
    tracing::warn!(\"Failed to persist custom models: {e}\");
}
return 201 Created;
\`\`\`

Caller saw **201 Created** while the on-disk \`custom_models.json\` didn't have the new entry — the model would vanish on the next daemon restart. Classic split-brain between in-memory and disk state.

### 2. \`DELETE /api/models/custom/{id}\` — same pattern

Same silent-failure shape: in-memory removed, disk write failed, caller told success.

### 3. \`POST /api/providers/{name}/test\` — \`.expect()\` panic

\`\`\`rust
.build().expect(\"HTTP client build\");
\`\`\`

Would panic if reqwest's builder failed (malformed \`HTTPS_PROXY\`, broken TLS config, etc). Axum catches panics, but the panic-per-request pattern is a bad look.

## Fix

**Add**: on save failure, roll back the in-memory add via \`remove_custom_model(id)\`, return 500 with the actual error.

**Delete**: snapshot the entry with \`find_model().cloned()\` *before* removing; if save fails, re-insert the snapshot and return 500. Catalog stays consistent with disk across failure paths.

**Test**: replace \`.expect()\` with a match that returns 500 via \`ApiErrorResponse::internal\` — same error surface as other failure paths in this handler.

## Context

Found by a code-scan subagent looking for silent write failures and panic sites in API handlers.

## Test plan

- [ ] Make \`save_custom_models\` fail (read-only filesystem) → add returns 500, model not in catalog afterward
- [ ] Same for delete → returns 500, model still in catalog
- [ ] Valid add/delete still work (regression)
- [ ] \`POST /api/providers/groq/test\` with broken proxy env → 500 instead of panic