### PR TITLE
feat(api): add minimal dashboard role-based auth paths

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -14,8 +14,16 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
   const [key, setKey] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [authMethod, setAuthMethod] = useState<"credentials" | "api_key">(
+    mode === "api_key" ? "api_key" : "credentials",
+  );
   const [errorKey, setErrorKey] = useState<"invalid_api_key" | "invalid_credentials" | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setAuthMethod(mode === "api_key" ? "api_key" : "credentials");
+    setErrorKey(null);
+  }, [mode]);
 
   async function handleApiKeySubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -67,7 +75,8 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
     }
   }
 
-  const isCredentials = mode === "credentials";
+  const isHybrid = mode === "hybrid";
+  const isCredentials = authMethod === "credentials";
 
   return (
     <div className="fixed inset-0 z-200 flex items-center justify-center bg-black/70 backdrop-blur-md">
@@ -80,6 +89,28 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
             <h2 className="text-xl font-black tracking-tight">{t(isCredentials ? "auth.credentials_title" : "auth.title")}</h2>
             <p className="text-sm text-text-dim mt-1">{t(isCredentials ? "auth.credentials_description" : "auth.description")}</p>
           </div>
+          {isHybrid && (
+            <div className="mb-4 grid grid-cols-2 gap-2 rounded-xl bg-main p-1">
+              <button
+                type="button"
+                onClick={() => { setAuthMethod("credentials"); setErrorKey(null); }}
+                className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
+                  isCredentials ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-brand"
+                }`}
+              >
+                {t("auth.credentials_tab")}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setAuthMethod("api_key"); setErrorKey(null); }}
+                className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
+                  !isCredentials ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-brand"
+                }`}
+              >
+                {t("auth.api_key_tab")}
+              </button>
+            </div>
+          )}
           <form onSubmit={isCredentials ? handleCredentialsSubmit : handleApiKeySubmit} className="space-y-4">
             {isCredentials ? (
               <>

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2067,7 +2067,7 @@ export function hasApiKey(): boolean {
   return !!key && key.length > 0;
 }
 
-export type AuthMode = "credentials" | "api_key" | "none";
+export type AuthMode = "credentials" | "api_key" | "hybrid" | "none";
 
 export async function checkDashboardAuthMode(): Promise<AuthMode> {
   try {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1318,6 +1318,8 @@
     "description": "This instance requires authentication to access.",
     "credentials_title": "Sign In Required",
     "credentials_description": "Enter your dashboard username and password to continue.",
+    "credentials_tab": "Password",
+    "api_key_tab": "API Key",
     "placeholder": "Enter API key...",
     "username_placeholder": "Enter username...",
     "password_placeholder": "Enter password...",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1293,6 +1293,8 @@
     "description": "此实例需要身份验证才能访问。",
     "credentials_title": "需要登录",
     "credentials_description": "请输入 Dashboard 用户名和密码以继续。",
+    "credentials_tab": "密码登录",
+    "api_key_tab": "API Key",
     "placeholder": "输入 API Key...",
     "username_placeholder": "输入用户名...",
     "password_placeholder": "输入密码...",

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -10,6 +10,7 @@
 use axum::body::Body;
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
+use librefang_kernel::auth::UserRole;
 use librefang_types::i18n;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,6 +31,46 @@ pub struct AuthState {
     /// Active sessions issued by dashboard login, keyed by token string.
     pub active_sessions:
         Arc<tokio::sync::RwLock<HashMap<String, crate::password_hash::SessionToken>>>,
+    /// Whether dashboard username/password auth is configured.
+    pub dashboard_auth_enabled: bool,
+    /// Optional per-user API-key hashes used for role-based API access.
+    pub user_api_keys: Arc<Vec<ApiUserAuth>>,
+}
+
+#[derive(Clone)]
+pub struct ApiUserAuth {
+    pub name: String,
+    pub role: UserRole,
+    pub api_key_hash: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthenticatedApiUser {
+    pub name: String,
+    pub role: UserRole,
+}
+
+fn user_role_allows_request(role: UserRole, method: &axum::http::Method, path: &str) -> bool {
+    if role >= UserRole::Admin || *method == axum::http::Method::GET {
+        return true;
+    }
+
+    if role < UserRole::User {
+        return false;
+    }
+
+    if method == axum::http::Method::POST {
+        let agent_message = path.starts_with("/api/agents/")
+            && (path.ends_with("/message") || path.ends_with("/message/stream"));
+        let agent_clone = path.starts_with("/api/agents/") && path.ends_with("/clone");
+        let approval_action = path == "/api/approvals/batch"
+            || path.ends_with("/approve")
+            || path.ends_with("/reject")
+            || path.ends_with("/modify");
+        return agent_message || agent_clone || approval_action;
+    }
+
+    false
 }
 
 /// Request ID header name (standard).
@@ -192,7 +233,7 @@ pub async fn api_version_headers(request: Request<Body>, next: Next) -> Response
 /// session store, cleaning up expired sessions on each check.
 pub async fn auth(
     axum::extract::State(auth_state): axum::extract::State<AuthState>,
-    request: Request<Body>,
+    mut request: Request<Body>,
     next: Next,
 ) -> Response<Body> {
     let api_key = auth_state.api_key_lock.read().await.clone();
@@ -286,7 +327,10 @@ pub async fn auth(
     // entirely. Users who don't set api_key accept that all endpoints are open.
     // To secure the dashboard, set a non-empty api_key in config.toml.
     let api_key = api_key.trim();
-    if api_key.is_empty() {
+    if api_key.is_empty()
+        && auth_state.user_api_keys.is_empty()
+        && !auth_state.dashboard_auth_enabled
+    {
         return next.run(request).await;
     }
 
@@ -347,6 +391,41 @@ pub async fn auth(
         });
         if sessions.contains_key(token_str) {
             drop(sessions);
+            return next.run(request).await;
+        }
+        drop(sessions);
+
+        if let Some(user) = auth_state
+            .user_api_keys
+            .iter()
+            .find(|user| crate::password_hash::verify_password(token_str, &user.api_key_hash))
+            .cloned()
+        {
+            if !user_role_allows_request(user.role, &method, path) {
+                let lang = request
+                    .extensions()
+                    .get::<RequestLanguage>()
+                    .map(|rl| rl.0)
+                    .unwrap_or(i18n::DEFAULT_LANGUAGE);
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header("content-language", lang)
+                    .body(Body::from(
+                        serde_json::json!({
+                            "error": format!(
+                                "Role '{}' is not allowed to access this endpoint",
+                                user.role
+                            )
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap_or_default();
+            }
+
+            request.extensions_mut().insert(AuthenticatedApiUser {
+                name: user.name,
+                role: user.role,
+            });
             return next.run(request).await;
         }
     }
@@ -508,6 +587,8 @@ mod tests {
         let auth_state = AuthState {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(Vec::new()),
         };
         let app = Router::new()
             .route("/api/private", get(|| async { "ok" }))
@@ -526,5 +607,73 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(response.headers()["x-api-version"], "v1");
+    }
+
+    #[tokio::test]
+    async fn test_user_api_key_can_post_agent_messages() {
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(vec![ApiUserAuth {
+                name: "Guest".to_string(),
+                role: UserRole::User,
+                api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
+            }]),
+        };
+        let app = Router::new()
+            .route(
+                "/api/agents/123/message",
+                get(|| async { "ok" }).post(|| async { "ok" }),
+            )
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/agents/123/message")
+                    .header("authorization", "Bearer user-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_user_api_key_cannot_spawn_agents() {
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(vec![ApiUserAuth {
+                name: "Guest".to_string(),
+                role: UserRole::User,
+                api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
+            }]),
+        };
+        let app = Router::new()
+            .route(
+                "/api/agents",
+                get(|| async { "ok" }).post(|| async { "ok" }),
+            )
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/agents")
+                    .header("authorization", "Bearer user-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -174,6 +174,41 @@ pub(crate) fn valid_api_tokens(kernel: &LibreFangKernel) -> Vec<String> {
     tokens
 }
 
+fn has_dashboard_credentials(kernel: &LibreFangKernel) -> bool {
+    let cfg = kernel.config_ref();
+    let username = resolve_dashboard_credential(
+        &cfg.dashboard_user,
+        "LIBREFANG_DASHBOARD_USER",
+        kernel.home_dir(),
+    );
+    let password = resolve_dashboard_credential(
+        &cfg.dashboard_pass,
+        "LIBREFANG_DASHBOARD_PASS",
+        kernel.home_dir(),
+    );
+    !username.trim().is_empty()
+        && (!cfg.dashboard_pass_hash.trim().is_empty() || !password.trim().is_empty())
+}
+
+fn configured_user_api_keys(kernel: &LibreFangKernel) -> Vec<middleware::ApiUserAuth> {
+    kernel
+        .config_ref()
+        .users
+        .iter()
+        .filter_map(|user| {
+            let api_key_hash = user.api_key_hash.as_deref()?.trim();
+            if api_key_hash.is_empty() {
+                return None;
+            }
+            Some(middleware::ApiUserAuth {
+                name: user.name.clone(),
+                role: librefang_kernel::auth::UserRole::from_str_role(&user.role),
+                api_key_hash: api_key_hash.to_string(),
+            })
+        })
+        .collect()
+}
+
 /// Dashboard credential login — validates username/password using Argon2id
 /// (with transparent fallback from legacy plaintext passwords) and returns
 /// a randomly generated session token with expiration metadata.
@@ -271,9 +306,23 @@ async fn dashboard_auth_check(
     let has_pass_hash = !cfg.dashboard_pass_hash.trim().is_empty();
     let has_credentials = !du.trim().is_empty() && (has_pass_hash || !dp.trim().is_empty());
     let has_api_key = !cfg.api_key.trim().is_empty();
+    let has_user_api_keys = cfg.users.iter().any(|user| {
+        user.api_key_hash
+            .as_deref()
+            .is_some_and(|hash| !hash.trim().is_empty())
+    });
+    let mode = if has_credentials && (has_api_key || has_user_api_keys) {
+        "hybrid"
+    } else if has_credentials {
+        "credentials"
+    } else if has_api_key || has_user_api_keys {
+        "api_key"
+    } else {
+        "none"
+    };
 
     axum::response::Json(serde_json::json!({
-        "mode": if has_credentials { "credentials" } else if has_api_key { "api_key" } else { "none" },
+        "mode": mode,
         "username": if has_credentials { du.trim().to_string() } else { String::new() },
     }))
 }
@@ -636,6 +685,8 @@ pub async fn build_router(
     let auth_state = middleware::AuthState {
         api_key_lock: api_key_lock.clone(),
         active_sessions: active_sessions.clone(),
+        dashboard_auth_enabled: has_dashboard_credentials(state.kernel.as_ref()),
+        user_api_keys: Arc::new(configured_user_api_keys(state.kernel.as_ref())),
     };
     let rl_cfg = state.kernel.config_ref().rate_limit.clone();
     let gcra_limiter = rate_limiter::GcraState {

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1371,6 +1371,8 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
     let api_key_state = middleware::AuthState {
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
+        dashboard_auth_enabled: false,
+        user_api_keys: Arc::new(Vec::new()),
     };
 
     let app = Router::new()


### PR DESCRIPTION
## Summary
- accept `users[].api_key_hash` as dashboard/API credentials and enforce a minimal role-based allowlist for user-scoped write actions
- keep dashboard password auth working even when no global `api_key` is configured, and expose a hybrid login mode when password and API-key auth are both available
- cover the new user API key behavior with middleware tests and update auth-state wiring in API integration harnesses

## Testing
- `~/.cargo/bin/rustup run 1.91.0 cargo fmt --check --all`
- `CARGO_TARGET_DIR=/tmp/librefang-target-2173 ~/.cargo/bin/rustup run 1.91.0 cargo check -p librefang-api --tests --message-format short`
- `CARGO_TARGET_DIR=/tmp/librefang-target-2173 ~/.cargo/bin/rustup run 1.91.0 cargo test -p librefang-api test_user_api_key_can_post_agent_messages -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/librefang-target-2173 ~/.cargo/bin/rustup run 1.91.0 cargo test -p librefang-api test_user_api_key_cannot_spawn_agents -- --nocapture`

Closes #2173.