### PR TITLE
fix(ci): pin Ubuntu test runner to 22.04 to bypass SIGTERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
     name: Test / Ubuntu
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Ubuntu test job on `ubuntu-latest` (24.04) consistently SIGTERMs ~2s into `librefang-runtime` unittests
- All memory/concurrency workarounds from #1807 already in place (per-crate cargo test, RUST_TEST_THREADS=2, -j 2 build)
- 24.04 ships systemd-oomd enabled by default; 22.04 uses classic OOM killer
- Change: pin `runs-on` to `ubuntu-22.04` on the test-ubuntu job only

## Test plan
- [ ] CI run on this PR passes Test / Ubuntu
- [ ] If it passes, merge and verify main CI stays green
- [ ] If it still SIGTERMs, close this and bisect 9e995baa..1ec10721 to find the commit that tipped runtime tests over the edge