### PR TITLE
feat: add extra_params support for openai compatible model

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4630,6 +4630,7 @@ mod tests {
             api_key_env: "OPENAI_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         };
         let override_dm = librefang_types::config::DefaultModelConfig {
             provider: "deepseek".to_string(),
@@ -4637,6 +4638,7 @@ mod tests {
             api_key_env: "DEEPSEEK_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         };
 
         let effective = effective_default_model(&base, Some(&override_dm));
@@ -4654,6 +4656,7 @@ mod tests {
             api_key_env: "OPENAI_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         };
 
         let effective = effective_default_model(&base, None);

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -81,6 +81,7 @@ async fn start_test_server_with_provider(
             api_key_env: api_key_env.to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };
@@ -212,6 +213,7 @@ async fn start_full_router(api_key: &str) -> FullRouterHarness {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };
@@ -1328,6 +1330,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -99,6 +99,7 @@ async fn test_full_daemon_lifecycle() {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };
@@ -238,6 +239,7 @@ async fn test_server_immediate_responsiveness() {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -43,6 +43,7 @@ async fn start_test_server() -> TestServer {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-hands/src/lib.rs
+++ b/crates/librefang-hands/src/lib.rs
@@ -317,6 +317,7 @@ impl From<LegacyHandAgentConfig> for AgentManifest {
                 system_prompt: legacy.system_prompt,
                 api_key_env: legacy.api_key_env,
                 base_url: legacy.base_url,
+                extra_params: std::collections::HashMap::new(),
             },
             autonomous: legacy.max_iterations.map(|max_iter| AutonomousConfig {
                 max_iterations: max_iter,

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2742,6 +2742,15 @@ impl LibreFangKernel {
                                     .base_url
                                     .clone_from(&dm.base_url);
                             }
+                            // Merge extra_params from default_model
+                            for (key, value) in &dm.extra_params {
+                                restored_entry
+                                    .manifest
+                                    .model
+                                    .extra_params
+                                    .entry(key.clone())
+                                    .or_insert(value.clone());
+                            }
                         }
                     }
 
@@ -4414,6 +4423,7 @@ system_prompt = "You are a helpful assistant."
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let result = match tokio::time::timeout(
@@ -4946,6 +4956,7 @@ system_prompt = "You are a helpful assistant."
                 prompt_caching: false,
                 response_format: None,
                 timeout_secs: None,
+                extra_body: None,
             };
             let (complexity, routed_model) = router.select_model(&probe);
             // Check if the routed model's provider has a valid API key.
@@ -6508,6 +6519,15 @@ system_prompt = "You are a helpful assistant."
             }
             if manifest.model.model == "default" {
                 manifest.model.model = cfg.default_model.model.clone();
+            }
+
+            // Merge extra_params from default_model (agent-level keys take precedence)
+            for (key, value) in &cfg.default_model.extra_params {
+                manifest
+                    .model
+                    .extra_params
+                    .entry(key.clone())
+                    .or_insert(value.clone());
             }
 
             // Hand-level tool inheritance: hand controls WHICH tools are available,
@@ -8566,6 +8586,7 @@ system_prompt = "You are a helpful assistant."
                         Some(gfb.api_key_env.clone())
                     },
                     base_url: gfb.base_url.clone(),
+                    extra_params: std::collections::HashMap::new(),
                 });
             }
         }
@@ -9948,6 +9969,14 @@ impl LibreFangKernel {
                         }
                         if dm.base_url.is_some() && e.manifest.model.base_url.is_none() {
                             e.manifest.model.base_url.clone_from(&dm.base_url);
+                        }
+                        // Merge extra_params from default_model (agent-level keys take precedence)
+                        for (key, value) in &dm.extra_params {
+                            e.manifest
+                                .model
+                                .extra_params
+                                .entry(key.clone())
+                                .or_insert(value.clone());
                         }
                         let _ = self.memory.save_agent(&e);
                     }
@@ -12426,6 +12455,7 @@ mod tests {
                         system_prompt: String::new(),
                         api_key_env: None,
                         base_url: None,
+                        extra_params: std::collections::HashMap::new(),
                     },
                     ..Default::default()
                 },

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -159,6 +159,7 @@ impl SetupWizard {
                 system_prompt,
                 api_key_env: None,
                 base_url: None,
+                extra_params: std::collections::HashMap::new(),
             },
             resources: ResourceQuota::default(),
             priority: Priority::default(),

--- a/crates/librefang-kernel/tests/integration_test.rs
+++ b/crates/librefang-kernel/tests/integration_test.rs
@@ -20,6 +20,7 @@ fn test_config() -> KernelConfig {
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -26,6 +26,7 @@ fn test_config(name: &str) -> KernelConfig {
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
+++ b/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
@@ -116,6 +116,7 @@ fn test_config(tmp: &tempfile::TempDir) -> KernelConfig {
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/workflow_integration_test.rs
+++ b/crates/librefang-kernel/tests/workflow_integration_test.rs
@@ -25,6 +25,7 @@ fn test_config(provider: &str, model: &str, api_key_env: &str) -> KernelConfig {
             api_key_env: api_key_env.to_string(),
             base_url: None,
             message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2085,8 +2085,47 @@ pub async fn run_agent_loop(
             apply_context_guard(&mut messages, &context_budget, available_tools);
         }
 
-        let request =
-            build_completion_request(manifest, &system_prompt, &messages, available_tools);
+        // Strip provider prefix: "openrouter/google/gemini-2.5-flash" → "google/gemini-2.5-flash"
+        let api_model = strip_provider_prefix(&manifest.model.model, &manifest.model.provider);
+
+        let prompt_caching = manifest
+            .metadata
+            .get("prompt_caching")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let timeout_override = manifest
+            .metadata
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                if available_tools
+                    .iter()
+                    .any(|t| t.name.starts_with("browser_") || t.name.starts_with("playwright_"))
+                {
+                    Some(600)
+                } else {
+                    None
+                }
+            });
+
+        let request = CompletionRequest {
+            model: api_model,
+            messages: messages.clone(),
+            tools: available_tools.to_vec(),
+            max_tokens: manifest.model.max_tokens,
+            temperature: manifest.model.temperature,
+            system: Some(system_prompt.clone()),
+            thinking: manifest.thinking.clone(),
+            prompt_caching,
+            response_format: manifest.response_format.clone(),
+            timeout_secs: timeout_override,
+            extra_body: if manifest.model.extra_params.is_empty() {
+                None
+            } else {
+                Some(manifest.model.extra_params.clone())
+            },
+        };
 
         // Notify phase: Thinking
         if let Some(cb) = on_phase {
@@ -2933,8 +2972,50 @@ pub async fn run_agent_loop_streaming(
             }
         }
 
-        let request =
-            build_completion_request(manifest, &system_prompt, &messages, available_tools);
+        // Strip provider prefix: "openrouter/google/gemini-2.5-flash" → "google/gemini-2.5-flash"
+        let api_model = strip_provider_prefix(&manifest.model.model, &manifest.model.provider);
+
+        let prompt_caching = manifest
+            .metadata
+            .get("prompt_caching")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        // Per-request timeout: manifest metadata takes priority, then browser
+        // heuristic, then driver default (None = use driver's configured value).
+        let timeout_override = manifest
+            .metadata
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                // Auto-extend for agents with browser tools
+                if available_tools
+                    .iter()
+                    .any(|t| t.name.starts_with("browser_") || t.name.starts_with("playwright_"))
+                {
+                    Some(600) // 10 minutes for browser tasks
+                } else {
+                    None
+                }
+            });
+
+        let request = CompletionRequest {
+            model: api_model,
+            messages: messages.clone(),
+            tools: available_tools.to_vec(),
+            max_tokens: manifest.model.max_tokens,
+            temperature: manifest.model.temperature,
+            system: Some(system_prompt.clone()),
+            thinking: manifest.thinking.clone(),
+            prompt_caching,
+            response_format: manifest.response_format.clone(),
+            timeout_secs: timeout_override,
+            extra_body: if manifest.model.extra_params.is_empty() {
+                None
+            } else {
+                Some(manifest.model.extra_params.clone())
+            },
+        };
 
         // Notify phase: on first iteration emit Streaming; on subsequent
         // iterations (after tool execution) emit Thinking so the UI shows

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -571,6 +571,7 @@ async fn summarize_messages(
         prompt_caching: false,
         response_format: None,
         timeout_secs: None,
+        extra_body: None,
     };
 
     // Retry logic for transient failures
@@ -693,6 +694,7 @@ async fn summarize_in_chunks(
         prompt_caching: false,
         response_format: None,
         timeout_secs: None,
+        extra_body: None,
     };
 
     match driver.complete(merge_request).await {

--- a/crates/librefang-runtime/src/drivers/chatgpt.rs
+++ b/crates/librefang-runtime/src/drivers/chatgpt.rs
@@ -1034,6 +1034,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.model, "gpt-4o");
@@ -1067,6 +1068,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.instructions.as_deref(), Some("System prompt."));
@@ -1092,6 +1094,7 @@ mod tests {
             prompt_caching: false,
             response_format: Some(ResponseFormat::Json),
             timeout_secs: None,
+            extra_body: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");
@@ -1126,6 +1129,7 @@ mod tests {
                 strict: Some(true),
             }),
             timeout_secs: None,
+            extra_body: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");

--- a/crates/librefang-runtime/src/drivers/claude_code.rs
+++ b/crates/librefang-runtime/src/drivers/claude_code.rs
@@ -896,6 +896,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -937,6 +938,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);

--- a/crates/librefang-runtime/src/drivers/fallback.rs
+++ b/crates/librefang-runtime/src/drivers/fallback.rs
@@ -264,6 +264,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         }
     }
 

--- a/crates/librefang-runtime/src/drivers/gemini.rs
+++ b/crates/librefang-runtime/src/drivers/gemini.rs
@@ -1283,6 +1283,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let tools = convert_tools(&request);
@@ -1304,6 +1305,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let tools = convert_tools(&request);

--- a/crates/librefang-runtime/src/drivers/openai.rs
+++ b/crates/librefang-runtime/src/drivers/openai.rs
@@ -10,6 +10,7 @@ use librefang_types::config::ResponseFormat;
 use librefang_types::message::{ContentBlock, MessageContent, Role, StopReason, TokenUsage};
 use librefang_types::tool::ToolCall;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
@@ -115,6 +116,9 @@ struct OaiRequest {
     /// Structured output: `response_format` field (json_object or json_schema).
     #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<serde_json::Value>,
+    /// Provider-specific extension parameters, flattened to the request top-level.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    extra_body: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Convert a [`ResponseFormat`] into the OpenAI `response_format` JSON value.
@@ -532,6 +536,7 @@ impl OpenAIDriver {
                 .response_format
                 .as_ref()
                 .and_then(oai_response_format),
+            extra_body: request.extra_body.clone(),
         })
     }
 }
@@ -1977,5 +1982,72 @@ mod tests {
             ensure_object(input),
             serde_json::json!({"raw_input": "[1, 2, 3]"})
         );
+    }
+
+    #[test]
+    fn test_oai_request_extra_body_flattening() {
+        let mut extra = HashMap::new();
+        extra.insert("enable_memory".to_string(), serde_json::json!(true));
+
+        let req = OaiRequest {
+            model: "qwen3.6".to_string(),
+            messages: vec![OaiMessage {
+                role: "user".to_string(),
+                content: Some(OaiMessageContent::Text("hello".to_string())),
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+            }],
+            max_tokens: Some(4096),
+            max_completion_tokens: None,
+            temperature: Some(0.7),
+            tools: vec![],
+            tool_choice: None,
+            stream: false,
+            stream_options: None,
+            thinking: None,
+            response_format: None,
+            extra_body: Some(extra),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // extra_body keys should be at top level (flattened)
+        assert_eq!(
+            parsed.get("enable_memory").unwrap(),
+            &serde_json::json!(true)
+        );
+        assert_eq!(parsed.get("model").unwrap(), "qwen3.6");
+        // There should be no nested "extra_body" key
+        assert!(parsed.get("extra_body").is_none());
+    }
+
+    #[test]
+    fn test_oai_request_extra_body_none_skipped() {
+        let req = OaiRequest {
+            model: "test-model".to_string(),
+            messages: vec![OaiMessage {
+                role: "user".to_string(),
+                content: Some(OaiMessageContent::Text("hi".to_string())),
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+            }],
+            max_tokens: Some(100),
+            max_completion_tokens: None,
+            temperature: Some(0.5),
+            tools: vec![],
+            tool_choice: None,
+            stream: false,
+            stream_options: None,
+            thinking: None,
+            response_format: None,
+            extra_body: None,
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("extra_body").is_none());
     }
 }

--- a/crates/librefang-runtime/src/drivers/qwen_code.rs
+++ b/crates/librefang-runtime/src/drivers/qwen_code.rs
@@ -623,6 +623,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let prompt = QwenCodeDriver::build_prompt(&request);

--- a/crates/librefang-runtime/src/drivers/token_rotation.rs
+++ b/crates/librefang-runtime/src/drivers/token_rotation.rs
@@ -274,6 +274,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         }
     }
 

--- a/crates/librefang-runtime/src/llm_driver.rs
+++ b/crates/librefang-runtime/src/llm_driver.rs
@@ -2,6 +2,8 @@
 //!
 //! Abstracts over multiple LLM providers (Anthropic, OpenAI, Ollama, etc.).
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use librefang_types::config::{AzureOpenAiConfig, ResponseFormat, VertexAiConfig};
 use librefang_types::message::{ContentBlock, Message, StopReason, TokenUsage};
@@ -91,6 +93,12 @@ pub struct CompletionRequest {
     /// this instead of the global `message_timeout_secs`.  Allows the agent
     /// loop to grant longer timeouts for requests that involve browser tools.
     pub timeout_secs: Option<u64>,
+    /// Provider-specific extension parameters merged directly into the
+    /// top-level API request body.
+    ///
+    /// When keys conflict with standard parameters (temperature, max_tokens, etc.),
+    /// values from `extra_body` take precedence (last-wins in JSON serialization).
+    pub extra_body: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// A response from an LLM completion.
@@ -359,6 +367,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let response = driver.stream(request, tx).await.unwrap();

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -254,6 +254,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         let response = self
@@ -307,6 +308,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         };
 
         match self.driver.complete(request).await {

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -196,6 +196,7 @@ mod tests {
             prompt_caching: false,
             response_format: None,
             timeout_secs: None,
+            extra_body: None,
         }
     }
 

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -112,6 +112,7 @@ async fn test_mock_llm_driver_recording() {
         prompt_caching: false,
         response_format: None,
         timeout_secs: None,
+        extra_body: None,
     };
 
     // First call
@@ -282,6 +283,7 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
         prompt_caching: false,
         response_format: None,
         timeout_secs: None,
+        extra_body: None,
     };
 
     let resp = driver.complete(request).await.unwrap();
@@ -321,6 +323,7 @@ async fn test_failing_llm_driver() {
         prompt_caching: false,
         response_format: None,
         timeout_secs: None,
+        extra_body: None,
     };
 
     let result = driver.complete(request).await;

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -451,6 +451,16 @@ pub struct ModelConfig {
     pub api_key_env: Option<String>,
     /// Optional base URL override for the provider.
     pub base_url: Option<String>,
+    /// Provider-specific extension parameters that are flattened directly
+    /// into the API request body.
+    ///
+    /// For example, Qwen 3.6's `enable_memory` parameter for agent memory
+    /// support. When serialized, these keys are merged into the top-level
+    /// API request body via `#[serde(flatten)]`. If a key conflicts with a
+    /// standard field (e.g. `temperature`), the `extra_params` value takes
+    /// precedence because it is serialized last.
+    #[serde(default, flatten)]
+    pub extra_params: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl Default for ModelConfig {
@@ -463,12 +473,14 @@ impl Default for ModelConfig {
             system_prompt: "You are a helpful AI agent.".to_string(),
             api_key_env: None,
             base_url: None,
+            extra_params: std::collections::HashMap::new(),
         }
     }
 }
 
 /// A fallback model entry in a chain.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct FallbackModel {
     pub provider: String,
     pub model: String,
@@ -476,6 +488,10 @@ pub struct FallbackModel {
     pub api_key_env: Option<String>,
     #[serde(default)]
     pub base_url: Option<String>,
+    /// Provider-specific extension parameters that are flattened directly
+    /// into the API request body.
+    #[serde(default, flatten)]
+    pub extra_params: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Tool configuration within an agent manifest.
@@ -1190,6 +1206,7 @@ mod tests {
             model: "llama-3.3-70b".to_string(),
             api_key_env: Some("GROQ_API_KEY".to_string()),
             base_url: None,
+            extra_params: std::collections::HashMap::new(),
         };
         let json = serde_json::to_string(&fb).unwrap();
         let back: FallbackModel = serde_json::from_str(&json).unwrap();
@@ -1207,6 +1224,7 @@ mod tests {
                 model: "llama-3.3-70b".to_string(),
                 api_key_env: None,
                 base_url: None,
+                extra_params: std::collections::HashMap::new(),
             }],
             ..Default::default()
         };
@@ -1620,6 +1638,46 @@ model = "llama-3.3-70b-versatile"
         let resolved = manifest.thinking.clone().unwrap_or(global);
         assert_eq!(resolved.budget_tokens, 5_000);
         assert!(resolved.stream_thinking);
+    }
+
+    #[test]
+    fn test_model_config_extra_params_roundtrip() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("enable_memory".to_string(), serde_json::json!(true));
+        extra.insert("memory_max_window".to_string(), serde_json::json!(50));
+
+        let config = ModelConfig {
+            provider: "qwen".to_string(),
+            model: "qwen3.6".to_string(),
+            max_tokens: 4096,
+            temperature: 0.7,
+            system_prompt: "test".to_string(),
+            api_key_env: None,
+            base_url: None,
+            extra_params: extra,
+        };
+
+        // Serialize to TOML
+        let toml_str = toml::to_string(&config).unwrap();
+        assert!(toml_str.contains("enable_memory = true"));
+        assert!(toml_str.contains("memory_max_window = 50"));
+
+        // Deserialize back
+        let parsed: ModelConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(
+            parsed.extra_params.get("enable_memory").unwrap(),
+            &serde_json::json!(true)
+        );
+        assert_eq!(
+            parsed.extra_params.get("memory_max_window").unwrap(),
+            &serde_json::json!(50)
+        );
+    }
+
+    #[test]
+    fn test_model_config_extra_params_empty_by_default() {
+        let config = ModelConfig::default();
+        assert!(config.extra_params.is_empty());
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3439,6 +3439,10 @@ pub struct DefaultModelConfig {
     /// many seconds of silence on stdout, not wall-clock time.
     #[serde(default = "default_message_timeout_secs")]
     pub message_timeout_secs: u64,
+    /// Provider-specific extension parameters that are flattened directly
+    /// into the API request body.
+    #[serde(default, flatten)]
+    pub extra_params: HashMap<String, serde_json::Value>,
 }
 
 fn default_message_timeout_secs() -> u64 {
@@ -3453,6 +3457,7 @@ impl Default for DefaultModelConfig {
             api_key_env: String::new(),
             base_url: None,
             message_timeout_secs: default_message_timeout_secs(),
+            extra_params: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Rebased from #2162 (shilkazx/librefang#feature/add_extra_param) — original PR approved but had merge conflicts after recent merges.

Add `extra_params` field to `ModelConfig` using `serde(flatten)` so users can pass provider-specific parameters (e.g. `enable_memory`, `memory_max_window` for Qwen) that get forwarded as `extra_body` in the completion request.

Co-authored-by: zhongxiong <zhongxiong@neuramatrix.net>
Closes #2162