### PR TITLE
fix(dashboard): show active agent count instead of total in overview card

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -126,6 +126,7 @@
     "alert": "System Alert",
     "active_agents": "Active Agents",
     "active": "active",
+    "total": "total",
     "active_count": "{{count}} active",
     "workflows": "Workflows",
     "design_with_canvas": "Design with visual canvas",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -126,6 +126,7 @@
     "alert": "系统告警",
     "active_agents": "活跃智能体",
     "active": "活跃",
+    "total": "总计",
     "active_count": "{{count}} 活跃",
     "workflows": "工作流",
     "design_with_canvas": "使用可视化画布设计",

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -80,8 +80,8 @@ export function OverviewPage() {
   const statsCards = [
     {
       title: t("overview.active_agents"),
-      value: agentsTotal,
-      subValue: `${agentsActive} ${t("overview.active")}`,
+      value: agentsActive,
+      subValue: `${agentsTotal} ${t("overview.total")}`,
       icon: Users,
       color: "brand",
       link: "/agents",


### PR DESCRIPTION
## Summary
Closes #2156

- The "Active Agents" stats card on the dashboard overview was showing `agent_count` (total templates, e.g. 59) as the primary number, with `active_agent_count` (actually running, e.g. 8) hidden in a small sub-label
- Swapped the values so the active/running count is the prominent number and total is shown as context ("59 total")
- Added missing `overview.total` translation key for en and zh locales

## Test plan
- [ ] Open the dashboard overview page
- [ ] Verify the "Active Agents" card shows the running agent count as the large primary number
- [ ] Verify the total template count appears as the sub-label (e.g. "59 total")
- [ ] Verify the progress bar still shows the correct ratio (active / total)