### PR TITLE
fix(dashboard): add error handling to channel config dialog

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -317,6 +317,7 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
 // Config Dialog — standard form with controlled inputs
 function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () => void; t: (key: string) => string }) {
   const queryClient = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
   const fields = useMemo(() => (channel.fields ?? []).filter(f => !f.advanced), [channel.fields]);
 
   // Build initial form values: non-secret fields use saved value, secrets start empty
@@ -362,8 +363,10 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
     mutationFn: (payload: Record<string, string>) => configureChannel(channel.name, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["channels", "list"] });
+      addToast(t("channels.config_success") || `${channel.display_name || channel.name} configured`, "success");
       onClose();
-    }
+    },
+    onError: (err: any) => addToast(err.message || t("channels.config_failed") || "Failed to configure channel", "error"),
   });
 
   return (


### PR DESCRIPTION
## Summary
- The `ConfigDialog` for channel setup (e.g. Telegram) had no `onError` handler on its mutation
- When the `POST /api/channels/{name}/configure` returned an error (e.g. 401 Unauthorized when no API key is set), the failure was silently swallowed — users saw no feedback after clicking Save
- Added `onError` toast and `onSuccess` toast using the same `addToast` pattern already used by `testMut` and `reloadMut` on the same page

## Test plan
- [ ] Open Channels page → click Config on any channel
- [ ] Fill in a field and click Save — verify success toast appears
- [ ] Without an API key configured, try saving — verify error toast appears instead of silent failure