### PR TITLE
fix(approval): three TOTP review fixes

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1514,8 +1514,8 @@ export async function totpStatus(): Promise<TotpStatusResponse> {
 }
 
 export async function totpRevoke(code: string): Promise<ApiActionResponse> {
-  const response = await fetch("/api/approvals/totp", {
-    method: "DELETE",
+  const response = await fetch("/api/approvals/totp/revoke", {
+    method: "POST",
     headers: buildHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify({ code }),
   });

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -72,8 +72,8 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::get(totp_status),
         )
         .route(
-            "/approvals/totp",
-            axum::routing::delete(totp_revoke),
+            "/approvals/totp/revoke",
+            axum::routing::post(totp_revoke),
         )
         .route("/approvals/{id}", axum::routing::get(get_approval))
         .route(
@@ -1417,6 +1417,7 @@ pub async fn approve_request(
     };
 
     // Verify TOTP code or recovery code if second factor is enabled
+    let totp_issuer = state.kernel.approvals().policy().totp_issuer.clone();
     let totp_verified = if state.kernel.approvals().requires_totp() {
         if state.kernel.approvals().is_totp_locked_out("api_admin") {
             return ApiErrorResponse::bad_request(
@@ -1467,8 +1468,8 @@ pub async fn approve_request(
                             .into_response();
                         }
                     };
-                    match librefang_kernel::approval::ApprovalManager::verify_totp_code(
-                        &secret, code,
+                    match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                        &secret, code, &totp_issuer,
                     ) {
                         Ok(true) => true,
                         Ok(false) => {
@@ -1763,6 +1764,7 @@ pub async fn totp_setup(
     State(state): State<Arc<AppState>>,
     Json(body): Json<TotpSetupBody>,
 ) -> impl IntoResponse {
+    let totp_issuer = state.kernel.approvals().policy().totp_issuer.clone();
     // If TOTP is already confirmed, require verification of the old code
     let already_confirmed = state.kernel.vault_get("totp_confirmed").as_deref() == Some("true");
 
@@ -1801,8 +1803,8 @@ pub async fn totp_setup(
                     // TOTP code
                     match state.kernel.vault_get("totp_secret") {
                         Some(secret) => {
-                            librefang_kernel::approval::ApprovalManager::verify_totp_code(
-                                &secret, code,
+                            librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                                &secret, code, &totp_issuer,
                             )
                             .unwrap_or(false)
                         }
@@ -1820,13 +1822,8 @@ pub async fn totp_setup(
         }
     }
 
-    let issuer = {
-        let policy = state.kernel.approvals().policy();
-        policy.totp_issuer.clone()
-    };
-
     let (secret_base32, otpauth_uri, qr_base64) =
-        match librefang_kernel::approval::ApprovalManager::generate_totp_secret(&issuer, "admin") {
+        match librefang_kernel::approval::ApprovalManager::generate_totp_secret(&totp_issuer, "admin") {
             Ok(v) => v,
             Err(e) => {
                 return ApiErrorResponse::internal(e).into_json_tuple();
@@ -1874,6 +1871,7 @@ pub async fn totp_confirm(
     State(state): State<Arc<AppState>>,
     Json(body): Json<TotpConfirmBody>,
 ) -> impl IntoResponse {
+    let totp_issuer = state.kernel.approvals().policy().totp_issuer.clone();
     if state.kernel.approvals().is_totp_locked_out("api_admin") {
         return ApiErrorResponse::bad_request("Too many failed TOTP attempts. Try again later.")
             .into_json_tuple();
@@ -1889,7 +1887,9 @@ pub async fn totp_confirm(
         }
     };
 
-    match librefang_kernel::approval::ApprovalManager::verify_totp_code(&secret, &body.code) {
+    match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+        &secret, &body.code, &totp_issuer,
+    ) {
         Ok(true) => {
             if let Err(e) = state.kernel.vault_set("totp_confirmed", "true") {
                 return ApiErrorResponse::internal(e).into_json_tuple();
@@ -1949,6 +1949,7 @@ pub async fn totp_revoke(
     State(state): State<Arc<AppState>>,
     Json(body): Json<TotpRevokeBody>,
 ) -> impl IntoResponse {
+    let totp_issuer = state.kernel.approvals().policy().totp_issuer.clone();
     if state.kernel.approvals().is_totp_locked_out("api_admin") {
         return ApiErrorResponse::bad_request("Too many failed TOTP attempts. Try again later.")
             .into_json_tuple();
@@ -1979,8 +1980,10 @@ pub async fn totp_revoke(
     } else {
         match state.kernel.vault_get("totp_secret") {
             Some(secret) => {
-                librefang_kernel::approval::ApprovalManager::verify_totp_code(&secret, &body.code)
-                    .unwrap_or(false)
+                librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                    &secret, &body.code, &totp_issuer,
+                )
+                .unwrap_or(false)
             }
             None => false,
         }

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -88,14 +88,66 @@ impl ApprovalManager {
 
     /// Create an approval manager with persistent audit logging.
     pub fn new_with_db(policy: ApprovalPolicy, conn: Arc<StdMutex<Connection>>) -> Self {
+        let failures = Self::load_totp_lockout(&conn);
         Self {
             pending: DashMap::new(),
             recent: std::sync::Mutex::new(VecDeque::new()),
             policy: std::sync::RwLock::new(policy),
             audit_db: Some(conn),
             totp_grace: StdMutex::new(HashMap::new()),
-            totp_failures: StdMutex::new(HashMap::new()),
+            totp_failures: StdMutex::new(failures),
         }
+    }
+
+    /// Load persisted TOTP lockout state from the database.
+    ///
+    /// Entries whose lockout window has already expired are discarded at load
+    /// time so a daemon restart does not extend the lockout beyond the original
+    /// 5-minute window.
+    fn load_totp_lockout(conn: &Arc<StdMutex<Connection>>) -> HashMap<String, (u32, Option<Instant>)> {
+        let Ok(guard) = conn.lock() else { return HashMap::new() };
+        let Ok(mut stmt) = guard.prepare(
+            "SELECT sender_id, failures, locked_at FROM totp_lockout",
+        ) else { return HashMap::new() };
+
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)? as u32,
+                    row.get::<_, Option<i64>>(2)?,
+                ))
+            })
+            .ok();
+
+        let Some(rows) = rows else { return HashMap::new() };
+        let mut map = HashMap::new();
+        for row in rows.filter_map(|r| r.ok()) {
+            let (sender_id, failures, locked_at_unix) = row;
+            let lockout_start = locked_at_unix.and_then(|ts| {
+                let ts = ts as u64;
+                let elapsed = now_unix.saturating_sub(ts);
+                if elapsed >= TOTP_LOCKOUT_SECS {
+                    None // Lockout has expired — don't restore
+                } else {
+                    // Reconstruct an Instant that is `elapsed` seconds in the past
+                    Some(Instant::now() - std::time::Duration::from_secs(elapsed))
+                }
+            });
+            // If lockout_start is None but failures >= threshold, the lockout
+            // expired during the downtime — reset the counter.
+            if failures >= TOTP_MAX_FAILURES && lockout_start.is_none() {
+                // Expired — omit entry entirely (effective reset)
+                continue;
+            }
+            map.insert(sender_id, (failures, lockout_start));
+        }
+        map
     }
 
     /// Check if a tool requires approval based on current policy.
@@ -631,7 +683,19 @@ impl ApprovalManager {
     /// Verify a TOTP code against a base32-encoded secret.
     ///
     /// Uses RFC 6238 with SHA-1, 6 digits, 30-second step, and +-1 window tolerance.
+    /// `issuer` should match the value used during enrollment (from `totp_issuer` in
+    /// the approval policy); it is included in the TOTP struct for consistency but
+    /// does not affect the HMAC computation.
     pub fn verify_totp_code(secret_base32: &str, code: &str) -> Result<bool, String> {
+        Self::verify_totp_code_with_issuer(secret_base32, code, "LibreFang")
+    }
+
+    /// Like `verify_totp_code` but uses the provided issuer label.
+    pub fn verify_totp_code_with_issuer(
+        secret_base32: &str,
+        code: &str,
+        issuer: &str,
+    ) -> Result<bool, String> {
         let secret = Secret::Encoded(secret_base32.to_string());
         let raw = secret
             .to_bytes()
@@ -642,7 +706,7 @@ impl ApprovalManager {
             1,
             30,
             raw,
-            Some("LibreFang".to_string()),
+            Some(issuer.to_string()),
             String::new(),
         )
         .map_err(|e| format!("TOTP init error: {e}"))?;
@@ -736,6 +800,8 @@ impl ApprovalManager {
         // Clear failure counter on success
         let mut failures = self.totp_failures.lock().unwrap_or_else(|e| e.into_inner());
         failures.remove(sender_id);
+        drop(failures);
+        self.persist_totp_lockout_clear(sender_id);
     }
 
     /// Check if a sender is locked out due to too many TOTP failures.
@@ -775,6 +841,40 @@ impl ApprovalManager {
                 "TOTP locked out: {} consecutive failures", entry.0
             );
         }
+        let (count, locked_at_instant) = *entry;
+        drop(failures);
+        // Persist lockout state so it survives a daemon restart
+        let locked_at_unix = locked_at_instant.map(|t| {
+            let elapsed = t.elapsed().as_secs();
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                .saturating_sub(elapsed) as i64
+        });
+        self.persist_totp_lockout_save(sender_id, count, locked_at_unix);
+    }
+
+    fn persist_totp_lockout_save(&self, sender_id: &str, failures: u32, locked_at: Option<i64>) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        let _ = conn.execute(
+            "INSERT INTO totp_lockout (sender_id, failures, locked_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(sender_id) DO UPDATE SET
+                 failures  = excluded.failures,
+                 locked_at = excluded.locked_at",
+            rusqlite::params![sender_id, failures as i64, locked_at],
+        );
+    }
+
+    fn persist_totp_lockout_clear(&self, sender_id: &str) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        let _ = conn.execute(
+            "DELETE FROM totp_lockout WHERE sender_id = ?1",
+            rusqlite::params![sender_id],
+        );
     }
 
     /// Write an audit entry to the persistent database.

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 17;
+const SCHEMA_VERSION: u32 = 18;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -77,6 +77,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 17 {
         migrate_v17(conn)?;
+    }
+
+    if current_version < 18 {
+        migrate_v18(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -604,6 +608,16 @@ fn migrate_v17(conn: &Connection) -> Result<(), rusqlite::Error> {
         [],
     );
     Ok(())
+}
+
+fn migrate_v18(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS totp_lockout (
+            sender_id  TEXT    PRIMARY KEY,
+            failures   INTEGER NOT NULL DEFAULT 0,
+            locked_at  INTEGER             -- Unix timestamp (seconds) when lockout started, NULL if below threshold
+        );",
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Review fixes for #2131 (`feat/totp-second-factor`):

- **Bug 1 — DELETE + JSON body**: `DELETE /api/approvals/totp` changed to `POST /api/approvals/totp/revoke`. Many HTTP clients (fetch API, nginx, some proxies) strip the body from DELETE requests, making revocation silently fail or return 422.

- **Bug 2 — In-memory lockout bypassable via restart**: TOTP failure state was only in-memory. A daemon restart reset all lockout counters. Now persisted to a new `totp_lockout` SQLite table (migration v18). `ApprovalManager::new_with_db` loads state on boot; expired lockouts are discarded at load time so restart doesn't extend the window.

- **Bug 3 — Hardcoded issuer in verify**: Added `verify_totp_code_with_issuer` and updated all 4 call sites in `system.rs` to pass the configured `totp_issuer` from the approval policy, keeping issuer consistent between enrollment and verification.

## Test plan

- [ ] `POST /api/approvals/totp/revoke` with valid code → 200
- [ ] `POST /api/approvals/totp/revoke` with invalid code → 400, lockout increments
- [ ] 5 consecutive failures → locked out; restart daemon → still locked out
- [ ] Lockout expires after 5 min → can attempt again
- [ ] Custom `totp_issuer` in config → issuer visible in authenticator app label, verification still works