### PR TITLE
fix(hands): use lower-bound assertion for hand count

### DIFF
--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -1147,7 +1147,7 @@ mod tests {
         let reg = HandRegistry::new();
         let home = ensure_test_home();
         let (count, _) = reg.reload_from_disk(&home);
-        assert_eq!(count, 15);
+        assert!(count >= 15, "expected at least 15 hands, got {count}");
         assert!(!reg.list_definitions().is_empty());
 
         // Clip hand should be loaded


### PR DESCRIPTION
## Summary
- Change `assert_eq!(count, 15)` to `assert!(count >= 15)` in `load_hands_from_disk` test
- The exact count assertion breaks every time a new hand is added to the registry, requiring a source code change for no real value

## Why
The test should verify that hands load correctly (specific hands exist, count is reasonable), not assert an exact number that changes with every registry addition.