### PR TITLE
fix(runtime): guard sandbox ptr arithmetic with checked_add

### DIFF
--- a/crates/librefang-runtime/src/sandbox.rs
+++ b/crates/librefang-runtime/src/sandbox.rs
@@ -219,10 +219,14 @@ impl WasmSandbox {
             .call(&mut store, input_bytes.len() as i32)
             .map_err(|e| SandboxError::AbiError(format!("alloc call failed: {e}")))?;
 
-        // Write input into guest memory
+        // Write input into guest memory. Use checked_add so a malicious or
+        // buggy guest returning an out-of-range alloc pointer can't wrap
+        // the bounds check (reachable on 32-bit hosts, defensive on 64-bit).
         let mem_data = memory.data_mut(&mut store);
         let start = input_ptr as usize;
-        let end = start + input_bytes.len();
+        let end = start.checked_add(input_bytes.len()).ok_or_else(|| {
+            SandboxError::AbiError("Input pointer + length overflows usize".into())
+        })?;
         if end > mem_data.len() {
             return Err(SandboxError::AbiError("Input exceeds memory bounds".into()));
         }
@@ -251,14 +255,19 @@ impl WasmSandbox {
         let result_ptr = (packed >> 32) as usize;
         let result_len = (packed & 0xFFFF_FFFF) as usize;
 
-        // Read output JSON from guest memory
+        // Read output JSON from guest memory. checked_add so a malicious
+        // or buggy guest can't wrap `ptr + len` and silently pass the
+        // bounds check (reachable on 32-bit hosts; defensive on 64-bit).
         let mem_data = memory.data(&store);
-        if result_ptr + result_len > mem_data.len() {
+        let end = result_ptr.checked_add(result_len).ok_or_else(|| {
+            SandboxError::AbiError("Result pointer + length overflows usize".into())
+        })?;
+        if end > mem_data.len() {
             return Err(SandboxError::AbiError(
                 "Result pointer out of bounds".into(),
             ));
         }
-        let output_bytes = &mem_data[result_ptr..result_ptr + result_len];
+        let output_bytes = &mem_data[result_ptr..end];
 
         let output: serde_json::Value = serde_json::from_slice(output_bytes)
             .map_err(|e| SandboxError::AbiError(format!("Invalid JSON output from guest: {e}")))?;


### PR DESCRIPTION
## Problem

Two sites in \`sandbox.rs\` computed \`ptr + len\` against WASM guest memory without \`checked_add\`:

- **Input write** (L225): \`start + input_bytes.len()\` checked against \`mem_data.len()\`. \`start\` comes from the guest's \`alloc()\` return value via \`as usize\`.
- **Output read** (L256): \`result_ptr + result_len > mem_data.len()\`, where both components come from a guest-returned \`i64\` (high 32 bits = ptr, low 32 bits = len).

On 64-bit hosts these can't overflow \`usize\` because each operand fits in u32 (max 4GB each, sum 8GB << \`u64::MAX\`), so the bounds checks are correct. On **32-bit hosts** the sum wraps to a tiny value, silently passing the check — then the subsequent slice \`mem_data[start..end]\` goes out of bounds and panics (or worse, reads uninitialized memory).

A buggy or malicious guest WASM module can trigger this on 32-bit with a crafted packed value like \`0xFFFFFFFF_00000001\`.

## Fix

Replace both sites with \`checked_add\`, returning \`AbiError\` on overflow. Matches the pattern already used at sandbox.rs:373 for host-side reads. No behavior change on 64-bit (the only overflow case is unreachable there).

## Context

Found by a code-scan subagent auditing \`as u*\` / \`as i*\` casts across the codebase.

## Test plan

- [ ] Guest module returning packed = 0xFFFFFFFF_00000001 → clean \`AbiError\` instead of panic (on 32-bit)
- [ ] Normal small-buffer allocation → works (regression)
- [ ] Large-but-valid buffer (e.g. 10MB result) → still works (regression, sum fits in u64)