### PR TITLE
fix(dashboard): default to unconfigured tab when no channels are set up

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -623,6 +623,16 @@ export function ChannelsPage() {
   const configuredCount = useMemo(() => channels.filter(c => c.configured).length, [channels]);
   const unconfiguredCount = useMemo(() => channels.filter(c => !c.configured).length, [channels]);
 
+  // Auto-switch to "unconfigured" tab when no channels are configured,
+  // so new users see the setup buttons instead of an empty page.
+  const hasInitTab = useRef(false);
+  useEffect(() => {
+    if (!hasInitTab.current && channels.length > 0) {
+      hasInitTab.current = true;
+      if (configuredCount === 0) setActiveTab("unconfigured");
+    }
+  }, [channels.length, configuredCount]);
+
   // Filter, search, and sort
   const filteredChannels = useMemo(
     () => [...channels]


### PR DESCRIPTION
## Summary
- New users opening the Channels page see an empty "Configured" tab with no visible way to set up channels
- The setup buttons are on the "Unconfigured" tab which may not be noticed
- Auto-switch to "Unconfigured" tab on first load when there are no configured channels

## Test plan
- [ ] Fresh install with no channels configured → Channels page should open on "Unconfigured" tab
- [ ] Install with at least one channel configured → should open on "Configured" tab as before
- [ ] Manually switching tabs should still work normally