### PR TITLE
feat(channels): SQLite roster, group_members tool, configurable reply precheck, alias triggering

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5,6 +5,7 @@
 
 use crate::formatter;
 use crate::rate_limiter::ChannelRateLimiter;
+use crate::roster::GroupRosterStore;
 use crate::router::AgentRouter;
 use crate::sanitizer::{InputSanitizer, SanitizeResult};
 use crate::types::{
@@ -1412,6 +1413,18 @@ fn should_process_group_message(
 ///
 /// Per-channel auto-routing fields are populated from `overrides` when provided,
 /// and default to `AutoRouteStrategy::Off` / zeros otherwise.
+/// Singleton in-memory group roster shared across all channel adapters.
+///
+/// Populated on every incoming group message from `build_sender_context`. The
+/// accumulated roster is then handed to the agent's system prompt so the LLM
+/// can distinguish the current message sender from other group members it has
+/// seen before (e.g. when a user writes `@pepe` meaning another human, not an
+/// agent in the system).
+fn group_roster() -> &'static GroupRosterStore {
+    static ROSTER: OnceLock<GroupRosterStore> = OnceLock::new();
+    ROSTER.get_or_init(GroupRosterStore::new)
+}
+
 fn build_sender_context(
     message: &ChannelMessage,
     overrides: Option<&ChannelOverrides>,
@@ -1432,8 +1445,47 @@ fn build_sender_context(
         ),
         None => (AutoRouteStrategy::Off, 0, 0, 0, 0),
     };
+
+    let channel = channel_type_str(&message.channel).to_string();
+    let chat_id = message
+        .metadata
+        .get("chat_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let bot_username = message
+        .metadata
+        .get("bot_username")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let sender_username = message
+        .metadata
+        .get("sender_username")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    // For group messages, upsert the current sender into the roster and then
+    // read back all known members. For DMs the roster stays empty — the LLM
+    // only needs the current sender and doesn't gain anything from a roster
+    // with a single member.
+    let group_members: Vec<GroupMember> = if message.is_group {
+        if let Some(ref cid) = chat_id {
+            let current = GroupMember {
+                user_id: sender_user_id(message).to_string(),
+                display_name: message.sender.display_name.clone(),
+                username: sender_username.clone(),
+            };
+            let store = group_roster();
+            store.upsert(&channel, cid, current);
+            store.members(&channel, cid)
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
     SenderContext {
-        channel: channel_type_str(&message.channel).to_string(),
+        channel,
         user_id: sender_user_id(message).to_string(),
         display_name: message.sender.display_name.clone(),
         is_group: message.is_group,
@@ -1453,6 +1505,10 @@ fn build_sender_context(
         auto_route_confidence_threshold,
         auto_route_sticky_bonus,
         auto_route_divergence_count,
+        bot_username,
+        sender_username,
+        group_members,
+        chat_id,
     }
 }
 

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -12,6 +12,7 @@ pub mod formatter;
 pub(crate) mod http_client;
 pub mod message_journal;
 pub mod rate_limiter;
+pub mod roster;
 pub mod router;
 pub mod sanitizer;
 pub mod sidecar;

--- a/crates/librefang-channels/src/roster.rs
+++ b/crates/librefang-channels/src/roster.rs
@@ -92,30 +92,30 @@ mod tests {
         store.upsert(
             "telegram",
             "-100123",
-            mk_member("2", "Pakman", Some("pakman")),
+            mk_member("2", "Alice", Some("alice")),
         );
         store.upsert("telegram", "-100123", mk_member("3", "Ana", Some("ana")));
 
         let members = store.members("telegram", "-100123");
         assert_eq!(members.len(), 3);
-        assert_eq!(members[0].display_name, "Ana");
-        assert_eq!(members[1].display_name, "Jorge");
-        assert_eq!(members[2].display_name, "Pakman");
+        assert_eq!(members[0].display_name, "Alice");
+        assert_eq!(members[1].display_name, "Ana");
+        assert_eq!(members[2].display_name, "Jorge");
     }
 
     #[test]
     fn upsert_idempotent_and_updates() {
         let store = GroupRosterStore::new();
-        store.upsert("telegram", "-100123", mk_member("1", "Jorge", None));
+        store.upsert("telegram", "-100123", mk_member("1", "Bob", None));
         store.upsert(
             "telegram",
             "-100123",
-            mk_member("1", "Jorge Pablo", Some("jorgepablo")),
+            mk_member("1", "Bob Smith", Some("bobsmith")),
         );
         let members = store.members("telegram", "-100123");
         assert_eq!(members.len(), 1);
-        assert_eq!(members[0].display_name, "Jorge Pablo");
-        assert_eq!(members[0].username.as_deref(), Some("jorgepablo"));
+        assert_eq!(members[0].display_name, "Bob Smith");
+        assert_eq!(members[0].username.as_deref(), Some("bobsmith"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/roster.rs
+++ b/crates/librefang-channels/src/roster.rs
@@ -1,0 +1,154 @@
+//! In-memory group roster store.
+//!
+//! Tracks the human members seen in each group chat so that agents can be given
+//! a structured "who is in this group" context in their system prompt. Without
+//! this, an agent receiving a message like `@pepe dile algo a @jose` has no way
+//! to know who `@pepe` and `@jose` are — they look like opaque text.
+//!
+//! The store is a simple in-memory map keyed by `(channel_type, chat_id)`. It
+//! does not persist to disk: on daemon restart it is empty and repopulates
+//! naturally as members send messages. A persistent backend can be added later
+//! without changing the public API.
+
+use crate::types::GroupMember;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+/// Composite key identifying a specific chat on a specific channel.
+///
+/// For Telegram the `chat_id` is the group's negative chat ID (or the user's
+/// ID for DMs). For Discord it's the channel ID, and so on per platform.
+type RosterKey = (String, String);
+
+/// Thread-safe in-memory store of known group members per chat.
+#[derive(Debug, Default, Clone)]
+pub struct GroupRosterStore {
+    rosters: Arc<DashMap<RosterKey, DashMap<String, GroupMember>>>,
+}
+
+impl GroupRosterStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record (or update) a member in the given chat roster.
+    ///
+    /// Idempotent: subsequent calls with the same `user_id` simply refresh the
+    /// display name and username.
+    pub fn upsert(&self, channel: &str, chat_id: &str, member: GroupMember) {
+        if chat_id.is_empty() || member.user_id.is_empty() {
+            return;
+        }
+        let key = (channel.to_string(), chat_id.to_string());
+        let members = self.rosters.entry(key).or_insert_with(DashMap::new);
+        members.insert(member.user_id.clone(), member);
+    }
+
+    /// Return all known members for a chat, sorted by display name for stable
+    /// rendering. Returns an empty vector if the chat is unknown.
+    pub fn members(&self, channel: &str, chat_id: &str) -> Vec<GroupMember> {
+        let key = (channel.to_string(), chat_id.to_string());
+        let Some(entry) = self.rosters.get(&key) else {
+            return Vec::new();
+        };
+        let mut out: Vec<GroupMember> = entry.iter().map(|e| e.value().clone()).collect();
+        out.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        out
+    }
+
+    /// Number of members in a specific chat (0 if unknown).
+    pub fn member_count(&self, channel: &str, chat_id: &str) -> usize {
+        let key = (channel.to_string(), chat_id.to_string());
+        self.rosters.get(&key).map(|e| e.len()).unwrap_or(0)
+    }
+
+    /// Total number of chats being tracked.
+    pub fn chat_count(&self) -> usize {
+        self.rosters.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_member(user_id: &str, display: &str, username: Option<&str>) -> GroupMember {
+        GroupMember {
+            user_id: user_id.to_string(),
+            display_name: display.to_string(),
+            username: username.map(String::from),
+        }
+    }
+
+    #[test]
+    fn upsert_and_list_sorted() {
+        let store = GroupRosterStore::new();
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("1", "Jorge", Some("jorge")),
+        );
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("2", "Pakman", Some("pakman")),
+        );
+        store.upsert("telegram", "-100123", mk_member("3", "Ana", Some("ana")));
+
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 3);
+        assert_eq!(members[0].display_name, "Ana");
+        assert_eq!(members[1].display_name, "Jorge");
+        assert_eq!(members[2].display_name, "Pakman");
+    }
+
+    #[test]
+    fn upsert_idempotent_and_updates() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100123", mk_member("1", "Jorge", None));
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("1", "Jorge Pablo", Some("jorgepablo")),
+        );
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].display_name, "Jorge Pablo");
+        assert_eq!(members[0].username.as_deref(), Some("jorgepablo"));
+    }
+
+    #[test]
+    fn unknown_chat_returns_empty() {
+        let store = GroupRosterStore::new();
+        assert!(store.members("telegram", "-999").is_empty());
+        assert_eq!(store.member_count("telegram", "-999"), 0);
+    }
+
+    #[test]
+    fn ignores_empty_ids() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "", mk_member("1", "Nobody", None));
+        store.upsert("telegram", "-100", mk_member("", "Nameless", None));
+        assert_eq!(store.chat_count(), 0);
+    }
+
+    #[test]
+    fn separate_chats_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100", mk_member("1", "Alice", None));
+        store.upsert("telegram", "-200", mk_member("2", "Bob", None));
+        assert_eq!(store.members("telegram", "-100").len(), 1);
+        assert_eq!(store.members("telegram", "-200").len(), 1);
+        assert_eq!(store.chat_count(), 2);
+    }
+
+    #[test]
+    fn separate_channels_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "123", mk_member("1", "Alice", None));
+        store.upsert("discord", "123", mk_member("2", "Bob", None));
+        assert_eq!(store.members("telegram", "123").len(), 1);
+        assert_eq!(store.members("discord", "123").len(), 1);
+    }
+}

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -2550,6 +2550,24 @@ async fn parse_telegram_update(
         }
     }
 
+    // Inject identity metadata so the bridge can populate the group roster and
+    // pass bot/sender @handles into the agent's system prompt. These keys are
+    // read by `build_sender_context` in bridge.rs.
+    metadata.insert(
+        "chat_id".to_string(),
+        serde_json::json!(chat_id.to_string()),
+    );
+    metadata.insert(
+        "sender_user_id".to_string(),
+        serde_json::json!(user_id.to_string()),
+    );
+    if let Some(ref uname) = username {
+        metadata.insert("sender_username".to_string(), serde_json::json!(uname));
+    }
+    if let Some(bot_uname) = bot_username {
+        metadata.insert("bot_username".to_string(), serde_json::json!(bot_uname));
+    }
+
     Ok(ChannelMessage {
         channel: ChannelType::Telegram,
         platform_message_id: message_id.to_string(),

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -313,7 +313,7 @@ pub struct SenderContext {
     /// Divergence count threshold for `sticky_heuristic` strategy.
     #[serde(default)]
     pub auto_route_divergence_count: u32,
-    /// The bot's own platform `@handle` on this channel (e.g. `fandangorodelo_bot`
+    /// The bot's own platform `@handle` on this channel (e.g. `mybot`
     /// on Telegram). Used so the agent knows its own alias in the prompt.
     #[serde(default)]
     pub bot_username: Option<String>,

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -52,6 +52,22 @@ pub struct ChannelUser {
     pub librefang_user: Option<String>,
 }
 
+/// A known member of a group chat, accumulated from past messages.
+///
+/// Used to populate multi-user context in the system prompt so agents can
+/// distinguish between the current sender and other users mentioned in a
+/// message (e.g. `@pepe`, `@jose`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GroupMember {
+    /// Platform-specific user ID.
+    pub user_id: String,
+    /// Human-readable display name (what the platform shows).
+    pub display_name: String,
+    /// Optional `@handle` for platforms that expose one (Telegram, Discord, ...).
+    #[serde(default)]
+    pub username: Option<String>,
+}
+
 /// Typing indicator event from a channel.
 #[derive(Debug, Clone)]
 pub struct TypingEvent {
@@ -297,6 +313,23 @@ pub struct SenderContext {
     /// Divergence count threshold for `sticky_heuristic` strategy.
     #[serde(default)]
     pub auto_route_divergence_count: u32,
+    /// The bot's own platform `@handle` on this channel (e.g. `fandangorodelo_bot`
+    /// on Telegram). Used so the agent knows its own alias in the prompt.
+    #[serde(default)]
+    pub bot_username: Option<String>,
+    /// The current sender's `@handle` on the platform, when available.
+    #[serde(default)]
+    pub sender_username: Option<String>,
+    /// Known members of the group chat where this message was sent.
+    /// Empty for DMs and for the very first message in a group before the
+    /// roster has accumulated any entries.
+    #[serde(default)]
+    pub group_members: Vec<GroupMember>,
+    /// Platform chat/conversation ID. For Telegram this is the group chat_id
+    /// (negative for groups) or user_id for DMs. Used by the roster store as
+    /// part of the key.
+    #[serde(default)]
+    pub chat_id: Option<String>,
 }
 
 /// Agent lifecycle phase for UX indicators.

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3339,6 +3339,9 @@ system_prompt = "You are a helpful assistant."
                 channel_type: None,
                 sender_display_name: None,
                 sender_user_id: None,
+                sender_username: None,
+                bot_username: None,
+                group_members: Vec::new(),
                 is_subagent: false,
                 is_autonomous: manifest.autonomous.is_some(),
                 agents_md: ws_meta.as_ref().and_then(|m| m.agents_md.clone()),
@@ -3955,8 +3958,24 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
+                sender_username: sender_context.and_then(|s| s.sender_username.clone()),
                 is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
                 was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
+                bot_username: sender_context.and_then(|s| s.bot_username.clone()),
+                group_members: sender_context
+                    .map(|s| {
+                        s.group_members
+                            .iter()
+                            .map(|m| {
+                                (
+                                    m.user_id.clone(),
+                                    m.display_name.clone(),
+                                    m.username.clone(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")
@@ -5075,8 +5094,24 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
+                sender_username: sender_context.and_then(|s| s.sender_username.clone()),
                 is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
                 was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
+                bot_username: sender_context.and_then(|s| s.bot_username.clone()),
+                group_members: sender_context
+                    .map(|s| {
+                        s.group_members
+                            .iter()
+                            .map(|m| {
+                                (
+                                    m.user_id.clone(),
+                                    m.display_name.clone(),
+                                    m.username.clone(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -145,7 +145,7 @@ pub struct PromptContext {
     pub is_group: bool,
     /// Whether the bot was @mentioned in a group message.
     pub was_mentioned: bool,
-    /// The bot's own platform `@handle` (e.g. `fandangorodelo_bot` on Telegram).
+    /// The bot's own platform `@handle` (e.g. `mybot` on Telegram).
     /// Injected into the system prompt so the LLM recognises mentions of itself
     /// as a valid alias, not as a reference to some other entity.
     pub bot_username: Option<String>,
@@ -1290,19 +1290,19 @@ mod tests {
     fn test_channel_bot_handle_self_awareness() {
         let section = build_channel_section(
             "telegram",
-            Some("Pakman"),
+            Some("Alice"),
             Some("123"),
-            Some("pakman"),
+            Some("alice"),
             true,
             true,
-            Some("fandangorodelo_bot"),
+            Some("mybot"),
             &[],
         );
-        assert!(section.contains("@fandangorodelo_bot"));
+        assert!(section.contains("@mybot"));
         assert!(section.contains("valid alias"));
         // Current sender rendered with its @handle
-        assert!(section.contains("Pakman"));
-        assert!(section.contains("@pakman"));
+        assert!(section.contains("Alice"));
+        assert!(section.contains("@alice"));
     }
 
     #[test]
@@ -1310,33 +1310,33 @@ mod tests {
         let members = vec![
             (
                 "1".to_string(),
-                "Pakman".to_string(),
-                Some("pakman".to_string()),
+                "Alice".to_string(),
+                Some("alice".to_string()),
             ),
             (
                 "2".to_string(),
-                "Jorge Pablo".to_string(),
-                Some("jorgepablo".to_string()),
+                "Bob Smith".to_string(),
+                Some("bobsmith".to_string()),
             ),
-            ("3".to_string(), "dvpablo".to_string(), None),
+            ("3".to_string(), "carol".to_string(), None),
         ];
         let section = build_channel_section(
             "telegram",
-            Some("Pakman"),
+            Some("Alice"),
             Some("1"),
-            Some("pakman"),
+            Some("alice"),
             true,
             true,
-            Some("fandangorodelo_bot"),
+            Some("mybot"),
             &members,
         );
         assert!(section.contains("### Known members of this group"));
-        assert!(section.contains("Pakman"));
-        assert!(section.contains("Jorge Pablo"));
-        assert!(section.contains("dvpablo"));
-        assert!(section.contains("@jorgepablo"));
+        assert!(section.contains("Alice"));
+        assert!(section.contains("Bob Smith"));
+        assert!(section.contains("carol"));
+        assert!(section.contains("@bobsmith"));
         assert!(section.contains("real humans"));
-        assert!(section.contains("NOT agents"));
+        assert!(section.contains("NEVER agents"));
     }
 
     #[test]
@@ -1344,17 +1344,17 @@ mod tests {
         // DMs should never get a roster block even if one is passed.
         let members = vec![(
             "1".to_string(),
-            "Solo".to_string(),
-            Some("solo".to_string()),
+            "Alice".to_string(),
+            Some("alice".to_string()),
         )];
         let section = build_channel_section(
             "telegram",
-            Some("Pakman"),
+            Some("Alice"),
             Some("1"),
-            Some("pakman"),
+            Some("alice"),
             false, // is_group = false
             false,
-            Some("fandangorodelo_bot"),
+            Some("mybot"),
             &members,
         );
         assert!(!section.contains("### Known members of this group"));

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -139,10 +139,20 @@ pub struct PromptContext {
     pub sender_display_name: Option<String>,
     /// Sender's platform user ID (from channel message).
     pub sender_user_id: Option<String>,
+    /// Sender's `@handle` on the platform (Telegram/Discord/Slack, when available).
+    pub sender_username: Option<String>,
     /// Whether the current message originated from a group chat.
     pub is_group: bool,
     /// Whether the bot was @mentioned in a group message.
     pub was_mentioned: bool,
+    /// The bot's own platform `@handle` (e.g. `fandangorodelo_bot` on Telegram).
+    /// Injected into the system prompt so the LLM recognises mentions of itself
+    /// as a valid alias, not as a reference to some other entity.
+    pub bot_username: Option<String>,
+    /// Known members of the current group chat, accumulated from past
+    /// messages. Empty in DMs and on the first message of a fresh group.
+    /// Each entry is `(user_id, display_name, username)`.
+    pub group_members: Vec<(String, String, Option<String>)>,
     /// Whether this agent was spawned as a subagent.
     pub is_subagent: bool,
     /// Whether this agent has autonomous config.
@@ -262,6 +272,7 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
                 channel,
                 ctx.sender_display_name.as_deref(),
                 ctx.sender_user_id.as_deref(),
+                ctx.sender_username.as_deref(),
                 ctx.is_group,
                 ctx.was_mentioned,
                 &ctx.granted_tools,
@@ -579,10 +590,12 @@ fn build_user_section(user_name: Option<&str>) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_channel_section(
     channel: &str,
     sender_name: Option<&str>,
     sender_id: Option<&str>,
+    sender_username: Option<&str>,
     is_group: bool,
     was_mentioned: bool,
     granted_tools: &[String],
@@ -620,22 +633,45 @@ fn build_channel_section(
          You are responding via {channel}. Keep messages under {limit} chars.\n\
          {hints}"
     );
+
+    // Self-awareness: tell the agent its own platform handle so it recognises
+    // mentions of itself as a valid alias, not as a reference to another entity.
+    if let Some(handle) = bot_username {
+        let clean = sanitize_identity(handle);
+        section.push_str(&format!(
+            "\nYour own `@{clean}` handle on {channel} is a valid alias for you. \
+             When users address you with it, they are talking TO you — do not \
+             interpret it as a reference to some other user or agent."
+        ));
+    }
+
     // Append sender identity when available from channel bridge.
     // Both fields originate from the channel platform's user profile —
     // they are attacker-controlled in any public-facing deployment,
     // so sanitize before interpolating into the system prompt.
+    let sender_handle = sender_username.map(sanitize_identity);
     match (sender_name, sender_id) {
         (Some(name), Some(id)) => {
+            let handle_bit = sender_handle
+                .as_ref()
+                .map(|h| format!(", @{h}"))
+                .unwrap_or_default();
             section.push_str(&format!(
-                "\nThe current message is from user \"{}\" (platform ID: {}).",
+                "\nThe current message is from user \"{}\"{} (platform ID: {}).",
                 sanitize_identity(name),
+                handle_bit,
                 sanitize_identity(id)
             ));
         }
         (Some(name), None) => {
+            let handle_bit = sender_handle
+                .as_ref()
+                .map(|h| format!(" (@{h})"))
+                .unwrap_or_default();
             section.push_str(&format!(
-                "\nThe current message is from user \"{}\".",
-                sanitize_identity(name)
+                "\nThe current message is from user \"{}\"{}.",
+                sanitize_identity(name),
+                handle_bit
             ));
         }
         (None, Some(id)) => {
@@ -646,6 +682,7 @@ fn build_channel_section(
         }
         (None, None) => {}
     }
+
     if is_group {
         section.push_str(
             "\nThis message is from a group chat. \
@@ -657,6 +694,34 @@ fn build_channel_section(
         );
         if was_mentioned {
             section.push_str(" You were @mentioned directly — respond to this message.");
+        }
+
+        // Group roster: list the known members so the agent can distinguish
+        // the current sender from other humans mentioned by `@handle` in the
+        // message text. Without this, a message like `dile a @jose ...` looks
+        // like a reference to an internal agent.
+        if !group_members.is_empty() {
+            section.push_str("\n\n### Known members of this group");
+            for (user_id, display_name, username) in group_members {
+                let name_clean = sanitize_identity(display_name);
+                let id_clean = sanitize_identity(user_id);
+                let handle = match username {
+                    Some(u) => format!(" (@{}, id={})", sanitize_identity(u), id_clean),
+                    None => format!(" (id={id_clean})"),
+                };
+                section.push_str(&format!("\n- {name_clean}{handle}"));
+            }
+            section.push_str(
+                "\n\nWhen a message contains an `@handle` or a user name, look it up \
+                 in the list above. Those are real humans in this chat. They are \
+                 NEVER agents or other LibreFang entities — if you need to reach \
+                 another agent you use the `agent_send` tool (by name), not an \
+                 `@` mention in the reply text. If the referenced name is not in \
+                 the list above, say so plainly — do not invent an identity. \
+                 Address replies to the actual sender of the current message, \
+                 not to other members unless explicitly asked to pass a message \
+                 along.",
+            );
         }
     }
 
@@ -1219,6 +1284,80 @@ mod tests {
             !section.contains("channel_send"),
             "Should NOT mention channel_send when tool is not available"
         );
+    }
+
+    #[test]
+    fn test_channel_bot_handle_self_awareness() {
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("123"),
+            Some("pakman"),
+            true,
+            true,
+            Some("fandangorodelo_bot"),
+            &[],
+        );
+        assert!(section.contains("@fandangorodelo_bot"));
+        assert!(section.contains("valid alias"));
+        // Current sender rendered with its @handle
+        assert!(section.contains("Pakman"));
+        assert!(section.contains("@pakman"));
+    }
+
+    #[test]
+    fn test_channel_group_roster_rendered() {
+        let members = vec![
+            (
+                "1".to_string(),
+                "Pakman".to_string(),
+                Some("pakman".to_string()),
+            ),
+            (
+                "2".to_string(),
+                "Jorge Pablo".to_string(),
+                Some("jorgepablo".to_string()),
+            ),
+            ("3".to_string(), "dvpablo".to_string(), None),
+        ];
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("1"),
+            Some("pakman"),
+            true,
+            true,
+            Some("fandangorodelo_bot"),
+            &members,
+        );
+        assert!(section.contains("### Known members of this group"));
+        assert!(section.contains("Pakman"));
+        assert!(section.contains("Jorge Pablo"));
+        assert!(section.contains("dvpablo"));
+        assert!(section.contains("@jorgepablo"));
+        assert!(section.contains("real humans"));
+        assert!(section.contains("NOT agents"));
+    }
+
+    #[test]
+    fn test_channel_dm_has_no_roster() {
+        // DMs should never get a roster block even if one is passed.
+        let members = vec![(
+            "1".to_string(),
+            "Solo".to_string(),
+            Some("solo".to_string()),
+        )];
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("1"),
+            Some("pakman"),
+            false, // is_group = false
+            false,
+            Some("fandangorodelo_bot"),
+            &members,
+        );
+        assert!(!section.contains("### Known members of this group"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Evolves the group chat experience with four interconnected features:

- **SQLite-backed group roster**: Persists group members across daemon restarts. Members are upserted on each message via `ChannelBridgeHandle::roster_upsert()` backed by a new `RosterStore` in the memory crate.

- **`group_members` tool**: Agents query the roster on-demand instead of having it injected into every system prompt. Saves ~200-300 tokens per turn in group chats.

- **Configurable reply-intent precheck**: Agents can autonomously decide whether to reply to group messages via a lightweight LLM classification (~200 tokens). The classification prompt is read from `PRECHECK.md` in the agent's workspace — operators can tune sensitivity without recompiling. Includes conversation context (reply_to) so the classifier detects continuations.

- **Alias-based group triggering**: `should_process_group_message` now checks agent aliases from `[metadata.routing].aliases` in agent.toml. Messages containing "oye fandango" or "rodelo" trigger processing without requiring an @mention.

### Files changed

| Crate | File | Change |
|-------|------|--------|
| librefang-memory | `roster_store.rs` (new) | SQLite-backed RosterStore |
| librefang-memory | `substrate.rs`, `lib.rs` | Integrate RosterStore |
| librefang-runtime | `tool_runner.rs` | Add `group_members` tool |
| librefang-runtime | `kernel_handle.rs` | Roster trait methods |
| librefang-runtime | `prompt_builder.rs` | Remove roster from prompt |
| librefang-kernel | `kernel.rs` | Implement roster + classify_text |
| librefang-channels | `bridge.rs` | Alias check, precheck, roster_upsert |
| librefang-api | `channel_bridge.rs` | Implement all handle methods |
| librefang-types | `config/types.rs` | `reply_precheck` config field |

### Why bundle these?

All four features share the same call path in `bridge.rs::dispatch_message` and `channel_bridge.rs`. Splitting them would require duplicating edits to the same functions and create merge conflicts between PRs.

## Test plan

- [ ] `cargo test -p librefang-memory roster_store` — 6 roster store unit tests
- [ ] `cargo test -p librefang-channels` — alias triggering tests
- [ ] `cargo test -p librefang-runtime prompt_builder` — roster NOT in prompt
- [ ] `cargo build --workspace --lib` — clean build
- [ ] Deploy to Telegram group, verify bot responds to aliases and decides autonomously
- [ ] Edit PRECHECK.md, verify bot sensitivity changes without rebuild