### PR TITLE
fix(runtime): resolve build errors in plugin runtime and context engine

### DIFF
--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -1125,11 +1125,12 @@ impl ScriptableContextEngine {
                             let schemas_c = hook_schemas.clone();
                             let state_c = shared_state_path.clone();
                             let store_c = trace_store.clone();
+                            let runtime_c = runtime.clone();
                             tokio::spawn(async move {
                                 let _ = ScriptableContextEngine::run_hook(
                                     "on_event",
                                     &script,
-                                    runtime,
+                                    runtime_c,
                                     input,
                                     hook_timeout_secs,
                                     &effective_env,
@@ -1421,7 +1422,7 @@ impl ScriptableContextEngine {
                 if std::path::Path::new(&resolved).exists() {
                     match self
                         .process_pool
-                        .prewarm(&resolved, runtime, &self.plugin_env)
+                        .prewarm(&resolved, runtime.clone(), &self.plugin_env)
                         .await
                     {
                         Ok(()) => debug!(hook = name, "Pre-warmed hook subprocess"),

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -624,7 +624,10 @@ pub fn run_doctor() -> DoctorReport {
         .map(|info| {
             let runtime_kind = PluginRuntime::from_tag(info.manifest.hooks.runtime.as_deref());
             let tag = runtime_kind.label();
-            let (available, hint) = availability.get(tag.as_ref()).copied().unwrap_or((false, ""));
+            let (available, hint) = availability
+                .get(tag.as_ref())
+                .copied()
+                .unwrap_or((false, ""));
             PluginDoctorEntry {
                 name: info.manifest.name,
                 runtime: tag.to_string(),
@@ -1030,7 +1033,7 @@ pub fn scaffold_plugin(
 
     // Each runtime declares its own hook filenames + template body so the
     // manifest + files stay in sync.
-    let files = hook_templates(runtime_kind);
+    let files = hook_templates(runtime_kind.clone());
     let (ingest_file, ingest_body) = files.ingest;
     let (after_file, after_body) = files.after_turn;
     let (assemble_file, assemble_body) = files.assemble;
@@ -1157,7 +1160,7 @@ after_turn = "hooks/{after_file}"
 
     info!(
         plugin = name,
-        runtime = runtime_tag,
+        runtime = runtime_tag.as_ref(),
         "Scaffolded new plugin"
     );
     Ok(plugin_dir)

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -690,9 +690,7 @@ fn build_command(
         // Custom launcher: use the full path verbatim, pass the script as the
         // sole argument.  This is the fix for hooks whose `runtime` is set to
         // a full binary path such as `/opt/homebrew/bin/python3`.
-        PluginRuntime::Custom(launcher) => {
-            Ok((launcher.clone(), vec![script_path.to_string()]))
-        }
+        PluginRuntime::Custom(launcher) => Ok((launcher.clone(), vec![script_path.to_string()])),
     }
 }
 
@@ -1095,7 +1093,7 @@ pub async fn run_hook_json(
     cmd.env_clear();
     cmd.env("LIBREFANG_AGENT_ID", agent_id);
     cmd.env("LIBREFANG_MESSAGE", message);
-    cmd.env("LIBREFANG_RUNTIME", runtime.label());
+    cmd.env("LIBREFANG_RUNTIME", runtime.label().as_ref());
     if let Ok(path) = std::env::var("PATH") {
         cmd.env("PATH", path);
     }


### PR DESCRIPTION
## Summary
- `plugin_runtime.rs`: `Cow<str>` from `PluginRuntime::label()` doesn't implement `AsRef<OsStr>` — add `.as_ref()` when passing to `cmd.env()`
- `plugin_manager.rs`: `runtime_kind` moved before use in `hook_templates()` — add `.clone()`; `Cow<str>` doesn't implement `tracing::Value` — add `.as_ref()`
- `context_engine.rs`: `runtime` moved into `tokio::spawn` closure and used again in loop — clone before move

These are pre-existing build errors on `main` that prevent compilation.

## Test plan
- [ ] `cargo build --workspace --lib` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cross build --release --target aarch64-unknown-linux-gnu -p librefang-cli` passes