### PR TITLE
style: remove extra blank line in agent_loop.rs

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -201,7 +201,6 @@ fn strip_processed_image_data(messages: &mut [Message]) {
     }
 }
 
-
 fn accumulate_token_usage(total_usage: &mut TokenUsage, usage: &TokenUsage) {
     total_usage.input_tokens += usage.input_tokens;
     total_usage.output_tokens += usage.output_tokens;


### PR DESCRIPTION
删除 #2198 删除死代码后遗留的多余空行，修复 rustfmt 格式检查。