### PR TITLE
fix(runtime): resolve build errors and clippy warnings

### DIFF
--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -1449,7 +1449,7 @@ impl ScriptableContextEngine {
             &self.compact_script,
             &self.on_event_script,
         ];
-        for ref script in hooks.iter().copied().flatten() {
+        for script in hooks.iter().copied().flatten() {
             let resolved = Self::resolve_script_path(script);
             self.process_pool.evict(&resolved).await;
         }
@@ -4249,8 +4249,8 @@ print(json.dumps({"type": payload.get("type"), "message": payload.get("message")
             &hook_schemas,
             None,
             None,
-            "",
-            "",
+            "test",
+            "test-correlation-id",
             false,
         )
         .await


### PR DESCRIPTION
Rebased from #2182 (rodela-ai) — resolved merge conflicts against current main.

## Changes

- `Uuid::as_str()` → `to_string()` in context_engine rate limiter
- Missing `PluginRuntime::Wasm` arm in `hook_templates` match
- Missing `ContextEngineConfig` fields in kernel init
- `run_hook` test: fix arg count and destructure tuple return
- Clippy: `map_or(false, ...)` → `is_some_and(...)`, `parts.len() >= 1` → `!parts.is_empty()`, remove useless `into()`, `for ref script` → `for script`

Closes #2182