### PR TITLE
release: v2026.4.6-beta15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.6] - 2026-04-06
+
+### Added
+
+- Hot-reload skills dir and per-agent manifest (#2069) (@houko)
+- Unify full-section empty/error states (#2088) (@houko)
+- Focus trap + aria-modal + more n-shortcut coverage (#2092) (@houko)
+- Add send-audio endpoint for voice notes and audio files (#2099) (@f-liva)
+- Language-agnostic hook runtime (V / Go / Deno / Node / native) (#2100) (@houko)
+
+### Fixed
+
+- Allow tool retry on failure instead of early loop termination (#2065) (@neo-wanderer)
+- Sync openclaw/openfang with current KernelConfig schema (#2066) (@houko)
+- Stop stale messages_before index from breaking auto_memorize & append_canonical (#2068) (@houko)
+- Agent_send/kill fall through to name lookup for stale UUIDs (#2070) (@houko)
+- Reject missing required tool params instead of silent empty (#2071) (@houko)
+- Surface silent session-cleanup failures and panic on empty chunks (#2072) (@houko)
+- Return 404 for missing agents and reject malformed target_agent_id (#2073) (@houko)
+- Log when webhook/dingtalk bridge drops incoming messages (#2074) (@houko)
+- Surface agent tick panics instead of silent join drop (#2075) (@houko)
+- Emit skills/workspace/tool_blocklist during OpenClaw import (#2076) (@houko)
+- Providers.rs persistence failures + expect() panic (#2077) (@houko)
+- Surface silent DB errors and wrap merge updates in tx (#2078) (@houko)
+- Surface episodic memory persist failures in agent_loop (#2079) (@houko)
+- Sanitize user-controlled identity fields in prompt builder (#2080) (@houko)
+- Reload path must clamp bounds and clamp max_cron_jobs=0 (#2081) (@houko)
+- Close SSRF via redirect + URL-encoding bypass in taint (#2082) (@houko)
+- Route media tools through workspace sandbox (#2083) (@houko)
+- Guard sandbox ptr arithmetic with checked_add (#2084) (@houko)
+- ChatPage session-cache save effect + tool call keys (#2085) (@houko)
+- Cascade agent-scoped tables on remove_agent (#2086) (@houko)
+- Authorize cron_cancel + cap knowledge_query depth (#2087) (@houko)
+- Use PAT for release creation so dashboard-build fires (#2094) (@houko)
+- Suppress error messages in groups, show rate-limit in DMs only (#2095) (@f-liva)
+- Auto-close unclosed HTML tags, plain-text fallback, and reply-to photo support (#2096) (@f-liva)
+- Drop Ubuntu RUST_TEST_THREADS to 1 (#2117) (@houko)
+- Unify agent manifest path on workspaces/agents/ (#2118) (@houko)
+
+### Changed
+
+- Align URL hierarchy with sidebar nav groups (#2119) (@houko)
+
+### Maintenance
+
+- Fix test_image_analyze_missing_file after sandbox wiring (#2103) (@houko)
+- Ignore plugin scaffold templates (#2120) (@houko)
+
+### Reverted
+
+- V2026.4.6 stable release (was meant to be beta15) (#2126) (@houko)
+
+
 ## [2026.4.5] - 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "aes",
  "async-trait",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "axum",
  "dirs 6.0.0",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "async-trait",
  "axum",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10593,7 +10593,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32064",
+  "version": "26.4.32075",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.5-beta14",
+  "version": "2026.4.6-beta15",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.5-beta14",
+  "version": "2026.4.6-beta15",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.5b14",
+    version="2026.4.6b15",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.5-beta14"
+version = "2026.4.6-beta15"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.6-beta15 -->
## Release v2026.4.6-beta15

### Added

- Hot-reload skills dir and per-agent manifest (#2069) (@houko)
- Unify full-section empty/error states (#2088) (@houko)
- Focus trap + aria-modal + more n-shortcut coverage (#2092) (@houko)
- Add send-audio endpoint for voice notes and audio files (#2099) (@f-liva)
- Language-agnostic hook runtime (V / Go / Deno / Node / native) (#2100) (@houko)

### Fixed

- Allow tool retry on failure instead of early loop termination (#2065) (@neo-wanderer)
- Sync openclaw/openfang with current KernelConfig schema (#2066) (@houko)
- Stop stale messages_before index from breaking auto_memorize & append_canonical (#2068) (@houko)
- Agent_send/kill fall through to name lookup for stale UUIDs (#2070) (@houko)
- Reject missing required tool params instead of silent empty (#2071) (@houko)
- Surface silent session-cleanup failures and panic on empty chunks (#2072) (@houko)
- Return 404 for missing agents and reject malformed target_agent_id (#2073) (@houko)
- Log when webhook/dingtalk bridge drops incoming messages (#2074) (@houko)
- Surface agent tick panics instead of silent join drop (#2075) (@houko)
- Emit skills/workspace/tool_blocklist during OpenClaw import (#2076) (@houko)
- Providers.rs persistence failures + expect() panic (#2077) (@houko)
- Surface silent DB errors and wrap merge updates in tx (#2078) (@houko)
- Surface episodic memory persist failures in agent_loop (#2079) (@houko)
- Sanitize user-controlled identity fields in prompt builder (#2080) (@houko)
- Reload path must clamp bounds and clamp max_cron_jobs=0 (#2081) (@houko)
- Close SSRF via redirect + URL-encoding bypass in taint (#2082) (@houko)
- Route media tools through workspace sandbox (#2083) (@houko)
- Guard sandbox ptr arithmetic with checked_add (#2084) (@houko)
- ChatPage session-cache save effect + tool call keys (#2085) (@houko)
- Cascade agent-scoped tables on remove_agent (#2086) (@houko)
- Authorize cron_cancel + cap knowledge_query depth (#2087) (@houko)
- Use PAT for release creation so dashboard-build fires (#2094) (@houko)
- Suppress error messages in groups, show rate-limit in DMs only (#2095) (@f-liva)
- Auto-close unclosed HTML tags, plain-text fallback, and reply-to photo support (#2096) (@f-liva)
- Drop Ubuntu RUST_TEST_THREADS to 1 (#2117) (@houko)
- Unify agent manifest path on workspaces/agents/ (#2118) (@houko)

### Changed

- Align URL hierarchy with sidebar nav groups (#2119) (@houko)

### Maintenance

- Fix test_image_analyze_missing_file after sandbox wiring (#2103) (@houko)
- Ignore plugin scaffold templates (#2120) (@houko)

### Reverted

- V2026.4.6 stable release (was meant to be beta15) (#2126) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.5-beta14...v2026.4.6-beta15