### PR TITLE
fix: remove dead completion_timeout_override and build_completion_request

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -201,50 +201,6 @@ fn strip_processed_image_data(messages: &mut [Message]) {
     }
 }
 
-fn completion_timeout_override(
-    manifest: &AgentManifest,
-    available_tools: &[ToolDefinition],
-) -> Option<u64> {
-    manifest
-        .metadata
-        .get("timeout_secs")
-        .and_then(|v| v.as_u64())
-        .or_else(|| {
-            if available_tools
-                .iter()
-                .any(|t| t.name.starts_with("browser_") || t.name.starts_with("playwright_"))
-            {
-                Some(600)
-            } else {
-                None
-            }
-        })
-}
-
-fn build_completion_request(
-    manifest: &AgentManifest,
-    system_prompt: &str,
-    messages: &[Message],
-    available_tools: &[ToolDefinition],
-) -> CompletionRequest {
-    CompletionRequest {
-        model: strip_provider_prefix(&manifest.model.model, &manifest.model.provider),
-        messages: messages.to_vec(),
-        tools: available_tools.to_vec(),
-        max_tokens: manifest.model.max_tokens,
-        temperature: manifest.model.temperature,
-        system: Some(system_prompt.to_string()),
-        thinking: manifest.thinking.clone(),
-        prompt_caching: manifest
-            .metadata
-            .get("prompt_caching")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true),
-        response_format: manifest.response_format.clone(),
-        timeout_secs: completion_timeout_override(manifest, available_tools),
-        extra_body: None,
-    }
-}
 
 fn accumulate_token_usage(total_usage: &mut TokenUsage, usage: &TokenUsage) {
     total_usage.input_tokens += usage.input_tokens;


### PR DESCRIPTION
## 问题

`agent_loop.rs` 中的两个函数 `completion_timeout_override` 和 `build_completion_request` 成为死代码后，CI 报错：

```
error: function `completion_timeout_override` is never used
error: function `build_completion_request` is never used
error: could not compile `librefang-runtime` (lib) due to 2 previous errors
```

## 原因

feat: add extra_params support PR (#212b56f4) 将这两个函数的逻辑直接内联到两个 `CompletionRequest` 构造位置（line ~2098 和 ~2990），原来的 helper 函数不再被调用。

## 修复

删除两个死函数。两个 inline 调用点已经包含了等价的 timeout 和 prompt_caching 逻辑。