### PR TITLE
style: fix rustfmt violations blocking CI

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1665,7 +1665,10 @@ pub async fn batch_resolve(
     // require a TOTP code. Check if any of the requested IDs need TOTP;
     // if so, reject the batch so each can be approved individually.
     // Batch reject is always allowed.
-    if matches!(decision, librefang_types::approval::ApprovalDecision::Approved) {
+    if matches!(
+        decision,
+        librefang_types::approval::ApprovalDecision::Approved
+    ) {
         let policy = state.kernel.approvals().policy();
         let any_needs_totp = body
             .ids

--- a/crates/librefang-runtime/src/drivers/claude_code.rs
+++ b/crates/librefang-runtime/src/drivers/claude_code.rs
@@ -1144,9 +1144,6 @@ mod tests {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .output();
-        assert!(
-            output.is_err(),
-            "spawning a nonexistent binary should fail"
-        );
+        assert!(output.is_err(), "spawning a nonexistent binary should fail");
     }
 }

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -496,6 +496,9 @@ mod tests {
         assert_eq!(percent_encode("hello world"), "hello+world");
         assert_eq!(percent_encode("rust"), "rust");
         assert_eq!(percent_encode("a&b=c"), "a%26b%3Dc");
-        assert_eq!(percent_encode("hello-world_2.0~test"), "hello-world_2.0~test");
+        assert_eq!(
+            percent_encode("hello-world_2.0~test"),
+            "hello-world_2.0~test"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three files introduced in recent commits have rustfmt violations that are blocking the Quality CI check — including on `main` itself and on all open PRs that have rebased onto it.

No logic changes. Pure formatting fixes to match what `cargo fmt` expects:

- `system.rs:1668` — break `matches!` call that exceeds line limit
- `claude_code.rs:1147` — collapse `assert!` to single line (below limit)
- `skillhub.rs:499` — break `assert_eq!` call that exceeds line limit

Merging this unblocks CI for #2176, #2177, and #2178.