### PR TITLE
chore: add desktop build/dev recipes to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,12 +50,12 @@ dashboard-build:
 dash:
     cd crates/librefang-api/dashboard && pnpm install && pnpm dev
 
-# Build desktop app (Tauri) — builds dashboard assets first
+# Build desktop app (Tauri) — builds dashboard assets first (requires: cargo install tauri-cli)
 desktop-build: dashboard-build
     cargo tauri build -c crates/librefang-desktop/tauri.conf.json
 
-# Start desktop app in dev mode
-desktop-dev:
+# Start desktop app in dev mode (requires: cargo install tauri-cli)
+desktop-dev: dashboard-build
     cargo tauri dev -c crates/librefang-desktop/tauri.conf.json
 
 # Build release CLI and install to ~/.librefang/bin


### PR DESCRIPTION
## Summary
- Add `just desktop-build` recipe for building the Tauri desktop app
- Add `just desktop-dev` recipe for desktop dev mode

## Test plan
- [ ] `just desktop-build` produces a working binary
- [ ] `just desktop-dev` starts the dev server