### PR TITLE
fix(api): resolve default provider in agent detail endpoint

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1654,6 +1654,30 @@ pub async fn get_agent(
         }
     };
 
+    let dm = {
+        let dm_override = state
+            .kernel
+            .default_model_override_ref()
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        effective_default_model(
+            &state.kernel.config_ref().default_model,
+            dm_override.as_ref(),
+        )
+    };
+    let resolved_provider =
+        if entry.manifest.model.provider.is_empty() || entry.manifest.model.provider == "default" {
+            dm.provider.as_str()
+        } else {
+            entry.manifest.model.provider.as_str()
+        };
+    let resolved_model =
+        if entry.manifest.model.model.is_empty() || entry.manifest.model.model == "default" {
+            dm.model.as_str()
+        } else {
+            entry.manifest.model.model.as_str()
+        };
+
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -1666,8 +1690,8 @@ pub async fn get_agent(
             "last_active": entry.last_active.to_rfc3339(),
             "session_id": entry.session_id.0.to_string(),
             "model": {
-                "provider": entry.manifest.model.provider,
-                "model": entry.manifest.model.model,
+                "provider": resolved_provider,
+                "model": resolved_model,
                 "max_tokens": entry.manifest.model.max_tokens,
                 "temperature": entry.manifest.model.temperature,
             },


### PR DESCRIPTION
## Summary
- The `GET /api/agents/{id}` endpoint returned the raw manifest provider value, which could be empty or `"default"`
- This caused the dashboard model editing UI to initialize with empty provider/model fields, making the **Save button permanently disabled**
- Applied the same provider/model resolution logic already used by the list endpoint (`enrich_agent_json`)

## Related Issue
Ref #2196

## Test plan
- [ ] Create an agent with `provider = "default"` in its manifest
- [ ] Call `GET /api/agents/{id}` — verify `model.provider` returns the effective provider name (e.g. "groq"), not "default"
- [ ] Open dashboard → Agents → click agent → Edit model → verify Save button is enabled