### PR TITLE
fix: replace librefang.dev with librefang.ai

### DIFF
--- a/crates/librefang-channels/benches/dispatch.rs
+++ b/crates/librefang-channels/benches/dispatch.rs
@@ -172,7 +172,7 @@ Features:\n\
 - [A2A protocol](https://a2a.example.com) integration\n\
 - **budget tracking** with per-agent cost limits\n\
 \n\
-Visit the [docs](https://docs.librefang.dev) for more info.";
+Visit the [docs](https://docs.librefang.ai) for more info.";
 
 const SHORT_TEXT: &str = "Hello world!";
 

--- a/crates/librefang-types/src/manifest_signing.rs
+++ b/crates/librefang-types/src/manifest_signing.rs
@@ -132,9 +132,9 @@ shell = false
 network = false
 "#;
 
-        let signed = SignedManifest::sign(manifest, &signing_key, "test@librefang.dev");
+        let signed = SignedManifest::sign(manifest, &signing_key, "test@librefang.ai");
         assert_eq!(signed.content_hash, hash_manifest(manifest));
-        assert_eq!(signed.signer_id, "test@librefang.dev");
+        assert_eq!(signed.signer_id, "test@librefang.ai");
         assert!(signed.verify().is_ok());
     }
 


### PR DESCRIPTION
## Summary
- Replace all remaining `librefang.dev` references with `librefang.ai` (docs URL in bench, test email in manifest_signing)

## Test plan
- [ ] `cargo test -p librefang-types` passes (manifest_signing test uses updated email)
- [ ] `cargo build -p librefang-channels --benches` compiles