### PR TITLE
fix(kernel): glob-match declared tools and auto-promote shell_exec exec_policy

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2605,11 +2605,18 @@ impl LibreFangKernel {
                     // Inherit kernel exec_policy for agents that lack one.
                     // Promote to Full when shell_exec is declared in capabilities.
                     if restored_entry.manifest.exec_policy.is_none() {
-                        if restored_entry.manifest.capabilities.tools.iter().any(|t| t == "shell_exec" || t == "*") {
-                            restored_entry.manifest.exec_policy = Some(librefang_types::config::ExecPolicy {
-                                mode: librefang_types::config::ExecSecurityMode::Full,
-                                ..cfg.exec_policy.clone()
-                            });
+                        if restored_entry
+                            .manifest
+                            .capabilities
+                            .tools
+                            .iter()
+                            .any(|t| t == "shell_exec" || t == "*")
+                        {
+                            restored_entry.manifest.exec_policy =
+                                Some(librefang_types::config::ExecPolicy {
+                                    mode: librefang_types::config::ExecSecurityMode::Full,
+                                    ..cfg.exec_policy.clone()
+                                });
                         } else {
                             restored_entry.manifest.exec_policy = Some(cfg.exec_policy.clone());
                         }
@@ -2837,7 +2844,12 @@ system_prompt = "You are a helpful assistant."
         let cfg = self.config.load();
         let mut manifest = manifest;
         if manifest.exec_policy.is_none() {
-            if manifest.capabilities.tools.iter().any(|t| t == "shell_exec" || t == "*") {
+            if manifest
+                .capabilities
+                .tools
+                .iter()
+                .any(|t| t == "shell_exec" || t == "*")
+            {
                 manifest.exec_policy = Some(librefang_types::config::ExecPolicy {
                     mode: librefang_types::config::ExecSecurityMode::Full,
                     ..cfg.exec_policy.clone()
@@ -8899,7 +8911,11 @@ system_prompt = "You are a helpful assistant."
         };
         for skill_tool in skill_tools {
             // If agent declares specific tools, only include matching skill tools
-            if !tools_unrestricted && !declared_tools.iter().any(|d| glob_matches(d, &skill_tool.name)) {
+            if !tools_unrestricted
+                && !declared_tools
+                    .iter()
+                    .any(|d| glob_matches(d, &skill_tool.name))
+            {
                 continue;
             }
             all_tools.push(ToolDefinition {
@@ -12389,7 +12405,10 @@ mod tests {
         let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
 
         // Verify exec_policy was promoted to Full
-        let entry = kernel.registry.get(agent_id).expect("agent must be registered");
+        let entry = kernel
+            .registry
+            .get(agent_id)
+            .expect("agent must be registered");
         assert_eq!(
             entry.manifest.exec_policy.as_ref().map(|p| p.mode),
             Some(librefang_types::config::ExecSecurityMode::Full),


### PR DESCRIPTION
## Summary

Two bugs that prevented MCP wildcard tools and `shell_exec` from working in user-defined agents.

### Bug 1 — MCP wildcard patterns silently dropped

`available_tools()` used exact string equality (`d == &t.name`) when filtering builtins, skill tools, and MCP tools against `capabilities.tools`. Patterns like `mcp_filesystem_*` never matched actual tool names like `mcp_filesystem_list_directory`, so those tools were silently excluded — even though the MCP server was connected and reporting 14 tools.

**Fix:** replace `==` with `glob_matches()` at all three filter sites (builtins, skills, MCP).

### Bug 2 — `shell_exec` blocked without explicit `exec_policy`

`ExecSecurityMode` derives `Default`, and its first variant is `Deny`. Agents without an explicit `exec_policy` inherited the global `ExecPolicy { mode: Deny }`, causing `shell_exec` to be stripped from `available_tools()` (step 6) — returning "Permission denied: agent does not have capability" even when `shell_exec` was explicitly listed in `capabilities.tools`.

**Fix:** at spawn and restore time, if the agent declares `shell_exec` (or `*`) in tools and has no explicit `exec_policy`, auto-promote to `Full` instead of inheriting the global `Deny`.

## User config that now works without workarounds

```toml
[capabilities]
tools = ["mcp_filesystem_*", "shell_exec", "file_read"]
shell = ["*"]
```

## Tests added

- `test_available_tools_glob_pattern_matches_mcp_tools`
- `test_shell_exec_available_when_declared_in_tools_without_explicit_exec_policy`