### PR TITLE
fix(config): reload path must clamp bounds and clamp max_cron_jobs=0

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6427,11 +6427,18 @@ system_prompt = "You are a helpful assistant."
 
         // Read and parse config file (using load_config to process $include directives)
         let config_path = self.home_dir_boot.join("config.toml");
-        let new_config = if config_path.exists() {
+        let mut new_config = if config_path.exists() {
             crate::config::load_config(Some(&config_path))
         } else {
             return Err("Config file not found".to_string());
         };
+
+        // Clamp bounds on the new config before validating or applying.
+        // Initial boot calls clamp_bounds() at kernel construction time,
+        // so without this call the reload path would apply out-of-range
+        // values (e.g. max_cron_jobs=0, timeouts=0) that the initial
+        // startup path normally corrects.
+        new_config.clamp_bounds();
 
         // Validate new config
         if let Err(errors) = validate_config_for_reload(&new_config) {

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -725,5 +725,15 @@ impl KernelConfig {
         } else if self.triggers.max_workflow_secs > 86400 {
             self.triggers.max_workflow_secs = 86400;
         }
+
+        // max_cron_jobs: min 1 (0 silently disables all cron job creation —
+        // CronScheduler's limit check is `len >= max`, so 0 rejects every
+        // create). Max 10_000 matches the validation warning threshold.
+        // Clamp upward to the same default used by serde (500).
+        if self.max_cron_jobs == 0 {
+            self.max_cron_jobs = 500;
+        } else if self.max_cron_jobs > 10_000 {
+            self.max_cron_jobs = 10_000;
+        }
     }
 }


### PR DESCRIPTION
## Problem

Two linked defects in the config hot-reload path:

### 1. \`reload_config()\` skips \`clamp_bounds()\`

\`\`\`rust
let new_config = crate::config::load_config(Some(&config_path));  // no clamp
if let Err(errors) = validate_config_for_reload(&new_config) { ... }
\`\`\`

Initial kernel boot calls \`clamp_bounds()\` at \`kernel.rs:1502\`, which corrects zero timeouts, zero concurrency lanes, over-large browser session counts, etc. The reload path **doesn't call it**, so any out-of-range value the user writes in config.toml can silently reach the running kernel via hot-reload. Concrete bad states:
- \`browser.timeout_secs = 0\` → browser requests hang forever
- \`queue.concurrency.main_lane = 0\` → queue deadlocks
- \`web.fetch.timeout_secs = 0\` → web_fetch hangs

### 2. \`max_cron_jobs\` had no clamp at all

Validation only flagged \`> 10_000\` as a warning. \`max_cron_jobs = 0\` (typo, copy-paste, migration) passed both validation and clamp. Downstream, \`CronScheduler\`'s insert check is:
\`\`\`rust
if self.jobs.len() >= max_jobs { return Err(\"job limit reached\"); }
\`\`\`
With \`max = 0\` every job creation fails silently — users think they have no limit, get \"job limit reached\" on every create.

## Fix

- Call \`new_config.clamp_bounds()\` before \`validate_config_for_reload()\` in \`reload_config()\`.
- Add \`max_cron_jobs\` clamping to \`clamp_bounds\`: 0 → 500 (matches serde default), > 10_000 → 10_000 (matches validation threshold).

## Context

Found by a code-scan subagent looking for config validation gaps.

## Test plan

- [ ] Write \`max_cron_jobs = 0\` to config.toml, hot-reload → config loaded with 500
- [ ] Write \`browser.timeout_secs = 0\`, hot-reload → loaded with 30 (existing clamp)
- [ ] Write \`queue.concurrency.main_lane = 0\`, hot-reload → loaded with 1
- [ ] Normal valid config still applies unchanged (regression)