### PR TITLE
fix: suppress CMD window flash on Windows (#2159)

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -86,6 +86,8 @@ pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         }
         #[cfg(windows)]
         {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
             std::process::Command::new("tasklist")
                 .args([
                     "/FI",
@@ -94,6 +96,7 @@ pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                     "CSV",
                     "/NH",
                 ])
+                .creation_flags(CREATE_NO_WINDOW)
                 .output()
                 .ok()
                 .and_then(|o| String::from_utf8(o.stdout).ok())

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -152,20 +152,21 @@ impl ChannelAdapter for SidecarAdapter {
             "Starting sidecar channel adapter"
         );
 
-        let mut child = Command::new(&self.command)
-            .args(&self.args)
+        let mut cmd = Command::new(&self.command);
+        cmd.args(&self.args)
             .envs(&self.env)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| {
-                format!(
-                    "Failed to spawn sidecar '{}' ({}): {e}",
-                    self.name, self.command
-                )
-            })?;
+            .kill_on_drop(true);
+        #[cfg(windows)]
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        let mut child = cmd.spawn().map_err(|e| {
+            format!(
+                "Failed to spawn sidecar '{}' ({}): {e}",
+                self.name, self.command
+            )
+        })?;
 
         // Take ownership of stdin
         let child_stdin = child

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2647,8 +2647,9 @@ fn spawn_detached_daemon(
 
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     }
 
     command

--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -56,14 +56,18 @@ pub async fn sync_catalog_to(
         tokio::task::spawn_blocking({
             let repo_dir = repo_dir.clone();
             move || {
-                std::process::Command::new("git")
-                    .args(["pull", "--ff-only", "-q"])
+                let mut cmd = std::process::Command::new("git");
+                cmd.args(["pull", "--ff-only", "-q"])
                     .current_dir(&repo_dir)
                     .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status()
-                    .map(|s| s.success())
-                    .unwrap_or(false)
+                    .stderr(std::process::Stdio::null());
+                #[cfg(windows)]
+                {
+                    use std::os::windows::process::CommandExt;
+                    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                    cmd.creation_flags(CREATE_NO_WINDOW);
+                }
+                cmd.status().map(|s| s.success()).unwrap_or(false)
             }
         })
         .await
@@ -74,14 +78,18 @@ pub async fn sync_catalog_to(
             let repo_dir = repo_dir.clone();
             let repo_url = repo_url.clone();
             move || {
-                std::process::Command::new("git")
-                    .args(["clone", "--depth", "1", "-q", &repo_url])
+                let mut cmd = std::process::Command::new("git");
+                cmd.args(["clone", "--depth", "1", "-q", &repo_url])
                     .arg(&repo_dir)
                     .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status()
-                    .map(|s| s.success())
-                    .unwrap_or(false)
+                    .stderr(std::process::Stdio::null());
+                #[cfg(windows)]
+                {
+                    use std::os::windows::process::CommandExt;
+                    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                    cmd.creation_flags(CREATE_NO_WINDOW);
+                }
+                cmd.status().map(|s| s.success()).unwrap_or(false)
             }
         })
         .await

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -382,7 +382,14 @@ fn host_shell_exec(state: &GuestState, params: &serde_json::Value) -> serde_json
 
     // Command::new does NOT use a shell — safe from shell injection.
     // Each argument is passed directly to the process.
-    match std::process::Command::new(command).args(&args).output() {
+    let mut cmd = std::process::Command::new(command);
+    cmd.args(&args);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    match cmd.output() {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/crates/librefang-runtime/src/process_manager.rs
+++ b/crates/librefang-runtime/src/process_manager.rs
@@ -84,11 +84,14 @@ impl ProcessManager {
             ));
         }
 
-        let mut child = tokio::process::Command::new(command)
-            .args(args)
+        let mut cmd = tokio::process::Command::new(command);
+        cmd.args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        #[cfg(windows)]
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        let mut child = cmd
             .spawn()
             .map_err(|e| format!("Failed to start process '{}': {}", command, e))?;
 

--- a/crates/librefang-runtime/src/python_runtime.rs
+++ b/crates/librefang-runtime/src/python_runtime.rs
@@ -99,15 +99,19 @@ pub fn find_python_interpreter() -> String {
     // Try python3, then python, then the Windows Python Launcher (`py`).
     // Kept aligned with `plugin_runtime::check_runtime_status` so the
     // doctor's availability report matches what hooks actually resolve to.
-    for cmd in &["python3", "python", "py"] {
-        if std::process::Command::new(cmd)
+    for name in &["python3", "python", "py"] {
+        let mut probe = std::process::Command::new(name);
+        probe
             .arg("--version")
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok()
+            .stderr(Stdio::null());
+        #[cfg(windows)]
         {
-            return cmd.to_string();
+            use std::os::windows::process::CommandExt;
+            probe.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        }
+        if probe.status().is_ok() {
+            return name.to_string();
         }
     }
     "python3".to_string() // default, will fail with helpful message


### PR DESCRIPTION
## Summary

Fixes #2159 — CMD window flashes constantly after opening LibreFang on Windows.

**Root cause:** Every child process spawned without the `CREATE_NO_WINDOW` flag (0x08000000) briefly creates a visible console window on Windows, then closes it. LibreFang spawns many child processes (git at startup, `tasklist` for memory checks, python/node detection via plugin doctor, sidecar adapters, shell_exec tool, managed processes) — each one causes a flash.

**Fix:** Add `CREATE_NO_WINDOW` to all child-process spawn sites via `#[cfg(windows)]` blocks and `CommandExt::creation_flags`.

Sites fixed:
- `librefang-cli` daemon launch — add to existing `DETACHED_PROCESS` flags
- `librefang-api/routes/config` — `tasklist` memory probe (polled every 30s by dashboard)
- `librefang-channels/sidecar` — sidecar adapter spawn
- `librefang-runtime/catalog_sync` — `git pull/clone` on startup and every 24h
- `librefang-runtime/host_functions` — `shell_exec` tool (called per agent turn)
- `librefang-runtime/process_manager` — managed child-process spawn
- `librefang-runtime/plugin_runtime` — `probe_launcher_version` (python, node, deno, etc.)
- `librefang-runtime/python_runtime` — `find_python_interpreter` probes

**Bonus compile fixes** (introduced in df9072dd, full context engine hooks):
- `context_engine.rs`: `AgentId.0` is `Uuid` — `.as_str()` doesn't exist; use `.to_string()`
- `plugin_manager.rs`: `hook_templates` match is non-exhaustive, missing `PluginRuntime::Wasm` arm
- `kernel.rs`: `ContextEngineConfig` struct literal missing `output_schema_strict` and `max_hook_calls_per_minute` fields added in the same commit

## Test plan

- [ ] Build on Windows and confirm no CMD window flashes on startup or during agent operation
- [ ] Verify `cargo check` passes (the three bonus compile errors are resolved)
- [ ] Verify daemon starts and all endpoints work normally after the changes