### PR TITLE
fix(memory): cascade agent-scoped tables on remove_agent

### DIFF
--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -306,17 +306,56 @@ impl StructuredStore {
         }
     }
 
-    /// Remove an agent from the database.
+    /// Remove an agent from the database, cascading to all agent-scoped tables.
+    ///
+    /// SQLite foreign keys are not enforced (`PRAGMA foreign_keys=OFF` default)
+    /// and none of these tables declared `ON DELETE CASCADE`, so prior to
+    /// this function rows keyed by `agent_id` would accumulate indefinitely
+    /// after agent deletion. All DELETEs run inside a single transaction so
+    /// a mid-cascade failure leaves no half-removed state.
+    ///
+    /// Tables covered: agents, kv_store, task_queue, memories,
+    /// canonical_sessions, audit_entries, usage_events, entities, relations,
+    /// approval_audit, prompt_versions, prompt_experiments (plus their
+    /// dependent experiment_variants and experiment_metrics rows), and
+    /// events via source_agent. sessions / sessions_fts are handled by
+    /// the caller (MemorySubstrate::remove_agent via SessionStore).
     pub fn remove_agent(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
-        conn.execute(
+        let id = agent_id.0.to_string();
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+        // Subquery-scoped deletes must happen BEFORE prompt_experiments
+        // is cleared, otherwise the IN (SELECT ...) matches nothing.
+        for stmt in [
+            "DELETE FROM experiment_metrics \
+             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+            "DELETE FROM experiment_variants \
+             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+            "DELETE FROM prompt_experiments WHERE agent_id = ?1",
+            "DELETE FROM prompt_versions WHERE agent_id = ?1",
+            "DELETE FROM approval_audit WHERE agent_id = ?1",
+            "DELETE FROM audit_entries WHERE agent_id = ?1",
+            "DELETE FROM usage_events WHERE agent_id = ?1",
+            "DELETE FROM memories WHERE agent_id = ?1",
+            "DELETE FROM canonical_sessions WHERE agent_id = ?1",
+            "DELETE FROM kv_store WHERE agent_id = ?1",
+            "DELETE FROM task_queue WHERE agent_id = ?1",
+            "DELETE FROM entities WHERE agent_id = ?1",
+            "DELETE FROM relations WHERE agent_id = ?1",
+            "DELETE FROM events WHERE source_agent = ?1",
             "DELETE FROM agents WHERE id = ?1",
-            rusqlite::params![agent_id.0.to_string()],
-        )
-        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        ] {
+            tx.execute(stmt, rusqlite::params![id])
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        }
+        tx.commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

\`StructuredStore::remove_agent\` only did \`DELETE FROM agents WHERE id = ?\`. SQLite foreign keys default to **OFF** and none of the agent-scoped tables declared \`ON DELETE CASCADE\`, so every agent deletion left behind rows in:

| table | column | populated by |
|---|---|---|
| prompt_versions | agent_id | prompt version history |
| prompt_experiments | agent_id | A/B test experiments |
| experiment_variants | experiment_id (via FK to above) | variant definitions |
| experiment_metrics | experiment_id / variant_id | per-variant usage stats |
| approval_audit | agent_id | HITL decisions |
| audit_entries | agent_id | audit log |
| usage_events | agent_id | token/cost events |
| memories | agent_id | recalled facts |
| canonical_sessions | agent_id | cross-channel history |
| kv_store | agent_id | shared KV |
| task_queue | agent_id | tasks |
| entities | agent_id | knowledge graph |
| relations | agent_id | knowledge graph |
| events | source_agent | event bus history |

For long-lived installs this leaks significant amounts of data — \`memories\` and \`usage_events\` especially can grow to a substantial share of the DB.

## Fix

Replace the single DELETE with a transaction that cascades to every agent-scoped table. The experiment-scoped tables (variants, metrics) join back via subquery on \`prompt_experiments.id\` and must run **before** \`prompt_experiments\` itself is cleared.

Wrapped in \`unchecked_transaction()\` so mid-cascade failure rolls back and the orphan state can't get worse than before.

sessions / sessions_fts continue to be handled by \`MemorySubstrate::remove_agent\` via \`SessionStore::delete_agent_sessions\`.

## Context

Found by a code-scan subagent auditing SQL migrations / schema correctness.

## Test plan

- [ ] Spawn agent, accumulate rows across all agent-scoped tables (use it, write memories, trigger approvals, run a cron), then delete → all agent-specific rows gone
- [ ] Delete one of two agents → other agent's rows unaffected (regression)
- [ ] Simulate partial failure (e.g. lock contention on one table) → transaction rolls back, no half-removed state
- [ ] Existing tests still pass (regression)