### PR TITLE
fix(dashboard): ChatPage session-cache save effect + tool call keys

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -148,15 +148,20 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
   const { ws, wsConnected, onDropRef } = useWebSocket(agentId);
   const addSkillOutput = useUIStore((s) => s.addSkillOutput);
 
-  // Save current messages to cache when switching away
+  // Save current messages to cache when switching away. The cleanup must
+  // read the LATEST messages at unmount/agent-swap time, so we keep a
+  // ref that tracks messages and only fire the save effect on agentId
+  // changes (previously had no deps, so cleanup+re-run every render).
   const prevAgentRef = useRef<string | null>(null);
+  const messagesRef = useRef<ChatMessage[]>(messages);
+  messagesRef.current = messages;
   useEffect(() => {
     return () => {
       if (prevAgentRef.current) {
-        sessionCache.set(prevAgentRef.current, messages);
+        sessionCache.set(prevAgentRef.current, messagesRef.current);
       }
     };
-  });
+  }, [agentId]);
   useEffect(() => { prevAgentRef.current = agentId; }, [agentId]);
 
   // Load history — use cache if available, otherwise fetch
@@ -536,7 +541,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
         {!isUser && message.tools && message.tools.length > 0 && (
           <div className="w-full mb-1">
             {message.tools.map((tool, i) => (
-              <ToolCallCard key={`${tool.name}-${i}`} tool={tool} />
+              <ToolCallCard key={tool._call_id ?? `${tool.name}-${i}`} tool={tool} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Problems

Two state-management bugs in \`useChatMessages\` / message rendering:

### 1. \`useEffect\` without dep array — writes cache every render

\`\`\`tsx
useEffect(() => {
  return () => {
    if (prevAgentRef.current) {
      sessionCache.set(prevAgentRef.current, messages);
    }
  };
});   // ← no deps
\`\`\`

React runs the cleanup before every re-run of the effect, and without a dep array the effect re-runs **every render**. So \`sessionCache.set()\` fires every render of ChatPage — many times per streamed chunk during an active conversation. Perf hit plus cache-write races with other readers.

### 2. Tool-call key collision on repeat calls

\`\`\`tsx
{message.tools.map((tool, i) => (
  <ToolCallCard key={\`\${tool.name}-\${i}\`} tool={tool} />
))}
\`\`\`

When an agent calls the same tool twice in one turn (e.g. two \`file_read\` calls), keys collide on \`file_read-0\` / \`file_read-1\` via their stable positions, but when React reconciles partial updates during streaming the cards can swap contents — second tool's \`result\` arrives but gets drawn onto the first card.

## Fix

1. Depend on \`[agentId]\` so the effect only re-runs on agent-switch/unmount. Cleanup needs the **latest** messages (not a closure capture from effect setup), so track via \`messagesRef\` that we update every render. Same pattern the file already uses for \`prevAgentRef\`.

2. Prefer the stable \`_call_id\` (populated from \`tool_use_id\` on \`tool_start\`) when available; fall back to name+index.

## Context

Found by a code-scan subagent auditing dashboard React state management.

## Test plan

- [ ] Open chat, stream a long response → cache write happens at most once (on agent change), not per-chunk
- [ ] Agent calls the same tool twice in one turn → each \`ToolCallCard\` shows its own result (no swap/duplicate)
- [ ] Switch agents → cache-restore works (regression)