### PR TITLE
fix(telegram): auto-close unclosed HTML tags, plain-text fallback, and reply-to photo support

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -179,6 +179,23 @@ impl TelegramAdapter {
             if !status.is_success() {
                 let body_text = resp.text().await.unwrap_or_default();
                 warn!("Telegram sendMessage failed ({status}): {body_text}");
+                // If HTML parsing failed, retry as plain text (no parse_mode)
+                if status == reqwest::StatusCode::BAD_REQUEST
+                    && body_text.contains("can't parse entities")
+                {
+                    let mut plain_body = serde_json::json!({
+                        "chat_id": chat_id,
+                        "text": chunk,
+                    });
+                    if let Some(tid) = thread_id {
+                        plain_body["message_thread_id"] = serde_json::json!(tid);
+                    }
+                    let retry = self.client.post(&url).json(&plain_body).send().await?;
+                    if !retry.status().is_success() {
+                        let retry_text = retry.text().await.unwrap_or_default();
+                        warn!("Telegram sendMessage plain fallback also failed: {retry_text}");
+                    }
+                }
             }
         }
         Ok(())
@@ -1523,11 +1540,69 @@ async fn parse_telegram_update(
 
     // Extract reply-to-message context (Telegram `reply_to_message` field).
     // Prepend the quoted original text so the agent sees what the user is replying to.
+    // If the quoted message has a photo, include it so the agent can see it.
     let content = if let Some(reply) = message.get("reply_to_message") {
+        let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
         let reply_text = reply["text"].as_str().or_else(|| reply["caption"].as_str());
-        if let Some(quoted) = reply_text {
-            let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
-            // Truncate long quotes to avoid feeding the LLM too much irrelevant context
+
+        // Check if the quoted message has a photo
+        let reply_photo_url = if let Some(photos) = reply["photo"].as_array() {
+            let file_id = photos
+                .last()
+                .and_then(|p| p["file_id"].as_str())
+                .unwrap_or("");
+            if !file_id.is_empty() {
+                telegram_get_file_url(token, client, file_id, api_base_url).await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(photo_url) = reply_photo_url {
+            // Quoted message has a photo.
+            // If the user's own message is already an image, keep it and add
+            // the quoted photo context as text (don't overwrite the user's photo).
+            let quote_context = reply_text
+                .map(|q| {
+                    let truncated = if q.len() > 200 {
+                        format!("{}...", &q[..q.floor_char_boundary(200)])
+                    } else {
+                        q.to_string()
+                    };
+                    format!("[Replying to {reply_sender}: \"{truncated}\"]\n")
+                })
+                .unwrap_or_else(|| format!("[Replying to {reply_sender}'s photo]\n"));
+
+            match content {
+                ChannelContent::Image {
+                    url,
+                    caption,
+                    mime_type,
+                } => {
+                    // User sent their own photo as reply — keep it, add quoted context to caption
+                    let cap = caption.unwrap_or_default();
+                    ChannelContent::Image {
+                        url,
+                        caption: Some(format!("{quote_context}{cap}")),
+                        mime_type,
+                    }
+                }
+                ChannelContent::Text(t) => {
+                    // User sent text reply to a photo — show the quoted photo
+                    let caption = format!("{quote_context}{t}");
+                    let mime_type = mime_type_from_telegram_path(&photo_url);
+                    ChannelContent::Image {
+                        url: photo_url,
+                        caption: Some(caption),
+                        mime_type,
+                    }
+                }
+                other => other,
+            }
+        } else if let Some(quoted) = reply_text {
+            // Quoted message has text only — prepend it
             let truncated = if quoted.len() > 200 {
                 format!("{}...", &quoted[..quoted.floor_char_boundary(200)])
             } else {
@@ -1536,7 +1611,7 @@ async fn parse_telegram_update(
             let prefix = format!("[Replying to {reply_sender}: \"{truncated}\"]\n");
             match content {
                 ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
-                other => other, // Leave Command/Image etc. unchanged
+                other => other,
             }
         } else {
             content
@@ -1663,6 +1738,7 @@ fn sanitize_telegram_html(text: &str) -> String {
 
     let mut result = String::with_capacity(text.len());
     let mut chars = text.char_indices().peekable();
+    let mut open_tags: Vec<String> = Vec::new();
 
     while let Some(&(i, ch)) = chars.peek() {
         if ch == '<' {
@@ -1670,6 +1746,7 @@ fn sanitize_telegram_html(text: &str) -> String {
             if let Some(end_offset) = text[i..].find('>') {
                 let tag_end = i + end_offset;
                 let tag_content = &text[i + 1..tag_end]; // content between < and >
+                let is_closing = tag_content.starts_with('/');
                 let tag_name = tag_content
                     .trim_start_matches('/')
                     .split(|c: char| c.is_whitespace() || c == '/' || c == '>')
@@ -1680,6 +1757,15 @@ fn sanitize_telegram_html(text: &str) -> String {
                 if !tag_name.is_empty() && ALLOWED.contains(&tag_name.as_str()) {
                     // Allowed tag — keep as-is
                     result.push_str(&text[i..tag_end + 1]);
+                    // Track open/close for balancing
+                    if is_closing {
+                        if let Some(pos) = open_tags.iter().rposition(|t| t == &tag_name) {
+                            open_tags.remove(pos);
+                        }
+                    } else if !tag_content.ends_with('/') {
+                        // Not self-closing
+                        open_tags.push(tag_name);
+                    }
                 } else {
                     // Unknown tag — escape both brackets
                     result.push_str("&lt;");
@@ -1702,6 +1788,13 @@ fn sanitize_telegram_html(text: &str) -> String {
             result.push(ch);
             chars.next();
         }
+    }
+
+    // Close any unclosed tags (prevents Telegram "can't parse entities" errors)
+    for tag in open_tags.into_iter().rev() {
+        result.push_str("</");
+        result.push_str(&tag);
+        result.push('>');
     }
 
     result


### PR DESCRIPTION
## Problem

Three related issues with Telegram message delivery:

### 1. Unclosed HTML tags cause message loss
When the agent's response contains unbalanced HTML tags (e.g., a `<code>` without `</code>`), Telegram rejects the message with 400 "can't parse entities". The message is silently lost — the user sees the thinking indicator but never gets a response.

**Real example:** Agent was asked to generate a prompt. The response contained code blocks that produced malformed HTML. Telegram rejected it, user saw nothing.

### 2. No fallback on HTML parse failure
When `sendMessage` fails due to HTML parsing, the adapter logs a warning but doesn't retry. The message is permanently lost.

### 3. Reply-to photo not visible to agent
When a user replies to a message that contains a photo (quote-reply), the adapter extracts only the text from the quoted message. The photo is ignored, so the agent cannot see or analyze the image the user is referring to.

**Real example:** User quotes a photo of a product and writes "Tell me about this" — agent responds "I don't see any image."

## Solution

### 1. Auto-close unclosed HTML tags
`sanitize_telegram_html()` now tracks open/close tags and appends closing tags for any that remain unclosed at the end:

```rust
// Track open tags during parsing
let mut open_tags: Vec<String> = Vec::new();
// ... existing tag parsing ...

// Close any unclosed tags at the end
for tag in open_tags.into_iter().rev() {
    result.push_str(&format!("</{tag}>"));
}
```

### 2. Plain-text fallback retry
When `sendMessage` fails with 400 "can't parse entities", retry without `parse_mode` so the message is delivered as plain text:

```rust
if status == 400 && body_text.contains("can't parse entities") {
    // Retry without parse_mode — delivers as plain text
    let plain_body = json!({ "chat_id": chat_id, "text": chunk });
    client.post(&url).json(&plain_body).send().await?;
}
```

### 3. Reply-to photo extraction
When `reply_to_message` contains a `photo` array, download the largest size and include it as `ChannelContent::Image` with the user's text as caption:

- User sends **text reply to photo** → agent receives the quoted photo + user text
- User sends **photo reply to photo** → agent receives user's own photo (preserved), quoted context in caption
- User sends **text reply to text** → unchanged behavior (prepend quoted text)

## Changes

- `crates/librefang-channels/src/telegram.rs` — tag balancing in sanitizer, plain-text retry in `api_send_message`, reply-to photo download in message parser

## Test plan

- [x] `cargo check -p librefang-channels` passes
- [x] Unclosed `<code>` tag gets auto-closed before sending
- [x] HTML parse failure retries as plain text (message delivered)
- [x] Reply to photo message: agent receives and can analyze the photo
- [x] Reply to photo with own photo: user's photo preserved, quoted context in caption
- [x] Existing text-only reply behavior unchanged