### PR TITLE
fix: derive Default for PluginManifest

### DIFF
--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2591,7 +2591,7 @@ pub enum HookFailurePolicy {
 /// ingest = "hooks/ingest.py"      # relative to plugin dir
 /// after_turn = "hooks/after_turn.py"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PluginManifest {
     /// Plugin name (must match directory name).
     pub name: String,


### PR DESCRIPTION
plugin_manager.rs 中的测试对 PluginManifest 使用 `..Default::default()`，但该结构体未实现 Default，导致 clippy 编译失败。

所有字段都有合理的默认值（String→空字符串, Option→None, Vec/HashMap→空集合, ContextEngineHooks→已实现Default），直接 derive 即可。