### PR TITLE
ci(todo-to-issue): ignore plugin scaffold templates

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -17,3 +17,6 @@ jobs:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL: "good first issue,help wanted"
           AUTO_ASSIGN: false
+          # Skip files that contain TODO markers inside string-literal code templates
+          # (e.g. plugin scaffolding) — those are placeholders for end users, not tasks.
+          IGNORE: crates/librefang-runtime/src/plugin_manager.rs


### PR DESCRIPTION
## Summary

The TODO-to-issue scanner was filing issues for TODO markers living inside raw-string plugin code templates in `crates/librefang-runtime/src/plugin_manager.rs`. Those markers are placeholders rendered into user-generated plugin projects (V / Go / Node / Deno / Ruby / Bash / Bun / PHP / Lua ingest/after_turn hooks), not tasks for the LibreFang team.

Closed issues #2104-#2115 were all false positives from this single file.

## Change

Add `crates/librefang-runtime/src/plugin_manager.rs` to the `IGNORE` list of `alstr/todo-to-issue-action` so it stops scraping those template strings.

## Test plan

- [ ] Next push to main triggers the workflow and no new issues get filed for plugin_manager.rs templates