### PR TITLE
fix(api): suppress error messages in groups, show rate-limit in DMs only

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -319,6 +319,7 @@ fn start_stream_text_bridge(
     kernel_handle: tokio::task::JoinHandle<
         KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
     >,
+    is_group: bool,
 ) -> mpsc::Receiver<String> {
     let (tx, rx) = mpsc::channel::<String>(64);
     let error_tx = tx.clone();
@@ -391,8 +392,30 @@ fn start_stream_text_bridge(
                         "\n\n---\n[Task timed out. The output above may be incomplete.]"
                             .to_string(),
                     )
+                } else if is_group {
+                    // In groups: suppress all errors (no leaked technical messages)
+                    None
                 } else {
-                    Some(sanitize_channel_error(&err_str))
+                    // In DMs: try to show original rate-limit message with reset time
+                    let lower = err_str.to_lowercase();
+                    if lower.contains("hit your limit")
+                        || lower.contains("out of extra usage")
+                        || lower.contains("resets")
+                    {
+                        // Extract original message after the first ": "
+                        let original =
+                            err_str.split(": ").skip(1).collect::<Vec<_>>().join(": ");
+                        if original.contains("hit your limit")
+                            || original.contains("out of extra usage")
+                            || original.contains("resets")
+                        {
+                            Some(original)
+                        } else {
+                            Some(sanitize_channel_error(&err_str))
+                        }
+                    } else {
+                        Some(sanitize_channel_error(&err_str))
+                    }
                 }
             }
             Ok(Ok(result)) => {
@@ -493,7 +516,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .send_message_streaming_with_routing(agent_id, message, None)
             .await
             .map_err(|e| format!("{e}"))?;
-        Ok(start_stream_text_bridge(event_rx, kernel_handle))
+        Ok(start_stream_text_bridge(event_rx, kernel_handle, false))
     }
 
     async fn send_message_streaming_with_sender(
@@ -507,7 +530,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
             .await
             .map_err(|e| format!("{e}"))?;
-        Ok(start_stream_text_bridge(event_rx, kernel_handle))
+        Ok(start_stream_text_bridge(
+            event_rx,
+            kernel_handle,
+            sender.is_group,
+        ))
     }
 
     async fn send_message_with_sender(


### PR DESCRIPTION
## Problem

When the LLM driver fails (rate-limit, crash, timeout), error messages are sent to ALL channels equally — including group chats where they confuse other users and leak internal details.

**Real-world example:** The message "You've hit your limit · resets 10am (UTC)" was sent 7 times to a WhatsApp group with friends during a rate-limit event, causing confusion. Internal driver errors like "[Sorry, something went wrong on my end]" also appeared in groups.

## Solution

Add `is_group` context to the streaming error handler so it can differentiate between group and DM contexts:

| Context | Rate-limit error | Driver error |
|---------|-----------------|--------------|
| **DM** | Original message with reset time | Sanitized user-friendly message |
| **Group** | Complete silence | Complete silence |

### Implementation

`start_stream_text_bridge()` receives a new `is_group: bool` parameter from `SenderContext.is_group` (already available at the call site). The error handler uses it:

```rust
fn start_stream_text_bridge(
    event_rx: ...,
    kernel_handle: ...,
    is_group: bool,  // NEW
) -> Receiver<String> {
    // In error handler:
    if is_group {
        None  // silence — no error leaked to group
    } else {
        // DMs: show original rate-limit message with reset time,
        // or sanitized message for other errors
    }
}
```

For DMs, the handler extracts the original rate-limit message (e.g., "You've hit your limit · resets 10am (UTC)") from the error chain so users see when service will resume, rather than a generic message.

## Changes

- `crates/librefang-api/src/channel_bridge.rs` — `is_group` parameter on `start_stream_text_bridge()`, context-aware error routing, original rate-limit message extraction for DMs

## Test plan

- [x] `cargo check -p librefang-api` passes
- [x] DM: shows original rate-limit message with reset time
- [x] Group: no error message sent (complete silence)
- [x] API streaming without sender context: defaults to DM behavior (is_group=false)
- [x] Verified on production deployment with Telegram and WhatsApp