### PR TITLE
fix(runtime): support full binary path for hook runtime

### DIFF
--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -964,7 +964,7 @@ pub async fn test_plugin_hook(
     match librefang_runtime::plugin_runtime::run_hook_json(
         &hook_name,
         &script_abs.to_string_lossy(),
-        runtime,
+        &runtime,
         &input,
         &config,
     )
@@ -1589,7 +1589,7 @@ pub async fn benchmark_plugin_hook(
         match librefang_runtime::plugin_runtime::run_hook_json(
             &hook_name,
             &script_abs.to_string_lossy(),
-            runtime,
+            &runtime,
             &input,
             &config,
         )

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -1078,7 +1078,7 @@ impl ScriptableContextEngine {
             // Using Arc clones keeps it cheap; the spawned task holds them for its lifetime.
             let plugin_name = self.plugin_name.clone();
             let on_event_script = self.on_event_script.clone().unwrap();
-            let runtime = self.runtime;
+            let runtime = self.runtime.clone();
             let hook_timeout_secs = self.hook_timeout_secs;
             let plugin_env = self.plugin_env.clone();
             let bootstrap_overrides = self.bootstrap_applied_overrides.clone();

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -609,7 +609,7 @@ pub fn run_doctor() -> DoctorReport {
 
     let runtimes: Vec<_> = PluginRuntime::all()
         .iter()
-        .map(|r| check_runtime_status(*r))
+        .map(|r| check_runtime_status(r.clone()))
         .collect();
 
     // Index by runtime tag so per-plugin entries can look up availability
@@ -624,10 +624,10 @@ pub fn run_doctor() -> DoctorReport {
         .map(|info| {
             let runtime_kind = PluginRuntime::from_tag(info.manifest.hooks.runtime.as_deref());
             let tag = runtime_kind.label();
-            let (available, hint) = availability.get(tag).copied().unwrap_or((false, ""));
+            let (available, hint) = availability.get(tag.as_str()).copied().unwrap_or((false, ""));
             PluginDoctorEntry {
                 name: info.manifest.name,
-                runtime: tag.to_string(),
+                runtime: tag.clone(),
                 runtime_available: available,
                 hooks_valid: info.hooks_valid,
                 install_hint: hint.to_string(),
@@ -1030,7 +1030,7 @@ pub fn scaffold_plugin(
 
     // Each runtime declares its own hook filenames + template body so the
     // manifest + files stay in sync.
-    let files = hook_templates(runtime_kind);
+    let files = hook_templates(runtime_kind.clone());
     let (ingest_file, ingest_body) = files.ingest;
     let (after_file, after_body) = files.after_turn;
     let (assemble_file, assemble_body) = files.assemble;
@@ -1296,6 +1296,17 @@ fn hook_templates(runtime: crate::plugin_runtime::PluginRuntime) -> HookFiles {
             bootstrap: ("bootstrap.wasm", STUB_LIFECYCLE_NATIVE),
             prepare_subagent: ("prepare_subagent.wasm", STUB_LIFECYCLE_NATIVE),
             merge_subagent: ("merge_subagent.wasm", STUB_LIFECYCLE_NATIVE),
+        },
+        // Custom launchers: fall back to the native (shell-wrapper) scaffold.
+        // Users can replace the stubs with scripts appropriate for their launcher.
+        R::Custom(_) => HookFiles {
+            ingest: ("ingest", NATIVE_INGEST),
+            after_turn: ("after_turn", NATIVE_AFTER_TURN),
+            assemble: ("assemble", STUB_ASSEMBLE_NATIVE),
+            compact: ("compact", STUB_COMPACT_NATIVE),
+            bootstrap: ("bootstrap", STUB_LIFECYCLE_NATIVE),
+            prepare_subagent: ("prepare_subagent", STUB_LIFECYCLE_NATIVE),
+            merge_subagent: ("merge_subagent", STUB_LIFECYCLE_NATIVE),
         },
     }
 }

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -1764,7 +1764,7 @@ impl HookProcessPool {
         &self,
         hook_name: &str,
         script_path: &str,
-        runtime: PluginRuntime,
+        runtime: &PluginRuntime,
         config: &HookConfig,
     ) -> usize {
         // Step 1: spawn the new process outside any lock so in-flight calls
@@ -1936,6 +1936,37 @@ mod tests {
             PluginRuntime::from_tag(Some("brainfuck")),
             PluginRuntime::Python
         );
+    }
+
+    #[test]
+    fn from_tag_full_path_becomes_custom() {
+        assert_eq!(
+            PluginRuntime::from_tag(Some("/opt/homebrew/bin/python3")),
+            PluginRuntime::Custom("/opt/homebrew/bin/python3".to_string())
+        );
+        assert_eq!(
+            PluginRuntime::from_tag(Some("/usr/bin/ruby")),
+            PluginRuntime::Custom("/usr/bin/ruby".to_string())
+        );
+        // Windows-style backslash path
+        assert_eq!(
+            PluginRuntime::from_tag(Some("C:\\Python312\\python.exe")),
+            PluginRuntime::Custom("C:\\Python312\\python.exe".to_string())
+        );
+        // Path with whitespace trimmed but preserved otherwise
+        assert_eq!(
+            PluginRuntime::from_tag(Some("  /usr/local/bin/node  ")),
+            PluginRuntime::Custom("/usr/local/bin/node".to_string())
+        );
+    }
+
+    #[test]
+    fn build_command_custom_launcher() {
+        let (l, a) =
+            build_command(&PluginRuntime::Custom("/opt/homebrew/bin/python3".to_string()), "hooks/ingest.py")
+                .unwrap();
+        assert_eq!(l, "/opt/homebrew/bin/python3");
+        assert_eq!(a, vec!["hooks/ingest.py".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2206.

When `runtime` in `[context_engine.hooks]` was set to a full binary path (e.g. `/opt/homebrew/bin/python3`), the hook silently never fired. The path did not match any known short name in `from_tag()`, so it fell back to `PluginRuntime::Python` and the original path was discarded.

**Changes:**

- Add `PluginRuntime::Custom(String)` variant to hold verbatim launcher paths
- Update `from_tag()`: if the tag contains `/` or `\`, treat it as a `Custom` path instead of falling back to Python; the original (un-lowercased) string is preserved so the path survives intact
- Update `build_command()`: `Custom(launcher)` uses the provided string directly as the command binary
- Update `label()` and all exhaustive `match` arms for the new variant
- Improve the fallback warning message to mention the full-path option

**Before:**
```toml
runtime = "/opt/homebrew/bin/python3"  # silently ignored, hook never fires
```

**After:**
```toml
runtime = "/opt/homebrew/bin/python3"  # works — runs /opt/homebrew/bin/python3 <script>
```

## Test plan

- [ ] Set `runtime = "/usr/bin/python3"` in a plugin's `plugin.toml` → hook fires correctly
- [ ] Set `runtime = "python"` (short name) → still works as before
- [ ] Set `runtime = "unknown"` → falls back to Python with a warning (backward-compatible)