### PR TITLE
style: apply rustfmt formatting across bridge, router, kernel, system

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -407,7 +407,10 @@ pub async fn get_agent_template_toml(
     match std::fs::read_to_string(&manifest_path) {
         Ok(content) => (
             StatusCode::OK,
-            [(axum::http::header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; charset=utf-8",
+            )],
             content,
         )
             .into_response(),

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -14,7 +14,9 @@ use crate::types::{
 use async_trait::async_trait;
 use futures::StreamExt;
 use librefang_types::agent::AgentId;
-use librefang_types::config::{AutoRouteStrategy, ChannelOverrides, DmPolicy, GroupPolicy, OutputFormat};
+use librefang_types::config::{
+    AutoRouteStrategy, ChannelOverrides, DmPolicy, GroupPolicy, OutputFormat,
+};
 use librefang_types::message::ContentBlock;
 use regex::RegexSet;
 use std::collections::HashMap;
@@ -1374,17 +1376,22 @@ fn build_sender_context(
     message: &ChannelMessage,
     overrides: Option<&ChannelOverrides>,
 ) -> SenderContext {
-    let (auto_route, auto_route_ttl_minutes, auto_route_confidence_threshold, auto_route_sticky_bonus, auto_route_divergence_count) =
-        match overrides {
-            Some(ov) => (
-                ov.auto_route.clone(),
-                ov.auto_route_ttl_minutes,
-                ov.auto_route_confidence_threshold,
-                ov.auto_route_sticky_bonus,
-                ov.auto_route_divergence_count,
-            ),
-            None => (AutoRouteStrategy::Off, 0, 0, 0, 0),
-        };
+    let (
+        auto_route,
+        auto_route_ttl_minutes,
+        auto_route_confidence_threshold,
+        auto_route_sticky_bonus,
+        auto_route_divergence_count,
+    ) = match overrides {
+        Some(ov) => (
+            ov.auto_route.clone(),
+            ov.auto_route_ttl_minutes,
+            ov.auto_route_confidence_threshold,
+            ov.auto_route_sticky_bonus,
+            ov.auto_route_divergence_count,
+        ),
+        None => (AutoRouteStrategy::Off, 0, 0, 0, 0),
+    };
     SenderContext {
         channel: channel_type_str(&message.channel).to_string(),
         user_id: sender_user_id(message).to_string(),

--- a/crates/librefang-channels/src/router.rs
+++ b/crates/librefang-channels/src/router.rs
@@ -661,13 +661,13 @@ mod tests {
             peer_id: Cow::Borrowed("23244855"),
             ..Default::default()
         };
-        let resolved = router.resolve_with_context(
-            &ChannelType::Telegram,
-            "23244855",
-            None,
-            &ctx_admin,
+        let resolved =
+            router.resolve_with_context(&ChannelType::Telegram, "23244855", None, &ctx_admin);
+        assert_eq!(
+            resolved,
+            Some(admin_agent),
+            "admin-bot should route to nick-assistant"
         );
-        assert_eq!(resolved, Some(admin_agent), "admin-bot should route to nick-assistant");
 
         let ctx_samapoedu = BindingContext {
             channel: Cow::Borrowed("telegram"),
@@ -675,13 +675,13 @@ mod tests {
             peer_id: Cow::Borrowed("23244855"),
             ..Default::default()
         };
-        let resolved = router.resolve_with_context(
-            &ChannelType::Telegram,
-            "23244855",
-            None,
-            &ctx_samapoedu,
+        let resolved =
+            router.resolve_with_context(&ChannelType::Telegram, "23244855", None, &ctx_samapoedu);
+        assert_eq!(
+            resolved,
+            Some(samapoedu_agent),
+            "samapoedu-bot should route to nika"
         );
-        assert_eq!(resolved, Some(samapoedu_agent), "samapoedu-bot should route to nika");
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2566,13 +2566,12 @@ impl LibreFangKernel {
                             Ok(toml_str) => {
                                 // Try parsing as AgentManifest first; fall back to
                                 // extracting from a hand.toml (HandDefinition format).
-                                let parsed = toml::from_str::<librefang_types::agent::AgentManifest>(
-                                    &toml_str,
-                                )
-                                .ok()
-                                .or_else(|| {
-                                    extract_manifest_from_hand_toml(&toml_str, &name)
-                                });
+                                let parsed =
+                                    toml::from_str::<librefang_types::agent::AgentManifest>(
+                                        &toml_str,
+                                    )
+                                    .ok()
+                                    .or_else(|| extract_manifest_from_hand_toml(&toml_str, &name));
                                 match parsed {
                                     Some(mut disk_manifest) => {
                                         // Compare key fields to detect changes
@@ -4574,10 +4573,8 @@ system_prompt = "You are a helpful assistant."
                             } else {
                                 // Disagreement — increment divergence counter.
                                 let count = {
-                                    let mut div_entry = self
-                                        .route_divergence
-                                        .entry(cache_key.clone())
-                                        .or_insert(0);
+                                    let mut div_entry =
+                                        self.route_divergence.entry(cache_key.clone()).or_insert(0);
                                     *div_entry += 1;
                                     *div_entry
                                 };


### PR DESCRIPTION
## 问题

CI Quality 步骤报告 7 处 rustfmt 格式差异，导致 `Check formatting` 失败。

## 修复内容

| 文件 | 行号 | 变更 |
|------|------|------|
| `system.rs` | 410 | 拆分 header 元组 |
| `bridge.rs` | 17 | 拆分长 use 导入 |
| `bridge.rs` | 1377 | 拆分长 let 解构 |
| `router.rs` | 664 | 重排 resolve_with_context 调用 |
| `router.rs` | 678 | 重排 resolve_with_context 调用 |
| `kernel.rs` | 2569 | 重排 toml 解析链式调用 |
| `kernel.rs` | 4577 | 重排 DashMap entry 调用 |

仅格式变更，无逻辑修改。