### PR TITLE
fix(runtime): use python -m pip for venv and conda installs

### DIFF
--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -2624,11 +2624,9 @@ pub async fn install_requirements(plugin_name: &str) -> Result<String, String> {
         return Ok("No requirements.txt found — nothing to install".to_string());
     }
 
-    // When running inside a virtualenv, --user is forbidden (PEP 668).
-    // Detect venv via VIRTUAL_ENV env var and omit --user accordingly.
-    let in_venv = std::env::var("VIRTUAL_ENV").is_ok();
-    let pip_cmd = if in_venv { "pip" } else { "pip3" };
-    let mut args = vec!["install"];
+    // In virtualenv/conda environments, pip forbids --user installs.
+    let in_venv = std::env::var("VIRTUAL_ENV").is_ok() || std::env::var("CONDA_PREFIX").is_ok();
+    let mut args = vec!["-m", "pip", "install"];
     if !in_venv {
         args.push("--user");
     }
@@ -2641,19 +2639,19 @@ pub async fn install_requirements(plugin_name: &str) -> Result<String, String> {
         "Installing Python requirements"
     );
 
-    let output = tokio::process::Command::new(pip_cmd)
+    let output = tokio::process::Command::new("python")
         .args(&args)
         .arg(&requirements)
         .output()
         .await
-        .map_err(|e| format!("Failed to run {pip_cmd}: {e}"))?;
+        .map_err(|e| format!("Failed to run python -m pip: {e}"))?;
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(stdout.to_string())
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!("pip3 install failed: {stderr}"))
+        Err(format!("python -m pip install failed: {stderr}"))
     }
 }
 


### PR DESCRIPTION
## Summary

Follow up on #2233 by making Python requirement installation more robust across virtualenv and conda setups.

## What changed

- detect both `VIRTUAL_ENV` and `CONDA_PREFIX` when deciding whether `--user` is allowed
- switch from invoking `pip` / `pip3` directly to `python -m pip`
- keep `--user` only for non-venv, non-conda installs

## Why

The previous fix handled standard virtualenvs, but conda environments can hit the same `--user` restriction.

It also relied on `pip` / `pip3` resolution from `PATH`, which can select the wrong installer on some systems. Using `python -m pip` is more reliable because it binds pip execution to the active Python interpreter.

## Impact

- plugin requirement installation is more reliable in virtualenv environments
- conda environments now avoid the same `--user` failure mode
- interpreter / pip mismatches are less likely

## Validation

- `~/.cargo/bin/rustup run 1.91.0 cargo fmt --check --all`
- `~/.cargo/bin/rustup run 1.91.0 cargo build -p librefang-runtime --lib`
