### PR TITLE
feat(runtime): add [[requires]] system binary checks to plugin.toml

### DIFF
--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -10,7 +10,7 @@
 //! - **Local path**: copy from a local directory
 //! - **Git URL**: clone a git repo into the plugins directory
 
-use librefang_types::config::PluginManifest;
+use librefang_types::config::{PluginManifest, PluginSystemRequirement};
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
@@ -690,6 +690,16 @@ pub async fn install_plugin(source: &PluginSource) -> Result<PluginInfo, String>
         // Don't remove the partially-installed plugin — let the user decide.
         // Just warn so they know what to install next.
         warn!("{e}");
+    }
+
+    // Warn about missing system binaries declared in [[requires]].
+    let missing_bins = check_system_requires(&info.manifest.requires);
+    for (bin, hint) in &missing_bins {
+        let hint_str = hint.as_deref().unwrap_or("(no install hint provided)");
+        warn!(
+            "Plugin '{}' requires system binary '{}' which was not found on PATH. {}",
+            info.manifest.name, bin, hint_str
+        );
     }
 
     Ok(info)
@@ -3292,6 +3302,43 @@ fn extract_needs(raw_toml: &str) -> Vec<String> {
         .collect()
 }
 
+/// Return `true` if `name` resolves to an executable on `PATH`.
+///
+/// Walks each directory in `PATH` and checks whether `name` (or `name.exe`
+/// on Windows) exists as a file in that directory.  No shell quoting or
+/// tilde-expansion is performed — the binary name should be a plain
+/// filename without path separators.
+fn binary_on_path(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if dir.join(name).exists() {
+                return true;
+            }
+            // Windows: also check with .exe extension
+            #[cfg(target_os = "windows")]
+            if dir.join(format!("{name}.exe")).exists() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check whether each `[[requires]]` binary is available on PATH.
+///
+/// Returns a list of `(binary, install_hint)` pairs for each missing binary.
+/// An empty list means all required binaries are present.
+fn check_system_requires(requires: &[PluginSystemRequirement]) -> Vec<(String, Option<String>)> {
+    requires
+        .iter()
+        .filter(|req| !req.binary.is_empty() && !binary_on_path(&req.binary))
+        .map(|req| (req.binary.clone(), req.install_hint.clone()))
+        .collect()
+}
+
 /// Check whether all plugins listed in `needs` are already installed and
 /// satisfy any declared version constraints.
 ///
@@ -3572,6 +3619,16 @@ pub fn lint_plugin(name: &str) -> Result<PluginLintReport, String> {
                 ));
             }
         }
+    }
+
+    // 8. Warn about missing system binaries declared in [[requires]]
+    let missing_bins = check_system_requires(&manifest.requires);
+    for (bin, hint) in &missing_bins {
+        let hint_str = hint.as_deref().unwrap_or("(no install hint provided)");
+        warnings.push(format!(
+            "Required binary '{}' not found on PATH — {}",
+            bin, hint_str
+        ));
     }
 
     let ok = errors.is_empty();

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2710,6 +2710,28 @@ pub struct PluginManifest {
     /// the path in `LIBREFANG_PLUGIN_CONFIG` before each hook subprocess runs.
     #[serde(default)]
     pub config: std::collections::HashMap<String, PluginConfigField>,
+    /// System binaries required by this plugin.
+    ///
+    /// The runtime checks each binary against `PATH` at install and lint time
+    /// and warns when one is missing. Hooks still execute — this is advisory only.
+    ///
+    /// ```toml
+    /// [[requires]]
+    /// binary = "ffmpeg"
+    /// install_hint = "brew install ffmpeg"
+    /// ```
+    #[serde(default)]
+    pub requires: Vec<PluginSystemRequirement>,
+}
+
+/// A single system-binary requirement declared in `plugin.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PluginSystemRequirement {
+    /// Name of the binary that must exist on `PATH`.
+    pub binary: String,
+    /// Human-readable install hint shown when the binary is missing.
+    #[serde(default)]
+    pub install_hint: Option<String>,
 }
 
 /// client_secret_env = "GITHUB_OAUTH_CLIENT_SECRET"


### PR DESCRIPTION
## Summary

Closes #2209

Plugins can now declare required system binaries in `plugin.toml`:

```toml
[[requires]]
binary = "ffmpeg"
install_hint = "brew install ffmpeg  # macOS\napt install ffmpeg  # Debian"

[[requires]]
binary = "whisper"
install_hint = "pip install openai-whisper"
```

At install time and lint time, the runtime checks each declared binary against `PATH` and warns if any are missing. Hooks still execute — the check is advisory only, not a hard failure.

## Changes

- **`librefang-types`**: Added `PluginSystemRequirement` struct (`binary: String`, `install_hint: Option<String>`) and `requires: Vec<PluginSystemRequirement>` field to `PluginManifest` — backward-compatible with `#[serde(default)]`
- **`librefang-runtime/plugin_manager`**: Added `binary_on_path()` PATH lookup (no new crate dependency), `check_system_requires()` helper, and calls at:
  - Install time: warns on missing binaries after installation
  - Lint time: adds missing binaries as lint warnings

## Test plan

- [ ] Plugin with `[[requires]]` for an existing binary (`ls`, `cat`) installs without warnings
- [ ] Plugin with `[[requires]]` for a missing binary installs with a `WARN` log listing the binary and install hint
- [ ] `lint_plugin` includes missing binary warnings in `PluginLintReport.warnings`
- [ ] Plugin without `[[requires]]` works as before (no change in behavior)