### PR TITLE
fix(runtime): surface episodic memory persist failures in agent_loop

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1106,7 +1106,7 @@ pub async fn run_agent_loop(
                 if let Some(emb) = embedding_driver {
                     match emb.embed_one(&interaction_text).await {
                         Ok(vec) => {
-                            let _ = memory
+                            if let Err(e) = memory
                                 .remember_with_embedding_async(
                                     session.agent_id,
                                     &interaction_text,
@@ -1115,11 +1115,14 @@ pub async fn run_agent_loop(
                                     HashMap::new(),
                                     Some(&vec),
                                 )
-                                .await;
+                                .await
+                            {
+                                warn!("Failed to persist episodic memory (with embedding): {e}");
+                            }
                         }
                         Err(e) => {
                             warn!("Embedding for remember failed: {e}");
-                            let _ = memory
+                            if let Err(e2) = memory
                                 .remember(
                                     session.agent_id,
                                     &interaction_text,
@@ -1127,19 +1130,23 @@ pub async fn run_agent_loop(
                                     "episodic",
                                     HashMap::new(),
                                 )
-                                .await;
+                                .await
+                            {
+                                warn!("Failed to persist episodic memory (no embedding fallback): {e2}");
+                            }
                         }
                     }
-                } else {
-                    let _ = memory
-                        .remember(
-                            session.agent_id,
-                            &interaction_text,
-                            MemorySource::Conversation,
-                            "episodic",
-                            HashMap::new(),
-                        )
-                        .await;
+                } else if let Err(e) = memory
+                    .remember(
+                        session.agent_id,
+                        &interaction_text,
+                        MemorySource::Conversation,
+                        "episodic",
+                        HashMap::new(),
+                    )
+                    .await
+                {
+                    warn!("Failed to persist episodic memory: {e}");
                 }
 
                 // Context engine: after_turn hook
@@ -2492,7 +2499,12 @@ pub async fn run_agent_loop_streaming(
                          Any partial output was already sent to the user.]"
                     );
                     session.messages.push(Message::assistant(note));
-                    let _ = memory.save_session_async(session).await;
+                    if let Err(save_err) = memory.save_session_async(session).await {
+                        warn!(
+                            "Failed to persist timeout note to session: {save_err}. \
+                             The timeout marker will not appear on next session load."
+                        );
+                    }
                 }
                 return Err(e);
             }
@@ -2691,7 +2703,7 @@ pub async fn run_agent_loop_streaming(
                 if let Some(emb) = embedding_driver {
                     match emb.embed_one(&interaction_text).await {
                         Ok(vec) => {
-                            let _ = memory
+                            if let Err(e) = memory
                                 .remember_with_embedding_async(
                                     session.agent_id,
                                     &interaction_text,
@@ -2700,11 +2712,14 @@ pub async fn run_agent_loop_streaming(
                                     HashMap::new(),
                                     Some(&vec),
                                 )
-                                .await;
+                                .await
+                            {
+                                warn!("Failed to persist episodic memory (streaming, with embedding): {e}");
+                            }
                         }
                         Err(e) => {
                             warn!("Embedding for remember failed (streaming): {e}");
-                            let _ = memory
+                            if let Err(e2) = memory
                                 .remember(
                                     session.agent_id,
                                     &interaction_text,
@@ -2712,19 +2727,23 @@ pub async fn run_agent_loop_streaming(
                                     "episodic",
                                     HashMap::new(),
                                 )
-                                .await;
+                                .await
+                            {
+                                warn!("Failed to persist episodic memory (streaming, no embedding fallback): {e2}");
+                            }
                         }
                     }
-                } else {
-                    let _ = memory
-                        .remember(
-                            session.agent_id,
-                            &interaction_text,
-                            MemorySource::Conversation,
-                            "episodic",
-                            HashMap::new(),
-                        )
-                        .await;
+                } else if let Err(e) = memory
+                    .remember(
+                        session.agent_id,
+                        &interaction_text,
+                        MemorySource::Conversation,
+                        "episodic",
+                        HashMap::new(),
+                    )
+                    .await
+                {
+                    warn!("Failed to persist episodic memory (streaming): {e}");
                 }
 
                 // Context engine: after_turn hook


### PR DESCRIPTION
## Problem

Seven \`let _ = memory.{remember,remember_with_embedding_async,save_session_async}(...).await\` sites in \`agent_loop.rs\` silently dropped errors from the memory layer, causing **invisible data loss**.

| site | location | what's lost on failure |
|---|---|---|
| non-streaming final turn, with embedding | L1109 | whole turn's episodic memory |
| non-streaming final turn, embedding-failed fallback | L1122 | same |
| non-streaming final turn, no-embedding path | L1134 | same |
| streaming final turn, with embedding | L2694 (pre-patch L2701) | same |
| streaming final turn, embedding-failed fallback | L2707 (pre-patch L2714) | same |
| streaming final turn, no-embedding path | L2719 (pre-patch L2726) | same |
| streaming timeout note save | L2495 (pre-patch L2495) | the \"task timed out\" message that should appear on session reload |

The timeout case is the nastiest: when an LLM call times out, we push a system note (\"your previous task timed out while doing X\") into the session and try to persist it. If that save fails, the next load of the session doesn't show the timeout marker — it just looks like the session stopped mid-turn with no explanation.

## Fix

All seven now log a \`warn!\` with the DB error and enough context to identify which path failed (with-embedding vs fallback, streaming vs non-streaming, timeout vs normal). The loop still completes normally; only the side-effect persistence is surfaced.

## Context

Found by a code-scan subagent looking for silent-drop patterns in the runtime layer.

## Test plan

- [ ] Force DB failure during final-turn remember → warn logged, loop still returns response
- [ ] Force DB failure during streaming final-turn remember → same
- [ ] Force DB failure during timeout save → warn logged, error still propagates to caller
- [ ] Happy path produces no new log lines (regression)