### PR TITLE
fix(memory): surface silent DB errors and wrap merge updates in tx

### DIFF
--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -82,22 +82,29 @@ impl ConsolidationEngine {
                     let sim = text_similarity(&rows[i].1.to_lowercase(), &rows[j].1.to_lowercase());
                     if sim > 0.9 {
                         // Keep the one with higher confidence (rows are sorted desc),
-                        // so rows[i] is the keeper. Soft-delete rows[j].
-                        conn.execute(
+                        // so rows[i] is the keeper. Soft-delete rows[j] and, if the
+                        // absorbed memory had higher confidence somehow, lift the
+                        // keeper to that value. Wrap both writes in a savepoint so
+                        // we never leave a keeper un-updated after its duplicate
+                        // was already soft-deleted.
+                        let tx = conn
+                            .unchecked_transaction()
+                            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                        tx.execute(
                             "UPDATE memories SET deleted = 1 WHERE id = ?1",
                             rusqlite::params![rows[j].0],
                         )
                         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-                        // If the absorbed memory had higher confidence somehow,
-                        // update the keeper.
                         if rows[j].2 > rows[i].2 {
-                            conn.execute(
+                            tx.execute(
                                 "UPDATE memories SET confidence = ?1 WHERE id = ?2",
                                 rusqlite::params![rows[j].2, rows[i].0],
                             )
                             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                         }
+                        tx.commit()
+                            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
                         absorbed.insert(rows[j].0.clone());
                         memories_merged += 1;

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -16,7 +16,7 @@ use librefang_types::memory::{
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Semantic store backed by SQLite with optional vector search.
 ///
@@ -406,12 +406,17 @@ impl SemanticStore {
             );
         }
 
-        // Update access counts for returned memories
+        // Update access counts for returned memories. Logged on failure
+        // because the decay/consolidation engine keys TTL decisions off
+        // accessed_at — silently losing updates means "active" memories
+        // can be garbage-collected when they shouldn't be.
         for frag in &fragments {
-            let _ = conn.execute(
+            if let Err(e) = conn.execute(
                 "UPDATE memories SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2",
                 rusqlite::params![Utc::now().to_rfc3339(), frag.id.0.to_string()],
-            );
+            ) {
+                warn!(memory_id = %frag.id.0, error = %e, "Failed to update access tracking");
+            }
         }
 
         Ok(fragments)
@@ -452,16 +457,19 @@ impl SemanticStore {
             }
         }
 
-        // Update access counts
+        // Update access counts — see note on the SQLite-path update above
+        // for why silent drops would corrupt decay logic.
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         for frag in &fragments {
-            let _ = conn.execute(
+            if let Err(e) = conn.execute(
                 "UPDATE memories SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2",
                 rusqlite::params![Utc::now().to_rfc3339(), frag.id.0.to_string()],
-            );
+            ) {
+                warn!(memory_id = %frag.id.0, error = %e, "Failed to update access tracking");
+            }
         }
 
         Ok(fragments)

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use tracing::warn;
 
 /// Result from a full-text session search.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -190,16 +191,23 @@ impl SessionStore {
         let session_id_str = session.id.0.to_string();
         let agent_id_str = session.agent_id.0.to_string();
 
-        // Delete existing FTS entry, then insert fresh content.
-        let _ = conn.execute(
+        // Delete existing FTS entry, then insert fresh content. Log on
+        // failure — silently dropping these keeps orphan/stale rows in
+        // sessions_fts whose JOINs to the real sessions table return
+        // NULL, poisoning full-text search results.
+        if let Err(e) = conn.execute(
             "DELETE FROM sessions_fts WHERE session_id = ?1",
             rusqlite::params![session_id_str],
-        );
+        ) {
+            warn!(session_id = %session_id_str, error = %e, "Failed to clear FTS entry for session");
+        }
         if !content.is_empty() {
-            let _ = conn.execute(
+            if let Err(e) = conn.execute(
                 "INSERT INTO sessions_fts (session_id, agent_id, content) VALUES (?1, ?2, ?3)",
                 rusqlite::params![session_id_str, agent_id_str, content],
-            );
+            ) {
+                warn!(session_id = %session_id_str, error = %e, "Failed to insert FTS entry for session");
+            }
         }
 
         Ok(())
@@ -227,10 +235,12 @@ impl SessionStore {
             rusqlite::params![id_str],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        let _ = conn.execute(
+        if let Err(e) = conn.execute(
             "DELETE FROM sessions_fts WHERE session_id = ?1",
             rusqlite::params![id_str],
-        );
+        ) {
+            warn!(session_id = %id_str, error = %e, "Failed to delete FTS entry; orphan row left in sessions_fts");
+        }
         Ok(())
     }
 
@@ -246,10 +256,12 @@ impl SessionStore {
             rusqlite::params![agent_id_str],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        let _ = conn.execute(
+        if let Err(e) = conn.execute(
             "DELETE FROM sessions_fts WHERE agent_id = ?1",
             rusqlite::params![agent_id_str],
-        );
+        ) {
+            warn!(agent_id = %agent_id_str, error = %e, "Failed to delete FTS entries for agent; orphans left in sessions_fts");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Problems

Three silent-failure defects in the memory crate (outside substrate.rs, which was fixed in #2072):

### 1. \`semantic.rs\` — access tracking UPDATE dropped after every recall

\`\`\`rust
let _ = conn.execute(
    \"UPDATE memories SET access_count = access_count + 1, accessed_at = ?1 WHERE id = ?2\", ...
);
\`\`\`

Two sites (SQLite recall + VectorStore recall). The decay/consolidation engine uses \`accessed_at\` to decide what to garbage-collect. If these updates fail silently, **recently-read memories get purged as if unused**.

### 2. \`session.rs\` — FTS5 sync dropped on save and delete

Three sites (save_session, delete_session, delete_agent_sessions). If FTS DELETE fails while the main table DELETE succeeds, **orphan rows stay in \`sessions_fts\`** whose JOINs back to \`sessions\` return NULL, breaking full-text search results.

### 3. \`consolidation.rs\` — merge race: soft-delete without tx around keeper update

\`\`\`rust
conn.execute(\"UPDATE memories SET deleted = 1 WHERE id = ?1\", ...)?;   // duplicate gone
if rows[j].2 > rows[i].2 {
    conn.execute(\"UPDATE memories SET confidence = ?1 WHERE id = ?2\", ...)?;  // keeper lifted
}
\`\`\`

Two separate SQLite statements → two separate auto-commits. If the second UPDATE fails, the duplicate is already soft-deleted but the keeper never inherits its higher confidence. The higher-confidence value is **lost**.

## Fix

1. Log \`warn!\` on every UPDATE/DELETE failure (memory_id / session_id / agent_id + error). The caller's main operation still returns Ok because the primary write succeeded; we just surface the side-channel inconsistency.
2. Wrap the consolidation merge pair in \`conn.unchecked_transaction()\` + \`tx.commit()\` — same pattern used in \`prompt.rs\`.

## Context

Found by a code-scan subagent. Skipped one adjacent finding (\`structured.rs\` silent ALTER TABLE) — that's an intentional idempotent migration pattern that expects \"duplicate column\" errors as the normal case.

## Test plan

- [ ] Force access-UPDATE failure → warn logged, recall still returns fragments
- [ ] Force FTS DELETE failure → warn logged, main DELETE still commits
- [ ] Force consolidation merge's second UPDATE to fail → first UPDATE rolled back (duplicate survives), no orphan state
- [ ] Normal paths produce no extra warnings (regression)