### PR TITLE
fix: parameter errors trigger self-correction not user report (#2144)

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -96,6 +96,20 @@ fn is_soft_error_content(content: &str) -> bool {
     content.contains(ERR_PATH_TRAVERSAL)
         || content.contains(ERR_SANDBOX_ESCAPE)
         || content.contains("arguments were truncated")
+        || is_parameter_error_content(content)
+}
+
+/// Detect tool errors that are caused by the LLM sending wrong/missing parameters.
+/// These are soft errors because the LLM can self-correct by retrying with different
+/// input — they should NOT count toward the consecutive-failure abort threshold.
+fn is_parameter_error_content(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    lower.contains("missing '") || // "Missing 'path' parameter"
+    lower.contains("missing parameter") ||
+    lower.contains("required parameter") ||
+    lower.contains("invalid parameter") ||
+    lower.contains("parameter is required") ||
+    lower.contains("argument is required")
 }
 
 /// Safely trim message history to `MAX_HISTORY_MESSAGES`, cutting at
@@ -294,14 +308,39 @@ fn append_tool_result_guidance_blocks(tool_result_blocks: &mut Vec<ContentBlock>
         .filter(|b| matches!(b, ContentBlock::ToolResult { is_error: true, .. }))
         .count();
     let non_denial_errors = error_count.saturating_sub(denial_count);
-    if non_denial_errors > 0 {
+    // Separate parameter errors (LLM can self-correct by retrying with valid args)
+    // from execution errors (network/IO/permission failures the LLM cannot fix).
+    let param_error_count = tool_result_blocks
+        .iter()
+        .filter(|b| match b {
+            ContentBlock::ToolResult {
+                is_error: true,
+                content,
+                ..
+            } => is_parameter_error_content(content),
+            _ => false,
+        })
+        .count();
+    let non_param_errors = non_denial_errors.saturating_sub(param_error_count);
+    if param_error_count > 0 {
+        tool_result_blocks.push(ContentBlock::Text {
+            text: format!(
+                "[System: {} tool call(s) failed due to missing or invalid parameters. \
+                 Read the error message, correct your tool call arguments, and retry \
+                 immediately. Do NOT ask the user for help — fix the parameters yourself.]",
+                param_error_count
+            ),
+            provider_metadata: None,
+        });
+    }
+    if non_param_errors > 0 {
         tool_result_blocks.push(ContentBlock::Text {
             text: format!(
                 "[System: {} tool(s) returned errors. Report the error honestly \
                  to the user. Do NOT fabricate results or pretend the tool succeeded. \
                  If a search or fetch failed, tell the user it failed and suggest \
                  alternatives instead of making up data.]",
-                non_denial_errors
+                non_param_errors
             ),
             provider_metadata: None,
         });

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -1627,7 +1627,9 @@ async fn tool_file_list(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
 ) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+    let raw_path = input["path"].as_str().ok_or(
+        "Missing 'path' parameter — retry with {\"path\": \".\"} to list the workspace root",
+    )?;
     let resolved = resolve_file_path(raw_path, workspace_root)?;
     let mut entries = tokio::fs::read_dir(&resolved)
         .await


### PR DESCRIPTION
## Summary

Fixes #2144 — agent sends empty `{}` to `file_list` and halts instead of self-correcting.

**Root cause (two parts):**

**Part 1 — Wrong guidance message:** When a tool returns an error, the agent loop injects a system message saying *"Report the error honestly to the user."* This is correct for network/IO failures, but wrong for parameter errors (missing required arguments). The LLM obeys this instruction and tells the user the tool failed, then stops — never retrying with the right parameters.

**Part 2 — Parameter errors counted as hard failures:** Missing-parameter errors were counted toward `consecutive_all_failed` (the threshold that terminates the agent loop after N consecutive all-failed iterations), making early termination more likely even if the model could have self-corrected.

**Fix:**

- Added `is_parameter_error_content(content: &str) -> bool` that matches strings like `"Missing 'path' parameter"`, `"required parameter"`, `"invalid parameter"`, etc.

- Parameter errors are now classified as **soft errors** (included in `is_soft_error_content`) so they don't count toward the abort threshold.

- Parameter errors get a dedicated retry instruction:
  ```
  [System: N tool call(s) failed due to missing or invalid parameters.
  Read the error message, correct your tool call arguments, and retry
  immediately. Do NOT ask the user for help — fix the parameters yourself.]
  ```

- Non-parameter errors keep the existing "report to user" instruction.

- Both `run_agent_loop` and `run_agent_loop_streaming` paths updated.

- `file_list` error message improved: *"Missing 'path' parameter — retry with `{"path": "."}` to list the workspace root"* — gives the LLM an explicit example to copy.

## Test plan

- [ ] Prompt an agent to "list files in the workspace" and verify it calls `file_list` with the correct `path` parameter (or self-corrects if it initially omits it)
- [ ] Manually inject an agent call with `{}` as arguments to `file_list` — verify the next turn uses corrected parameters
- [ ] Verify agents with `file_list` errors no longer prematurely halt the conversation