### PR TITLE
fix: replace as_deref() with as_ref() for ChannelOverrides in bridge.rs

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -724,7 +724,7 @@ fn flush_debounced(
                 ct_str,
                 thread_id,
                 output_format,
-                overrides.as_deref(),
+                overrides.as_ref(),
                 journal.as_ref(),
             )
             .await;
@@ -1836,7 +1836,7 @@ async fn dispatch_message(
                 ct_str,
                 thread_id,
                 output_format,
-                overrides.as_deref(),
+                overrides.as_ref(),
                 journal,
             )
             .await;
@@ -2137,7 +2137,7 @@ async fn dispatch_message(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
     // Build sender context to propagate identity to the agent
-    let sender_ctx = build_sender_context(message, overrides.as_deref());
+    let sender_ctx = build_sender_context(message, overrides.as_ref());
 
     // Streaming path: if the adapter supports progressive output, pipe text
     // deltas directly to it instead of waiting for the full response.


### PR DESCRIPTION
## 问题

PR #2189 在 `bridge.rs` 三处调用了 `overrides.as_deref()`，但 `ChannelOverrides` 是普通结构体，未实现 `Deref` trait，导致 CI 编译失败：

```
error[E0599]: the method `as_deref` exists for enum `Option<ChannelOverrides>`,
but its trait bounds were not satisfied
  --> crates/librefang-channels/src/bridge.rs:727
  --> crates/librefang-channels/src/bridge.rs:1839
  --> crates/librefang-channels/src/bridge.rs:2140
```

## 修复

将三处 `.as_deref()` 改为 `.as_ref()`，返回 `Option<&ChannelOverrides>`，与 `dispatch_with_blocks`、`dispatch_message`、`build_sender_context` 的参数签名一致。

## 变更

- `bridge.rs:727` — `overrides.as_deref()` → `overrides.as_ref()`
- `bridge.rs:1839` — `overrides.as_deref()` → `overrides.as_ref()`
- `bridge.rs:2140` — `overrides.as_deref()` → `overrides.as_ref()`