### PR TITLE
fix(runtime): resolve build errors and clippy warnings

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2325,6 +2325,8 @@ impl LibreFangKernel {
             stable_prefix_mode: config.stable_prefix_mode,
             max_recall_results: 5,
             compaction: Some(config.compaction.clone()),
+            output_schema_strict: false,
+            max_hook_calls_per_minute: 0,
         };
         let context_engine: Option<Box<dyn librefang_runtime::context_engine::ContextEngine>> = {
             let emb_arc: Option<
@@ -2605,11 +2607,18 @@ impl LibreFangKernel {
                     // Inherit kernel exec_policy for agents that lack one.
                     // Promote to Full when shell_exec is declared in capabilities.
                     if restored_entry.manifest.exec_policy.is_none() {
-                        if restored_entry.manifest.capabilities.tools.iter().any(|t| t == "shell_exec" || t == "*") {
-                            restored_entry.manifest.exec_policy = Some(librefang_types::config::ExecPolicy {
-                                mode: librefang_types::config::ExecSecurityMode::Full,
-                                ..cfg.exec_policy.clone()
-                            });
+                        if restored_entry
+                            .manifest
+                            .capabilities
+                            .tools
+                            .iter()
+                            .any(|t| t == "shell_exec" || t == "*")
+                        {
+                            restored_entry.manifest.exec_policy =
+                                Some(librefang_types::config::ExecPolicy {
+                                    mode: librefang_types::config::ExecSecurityMode::Full,
+                                    ..cfg.exec_policy.clone()
+                                });
                         } else {
                             restored_entry.manifest.exec_policy = Some(cfg.exec_policy.clone());
                         }
@@ -2837,7 +2846,12 @@ system_prompt = "You are a helpful assistant."
         let cfg = self.config.load();
         let mut manifest = manifest;
         if manifest.exec_policy.is_none() {
-            if manifest.capabilities.tools.iter().any(|t| t == "shell_exec" || t == "*") {
+            if manifest
+                .capabilities
+                .tools
+                .iter()
+                .any(|t| t == "shell_exec" || t == "*")
+            {
                 manifest.exec_policy = Some(librefang_types::config::ExecPolicy {
                     mode: librefang_types::config::ExecSecurityMode::Full,
                     ..cfg.exec_policy.clone()
@@ -8899,7 +8913,11 @@ system_prompt = "You are a helpful assistant."
         };
         for skill_tool in skill_tools {
             // If agent declares specific tools, only include matching skill tools
-            if !tools_unrestricted && !declared_tools.iter().any(|d| glob_matches(d, &skill_tool.name)) {
+            if !tools_unrestricted
+                && !declared_tools
+                    .iter()
+                    .any(|d| glob_matches(d, &skill_tool.name))
+            {
                 continue;
             }
             all_tools.push(ToolDefinition {
@@ -12389,7 +12407,10 @@ mod tests {
         let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
 
         // Verify exec_policy was promoted to Full
-        let entry = kernel.registry.get(agent_id).expect("agent must be registered");
+        let entry = kernel
+            .registry
+            .get(agent_id)
+            .expect("agent must be registered");
         assert_eq!(
             entry.manifest.exec_policy.as_ref().map(|p| p.mode),
             Some(librefang_types::config::ExecSecurityMode::Full),

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -65,7 +65,13 @@ fn agent_scoped_state_path(
             // Sanitise the agent ID — keep only alphanumeric, '-', '_'.
             let safe_id: String = id
                 .chars()
-                .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
                 .collect();
             // base_path is e.g. `/home/user/.librefang/plugins/my_plugin/state.json`
             // We place agent state alongside: `…/agents/{safe_id}/state.json`
@@ -631,7 +637,11 @@ struct CircuitBreakerState {
 
 impl CircuitBreakerState {
     fn new() -> Self {
-        Self { consecutive_failures: 0, opened_at: None, half_open: false }
+        Self {
+            consecutive_failures: 0,
+            opened_at: None,
+            half_open: false,
+        }
     }
 
     /// Returns `true` when the hook should be skipped (circuit open + not half-open).
@@ -671,7 +681,7 @@ impl CircuitBreakerState {
     fn record_failure(&mut self, max_failures: u32) {
         self.consecutive_failures += 1;
         self.half_open = false; // probe failed → close half-open window
-        // (Re-)latch the circuit when threshold is reached
+                                // (Re-)latch the circuit when threshold is reached
         if self.consecutive_failures >= max_failures {
             self.opened_at = Some(std::time::Instant::now());
         }
@@ -702,7 +712,11 @@ impl HookRateLimiter {
         let now = std::time::Instant::now();
         let window = std::time::Duration::from_secs(60);
         // Evict calls older than the window.
-        while self.calls.front().map_or(false, |t| now.duration_since(*t) > window) {
+        while self
+            .calls
+            .front()
+            .is_some_and(|t| now.duration_since(*t) > window)
+        {
             self.calls.pop_front();
         }
         if self.calls.len() >= max_per_minute as usize {
@@ -818,7 +832,8 @@ pub struct ScriptableContextEngine {
     /// Path to the per-plugin shared state JSON file (when `enable_shared_state = true`).
     shared_state_path: Option<std::path::PathBuf>,
     /// Circuit breaker states per hook name.
-    circuit_breakers: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, CircuitBreakerState>>>,
+    circuit_breakers:
+        std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, CircuitBreakerState>>>,
     /// Circuit breaker config (None = disabled).
     circuit_breaker_cfg: Option<librefang_types::config::CircuitBreakerConfig>,
     /// Semaphore bounding concurrent `after_turn` background tasks.
@@ -826,7 +841,8 @@ pub struct ScriptableContextEngine {
     /// Whether to pre-warm subprocesses on engine init.
     prewarm_subprocesses: bool,
     /// Per-agent hook call counters: agent_id → HookStats.
-    per_agent_metrics: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, HookStats>>>,
+    per_agent_metrics:
+        std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, HookStats>>>,
     /// OTel OTLP endpoint for this plugin (advisory; logged if set).
     #[allow(dead_code)]
     otel_endpoint: Option<String>,
@@ -841,7 +857,8 @@ pub struct ScriptableContextEngine {
     /// Overrides applied by the bootstrap hook at startup.
     bootstrap_applied_overrides: std::sync::Arc<std::sync::Mutex<BootstrapOverrides>>,
     /// Per-hook sliding-window rate limiters.
-    rate_limiters: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, HookRateLimiter>>>,
+    rate_limiters:
+        std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, HookRateLimiter>>>,
     /// Script to invoke when an event is received from the event bus.
     on_event_script: Option<String>,
     /// Optional shared event bus. When set, events emitted by this plugin's
@@ -861,14 +878,14 @@ impl ScriptableContextEngine {
     ) -> Self {
         // Warn at construction time for any declared script that cannot be found.
         let all_declared: &[(&str, &Option<String>)] = &[
-            ("ingest",           &hooks.ingest),
-            ("after_turn",       &hooks.after_turn),
-            ("bootstrap",        &hooks.bootstrap),
-            ("assemble",         &hooks.assemble),
-            ("compact",          &hooks.compact),
+            ("ingest", &hooks.ingest),
+            ("after_turn", &hooks.after_turn),
+            ("bootstrap", &hooks.bootstrap),
+            ("assemble", &hooks.assemble),
+            ("compact", &hooks.compact),
             ("prepare_subagent", &hooks.prepare_subagent),
-            ("merge_subagent",   &hooks.merge_subagent),
-            ("on_event",         &hooks.on_event),
+            ("merge_subagent", &hooks.merge_subagent),
+            ("on_event", &hooks.on_event),
         ];
         for (name, path_opt) in all_declared {
             if let Some(path) = path_opt {
@@ -935,15 +952,15 @@ impl ScriptableContextEngine {
             compact_cache: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::HashMap::new(),
             )),
-            ingest_regex: hooks.ingest_regex.as_deref().and_then(|pat| {
-                match regex_lite::Regex::new(pat) {
+            ingest_regex: hooks.ingest_regex.as_deref().and_then(
+                |pat| match regex_lite::Regex::new(pat) {
                     Ok(r) => Some(r),
                     Err(e) => {
                         warn!(pattern = pat, error = %e, "Invalid ingest_regex — ignored");
                         None
                     }
-                }
-            }),
+                },
+            ),
             // When enable_shared_state is true, set a placeholder path; the
             // actual plugin-scoped path is filled in by `with_plugin_name()`.
             shared_state_path: if hooks.enable_shared_state {
@@ -965,10 +982,16 @@ impl ScriptableContextEngine {
             otel_endpoint: hooks.otel_endpoint.clone(),
             plugin_name: String::new(), // filled in by with_plugin_name()
             trace_store: None,          // filled in by with_plugin_name()
-            after_turn_tasks: std::sync::Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new())),
+            after_turn_tasks: std::sync::Arc::new(tokio::sync::Mutex::new(
+                tokio::task::JoinSet::new(),
+            )),
             memory_substrate,
-            bootstrap_applied_overrides: std::sync::Arc::new(std::sync::Mutex::new(BootstrapOverrides::default())),
-            rate_limiters: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            bootstrap_applied_overrides: std::sync::Arc::new(std::sync::Mutex::new(
+                BootstrapOverrides::default(),
+            )),
+            rate_limiters: std::sync::Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
             on_event_script: hooks.on_event.clone(),
             event_bus: None,
         }
@@ -1012,7 +1035,8 @@ impl ScriptableContextEngine {
                                     let elapsed_secs = chrono::Utc::now()
                                         .signed_duration_since(dt.with_timezone(&chrono::Utc))
                                         .num_seconds()
-                                        .max(0) as u64;
+                                        .max(0)
+                                        as u64;
                                     std::time::Instant::now()
                                         .checked_sub(std::time::Duration::from_secs(elapsed_secs))
                                         .unwrap_or_else(std::time::Instant::now)
@@ -1072,7 +1096,9 @@ impl ScriptableContextEngine {
                     match rx.recv().await {
                         Ok(event) => {
                             // Skip events emitted by this same plugin to avoid infinite loops.
-                            if event.source_plugin == plugin_name { continue; }
+                            if event.source_plugin == plugin_name {
+                                continue;
+                            }
 
                             let effective_env = {
                                 let guard = bootstrap_overrides
@@ -1136,7 +1162,10 @@ impl ScriptableContextEngine {
 
     /// Return a snapshot of all hook invocation metrics.
     pub fn metrics(&self) -> HookMetrics {
-        self.metrics.lock().unwrap_or_else(|p| p.into_inner()).clone()
+        self.metrics
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// Return recent hook invocation traces (up to `TRACE_BUFFER_CAPACITY`).
@@ -1186,20 +1215,24 @@ impl ScriptableContextEngine {
     ///
     /// Returns a list of human-readable violation messages (empty = valid).
     /// The caller decides whether to warn or error based on `output_schema_strict`.
-    fn validate_schema(schema: &serde_json::Value, value: &serde_json::Value, context: &str) -> Vec<String> {
+    fn validate_schema(
+        schema: &serde_json::Value,
+        value: &serde_json::Value,
+        context: &str,
+    ) -> Vec<String> {
         let mut errors: Vec<String> = Vec::new();
 
         // --- type check ---
         if let Some(expected_type) = schema.get("type").and_then(|t| t.as_str()) {
             let actual_matches = match expected_type {
-                "object"  => value.is_object(),
-                "array"   => value.is_array(),
-                "string"  => value.is_string(),
-                "number"  => value.is_number(),
+                "object" => value.is_object(),
+                "array" => value.is_array(),
+                "string" => value.is_string(),
+                "number" => value.is_number(),
                 "integer" => value.is_i64() || value.is_u64(),
                 "boolean" => value.is_boolean(),
-                "null"    => value.is_null(),
-                _         => true, // unknown type — don't reject
+                "null" => value.is_null(),
+                _ => true, // unknown type — don't reject
             };
             if !actual_matches {
                 errors.push(format!(
@@ -1223,12 +1256,16 @@ impl ScriptableContextEngine {
         if let Some(n) = value.as_f64() {
             if let Some(min) = schema.get("minimum").and_then(|v| v.as_f64()) {
                 if n < min {
-                    errors.push(format!("[{context}] below minimum: value={n}, minimum={min}"));
+                    errors.push(format!(
+                        "[{context}] below minimum: value={n}, minimum={min}"
+                    ));
                 }
             }
             if let Some(max) = schema.get("maximum").and_then(|v| v.as_f64()) {
                 if n > max {
-                    errors.push(format!("[{context}] above maximum: value={n}, maximum={max}"));
+                    errors.push(format!(
+                        "[{context}] above maximum: value={n}, maximum={max}"
+                    ));
                 }
             }
         }
@@ -1237,12 +1274,18 @@ impl ScriptableContextEngine {
         if let Some(s) = value.as_str() {
             if let Some(min_len) = schema.get("minLength").and_then(|v| v.as_u64()) {
                 if (s.len() as u64) < min_len {
-                    errors.push(format!("[{context}] string too short: len={}, min_len={min_len}", s.len()));
+                    errors.push(format!(
+                        "[{context}] string too short: len={}, min_len={min_len}",
+                        s.len()
+                    ));
                 }
             }
             if let Some(max_len) = schema.get("maxLength").and_then(|v| v.as_u64()) {
                 if (s.len() as u64) > max_len {
-                    errors.push(format!("[{context}] string too long: len={}, max_len={max_len}", s.len()));
+                    errors.push(format!(
+                        "[{context}] string too long: len={}, max_len={max_len}",
+                        s.len()
+                    ));
                 }
             }
         }
@@ -1279,26 +1322,33 @@ impl ScriptableContextEngine {
     }
 
     fn circuit_is_open(&self, hook: &str, agent_id: Option<&AgentId>) -> bool {
-        let Some(ref cfg) = self.circuit_breaker_cfg else { return false; };
+        let Some(ref cfg) = self.circuit_breaker_cfg else {
+            return false;
+        };
         let key = match agent_id {
             Some(id) => format!("{}:{}", id.0, hook),
             None => hook.to_string(),
         };
         let mut guard = self.circuit_breakers.lock().unwrap();
-        guard.entry(key)
-             .or_insert_with(CircuitBreakerState::new)
-             .is_open(cfg.max_failures, cfg.reset_secs)
+        guard
+            .entry(key)
+            .or_insert_with(CircuitBreakerState::new)
+            .is_open(cfg.max_failures, cfg.reset_secs)
     }
 
     fn circuit_record(&self, hook: &str, agent_id: Option<&AgentId>, success: bool) {
-        let Some(ref cfg) = self.circuit_breaker_cfg else { return; };
+        let Some(ref cfg) = self.circuit_breaker_cfg else {
+            return;
+        };
         let key = match agent_id {
             Some(id) => format!("{}:{}", id.0, hook),
             None => hook.to_string(),
         };
         let (failures, opened_at_rfc3339, just_reset) = {
             let mut guard = self.circuit_breakers.lock().unwrap();
-            let state = guard.entry(key.clone()).or_insert_with(CircuitBreakerState::new);
+            let state = guard
+                .entry(key.clone())
+                .or_insert_with(CircuitBreakerState::new);
             if success {
                 state.record_success();
                 // Reset — signal deletion from SQLite.
@@ -1306,7 +1356,11 @@ impl ScriptableContextEngine {
             } else {
                 state.record_failure(cfg.max_failures);
                 if state.consecutive_failures == cfg.max_failures {
-                    warn!(hook, cooldown_secs = cfg.reset_secs, "Hook circuit breaker opened");
+                    warn!(
+                        hook,
+                        cooldown_secs = cfg.reset_secs,
+                        "Hook circuit breaker opened"
+                    );
                 }
                 // Compute RFC-3339 opened_at from the stored Instant if available.
                 let opened_str = state.opened_at.map(|instant| {
@@ -1333,16 +1387,25 @@ impl ScriptableContextEngine {
             let stats = map.entry(agent_id.0.to_string()).or_default();
             stats.calls += 1;
             stats.total_ms += elapsed_ms;
-            if success { stats.successes += 1; } else { stats.failures += 1; }
+            if success {
+                stats.successes += 1;
+            } else {
+                stats.failures += 1;
+            }
         }
     }
 
     pub fn per_agent_metrics_snapshot(&self) -> std::collections::HashMap<String, HookStats> {
-        self.per_agent_metrics.lock().unwrap_or_else(|p| p.into_inner()).clone()
+        self.per_agent_metrics
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     pub async fn prewarm(&self) {
-        if !self.prewarm_subprocesses || !self.persistent_subprocess { return; }
+        if !self.prewarm_subprocesses || !self.persistent_subprocess {
+            return;
+        }
         let runtime = self.runtime;
         let hooks: &[(&str, &Option<String>)] = &[
             ("ingest", &self.ingest_script),
@@ -1356,7 +1419,11 @@ impl ScriptableContextEngine {
             if let Some(ref script) = script_opt {
                 let resolved = Self::resolve_script_path(script);
                 if std::path::Path::new(&resolved).exists() {
-                    match self.process_pool.prewarm(&resolved, runtime, &self.plugin_env).await {
+                    match self
+                        .process_pool
+                        .prewarm(&resolved, runtime, &self.plugin_env)
+                        .await
+                    {
                         Ok(()) => debug!(hook = name, "Pre-warmed hook subprocess"),
                         Err(e) => warn!(hook = name, error = %e, "Pre-warm failed"),
                     }
@@ -1371,7 +1438,9 @@ impl ScriptableContextEngine {
     /// a plugin hot-reload so the new script version is picked up immediately
     /// rather than waiting for the old process to die naturally.
     pub async fn evict_hook_processes(&self) {
-        if !self.persistent_subprocess { return; }
+        if !self.persistent_subprocess {
+            return;
+        }
         let hooks: &[&Option<String>] = &[
             &self.ingest_script,
             &self.after_turn_script,
@@ -1380,11 +1449,9 @@ impl ScriptableContextEngine {
             &self.compact_script,
             &self.on_event_script,
         ];
-        for script_opt in hooks {
-            if let Some(ref script) = script_opt {
-                let resolved = Self::resolve_script_path(script);
-                self.process_pool.evict(&resolved).await;
-            }
+        for script in hooks.iter().copied().flatten() {
+            let resolved = Self::resolve_script_path(script);
+            self.process_pool.evict(&resolved).await;
         }
     }
 
@@ -1393,8 +1460,7 @@ impl ScriptableContextEngine {
     /// Call this during daemon shutdown after stopping the agent loop so that
     /// no after_turn work is silently dropped. Times out after `timeout_secs`.
     pub async fn wait_for_after_turn_tasks(&self, timeout_secs: u64) {
-        let deadline = tokio::time::Instant::now()
-            + std::time::Duration::from_secs(timeout_secs);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
         // Lock once and drain; this is called during shutdown so no new tasks will
         // be spawned. Holding the async Mutex across join_next().await is safe here.
         let mut tasks = self.after_turn_tasks.lock().await;
@@ -1419,7 +1485,9 @@ impl ScriptableContextEngine {
             return true;
         }
         let id_str = agent_id.0.to_string();
-        self.agent_id_filter.iter().any(|f| id_str.contains(f.as_str()))
+        self.agent_id_filter
+            .iter()
+            .any(|f| id_str.contains(f.as_str()))
     }
 
     /// Record the outcome of one hook invocation into the named slot.
@@ -1469,14 +1537,23 @@ impl ScriptableContextEngine {
         // "log" field — emit as info log from the plugin's perspective.
         if let Some(msg) = output.get("log").and_then(|v| v.as_str()) {
             let trimmed = msg.chars().take(512).collect::<String>();
-            tracing::info!(agent_id, plugin_log = trimmed.as_str(), "after_turn hook log");
+            tracing::info!(
+                agent_id,
+                plugin_log = trimmed.as_str(),
+                "after_turn hook log"
+            );
         }
 
         // "annotations" field — debug-level dump for observability.
         if let Some(ann) = output.get("annotations") {
             tracing::debug!(
                 agent_id,
-                annotations = ann.to_string().chars().take(1024).collect::<String>().as_str(),
+                annotations = ann
+                    .to_string()
+                    .chars()
+                    .take(1024)
+                    .collect::<String>()
+                    .as_str(),
                 "after_turn hook annotations"
             );
         }
@@ -1494,9 +1571,9 @@ impl ScriptableContextEngine {
                         .and_then(|v| v.as_array())
                         .map(|arr| {
                             arr.iter()
-                               .filter_map(|t| t.as_str().map(String::from))
-                               .take(16)
-                               .collect()
+                                .filter_map(|t| t.as_str().map(String::from))
+                                .take(16)
+                                .collect()
                         })
                         .unwrap_or_default();
 
@@ -1535,7 +1612,9 @@ impl ScriptableContextEngine {
             for ev in events {
                 if let (Some(name), payload) = (
                     ev.get("name").and_then(|v| v.as_str()),
-                    ev.get("payload").cloned().unwrap_or(serde_json::Value::Null),
+                    ev.get("payload")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
                 ) {
                     let event = PluginEvent {
                         name: name.to_string(),
@@ -1565,7 +1644,10 @@ impl ScriptableContextEngine {
         let runtime = self.runtime;
         let timeout_secs = self.hook_timeout_secs;
         let plugin_env = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             let mut env = self.plugin_env.clone();
             for (k, v) in &guard.env_overrides {
                 if !env.iter().any(|(ek, _)| ek == k) {
@@ -1582,7 +1664,10 @@ impl ScriptableContextEngine {
         let retry_delay_ms = 0u64;
         let max_memory_mb = self.max_memory_mb;
         let allow_network = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             guard.allow_network.unwrap_or(self.allow_network)
         };
         let output_schema_strict = self.inner.config.output_schema_strict;
@@ -1655,7 +1740,8 @@ impl ScriptableContextEngine {
         // Validate input schema if declared (always warn-only — input validation is advisory).
         if let Some(schema) = hook_schemas.get(hook_name) {
             if let Some(ref input_schema) = schema.input {
-                let errs = Self::validate_schema(input_schema, &input, &format!("{hook_name}/input"));
+                let errs =
+                    Self::validate_schema(input_schema, &input, &format!("{hook_name}/input"));
                 for e in &errs {
                     warn!("{e}");
                 }
@@ -1685,21 +1771,30 @@ impl ScriptableContextEngine {
         let mut last_err = String::new();
         for attempt in 0..=max_retries {
             if attempt > 0 {
-                tokio::time::sleep(std::time::Duration::from_millis(config.delay_for_attempt(attempt))).await;
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    config.delay_for_attempt(attempt),
+                ))
+                .await;
                 debug!(
                     script = resolved.as_str(),
-                    attempt,
-                    max_retries,
-                    "Retrying hook after failure: {last_err}"
+                    attempt, max_retries, "Retrying hook after failure: {last_err}"
                 );
             }
-            match crate::plugin_runtime::run_hook_json(hook_name, &resolved, runtime, &input, &config).await {
+            match crate::plugin_runtime::run_hook_json(
+                hook_name, &resolved, runtime, &input, &config,
+            )
+            .await
+            {
                 Ok(v) => {
                     let elapsed_ms = t.elapsed().as_millis() as u64;
                     // Validate output schema if declared.
                     if let Some(schema) = hook_schemas.get(hook_name) {
                         if let Some(ref output_schema) = schema.output {
-                            let errs = Self::validate_schema(output_schema, &v, &format!("{hook_name}/output"));
+                            let errs = Self::validate_schema(
+                                output_schema,
+                                &v,
+                                &format!("{hook_name}/output"),
+                            );
                             if !errs.is_empty() {
                                 if output_schema_strict {
                                     let err_msg = format!(
@@ -1708,18 +1803,23 @@ impl ScriptableContextEngine {
                                     );
                                     // Record the failure trace before surfacing the error so
                                     // the trace store is never missing an entry for this call.
-                                    Self::push_trace(traces, HookTrace {
-                                        trace_id: trace_id.clone(),
-                                        correlation_id: correlation_id.to_string(),
-                                        hook: hook_name.to_string(),
-                                        started_at: started_at.clone(),
-                                        elapsed_ms: t.elapsed().as_millis() as u64,
-                                        success: false,
-                                        error: Some(err_msg.clone()),
-                                        input_preview: input_preview.clone(),
-                                        output_preview: None,
-                                        annotations: None,
-                                    }, trace_store, plugin_name);
+                                    Self::push_trace(
+                                        traces,
+                                        HookTrace {
+                                            trace_id: trace_id.clone(),
+                                            correlation_id: correlation_id.to_string(),
+                                            hook: hook_name.to_string(),
+                                            started_at: started_at.clone(),
+                                            elapsed_ms: t.elapsed().as_millis() as u64,
+                                            success: false,
+                                            error: Some(err_msg.clone()),
+                                            input_preview: input_preview.clone(),
+                                            output_preview: None,
+                                            annotations: None,
+                                        },
+                                        trace_store,
+                                        plugin_name,
+                                    );
                                     return Err(err_msg);
                                 }
                                 for e in &errs {
@@ -1728,18 +1828,23 @@ impl ScriptableContextEngine {
                             }
                         }
                     }
-                    Self::push_trace(traces, HookTrace {
-                        trace_id: trace_id.clone(),
-                        correlation_id: correlation_id.to_string(),
-                        hook: hook_name.to_string(),
-                        started_at: started_at.clone(),
-                        elapsed_ms,
-                        success: true,
-                        error: None,
-                        input_preview: input_preview.clone(),
-                        output_preview: Some(v.clone()),
-                        annotations: v.get("annotations").cloned(),
-                    }, trace_store, plugin_name);
+                    Self::push_trace(
+                        traces,
+                        HookTrace {
+                            trace_id: trace_id.clone(),
+                            correlation_id: correlation_id.to_string(),
+                            hook: hook_name.to_string(),
+                            started_at: started_at.clone(),
+                            elapsed_ms,
+                            success: true,
+                            error: None,
+                            input_preview: input_preview.clone(),
+                            output_preview: Some(v.clone()),
+                            annotations: v.get("annotations").cloned(),
+                        },
+                        trace_store,
+                        plugin_name,
+                    );
                     return Ok((v, elapsed_ms));
                 }
                 Err(e) => last_err = e.to_string(),
@@ -1747,18 +1852,23 @@ impl ScriptableContextEngine {
         }
         let elapsed_ms = t.elapsed().as_millis() as u64;
         let err_msg = format!("Hook script failed after {max_retries} retries: {last_err}");
-        Self::push_trace(traces, HookTrace {
-            trace_id: trace_id.clone(),
-            correlation_id: correlation_id.to_string(),
-            hook: hook_name.to_string(),
-            started_at,
-            elapsed_ms,
-            success: false,
-            error: Some(err_msg.clone()),
-            input_preview,
-            output_preview: None,
-            annotations: None,
-        }, trace_store, plugin_name);
+        Self::push_trace(
+            traces,
+            HookTrace {
+                trace_id: trace_id.clone(),
+                correlation_id: correlation_id.to_string(),
+                hook: hook_name.to_string(),
+                started_at,
+                elapsed_ms,
+                success: false,
+                error: Some(err_msg.clone()),
+                input_preview,
+                output_preview: None,
+                annotations: None,
+            },
+            trace_store,
+            plugin_name,
+        );
         Err(err_msg)
     }
 
@@ -1778,7 +1888,9 @@ impl ScriptableContextEngine {
     ) -> Result<(serde_json::Value, u64), String> {
         // Circuit breaker: reject immediately when open
         if self.circuit_is_open(hook_name, agent_id) {
-            return Err(format!("circuit-open: '{hook_name}' suspended after repeated failures"));
+            return Err(format!(
+                "circuit-open: '{hook_name}' suspended after repeated failures"
+            ));
         }
         // Rate limiting check.
         let max_rpm = self.inner.config.max_hook_calls_per_minute;
@@ -1788,15 +1900,14 @@ impl ScriptableContextEngine {
             // rate limit for all other agents sharing the same plugin.
             let rl_key = format!(
                 "{}:{}",
-                agent_id.map(|id| id.0.as_str()).unwrap_or(""),
+                agent_id.map(|id| id.0.to_string()).unwrap_or_default(),
                 hook_name
             );
             let limiter = limiters.entry(rl_key).or_default();
             if !limiter.check_and_record(max_rpm) {
                 warn!(
                     hook = hook_name,
-                    max_rpm,
-                    "hook rate limit exceeded — skipping call"
+                    max_rpm, "hook rate limit exceeded — skipping call"
                 );
                 // Return a neutral result: empty object (passthrough for callers).
                 return Ok((serde_json::Value::Object(serde_json::Map::new()), 0));
@@ -1804,7 +1915,16 @@ impl ScriptableContextEngine {
         }
         let correlation_id = generate_trace_id();
         let agent_id_str = agent_id.map(|id| id.0.to_string());
-        let result = self.call_hook_dispatch_raw(hook_name, script_path, input, timeout_secs, &correlation_id, agent_id_str.as_deref()).await;
+        let result = self
+            .call_hook_dispatch_raw(
+                hook_name,
+                script_path,
+                input,
+                timeout_secs,
+                &correlation_id,
+                agent_id_str.as_deref(),
+            )
+            .await;
         // Update circuit breaker.
         // Schema validation is performed inside call_hook_dispatch_raw (persistent path)
         // and run_hook (non-persistent path) so that Err propagates here correctly.
@@ -1826,7 +1946,10 @@ impl ScriptableContextEngine {
     ) -> Result<(serde_json::Value, u64), String> {
         // Compute effective env and network permission, merging bootstrap overrides.
         let (effective_env, effective_allow_network) = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             let mut env = self.plugin_env.clone();
             for (k, v) in &guard.env_overrides {
                 if !env.iter().any(|(ek, _)| ek == k) {
@@ -1838,9 +1961,10 @@ impl ScriptableContextEngine {
         };
 
         // Scope state file to this agent when agent_id is known.
-        let effective_state_path = self.shared_state_path.as_deref().map(|p| {
-            agent_scoped_state_path(p, agent_id)
-        });
+        let effective_state_path = self
+            .shared_state_path
+            .as_deref()
+            .map(|p| agent_scoped_state_path(p, agent_id));
 
         if self.persistent_subprocess {
             let config = crate::plugin_runtime::HookConfig {
@@ -1872,7 +1996,11 @@ impl ScriptableContextEngine {
                     // circuit_record(false)).  Mirrors the identical logic in run_hook().
                     if let Some(schema) = self.hook_schemas.get(hook_name) {
                         if let Some(ref output_schema) = schema.output {
-                            let errs = Self::validate_schema(output_schema, &output, &format!("{hook_name}/output"));
+                            let errs = Self::validate_schema(
+                                output_schema,
+                                &output,
+                                &format!("{hook_name}/output"),
+                            );
                             if !errs.is_empty() {
                                 if self.inner.config.output_schema_strict {
                                     let err_msg = format!(
@@ -1973,21 +2101,21 @@ impl ScriptableContextEngine {
     ///
     /// Returns `Ok(None)` when the policy is Warn or Skip (continue with
     /// fallback), or `Err(…)` when the policy is Abort.
-    fn apply_failure_policy(
-        &self,
-        hook: &str,
-        err: &str,
-    ) -> LibreFangResult<()> {
+    fn apply_failure_policy(&self, hook: &str, err: &str) -> LibreFangResult<()> {
         use librefang_types::config::HookFailurePolicy;
         match self.on_hook_failure {
             HookFailurePolicy::Warn => {
-                warn!(hook, error = err, "Hook failed (warn policy — using fallback)");
+                warn!(
+                    hook,
+                    error = err,
+                    "Hook failed (warn policy — using fallback)"
+                );
                 Ok(())
             }
             HookFailurePolicy::Skip => Ok(()), // silent
-            HookFailurePolicy::Abort => Err(LibreFangError::Internal(
-                format!("Hook '{hook}' failed (abort policy): {err}"),
-            )),
+            HookFailurePolicy::Abort => Err(LibreFangError::Internal(format!(
+                "Hook '{hook}' failed (abort policy): {err}"
+            ))),
         }
     }
 
@@ -1997,7 +2125,10 @@ impl ScriptableContextEngine {
         // Keys are stored as "{agent_id}:{hook}" or bare "{hook}".
         // We report bare hook names; agent-scoped keys use the portion after the last ':'.
         let circuit_open: std::collections::HashMap<String, bool> = {
-            let guard = self.circuit_breakers.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .circuit_breakers
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             guard
                 .iter()
                 .map(|(key, state)| {
@@ -2130,7 +2261,10 @@ impl ContextEngine for ScriptableContextEngine {
                 "stable_prefix_mode": config.stable_prefix_mode,
                 "max_recall_results": config.max_recall_results,
             });
-            match self.call_hook_dispatch("bootstrap", script, input, bootstrap_timeout, None).await {
+            match self
+                .call_hook_dispatch("bootstrap", script, input, bootstrap_timeout, None)
+                .await
+            {
                 Ok((ref output, ms)) => {
                     Self::record_hook(&self.metrics, "bootstrap", ms, true);
                     debug!("Bootstrap hook completed (timeout={bootstrap_timeout}s, {ms}ms)");
@@ -2167,12 +2301,21 @@ impl ContextEngine for ScriptableContextEngine {
         // Apply ingest_filter — skip hook when message doesn't match.
         // Bootstrap overrides take precedence over the statically configured filter.
         let effective_ingest_filter: Option<String> = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
-            guard.ingest_filter.clone().or_else(|| self.ingest_filter.clone())
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            guard
+                .ingest_filter
+                .clone()
+                .or_else(|| self.ingest_filter.clone())
         };
         if let Some(ref filter) = effective_ingest_filter {
             if !user_message.contains(filter.as_str()) {
-                debug!(filter = filter.as_str(), "Ingest hook skipped (filter mismatch)");
+                debug!(
+                    filter = filter.as_str(),
+                    "Ingest hook skipped (filter mismatch)"
+                );
                 return self.inner.ingest(agent_id, user_message, peer_id).await;
             }
         }
@@ -2211,13 +2354,19 @@ impl ContextEngine for ScriptableContextEngine {
             let cached = {
                 let guard = self.ingest_cache.lock().unwrap();
                 guard.get(&cache_key).and_then(|(val, inserted_at)| {
-                    if inserted_at.elapsed().as_secs() < ttl_secs { Some(val.clone()) } else { None }
+                    if inserted_at.elapsed().as_secs() < ttl_secs {
+                        Some(val.clone())
+                    } else {
+                        None
+                    }
                 })
             };
             if let Some(cached_output) = cached {
                 debug!("Ingest hook cache hit (ttl={}s)", ttl_secs);
                 let mut memories = default_result.recalled_memories;
-                if let Some(hook_memories) = cached_output.get("memories").and_then(|m| m.as_array()) {
+                if let Some(hook_memories) =
+                    cached_output.get("memories").and_then(|m| m.as_array())
+                {
                     for mem in hook_memories {
                         if let Some(content) = mem.get("content").and_then(|c| c.as_str()) {
                             memories.push(MemoryFragment {
@@ -2239,12 +2388,23 @@ impl ContextEngine for ScriptableContextEngine {
                         }
                     }
                 }
-                return Ok(IngestResult { recalled_memories: memories });
+                return Ok(IngestResult {
+                    recalled_memories: memories,
+                });
             }
             // Cache miss — run hook and store result below
             let cache_key_owned = cache_key;
             let cache_arc = self.ingest_cache.clone();
-            match self.call_hook_dispatch("ingest", script, input.clone(), self.hook_timeout_secs, Some(&agent_id)).await {
+            match self
+                .call_hook_dispatch(
+                    "ingest",
+                    script,
+                    input.clone(),
+                    self.hook_timeout_secs,
+                    Some(&agent_id),
+                )
+                .await
+            {
                 Ok((output, ms)) => {
                     Self::record_hook(&self.metrics, "ingest", ms, true);
                     // Store in cache
@@ -2253,7 +2413,9 @@ impl ContextEngine for ScriptableContextEngine {
                         guard.insert(cache_key_owned, (output.clone(), std::time::Instant::now()));
                         // Evict expired entries when cache grows large
                         if guard.len() > 512 {
-                            guard.retain(|_, (_, inserted_at)| inserted_at.elapsed().as_secs() < ttl_secs);
+                            guard.retain(|_, (_, inserted_at)| {
+                                inserted_at.elapsed().as_secs() < ttl_secs
+                            });
                         }
                     }
                     let mut memories = default_result.recalled_memories;
@@ -2279,7 +2441,9 @@ impl ContextEngine for ScriptableContextEngine {
                             }
                         }
                     }
-                    return Ok(IngestResult { recalled_memories: memories });
+                    return Ok(IngestResult {
+                        recalled_memories: memories,
+                    });
                 }
                 Err(err) => {
                     Self::record_hook(&self.metrics, "ingest", 0, false);
@@ -2289,7 +2453,16 @@ impl ContextEngine for ScriptableContextEngine {
             }
         }
 
-        match self.call_hook_dispatch("ingest", script, input, self.hook_timeout_secs, Some(&agent_id)).await {
+        match self
+            .call_hook_dispatch(
+                "ingest",
+                script,
+                input,
+                self.hook_timeout_secs,
+                Some(&agent_id),
+            )
+            .await
+        {
             Ok((output, ms)) => {
                 Self::record_hook(&self.metrics, "ingest", ms, true);
                 self.record_per_agent(&agent_id, ms, true);
@@ -2341,7 +2514,13 @@ impl ContextEngine for ScriptableContextEngine {
         let Some(ref script) = self.assemble_script else {
             return self
                 .inner
-                .assemble(agent_id, messages, system_prompt, tools, context_window_tokens)
+                .assemble(
+                    agent_id,
+                    messages,
+                    system_prompt,
+                    tools,
+                    context_window_tokens,
+                )
                 .await;
         };
 
@@ -2361,7 +2540,16 @@ impl ContextEngine for ScriptableContextEngine {
 
         // Apply agent_id_filter for assemble hook.
         if !self.agent_passes_filter(&agent_id) {
-            return self.inner.assemble(agent_id, messages, system_prompt, tools, context_window_tokens).await;
+            return self
+                .inner
+                .assemble(
+                    agent_id,
+                    messages,
+                    system_prompt,
+                    tools,
+                    context_window_tokens,
+                )
+                .await;
         }
 
         // TTL-based cache for assemble hook.
@@ -2372,7 +2560,11 @@ impl ContextEngine for ScriptableContextEngine {
             let cached = {
                 let guard = self.assemble_cache.lock().unwrap();
                 guard.get(&cache_key).and_then(|(val, inserted_at)| {
-                    if inserted_at.elapsed().as_secs() < ttl_secs { Some(val.clone()) } else { None }
+                    if inserted_at.elapsed().as_secs() < ttl_secs {
+                        Some(val.clone())
+                    } else {
+                        None
+                    }
                 })
             };
             if let Some(cached_output) = cached {
@@ -2390,18 +2582,37 @@ impl ContextEngine for ScriptableContextEngine {
                     }
                 }
                 // Cached result had no messages; fall through to default
-                return self.inner.assemble(agent_id, messages, system_prompt, tools, context_window_tokens).await;
+                return self
+                    .inner
+                    .assemble(
+                        agent_id,
+                        messages,
+                        system_prompt,
+                        tools,
+                        context_window_tokens,
+                    )
+                    .await;
             }
             // Cache miss — run hook and store result.
             let cache_arc = self.assemble_cache.clone();
-            let result = self.call_hook_dispatch("assemble", script, input, self.hook_timeout_secs, Some(&agent_id)).await;
+            let result = self
+                .call_hook_dispatch(
+                    "assemble",
+                    script,
+                    input,
+                    self.hook_timeout_secs,
+                    Some(&agent_id),
+                )
+                .await;
             match result {
                 Ok((output, ms)) => {
                     {
                         let mut guard = cache_arc.lock().unwrap();
                         guard.insert(cache_key, (output.clone(), std::time::Instant::now()));
                         if guard.len() > 256 {
-                            guard.retain(|_, (_, inserted_at)| inserted_at.elapsed().as_secs() < ttl_secs);
+                            guard.retain(|_, (_, inserted_at)| {
+                                inserted_at.elapsed().as_secs() < ttl_secs
+                            });
                         }
                     }
                     if let Some(new_msgs) = output.get("messages").and_then(|v| v.as_array()) {
@@ -2418,17 +2629,44 @@ impl ContextEngine for ScriptableContextEngine {
                         }
                     }
                     Self::record_hook(&self.metrics, "assemble", ms, false);
-                    return self.inner.assemble(agent_id, messages, system_prompt, tools, context_window_tokens).await;
+                    return self
+                        .inner
+                        .assemble(
+                            agent_id,
+                            messages,
+                            system_prompt,
+                            tools,
+                            context_window_tokens,
+                        )
+                        .await;
                 }
                 Err(e) => {
                     Self::record_hook(&self.metrics, "assemble", 0, false);
                     self.apply_failure_policy("assemble", &e)?;
-                    return self.inner.assemble(agent_id, messages, system_prompt, tools, context_window_tokens).await;
+                    return self
+                        .inner
+                        .assemble(
+                            agent_id,
+                            messages,
+                            system_prompt,
+                            tools,
+                            context_window_tokens,
+                        )
+                        .await;
                 }
             }
         }
 
-        match self.call_hook_dispatch("assemble", script, input, self.hook_timeout_secs, Some(&agent_id)).await {
+        match self
+            .call_hook_dispatch(
+                "assemble",
+                script,
+                input,
+                self.hook_timeout_secs,
+                Some(&agent_id),
+            )
+            .await
+        {
             Ok((output, ms)) => {
                 if let Some(new_msgs) = output.get("messages").and_then(|v| v.as_array()) {
                     let assembled: Vec<Message> = new_msgs
@@ -2445,20 +2683,30 @@ impl ContextEngine for ScriptableContextEngine {
                     }
                     warn!("Assemble hook returned empty messages, falling back to default");
                 } else {
-                    warn!(
-                        "Assemble hook returned no 'messages' field, falling back to default"
-                    );
+                    warn!("Assemble hook returned no 'messages' field, falling back to default");
                 }
                 Self::record_hook(&self.metrics, "assemble", ms, false);
                 self.inner
-                    .assemble(agent_id, messages, system_prompt, tools, context_window_tokens)
+                    .assemble(
+                        agent_id,
+                        messages,
+                        system_prompt,
+                        tools,
+                        context_window_tokens,
+                    )
                     .await
             }
             Err(e) => {
                 Self::record_hook(&self.metrics, "assemble", 0, false);
                 self.apply_failure_policy("assemble", &e)?;
                 self.inner
-                    .assemble(agent_id, messages, system_prompt, tools, context_window_tokens)
+                    .assemble(
+                        agent_id,
+                        messages,
+                        system_prompt,
+                        tools,
+                        context_window_tokens,
+                    )
                     .await
             }
         }
@@ -2487,7 +2735,11 @@ impl ContextEngine for ScriptableContextEngine {
 
         // Build token pressure metadata for the compact hook.
         let used_tokens = crate::compactor::estimate_token_count(messages, None, None);
-        let max_ctx = if context_window_tokens > 0 { context_window_tokens } else { 100_000 };
+        let max_ctx = if context_window_tokens > 0 {
+            context_window_tokens
+        } else {
+            100_000
+        };
         let pressure = (used_tokens as f64 / max_ctx as f64).min(1.0);
         let recommendation = match pressure {
             p if p >= 0.9 => "critical",
@@ -2521,7 +2773,11 @@ impl ContextEngine for ScriptableContextEngine {
             let cached = {
                 let guard = self.compact_cache.lock().unwrap();
                 guard.get(&cache_key).and_then(|(val, inserted_at)| {
-                    if inserted_at.elapsed().as_secs() < ttl_secs { Some(val.clone()) } else { None }
+                    if inserted_at.elapsed().as_secs() < ttl_secs {
+                        Some(val.clone())
+                    } else {
+                        None
+                    }
                 })
             };
             if let Some(cached_output) = cached {
@@ -2532,8 +2788,11 @@ impl ContextEngine for ScriptableContextEngine {
                         .filter_map(|v| serde_json::from_value(v.clone()).ok())
                         .collect();
                     if !compacted.is_empty() {
-                        let summary = cached_output.get("summary").and_then(|v| v.as_str())
-                            .unwrap_or("plugin compaction (cached)").to_string();
+                        let summary = cached_output
+                            .get("summary")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("plugin compaction (cached)")
+                            .to_string();
                         let removed = messages.len().saturating_sub(compacted.len());
                         return Ok(CompactionResult {
                             summary,
@@ -2544,28 +2803,45 @@ impl ContextEngine for ScriptableContextEngine {
                         });
                     }
                 }
-                return self.inner.compact(agent_id, messages, driver, model, context_window_tokens).await;
+                return self
+                    .inner
+                    .compact(agent_id, messages, driver, model, context_window_tokens)
+                    .await;
             }
             // Cache miss — run hook and store result.
             let cache_arc = self.compact_cache.clone();
-            let result = self.call_hook_dispatch("compact", script, input, self.hook_timeout_secs, Some(&agent_id)).await;
+            let result = self
+                .call_hook_dispatch(
+                    "compact",
+                    script,
+                    input,
+                    self.hook_timeout_secs,
+                    Some(&agent_id),
+                )
+                .await;
             match result {
                 Ok((output, ms)) => {
                     {
                         let mut guard = cache_arc.lock().unwrap();
                         guard.insert(cache_key, (output.clone(), std::time::Instant::now()));
                         if guard.len() > 256 {
-                            guard.retain(|_, (_, inserted_at)| inserted_at.elapsed().as_secs() < ttl_secs);
+                            guard.retain(|_, (_, inserted_at)| {
+                                inserted_at.elapsed().as_secs() < ttl_secs
+                            });
                         }
                     }
                     if let Some(new_msgs) = output.get("messages").and_then(|v| v.as_array()) {
-                        let compacted: Vec<Message> = new_msgs.iter()
+                        let compacted: Vec<Message> = new_msgs
+                            .iter()
                             .filter_map(|v| serde_json::from_value(v.clone()).ok())
                             .collect();
                         if !compacted.is_empty() {
                             Self::record_hook(&self.metrics, "compact", ms, true);
-                            let summary = output.get("summary").and_then(|v| v.as_str())
-                                .unwrap_or("plugin compaction").to_string();
+                            let summary = output
+                                .get("summary")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("plugin compaction")
+                                .to_string();
                             let removed = messages.len().saturating_sub(compacted.len());
                             return Ok(CompactionResult {
                                 summary,
@@ -2577,17 +2853,32 @@ impl ContextEngine for ScriptableContextEngine {
                         }
                     }
                     Self::record_hook(&self.metrics, "compact", ms, false);
-                    return self.inner.compact(agent_id, messages, driver, model, context_window_tokens).await;
+                    return self
+                        .inner
+                        .compact(agent_id, messages, driver, model, context_window_tokens)
+                        .await;
                 }
                 Err(e) => {
                     Self::record_hook(&self.metrics, "compact", 0, false);
                     self.apply_failure_policy("compact", &e)?;
-                    return self.inner.compact(agent_id, messages, driver, model, context_window_tokens).await;
+                    return self
+                        .inner
+                        .compact(agent_id, messages, driver, model, context_window_tokens)
+                        .await;
                 }
             }
         }
 
-        match self.call_hook_dispatch("compact", script, input, self.hook_timeout_secs, Some(&agent_id)).await {
+        match self
+            .call_hook_dispatch(
+                "compact",
+                script,
+                input,
+                self.hook_timeout_secs,
+                Some(&agent_id),
+            )
+            .await
+        {
             Ok((output, ms)) => {
                 if let Some(new_msgs) = output.get("messages").and_then(|v| v.as_array()) {
                     let compacted: Vec<Message> = new_msgs
@@ -2613,9 +2904,7 @@ impl ContextEngine for ScriptableContextEngine {
                     }
                     warn!("Compact hook returned empty messages, falling back to default");
                 } else {
-                    warn!(
-                        "Compact hook returned no 'messages' field, falling back to default"
-                    );
+                    warn!("Compact hook returned no 'messages' field, falling back to default");
                 }
                 Self::record_hook(&self.metrics, "compact", ms, false);
                 self.inner
@@ -2672,7 +2961,10 @@ impl ContextEngine for ScriptableContextEngine {
         let timeout_secs = self.hook_timeout_secs;
         // Merge bootstrap env overrides into the env passed to the background task.
         let plugin_env = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             let mut env = self.plugin_env.clone();
             for (k, v) in &guard.env_overrides {
                 if !env.iter().any(|(ek, _)| ek == k) {
@@ -2686,7 +2978,10 @@ impl ContextEngine for ScriptableContextEngine {
         let retry_delay_ms = self.retry_delay_ms;
         let max_memory_mb = self.max_memory_mb;
         let allow_network = {
-            let guard = self.bootstrap_applied_overrides.lock().unwrap_or_else(|p| p.into_inner());
+            let guard = self
+                .bootstrap_applied_overrides
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             guard.allow_network.unwrap_or(self.allow_network)
         };
         let traces = std::sync::Arc::clone(&self.traces);
@@ -2698,9 +2993,10 @@ impl ContextEngine for ScriptableContextEngine {
         let plugin_name = self.plugin_name.clone();
         let agent_id_str = agent_id.0.to_string();
         // Compute agent-scoped state path for this after_turn call.
-        let shared_state_path = self.shared_state_path.as_deref().map(|p| {
-            agent_scoped_state_path(p, Some(agent_id_str.as_str()))
-        });
+        let shared_state_path = self
+            .shared_state_path
+            .as_deref()
+            .map(|p| agent_scoped_state_path(p, Some(agent_id_str.as_str())));
         let memory_substrate = std::sync::Arc::clone(&self.memory_substrate);
         let output_schema_strict = self.inner.config.output_schema_strict;
         let after_turn_correlation_id = generate_trace_id();
@@ -2785,7 +3081,26 @@ impl ContextEngine for ScriptableContextEngine {
                         }
                     }
                 } else {
-                    Self::run_hook("after_turn", &script, runtime, input, timeout_secs, &plugin_env, max_retries, retry_delay_ms, max_memory_mb, allow_network, &traces, &hook_schemas, shared_state_path.as_deref(), trace_store.as_ref(), &plugin_name, &correlation_id_at, output_schema_strict).await
+                    Self::run_hook(
+                        "after_turn",
+                        &script,
+                        runtime,
+                        input,
+                        timeout_secs,
+                        &plugin_env,
+                        max_retries,
+                        retry_delay_ms,
+                        max_memory_mb,
+                        allow_network,
+                        &traces,
+                        &hook_schemas,
+                        shared_state_path.as_deref(),
+                        trace_store.as_ref(),
+                        &plugin_name,
+                        &correlation_id_at,
+                        output_schema_strict,
+                    )
+                    .await
                 };
                 let success = result.is_ok();
                 match result {
@@ -2793,7 +3108,13 @@ impl ContextEngine for ScriptableContextEngine {
                         Self::record_hook(&metrics, "after_turn", ms, true);
                         debug!("After-turn hook completed ({ms}ms)");
                         // Inspect hook output for memories, logs, and annotations.
-                        Self::process_after_turn_output(&output, &agent_id_str, Some(&memory_substrate), &plugin_name, event_bus_arc.as_ref());
+                        Self::process_after_turn_output(
+                            &output,
+                            &agent_id_str,
+                            Some(&memory_substrate),
+                            &plugin_name,
+                            event_bus_arc.as_ref(),
+                        );
                     }
                     Err(e) => {
                         Self::record_hook(&metrics, "after_turn", 0, false);
@@ -2806,19 +3127,26 @@ impl ContextEngine for ScriptableContextEngine {
                     let key = format!("{}:after_turn", agent_id_str);
                     let (failures, opened_at_rfc3339, just_reset) = {
                         let mut guard = cb_breakers.lock().unwrap();
-                        let state = guard.entry(key.clone()).or_insert_with(CircuitBreakerState::new);
+                        let state = guard
+                            .entry(key.clone())
+                            .or_insert_with(CircuitBreakerState::new);
                         if success {
                             state.record_success();
                             (0u32, None::<String>, true)
                         } else {
                             state.record_failure(cfg.max_failures);
                             if state.consecutive_failures == cfg.max_failures {
-                                warn!(hook = "after_turn", cooldown_secs = cfg.reset_secs, "Hook circuit breaker opened");
+                                warn!(
+                                    hook = "after_turn",
+                                    cooldown_secs = cfg.reset_secs,
+                                    "Hook circuit breaker opened"
+                                );
                             }
                             let opened_str = state.opened_at.map(|instant| {
                                 let elapsed = instant.elapsed();
-                                (chrono::Utc::now() - chrono::Duration::from_std(elapsed).unwrap_or_default())
-                                    .to_rfc3339()
+                                (chrono::Utc::now()
+                                    - chrono::Duration::from_std(elapsed).unwrap_or_default())
+                                .to_rfc3339()
                             });
                             (state.consecutive_failures, opened_str, false)
                         }
@@ -2827,7 +3155,11 @@ impl ContextEngine for ScriptableContextEngine {
                         if just_reset {
                             let _ = store.delete_circuit_state(&key);
                         } else {
-                            let _ = store.save_circuit_state(&key, failures, opened_at_rfc3339.as_deref());
+                            let _ = store.save_circuit_state(
+                                &key,
+                                failures,
+                                opened_at_rfc3339.as_deref(),
+                            );
                         }
                     }
                 }
@@ -2852,7 +3184,16 @@ impl ContextEngine for ScriptableContextEngine {
                 "parent_id": parent_id.0.to_string(),
                 "child_id": child_id.0.to_string(),
             });
-            match self.call_hook_dispatch("prepare_subagent", script, input, self.hook_timeout_secs, None).await {
+            match self
+                .call_hook_dispatch(
+                    "prepare_subagent",
+                    script,
+                    input,
+                    self.hook_timeout_secs,
+                    None,
+                )
+                .await
+            {
                 Ok((_, ms)) => {
                     Self::record_hook(&self.metrics, "prepare_subagent", ms, true);
                     debug!("Prepare-subagent hook completed ({ms}ms)");
@@ -2882,7 +3223,16 @@ impl ContextEngine for ScriptableContextEngine {
                 "parent_id": parent_id.0.to_string(),
                 "child_id": child_id.0.to_string(),
             });
-            match self.call_hook_dispatch("merge_subagent", script, input, self.hook_timeout_secs, None).await {
+            match self
+                .call_hook_dispatch(
+                    "merge_subagent",
+                    script,
+                    input,
+                    self.hook_timeout_secs,
+                    None,
+                )
+                .await
+            {
                 Ok((_, ms)) => {
                     Self::record_hook(&self.metrics, "merge_subagent", ms, true);
                     debug!("Merge-subagent hook completed ({ms}ms)");
@@ -3159,7 +3509,11 @@ impl StackedContextEngine {
             "StackedContextEngine requires at least one engine"
         );
         let layer_weights = vec![1.0f32; engines.len()];
-        Self { engines, layer_weights, event_bus: bus }
+        Self {
+            engines,
+            layer_weights,
+            event_bus: bus,
+        }
     }
 
     /// Override the default per-layer weights (all `1.0`) with caller-supplied
@@ -3194,12 +3548,30 @@ impl StackedContextEngine {
                 if let Some(ref m) = metrics_opt {
                     [
                         ("ingest", m.ingest.failures > 0 && m.ingest.successes == 0),
-                        ("after_turn", m.after_turn.failures > 0 && m.after_turn.successes == 0),
-                        ("bootstrap", m.bootstrap.failures > 0 && m.bootstrap.successes == 0),
-                        ("assemble", m.assemble.failures > 0 && m.assemble.successes == 0),
-                        ("compact", m.compact.failures > 0 && m.compact.successes == 0),
-                        ("prepare_subagent", m.prepare_subagent.failures > 0 && m.prepare_subagent.successes == 0),
-                        ("merge_subagent", m.merge_subagent.failures > 0 && m.merge_subagent.successes == 0),
+                        (
+                            "after_turn",
+                            m.after_turn.failures > 0 && m.after_turn.successes == 0,
+                        ),
+                        (
+                            "bootstrap",
+                            m.bootstrap.failures > 0 && m.bootstrap.successes == 0,
+                        ),
+                        (
+                            "assemble",
+                            m.assemble.failures > 0 && m.assemble.successes == 0,
+                        ),
+                        (
+                            "compact",
+                            m.compact.failures > 0 && m.compact.successes == 0,
+                        ),
+                        (
+                            "prepare_subagent",
+                            m.prepare_subagent.failures > 0 && m.prepare_subagent.successes == 0,
+                        ),
+                        (
+                            "merge_subagent",
+                            m.merge_subagent.failures > 0 && m.merge_subagent.successes == 0,
+                        ),
                     ]
                     .into_iter()
                     .map(|(k, v)| (k.to_string(), v))
@@ -3239,7 +3611,11 @@ impl StackedContextEngine {
             .filter(|l| l.circuit_open.values().any(|&open| open))
             .count();
         let total_layers = layers.len();
-        StackHealth { layers, total_layers, layers_with_open_circuit }
+        StackHealth {
+            layers,
+            total_layers,
+            layers_with_open_circuit,
+        }
     }
 }
 
@@ -3264,27 +3640,36 @@ impl ContextEngine for StackedContextEngine {
         // Each engine is guarded by a 30-second timeout so a single slow or
         // hung engine cannot block the entire stack indefinitely.
         let timeout_dur = std::time::Duration::from_secs(30);
-        let futs = self.engines.iter().enumerate().map(|(i, engine)| async move {
-            match tokio::time::timeout(timeout_dur, engine.ingest(agent_id, user_message, peer_id)).await {
-                Ok(Ok(r)) => Some(r.recalled_memories),
-                Ok(Err(e)) => {
-                    warn!(
-                        engine_index = i,
-                        error = %e,
-                        "StackedContextEngine: ingest engine failed (skipping)"
-                    );
-                    None
+        let futs = self
+            .engines
+            .iter()
+            .enumerate()
+            .map(|(i, engine)| async move {
+                match tokio::time::timeout(
+                    timeout_dur,
+                    engine.ingest(agent_id, user_message, peer_id),
+                )
+                .await
+                {
+                    Ok(Ok(r)) => Some(r.recalled_memories),
+                    Ok(Err(e)) => {
+                        warn!(
+                            engine_index = i,
+                            error = %e,
+                            "StackedContextEngine: ingest engine failed (skipping)"
+                        );
+                        None
+                    }
+                    Err(_elapsed) => {
+                        warn!(
+                            engine_index = i,
+                            timeout_secs = 30,
+                            "StackedContextEngine: ingest engine timed out (skipping)"
+                        );
+                        None
+                    }
                 }
-                Err(_elapsed) => {
-                    warn!(
-                        engine_index = i,
-                        timeout_secs = 30,
-                        "StackedContextEngine: ingest engine timed out (skipping)"
-                    );
-                    None
-                }
-            }
-        });
+            });
 
         let default_weight = 1.0f32;
         let mut succeeded: usize = 0;
@@ -3293,7 +3678,11 @@ impl ContextEngine for StackedContextEngine {
         // Collect (weight, memories) pairs, preserving layer index so we can
         // sort by weight without losing provenance.
         let mut weighted_results: Vec<(f32, Vec<MemoryFragment>)> = Vec::new();
-        for (i, memories) in futures::future::join_all(futs).await.into_iter().enumerate() {
+        for (i, memories) in futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .enumerate()
+        {
             match memories {
                 Some(m) => {
                     succeeded += 1;
@@ -3308,16 +3697,13 @@ impl ContextEngine for StackedContextEngine {
         if failed > 0 {
             warn!(
                 succeeded,
-                failed,
-                "StackedContextEngine: ingest completed with some engine failures"
+                failed, "StackedContextEngine: ingest completed with some engine failures"
             );
         }
 
         // Sort layers by weight descending so higher-priority layers' memories
         // appear first in the merged result.
-        weighted_results.sort_by(|a, b| {
-            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-        });
+        weighted_results.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
         let all_memories: Vec<MemoryFragment> =
             weighted_results.into_iter().flat_map(|(_, m)| m).collect();
@@ -3438,27 +3824,32 @@ impl ContextEngine for StackedContextEngine {
         // Each engine is guarded by a 30-second timeout so a single slow or hung
         // engine cannot stall the entire stack.
         let timeout_dur = std::time::Duration::from_secs(30);
-        let futs = self.engines.iter().enumerate().map(|(i, engine)| async move {
-            match tokio::time::timeout(timeout_dur, engine.after_turn(agent_id, messages)).await {
-                Ok(Ok(())) => true,
-                Ok(Err(e)) => {
-                    warn!(
-                        engine_index = i,
-                        error = %e,
-                        "StackedContextEngine: after_turn engine failed"
-                    );
-                    false
+        let futs = self
+            .engines
+            .iter()
+            .enumerate()
+            .map(|(i, engine)| async move {
+                match tokio::time::timeout(timeout_dur, engine.after_turn(agent_id, messages)).await
+                {
+                    Ok(Ok(())) => true,
+                    Ok(Err(e)) => {
+                        warn!(
+                            engine_index = i,
+                            error = %e,
+                            "StackedContextEngine: after_turn engine failed"
+                        );
+                        false
+                    }
+                    Err(_elapsed) => {
+                        warn!(
+                            engine_index = i,
+                            timeout_secs = 30,
+                            "StackedContextEngine: after_turn engine timed out"
+                        );
+                        false
+                    }
                 }
-                Err(_elapsed) => {
-                    warn!(
-                        engine_index = i,
-                        timeout_secs = 30,
-                        "StackedContextEngine: after_turn engine timed out"
-                    );
-                    false
-                }
-            }
-        });
+            });
 
         let outcomes = futures::future::join_all(futs).await;
         let succeeded = outcomes.iter().filter(|&&ok| ok).count();
@@ -3466,8 +3857,7 @@ impl ContextEngine for StackedContextEngine {
         if failed > 0 {
             warn!(
                 succeeded,
-                failed,
-                "StackedContextEngine: after_turn completed with some engine failures"
+                failed, "StackedContextEngine: after_turn completed with some engine failures"
             );
         }
         Ok(())
@@ -3538,11 +3928,16 @@ impl ContextEngine for StackedContextEngine {
                 add_stats!(merge_subagent);
             }
         }
-        if any { Some(aggregate) } else { None }
+        if any {
+            Some(aggregate)
+        } else {
+            None
+        }
     }
 
     fn per_agent_metrics(&self) -> std::collections::HashMap<String, HookStats> {
-        let mut merged: std::collections::HashMap<String, HookStats> = std::collections::HashMap::new();
+        let mut merged: std::collections::HashMap<String, HookStats> =
+            std::collections::HashMap::new();
         for engine in &self.engines {
             for (agent_id, stats) in engine.per_agent_metrics() {
                 let entry = merged.entry(agent_id).or_default();
@@ -3590,8 +3985,7 @@ pub fn build_context_engine(
             for plugin_name in stack {
                 let eng_memory = memory.clone();
                 let eng_emb = embedding_driver.clone();
-                let inner =
-                    DefaultContextEngine::new(runtime_config.clone(), eng_memory, eng_emb);
+                let inner = DefaultContextEngine::new(runtime_config.clone(), eng_memory, eng_emb);
                 match load_plugin(plugin_name) {
                     Ok((manifest, hooks)) => {
                         if hooks.ingest.is_some()
@@ -3602,8 +3996,7 @@ pub fn build_context_engine(
                             || hooks.prepare_subagent.is_some()
                             || hooks.merge_subagent.is_some()
                         {
-                            let env: Vec<(String, String)> =
-                                manifest.env.into_iter().collect();
+                            let env: Vec<(String, String)> = manifest.env.into_iter().collect();
                             engines.push(Box::new(
                                 ScriptableContextEngine::new(inner, &hooks)
                                     .with_plugin_name(plugin_name)
@@ -3835,11 +4228,9 @@ print(json.dumps({"type": payload.get("type"), "message": payload.get("message")
         )
         .unwrap();
 
-        let traces = std::sync::Arc::new(std::sync::Mutex::new(
-            std::collections::VecDeque::new(),
-        ));
+        let traces = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
         let hook_schemas = std::collections::HashMap::new();
-        let output = ScriptableContextEngine::run_hook(
+        let (output, _elapsed) = ScriptableContextEngine::run_hook(
             "ingest",
             script_path.to_str().unwrap(),
             crate::plugin_runtime::PluginRuntime::Python,
@@ -3858,7 +4249,9 @@ print(json.dumps({"type": payload.get("type"), "message": payload.get("message")
             &hook_schemas,
             None,
             None,
-            "",
+            "test",
+            "test-correlation-id",
+            false,
         )
         .await
         .unwrap();

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -19,9 +19,8 @@ use tracing::{debug, info, warn};
 /// This is an Ed25519 public key (32 bytes, base64url-encoded).
 /// Override via `LIBREFANG_REGISTRY_PUBKEY` env var for custom registries.
 /// Set to `LIBREFANG_REGISTRY_VERIFY=0` to skip verification entirely.
-const OFFICIAL_REGISTRY_PUBKEY_B64: &str =
-    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-    // ^ placeholder — real key would be the registry operator's public key
+const OFFICIAL_REGISTRY_PUBKEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+// ^ placeholder — real key would be the registry operator's public key
 
 /// Verify an Ed25519 signature over registry index JSON bytes.
 ///
@@ -59,8 +58,8 @@ fn verify_registry_index(
         .map_err(|_| "Public key must be exactly 32 bytes".to_string())?;
 
     let signature = Signature::from_bytes(&sig_arr);
-    let verifying_key = VerifyingKey::from_bytes(&key_arr)
-        .map_err(|e| format!("Invalid public key: {e}"))?;
+    let verifying_key =
+        VerifyingKey::from_bytes(&key_arr).map_err(|e| format!("Invalid public key: {e}"))?;
 
     verifying_key
         .verify(index_bytes, &signature)
@@ -147,7 +146,13 @@ fn registry_cache_path(registry: &str) -> std::path::PathBuf {
     // Sanitise the URL into a safe filename (replace non-alphanumeric with '_').
     let safe_name: String = registry
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '.' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     cache_dir.join(format!("{safe_name}.json"))
 }
@@ -211,12 +216,8 @@ pub async fn fetch_verified_index(
         }
     }
 
-    let index_url = format!(
-        "https://raw.githubusercontent.com/{registry}/main/index.json"
-    );
-    let sig_url = format!(
-        "https://raw.githubusercontent.com/{registry}/main/index.json.sig"
-    );
+    let index_url = format!("https://raw.githubusercontent.com/{registry}/main/index.json");
+    let sig_url = format!("https://raw.githubusercontent.com/{registry}/main/index.json.sig");
 
     // Fetch index bytes.
     let index_resp = client
@@ -493,7 +494,9 @@ pub fn load_plugin_manifest(plugin_dir: &Path) -> Result<PluginManifest, String>
 /// `YYYY.M.D-betaN` versioning, so a real semver library is overkill.
 fn version_satisfies(running: &str, required: &str) -> bool {
     fn semver_parts(v: &str) -> Vec<u64> {
-        v.split('-').next().unwrap_or(v)
+        v.split('-')
+            .next()
+            .unwrap_or(v)
             .split('.')
             .filter_map(|p| p.parse().ok())
             .collect()
@@ -839,7 +842,9 @@ async fn install_from_registry(
     } else {
         let pubkey = std::env::var("LIBREFANG_REGISTRY_PUBKEY")
             .unwrap_or_else(|_| OFFICIAL_REGISTRY_PUBKEY_B64.to_string());
-        if let Err(e) = verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await {
+        if let Err(e) =
+            verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await
+        {
             let _ = std::fs::remove_dir_all(&target_dir);
             return Err(e);
         }
@@ -1041,12 +1046,12 @@ pub fn scaffold_plugin(
     } else {
         format!("runtime = \"{runtime_tag}\"\n")
     };
-    let requirements_line =
-        if matches!(runtime_kind, crate::plugin_runtime::PluginRuntime::Python) {
-            "requirements = \"requirements.txt\"\n".to_string()
-        } else {
-            String::new()
-        };
+    let requirements_line = if matches!(runtime_kind, crate::plugin_runtime::PluginRuntime::Python)
+    {
+        "requirements = \"requirements.txt\"\n".to_string()
+    } else {
+        String::new()
+    };
     let manifest_toml = format!(
         r#"name = "{name}"
 version = "0.1.0"
@@ -1280,6 +1285,16 @@ fn hook_templates(runtime: crate::plugin_runtime::PluginRuntime) -> HookFiles {
             bootstrap: ("bootstrap", STUB_LIFECYCLE_NATIVE),
             prepare_subagent: ("prepare_subagent", STUB_LIFECYCLE_NATIVE),
             merge_subagent: ("merge_subagent", STUB_LIFECYCLE_NATIVE),
+        },
+        R::Wasm => HookFiles {
+            // Wasm hooks — stub templates; users supply compiled .wasm modules.
+            ingest: ("ingest.wasm", STUB_ASSEMBLE_NATIVE),
+            after_turn: ("after_turn.wasm", STUB_ASSEMBLE_NATIVE),
+            assemble: ("assemble.wasm", STUB_ASSEMBLE_NATIVE),
+            compact: ("compact.wasm", STUB_COMPACT_NATIVE),
+            bootstrap: ("bootstrap.wasm", STUB_LIFECYCLE_NATIVE),
+            prepare_subagent: ("prepare_subagent.wasm", STUB_LIFECYCLE_NATIVE),
+            merge_subagent: ("merge_subagent.wasm", STUB_LIFECYCLE_NATIVE),
         },
     }
 }
@@ -2743,34 +2758,27 @@ async fn download_github_entry(
 /// Check that all declared hook scripts exist on disk and are within the plugin directory.
 /// Compute a hex-encoded SHA-256 digest of `bytes`.
 pub fn sha256_hex(bytes: &[u8]) -> String {
-
     // NOTE: Rust's `DefaultHasher` is NOT cryptographic. We use a simple
     // hand-rolled SHA-256 here so we don't pull in a new crate. If the project
     // adds `sha2` in future, swap this implementation out.
     //
     // This is a pure-Rust SHA-256 implementation (RFC 6234).
     const K: [u32; 64] = [
-        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
-        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
-        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
-        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
-        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
     ];
 
     let mut h: [u32; 8] = [
-        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
     ];
 
     // Pre-processing: padding
@@ -2786,31 +2794,51 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     for block in msg.chunks(64) {
         let mut w = [0u32; 64];
         for i in 0..16 {
-            w[i] = u32::from_be_bytes([block[i*4], block[i*4+1], block[i*4+2], block[i*4+3]]);
+            w[i] = u32::from_be_bytes([
+                block[i * 4],
+                block[i * 4 + 1],
+                block[i * 4 + 2],
+                block[i * 4 + 3],
+            ]);
         }
         for i in 16..64 {
-            let s0 = w[i-15].rotate_right(7) ^ w[i-15].rotate_right(18) ^ (w[i-15] >> 3);
-            let s1 = w[i-2].rotate_right(17) ^ w[i-2].rotate_right(19) ^ (w[i-2] >> 10);
-            w[i] = w[i-16].wrapping_add(s0).wrapping_add(w[i-7]).wrapping_add(s1);
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
         }
         let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] =
             [h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]];
         for i in 0..64 {
             let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
             let ch = (e & f) ^ ((!e) & g);
-            let temp1 = hh.wrapping_add(s1).wrapping_add(ch).wrapping_add(K[i]).wrapping_add(w[i]);
+            let temp1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
             let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
             let maj = (a & b) ^ (a & c) ^ (b & c);
             let temp2 = s0.wrapping_add(maj);
-            hh = g; g = f; f = e;
+            hh = g;
+            g = f;
+            f = e;
             e = d.wrapping_add(temp1);
-            d = c; c = b; b = a;
+            d = c;
+            c = b;
+            b = a;
             a = temp1.wrapping_add(temp2);
         }
-        h[0] = h[0].wrapping_add(a); h[1] = h[1].wrapping_add(b);
-        h[2] = h[2].wrapping_add(c); h[3] = h[3].wrapping_add(d);
-        h[4] = h[4].wrapping_add(e); h[5] = h[5].wrapping_add(f);
-        h[6] = h[6].wrapping_add(g); h[7] = h[7].wrapping_add(hh);
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
     }
 
     format!(
@@ -2850,13 +2878,13 @@ async fn fetch_checksum(
     plugin_name: &str,
 ) -> Option<String> {
     // Try {archive_url}.sha256 first, then checksums.txt in the same directory.
-    let candidates = [
-        format!("{archive_url}.sha256"),
-        {
-            let base = archive_url.rsplit_once('/').map(|(b, _)| b).unwrap_or(archive_url);
-            format!("{base}/checksums.txt")
-        },
-    ];
+    let candidates = [format!("{archive_url}.sha256"), {
+        let base = archive_url
+            .rsplit_once('/')
+            .map(|(b, _)| b)
+            .unwrap_or(archive_url);
+        format!("{base}/checksums.txt")
+    }];
 
     for url in &candidates {
         if let Ok(resp) = client.get(url).send().await {
@@ -2865,7 +2893,7 @@ async fn fetch_checksum(
                     // checksums.txt format: "<sha256>  <filename>" per line
                     for line in text.lines() {
                         let parts: Vec<&str> = line.splitn(2, ' ').collect();
-                        if parts.len() >= 1 {
+                        if !parts.is_empty() {
                             let hash = parts[0].trim();
                             if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
                                 // If it's a checksums.txt, check the filename matches
@@ -2895,8 +2923,7 @@ pub fn enable_plugin(name: &str) -> Result<(), String> {
     if !marker.exists() {
         return Err(format!("Plugin '{name}' is already enabled"));
     }
-    std::fs::remove_file(&marker)
-        .map_err(|e| format!("Failed to enable plugin '{name}': {e}"))?;
+    std::fs::remove_file(&marker).map_err(|e| format!("Failed to enable plugin '{name}': {e}"))?;
     info!(plugin = name, "Plugin enabled");
     Ok(())
 }
@@ -2915,8 +2942,7 @@ pub fn disable_plugin(name: &str) -> Result<(), String> {
     if marker.exists() {
         return Err(format!("Plugin '{name}' is already disabled"));
     }
-    std::fs::write(&marker, "")
-        .map_err(|e| format!("Failed to disable plugin '{name}': {e}"))?;
+    std::fs::write(&marker, "").map_err(|e| format!("Failed to disable plugin '{name}': {e}"))?;
     info!(plugin = name, "Plugin disabled");
     Ok(())
 }
@@ -2924,20 +2950,14 @@ pub fn disable_plugin(name: &str) -> Result<(), String> {
 /// Compare two plugin manifests and return a list of backward-incompatibility warnings.
 ///
 /// An empty return value means the upgrade is safe.
-fn check_manifest_compat(
-    old: &PluginManifest,
-    new: &PluginManifest,
-) -> Vec<ManifestCompatWarning> {
+fn check_manifest_compat(old: &PluginManifest, new: &PluginManifest) -> Vec<ManifestCompatWarning> {
     let mut warnings = Vec::new();
 
     // Name change
     if old.name != new.name {
         warnings.push(ManifestCompatWarning {
             kind: ManifestCompatKind::NameChanged,
-            message: format!(
-                "plugin name changed from '{}' to '{}'",
-                old.name, new.name
-            ),
+            message: format!("plugin name changed from '{}' to '{}'", old.name, new.name),
         });
     }
 
@@ -2954,13 +2974,41 @@ fn check_manifest_compat(
 
     // Removed hooks — check each of the 7 known hook script fields
     let hook_pairs = [
-        ("bootstrap",        old.hooks.bootstrap.as_ref(),        new.hooks.bootstrap.as_ref()),
-        ("ingest",           old.hooks.ingest.as_ref(),           new.hooks.ingest.as_ref()),
-        ("assemble",         old.hooks.assemble.as_ref(),         new.hooks.assemble.as_ref()),
-        ("compact",          old.hooks.compact.as_ref(),          new.hooks.compact.as_ref()),
-        ("after_turn",       old.hooks.after_turn.as_ref(),       new.hooks.after_turn.as_ref()),
-        ("prepare_subagent", old.hooks.prepare_subagent.as_ref(), new.hooks.prepare_subagent.as_ref()),
-        ("merge_subagent",   old.hooks.merge_subagent.as_ref(),   new.hooks.merge_subagent.as_ref()),
+        (
+            "bootstrap",
+            old.hooks.bootstrap.as_ref(),
+            new.hooks.bootstrap.as_ref(),
+        ),
+        (
+            "ingest",
+            old.hooks.ingest.as_ref(),
+            new.hooks.ingest.as_ref(),
+        ),
+        (
+            "assemble",
+            old.hooks.assemble.as_ref(),
+            new.hooks.assemble.as_ref(),
+        ),
+        (
+            "compact",
+            old.hooks.compact.as_ref(),
+            new.hooks.compact.as_ref(),
+        ),
+        (
+            "after_turn",
+            old.hooks.after_turn.as_ref(),
+            new.hooks.after_turn.as_ref(),
+        ),
+        (
+            "prepare_subagent",
+            old.hooks.prepare_subagent.as_ref(),
+            new.hooks.prepare_subagent.as_ref(),
+        ),
+        (
+            "merge_subagent",
+            old.hooks.merge_subagent.as_ref(),
+            new.hooks.merge_subagent.as_ref(),
+        ),
     ];
     for (hook_name, old_script, new_script) in &hook_pairs {
         if old_script.is_some() && new_script.is_none() {
@@ -3010,7 +3058,9 @@ pub async fn upgrade_plugin(name: &str, source: &PluginSource) -> Result<PluginI
     validate_plugin_name(name)?;
     let plugin_dir = plugins_dir().join(name);
     if !plugin_dir.exists() {
-        return Err(format!("Plugin '{name}' is not installed. Use install instead."));
+        return Err(format!(
+            "Plugin '{name}' is not installed. Use install instead."
+        ));
     }
 
     // Capture old manifest before removing so we can compare with the new one.
@@ -3085,9 +3135,8 @@ pub fn sign_plugin(name: &str) -> Result<std::collections::HashMap<String, Strin
     let mut hashes = std::collections::HashMap::new();
     for rel_path in &hook_paths {
         let abs_path = plugin_dir.join(rel_path);
-        let bytes = std::fs::read(&abs_path).map_err(|e| {
-            format!("Cannot read '{}' for signing: {e}", abs_path.display())
-        })?;
+        let bytes = std::fs::read(&abs_path)
+            .map_err(|e| format!("Cannot read '{}' for signing: {e}", abs_path.display()))?;
         hashes.insert(rel_path.clone(), sha256_hex(&bytes));
     }
 
@@ -3115,7 +3164,11 @@ pub fn sign_plugin(name: &str) -> Result<std::collections::HashMap<String, Strin
     std::fs::write(&manifest_path, &new_content)
         .map_err(|e| format!("Failed to write plugin.toml: {e}"))?;
 
-    info!(plugin = name, hooks = hook_paths.len(), "Plugin signed — integrity hashes written");
+    info!(
+        plugin = name,
+        hooks = hook_paths.len(),
+        "Plugin signed — integrity hashes written"
+    );
     Ok(hashes)
 }
 
@@ -3287,7 +3340,9 @@ pub fn resolve_install_order(
             return Ok(());
         }
         if in_stack.contains(name) {
-            return Err(format!("Circular dependency detected: '{name}' depends on itself"));
+            return Err(format!(
+                "Circular dependency detected: '{name}' depends on itself"
+            ));
         }
         in_stack.insert(name.to_string());
 
@@ -3299,8 +3354,8 @@ pub fn resolve_install_order(
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                   .filter_map(|v| v.as_str().map(String::from))
-                   .collect()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
             })
             .unwrap_or_default();
 
@@ -3315,7 +3370,13 @@ pub fn resolve_install_order(
         Ok(())
     }
 
-    dfs(root, registry_plugins, &mut order, &mut visited, &mut in_stack)?;
+    dfs(
+        root,
+        registry_plugins,
+        &mut order,
+        &mut visited,
+        &mut in_stack,
+    )?;
     Ok(order)
 }
 
@@ -3345,11 +3406,7 @@ fn strip_toml_section(src: &str, section_name: &str) -> String {
             continue;
         }
         // Any new bare [section] ends the skip (but not [[array]] tables)
-        if skip
-            && trimmed.starts_with('[')
-            && !trimmed.starts_with("[[")
-            && trimmed != header
-        {
+        if skip && trimmed.starts_with('[') && !trimmed.starts_with("[[") && trimmed != header {
             skip = false;
         }
         if !skip {
@@ -3422,19 +3479,35 @@ pub fn lint_plugin(name: &str) -> Result<PluginLintReport, String> {
             use std::os::unix::fs::PermissionsExt;
             if let Ok(meta) = std::fs::metadata(&abs) {
                 if meta.permissions().mode() & 0o111 == 0 {
-                    errors.push(format!("Hook '{rel}' is not executable (chmod +x required for native runtime)"));
+                    errors.push(format!(
+                        "Hook '{rel}' is not executable (chmod +x required for native runtime)"
+                    ));
                 }
             }
         }
     };
 
-    if let Some(ref p) = hooks.ingest { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.after_turn { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.assemble { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.compact { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.bootstrap { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.prepare_subagent { check_hook(p, &mut errors, &mut warnings); }
-    if let Some(ref p) = hooks.merge_subagent { check_hook(p, &mut errors, &mut warnings); }
+    if let Some(ref p) = hooks.ingest {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.after_turn {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.assemble {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.compact {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.bootstrap {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.prepare_subagent {
+        check_hook(p, &mut errors, &mut warnings);
+    }
+    if let Some(ref p) = hooks.merge_subagent {
+        check_hook(p, &mut errors, &mut warnings);
+    }
 
     // 3. Warn on missing optional but recommended fields
     if manifest.description.is_none() {
@@ -3474,8 +3547,7 @@ pub fn lint_plugin(name: &str) -> Result<PluginLintReport, String> {
     let manifest_path = plugin_dir.join("plugin.toml");
     if let Ok(raw) = std::fs::read_to_string(&manifest_path) {
         let needs = extract_needs(&raw);
-        const KNOWN_CAPABILITIES: &[&str] =
-            &["network", "filesystem", "env", "subprocess", "gpu"];
+        const KNOWN_CAPABILITIES: &[&str] = &["network", "filesystem", "env", "subprocess", "gpu"];
         for cap in &needs {
             if !KNOWN_CAPABILITIES.contains(&cap.as_str()) {
                 warnings.push(format!(
@@ -3594,11 +3666,14 @@ pub async fn install_plugin_deps(name: &str) -> Result<Vec<String>, String> {
 
     // Determine the install command based on runtime and package manifest presence.
     // Returns `(executable, args, package_manifest_filename)`.
-    let cmd_info: Option<(&'static str, Vec<&'static str>, &'static str)> = match runtime.as_str()
-    {
+    let cmd_info: Option<(&'static str, Vec<&'static str>, &'static str)> = match runtime.as_str() {
         "python" | "py" => {
             if plugin_dir.join("requirements.txt").exists() {
-                Some(("pip", vec!["install", "-r", "requirements.txt"], "requirements.txt"))
+                Some((
+                    "pip",
+                    vec!["install", "-r", "requirements.txt"],
+                    "requirements.txt",
+                ))
             } else {
                 None
             }
@@ -3714,7 +3789,10 @@ pub async fn install_plugin_with_deps(
     let mut newly_installed = Vec::new();
     for dep_name in &order {
         if installed_names.contains(dep_name) {
-            info!(plugin = dep_name.as_str(), "Dependency already installed, skipping");
+            info!(
+                plugin = dep_name.as_str(),
+                "Dependency already installed, skipping"
+            );
             continue;
         }
         let source = PluginSource::Registry {
@@ -3838,9 +3916,13 @@ after_turn = "hooks/after_turn.py"
             hooks: librefang_types::config::ContextEngineHooks {
                 ingest: Some("hooks/ingest.py".to_string()),
                 after_turn: Some("hooks/after_turn.py".to_string()), // missing
-                runtime: None,
+                ..Default::default()
             },
             requirements: None,
+            env: Default::default(),
+            integrity: Default::default(),
+            librefang_min_version: None,
+            plugin_depends: Default::default(),
         };
 
         assert!(!check_hooks_exist(&plugin_dir, &manifest));
@@ -3857,10 +3939,13 @@ after_turn = "hooks/after_turn.py"
             author: None,
             hooks: librefang_types::config::ContextEngineHooks {
                 ingest: Some("../../etc/passwd".to_string()),
-                after_turn: None,
-                runtime: None,
+                ..Default::default()
             },
             requirements: None,
+            env: Default::default(),
+            integrity: Default::default(),
+            librefang_min_version: None,
+            plugin_depends: Default::default(),
         };
         assert!(!check_hooks_exist(&plugin_dir, &manifest_escape));
     }

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -46,10 +46,10 @@ fn classify_exit_status(status: &std::process::ExitStatus) -> String {
     use std::os::unix::process::ExitStatusExt;
     if let Some(signal) = status.signal() {
         return match signal {
-            9  => format!("OOM-killed or SIGKILL (signal {signal})"),
+            9 => format!("OOM-killed or SIGKILL (signal {signal})"),
             11 => format!("SIGSEGV — segfault (signal {signal})"),
             31 => format!("SIGSYS — disallowed syscall, seccomp triggered (signal {signal})"),
-            _  => format!("killed by signal {signal}"),
+            _ => format!("killed by signal {signal}"),
         };
     }
     // On Unix, exit code 128+N means "killed by signal N" when reported via wait().
@@ -58,7 +58,7 @@ fn classify_exit_status(status: &std::process::ExitStatus) -> String {
             137 => "OOM-killed or SIGKILL (exit 137)".to_string(),
             139 => "SIGSEGV — segfault (exit 139)".to_string(),
             159 => "SIGSYS — disallowed syscall, seccomp triggered (exit 159)".to_string(),
-            _   => format!("exit code {code}"),
+            _ => format!("exit code {code}"),
         };
     }
     "unknown exit status".to_string()
@@ -131,8 +131,8 @@ pub async fn lock_state_file(path: &std::path::Path) -> tokio::sync::OwnedMutexG
     let arc = {
         let mut map = STATE_FILE_LOCKS.lock().unwrap();
         map.entry(path.to_string_lossy().into_owned())
-           .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
-           .clone()
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     };
     arc.lock_owned().await
 }
@@ -578,8 +578,7 @@ impl HookConfig {
         if attempt == 0 {
             return self.retry_delay_ms;
         }
-        let delay = self.retry_delay_ms as f64
-            * self.retry_backoff_multiplier.powi(attempt as i32);
+        let delay = self.retry_delay_ms as f64 * self.retry_backoff_multiplier.powi(attempt as i32);
         delay.min(self.max_retry_delay_ms as f64) as u64
     }
 }
@@ -708,11 +707,7 @@ fn try_wrap_with_unshare(launcher: &str, args: &[String]) -> (String, Vec<String
         .unwrap_or(false);
 
     if available {
-        let mut new_args = vec![
-            "--net".to_string(),
-            "--".to_string(),
-            launcher.to_string(),
-        ];
+        let mut new_args = vec!["--net".to_string(), "--".to_string(), launcher.to_string()];
         new_args.extend_from_slice(args);
         return ("unshare".to_string(), new_args);
     }
@@ -814,47 +809,131 @@ fn try_apply_landlock_readonly(_allow_write_dir: Option<&std::path::Path>) -> bo
 /// when compiled without the `seccomp-sandbox` feature.
 #[cfg(all(target_os = "linux", feature = "seccomp-sandbox"))]
 fn apply_seccomp_allowlist(allow_network: bool) -> bool {
-    use seccompiler::{
-        BpfProgram, SeccompAction, SeccompFilter, SeccompRule,
-        syscall_name_to_num,
-    };
+    use seccompiler::{syscall_name_to_num, BpfProgram, SeccompAction, SeccompFilter, SeccompRule};
 
     // Core syscalls every process needs.
     let allowed: Vec<&str> = vec![
         // Memory
-        "mmap", "mprotect", "munmap", "brk", "madvise", "mremap",
+        "mmap",
+        "mprotect",
+        "munmap",
+        "brk",
+        "madvise",
+        "mremap",
         // File I/O
-        "read", "write", "readv", "writev", "pread64", "pwrite64",
-        "open", "openat", "close", "fstat", "stat", "lstat",
-        "lseek", "dup", "dup2", "dup3", "pipe", "pipe2",
-        "fcntl", "ioctl", "fsync", "fdatasync",
-        "mkdir", "rmdir", "unlink", "rename", "symlink", "readlink",
-        "getcwd", "chdir",
+        "read",
+        "write",
+        "readv",
+        "writev",
+        "pread64",
+        "pwrite64",
+        "open",
+        "openat",
+        "close",
+        "fstat",
+        "stat",
+        "lstat",
+        "lseek",
+        "dup",
+        "dup2",
+        "dup3",
+        "pipe",
+        "pipe2",
+        "fcntl",
+        "ioctl",
+        "fsync",
+        "fdatasync",
+        "mkdir",
+        "rmdir",
+        "unlink",
+        "rename",
+        "symlink",
+        "readlink",
+        "getcwd",
+        "chdir",
         // Process
-        "exit", "exit_group", "getpid", "getppid", "gettid",
-        "set_tid_address", "futex", "nanosleep", "clock_gettime",
-        "clock_nanosleep", "getrlimit", "setrlimit", "prlimit64",
-        "uname", "sysinfo", "times",
+        "exit",
+        "exit_group",
+        "getpid",
+        "getppid",
+        "gettid",
+        "set_tid_address",
+        "futex",
+        "nanosleep",
+        "clock_gettime",
+        "clock_nanosleep",
+        "getrlimit",
+        "setrlimit",
+        "prlimit64",
+        "uname",
+        "sysinfo",
+        "times",
         // Signals
-        "rt_sigaction", "rt_sigprocmask", "rt_sigreturn", "sigaltstack",
-        "kill", "tgkill",
+        "rt_sigaction",
+        "rt_sigprocmask",
+        "rt_sigreturn",
+        "sigaltstack",
+        "kill",
+        "tgkill",
         // Threads
-        "clone", "clone3", "fork", "execve", "execveat", "wait4", "waitid",
+        "clone",
+        "clone3",
+        "fork",
+        "execve",
+        "execveat",
+        "wait4",
+        "waitid",
         // I/O multiplexing
-        "select", "pselect6", "poll", "ppoll", "epoll_create", "epoll_create1",
-        "epoll_ctl", "epoll_wait", "epoll_pwait",
+        "select",
+        "pselect6",
+        "poll",
+        "ppoll",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_wait",
+        "epoll_pwait",
         // Sockets (needed even without network for Unix domain sockets / IPC)
-        "socket", "connect", "bind", "listen", "accept", "accept4",
-        "getsockopt", "setsockopt", "getsockname", "getpeername",
-        "sendto", "recvfrom", "sendmsg", "recvmsg", "shutdown",
+        "socket",
+        "connect",
+        "bind",
+        "listen",
+        "accept",
+        "accept4",
+        "getsockopt",
+        "setsockopt",
+        "getsockname",
+        "getpeername",
+        "sendto",
+        "recvfrom",
+        "sendmsg",
+        "recvmsg",
+        "shutdown",
         // Anonymous pipes / tmpfiles
-        "eventfd", "eventfd2", "timerfd_create", "timerfd_settime", "timerfd_gettime",
+        "eventfd",
+        "eventfd2",
+        "timerfd_create",
+        "timerfd_settime",
+        "timerfd_gettime",
         // Misc
-        "arch_prctl", "prctl", "getdents", "getdents64",
-        "access", "faccessat", "newfstatat",
-        "readdir", "getuid", "getgid", "geteuid", "getegid",
-        "getgroups", "setgroups",
-        "mlock", "munlock", "mlockall", "munlockall",
+        "arch_prctl",
+        "prctl",
+        "getdents",
+        "getdents64",
+        "access",
+        "faccessat",
+        "newfstatat",
+        "readdir",
+        "getuid",
+        "getgid",
+        "geteuid",
+        "getegid",
+        "getgroups",
+        "setgroups",
+        "mlock",
+        "munlock",
+        "mlockall",
+        "munlockall",
         "getrandom",
     ];
 
@@ -870,7 +949,9 @@ fn apply_seccomp_allowlist(allow_network: bool) -> bool {
         rules.into_iter().collect(),
         SeccompAction::KillProcess,
         SeccompAction::Allow,
-        std::env::consts::ARCH.try_into().unwrap_or(seccompiler::TargetArch::x86_64),
+        std::env::consts::ARCH
+            .try_into()
+            .unwrap_or(seccompiler::TargetArch::x86_64),
     ) {
         Ok(f) => f,
         Err(_) => return false,
@@ -1006,7 +1087,8 @@ pub async fn run_hook_json(
     // Plugin-declared env vars from [env] in plugin.toml.
     // Values of the form `${VAR_NAME}` are expanded from the daemon's env.
     for (key, val) in &config.plugin_env {
-        let expanded = if let Some(inner) = val.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+        let expanded = if let Some(inner) = val.strip_prefix("${").and_then(|s| s.strip_suffix('}'))
+        {
             std::env::var(inner).unwrap_or_default()
         } else {
             val.clone()
@@ -1034,8 +1116,7 @@ pub async fn run_hook_json(
     let _hook_tmpdir: Option<std::path::PathBuf> = if !config.allow_filesystem {
         cmd.env("LIBREFANG_READONLY_FS", "1");
         cmd.env("HOME", "/dev/null");
-        let tmp = std::env::temp_dir()
-            .join(format!("librefang_hook_{}", uuid_v4_hex()));
+        let tmp = std::env::temp_dir().join(format!("librefang_hook_{}", uuid_v4_hex()));
         let _ = std::fs::create_dir_all(&tmp);
         cmd.env("TMPDIR", tmp.display().to_string());
         debug!(
@@ -1054,7 +1135,10 @@ pub async fn run_hook_json(
     // their own limits.
     if let Some(mb) = config.max_memory_mb {
         cmd.env("LIBREFANG_MAX_MEMORY_MB", mb.to_string());
-        debug!(max_memory_mb = mb, "Memory limit set (advisory via env var; hard limit requires libc dep)");
+        debug!(
+            max_memory_mb = mb,
+            "Memory limit set (advisory via env var; hard limit requires libc dep)"
+        );
     }
 
     // Shared state KV store: ensure the file exists and inject its path so hook
@@ -1066,7 +1150,10 @@ pub async fn run_hook_json(
             }
             let _ = std::fs::write(state_path, "{}");
         }
-        cmd.env("LIBREFANG_STATE_FILE", state_path.to_string_lossy().as_ref());
+        cmd.env(
+            "LIBREFANG_STATE_FILE",
+            state_path.to_string_lossy().as_ref(),
+        );
         debug!(state_file = %state_path.display(), "Shared state file injected");
     }
 
@@ -1200,7 +1287,7 @@ pub async fn run_hook_json(
         Ok::<(Vec<String>, String, std::process::ExitStatus), PluginRuntimeError>((
             stdout_lines,
             stderr_text,
-            status.into(),
+            status,
         ))
     })
     .await;
@@ -1224,8 +1311,7 @@ pub async fn run_hook_json(
                     return Err(PluginRuntimeError::InvalidOutput(format!(
                         "Hook output exceeds maximum size ({} bytes > {} bytes limit). \
                          Truncate your hook's JSON response.",
-                        total_output_bytes,
-                        MAX_OUTPUT_BYTES
+                        total_output_bytes, MAX_OUTPUT_BYTES
                     )));
                 }
                 parse_output(&stdout_lines)
@@ -1350,7 +1436,10 @@ struct PersistentProcess {
 #[derive(Default)]
 pub struct HookProcessPool {
     procs: std::sync::Mutex<
-        std::collections::HashMap<String, std::sync::Arc<tokio::sync::Mutex<Option<PersistentProcess>>>>,
+        std::collections::HashMap<
+            String,
+            std::sync::Arc<tokio::sync::Mutex<Option<PersistentProcess>>>,
+        >,
     >,
 }
 
@@ -1562,7 +1651,10 @@ impl HookProcessPool {
     /// Returns the list of script-path keys for alive processes.
     pub async fn health_check(&self) -> Vec<String> {
         let mut alive = Vec::new();
-        let entries: Vec<(String, std::sync::Arc<tokio::sync::Mutex<Option<PersistentProcess>>>)> = {
+        let entries: Vec<(
+            String,
+            std::sync::Arc<tokio::sync::Mutex<Option<PersistentProcess>>>,
+        )> = {
             let procs = self.procs.lock().unwrap();
             procs.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         };
@@ -1643,7 +1735,10 @@ impl HookProcessPool {
         let new_proc = match Self::spawn(script_path, runtime, config).await {
             Ok(p) => p,
             Err(e) => {
-                tracing::warn!(hook = hook_name, "swap_prewarm: failed to spawn new process: {e}");
+                tracing::warn!(
+                    hook = hook_name,
+                    "swap_prewarm: failed to spawn new process: {e}"
+                );
                 return 0;
             }
         };
@@ -1651,7 +1746,10 @@ impl HookProcessPool {
         // Step 2: verify the new process is alive — child.id() returns Some
         // only while the process is still running.
         if new_proc.child.id().is_none() {
-            tracing::warn!(hook = hook_name, "swap_prewarm: new process died immediately");
+            tracing::warn!(
+                hook = hook_name,
+                "swap_prewarm: new process died immediately"
+            );
             return 0;
         }
 
@@ -1672,7 +1770,11 @@ impl HookProcessPool {
             let _ = old_proc.child.kill().await;
         }
         *guard = Some(new_proc);
-        tracing::info!(hook = hook_name, script = script_path, "swap_prewarm: hot-reload complete, slot replaced");
+        tracing::info!(
+            hook = hook_name,
+            script = script_path,
+            "swap_prewarm: hot-reload complete, slot replaced"
+        );
         1
     }
 


### PR DESCRIPTION
## Summary

Fixes pre-existing build errors and clippy warnings that prevent `cargo build --workspace`, `cargo test --workspace`, and `cargo clippy` from passing on main.

### Build errors fixed:
- `Uuid::as_str()` no longer exists — replaced with `to_string()` in context_engine rate limiter
- Missing `PluginRuntime::Wasm` arm in `hook_templates` match (non-exhaustive pattern)
- Missing `ContextEngineConfig` fields (`output_schema_strict`, `max_hook_calls_per_minute`) in kernel init
- Missing `PluginManifest` fields (`env`, `integrity`, `librefang_min_version`, `plugin_depends`) in test structs
- `run_hook` test calling with 15 args instead of 17, and not destructuring tuple return

### Clippy warnings fixed:
- `map_or(false, ...)` → `is_some_and(...)` 
- `parts.len() >= 1` → `!parts.is_empty()`
- Useless `status.into()` conversion removed
- `if let Some` on iterator → `iter().copied().flatten()`

## Test plan
- [x] `cargo build --workspace --lib` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 399 passed, 7 failed (pre-existing semantic router tests, unrelated)