### PR TITLE
test(runtime): cover full-path context hook launchers

### DIFF
--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -4393,6 +4393,51 @@ print(json.dumps({"type": payload.get("type"), "message": payload.get("message")
         assert_eq!(output["message"], "hello");
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_scriptable_hook_accepts_full_runtime_path() {
+        let tmp = tempdir().unwrap();
+        let script_path = tmp.path().join("hook.sh");
+        std::fs::write(
+            &script_path,
+            r#"read _input
+printf '{"type":"ingest_result","memories":[{"content":"full-path-runtime"}]}\n'
+"#,
+        )
+        .unwrap();
+
+        let traces = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
+        let hook_schemas = std::collections::HashMap::new();
+        let (output, _duration_ms) = ScriptableContextEngine::run_hook(
+            "ingest",
+            script_path.to_str().unwrap(),
+            crate::plugin_runtime::PluginRuntime::from_tag(Some("/bin/sh")),
+            serde_json::json!({
+                "type": "ingest",
+                "agent_id": "agent-123",
+                "message": "hello",
+            }),
+            30,
+            &[],
+            0,
+            0,
+            None,
+            true,
+            &traces,
+            &hook_schemas,
+            None,
+            None,
+            "",
+            "",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output["type"], "ingest_result");
+        assert_eq!(output["memories"][0]["content"], "full-path-runtime");
+    }
+
     #[test]
     fn test_plugins_dir() {
         let dir = plugins_dir();

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -1956,6 +1956,18 @@ mod tests {
     }
 
     #[test]
+    fn from_tag_full_path_uses_custom_runtime() {
+        assert_eq!(
+            PluginRuntime::from_tag(Some("/opt/homebrew/bin/python3")),
+            PluginRuntime::Custom("/opt/homebrew/bin/python3".to_string())
+        );
+        assert_eq!(
+            PluginRuntime::from_tag(Some("C:\\Python313\\python.exe")),
+            PluginRuntime::Custom("C:\\Python313\\python.exe".to_string())
+        );
+    }
+
+    #[test]
     fn parse_output_picks_last_json_line() {
         let lines = vec![
             "warming up...".to_string(),
@@ -2005,6 +2017,14 @@ mod tests {
         let (l, a) = build_command(PluginRuntime::Deno, "hooks/ingest.ts").unwrap();
         assert_eq!(l, "deno");
         assert!(a.contains(&"--allow-read".to_string()));
+
+        let (l, a) = build_command(
+            PluginRuntime::Custom("/opt/homebrew/bin/python3".to_string()),
+            "hooks/ingest.py",
+        )
+        .unwrap();
+        assert_eq!(l, "/opt/homebrew/bin/python3");
+        assert_eq!(a, vec!["hooks/ingest.py".to_string()]);
     }
 
     /// End-to-end: scaffold a sh-based native hook, run it, check JSON round-trip.


### PR DESCRIPTION
## Summary
- add regression coverage for hook runtimes configured as full binary paths
- verify `PluginRuntime::from_tag()` preserves full launcher paths as `Custom(...)`
- verify `build_command()` executes full-path launchers verbatim
- add an end-to-end `context_engine` hook test that runs with `runtime = "/bin/sh"`

## Why
Issue #2206 reports that `context_engine.hooks.runtime` set to a full binary path is silently ignored and the hook never fires. The runtime-side full-path support already exists in `PluginRuntime`; this PR locks that behavior in with explicit regression tests so it cannot silently regress again.

## Test Plan
- [x] `cargo fmt --check --all`
- [x] `cargo test -p librefang-runtime from_tag_full_path_uses_custom_runtime -- --nocapture`
- [x] `cargo test -p librefang-runtime test_scriptable_hook_accepts_full_runtime_path -- --nocapture`
- [x] `cargo test -p librefang-runtime build_command_shapes -- --nocapture`

Closes #2206