### PR TITLE
fix(channels): exclude Hand sub-agents from channel routing fallback

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -609,6 +609,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .agent_registry()
             .list()
             .iter()
+            .filter(|e| !e.is_hand)
             .map(|e| (e.id, e.name.clone()))
             .collect())
     }


### PR DESCRIPTION
## Summary
- Filter `is_hand` agents from `list_agents()` in `channel_bridge.rs`
- Prevents the routing fallback from picking a Hand sub-agent (e.g. `Analytics Hand`) when no `default_agent` is configured

## Root cause
`list_agents()` returned ALL agents including Hand sub-agents. The fallback logic in `resolve_or_fallback()` picks `agents.first()`, which alphabetically could be a Hand sub-agent.

Fixes #2261

## Test plan
- [ ] Configure Telegram with no `default_agent`
- [ ] Delete `assistant` agent, keep a custom agent
- [ ] Send a message — should route to the custom agent, not a Hand sub-agent
- [ ] `/agents` command should only list regular agents