### PR TITLE
fix(ci): skip Discord notification when release workflows are cancelled

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -85,16 +85,25 @@ jobs:
           echo "Docker:  $DOCKER_STATUS"
           echo "SDK:     $SDK_STATUS"
 
-          # Check if all workflows have completed
+          # Check if all workflows have completed (cancelled = abort, skip notification)
+          HAS_CANCELLED=false
           for status in "$SHELL_STATUS" "$DESKTOP_STATUS" "$DOCKER_STATUS" "$SDK_STATUS"; do
             if [ "$status" = "running" ] || [ "$status" = "pending" ] || [ "$status" = "not_found" ]; then
               ALL_DONE=false
               break
             fi
+            if [ "$status" = "cancelled" ]; then
+              HAS_CANCELLED=true
+            fi
           done
 
           if [ "$ALL_DONE" = "false" ]; then
             echo "Not all workflows completed yet, waiting for next trigger"
+            exit 0
+          fi
+
+          if [ "$HAS_CANCELLED" = "true" ]; then
+            echo "Some workflows were cancelled, skipping notification"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- When release workflows are cancelled (e.g. accidental tag push + revert), the notify workflow was still sending Discord/Bluesky notifications showing "0/4 succeeded" with all ❌
- Root cause: `cancelled` conclusion was not in the early-exit check alongside `running`/`pending`/`not_found`, so the script treated cancelled workflows as "completed" and sent failure notifications
- Fix: detect `cancelled` status and skip notification entirely

## Test plan
- [ ] Cancel a release workflow manually and verify no Discord notification is sent
- [ ] Normal release still sends ✅ notification as before