### PR TITLE
fix(skills): handle SkillHub search response format with proper headers

### DIFF
--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -106,6 +106,8 @@ pub struct SkillhubClient {
     inner: ClawHubClient,
     /// Separate HTTP client for the static index fetch.
     http: reqwest::Client,
+    /// Base API URL (e.g. `https://skillhub.tencent.com/api/v1`).
+    base_url: String,
 }
 
 impl SkillhubClient {
@@ -119,6 +121,7 @@ impl SkillhubClient {
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
                 .expect("HTTP client build"),
+            base_url: base_url.to_string(),
         }
     }
 
@@ -142,7 +145,7 @@ impl SkillhubClient {
     ) -> Result<ClawHubSearchResponse, SkillError> {
         let url = format!(
             "{}/search?q={}&limit={}",
-            DEFAULT_SKILLHUB_URL,
+            self.base_url,
             percent_encode(query),
             limit.min(50)
         );
@@ -167,34 +170,35 @@ impl SkillhubClient {
             SkillError::Network(format!("Failed to read Skillhub search response: {e}"))
         })?;
 
-        // Try ClawHub-compatible format first (camelCase, `results` key).
-        if let Ok(clawhub_resp) = serde_json::from_slice::<ClawHubSearchResponse>(&body) {
-            return Ok(clawhub_resp);
+        // Try SkillHub-native format first (snake_case, `skills` or `results` key).
+        // We parse this first because ClawHubSearchResponse with serde(default)
+        // would accept any JSON as empty results, masking the real data.
+        if let Ok(skillhub_resp) = serde_json::from_slice::<SkillhubSearchResponse>(&body) {
+            if !skillhub_resp.results.is_empty() {
+                return Ok(ClawHubSearchResponse {
+                    results: skillhub_resp
+                        .results
+                        .into_iter()
+                        .map(|e| ClawHubSearchEntry {
+                            score: e.score,
+                            slug: e.slug,
+                            display_name: e.name,
+                            summary: e.description,
+                            version: if e.version.is_empty() {
+                                None
+                            } else {
+                                Some(e.version)
+                            },
+                            updated_at: e.updated_at,
+                        })
+                        .collect(),
+                });
+            }
         }
 
-        // Fall back to SkillHub-native format (snake_case, may use `skills` key).
-        let skillhub_resp: SkillhubSearchResponse =
-            serde_json::from_slice(&body).map_err(|e| {
-                SkillError::Network(format!("Failed to parse Skillhub search response: {e}"))
-            })?;
-
-        Ok(ClawHubSearchResponse {
-            results: skillhub_resp
-                .results
-                .into_iter()
-                .map(|e| ClawHubSearchEntry {
-                    score: e.score,
-                    slug: e.slug,
-                    display_name: e.name,
-                    summary: e.description,
-                    version: if e.version.is_empty() {
-                        None
-                    } else {
-                        Some(e.version)
-                    },
-                    updated_at: e.updated_at,
-                })
-                .collect(),
+        // Fall back to ClawHub-compatible format (camelCase, `results` key).
+        serde_json::from_slice::<ClawHubSearchResponse>(&body).map_err(|e| {
+            SkillError::Network(format!("Failed to parse Skillhub search response: {e}"))
         })
     }
 
@@ -350,7 +354,7 @@ impl SkillhubClient {
     }
 }
 
-/// RFC 3986 percent-encoding for URL query parameters.
+/// URL query parameter encoding (`application/x-www-form-urlencoded`).
 /// Unreserved characters pass through unchanged, space becomes `+`,
 /// everything else is `%XX` encoded.
 fn percent_encode(s: &str) -> String {

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -10,7 +10,8 @@
 //! - Browse: static JSON at COS bucket
 
 use crate::clawhub::{
-    ClawHubClient, ClawHubInstallResult, ClawHubSearchResponse, ClawHubSkillDetail,
+    ClawHubClient, ClawHubInstallResult, ClawHubSearchEntry, ClawHubSearchResponse,
+    ClawHubSkillDetail,
 };
 use crate::SkillError;
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,34 @@ const SKILLHUB_INDEX_URL: &str =
 
 /// COS accelerate base URL for skill zip downloads.
 const SKILLHUB_COS_BASE: &str = "https://skillhub-1388575217.cos.accelerate.myqcloud.com";
+
+// ---------------------------------------------------------------------------
+// Search response types (SkillHub-native format)
+// ---------------------------------------------------------------------------
+
+/// A skill entry from the SkillHub search API (snake_case, may differ from ClawHub).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillhubSearchEntry {
+    pub slug: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub score: f64,
+    #[serde(default)]
+    pub updated_at: i64,
+}
+
+/// Response from the SkillHub search API.
+/// Supports both `results` (ClawHub-compatible) and `skills` (SkillHub-native) keys.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillhubSearchResponse {
+    #[serde(default, alias = "skills")]
+    pub results: Vec<SkillhubSearchEntry>,
+}
 
 // ---------------------------------------------------------------------------
 // Browse response types (static index format)
@@ -100,13 +129,73 @@ impl SkillhubClient {
 
     // -- Delegated to ClawHubClient (compatible APIs) -----------------------
 
-    /// Search skills on Skillhub (compatible with ClawHub search API).
+    /// Search skills on Skillhub.
+    ///
+    /// Overrides the ClawHub delegation to add `Accept: application/json` header,
+    /// which prevents Skillhub from returning HTML instead of JSON. Also handles
+    /// the SkillHub-native response format (snake_case, `skills` key) as a fallback
+    /// to the ClawHub-compatible format (camelCase, `results` key).
     pub async fn search(
         &self,
         query: &str,
         limit: u32,
     ) -> Result<ClawHubSearchResponse, SkillError> {
-        self.inner.search(query, limit).await
+        let url = format!(
+            "{}/search?q={}&limit={}",
+            DEFAULT_SKILLHUB_URL,
+            percent_encode(query),
+            limit.min(50)
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("User-Agent", "LibreFang/0.1")
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| SkillError::Network(format!("Skillhub search request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            return Err(SkillError::Network(format!(
+                "Skillhub search returned {}",
+                resp.status()
+            )));
+        }
+
+        let body = resp.bytes().await.map_err(|e| {
+            SkillError::Network(format!("Failed to read Skillhub search response: {e}"))
+        })?;
+
+        // Try ClawHub-compatible format first (camelCase, `results` key).
+        if let Ok(clawhub_resp) = serde_json::from_slice::<ClawHubSearchResponse>(&body) {
+            return Ok(clawhub_resp);
+        }
+
+        // Fall back to SkillHub-native format (snake_case, may use `skills` key).
+        let skillhub_resp: SkillhubSearchResponse =
+            serde_json::from_slice(&body).map_err(|e| {
+                SkillError::Network(format!("Failed to parse Skillhub search response: {e}"))
+            })?;
+
+        Ok(ClawHubSearchResponse {
+            results: skillhub_resp
+                .results
+                .into_iter()
+                .map(|e| ClawHubSearchEntry {
+                    score: e.score,
+                    slug: e.slug,
+                    display_name: e.name,
+                    summary: e.description,
+                    version: if e.version.is_empty() {
+                        None
+                    } else {
+                        Some(e.version)
+                    },
+                    updated_at: e.updated_at,
+                })
+                .collect(),
+        })
     }
 
     /// Get detailed info about a specific skill.
@@ -261,6 +350,28 @@ impl SkillhubClient {
     }
 }
 
+/// RFC 3986 percent-encoding for URL query parameters.
+/// Unreserved characters pass through unchanged, space becomes `+`,
+/// everything else is `%XX` encoded.
+fn percent_encode(s: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(s.len() * 3);
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            b' ' => out.push('+'),
+            _ => {
+                out.push('%');
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0xf) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,5 +431,67 @@ mod tests {
         let client = SkillhubClient::with_defaults(PathBuf::from("/tmp/cache"));
         // Just verify it doesn't panic
         assert!(!client.is_installed("nonexistent", Path::new("/tmp/nope")));
+    }
+
+    #[test]
+    fn test_skillhub_search_response_results_key() {
+        // SkillHub-native format using `results` key (same as alias)
+        let json = r#"{
+            "results": [
+                {
+                    "slug": "rust-helper",
+                    "name": "Rust Helper",
+                    "description": "Helps with Rust",
+                    "version": "1.2.0",
+                    "score": 0.95,
+                    "updated_at": 1700000000
+                }
+            ]
+        }"#;
+        let resp: SkillhubSearchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].slug, "rust-helper");
+        assert_eq!(resp.results[0].name, "Rust Helper");
+        assert!((resp.results[0].score - 0.95).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_skillhub_search_response_skills_key() {
+        // SkillHub-native format using `skills` key (alias)
+        let json = r#"{
+            "skills": [
+                {
+                    "slug": "python-expert",
+                    "name": "Python Expert",
+                    "description": "Expert Python assistance",
+                    "version": "2.0.0",
+                    "score": 0.88,
+                    "updated_at": 0
+                }
+            ]
+        }"#;
+        let resp: SkillhubSearchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].slug, "python-expert");
+        assert_eq!(resp.results[0].version, "2.0.0");
+    }
+
+    #[test]
+    fn test_skillhub_search_entry_minimal() {
+        // Only slug is required; all other fields have defaults
+        let json = r#"{"slug": "minimal"}"#;
+        let entry: SkillhubSearchEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.slug, "minimal");
+        assert_eq!(entry.name, "");
+        assert_eq!(entry.score, 0.0);
+        assert_eq!(entry.updated_at, 0);
+    }
+
+    #[test]
+    fn test_percent_encode() {
+        assert_eq!(percent_encode("hello world"), "hello+world");
+        assert_eq!(percent_encode("rust"), "rust");
+        assert_eq!(percent_encode("a&b=c"), "a%26b%3Dc");
+        assert_eq!(percent_encode("hello-world_2.0~test"), "hello-world_2.0~test");
     }
 }


### PR DESCRIPTION
## Summary
Closes #2158

- SkillHub search was always returning empty results because `SkillhubClient::search()` delegated to `ClawHubClient` which did not send an `Accept: application/json` header, causing `skillhub.tencent.com` to return HTML instead of JSON
- Overrode `search()` in `SkillhubClient` to use its own HTTP client with proper `Accept: application/json` header
- Added `SkillhubSearchEntry` and `SkillhubSearchResponse` structs to handle SkillHub's native response format (snake_case, `skills` key) with fallback to ClawHub format (`camelCase`, `results` key)
- Added 4 unit tests for response parsing and URL encoding

## Test plan
- [ ] Open the Skills panel in the dashboard, switch to SkillHub tab
- [ ] Type a search query (e.g. "rust") and verify results are returned
- [ ] Verify search results display name, description, version, and score correctly
- [ ] Run `cargo test -p librefang-skills` — all tests should pass