### PR TITLE
test(runtime): fix test_image_analyze_missing_file after sandbox wiring

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -403,8 +403,7 @@ fn start_stream_text_bridge(
                         || lower.contains("resets")
                     {
                         // Extract original message after the first ": "
-                        let original =
-                            err_str.split(": ").skip(1).collect::<Vec<_>>().join(": ");
+                        let original = err_str.split(": ").skip(1).collect::<Vec<_>>().join(": ");
                         if original.contains("hit your limit")
                             || original.contains("out of extra usage")
                             || original.contains("resets")

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -4877,10 +4877,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_image_analyze_missing_file() {
+        let workspace = tempfile::tempdir().expect("tempdir");
         let result = execute_tool(
             "test-id",
             "image_analyze",
-            &serde_json::json!({"path": "/nonexistent/image.png"}),
+            &serde_json::json!({"path": "nonexistent_image.png"}),
             None,
             None,
             None,
@@ -4889,7 +4890,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(workspace.path()),
             None, // media_engine
             None, // media_drivers
             None, // exec_policy
@@ -4901,7 +4902,11 @@ mod tests {
         )
         .await;
         assert!(result.is_error);
-        assert!(result.content.contains("Failed to read"));
+        assert!(
+            result.content.contains("Failed to read"),
+            "unexpected error content: {}",
+            result.content
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Main CI has been red on all three platforms since #2083 landed. That PR routed \`image_analyze\` through the workspace sandbox but did not update \`test_image_analyze_missing_file\` — the test still passes \`None\` for \`workspace_root\`, so \`resolve_file_path\` now short-circuits with \`\"Workspace sandbox not configured\"\` before the code ever tries to read the file, and the \`\"Failed to read\"\` assertion fails.

## Fix

Give the test a tempdir workspace and a nonexistent relative path, so it actually exercises the missing-file branch it was named for.

Also bundles a trivial rustfmt autoformat on \`crates/librefang-api/src/channel_bridge.rs\` that the pre-commit hook kept regenerating (merges a split statement onto one line, no semantic change).

## Test plan

- [x] \`cargo test -p librefang-runtime --lib tool_runner::tests::test_image_analyze_missing_file\` — passes
- [x] \`cargo clippy -p librefang-runtime --lib --tests -- -D warnings\` — clean