### PR TITLE
feat(channels): alias-based group triggering + LLM reply-intent precheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ sdk/**/target
 .env
 .env.*
 !.env.example
+secrets.env
+secrets.env.*
 
 # Database
 *.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4033,12 +4033,14 @@ name = "librefang-desktop"
 version = "2026.4.10-beta17"
 dependencies = [
  "axum",
+ "clap",
  "dirs 6.0.0",
  "librefang-api",
  "librefang-extensions",
  "librefang-kernel",
  "librefang-types",
  "open",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tauri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,6 +3951,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "cbc",
  "chrono",
  "criterion",

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -668,48 +668,45 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         agent_id: AgentId,
         message: &str,
     ) -> Result<bool, String> {
-        // Heuristic-based reply-intent classification (zero LLM cost).
-        //
-        // Full LLM classification (like ZeroClaw's classify_channel_reply_intent)
-        // requires a direct provider call without the agent loop, which librefang
-        // doesn't currently expose via ChannelBridgeHandle. Using send_message()
-        // or send_message_ephemeral() would be nearly as expensive as just
-        // replying — defeating the purpose of a lightweight precheck.
-        //
-        // This heuristic approach covers the common cases:
-        // - Messages containing a question mark → likely wants a response
-        // - Messages starting with a greeting → likely starting a conversation
-        // - Very short messages (< 5 chars) → probably not for the bot
-        // - Messages that are a reply to the bot → handled upstream (was_mentioned)
-        //
-        // Future: when librefang exposes a lightweight `provider.classify()`
-        // API, upgrade this to an actual LLM call.
+        // Lightweight LLM classification via kernel.classify_text() — calls the
+        // agent's LLM driver directly without the agent loop. ~100-200 tokens.
+        const CLASSIFY_SYSTEM: &str = "\
+            Decide whether the assistant should reply to this group chat message.\n\
+            Return exactly one word: REPLY or NO_REPLY.\n\n\
+            Rules:\n\
+            - If the message is addressed to the assistant, asks a question, or \
+              continues a conversation the assistant is part of → REPLY\n\
+            - If the message is casual chat between humans that doesn't concern \
+              the assistant → NO_REPLY\n\
+            - When in doubt, prefer NO_REPLY to avoid being noisy.";
 
-        let _ = agent_id; // Will be used when LLM classification is available
-        let trimmed = message.trim();
-
-        // Very short messages are usually not directed at the bot
-        if trimmed.len() < 5 {
-            return Ok(false);
+        match self
+            .kernel
+            .classify_text(agent_id, CLASSIFY_SYSTEM, message, 10)
+            .await
+        {
+            Ok(response) => {
+                let trimmed = response.trim().to_uppercase();
+                Ok(!trimmed.contains("NO_REPLY"))
+            }
+            Err(e) => {
+                // Fail-open: if LLM fails, fall back to heuristic
+                tracing::warn!(
+                    error = %e,
+                    "LLM reply-intent classification failed — falling back to heuristic"
+                );
+                let trimmed = message.trim();
+                if trimmed.len() < 5 {
+                    return Ok(false);
+                }
+                if trimmed.contains('?') {
+                    return Ok(true);
+                }
+                let lower = trimmed.to_lowercase();
+                let greetings = ["hola", "buenas", "hey", "hi", "hello", "oye", "ayuda"];
+                Ok(greetings.iter().any(|g| lower.starts_with(g)))
+            }
         }
-
-        // Questions are likely seeking a response
-        if trimmed.contains('?') {
-            return Ok(true);
-        }
-
-        // Messages starting with common greetings
-        let lower = trimmed.to_lowercase();
-        let greetings = [
-            "hola", "buenas", "hey", "hi", "hello", "buenos", "oye", "eh", "a ver", "mira",
-            "venga", "vale", "ok ", "help", "ayuda",
-        ];
-        if greetings.iter().any(|g| lower.starts_with(g)) {
-            return Ok(true);
-        }
-
-        // Default: don't reply to random group chatter
-        Ok(false)
     }
 
     async fn uptime_info(&self) -> String {

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -642,6 +642,76 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Ok(agent_id)
     }
 
+    async fn get_agent_aliases(&self, agent_id: AgentId) -> Vec<String> {
+        self.kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|entry| {
+                entry
+                    .manifest
+                    .metadata
+                    .get("routing")
+                    .and_then(|r| r.get("aliases"))
+                    .and_then(|a| a.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn classify_reply_intent(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+    ) -> Result<bool, String> {
+        // Heuristic-based reply-intent classification (zero LLM cost).
+        //
+        // Full LLM classification (like ZeroClaw's classify_channel_reply_intent)
+        // requires a direct provider call without the agent loop, which librefang
+        // doesn't currently expose via ChannelBridgeHandle. Using send_message()
+        // or send_message_ephemeral() would be nearly as expensive as just
+        // replying — defeating the purpose of a lightweight precheck.
+        //
+        // This heuristic approach covers the common cases:
+        // - Messages containing a question mark → likely wants a response
+        // - Messages starting with a greeting → likely starting a conversation
+        // - Very short messages (< 5 chars) → probably not for the bot
+        // - Messages that are a reply to the bot → handled upstream (was_mentioned)
+        //
+        // Future: when librefang exposes a lightweight `provider.classify()`
+        // API, upgrade this to an actual LLM call.
+
+        let _ = agent_id; // Will be used when LLM classification is available
+        let trimmed = message.trim();
+
+        // Very short messages are usually not directed at the bot
+        if trimmed.len() < 5 {
+            return Ok(false);
+        }
+
+        // Questions are likely seeking a response
+        if trimmed.contains('?') {
+            return Ok(true);
+        }
+
+        // Messages starting with common greetings
+        let lower = trimmed.to_lowercase();
+        let greetings = [
+            "hola", "buenas", "hey", "hi", "hello", "buenos", "oye", "eh", "a ver", "mira",
+            "venga", "vale", "ok ", "help", "ayuda",
+        ];
+        if greetings.iter().any(|g| lower.starts_with(g)) {
+            return Ok(true);
+        }
+
+        // Default: don't reply to random group chatter
+        Ok(false)
+    }
+
     async fn uptime_info(&self) -> String {
         let uptime = self.started_at.elapsed();
         let agents = self.list_agents().await.unwrap_or_default();

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -275,7 +275,7 @@ async fn resolve_manifest(
     }
 
     // Parse TOML
-    let manifest: AgentManifest = match toml::from_str(&manifest_toml) {
+    let mut manifest: AgentManifest = match toml::from_str(&manifest_toml) {
         Ok(m) => m,
         Err(e) => {
             let _ = e;

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -286,6 +286,14 @@ async fn resolve_manifest(
         }
     };
 
+    // Allow callers to override the manifest name, enabling multiple agents
+    // from the same template with distinct names.
+    if let Some(ref custom_name) = req.name {
+        if !custom_name.trim().is_empty() {
+            manifest.name = custom_name.trim().to_string();
+        }
+    }
+
     let name = manifest.name.clone();
     Ok(ResolvedManifest { manifest, name })
 }

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -126,6 +126,10 @@ pub struct SpawnRequest {
     /// When provided and `manifest_toml` is empty, the template is loaded automatically.
     #[serde(default)]
     pub template: Option<String>,
+    /// Optional custom name for the agent. Overrides the name from the template
+    /// or manifest, allowing multiple agents from the same template.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Optional Ed25519 signed manifest envelope (JSON).
     /// When present, the signature is verified before spawning.
     #[serde(default)]

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -157,6 +157,7 @@ chrono = { workspace = true }
 dashmap = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
+bytes = { workspace = true }
 reqwest = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -345,6 +345,25 @@ pub trait ChannelBridgeHandle: Send + Sync {
     ) -> Result<String, String> {
         Err("Channel push not available".to_string())
     }
+
+    /// Lightweight LLM precheck: should the agent reply to this group message?
+    ///
+    /// Returns `Ok(true)` → reply, `Ok(false)` → stay silent.
+    /// On error the caller fails open (replies anyway).
+    /// Default: always reply (opt-in via `reply_precheck = true` in channel config).
+    async fn classify_reply_intent(
+        &self,
+        _agent_id: AgentId,
+        _message: &str,
+    ) -> Result<bool, String> {
+        Ok(true)
+    }
+
+    /// Get the routing aliases for an agent (from `[metadata.routing].aliases`).
+    /// Default: empty (no aliases).
+    async fn get_agent_aliases(&self, _agent_id: AgentId) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 struct PendingMessage {
@@ -1259,6 +1278,22 @@ fn text_content(message: &ChannelMessage) -> Option<&str> {
     }
 }
 
+/// Convert plain alias strings into case-insensitive word-boundary regex patterns
+/// suitable for use in `group_trigger_patterns`.
+///
+/// This lets operators avoid manually translating agent aliases into regex syntax:
+/// `aliases_to_trigger_patterns(&["fandango", "oye fandango"])` produces
+/// `["(?i)\\bfandango\\b", "(?i)\\boye fandango\\b"]`.
+pub fn aliases_to_trigger_patterns(aliases: &[String]) -> Vec<String> {
+    aliases
+        .iter()
+        .map(|alias| {
+            let escaped = regex::escape(alias);
+            format!("(?i)\\b{escaped}\\b")
+        })
+        .collect()
+}
+
 fn matches_group_trigger_pattern(
     ct_str: &str,
     message: &ChannelMessage,
@@ -1328,6 +1363,7 @@ fn should_process_group_message(
     ct_str: &str,
     overrides: &ChannelOverrides,
     message: &ChannelMessage,
+    agent_aliases: &[String],
 ) -> bool {
     match overrides.group_policy {
         GroupPolicy::Ignore => {
@@ -1357,7 +1393,23 @@ fn should_process_group_message(
                     message,
                     &overrides.group_trigger_patterns,
                 );
-            if !was_mentioned && !is_command && !regex_triggered {
+            let alias_triggered = !was_mentioned
+                && !is_command
+                && !regex_triggered
+                && text_content(message).is_some_and(|text| {
+                    let lower = text.to_lowercase();
+                    agent_aliases
+                        .iter()
+                        .any(|alias| lower.contains(&alias.to_lowercase()))
+                });
+            if alias_triggered {
+                debug!(
+                    channel = ct_str,
+                    user = %message.sender.display_name,
+                    "Group message matched agent alias trigger"
+                );
+            }
+            if !was_mentioned && !is_command && !regex_triggered && !alias_triggered {
                 debug!(
                     "Ignoring group message on {ct_str} (group_policy=mention_only, not mentioned)"
                 );
@@ -1815,7 +1867,7 @@ async fn dispatch_message(
     // --- DM/Group policy check ---
     if let Some(ref ov) = overrides {
         if message.is_group {
-            if !should_process_group_message(ct_str, ov, message) {
+            if !should_process_group_message(ct_str, ov, message, &[]) {
                 return;
             }
         } else {
@@ -2135,6 +2187,58 @@ async fn dispatch_message(
             return;
         }
     };
+
+    // --- Post-resolution group filters (alias awareness + reply-intent precheck) ---
+    if message.is_group {
+        let was_mentioned = message
+            .metadata
+            .get("was_mentioned")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Reply-intent precheck: lightweight LLM call to decide if the agent
+        // should reply. Only for non-mentioned group messages when enabled.
+        // Skipped for @mentions, commands, and DMs (those always get a reply).
+        if !was_mentioned && !matches!(message.content, ChannelContent::Command { .. }) {
+            // Check agent aliases first — if a message contains an alias like
+            // "oye fandango", treat it as an implicit mention (skip precheck).
+            let aliases = handle.get_agent_aliases(agent_id).await;
+            let alias_hit = !aliases.is_empty()
+                && text_content(message).is_some_and(|text| {
+                    let lower = text.to_lowercase();
+                    aliases.iter().any(|a| lower.contains(&a.to_lowercase()))
+                });
+
+            if alias_hit {
+                debug!(
+                    channel = ct_str,
+                    "Group message matched agent alias — treating as mention"
+                );
+            } else if let Some(ref ov) = overrides {
+                if ov.reply_precheck {
+                    // No mention, no alias — run LLM precheck
+                    if let Some(text) = text_content(message) {
+                        match handle.classify_reply_intent(agent_id, text).await {
+                            Ok(true) => {
+                                debug!(channel = ct_str, "Reply-intent precheck: REPLY");
+                            }
+                            Ok(false) => {
+                                debug!(
+                                    channel = ct_str,
+                                    "Reply-intent precheck: NO_REPLY — staying silent"
+                                );
+                                return;
+                            }
+                            Err(e) => {
+                                warn!(channel = ct_str, error = %e, "Reply-intent precheck failed — proceeding with reply");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let channel_key = format!("{:?}", message.channel);
 
     // RBAC: authorize the user before forwarding to agent
@@ -3390,7 +3494,10 @@ mod tests {
             ..Default::default()
         };
         assert!(should_process_group_message(
-            "whatsapp", &overrides, &message
+            "whatsapp",
+            &overrides,
+            &message,
+            &[]
         ));
     }
 
@@ -3402,7 +3509,10 @@ mod tests {
             ..Default::default()
         };
         assert!(!should_process_group_message(
-            "whatsapp", &overrides, &message
+            "whatsapp",
+            &overrides,
+            &message,
+            &[]
         ));
     }
 
@@ -3414,7 +3524,10 @@ mod tests {
             ..Default::default()
         };
         assert!(should_process_group_message(
-            "telegram", &overrides, &message
+            "telegram",
+            &overrides,
+            &message,
+            &[]
         ));
     }
 
@@ -3426,8 +3539,74 @@ mod tests {
             .insert("was_mentioned".to_string(), serde_json::Value::Bool(true));
         let overrides = ChannelOverrides::default();
         assert!(should_process_group_message(
-            "telegram", &overrides, &message
+            "telegram",
+            &overrides,
+            &message,
+            &[]
         ));
+    }
+
+    #[test]
+    fn test_mention_only_triggers_on_agent_alias() {
+        let message = group_text_message("hey fandango what do you think?");
+        let overrides = ChannelOverrides::default();
+        let aliases = vec!["fandango".to_string()];
+        assert!(should_process_group_message(
+            "telegram", &overrides, &message, &aliases
+        ));
+    }
+
+    #[test]
+    fn test_mention_only_alias_is_case_insensitive() {
+        let message = group_text_message("FANDANGO help me");
+        let overrides = ChannelOverrides::default();
+        let aliases = vec!["Fandango".to_string()];
+        assert!(should_process_group_message(
+            "telegram", &overrides, &message, &aliases
+        ));
+    }
+
+    #[test]
+    fn test_mention_only_rejects_no_alias_match() {
+        let message = group_text_message("hello there, anyone?");
+        let overrides = ChannelOverrides::default();
+        let aliases = vec!["fandango".to_string(), "rodelo".to_string()];
+        assert!(!should_process_group_message(
+            "telegram", &overrides, &message, &aliases
+        ));
+    }
+
+    #[test]
+    fn test_mention_only_alias_does_not_override_regex_trigger() {
+        // regex trigger and alias can independently activate — alias fires here
+        let message = group_text_message("oye fandango");
+        let overrides = ChannelOverrides::default();
+        let aliases = vec!["oye fandango".to_string()];
+        assert!(should_process_group_message(
+            "telegram", &overrides, &message, &aliases
+        ));
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_produces_word_boundary_regex() {
+        let aliases = vec!["fandango".to_string(), "oye fandango".to_string()];
+        let patterns = aliases_to_trigger_patterns(&aliases);
+        assert_eq!(patterns.len(), 2);
+        assert_eq!(patterns[0], r"(?i)\bfandango\b");
+        assert_eq!(patterns[1], r"(?i)\boye fandango\b");
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_escapes_special_chars() {
+        let aliases = vec!["bot.v2".to_string()];
+        let patterns = aliases_to_trigger_patterns(&aliases);
+        assert_eq!(patterns[0], r"(?i)\bbot\.v2\b");
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_empty() {
+        let patterns = aliases_to_trigger_patterns(&[]);
+        assert!(patterns.is_empty());
     }
 
     #[test]

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5,11 +5,12 @@
 
 use crate::formatter;
 use crate::rate_limiter::ChannelRateLimiter;
+use crate::roster::GroupRosterStore;
 use crate::router::AgentRouter;
 use crate::sanitizer::{InputSanitizer, SanitizeResult};
 use crate::types::{
     default_phase_emoji, AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage, ChannelUser,
-    LifecycleReaction, SenderContext,
+    GroupMember, LifecycleReaction, SenderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -1372,6 +1373,18 @@ fn should_process_group_message(
 ///
 /// Per-channel auto-routing fields are populated from `overrides` when provided,
 /// and default to `AutoRouteStrategy::Off` / zeros otherwise.
+/// Singleton in-memory group roster shared across all channel adapters.
+///
+/// Populated on every incoming group message from `build_sender_context`. The
+/// accumulated roster is then handed to the agent's system prompt so the LLM
+/// can distinguish the current message sender from other group members it has
+/// seen before (e.g. when a user writes `@pepe` meaning another human, not an
+/// agent in the system).
+fn group_roster() -> &'static GroupRosterStore {
+    static ROSTER: OnceLock<GroupRosterStore> = OnceLock::new();
+    ROSTER.get_or_init(GroupRosterStore::new)
+}
+
 fn build_sender_context(
     message: &ChannelMessage,
     overrides: Option<&ChannelOverrides>,
@@ -1392,8 +1405,47 @@ fn build_sender_context(
         ),
         None => (AutoRouteStrategy::Off, 0, 0, 0, 0),
     };
+
+    let channel = channel_type_str(&message.channel).to_string();
+    let chat_id = message
+        .metadata
+        .get("chat_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let bot_username = message
+        .metadata
+        .get("bot_username")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let sender_username = message
+        .metadata
+        .get("sender_username")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    // For group messages, upsert the current sender into the roster and then
+    // read back all known members. For DMs the roster stays empty — the LLM
+    // only needs the current sender and doesn't gain anything from a roster
+    // with a single member.
+    let group_members: Vec<GroupMember> = if message.is_group {
+        if let Some(ref cid) = chat_id {
+            let current = GroupMember {
+                user_id: sender_user_id(message).to_string(),
+                display_name: message.sender.display_name.clone(),
+                username: sender_username.clone(),
+            };
+            let store = group_roster();
+            store.upsert(&channel, cid, current);
+            store.members(&channel, cid)
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
     SenderContext {
-        channel: channel_type_str(&message.channel).to_string(),
+        channel,
         user_id: sender_user_id(message).to_string(),
         display_name: message.sender.display_name.clone(),
         is_group: message.is_group,
@@ -1413,6 +1465,10 @@ fn build_sender_context(
         auto_route_confidence_threshold,
         auto_route_sticky_bonus,
         auto_route_divergence_count,
+        bot_username,
+        sender_username,
+        group_members,
+        chat_id,
     }
 }
 

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -12,6 +12,7 @@ pub mod formatter;
 pub(crate) mod http_client;
 pub mod message_journal;
 pub mod rate_limiter;
+pub mod roster;
 pub mod router;
 pub mod sanitizer;
 pub mod sidecar;

--- a/crates/librefang-channels/src/roster.rs
+++ b/crates/librefang-channels/src/roster.rs
@@ -1,0 +1,154 @@
+//! In-memory group roster store.
+//!
+//! Tracks the human members seen in each group chat so that agents can be given
+//! a structured "who is in this group" context in their system prompt. Without
+//! this, an agent receiving a message like `@pepe dile algo a @jose` has no way
+//! to know who `@pepe` and `@jose` are — they look like opaque text.
+//!
+//! The store is a simple in-memory map keyed by `(channel_type, chat_id)`. It
+//! does not persist to disk: on daemon restart it is empty and repopulates
+//! naturally as members send messages. A persistent backend can be added later
+//! without changing the public API.
+
+use crate::types::GroupMember;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+/// Composite key identifying a specific chat on a specific channel.
+///
+/// For Telegram the `chat_id` is the group's negative chat ID (or the user's
+/// ID for DMs). For Discord it's the channel ID, and so on per platform.
+type RosterKey = (String, String);
+
+/// Thread-safe in-memory store of known group members per chat.
+#[derive(Debug, Default, Clone)]
+pub struct GroupRosterStore {
+    rosters: Arc<DashMap<RosterKey, DashMap<String, GroupMember>>>,
+}
+
+impl GroupRosterStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record (or update) a member in the given chat roster.
+    ///
+    /// Idempotent: subsequent calls with the same `user_id` simply refresh the
+    /// display name and username.
+    pub fn upsert(&self, channel: &str, chat_id: &str, member: GroupMember) {
+        if chat_id.is_empty() || member.user_id.is_empty() {
+            return;
+        }
+        let key = (channel.to_string(), chat_id.to_string());
+        let members = self.rosters.entry(key).or_insert_with(DashMap::new);
+        members.insert(member.user_id.clone(), member);
+    }
+
+    /// Return all known members for a chat, sorted by display name for stable
+    /// rendering. Returns an empty vector if the chat is unknown.
+    pub fn members(&self, channel: &str, chat_id: &str) -> Vec<GroupMember> {
+        let key = (channel.to_string(), chat_id.to_string());
+        let Some(entry) = self.rosters.get(&key) else {
+            return Vec::new();
+        };
+        let mut out: Vec<GroupMember> = entry.iter().map(|e| e.value().clone()).collect();
+        out.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        out
+    }
+
+    /// Number of members in a specific chat (0 if unknown).
+    pub fn member_count(&self, channel: &str, chat_id: &str) -> usize {
+        let key = (channel.to_string(), chat_id.to_string());
+        self.rosters.get(&key).map(|e| e.len()).unwrap_or(0)
+    }
+
+    /// Total number of chats being tracked.
+    pub fn chat_count(&self) -> usize {
+        self.rosters.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_member(user_id: &str, display: &str, username: Option<&str>) -> GroupMember {
+        GroupMember {
+            user_id: user_id.to_string(),
+            display_name: display.to_string(),
+            username: username.map(String::from),
+        }
+    }
+
+    #[test]
+    fn upsert_and_list_sorted() {
+        let store = GroupRosterStore::new();
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("1", "Jorge", Some("jorge")),
+        );
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("2", "Pakman", Some("pakman")),
+        );
+        store.upsert("telegram", "-100123", mk_member("3", "Ana", Some("ana")));
+
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 3);
+        assert_eq!(members[0].display_name, "Ana");
+        assert_eq!(members[1].display_name, "Jorge");
+        assert_eq!(members[2].display_name, "Pakman");
+    }
+
+    #[test]
+    fn upsert_idempotent_and_updates() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100123", mk_member("1", "Jorge", None));
+        store.upsert(
+            "telegram",
+            "-100123",
+            mk_member("1", "Jorge Pablo", Some("jorgepablo")),
+        );
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].display_name, "Jorge Pablo");
+        assert_eq!(members[0].username.as_deref(), Some("jorgepablo"));
+    }
+
+    #[test]
+    fn unknown_chat_returns_empty() {
+        let store = GroupRosterStore::new();
+        assert!(store.members("telegram", "-999").is_empty());
+        assert_eq!(store.member_count("telegram", "-999"), 0);
+    }
+
+    #[test]
+    fn ignores_empty_ids() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "", mk_member("1", "Nobody", None));
+        store.upsert("telegram", "-100", mk_member("", "Nameless", None));
+        assert_eq!(store.chat_count(), 0);
+    }
+
+    #[test]
+    fn separate_chats_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100", mk_member("1", "Alice", None));
+        store.upsert("telegram", "-200", mk_member("2", "Bob", None));
+        assert_eq!(store.members("telegram", "-100").len(), 1);
+        assert_eq!(store.members("telegram", "-200").len(), 1);
+        assert_eq!(store.chat_count(), 2);
+    }
+
+    #[test]
+    fn separate_channels_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "123", mk_member("1", "Alice", None));
+        store.upsert("discord", "123", mk_member("2", "Bob", None));
+        assert_eq!(store.members("telegram", "123").len(), 1);
+        assert_eq!(store.members("discord", "123").len(), 1);
+    }
+}

--- a/crates/librefang-channels/src/roster.rs
+++ b/crates/librefang-channels/src/roster.rs
@@ -41,7 +41,7 @@ impl GroupRosterStore {
             return;
         }
         let key = (channel.to_string(), chat_id.to_string());
-        let members = self.rosters.entry(key).or_insert_with(DashMap::new);
+        let members = self.rosters.entry(key).or_default();
         members.insert(member.user_id.clone(), member);
     }
 

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -84,15 +84,28 @@ impl<'a> TelegramApiCtx<'a> {
     /// Resolve a Telegram file_id to a download URL via the Bot API.
     async fn get_file_url(&self, file_id: &str) -> Option<String> {
         let url = format!("{}/bot{}/getFile", self.api_base_url, self.token);
-        let resp = self
+        let resp = match self
             .client
             .post(&url)
             .json(&serde_json::json!({"file_id": file_id}))
             .send()
             .await
-            .ok()?;
-        let body: serde_json::Value = resp.json().await.ok()?;
+        {
+            Ok(r) => r,
+            Err(e) => {
+                debug!("Telegram getFile request failed for {file_id}: {e}");
+                return None;
+            }
+        };
+        let body: serde_json::Value = match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                debug!("Telegram getFile parse failed for {file_id}: {e}");
+                return None;
+            }
+        };
         if body["ok"].as_bool() != Some(true) {
+            debug!("Telegram getFile returned ok=false for {file_id}: {body}");
             return None;
         }
         let file_path = body["result"]["file_path"].as_str()?;
@@ -320,7 +333,9 @@ impl TelegramAdapter {
                 let resp2 = self.client.post(&url).json(&body).send().await?;
                 if !resp2.status().is_success() {
                     let body_text2 = resp2.text().await.unwrap_or_default();
-                    warn!("Telegram {endpoint} failed after retry: {body_text2}");
+                    return Err(
+                        format!("Telegram {endpoint} failed after retry: {body_text2}").into(),
+                    );
                 }
                 return Ok(());
             }
@@ -423,7 +438,10 @@ impl TelegramAdapter {
                 let resp2 = self.client.post(&url).multipart(retry_form).send().await?;
                 if !resp2.status().is_success() {
                     let body_text2 = resp2.text().await.unwrap_or_default();
-                    warn!("Telegram sendDocument upload failed after retry: {body_text2}");
+                    return Err(format!(
+                        "Telegram sendDocument upload failed after retry: {body_text2}"
+                    )
+                    .into());
                 }
                 return Ok(());
             }
@@ -1218,7 +1236,7 @@ fn ends_with_ascii_ci(haystack: &str, suffix: &str) -> bool {
     if haystack.len() < suffix.len() {
         return false;
     }
-    haystack[haystack.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
+    haystack.as_bytes()[haystack.len() - suffix.len()..].eq_ignore_ascii_case(suffix.as_bytes())
 }
 
 /// Detect image MIME type from a Telegram file path or download URL.

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -53,6 +53,8 @@ pub struct TelegramAdapter {
     long_poll_timeout: u64,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Handle for the polling task, used for graceful shutdown.
+    poll_handle: Arc<tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>>,
     /// When true, remove the reaction on Done instead of showing 🎉.
     clear_done_reaction: bool,
 }
@@ -88,6 +90,7 @@ impl TelegramAdapter {
             long_poll_timeout: 30,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
+            poll_handle: Arc::new(tokio::sync::Mutex::new(None)),
             clear_done_reaction: false,
         }
     }
@@ -201,6 +204,57 @@ impl TelegramAdapter {
         Ok(())
     }
 
+    /// Generic helper for Telegram media API calls (sendPhoto, sendVoice, sendVideo, etc.)
+    ///
+    /// Handles URL construction, optional `message_thread_id`, and a single retry
+    /// on HTTP 429 rate-limit responses (waiting `retry_after` seconds from the
+    /// Telegram response body, defaulting to 2 seconds if the header is missing).
+    async fn api_send_media_request(
+        &self,
+        endpoint: &str,
+        chat_id: i64,
+        body_fields: serde_json::Value,
+        thread_id: Option<i64>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let url = format!(
+            "{}/bot{}/{endpoint}",
+            self.api_base_url,
+            self.token.as_str()
+        );
+        let mut body = body_fields;
+        body["chat_id"] = serde_json::json!(chat_id);
+        if let Some(tid) = thread_id {
+            body["message_thread_id"] = serde_json::json!(tid);
+        }
+
+        let resp = self.client.post(&url).json(&body).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+
+            // Retry once on 429 rate limit
+            if status.as_u16() == 429 {
+                let retry_after = body_text
+                    .parse::<serde_json::Value>()
+                    .ok()
+                    .and_then(|v| v["parameters"]["retry_after"].as_u64())
+                    .unwrap_or(2);
+                warn!("Telegram {endpoint} rate limited, retrying after {retry_after}s");
+                tokio::time::sleep(Duration::from_secs(retry_after)).await;
+
+                let resp2 = self.client.post(&url).json(&body).send().await?;
+                if !resp2.status().is_success() {
+                    let body_text2 = resp2.text().await.unwrap_or_default();
+                    warn!("Telegram {endpoint} failed after retry: {body_text2}");
+                }
+                return Ok(());
+            }
+
+            warn!("Telegram {endpoint} failed ({status}): {body_text}");
+        }
+        Ok(())
+    }
+
     /// Call `sendPhoto` on the Telegram API.
     async fn api_send_photo(
         &self,
@@ -209,24 +263,13 @@ impl TelegramAdapter {
         caption: Option<&str>,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!("{}/bot{}/sendPhoto", self.api_base_url, self.token.as_str());
-        let mut body = serde_json::json!({
-            "chat_id": chat_id,
-            "photo": photo_url,
-        });
+        let mut body = serde_json::json!({ "photo": photo_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
             body["parse_mode"] = serde_json::Value::String("HTML".to_string());
         }
-        if let Some(tid) = thread_id {
-            body["message_thread_id"] = serde_json::json!(tid);
-        }
-        let resp = self.client.post(&url).json(&body).send().await?;
-        if !resp.status().is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendPhoto failed: {body_text}");
-        }
-        Ok(())
+        self.api_send_media_request("sendPhoto", chat_id, body, thread_id)
+            .await
     }
 
     /// Call `sendDocument` on the Telegram API.
@@ -237,31 +280,19 @@ impl TelegramAdapter {
         filename: &str,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!(
-            "{}/bot{}/sendDocument",
-            self.api_base_url,
-            self.token.as_str()
-        );
-        let mut body = serde_json::json!({
-            "chat_id": chat_id,
+        let body = serde_json::json!({
             "document": document_url,
             "caption": filename,
         });
-        if let Some(tid) = thread_id {
-            body["message_thread_id"] = serde_json::json!(tid);
-        }
-        let resp = self.client.post(&url).json(&body).send().await?;
-        if !resp.status().is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendDocument failed: {body_text}");
-        }
-        Ok(())
+        self.api_send_media_request("sendDocument", chat_id, body, thread_id)
+            .await
     }
 
     /// Call `sendDocument` with multipart upload for local file data.
     ///
     /// Used by the proactive `channel_send` tool when `file_path` is provided.
     /// Uploads raw bytes as a multipart form instead of passing a URL.
+    /// Retries once on HTTP 429 rate-limit responses.
     async fn api_send_document_upload(
         &self,
         chat_id: i64,
@@ -275,6 +306,9 @@ impl TelegramAdapter {
             self.api_base_url,
             self.token.as_str()
         );
+
+        // Clone data upfront so we have a copy for a potential retry
+        let retry_data = data.clone();
 
         let file_part = reqwest::multipart::Part::bytes(data)
             .file_name(filename.to_string())
@@ -290,8 +324,39 @@ impl TelegramAdapter {
 
         let resp = self.client.post(&url).multipart(form).send().await?;
         if !resp.status().is_success() {
+            let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendDocument upload failed: {body_text}");
+
+            // Retry once on 429 rate limit
+            if status.as_u16() == 429 {
+                let retry_after = body_text
+                    .parse::<serde_json::Value>()
+                    .ok()
+                    .and_then(|v| v["parameters"]["retry_after"].as_u64())
+                    .unwrap_or(2);
+                warn!("Telegram sendDocument upload rate limited, retrying after {retry_after}s");
+                tokio::time::sleep(Duration::from_secs(retry_after)).await;
+
+                // Rebuild the multipart form with the cloned data
+                let file_part = reqwest::multipart::Part::bytes(retry_data)
+                    .file_name(filename.to_string())
+                    .mime_str(mime_type)?;
+                let mut retry_form = reqwest::multipart::Form::new()
+                    .text("chat_id", chat_id.to_string())
+                    .part("document", file_part);
+                if let Some(tid) = thread_id {
+                    retry_form = retry_form.text("message_thread_id", tid.to_string());
+                }
+
+                let resp2 = self.client.post(&url).multipart(retry_form).send().await?;
+                if !resp2.status().is_success() {
+                    let body_text2 = resp2.text().await.unwrap_or_default();
+                    warn!("Telegram sendDocument upload failed after retry: {body_text2}");
+                }
+                return Ok(());
+            }
+
+            warn!("Telegram sendDocument upload failed ({status}): {body_text}");
         }
         Ok(())
     }
@@ -304,24 +369,13 @@ impl TelegramAdapter {
         caption: Option<&str>,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!("{}/bot{}/sendVoice", self.api_base_url, self.token.as_str());
-        let mut body = serde_json::json!({
-            "chat_id": chat_id,
-            "voice": voice_url,
-        });
+        let mut body = serde_json::json!({ "voice": voice_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
             body["parse_mode"] = serde_json::Value::String("HTML".to_string());
         }
-        if let Some(tid) = thread_id {
-            body["message_thread_id"] = serde_json::json!(tid);
-        }
-        let resp = self.client.post(&url).json(&body).send().await?;
-        if !resp.status().is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendVoice failed: {body_text}");
-        }
-        Ok(())
+        self.api_send_media_request("sendVoice", chat_id, body, thread_id)
+            .await
     }
 
     /// Call `sendVideo` on the Telegram API.
@@ -332,24 +386,13 @@ impl TelegramAdapter {
         caption: Option<&str>,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!("{}/bot{}/sendVideo", self.api_base_url, self.token.as_str());
-        let mut body = serde_json::json!({
-            "chat_id": chat_id,
-            "video": video_url,
-        });
+        let mut body = serde_json::json!({ "video": video_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
             body["parse_mode"] = serde_json::Value::String("HTML".to_string());
         }
-        if let Some(tid) = thread_id {
-            body["message_thread_id"] = serde_json::json!(tid);
-        }
-        let resp = self.client.post(&url).json(&body).send().await?;
-        if !resp.status().is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendVideo failed: {body_text}");
-        }
-        Ok(())
+        self.api_send_media_request("sendVideo", chat_id, body, thread_id)
+            .await
     }
 
     /// Call `sendLocation` on the Telegram API.
@@ -360,25 +403,12 @@ impl TelegramAdapter {
         lon: f64,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let url = format!(
-            "{}/bot{}/sendLocation",
-            self.api_base_url,
-            self.token.as_str()
-        );
-        let mut body = serde_json::json!({
-            "chat_id": chat_id,
+        let body = serde_json::json!({
             "latitude": lat,
             "longitude": lon,
         });
-        if let Some(tid) = thread_id {
-            body["message_thread_id"] = serde_json::json!(tid);
-        }
-        let resp = self.client.post(&url).json(&body).send().await?;
-        if !resp.status().is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            warn!("Telegram sendLocation failed: {body_text}");
-        }
-        Ok(())
+        self.api_send_media_request("sendLocation", chat_id, body, thread_id)
+            .await
     }
 
     /// Call `sendMessage` with an `InlineKeyboardMarkup` reply_markup.
@@ -452,38 +482,6 @@ impl TelegramAdapter {
         Ok(())
     }
 
-    /// Answer a callback query to dismiss the loading indicator on the button.
-    ///
-    /// Telegram shows a progress spinner on the button until the bot calls
-    /// `answerCallbackQuery`. Fire-and-forget.
-    #[allow(dead_code)]
-    fn fire_answer_callback_query(&self, callback_query_id: &str, notification_text: Option<&str>) {
-        let url = format!(
-            "{}/bot{}/answerCallbackQuery",
-            self.api_base_url,
-            self.token.as_str()
-        );
-        let mut body = serde_json::json!({
-            "callback_query_id": callback_query_id,
-        });
-        if let Some(text) = notification_text {
-            body["text"] = serde_json::json!(text);
-        }
-        let client = self.client.clone();
-        tokio::spawn(async move {
-            match client.post(&url).json(&body).send().await {
-                Ok(resp) if !resp.status().is_success() => {
-                    let body_text = resp.text().await.unwrap_or_default();
-                    debug!("Telegram answerCallbackQuery failed: {body_text}");
-                }
-                Err(e) => {
-                    debug!("Telegram answerCallbackQuery error: {e}");
-                }
-                _ => {}
-            }
-        });
-    }
-
     /// Call `sendChatAction` to show "typing..." indicator.
     ///
     /// When `thread_id` is provided, the typing indicator appears in the forum topic.
@@ -513,9 +511,9 @@ impl TelegramAdapter {
     /// Used for streaming: we send an initial placeholder, then edit it in-place
     /// as tokens arrive. Returns `None` if the API call fails.
     ///
-    /// The initial message is sent as plain text (no `parse_mode`) because the
-    /// content is raw, unformatted LLM output that may contain `<`, `>`, `&`
-    /// characters. HTML formatting is only applied on the final edit.
+    /// The initial message is sent with `parse_mode: HTML` after sanitization.
+    /// The `formatter::format_for_channel` output is expected as input, which
+    /// produces Telegram-compatible HTML from Markdown.
     async fn api_send_message_returning_id(
         &self,
         chat_id: i64,
@@ -527,10 +525,12 @@ impl TelegramAdapter {
             self.api_base_url,
             self.token.as_str()
         );
-        let sanitized = sanitize_telegram_html(text);
+        // No sanitization here — callers (send_streaming) already format via
+        // formatter::format_for_channel which produces Telegram-safe HTML.
+        // Double-sanitizing would escape already-valid entities.
         let mut body = serde_json::json!({
             "chat_id": chat_id,
-            "text": sanitized,
+            "text": text,
             "parse_mode": "HTML",
         });
         if let Some(tid) = thread_id {
@@ -588,11 +588,13 @@ impl TelegramAdapter {
             self.token.as_str()
         );
         let body = if html {
-            let sanitized = sanitize_telegram_html(text);
+            // No sanitization here — callers (send_streaming) already format via
+            // formatter::format_for_channel which produces Telegram-safe HTML.
+            // Double-sanitizing would escape already-valid entities.
             serde_json::json!({
                 "chat_id": chat_id,
                 "message_id": message_id,
-                "text": sanitized,
+                "text": text,
                 "parse_mode": "HTML",
             })
         } else {
@@ -792,8 +794,9 @@ impl ChannelAdapter for TelegramAdapter {
         let initial_backoff = self.initial_backoff;
         let max_backoff = self.max_backoff;
         let long_poll_timeout = self.long_poll_timeout;
+        let poll_handle = self.poll_handle.clone();
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut offset: Option<i64> = None;
             let mut backoff = initial_backoff;
 
@@ -818,7 +821,7 @@ impl ChannelAdapter for TelegramAdapter {
                 let result = tokio::select! {
                     res = async {
                         client
-                            .get(&url)
+                            .post(&url)
                             .json(&params)
                             .timeout(request_timeout)
                             .send()
@@ -834,7 +837,7 @@ impl ChannelAdapter for TelegramAdapter {
                     Err(e) => {
                         warn!("Telegram getUpdates network error: {e}, retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(max_backoff);
+                        backoff = calculate_backoff(backoff, max_backoff);
                         continue;
                     }
                 };
@@ -856,7 +859,7 @@ impl ChannelAdapter for TelegramAdapter {
                 if status.as_u16() == 409 {
                     warn!("Telegram 409 Conflict — stale polling session, retrying in {backoff:?}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(max_backoff);
+                    backoff = calculate_backoff(backoff, max_backoff);
                     continue;
                 }
 
@@ -864,7 +867,7 @@ impl ChannelAdapter for TelegramAdapter {
                     let body_text = resp.text().await.unwrap_or_default();
                     warn!("Telegram getUpdates failed ({status}): {body_text}, retrying in {backoff:?}");
                     tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(max_backoff);
+                    backoff = calculate_backoff(backoff, max_backoff);
                     continue;
                 }
 
@@ -874,19 +877,19 @@ impl ChannelAdapter for TelegramAdapter {
                     Err(e) => {
                         warn!("Telegram getUpdates parse error: {e}");
                         tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(max_backoff);
+                        backoff = calculate_backoff(backoff, max_backoff);
                         continue;
                     }
                 };
-
-                // Reset backoff on success
-                backoff = initial_backoff;
 
                 if body["ok"].as_bool() != Some(true) {
                     warn!("Telegram getUpdates returned ok=false");
                     tokio::time::sleep(poll_interval).await;
                     continue;
                 }
+
+                // Reset backoff on success
+                backoff = initial_backoff;
 
                 let updates = match body["result"].as_array() {
                     Some(arr) => arr,
@@ -995,6 +998,12 @@ impl ChannelAdapter for TelegramAdapter {
 
             info!("Telegram polling loop stopped");
         });
+
+        // Store handle for graceful shutdown in stop()
+        {
+            let mut guard = poll_handle.lock().await;
+            *guard = Some(handle);
+        }
 
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(Box::pin(stream))
@@ -1164,6 +1173,15 @@ impl ChannelAdapter for TelegramAdapter {
 
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let _ = self.shutdown_tx.send(true);
+        let mut guard = self.poll_handle.lock().await;
+        if let Some(handle) = guard.take() {
+            // Give the polling loop up to 5 seconds to finish
+            match tokio::time::timeout(Duration::from_secs(5), handle).await {
+                Ok(Ok(())) => info!("Telegram polling loop stopped gracefully"),
+                Ok(Err(e)) => warn!("Telegram polling task panicked: {e}"),
+                Err(_) => warn!("Telegram polling loop did not stop within 5s timeout"),
+            }
+        }
         Ok(())
     }
 }
@@ -1351,6 +1369,293 @@ fn parse_telegram_callback_query(
     })
 }
 
+/// Extract sender identity from a Telegram message.
+///
+/// Tries `from` (user) first, then falls back to `sender_chat` (channel/group).
+/// Returns `(user_id, display_name, Option<username>)`.
+fn extract_telegram_sender(
+    message: &serde_json::Value,
+    update_id: i64,
+) -> Result<(i64, String, Option<String>), DropReason> {
+    if let Some(from) = message.get("from") {
+        let uid = match from["id"].as_i64() {
+            Some(id) => id,
+            None => {
+                return Err(DropReason::ParseError(format!(
+                    "update {update_id}: from.id is not an integer"
+                )));
+            }
+        };
+        let first_name = from["first_name"].as_str().unwrap_or("Unknown");
+        let last_name = from["last_name"].as_str().unwrap_or("");
+        let name = if last_name.is_empty() {
+            first_name.to_string()
+        } else {
+            format!("{first_name} {last_name}")
+        };
+        let username = from["username"].as_str().map(String::from);
+        Ok((uid, name, username))
+    } else if let Some(sender_chat) = message.get("sender_chat") {
+        // Messages sent on behalf of a channel or group have `sender_chat` instead of `from`.
+        let uid = match sender_chat["id"].as_i64() {
+            Some(id) => id,
+            None => {
+                return Err(DropReason::ParseError(format!(
+                    "update {update_id}: sender_chat.id is not an integer"
+                )));
+            }
+        };
+        let title = sender_chat["title"].as_str().unwrap_or("Unknown Channel");
+        Ok((uid, title.to_string(), None))
+    } else {
+        Err(DropReason::ParseError(format!(
+            "update {update_id} has no from or sender_chat field"
+        )))
+    }
+}
+
+/// Determine the content type from a Telegram message.
+///
+/// Handles: text, photo, document, audio, voice, video, video_note, location.
+/// Falls back to DropReason::Filtered for unsupported types.
+async fn extract_telegram_content(
+    message: &serde_json::Value,
+    update_id: i64,
+    token: &str,
+    client: &reqwest::Client,
+    api_base_url: &str,
+) -> Result<ChannelContent, DropReason> {
+    if let Some(text) = message["text"].as_str() {
+        // Parse bot commands (Telegram sends entities for /commands)
+        if let Some(entities) = message["entities"].as_array() {
+            let is_bot_command = entities.iter().any(|e| {
+                e["type"].as_str() == Some("bot_command") && e["offset"].as_i64() == Some(0)
+            });
+            if is_bot_command {
+                let parts: Vec<&str> = text.splitn(2, ' ').collect();
+                let cmd_name = parts[0].trim_start_matches('/');
+                let cmd_name = cmd_name.split('@').next().unwrap_or(cmd_name);
+                let args = if parts.len() > 1 {
+                    parts[1].split_whitespace().map(String::from).collect()
+                } else {
+                    vec![]
+                };
+                Ok(ChannelContent::Command {
+                    name: cmd_name.to_string(),
+                    args,
+                })
+            } else {
+                Ok(ChannelContent::Text(text.to_string()))
+            }
+        } else {
+            Ok(ChannelContent::Text(text.to_string()))
+        }
+    } else if let Some(photos) = message["photo"].as_array() {
+        // Photos come as array of sizes; pick the largest (last)
+        let file_id = photos
+            .last()
+            .and_then(|p| p["file_id"].as_str())
+            .unwrap_or("");
+        let caption = message["caption"].as_str().map(String::from);
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => {
+                let mime_type = mime_type_from_telegram_path(&url);
+                Ok(ChannelContent::Image {
+                    url,
+                    caption,
+                    mime_type,
+                })
+            }
+            None => Ok(ChannelContent::Text(format!(
+                "[Photo received{}]",
+                caption
+                    .as_deref()
+                    .map(|c| format!(": {c}"))
+                    .unwrap_or_default()
+            ))),
+        }
+    } else if message.get("document").is_some() {
+        let file_id = message["document"]["file_id"].as_str().unwrap_or("");
+        let filename = message["document"]["file_name"]
+            .as_str()
+            .unwrap_or("document")
+            .to_string();
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => Ok(ChannelContent::File { url, filename }),
+            None => Ok(ChannelContent::Text(format!(
+                "[Document received: {filename}]"
+            ))),
+        }
+    } else if message.get("audio").is_some() {
+        // Audio files (mp3, etc.) — treat as voice for transcription
+        let file_id = message["audio"]["file_id"].as_str().unwrap_or("");
+        let duration = message["audio"]["duration"].as_u64().unwrap_or(0) as u32;
+        let caption = message["caption"].as_str().map(String::from);
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => Ok(ChannelContent::Voice {
+                url,
+                caption,
+                duration_seconds: duration,
+            }),
+            None => Ok(ChannelContent::Text(format!(
+                "[Audio received, {duration}s{}]",
+                caption
+                    .as_deref()
+                    .map(|c| format!(": {c}"))
+                    .unwrap_or_default()
+            ))),
+        }
+    } else if message.get("voice").is_some() {
+        let file_id = message["voice"]["file_id"].as_str().unwrap_or("");
+        let duration = message["voice"]["duration"].as_u64().unwrap_or(0) as u32;
+        let caption = message["caption"].as_str().map(String::from);
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => Ok(ChannelContent::Voice {
+                url,
+                caption,
+                duration_seconds: duration,
+            }),
+            None => Ok(ChannelContent::Text(format!(
+                "[Voice message, {duration}s]"
+            ))),
+        }
+    } else if message.get("video").is_some() {
+        let file_id = message["video"]["file_id"].as_str().unwrap_or("");
+        let duration = message["video"]["duration"].as_u64().unwrap_or(0) as u32;
+        let caption = message["caption"].as_str().map(String::from);
+        let filename = message["video"]["file_name"].as_str().map(String::from);
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => Ok(ChannelContent::Video {
+                url,
+                caption,
+                duration_seconds: duration,
+                filename,
+            }),
+            None => Ok(ChannelContent::Text(format!(
+                "[Video received, {duration}s{}]",
+                caption
+                    .as_deref()
+                    .map(|c| format!(": {c}"))
+                    .unwrap_or_default()
+            ))),
+        }
+    } else if message.get("video_note").is_some() {
+        // Video notes are round video messages (no caption/filename)
+        let file_id = message["video_note"]["file_id"].as_str().unwrap_or("");
+        let duration = message["video_note"]["duration"].as_u64().unwrap_or(0) as u32;
+        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+            Some(url) => Ok(ChannelContent::Video {
+                url,
+                caption: None,
+                duration_seconds: duration,
+                filename: None,
+            }),
+            None => Ok(ChannelContent::Text(format!("[Video note, {duration}s]"))),
+        }
+    } else if message.get("location").is_some() {
+        let lat = message["location"]["latitude"].as_f64().unwrap_or(0.0);
+        let lon = message["location"]["longitude"].as_f64().unwrap_or(0.0);
+        Ok(ChannelContent::Location { lat, lon })
+    } else {
+        // Unsupported message type (stickers, polls, etc.)
+        Err(DropReason::Filtered(format!(
+            "update {update_id}: unsupported message type (no text/photo/document/voice/video/video_note/location)"
+        )))
+    }
+}
+
+/// Apply reply-to-message context to the content.
+///
+/// If the message is a reply, prepends the quoted text and optionally includes
+/// the quoted photo.
+async fn apply_reply_context(
+    content: ChannelContent,
+    message: &serde_json::Value,
+    token: &str,
+    client: &reqwest::Client,
+    api_base_url: &str,
+) -> ChannelContent {
+    let reply = match message.get("reply_to_message") {
+        Some(r) => r,
+        None => return content,
+    };
+
+    let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
+    let reply_text = reply["text"].as_str().or_else(|| reply["caption"].as_str());
+
+    // Check if the quoted message has a photo
+    let reply_photo_url = if let Some(photos) = reply["photo"].as_array() {
+        let file_id = photos
+            .last()
+            .and_then(|p| p["file_id"].as_str())
+            .unwrap_or("");
+        if !file_id.is_empty() {
+            telegram_get_file_url(token, client, file_id, api_base_url).await
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(photo_url) = reply_photo_url {
+        // Quoted message has a photo.
+        // If the user's own message is already an image, keep it and add
+        // the quoted photo context as text (don't overwrite the user's photo).
+        let quote_context = reply_text
+            .map(|q| {
+                let truncated = if q.len() > 200 {
+                    format!("{}...", &q[..q.floor_char_boundary(200)])
+                } else {
+                    q.to_string()
+                };
+                format!("[Replying to {reply_sender}: \"{truncated}\"]\n")
+            })
+            .unwrap_or_else(|| format!("[Replying to {reply_sender}'s photo]\n"));
+
+        match content {
+            ChannelContent::Image {
+                url,
+                caption,
+                mime_type,
+            } => {
+                // User sent their own photo as reply — keep it, add quoted context to caption
+                let cap = caption.unwrap_or_default();
+                ChannelContent::Image {
+                    url,
+                    caption: Some(format!("{quote_context}{cap}")),
+                    mime_type,
+                }
+            }
+            ChannelContent::Text(t) => {
+                // User sent text reply to a photo — show the quoted photo
+                let caption = format!("{quote_context}{t}");
+                let mime_type = mime_type_from_telegram_path(&photo_url);
+                ChannelContent::Image {
+                    url: photo_url,
+                    caption: Some(caption),
+                    mime_type,
+                }
+            }
+            other => other,
+        }
+    } else if let Some(quoted) = reply_text {
+        // Quoted message has text only — prepend it
+        let truncated = if quoted.len() > 200 {
+            format!("{}...", &quoted[..quoted.floor_char_boundary(200)])
+        } else {
+            quoted.to_string()
+        };
+        let prefix = format!("[Replying to {reply_sender}: \"{truncated}\"]\n");
+        match content {
+            ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
+            other => other,
+        }
+    } else {
+        content
+    }
+}
+
 async fn parse_telegram_update(
     update: &serde_json::Value,
     allowed_users: &[String],
@@ -1372,42 +1677,7 @@ async fn parse_telegram_update(
         }
     };
 
-    // Extract sender info: prefer `from` (user), fall back to `sender_chat` (channel/group)
-    let (user_id, display_name, username) = if let Some(from) = message.get("from") {
-        let uid = match from["id"].as_i64() {
-            Some(id) => id,
-            None => {
-                return Err(DropReason::ParseError(format!(
-                    "update {update_id}: from.id is not an integer"
-                )));
-            }
-        };
-        let first_name = from["first_name"].as_str().unwrap_or("Unknown");
-        let last_name = from["last_name"].as_str().unwrap_or("");
-        let name = if last_name.is_empty() {
-            first_name.to_string()
-        } else {
-            format!("{first_name} {last_name}")
-        };
-        let username = from["username"].as_str().map(String::from);
-        (uid, name, username)
-    } else if let Some(sender_chat) = message.get("sender_chat") {
-        // Messages sent on behalf of a channel or group have `sender_chat` instead of `from`.
-        let uid = match sender_chat["id"].as_i64() {
-            Some(id) => id,
-            None => {
-                return Err(DropReason::ParseError(format!(
-                    "update {update_id}: sender_chat.id is not an integer"
-                )));
-            }
-        };
-        let title = sender_chat["title"].as_str().unwrap_or("Unknown Channel");
-        (uid, title.to_string(), None)
-    } else {
-        return Err(DropReason::ParseError(format!(
-            "update {update_id} has no from or sender_chat field"
-        )));
-    };
+    let (user_id, display_name, username) = extract_telegram_sender(message, update_id)?;
 
     // Security: check allowed_users (supports user ID and username)
     if !telegram_user_allowed(allowed_users, user_id, username.as_deref()) {
@@ -1417,15 +1687,9 @@ async fn parse_telegram_update(
         )));
     }
 
-    let chat_id = match message["chat"]["id"].as_i64() {
-        Some(id) => id,
-        None => {
-            return Err(DropReason::ParseError(format!(
-                "update {update_id}: chat.id is not an integer"
-            )));
-        }
-    };
-
+    let chat_id = message["chat"]["id"].as_i64().ok_or_else(|| {
+        DropReason::ParseError(format!("update {update_id}: chat.id is not an integer"))
+    })?;
     let chat_type = message["chat"]["type"].as_str().unwrap_or("private");
     let is_group = chat_type == "group" || chat_type == "supergroup";
     let message_id = message["message_id"].as_i64().unwrap_or(0);
@@ -1434,222 +1698,8 @@ async fn parse_telegram_update(
         .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
         .unwrap_or_else(chrono::Utc::now);
 
-    // Determine content: text, photo, document, voice, or location
-    let content = if let Some(text) = message["text"].as_str() {
-        // Parse bot commands (Telegram sends entities for /commands)
-        if let Some(entities) = message["entities"].as_array() {
-            let is_bot_command = entities.iter().any(|e| {
-                e["type"].as_str() == Some("bot_command") && e["offset"].as_i64() == Some(0)
-            });
-            if is_bot_command {
-                let parts: Vec<&str> = text.splitn(2, ' ').collect();
-                let cmd_name = parts[0].trim_start_matches('/');
-                let cmd_name = cmd_name.split('@').next().unwrap_or(cmd_name);
-                let args = if parts.len() > 1 {
-                    parts[1].split_whitespace().map(String::from).collect()
-                } else {
-                    vec![]
-                };
-                ChannelContent::Command {
-                    name: cmd_name.to_string(),
-                    args,
-                }
-            } else {
-                ChannelContent::Text(text.to_string())
-            }
-        } else {
-            ChannelContent::Text(text.to_string())
-        }
-    } else if let Some(photos) = message["photo"].as_array() {
-        // Photos come as array of sizes; pick the largest (last)
-        let file_id = photos
-            .last()
-            .and_then(|p| p["file_id"].as_str())
-            .unwrap_or("");
-        let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => {
-                let mime_type = mime_type_from_telegram_path(&url);
-                ChannelContent::Image {
-                    url,
-                    caption,
-                    mime_type,
-                }
-            }
-            None => ChannelContent::Text(format!(
-                "[Photo received{}]",
-                caption
-                    .as_deref()
-                    .map(|c| format!(": {c}"))
-                    .unwrap_or_default()
-            )),
-        }
-    } else if message.get("document").is_some() {
-        let file_id = message["document"]["file_id"].as_str().unwrap_or("");
-        let filename = message["document"]["file_name"]
-            .as_str()
-            .unwrap_or("document")
-            .to_string();
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::File { url, filename },
-            None => ChannelContent::Text(format!("[Document received: {filename}]")),
-        }
-    } else if message.get("audio").is_some() {
-        // Audio files (mp3, etc.) — treat as voice for transcription
-        let file_id = message["audio"]["file_id"].as_str().unwrap_or("");
-        let duration = message["audio"]["duration"].as_u64().unwrap_or(0) as u32;
-        let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::Voice {
-                url,
-                caption,
-                duration_seconds: duration,
-            },
-            None => ChannelContent::Text(format!(
-                "[Audio received, {duration}s{}]",
-                caption
-                    .as_deref()
-                    .map(|c| format!(": {c}"))
-                    .unwrap_or_default()
-            )),
-        }
-    } else if message.get("voice").is_some() {
-        let file_id = message["voice"]["file_id"].as_str().unwrap_or("");
-        let duration = message["voice"]["duration"].as_u64().unwrap_or(0) as u32;
-        let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::Voice {
-                url,
-                caption,
-                duration_seconds: duration,
-            },
-            None => ChannelContent::Text(format!("[Voice message, {duration}s]")),
-        }
-    } else if message.get("video").is_some() {
-        let file_id = message["video"]["file_id"].as_str().unwrap_or("");
-        let duration = message["video"]["duration"].as_u64().unwrap_or(0) as u32;
-        let caption = message["caption"].as_str().map(String::from);
-        let filename = message["video"]["file_name"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::Video {
-                url,
-                caption,
-                duration_seconds: duration,
-                filename,
-            },
-            None => ChannelContent::Text(format!(
-                "[Video received, {duration}s{}]",
-                caption
-                    .as_deref()
-                    .map(|c| format!(": {c}"))
-                    .unwrap_or_default()
-            )),
-        }
-    } else if message.get("video_note").is_some() {
-        // Video notes are round video messages (no caption/filename)
-        let file_id = message["video_note"]["file_id"].as_str().unwrap_or("");
-        let duration = message["video_note"]["duration"].as_u64().unwrap_or(0) as u32;
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
-            Some(url) => ChannelContent::Video {
-                url,
-                caption: None,
-                duration_seconds: duration,
-                filename: None,
-            },
-            None => ChannelContent::Text(format!("[Video note, {duration}s]")),
-        }
-    } else if message.get("location").is_some() {
-        let lat = message["location"]["latitude"].as_f64().unwrap_or(0.0);
-        let lon = message["location"]["longitude"].as_f64().unwrap_or(0.0);
-        ChannelContent::Location { lat, lon }
-    } else {
-        // Unsupported message type (stickers, polls, etc.)
-        return Err(DropReason::Filtered(format!(
-            "update {update_id}: unsupported message type (no text/photo/document/voice/video/video_note/location)"
-        )));
-    };
-
-    // Extract reply-to-message context (Telegram `reply_to_message` field).
-    // Prepend the quoted original text so the agent sees what the user is replying to.
-    // If the quoted message has a photo, include it so the agent can see it.
-    let content = if let Some(reply) = message.get("reply_to_message") {
-        let reply_sender = reply["from"]["first_name"].as_str().unwrap_or("Someone");
-        let reply_text = reply["text"].as_str().or_else(|| reply["caption"].as_str());
-
-        // Check if the quoted message has a photo
-        let reply_photo_url = if let Some(photos) = reply["photo"].as_array() {
-            let file_id = photos
-                .last()
-                .and_then(|p| p["file_id"].as_str())
-                .unwrap_or("");
-            if !file_id.is_empty() {
-                telegram_get_file_url(token, client, file_id, api_base_url).await
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        if let Some(photo_url) = reply_photo_url {
-            // Quoted message has a photo.
-            // If the user's own message is already an image, keep it and add
-            // the quoted photo context as text (don't overwrite the user's photo).
-            let quote_context = reply_text
-                .map(|q| {
-                    let truncated = if q.len() > 200 {
-                        format!("{}...", &q[..q.floor_char_boundary(200)])
-                    } else {
-                        q.to_string()
-                    };
-                    format!("[Replying to {reply_sender}: \"{truncated}\"]\n")
-                })
-                .unwrap_or_else(|| format!("[Replying to {reply_sender}'s photo]\n"));
-
-            match content {
-                ChannelContent::Image {
-                    url,
-                    caption,
-                    mime_type,
-                } => {
-                    // User sent their own photo as reply — keep it, add quoted context to caption
-                    let cap = caption.unwrap_or_default();
-                    ChannelContent::Image {
-                        url,
-                        caption: Some(format!("{quote_context}{cap}")),
-                        mime_type,
-                    }
-                }
-                ChannelContent::Text(t) => {
-                    // User sent text reply to a photo — show the quoted photo
-                    let caption = format!("{quote_context}{t}");
-                    let mime_type = mime_type_from_telegram_path(&photo_url);
-                    ChannelContent::Image {
-                        url: photo_url,
-                        caption: Some(caption),
-                        mime_type,
-                    }
-                }
-                other => other,
-            }
-        } else if let Some(quoted) = reply_text {
-            // Quoted message has text only — prepend it
-            let truncated = if quoted.len() > 200 {
-                format!("{}...", &quoted[..quoted.floor_char_boundary(200)])
-            } else {
-                quoted.to_string()
-            };
-            let prefix = format!("[Replying to {reply_sender}: \"{truncated}\"]\n");
-            match content {
-                ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
-                other => other,
-            }
-        } else {
-            content
-        }
-    } else {
-        content
-    };
+    let content = extract_telegram_content(message, update_id, token, client, api_base_url).await?;
+    let content = apply_reply_context(content, message, token, client, api_base_url).await;
 
     // Extract forum topic thread_id (Telegram sends this as `message_thread_id`
     // for messages inside forum topics / reply threads).
@@ -1657,7 +1707,7 @@ async fn parse_telegram_update(
         .as_i64()
         .map(|tid| tid.to_string());
 
-    // Detect @mention of the bot in entities / caption_entities for MentionOnly group policy.
+    // Build metadata
     let mut metadata = HashMap::new();
 
     // Store reply-to-message metadata for downstream consumers.
@@ -1680,6 +1730,7 @@ async fn parse_telegram_update(
             }),
         );
     }
+
     if is_group {
         if let Some(bot_uname) = bot_username {
             let was_mentioned = check_mention_entities(message, bot_uname);
@@ -1706,6 +1757,20 @@ async fn parse_telegram_update(
     })
 }
 
+/// Convert a UTF-16 code unit offset (as returned by Telegram API) to a byte
+/// offset suitable for Rust `&str` slicing.
+fn utf16_offset_to_byte_offset(text: &str, utf16_offset: usize) -> usize {
+    let mut utf16_count = 0usize;
+    for (byte_idx, ch) in text.char_indices() {
+        if utf16_count >= utf16_offset {
+            return byte_idx;
+        }
+        // BMP characters = 1 UTF-16 unit, non-BMP (surrogate pairs) = 2
+        utf16_count += if ch as u32 > 0xFFFF { 2 } else { 1 };
+    }
+    text.len()
+}
+
 /// Check whether the bot was @mentioned in a Telegram message.
 ///
 /// Inspects both `entities` (for text messages) and `caption_entities` (for media
@@ -1727,10 +1792,12 @@ fn check_mention_entities(message: &serde_json::Value, bot_username: &str) -> bo
                 if entity["type"].as_str() != Some("mention") {
                     continue;
                 }
-                let offset = entity["offset"].as_i64().unwrap_or(0) as usize;
-                let length = entity["length"].as_i64().unwrap_or(0) as usize;
-                if offset + length <= text.len() {
-                    let mention_text = &text[offset..offset + length];
+                let utf16_offset = entity["offset"].as_i64().unwrap_or(0) as usize;
+                let utf16_length = entity["length"].as_i64().unwrap_or(0) as usize;
+                let start = utf16_offset_to_byte_offset(text, utf16_offset);
+                let end = utf16_offset_to_byte_offset(text, utf16_offset + utf16_length);
+                if start < text.len() && end <= text.len() {
+                    let mention_text = &text[start..end];
                     if mention_text.to_lowercase() == bot_mention {
                         return true;
                     }
@@ -2825,6 +2892,131 @@ mod tests {
         let output = sanitize_telegram_html(input);
         assert!(output.contains("<b>bold</b>"));
         assert!(output.contains("&lt;thinking&gt;"));
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_unclosed_tags() {
+        // Unclosed tags should be auto-closed at the end
+        let input = "<b>bold text";
+        let output = sanitize_telegram_html(input);
+        assert!(
+            output.contains("<b>bold text"),
+            "content should be preserved"
+        );
+        assert!(
+            output.ends_with("</b>"),
+            "unclosed <b> should be auto-closed"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_nested_tags() {
+        // Nested allowed tags should work correctly
+        let input = "<pre><code>fn main() {}</code></pre>";
+        let output = sanitize_telegram_html(input);
+        assert_eq!(output, input, "nested pre+code should be preserved as-is");
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_link_with_attributes() {
+        // <a> tags with href attribute should be preserved
+        let input = r#"<a href="https://example.com">link</a>"#;
+        let output = sanitize_telegram_html(input);
+        assert!(
+            output.contains(r#"href="https://example.com""#),
+            "href attribute should be preserved"
+        );
+        assert!(
+            output.contains(">link</a>"),
+            "link text should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_self_closing_tags() {
+        // Tags ending with /> should not be tracked as open
+        let input = "before <br/> after";
+        let output = sanitize_telegram_html(input);
+        // <br/> is not in ALLOWED, so it gets escaped
+        assert!(output.contains("before"), "text before should remain");
+        assert!(output.contains("after"), "text after should remain");
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_empty_angle_brackets() {
+        // Lone <> should be escaped
+        let input = "text <> more";
+        let output = sanitize_telegram_html(input);
+        assert!(output.contains("&lt;"), "empty <> should be escaped");
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_lone_open_bracket() {
+        // Lone < without closing > should be escaped
+        let input = "text < more";
+        let output = sanitize_telegram_html(input);
+        assert!(output.contains("&lt;"), "lone < should be escaped");
+        assert!(output.contains(" more"), "rest of text should be preserved");
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_unicode() {
+        // Unicode/emoji in text should not be corrupted
+        let input = "<b>Привет 🌍 мир</b> <unknown>test</unknown>";
+        let output = sanitize_telegram_html(input);
+        assert!(
+            output.contains("<b>Привет 🌍 мир</b>"),
+            "unicode in allowed tags should be preserved"
+        );
+        assert!(
+            output.contains("&lt;unknown&gt;"),
+            "unknown tags should be escaped"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_idempotent() {
+        // Sanitizing twice should produce the same output as sanitizing once
+        let input = "<b>bold</b> <thinking>hmm</thinking> <code>inline</code> <foo>bar</foo>";
+        let first = sanitize_telegram_html(input);
+        let second = sanitize_telegram_html(&first);
+        assert_eq!(first, second, "sanitize_telegram_html should be idempotent");
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_all_allowed_tags() {
+        // Every tag in the ALLOWED list should pass through
+        let tags = [
+            "b",
+            "i",
+            "u",
+            "s",
+            "em",
+            "strong",
+            "code",
+            "pre",
+            "blockquote",
+        ];
+        for tag in tags {
+            let input = format!("<{tag}>text</{tag}>");
+            let output = sanitize_telegram_html(&input);
+            assert_eq!(output, input, "allowed tag <{tag}> should pass through");
+        }
+    }
+
+    #[test]
+    fn test_sanitize_telegram_html_multiple_unknown_tags() {
+        // Multiple unknown tags should all be escaped
+        let input = "<name>John</name> <age>25</age>";
+        let output = sanitize_telegram_html(input);
+        assert!(output.contains("&lt;name&gt;"), "<name> should be escaped");
+        assert!(
+            output.contains("&lt;/name&gt;"),
+            "</name> should be escaped"
+        );
+        assert!(output.contains("&lt;age&gt;"), "<age> should be escaped");
+        assert!(output.contains("John"), "inner text should be preserved");
+        assert!(output.contains("25"), "inner text should be preserved");
     }
 
     #[test]

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -29,18 +29,91 @@ const DEFAULT_API_URL: &str = "https://api.telegram.org";
 /// provides a safe margin while keeping the UX responsive.
 const STREAMING_EDIT_INTERVAL: Duration = Duration::from_millis(1000);
 
+/// Truncate text to `max_len` bytes (respecting char boundaries) and append "..." if truncated.
+fn truncate_with_ellipsis(text: &str, max_len: usize) -> String {
+    if text.len() > max_len {
+        format!("{}...", &text[..text.floor_char_boundary(max_len)])
+    } else {
+        text.to_string()
+    }
+}
+
+/// Default retry delay (seconds) when Telegram doesn't specify `retry_after`.
+const RETRY_AFTER_DEFAULT_SECS: u64 = 2;
+
+/// Extract `retry_after` from a Telegram 429 response body.
+fn extract_retry_after(body: &str, default: u64) -> u64 {
+    body.parse::<serde_json::Value>()
+        .ok()
+        .and_then(|v| v["parameters"]["retry_after"].as_u64())
+        .unwrap_or(default)
+}
+
+/// Telegram `parse_mode` for HTML formatting.
+const PARSE_MODE_HTML: &str = "HTML";
+
+/// Check if a Telegram chat type represents a group.
+fn is_group_chat(chat_type: &str) -> bool {
+    chat_type == "group" || chat_type == "supergroup"
+}
+
+/// Fire-and-forget HTTP POST. Logs errors at debug level.
+fn fire_and_forget_post(client: reqwest::Client, url: String, body: serde_json::Value) {
+    tokio::spawn(async move {
+        match client.post(&url).json(&body).send().await {
+            Ok(resp) if !resp.status().is_success() => {
+                let body_text = resp.text().await.unwrap_or_default();
+                debug!("Telegram fire-and-forget POST failed: {body_text}");
+            }
+            Err(e) => {
+                debug!("Telegram fire-and-forget POST error: {e}");
+            }
+            _ => {}
+        }
+    });
+}
+
+/// Shared Telegram API context for free functions that need token/client/base_url.
+struct TelegramApiCtx<'a> {
+    token: &'a str,
+    client: &'a reqwest::Client,
+    api_base_url: &'a str,
+}
+
+impl<'a> TelegramApiCtx<'a> {
+    /// Resolve a Telegram file_id to a download URL via the Bot API.
+    async fn get_file_url(&self, file_id: &str) -> Option<String> {
+        let url = format!("{}/bot{}/getFile", self.api_base_url, self.token);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({"file_id": file_id}))
+            .send()
+            .await
+            .ok()?;
+        let body: serde_json::Value = resp.json().await.ok()?;
+        if body["ok"].as_bool() != Some(true) {
+            return None;
+        }
+        let file_path = body["result"]["file_path"].as_str()?;
+        Some(format!(
+            "{}/file/bot{}/{}",
+            self.api_base_url, self.token, file_path
+        ))
+    }
+}
+
 /// Telegram Bot API adapter using long-polling.
 pub struct TelegramAdapter {
     /// SECURITY: Bot token is zeroized on drop to prevent memory disclosure.
     token: Zeroizing<String>,
     client: reqwest::Client,
-    allowed_users: Vec<String>,
+    allowed_users: Arc<[String]>,
     poll_interval: Duration,
     /// Base URL for Telegram Bot API (supports proxies/mirrors).
     api_base_url: String,
     /// Bot username (without @), populated from `getMe` during `start()`.
-    /// Used for @mention detection in group messages.
-    bot_username: Arc<tokio::sync::RwLock<Option<String>>>,
+    bot_username: std::sync::OnceLock<String>,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
     /// Thread-based agent routing: thread_id -> agent name.
@@ -79,10 +152,10 @@ impl TelegramAdapter {
         Self {
             token: Zeroizing::new(token),
             client: crate::http_client::new_client(),
-            allowed_users,
+            allowed_users: allowed_users.into(),
             poll_interval,
             api_base_url,
-            bot_username: Arc::new(tokio::sync::RwLock::new(None)),
+            bot_username: std::sync::OnceLock::new(),
             account_id: None,
             thread_routes: HashMap::new(),
             initial_backoff: Duration::from_secs(1),
@@ -125,6 +198,13 @@ impl TelegramAdapter {
     pub fn with_thread_routes(mut self, thread_routes: HashMap<String, String>) -> Self {
         self.thread_routes = thread_routes;
         self
+    }
+
+    /// Parse the platform_id from a ChannelUser as a Telegram chat_id (i64).
+    fn parse_chat_id(user: &ChannelUser) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+        user.platform_id
+            .parse()
+            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id).into())
     }
 
     /// Validate the bot token by calling `getMe`.
@@ -171,7 +251,7 @@ impl TelegramAdapter {
             let mut body = serde_json::json!({
                 "chat_id": chat_id,
                 "text": chunk,
-                "parse_mode": "HTML",
+                "parse_mode": PARSE_MODE_HTML,
             });
             if let Some(tid) = thread_id {
                 body["message_thread_id"] = serde_json::json!(tid);
@@ -232,13 +312,8 @@ impl TelegramAdapter {
             let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
 
-            // Retry once on 429 rate limit
             if status.as_u16() == 429 {
-                let retry_after = body_text
-                    .parse::<serde_json::Value>()
-                    .ok()
-                    .and_then(|v| v["parameters"]["retry_after"].as_u64())
-                    .unwrap_or(2);
+                let retry_after = extract_retry_after(&body_text, RETRY_AFTER_DEFAULT_SECS);
                 warn!("Telegram {endpoint} rate limited, retrying after {retry_after}s");
                 tokio::time::sleep(Duration::from_secs(retry_after)).await;
 
@@ -266,7 +341,7 @@ impl TelegramAdapter {
         let mut body = serde_json::json!({ "photo": photo_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
-            body["parse_mode"] = serde_json::Value::String("HTML".to_string());
+            body["parse_mode"] = serde_json::Value::String(PARSE_MODE_HTML.to_string());
         }
         self.api_send_media_request("sendPhoto", chat_id, body, thread_id)
             .await
@@ -307,10 +382,12 @@ impl TelegramAdapter {
             self.token.as_str()
         );
 
-        // Clone data upfront so we have a copy for a potential retry
-        let retry_data = data.clone();
+        // Convert to ref-counted Bytes so cloning is O(1) (atomic ref-count bump)
+        // instead of O(n) Vec deep-copy. Part::stream() accepts Bytes directly
+        // (Into<Body>), unlike Part::bytes() which requires Into<Cow<'static, [u8]>>.
+        let data_bytes = bytes::Bytes::from(data);
 
-        let file_part = reqwest::multipart::Part::bytes(data)
+        let file_part = reqwest::multipart::Part::stream(data_bytes.clone())
             .file_name(filename.to_string())
             .mime_str(mime_type)?;
 
@@ -327,18 +404,13 @@ impl TelegramAdapter {
             let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
 
-            // Retry once on 429 rate limit
             if status.as_u16() == 429 {
-                let retry_after = body_text
-                    .parse::<serde_json::Value>()
-                    .ok()
-                    .and_then(|v| v["parameters"]["retry_after"].as_u64())
-                    .unwrap_or(2);
+                let retry_after = extract_retry_after(&body_text, RETRY_AFTER_DEFAULT_SECS);
                 warn!("Telegram sendDocument upload rate limited, retrying after {retry_after}s");
                 tokio::time::sleep(Duration::from_secs(retry_after)).await;
 
-                // Rebuild the multipart form with the cloned data
-                let file_part = reqwest::multipart::Part::bytes(retry_data)
+                // Rebuild the multipart form — Bytes::clone() is O(1)
+                let file_part = reqwest::multipart::Part::stream(data_bytes.clone())
                     .file_name(filename.to_string())
                     .mime_str(mime_type)?;
                 let mut retry_form = reqwest::multipart::Form::new()
@@ -372,7 +444,7 @@ impl TelegramAdapter {
         let mut body = serde_json::json!({ "voice": voice_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
-            body["parse_mode"] = serde_json::Value::String("HTML".to_string());
+            body["parse_mode"] = serde_json::Value::String(PARSE_MODE_HTML.to_string());
         }
         self.api_send_media_request("sendVoice", chat_id, body, thread_id)
             .await
@@ -389,7 +461,7 @@ impl TelegramAdapter {
         let mut body = serde_json::json!({ "video": video_url });
         if let Some(cap) = caption {
             body["caption"] = serde_json::Value::String(cap.to_string());
-            body["parse_mode"] = serde_json::Value::String("HTML".to_string());
+            body["parse_mode"] = serde_json::Value::String(PARSE_MODE_HTML.to_string());
         }
         self.api_send_media_request("sendVideo", chat_id, body, thread_id)
             .await
@@ -463,7 +535,7 @@ impl TelegramAdapter {
         let mut body = serde_json::json!({
             "chat_id": chat_id,
             "text": sanitized,
-            "parse_mode": "HTML",
+            "parse_mode": PARSE_MODE_HTML,
             "reply_markup": {
                 "inline_keyboard": keyboard,
             },
@@ -531,7 +603,7 @@ impl TelegramAdapter {
         let mut body = serde_json::json!({
             "chat_id": chat_id,
             "text": text,
-            "parse_mode": "HTML",
+            "parse_mode": PARSE_MODE_HTML,
         });
         if let Some(tid) = thread_id {
             body["message_thread_id"] = serde_json::json!(tid);
@@ -572,38 +644,28 @@ impl TelegramAdapter {
     /// accumulated tokens. Silently ignores errors (best-effort) since the final
     /// complete text will be sent as a fallback if editing fails.
     ///
-    /// When `html` is true, the text is sanitized and sent with `parse_mode: HTML`.
-    /// During intermediate streaming edits this should be `false` (raw text);
-    /// only the final edit should use `true` for proper formatting.
+    /// Sends the text with `parse_mode: HTML`. Callers are expected to provide
+    /// Telegram-safe HTML (e.g., via `formatter::format_for_channel`).
     async fn api_edit_message(
         &self,
         chat_id: i64,
         message_id: i64,
         text: &str,
-        html: bool,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let url = format!(
             "{}/bot{}/editMessageText",
             self.api_base_url,
             self.token.as_str()
         );
-        let body = if html {
-            // No sanitization here — callers (send_streaming) already format via
-            // formatter::format_for_channel which produces Telegram-safe HTML.
-            // Double-sanitizing would escape already-valid entities.
-            serde_json::json!({
-                "chat_id": chat_id,
-                "message_id": message_id,
-                "text": text,
-                "parse_mode": "HTML",
-            })
-        } else {
-            serde_json::json!({
-                "chat_id": chat_id,
-                "message_id": message_id,
-                "text": text,
-            })
-        };
+        // No sanitization here — callers (send_streaming) already format via
+        // formatter::format_for_channel which produces Telegram-safe HTML.
+        // Double-sanitizing would escape already-valid entities.
+        let body = serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": text,
+            "parse_mode": PARSE_MODE_HTML,
+        });
 
         let resp = self.client.post(&url).json(&body).send().await?;
         if !resp.status().is_success() {
@@ -653,19 +715,7 @@ impl TelegramAdapter {
     }
 
     fn fire_reaction_body(&self, url: String, body: serde_json::Value) {
-        let client = self.client.clone();
-        tokio::spawn(async move {
-            match client.post(&url).json(&body).send().await {
-                Ok(resp) if !resp.status().is_success() => {
-                    let body_text = resp.text().await.unwrap_or_default();
-                    debug!("Telegram setMessageReaction failed: {body_text}");
-                }
-                Err(e) => {
-                    debug!("Telegram setMessageReaction error: {e}");
-                }
-                _ => {}
-            }
-        });
+        fire_and_forget_post(self.client.clone(), url, body);
     }
 }
 
@@ -681,10 +731,7 @@ impl TelegramAdapter {
         content: ChannelContent,
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chat_id: i64 = user
-            .platform_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id))?;
+        let chat_id = Self::parse_chat_id(user)?;
 
         match content {
             ChannelContent::Text(text) => {
@@ -753,10 +800,7 @@ impl ChannelAdapter for TelegramAdapter {
     > {
         // Validate token first (fail fast) and store bot username for mention detection
         let bot_name = self.validate_token().await?;
-        {
-            let mut username = self.bot_username.write().await;
-            *username = Some(bot_name.clone());
-        }
+        let _ = self.bot_username.set(bot_name.clone());
         info!("Telegram bot @{bot_name} connected");
 
         // Clear any existing webhook to avoid 409 Conflict during getUpdates polling.
@@ -787,7 +831,7 @@ impl ChannelAdapter for TelegramAdapter {
         let allowed_users = self.allowed_users.clone();
         let poll_interval = self.poll_interval;
         let api_base_url = self.api_base_url.clone();
-        let bot_username = self.bot_username.clone();
+        let bot_username = self.bot_username.get().cloned();
         let account_id = self.account_id.clone();
         let thread_routes = self.thread_routes.clone();
         let mut shutdown = self.shutdown_rx.clone();
@@ -797,11 +841,15 @@ impl ChannelAdapter for TelegramAdapter {
         let poll_handle = self.poll_handle.clone();
 
         let handle = tokio::spawn(async move {
+            let ctx = TelegramApiCtx {
+                token: token.as_str(),
+                client: &client,
+                api_base_url: &api_base_url,
+            };
             let mut offset: Option<i64> = None;
             let mut backoff = initial_backoff;
 
             loop {
-                // Check shutdown
                 if *shutdown.borrow() {
                     break;
                 }
@@ -846,8 +894,8 @@ impl ChannelAdapter for TelegramAdapter {
 
                 // Handle rate limiting
                 if status.as_u16() == 429 {
-                    let body: serde_json::Value = resp.json().await.unwrap_or_default();
-                    let retry_after = body["parameters"]["retry_after"].as_u64().unwrap_or(5);
+                    let body_text = resp.text().await.unwrap_or_default();
+                    let retry_after = extract_retry_after(&body_text, RETRY_AFTER_DEFAULT_SECS);
                     warn!("Telegram rate limited, retry after {retry_after}s");
                     tokio::time::sleep(Duration::from_secs(retry_after)).await;
                     continue;
@@ -888,7 +936,6 @@ impl ChannelAdapter for TelegramAdapter {
                     continue;
                 }
 
-                // Reset backoff on success
                 backoff = initial_backoff;
 
                 let updates = match body["result"].as_array() {
@@ -904,20 +951,15 @@ impl ChannelAdapter for TelegramAdapter {
                 };
 
                 for update in updates {
-                    // Track offset for dedup
                     if let Some(update_id) = update["update_id"].as_i64() {
                         offset = Some(update_id + 1);
                     }
 
                     // Handle callback_query (inline keyboard button clicks)
                     if let Some(callback) = update.get("callback_query") {
-                        if let Some(mut msg) = parse_telegram_callback_query(
-                            callback,
-                            &allowed_users,
-                            &token,
-                            &api_base_url,
-                            &client,
-                        ) {
+                        if let Some(mut msg) =
+                            parse_telegram_callback_query(callback, &allowed_users, &ctx)
+                        {
                             if let Some(ref aid) = account_id {
                                 msg.metadata
                                     .insert("account_id".to_string(), serde_json::json!(aid));
@@ -937,14 +979,11 @@ impl ChannelAdapter for TelegramAdapter {
                         continue;
                     }
 
-                    // Parse the message
-                    let bot_uname = bot_username.read().await.clone();
+                    let bot_uname = bot_username.clone();
                     let mut msg = match parse_telegram_update(
                         update,
                         &allowed_users,
-                        token.as_str(),
-                        &client,
-                        &api_base_url,
+                        &ctx,
                         bot_uname.as_deref(),
                     )
                     .await
@@ -992,14 +1031,12 @@ impl ChannelAdapter for TelegramAdapter {
                     }
                 }
 
-                // Small delay between polls even on success to avoid tight loops
                 tokio::time::sleep(poll_interval).await;
             }
 
             info!("Telegram polling loop stopped");
         });
 
-        // Store handle for graceful shutdown in stop()
         {
             let mut guard = poll_handle.lock().await;
             *guard = Some(handle);
@@ -1022,10 +1059,7 @@ impl ChannelAdapter for TelegramAdapter {
         user: &ChannelUser,
         message: &InteractiveMessage,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chat_id: i64 = user
-            .platform_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id))?;
+        let chat_id = Self::parse_chat_id(user)?;
         self.api_send_interactive_message(chat_id, &message.text, &message.buttons, None)
             .await
     }
@@ -1034,10 +1068,7 @@ impl ChannelAdapter for TelegramAdapter {
         &self,
         user: &ChannelUser,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chat_id: i64 = user
-            .platform_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id))?;
+        let chat_id = Self::parse_chat_id(user)?;
         self.api_send_typing(chat_id, None).await
     }
 
@@ -1057,10 +1088,7 @@ impl ChannelAdapter for TelegramAdapter {
         message_id: &str,
         reaction: &LifecycleReaction,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chat_id: i64 = user
-            .platform_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id))?;
+        let chat_id = Self::parse_chat_id(user)?;
         let msg_id: i64 = message_id
             .parse()
             .map_err(|_| format!("Invalid Telegram message_id: {message_id}"))?;
@@ -1094,10 +1122,7 @@ impl ChannelAdapter for TelegramAdapter {
         mut delta_rx: mpsc::Receiver<String>,
         thread_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let chat_id: i64 = user
-            .platform_id
-            .parse()
-            .map_err(|_| format!("Invalid Telegram chat_id: {}", user.platform_id))?;
+        let chat_id = Self::parse_chat_id(user)?;
         let tid: Option<i64> = thread_id.and_then(|t| t.parse().ok());
 
         // Send typing indicator while we wait for the first token.
@@ -1111,13 +1136,10 @@ impl ChannelAdapter for TelegramAdapter {
         while let Some(delta) = delta_rx.recv().await {
             full_text.push_str(&delta);
 
-            // Format intermediate text so the user sees proper Telegram HTML
-            // (not raw markdown) even during streaming.
-            let intermediate =
-                formatter::format_for_channel(&full_text, OutputFormat::TelegramHtml);
-
             // Send the initial message on the first token.
             if sent_message_id.is_none() {
+                let intermediate =
+                    formatter::format_for_channel(&full_text, OutputFormat::TelegramHtml);
                 if let Some(msg_id) = self
                     .api_send_message_returning_id(chat_id, &intermediate, tid)
                     .await
@@ -1130,10 +1152,10 @@ impl ChannelAdapter for TelegramAdapter {
 
             // Throttle edits to respect Telegram rate limits.
             if last_edit.elapsed() >= STREAMING_EDIT_INTERVAL {
+                let intermediate =
+                    formatter::format_for_channel(&full_text, OutputFormat::TelegramHtml);
                 if let Some(msg_id) = sent_message_id {
-                    let _ = self
-                        .api_edit_message(chat_id, msg_id, &intermediate, true)
-                        .await;
+                    let _ = self.api_edit_message(chat_id, msg_id, &intermediate).await;
                     last_edit = Instant::now();
                 }
             }
@@ -1149,15 +1171,11 @@ impl ChannelAdapter for TelegramAdapter {
             let chunks = split_message(&formatted, 4096);
             if chunks.len() <= 1 {
                 // Single message — just edit in place.
-                let _ = self
-                    .api_edit_message(chat_id, msg_id, &formatted, true)
-                    .await;
+                let _ = self.api_edit_message(chat_id, msg_id, &formatted).await;
             } else {
                 // Response exceeds 4096 chars — edit the first chunk in place,
                 // then send remaining chunks as new messages.
-                let _ = self
-                    .api_edit_message(chat_id, msg_id, chunks[0], true)
-                    .await;
+                let _ = self.api_edit_message(chat_id, msg_id, chunks[0]).await;
                 for chunk in &chunks[1..] {
                     let _ = self.api_send_message(chat_id, chunk, tid).await;
                 }
@@ -1195,28 +1213,12 @@ enum DropReason {
     ParseError(String),
 }
 
-/// Parse a Telegram update JSON into a `ChannelMessage`, or a `DropReason` if it cannot be dispatched.
-/// Handles both `message` and `edited_message` update types.
-/// Resolve a Telegram file_id to a download URL via the Bot API.
-async fn telegram_get_file_url(
-    token: &str,
-    client: &reqwest::Client,
-    file_id: &str,
-    api_base_url: &str,
-) -> Option<String> {
-    let url = format!("{api_base_url}/bot{token}/getFile");
-    let resp = client
-        .post(&url)
-        .json(&serde_json::json!({"file_id": file_id}))
-        .send()
-        .await
-        .ok()?;
-    let body: serde_json::Value = resp.json().await.ok()?;
-    if body["ok"].as_bool() != Some(true) {
-        return None;
+/// Check if `haystack` ends with `suffix`, comparing ASCII case-insensitively.
+fn ends_with_ascii_ci(haystack: &str, suffix: &str) -> bool {
+    if haystack.len() < suffix.len() {
+        return false;
     }
-    let file_path = body["result"]["file_path"].as_str()?;
-    Some(format!("{api_base_url}/file/bot{token}/{file_path}"))
+    haystack[haystack.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
 }
 
 /// Detect image MIME type from a Telegram file path or download URL.
@@ -1225,20 +1227,19 @@ async fn telegram_get_file_url(
 /// extension is a reliable signal. Falls back to `None` if no known
 /// image extension is found, letting downstream code use magic-byte
 /// detection or a safe default.
-fn mime_type_from_telegram_path(url_or_path: &str) -> Option<String> {
-    let lower = url_or_path.to_ascii_lowercase();
-    if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
-        Some("image/jpeg".to_string())
-    } else if lower.ends_with(".png") {
-        Some("image/png".to_string())
-    } else if lower.ends_with(".gif") {
-        Some("image/gif".to_string())
-    } else if lower.ends_with(".webp") {
-        Some("image/webp".to_string())
-    } else if lower.ends_with(".bmp") {
-        Some("image/bmp".to_string())
-    } else if lower.ends_with(".tiff") || lower.ends_with(".tif") {
-        Some("image/tiff".to_string())
+fn mime_type_from_telegram_path(url_or_path: &str) -> Option<&'static str> {
+    if ends_with_ascii_ci(url_or_path, ".jpg") || ends_with_ascii_ci(url_or_path, ".jpeg") {
+        Some("image/jpeg")
+    } else if ends_with_ascii_ci(url_or_path, ".png") {
+        Some("image/png")
+    } else if ends_with_ascii_ci(url_or_path, ".gif") {
+        Some("image/gif")
+    } else if ends_with_ascii_ci(url_or_path, ".webp") {
+        Some("image/webp")
+    } else if ends_with_ascii_ci(url_or_path, ".bmp") {
+        Some("image/bmp")
+    } else if ends_with_ascii_ci(url_or_path, ".tiff") || ends_with_ascii_ci(url_or_path, ".tif") {
+        Some("image/tiff")
     } else {
         None
     }
@@ -1277,9 +1278,7 @@ fn telegram_user_allowed(allowed_users: &[String], user_id: i64, username: Optio
 fn parse_telegram_callback_query(
     callback: &serde_json::Value,
     allowed_users: &[String],
-    token: &str,
-    api_base_url: &str,
-    client: &reqwest::Client,
+    ctx: &TelegramApiCtx<'_>,
 ) -> Option<ChannelMessage> {
     let callback_query_id = callback["id"].as_str()?;
     let from = callback.get("from")?;
@@ -1316,7 +1315,7 @@ fn parse_telegram_callback_query(
     let message_id = message["message_id"].as_i64().unwrap_or(0);
     let message_text = message["text"].as_str().map(String::from);
     let chat_type = message["chat"]["type"].as_str().unwrap_or("private");
-    let is_group = chat_type == "group" || chat_type == "supergroup";
+    let is_group = is_group_chat(chat_type);
 
     let timestamp = message["date"]
         .as_i64()
@@ -1325,14 +1324,11 @@ fn parse_telegram_callback_query(
 
     // Fire-and-forget answer to dismiss the button loading state
     {
-        let url = format!("{api_base_url}/bot{token}/answerCallbackQuery");
+        let url = format!("{}/bot{}/answerCallbackQuery", ctx.api_base_url, ctx.token);
         let body = serde_json::json!({
             "callback_query_id": callback_query_id,
         });
-        let client = client.clone();
-        tokio::spawn(async move {
-            let _ = client.post(&url).json(&body).send().await;
-        });
+        fire_and_forget_post(ctx.client.clone(), url, body);
     }
 
     let mut metadata = HashMap::new();
@@ -1421,9 +1417,7 @@ fn extract_telegram_sender(
 async fn extract_telegram_content(
     message: &serde_json::Value,
     update_id: i64,
-    token: &str,
-    client: &reqwest::Client,
-    api_base_url: &str,
+    ctx: &TelegramApiCtx<'_>,
 ) -> Result<ChannelContent, DropReason> {
     if let Some(text) = message["text"].as_str() {
         // Parse bot commands (Telegram sends entities for /commands)
@@ -1457,9 +1451,9 @@ async fn extract_telegram_content(
             .and_then(|p| p["file_id"].as_str())
             .unwrap_or("");
         let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => {
-                let mime_type = mime_type_from_telegram_path(&url);
+                let mime_type = mime_type_from_telegram_path(&url).map(String::from);
                 Ok(ChannelContent::Image {
                     url,
                     caption,
@@ -1480,7 +1474,7 @@ async fn extract_telegram_content(
             .as_str()
             .unwrap_or("document")
             .to_string();
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => Ok(ChannelContent::File { url, filename }),
             None => Ok(ChannelContent::Text(format!(
                 "[Document received: {filename}]"
@@ -1491,7 +1485,7 @@ async fn extract_telegram_content(
         let file_id = message["audio"]["file_id"].as_str().unwrap_or("");
         let duration = message["audio"]["duration"].as_u64().unwrap_or(0) as u32;
         let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => Ok(ChannelContent::Voice {
                 url,
                 caption,
@@ -1509,7 +1503,7 @@ async fn extract_telegram_content(
         let file_id = message["voice"]["file_id"].as_str().unwrap_or("");
         let duration = message["voice"]["duration"].as_u64().unwrap_or(0) as u32;
         let caption = message["caption"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => Ok(ChannelContent::Voice {
                 url,
                 caption,
@@ -1524,7 +1518,7 @@ async fn extract_telegram_content(
         let duration = message["video"]["duration"].as_u64().unwrap_or(0) as u32;
         let caption = message["caption"].as_str().map(String::from);
         let filename = message["video"]["file_name"].as_str().map(String::from);
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => Ok(ChannelContent::Video {
                 url,
                 caption,
@@ -1543,7 +1537,7 @@ async fn extract_telegram_content(
         // Video notes are round video messages (no caption/filename)
         let file_id = message["video_note"]["file_id"].as_str().unwrap_or("");
         let duration = message["video_note"]["duration"].as_u64().unwrap_or(0) as u32;
-        match telegram_get_file_url(token, client, file_id, api_base_url).await {
+        match ctx.get_file_url(file_id).await {
             Some(url) => Ok(ChannelContent::Video {
                 url,
                 caption: None,
@@ -1571,9 +1565,7 @@ async fn extract_telegram_content(
 async fn apply_reply_context(
     content: ChannelContent,
     message: &serde_json::Value,
-    token: &str,
-    client: &reqwest::Client,
-    api_base_url: &str,
+    ctx: &TelegramApiCtx<'_>,
 ) -> ChannelContent {
     let reply = match message.get("reply_to_message") {
         Some(r) => r,
@@ -1590,7 +1582,7 @@ async fn apply_reply_context(
             .and_then(|p| p["file_id"].as_str())
             .unwrap_or("");
         if !file_id.is_empty() {
-            telegram_get_file_url(token, client, file_id, api_base_url).await
+            ctx.get_file_url(file_id).await
         } else {
             None
         }
@@ -1604,11 +1596,7 @@ async fn apply_reply_context(
         // the quoted photo context as text (don't overwrite the user's photo).
         let quote_context = reply_text
             .map(|q| {
-                let truncated = if q.len() > 200 {
-                    format!("{}...", &q[..q.floor_char_boundary(200)])
-                } else {
-                    q.to_string()
-                };
+                let truncated = truncate_with_ellipsis(q, 200);
                 format!("[Replying to {reply_sender}: \"{truncated}\"]\n")
             })
             .unwrap_or_else(|| format!("[Replying to {reply_sender}'s photo]\n"));
@@ -1630,7 +1618,7 @@ async fn apply_reply_context(
             ChannelContent::Text(t) => {
                 // User sent text reply to a photo — show the quoted photo
                 let caption = format!("{quote_context}{t}");
-                let mime_type = mime_type_from_telegram_path(&photo_url);
+                let mime_type = mime_type_from_telegram_path(&photo_url).map(String::from);
                 ChannelContent::Image {
                     url: photo_url,
                     caption: Some(caption),
@@ -1641,11 +1629,7 @@ async fn apply_reply_context(
         }
     } else if let Some(quoted) = reply_text {
         // Quoted message has text only — prepend it
-        let truncated = if quoted.len() > 200 {
-            format!("{}...", &quoted[..quoted.floor_char_boundary(200)])
-        } else {
-            quoted.to_string()
-        };
+        let truncated = truncate_with_ellipsis(quoted, 200);
         let prefix = format!("[Replying to {reply_sender}: \"{truncated}\"]\n");
         match content {
             ChannelContent::Text(t) => ChannelContent::Text(format!("{prefix}{t}")),
@@ -1659,9 +1643,7 @@ async fn apply_reply_context(
 async fn parse_telegram_update(
     update: &serde_json::Value,
     allowed_users: &[String],
-    token: &str,
-    client: &reqwest::Client,
-    api_base_url: &str,
+    ctx: &TelegramApiCtx<'_>,
     bot_username: Option<&str>,
 ) -> Result<ChannelMessage, DropReason> {
     let update_id = update["update_id"].as_i64().unwrap_or(0);
@@ -1691,15 +1673,15 @@ async fn parse_telegram_update(
         DropReason::ParseError(format!("update {update_id}: chat.id is not an integer"))
     })?;
     let chat_type = message["chat"]["type"].as_str().unwrap_or("private");
-    let is_group = chat_type == "group" || chat_type == "supergroup";
+    let is_group = is_group_chat(chat_type);
     let message_id = message["message_id"].as_i64().unwrap_or(0);
     let timestamp = message["date"]
         .as_i64()
         .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
         .unwrap_or_else(chrono::Utc::now);
 
-    let content = extract_telegram_content(message, update_id, token, client, api_base_url).await?;
-    let content = apply_reply_context(content, message, token, client, api_base_url).await;
+    let content = extract_telegram_content(message, update_id, ctx).await?;
+    let content = apply_reply_context(content, message, ctx).await;
 
     // Extract forum topic thread_id (Telegram sends this as `message_thread_id`
     // for messages inside forum topics / reply threads).
@@ -1809,7 +1791,7 @@ fn check_mention_entities(message: &serde_json::Value, bot_username: &str) -> bo
 }
 
 /// Calculate exponential backoff capped at the given maximum.
-pub fn calculate_backoff(current: Duration, max: Duration) -> Duration {
+fn calculate_backoff(current: Duration, max: Duration) -> Duration {
     (current * 2).min(max)
 }
 
@@ -1834,7 +1816,7 @@ fn sanitize_telegram_html(text: &str) -> String {
         "tg-emoji",
     ];
 
-    let mut result = String::with_capacity(text.len());
+    let mut result = String::with_capacity(text.len() + text.len() / 4);
     let mut chars = text.char_indices().peekable();
     let mut open_tags: Vec<String> = Vec::new();
 
@@ -1845,16 +1827,18 @@ fn sanitize_telegram_html(text: &str) -> String {
                 let tag_end = i + end_offset;
                 let tag_content = &text[i + 1..tag_end]; // content between < and >
                 let is_closing = tag_content.starts_with('/');
-                let tag_name = tag_content
+                let tag_name_raw = tag_content
                     .trim_start_matches('/')
                     .split(|c: char| c.is_whitespace() || c == '/' || c == '>')
                     .next()
-                    .unwrap_or("")
-                    .to_lowercase();
+                    .unwrap_or("");
 
-                if !tag_name.is_empty() && ALLOWED.contains(&tag_name.as_str()) {
+                if !tag_name_raw.is_empty()
+                    && ALLOWED.iter().any(|a| a.eq_ignore_ascii_case(tag_name_raw))
+                {
                     // Allowed tag — keep as-is
                     result.push_str(&text[i..tag_end + 1]);
+                    let tag_name = tag_name_raw.to_ascii_lowercase();
                     // Track open/close for balancing
                     if is_closing {
                         if let Some(pos) = open_tags.iter().rposition(|t| t == &tag_name) {
@@ -1906,6 +1890,15 @@ mod tests {
         crate::http_client::new_client()
     }
 
+    /// Helper to create a TelegramApiCtx for tests.
+    fn test_ctx<'a>(client: &'a reqwest::Client) -> TelegramApiCtx<'a> {
+        TelegramApiCtx {
+            token: "fake:token",
+            client,
+            api_base_url: DEFAULT_API_URL,
+        }
+    }
+
     #[tokio::test]
     async fn test_parse_telegram_update() {
         let update = serde_json::json!({
@@ -1927,7 +1920,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.channel, ChannelType::Telegram);
@@ -1961,7 +1954,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -1995,34 +1988,17 @@ mod tests {
         let client = test_client();
 
         // Empty allowed_users = allow all
-        let msg =
-            parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None).await;
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None).await;
         assert!(msg.is_ok());
 
         // Non-matching allowed_users = filter out
         let blocked: Vec<String> = vec!["111".to_string(), "222".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &blocked,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &blocked, &test_ctx(&client), None).await;
         assert!(msg.is_err());
 
         // Matching allowed_users = allow
         let allowed: Vec<String> = vec!["999".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_ok());
     }
 
@@ -2050,54 +2026,22 @@ mod tests {
 
         // Username match (no @)
         let allowed = vec!["bobuser".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_ok(), "username without @ should match");
 
         // Username match (with @)
         let allowed = vec!["@bobuser".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_ok(), "username with @ should match");
 
         // Case-insensitive username match
         let allowed = vec!["BoBuSeR".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_ok(), "username match should be case-insensitive");
 
         // ID mismatch but username match
         let allowed = vec!["111".to_string(), "bobuser".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(
             msg.is_ok(),
             "should match by username when ID doesn't match"
@@ -2105,15 +2049,7 @@ mod tests {
 
         // Wrong username, wrong ID → reject
         let allowed = vec!["otheruser".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_err(), "wrong username should be rejected");
     }
 
@@ -2139,7 +2075,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.channel, ChannelType::Telegram);
@@ -2178,7 +2114,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2204,7 +2140,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert!(matches!(msg.content, ChannelContent::Location { .. }));
@@ -2230,7 +2166,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         // With a fake token, getFile will fail, so we get a text fallback
@@ -2267,7 +2203,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2300,7 +2236,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2337,7 +2273,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2374,7 +2310,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.thread_id, Some("42".to_string()));
@@ -2396,7 +2332,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.thread_id, None);
@@ -2420,7 +2356,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.thread_id, Some("99".to_string()));
@@ -2445,7 +2381,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert_eq!(msg.sender.display_name, "My Channel");
@@ -2477,28 +2413,12 @@ mod tests {
 
         // Allowed by sender_chat ID (as string)
         let allowed = vec!["-1001999888777".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(msg.is_ok(), "sender_chat should be allowed by numeric ID");
 
         // NOT allowed by channel title alone — sender_chat has no username field
         let allowed = vec!["My Channel".to_string()];
-        let msg = parse_telegram_update(
-            &update,
-            &allowed,
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            None,
-        )
-        .await;
+        let msg = parse_telegram_update(&update, &allowed, &test_ctx(&client), None).await;
         assert!(
             msg.is_err(),
             "sender_chat should NOT match by channel title"
@@ -2519,8 +2439,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg =
-            parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None).await;
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None).await;
         assert!(msg.is_err());
     }
 
@@ -2544,16 +2463,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert!(msg.is_group);
         assert_eq!(
             msg.metadata.get("was_mentioned").and_then(|v| v.as_bool()),
@@ -2576,16 +2488,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert!(msg.is_group);
         assert!(!msg.metadata.contains_key("was_mentioned"));
     }
@@ -2610,16 +2515,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert!(msg.is_group);
         assert!(!msg.metadata.contains_key("was_mentioned"));
     }
@@ -2647,16 +2545,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert!(msg.is_group);
         assert_eq!(
             msg.metadata.get("was_mentioned").and_then(|v| v.as_bool()),
@@ -2684,16 +2575,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert_eq!(
             msg.metadata.get("was_mentioned").and_then(|v| v.as_bool()),
             Some(true)
@@ -2720,16 +2604,9 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(
-            &update,
-            &[],
-            "fake:token",
-            &client,
-            DEFAULT_API_URL,
-            Some("testbot"),
-        )
-        .await
-        .unwrap();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), Some("testbot"))
+            .await
+            .unwrap();
         assert!(!msg.is_group);
         // In private chats, mention detection is skipped — no metadata set
         assert!(!msg.metadata.contains_key("was_mentioned"));
@@ -2771,7 +2648,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2806,7 +2683,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         assert!(
@@ -2836,7 +2713,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         match &msg.content {
@@ -2873,7 +2750,7 @@ mod tests {
         });
 
         let client = test_client();
-        let msg = parse_telegram_update(&update, &[], "fake:token", &client, DEFAULT_API_URL, None)
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
             .await
             .unwrap();
         let reply_to = msg
@@ -3060,14 +2937,7 @@ mod tests {
             }
         });
 
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &[],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        )
-        .unwrap();
+        let msg = parse_telegram_callback_query(&callback, &[], &test_ctx(&client)).unwrap();
 
         assert_eq!(msg.channel, ChannelType::Telegram);
         assert_eq!(msg.sender.platform_id, "-100123");
@@ -3102,13 +2972,8 @@ mod tests {
         });
 
         // User 42 not in allowed list
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &["999".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        );
+        let msg =
+            parse_telegram_callback_query(&callback, &["999".to_string()], &test_ctx(&client));
         assert!(msg.is_none());
     }
 
@@ -3128,33 +2993,21 @@ mod tests {
         });
 
         // Username match (no @) — should allow
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &["alicebot".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        );
+        let msg =
+            parse_telegram_callback_query(&callback, &["alicebot".to_string()], &test_ctx(&client));
         assert!(msg.is_some(), "callback: username without @ should match");
 
         // Username match (with @) — should allow
         let msg = parse_telegram_callback_query(
             &callback,
             &["@alicebot".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
+            &test_ctx(&client),
         );
         assert!(msg.is_some(), "callback: username with @ should match");
 
         // Case-insensitive username — should allow
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &["AlIcEbOt".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        );
+        let msg =
+            parse_telegram_callback_query(&callback, &["AlIcEbOt".to_string()], &test_ctx(&client));
         assert!(
             msg.is_some(),
             "callback: case-insensitive username should match"
@@ -3164,9 +3017,7 @@ mod tests {
         let msg = parse_telegram_callback_query(
             &callback,
             &["999".to_string(), "alicebot".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
+            &test_ctx(&client),
         );
         assert!(
             msg.is_some(),
@@ -3177,9 +3028,7 @@ mod tests {
         let msg = parse_telegram_callback_query(
             &callback,
             &["wronguser".to_string()],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
+            &test_ctx(&client),
         );
         assert!(msg.is_none(), "callback: wrong username should be rejected");
     }
@@ -3198,13 +3047,7 @@ mod tests {
             }
         });
 
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &[],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        );
+        let msg = parse_telegram_callback_query(&callback, &[], &test_ctx(&client));
         assert!(msg.is_none());
     }
 
@@ -3223,14 +3066,7 @@ mod tests {
             }
         });
 
-        let msg = parse_telegram_callback_query(
-            &callback,
-            &[],
-            "fake_token",
-            "https://api.telegram.org",
-            &client,
-        )
-        .unwrap();
+        let msg = parse_telegram_callback_query(&callback, &[], &test_ctx(&client)).unwrap();
         assert!(!msg.is_group);
         assert_eq!(msg.sender.display_name, "Bob");
     }

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -1740,6 +1740,24 @@ async fn parse_telegram_update(
         }
     }
 
+    // Inject identity metadata so the bridge can populate the group roster and
+    // pass bot/sender @handles into the agent's system prompt. These keys are
+    // read by `build_sender_context` in bridge.rs.
+    metadata.insert(
+        "chat_id".to_string(),
+        serde_json::json!(chat_id.to_string()),
+    );
+    metadata.insert(
+        "sender_user_id".to_string(),
+        serde_json::json!(user_id.to_string()),
+    );
+    if let Some(ref uname) = username {
+        metadata.insert("sender_username".to_string(), serde_json::json!(uname));
+    }
+    if let Some(bot_uname) = bot_username {
+        metadata.insert("bot_username".to_string(), serde_json::json!(bot_uname));
+    }
+
     Ok(ChannelMessage {
         channel: ChannelType::Telegram,
         platform_message_id: message_id.to_string(),

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -40,6 +40,22 @@ pub struct ChannelUser {
     pub librefang_user: Option<String>,
 }
 
+/// A known member of a group chat, accumulated from past messages.
+///
+/// Used to populate multi-user context in the system prompt so agents can
+/// distinguish between the current sender and other users mentioned in a
+/// message (e.g. `@pepe`, `@jose`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GroupMember {
+    /// Platform-specific user ID.
+    pub user_id: String,
+    /// Human-readable display name (what the platform shows).
+    pub display_name: String,
+    /// Optional `@handle` for platforms that expose one (Telegram, Discord, ...).
+    #[serde(default)]
+    pub username: Option<String>,
+}
+
 /// Typing indicator event from a channel.
 #[derive(Debug, Clone)]
 pub struct TypingEvent {
@@ -209,6 +225,23 @@ pub struct SenderContext {
     /// Divergence count threshold for `sticky_heuristic` strategy.
     #[serde(default)]
     pub auto_route_divergence_count: u32,
+    /// The bot's own platform `@handle` on this channel (e.g. `fandangorodelo_bot`
+    /// on Telegram). Used so the agent knows its own alias in the prompt.
+    #[serde(default)]
+    pub bot_username: Option<String>,
+    /// The current sender's `@handle` on the platform, when available.
+    #[serde(default)]
+    pub sender_username: Option<String>,
+    /// Known members of the group chat where this message was sent.
+    /// Empty for DMs and for the very first message in a group before the
+    /// roster has accumulated any entries.
+    #[serde(default)]
+    pub group_members: Vec<GroupMember>,
+    /// Platform chat/conversation ID. For Telegram this is the group chat_id
+    /// (negative for groups) or user_id for DMs. Used by the roster store as
+    /// part of the key.
+    #[serde(default)]
+    pub chat_id: Option<String>,
 }
 
 /// Agent lifecycle phase for UX indicators.

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -564,7 +564,17 @@ pub fn split_message(text: &str, max_len: usize) -> Vec<&str> {
 fn retreat_past_html_entity(text: &str, pos: usize) -> usize {
     // Maximum entity length we consider (e.g. `&#1114111;` = 10 chars).
     const MAX_ENTITY_LEN: usize = 12;
-    let search_start = pos.saturating_sub(MAX_ENTITY_LEN);
+    let raw_start = pos.saturating_sub(MAX_ENTITY_LEN);
+    // Snap to the nearest char boundary so we never slice inside a multi-byte
+    // UTF-8 sequence (e.g. `ñ` = 2 bytes, emoji = 4 bytes). Without this,
+    // text containing non-ASCII characters panics on the `text[start..pos]`
+    // slice below. See #2285.
+    let search_start = (raw_start..=pos)
+        .find(|&i| text.is_char_boundary(i))
+        .unwrap_or(pos);
+    if search_start >= pos {
+        return pos;
+    }
     // Look for the last `&` in the window ending at `pos`.
     if let Some(rel) = text[search_start..pos].rfind('&') {
         let amp_pos = search_start + rel;
@@ -614,6 +624,40 @@ mod tests {
         let text = "line1\nline2\nline3";
         let chunks = split_message(text, 10);
         assert_eq!(chunks, vec!["line1", "line2", "line3"]);
+    }
+
+    #[test]
+    fn test_split_message_multibyte_utf8_no_panic() {
+        // Regression test for #2285: retreat_past_html_entity panicked when
+        // search_start landed inside a multi-byte char like ñ (2 bytes).
+        // Build a string where ñ straddles the max_len - 12 boundary.
+        let text = "coño ".repeat(300); // 1500 chars, plenty of ñ near any boundary
+        let chunks = split_message(&text, 50);
+        assert!(!chunks.is_empty());
+        // Verify all chunks are valid UTF-8 (implicit — they're &str)
+        for chunk in &chunks {
+            assert!(chunk.len() <= 50);
+        }
+    }
+
+    #[test]
+    fn test_split_message_emoji_no_panic() {
+        // Emoji are 4 bytes in UTF-8 — even more fragile than ñ.
+        let text = "hello 😀 ".repeat(200);
+        let chunks = split_message(&text, 40);
+        assert!(!chunks.is_empty());
+        for chunk in &chunks {
+            assert!(chunk.len() <= 40);
+        }
+    }
+
+    #[test]
+    fn test_retreat_past_html_entity_multibyte_safe() {
+        // Direct test: pos just after a ñ, search window crosses into it.
+        let text = "aaaaaaaaañbbbbb"; // ñ at byte 9-10
+        let result = retreat_past_html_entity(text, 11);
+        // Should not panic, and should return 11 (no & found)
+        assert_eq!(result, 11);
     }
 
     #[test]

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -13,7 +13,9 @@ librefang-kernel = { path = "../librefang-kernel" }
 librefang-api = { path = "../librefang-api", default-features = false }
 librefang-types = { path = "../librefang-types" }
 librefang-extensions = { path = "../librefang-extensions" }
+clap = { workspace = true }
 dirs = { workspace = true }
+reqwest = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/librefang-desktop/src/commands.rs
+++ b/crates/librefang-desktop/src/commands.rs
@@ -8,8 +8,11 @@ use tracing::info;
 
 /// Get the port the embedded server is listening on.
 #[tauri::command]
-pub fn get_port(port: tauri::State<'_, PortState>) -> u16 {
+pub fn get_port(port: tauri::State<'_, PortState>) -> Result<u16, String> {
     port.0
+        .read()
+        .unwrap()
+        .ok_or_else(|| "No local server running".to_string())
 }
 
 /// Get a status summary of the running kernel.
@@ -17,22 +20,35 @@ pub fn get_port(port: tauri::State<'_, PortState>) -> u16 {
 pub fn get_status(
     port: tauri::State<'_, PortState>,
     kernel_state: tauri::State<'_, KernelState>,
-) -> serde_json::Value {
-    let agents = kernel_state.kernel.agent_registry().list().len();
-    let uptime_secs = kernel_state.started_at.elapsed().as_secs();
+) -> Result<serde_json::Value, String> {
+    let p = port
+        .0
+        .read()
+        .unwrap()
+        .ok_or_else(|| "No local server running".to_string())?;
+    let guard = kernel_state.0.read().unwrap();
+    let inner = guard
+        .as_ref()
+        .ok_or_else(|| "No local server running".to_string())?;
+    let agents = inner.kernel.agent_registry().list().len();
+    let uptime_secs = inner.started_at.elapsed().as_secs();
 
-    serde_json::json!({
+    Ok(serde_json::json!({
         "status": "running",
-        "port": port.0,
+        "port": p,
         "agents": agents,
         "uptime_secs": uptime_secs,
-    })
+    }))
 }
 
 /// Get the number of registered agents.
 #[tauri::command]
-pub fn get_agent_count(kernel_state: tauri::State<'_, KernelState>) -> usize {
-    kernel_state.kernel.agent_registry().list().len()
+pub fn get_agent_count(kernel_state: tauri::State<'_, KernelState>) -> Result<usize, String> {
+    let guard = kernel_state.0.read().unwrap();
+    let inner = guard
+        .as_ref()
+        .ok_or_else(|| "No local server running".to_string())?;
+    Ok(inner.kernel.agent_registry().list().len())
 }
 
 /// Open a native file picker to import an agent TOML manifest.
@@ -73,7 +89,11 @@ pub fn import_agent_toml(
     let dest = agent_dir.join("agent.toml");
     std::fs::write(&dest, &content).map_err(|e| format!("Failed to write manifest: {e}"))?;
 
-    kernel_state
+    let guard = kernel_state.0.read().unwrap();
+    let inner = guard
+        .as_ref()
+        .ok_or_else(|| "No local server running".to_string())?;
+    inner
         .kernel
         .spawn_agent(manifest)
         .map_err(|e| format!("Failed to spawn agent: {e}"))?;
@@ -117,7 +137,11 @@ pub fn import_skill_file(
     let dest = skills_dir.join(&file_name);
     std::fs::copy(src, &dest).map_err(|e| format!("Failed to copy skill file: {e}"))?;
 
-    kernel_state.kernel.reload_skills();
+    let guard = kernel_state.0.read().unwrap();
+    let inner = guard
+        .as_ref()
+        .ok_or_else(|| "No local server running".to_string())?;
+    inner.kernel.reload_skills();
 
     info!("Imported skill file \"{file_name}\" and reloaded registry");
     Ok(file_name)

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -1,0 +1,425 @@
+//! Connection screen and remote/local mode switching for the desktop app.
+//!
+//! Provides a self-contained HTML connection page and Tauri IPC commands
+//! for testing connections, connecting to remote servers, and starting local
+//! servers on demand.
+
+use librefang_kernel::config::librefang_home;
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+use tauri::Manager;
+use tracing::{info, warn};
+
+/// Persisted connection preference stored in `~/.librefang/desktop.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionPreference {
+    pub mode: String,
+    #[serde(default)]
+    pub server_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct DesktopConfig {
+    #[serde(default)]
+    connection: Option<ConnectionPreference>,
+}
+
+/// Load saved connection preference from `~/.librefang/desktop.toml`.
+pub fn load_saved_preference() -> Option<ConnectionPreference> {
+    let path = librefang_home().join("desktop.toml");
+    let content = std::fs::read_to_string(path).ok()?;
+    let config: DesktopConfig = toml::from_str(&content).ok()?;
+    config.connection
+}
+
+/// Save connection preference to `~/.librefang/desktop.toml`.
+pub fn save_preference(pref: &ConnectionPreference) {
+    let path = librefang_home().join("desktop.toml");
+    let config = DesktopConfig {
+        connection: Some(pref.clone()),
+    };
+    if let Ok(content) = toml::to_string_pretty(&config) {
+        let _ = std::fs::create_dir_all(librefang_home());
+        if let Err(e) = std::fs::write(&path, content) {
+            warn!("Failed to save desktop preference: {e}");
+        }
+    }
+}
+
+/// Test connectivity to a remote LibreFang server by hitting `/api/health`.
+#[tauri::command]
+pub async fn test_connection(url: String) -> Result<serde_json::Value, String> {
+    let url = url.trim_end_matches('/').to_string();
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("URL must start with http:// or https://".to_string());
+    }
+
+    let health_url = format!("{url}/api/health");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let resp = client
+        .get(&health_url)
+        .send()
+        .await
+        .map_err(|e| format!("Connection failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("Server returned status {}", resp.status()));
+    }
+
+    resp.json::<serde_json::Value>()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))
+}
+
+/// Connect to a remote LibreFang server. Validates the URL, optionally saves
+/// the preference, and navigates the WebView to the remote dashboard.
+#[tauri::command]
+pub async fn connect_remote(
+    url: String,
+    remember: bool,
+    window: tauri::WebviewWindow,
+) -> Result<(), String> {
+    let url = url.trim_end_matches('/').to_string();
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("URL must start with http:// or https://".to_string());
+    }
+
+    if remember {
+        save_preference(&ConnectionPreference {
+            mode: "remote".to_string(),
+            server_url: Some(url.clone()),
+        });
+    }
+
+    // Store the server URL in managed state
+    let app = window.app_handle();
+    app.manage(crate::ServerUrlState(url.clone()));
+    app.manage(crate::RemoteMode(true));
+
+    info!("Connecting to remote server: {url}");
+
+    // Navigate WebView to the remote dashboard
+    let js = format!(
+        "window.location.href = {};",
+        serde_json::to_string(&url).unwrap_or_default()
+    );
+    window
+        .eval(&js)
+        .map_err(|e| format!("Navigation failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Start a local LibreFang server, store state, optionally save preference,
+/// and navigate the WebView to the local dashboard.
+#[tauri::command]
+pub async fn start_local(
+    remember: bool,
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+) -> Result<(), String> {
+    info!("Starting local LibreFang server...");
+
+    // Boot kernel + server on a blocking thread.
+    // Wrap in a closure to convert the non-Send error into a String.
+    let handle =
+        tokio::task::spawn_blocking(|| crate::server::start_server().map_err(|e| e.to_string()))
+            .await
+            .map_err(|e| format!("Server task panicked: {e}"))?
+            .map_err(|e| format!("Failed to start server: {e}"))?;
+
+    let port = handle.port;
+    let url = format!("http://127.0.0.1:{port}");
+
+    // Store state for tray and commands
+    app.manage(crate::PortState(port));
+    app.manage(crate::KernelState {
+        kernel: handle.kernel.clone(),
+        started_at: Instant::now(),
+    });
+    app.manage(crate::ServerUrlState(url.clone()));
+    app.manage(crate::RemoteMode(false));
+
+    // Store the ServerHandle for shutdown
+    if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
+        let mut guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
+        *guard = Some(handle);
+    }
+
+    // Start event forwarding for native notifications
+    if let Some(ks) = app.try_state::<crate::KernelState>() {
+        let app_handle = app.clone();
+        let mut event_rx = ks.kernel.event_bus_ref().subscribe_all();
+        tauri::async_runtime::spawn(async move {
+            crate::forward_kernel_events(app_handle, &mut event_rx).await;
+        });
+    }
+
+    if remember {
+        save_preference(&ConnectionPreference {
+            mode: "local".to_string(),
+            server_url: None,
+        });
+    }
+
+    info!("Local server running on port {port}");
+
+    // Navigate WebView to the local dashboard
+    let js = format!(
+        "window.location.href = {};",
+        serde_json::to_string(&url).unwrap_or_default()
+    );
+    window
+        .eval(&js)
+        .map_err(|e| format!("Navigation failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Returns self-contained HTML/CSS/JS for the connection screen.
+pub fn connection_html() -> String {
+    r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LibreFang — Connect</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
+    background: #0f1117;
+    color: #e4e4e7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+  }
+  .container {
+    width: 420px;
+    max-width: 90vw;
+    background: #1a1b23;
+    border: 1px solid #2a2b35;
+    border-radius: 16px;
+    padding: 40px 36px 36px;
+  }
+  .logo {
+    text-align: center;
+    margin-bottom: 32px;
+  }
+  .logo h1 {
+    font-size: 28px;
+    font-weight: 700;
+    color: #f4f4f5;
+    letter-spacing: -0.5px;
+  }
+  .logo p {
+    font-size: 14px;
+    color: #71717a;
+    margin-top: 6px;
+  }
+  label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: #a1a1aa;
+    margin-bottom: 6px;
+  }
+  input[type="text"] {
+    width: 100%;
+    padding: 10px 14px;
+    font-size: 14px;
+    background: #0f1117;
+    border: 1px solid #2a2b35;
+    border-radius: 8px;
+    color: #f4f4f5;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  input[type="text"]:focus {
+    border-color: #6366f1;
+  }
+  input[type="text"]::placeholder {
+    color: #52525b;
+  }
+  .btn-row {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s, opacity 0.15s;
+  }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .btn-test {
+    background: #27272a;
+    color: #d4d4d8;
+  }
+  .btn-test:hover:not(:disabled) {
+    background: #3f3f46;
+  }
+  .btn-connect {
+    background: #6366f1;
+    color: #fff;
+  }
+  .btn-connect:hover:not(:disabled) {
+    background: #4f46e5;
+  }
+  .divider {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin: 24px 0;
+    color: #52525b;
+    font-size: 13px;
+  }
+  .divider::before, .divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #27272a;
+  }
+  .btn-local {
+    width: 100%;
+    padding: 10px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    background: #27272a;
+    color: #d4d4d8;
+    border: 1px solid #3f3f46;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .btn-local:hover:not(:disabled) {
+    background: #3f3f46;
+  }
+  .remember-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+  }
+  .remember-row input[type="checkbox"] {
+    accent-color: #6366f1;
+  }
+  .remember-row label {
+    margin: 0;
+    font-size: 13px;
+    color: #a1a1aa;
+    cursor: pointer;
+  }
+  .status {
+    margin-top: 16px;
+    min-height: 20px;
+    font-size: 13px;
+    text-align: center;
+    transition: color 0.2s;
+  }
+  .status.error { color: #ef4444; }
+  .status.success { color: #22c55e; }
+  .status.info { color: #6366f1; }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="logo">
+    <h1>LibreFang</h1>
+    <p>Agent Operating System</p>
+  </div>
+
+  <label for="url-input">Server URL</label>
+  <input type="text" id="url-input" placeholder="http://192.168.1.100:4545" spellcheck="false">
+
+  <div class="btn-row">
+    <button class="btn btn-test" id="btn-test" onclick="testConn()">Test Connection</button>
+    <button class="btn btn-connect" id="btn-connect" onclick="connectRemote()">Connect</button>
+  </div>
+
+  <div class="divider">or</div>
+
+  <button class="btn-local" id="btn-local" onclick="startLocal()">Start Local Server</button>
+
+  <div class="remember-row">
+    <input type="checkbox" id="remember" checked>
+    <label for="remember">Remember this choice</label>
+  </div>
+
+  <div class="status" id="status"></div>
+</div>
+
+<script>
+  const { invoke } = window.__TAURI__.core;
+
+  function setStatus(msg, cls) {
+    const el = document.getElementById('status');
+    el.textContent = msg;
+    el.className = 'status ' + (cls || '');
+  }
+
+  function setAllDisabled(disabled) {
+    document.getElementById('btn-test').disabled = disabled;
+    document.getElementById('btn-connect').disabled = disabled;
+    document.getElementById('btn-local').disabled = disabled;
+    document.getElementById('url-input').disabled = disabled;
+  }
+
+  async function testConn() {
+    const url = document.getElementById('url-input').value.trim();
+    if (!url) { setStatus('Please enter a server URL.', 'error'); return; }
+    setStatus('Testing connection...', 'info');
+    setAllDisabled(true);
+    try {
+      const result = await invoke('test_connection', { url });
+      setStatus('Connected! Server is healthy.', 'success');
+    } catch (e) {
+      setStatus(String(e), 'error');
+    } finally {
+      setAllDisabled(false);
+    }
+  }
+
+  async function connectRemote() {
+    const url = document.getElementById('url-input').value.trim();
+    if (!url) { setStatus('Please enter a server URL.', 'error'); return; }
+    const remember = document.getElementById('remember').checked;
+    setStatus('Connecting...', 'info');
+    setAllDisabled(true);
+    try {
+      await invoke('connect_remote', { url, remember });
+    } catch (e) {
+      setStatus(String(e), 'error');
+      setAllDisabled(false);
+    }
+  }
+
+  async function startLocal() {
+    const remember = document.getElementById('remember').checked;
+    setStatus('Starting local server...', 'info');
+    setAllDisabled(true);
+    try {
+      await invoke('start_local', { remember });
+    } catch (e) {
+      setStatus(String(e), 'error');
+      setAllDisabled(false);
+    }
+  }
+</script>
+</body>
+</html>"##
+        .to_string()
+}

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -75,8 +75,9 @@ pub async fn test_connection(url: String) -> Result<serde_json::Value, String> {
         .map_err(|e| format!("Invalid response: {e}"))
 }
 
-/// Connect to a remote LibreFang server. Validates the URL, optionally saves
-/// the preference, and navigates the WebView to the remote dashboard.
+/// Connect to a remote LibreFang server. Validates the URL, verifies the
+/// server is reachable, optionally saves the preference, and navigates the
+/// WebView to the remote dashboard.
 #[tauri::command]
 pub async fn connect_remote(
     url: String,
@@ -88,6 +89,22 @@ pub async fn connect_remote(
         return Err("URL must start with http:// or https://".to_string());
     }
 
+    // Verify server is reachable before committing to the connection.
+    let health_url = format!("{url}/api/health");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+    let resp = client
+        .get(&health_url)
+        .send()
+        .await
+        .map_err(|e| format!("Cannot reach server: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("Server returned {}", resp.status()));
+    }
+
+    // Save preference only after health check succeeds.
     if remember {
         save_preference(&ConnectionPreference {
             mode: "remote".to_string(),
@@ -95,10 +112,21 @@ pub async fn connect_remote(
         });
     }
 
-    // Store the server URL in managed state
+    // Update interior-mutable managed state (registered once at startup).
     let app = window.app_handle();
-    app.manage(crate::ServerUrlState(url.clone()));
-    app.manage(crate::RemoteMode(true));
+    if let Some(state) = app.try_state::<crate::ServerUrlState>() {
+        *state.0.write().unwrap() = url.clone();
+    }
+    if let Some(state) = app.try_state::<crate::RemoteMode>() {
+        *state.0.write().unwrap() = true;
+    }
+    // Clear local-only state when switching to remote.
+    if let Some(state) = app.try_state::<crate::PortState>() {
+        *state.0.write().unwrap() = None;
+    }
+    if let Some(state) = app.try_state::<crate::KernelState>() {
+        *state.0.write().unwrap() = None;
+    }
 
     info!("Connecting to remote server: {url}");
 
@@ -135,14 +163,22 @@ pub async fn start_local(
     let port = handle.port;
     let url = format!("http://127.0.0.1:{port}");
 
-    // Store state for tray and commands
-    app.manage(crate::PortState(port));
-    app.manage(crate::KernelState {
-        kernel: handle.kernel.clone(),
-        started_at: Instant::now(),
-    });
-    app.manage(crate::ServerUrlState(url.clone()));
-    app.manage(crate::RemoteMode(false));
+    // Update interior-mutable managed state (registered once at startup).
+    if let Some(state) = app.try_state::<crate::PortState>() {
+        *state.0.write().unwrap() = Some(port);
+    }
+    if let Some(state) = app.try_state::<crate::KernelState>() {
+        *state.0.write().unwrap() = Some(crate::KernelInner {
+            kernel: handle.kernel.clone(),
+            started_at: Instant::now(),
+        });
+    }
+    if let Some(state) = app.try_state::<crate::ServerUrlState>() {
+        *state.0.write().unwrap() = url.clone();
+    }
+    if let Some(state) = app.try_state::<crate::RemoteMode>() {
+        *state.0.write().unwrap() = false;
+    }
 
     // Store the ServerHandle for shutdown
     if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
@@ -152,11 +188,15 @@ pub async fn start_local(
 
     // Start event forwarding for native notifications
     if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let app_handle = app.clone();
-        let mut event_rx = ks.kernel.event_bus_ref().subscribe_all();
-        tauri::async_runtime::spawn(async move {
-            crate::forward_kernel_events(app_handle, &mut event_rx).await;
-        });
+        let guard = ks.0.read().unwrap();
+        if let Some(ref inner) = *guard {
+            let app_handle = app.clone();
+            let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();
+            drop(guard);
+            tauri::async_runtime::spawn(async move {
+                crate::forward_kernel_events(app_handle, &mut event_rx).await;
+            });
+        }
     }
 
     if remember {

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -24,19 +24,26 @@ use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
 
 /// Managed state: the port the embedded server listens on.
-pub struct PortState(pub u16);
+/// Wrapped in `RwLock<Option<_>>` — `None` when running in remote mode or before local boot.
+pub struct PortState(pub std::sync::RwLock<Option<u16>>);
 
-/// Managed state: the kernel instance and startup time.
-pub struct KernelState {
+/// Inner data for `KernelState`.
+pub struct KernelInner {
     pub kernel: Arc<LibreFangKernel>,
     pub started_at: Instant,
 }
 
+/// Managed state: the kernel instance and startup time.
+/// Wrapped in `RwLock<Option<_>>` — `None` when running in remote mode or before local boot.
+pub struct KernelState(pub std::sync::RwLock<Option<KernelInner>>);
+
 /// Managed state: the server URL (local or remote) the WebView points at.
-pub struct ServerUrlState(pub String);
+/// Uses interior mutability so it can be updated when the user changes servers.
+pub struct ServerUrlState(pub std::sync::RwLock<String>);
 
 /// Managed state: whether the app is connected to a remote server.
-pub struct RemoteMode(pub bool);
+/// Uses interior mutability so it can be updated when the user changes servers.
+pub struct RemoteMode(pub std::sync::RwLock<bool>);
 
 /// Managed state: holds the `ServerHandle` for shutdown when running in local mode.
 /// Wrapped in a `Mutex<Option<_>>` so it can be filled after app setup (from the
@@ -149,7 +156,8 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     let (initial_url, server_handle, is_remote) = match &mode {
         StartupMode::Remote(url) => {
             if !url.starts_with("http://") && !url.starts_with("https://") {
-                panic!("Server URL must use http:// or https://, got: {url}");
+                eprintln!("Server URL must use http:// or https://, got: {url}");
+                std::process::exit(1);
             }
             info!("Remote mode: connecting to {url}");
             (url.clone(), None, true)
@@ -207,28 +215,35 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     // Always register the ServerHandleHolder so start_local can fill it later.
     let holder = ServerHandleHolder(std::sync::Mutex::new(server_handle));
 
-    // Conditionally register state depending on the mode.
-    // For direct modes, we know port/kernel/url/remote up front.
-    // For connection screen mode, these are registered later by IPC commands.
-    if let StartupMode::Remote(_) = &mode {
-        builder = builder
-            .manage(ServerUrlState(initial_url.clone()))
-            .manage(RemoteMode(true));
-    } else if let StartupMode::Local = &mode {
-        // Retrieve port + kernel from the holder before Tauri takes ownership.
-        let guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
-        if let Some(ref handle) = *guard {
-            builder = builder
-                .manage(PortState(handle.port))
-                .manage(KernelState {
-                    kernel: handle.kernel.clone(),
-                    started_at: Instant::now(),
-                })
-                .manage(ServerUrlState(initial_url.clone()))
-                .manage(RemoteMode(false));
+    // Pre-compute initial values for interior-mutable state.
+    let (init_port, init_kernel_inner, init_url, init_remote) = match &mode {
+        StartupMode::Remote(_) => (None, None, initial_url.clone(), true),
+        StartupMode::Local => {
+            let guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
+            let (p, k) = if let Some(ref handle) = *guard {
+                (
+                    Some(handle.port),
+                    Some(KernelInner {
+                        kernel: handle.kernel.clone(),
+                        started_at: Instant::now(),
+                    }),
+                )
+            } else {
+                (None, None)
+            };
+            drop(guard);
+            (p, k, initial_url.clone(), false)
         }
-        drop(guard);
-    }
+        StartupMode::ConnectionScreen => (None, None, String::new(), false),
+    };
+
+    // Register ALL state types ONCE with initial values. Updates go through
+    // interior-mutable RwLocks — Tauri `manage()` is a no-op for duplicates.
+    builder = builder
+        .manage(PortState(std::sync::RwLock::new(init_port)))
+        .manage(KernelState(std::sync::RwLock::new(init_kernel_inner)))
+        .manage(ServerUrlState(std::sync::RwLock::new(init_url)))
+        .manage(RemoteMode(std::sync::RwLock::new(init_remote)));
 
     builder
         .manage(holder)
@@ -291,11 +306,15 @@ pub fn run(server_url: Option<String>, force_local: bool) {
             // For local direct-boot mode, start event forwarding for notifications
             if !is_remote && !show_connection_screen {
                 if let Some(ks) = app.try_state::<KernelState>() {
-                    let app_handle = app.handle().clone();
-                    let mut event_rx = ks.kernel.event_bus_ref().subscribe_all();
-                    tauri::async_runtime::spawn(async move {
-                        forward_kernel_events(app_handle, &mut event_rx).await;
-                    });
+                    let guard = ks.0.read().unwrap();
+                    if let Some(ref inner) = *guard {
+                        let app_handle = app.handle().clone();
+                        let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();
+                        drop(guard);
+                        tauri::async_runtime::spawn(async move {
+                            forward_kernel_events(app_handle, &mut event_rx).await;
+                        });
+                    }
                 }
             }
 

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -3,8 +3,12 @@
 //! Boots the kernel + embedded API server, then opens a native window pointing
 //! at the WebUI. Includes system tray, single-instance enforcement, native OS
 //! notifications, global shortcuts, auto-start, and update checking.
+//!
+//! Supports remote server mode: connect to a running LibreFang instance instead
+//! of always starting a local one. Priority: CLI arg > env var > saved pref > connection screen.
 
 mod commands;
+mod connection;
 mod dotenv;
 mod server;
 mod shortcuts;
@@ -28,9 +32,84 @@ pub struct KernelState {
     pub started_at: Instant,
 }
 
+/// Managed state: the server URL (local or remote) the WebView points at.
+pub struct ServerUrlState(pub String);
+
+/// Managed state: whether the app is connected to a remote server.
+pub struct RemoteMode(pub bool);
+
+/// Managed state: holds the `ServerHandle` for shutdown when running in local mode.
+/// Wrapped in a `Mutex<Option<_>>` so it can be filled after app setup (from the
+/// `start_local` command) and taken on app exit.
+pub struct ServerHandleHolder(pub std::sync::Mutex<Option<server::ServerHandle>>);
+
+/// Forward critical kernel events as native OS notifications.
+///
+/// Only truly critical events — crashes, hard quota limits, and kernel shutdown.
+pub async fn forward_kernel_events(
+    app_handle: tauri::AppHandle,
+    event_rx: &mut tokio::sync::broadcast::Receiver<librefang_types::event::Event>,
+) {
+    loop {
+        match event_rx.recv().await {
+            Ok(event) => {
+                let (title, body) = match &event.payload {
+                    EventPayload::Lifecycle(LifecycleEvent::Crashed { agent_id, error }) => (
+                        "Agent Crashed".to_string(),
+                        format!("Agent {agent_id} crashed: {error}"),
+                    ),
+                    EventPayload::System(SystemEvent::KernelStopping) => (
+                        "Kernel Stopping".to_string(),
+                        "LibreFang kernel is shutting down".to_string(),
+                    ),
+                    EventPayload::System(SystemEvent::QuotaEnforced {
+                        agent_id,
+                        spent,
+                        limit,
+                    }) => (
+                        "Quota Enforced".to_string(),
+                        format!("Agent {agent_id} quota hit: ${spent:.4} / ${limit:.4}"),
+                    ),
+                    _ => continue,
+                };
+
+                if let Err(e) = app_handle
+                    .notification()
+                    .builder()
+                    .title(&title)
+                    .body(&body)
+                    .show()
+                {
+                    warn!("Failed to send desktop notification: {e}");
+                }
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                warn!("Notification listener lagged, skipped {n} events");
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                info!("Event bus closed, stopping notification listener");
+                break;
+            }
+        }
+    }
+}
+
+/// Resolved startup mode.
+enum StartupMode {
+    /// Connect directly to a remote server URL (skip connection screen).
+    Remote(String),
+    /// Boot a local server (skip connection screen).
+    Local,
+    /// Show the connection screen and let the user decide.
+    ConnectionScreen,
+}
+
 /// Entry point for the Tauri application.
+///
+/// `server_url` — CLI `--server-url` override (remote mode).
+/// `force_local` — CLI `--local` flag (skip connection screen, start local).
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(server_url: Option<String>, force_local: bool) {
     // Init tracing
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -44,14 +123,50 @@ pub fn run() {
     // Load ~/.librefang/.env into process environment (system env takes priority).
     dotenv::load_dotenv();
 
-    // Boot kernel + embedded server (blocks until port is known)
-    let server_handle = server::start_server().expect("Failed to start LibreFang server");
-    let port = server_handle.port;
-    let kernel_for_notifications = server_handle.kernel.clone();
+    // Resolve connection mode (priority: CLI > env var > saved preference > connection screen)
+    let mode = if let Some(ref url) = server_url {
+        StartupMode::Remote(url.trim_end_matches('/').to_string())
+    } else if force_local {
+        StartupMode::Local
+    } else if let Some(url) = std::env::var("LIBREFANG_SERVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        StartupMode::Remote(url.trim_end_matches('/').to_string())
+    } else if let Some(pref) = connection::load_saved_preference() {
+        match pref.mode.as_str() {
+            "remote" if pref.server_url.is_some() => {
+                StartupMode::Remote(pref.server_url.unwrap().trim_end_matches('/').to_string())
+            }
+            "local" => StartupMode::Local,
+            _ => StartupMode::ConnectionScreen,
+        }
+    } else {
+        StartupMode::ConnectionScreen
+    };
 
-    info!("LibreFang server running on port {port}");
+    // For direct modes (remote or forced local), resolve URL + optional server handle now.
+    let (initial_url, server_handle, is_remote) = match &mode {
+        StartupMode::Remote(url) => {
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                panic!("Server URL must use http:// or https://, got: {url}");
+            }
+            info!("Remote mode: connecting to {url}");
+            (url.clone(), None, true)
+        }
+        StartupMode::Local => {
+            let handle = server::start_server().expect("Failed to start LibreFang server");
+            let port = handle.port;
+            info!("LibreFang server running on port {port}");
+            (format!("http://127.0.0.1:{port}"), Some(handle), false)
+        }
+        StartupMode::ConnectionScreen => {
+            // Will be resolved later via the connection screen IPC commands.
+            (String::new(), None, false)
+        }
+    };
 
-    let url = format!("http://127.0.0.1:{port}");
+    let show_connection_screen = matches!(mode, StartupMode::ConnectionScreen);
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
@@ -89,12 +204,34 @@ pub fn run() {
         }
     }
 
+    // Always register the ServerHandleHolder so start_local can fill it later.
+    let holder = ServerHandleHolder(std::sync::Mutex::new(server_handle));
+
+    // Conditionally register state depending on the mode.
+    // For direct modes, we know port/kernel/url/remote up front.
+    // For connection screen mode, these are registered later by IPC commands.
+    if let StartupMode::Remote(_) = &mode {
+        builder = builder
+            .manage(ServerUrlState(initial_url.clone()))
+            .manage(RemoteMode(true));
+    } else if let StartupMode::Local = &mode {
+        // Retrieve port + kernel from the holder before Tauri takes ownership.
+        let guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
+        if let Some(ref handle) = *guard {
+            builder = builder
+                .manage(PortState(handle.port))
+                .manage(KernelState {
+                    kernel: handle.kernel.clone(),
+                    started_at: Instant::now(),
+                })
+                .manage(ServerUrlState(initial_url.clone()))
+                .manage(RemoteMode(false));
+        }
+        drop(guard);
+    }
+
     builder
-        .manage(PortState(port))
-        .manage(KernelState {
-            kernel: server_handle.kernel.clone(),
-            started_at: Instant::now(),
-        })
+        .manage(holder)
         .invoke_handler(tauri::generate_handler![
             commands::get_port,
             commands::get_status,
@@ -107,84 +244,60 @@ pub fn run() {
             commands::install_update,
             commands::open_config_dir,
             commands::open_logs_dir,
+            connection::test_connection,
+            connection::connect_remote,
+            connection::start_local,
         ])
         .setup(move |app| {
-            // Create the main window pointing directly at the embedded HTTP server.
-            // We do NOT define windows in tauri.conf.json because Tauri would try to
-            // load index.html from embedded assets (which don't exist), causing a race
-            // condition where AssetNotFound overwrites the navigated page.
-            let _window = WebviewWindowBuilder::new(
-                app,
-                "main",
-                WebviewUrl::External(url.parse().expect("Invalid server URL")),
-            )
-            .title("LibreFang")
-            .inner_size(1280.0, 800.0)
-            .min_inner_size(800.0, 600.0)
-            .center()
-            .visible(true)
-            .build()?;
+            if show_connection_screen {
+                // Show the connection screen via about:blank + eval
+                let window = WebviewWindowBuilder::new(
+                    app,
+                    "main",
+                    WebviewUrl::External("about:blank".parse().expect("Invalid about:blank URL")),
+                )
+                .title("LibreFang — Connect")
+                .inner_size(1280.0, 800.0)
+                .min_inner_size(800.0, 600.0)
+                .center()
+                .visible(true)
+                .build()?;
+
+                // Inject the connection screen HTML into the blank page
+                let html = connection::connection_html();
+                let escaped = serde_json::to_string(&html).unwrap_or_default();
+                window.eval(format!(
+                    "document.open(); document.write({escaped}); document.close();"
+                ))?;
+            } else {
+                // Direct mode — navigate to the resolved URL
+                let _window = WebviewWindowBuilder::new(
+                    app,
+                    "main",
+                    WebviewUrl::External(initial_url.parse().expect("Invalid server URL")),
+                )
+                .title("LibreFang")
+                .inner_size(1280.0, 800.0)
+                .min_inner_size(800.0, 600.0)
+                .center()
+                .visible(true)
+                .build()?;
+            }
 
             // Set up system tray (desktop only)
             #[cfg(desktop)]
             tray::setup_tray(app)?;
 
-            // Spawn background task to forward critical kernel events as native
-            // OS notifications. Only truly critical events — crashes, hard quota
-            // limits, and kernel shutdown. Health checks and quota warnings are
-            // too noisy for desktop notifications.
-            let app_handle = app.handle().clone();
-            let mut event_rx = kernel_for_notifications.event_bus_ref().subscribe_all();
-            tauri::async_runtime::spawn(async move {
-                loop {
-                    match event_rx.recv().await {
-                        Ok(event) => {
-                            let (title, body) = match &event.payload {
-                                EventPayload::Lifecycle(LifecycleEvent::Crashed {
-                                    agent_id,
-                                    error,
-                                }) => (
-                                    "Agent Crashed".to_string(),
-                                    format!("Agent {agent_id} crashed: {error}"),
-                                ),
-                                EventPayload::System(SystemEvent::KernelStopping) => (
-                                    "Kernel Stopping".to_string(),
-                                    "LibreFang kernel is shutting down".to_string(),
-                                ),
-                                EventPayload::System(SystemEvent::QuotaEnforced {
-                                    agent_id,
-                                    spent,
-                                    limit,
-                                }) => (
-                                    "Quota Enforced".to_string(),
-                                    format!(
-                                        "Agent {agent_id} quota hit: ${spent:.4} / ${limit:.4}"
-                                    ),
-                                ),
-                                // Skip everything else (health checks, spawns, suspends, etc.)
-                                _ => continue,
-                            };
-
-                            if let Err(e) = app_handle
-                                .notification()
-                                .builder()
-                                .title(&title)
-                                .body(&body)
-                                .show()
-                            {
-                                warn!("Failed to send desktop notification: {e}");
-                            }
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!("Notification listener lagged, skipped {n} events");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            info!("Event bus closed, stopping notification listener");
-                            break;
-                        }
-                    }
+            // For local direct-boot mode, start event forwarding for notifications
+            if !is_remote && !show_connection_screen {
+                if let Some(ks) = app.try_state::<KernelState>() {
+                    let app_handle = app.handle().clone();
+                    let mut event_rx = ks.kernel.event_bus_ref().subscribe_all();
+                    tauri::async_runtime::spawn(async move {
+                        forward_kernel_events(app_handle, &mut event_rx).await;
+                    });
                 }
-            });
+            }
 
             // Spawn startup update check (desktop only, after event forwarding is set up)
             #[cfg(desktop)]
@@ -209,7 +322,8 @@ pub fn run() {
             }
         });
 
-    // App event loop has ended — shut down the embedded server + kernel
-    info!("Tauri app closed, shutting down embedded server...");
-    server_handle.shutdown();
+    // App event loop has ended — shut down the embedded server + kernel if local
+    info!("Tauri app closed, shutting down...");
+    // The ServerHandle's Drop impl will signal shutdown automatically when
+    // Tauri's managed state is dropped.
 }

--- a/crates/librefang-desktop/src/main.rs
+++ b/crates/librefang-desktop/src/main.rs
@@ -1,6 +1,21 @@
 // Prevents additional console window on Windows in release.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "librefang-desktop", about = "LibreFang Desktop — Agent OS")]
+struct Cli {
+    /// Connect to a remote LibreFang server URL (e.g. http://192.168.1.100:4545)
+    #[arg(long, value_name = "URL")]
+    server_url: Option<String>,
+
+    /// Start local server without showing connection screen
+    #[arg(long)]
+    local: bool,
+}
+
 fn main() {
-    librefang_desktop::run();
+    let cli = Cli::parse();
+    librefang_desktop::run(cli.server_url, cli.local);
 }

--- a/crates/librefang-desktop/src/tray.rs
+++ b/crates/librefang-desktop/src/tray.rs
@@ -30,19 +30,35 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Action items
     let show = MenuItem::with_id(app, "show", "Show Window", true, None::<&str>)?;
     let browser = MenuItem::with_id(app, "browser", "Open in Browser", true, None::<&str>)?;
+    let change_server =
+        MenuItem::with_id(app, "change_server", "Change Server...", true, None::<&str>)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
 
     // Informational items (disabled — display only)
+    let is_remote = app
+        .try_state::<crate::RemoteMode>()
+        .map(|r| r.0)
+        .unwrap_or(false);
+
+    let status_text = if is_remote {
+        let url = app
+            .try_state::<crate::ServerUrlState>()
+            .map(|s| s.0.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        format!("Status: Remote ({url})")
+    } else if let Some(ks) = app.try_state::<crate::KernelState>() {
+        let uptime = format_uptime(ks.started_at.elapsed().as_secs());
+        format!("Status: Running ({uptime})")
+    } else {
+        "Status: Not connected".to_string()
+    };
+
     let agent_count = if let Some(ks) = app.try_state::<crate::KernelState>() {
         ks.kernel.agent_registry().list().len()
     } else {
         0
     };
-    let uptime = if let Some(ks) = app.try_state::<crate::KernelState>() {
-        format_uptime(ks.started_at.elapsed().as_secs())
-    } else {
-        "0s".to_string()
-    };
+
     let agents_info = MenuItem::with_id(
         app,
         "agents_info",
@@ -50,13 +66,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         false,
         None::<&str>,
     )?;
-    let status_info = MenuItem::with_id(
-        app,
-        "status_info",
-        format!("Status: Running ({uptime})"),
-        false,
-        None::<&str>,
-    )?;
+    let status_info = MenuItem::with_id(app, "status_info", &status_text, false, None::<&str>)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
 
     // Settings items
@@ -92,6 +102,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         &[
             &show,
             &browser,
+            &change_server,
             &sep1,
             &agents_info,
             &status_info,
@@ -121,9 +132,29 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             "browser" => {
-                if let Some(port) = app.try_state::<crate::PortState>() {
+                // Use ServerUrlState (works for both remote and local modes)
+                if let Some(url_state) = app.try_state::<crate::ServerUrlState>() {
+                    let _ = open::that(&url_state.0);
+                } else if let Some(port) = app.try_state::<crate::PortState>() {
+                    // Fallback for backward compatibility
                     let url = format!("http://127.0.0.1:{}", port.0);
                     let _ = open::that(&url);
+                }
+            }
+            "change_server" => {
+                // Navigate back to the connection screen
+                if let Some(w) = app.get_webview_window("main") {
+                    let html = crate::connection::connection_html();
+                    let escaped = serde_json::to_string(&html).unwrap_or_default();
+                    let js =
+                        format!("document.open(); document.write({escaped}); document.close();");
+                    if let Err(e) = w.eval(&js) {
+                        warn!("Failed to show connection screen: {e}");
+                    }
+                    let _ = w.set_title("LibreFang — Connect");
+                    let _ = w.show();
+                    let _ = w.unminimize();
+                    let _ = w.set_focus();
                 }
             }
             "launch_at_login" => {

--- a/crates/librefang-desktop/src/tray.rs
+++ b/crates/librefang-desktop/src/tray.rs
@@ -37,24 +37,34 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Informational items (disabled — display only)
     let is_remote = app
         .try_state::<crate::RemoteMode>()
-        .map(|r| r.0)
+        .map(|r| *r.0.read().unwrap())
         .unwrap_or(false);
 
     let status_text = if is_remote {
         let url = app
             .try_state::<crate::ServerUrlState>()
-            .map(|s| s.0.clone())
+            .map(|s| s.0.read().unwrap().clone())
             .unwrap_or_else(|| "unknown".to_string());
         format!("Status: Remote ({url})")
     } else if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let uptime = format_uptime(ks.started_at.elapsed().as_secs());
-        format!("Status: Running ({uptime})")
+        let guard = ks.0.read().unwrap();
+        if let Some(ref inner) = *guard {
+            let uptime = format_uptime(inner.started_at.elapsed().as_secs());
+            format!("Status: Running ({uptime})")
+        } else {
+            "Status: Not connected".to_string()
+        }
     } else {
         "Status: Not connected".to_string()
     };
 
     let agent_count = if let Some(ks) = app.try_state::<crate::KernelState>() {
-        ks.kernel.agent_registry().list().len()
+        let guard = ks.0.read().unwrap();
+        if let Some(ref inner) = *guard {
+            inner.kernel.agent_registry().list().len()
+        } else {
+            0
+        }
     } else {
         0
     };
@@ -134,14 +144,34 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "browser" => {
                 // Use ServerUrlState (works for both remote and local modes)
                 if let Some(url_state) = app.try_state::<crate::ServerUrlState>() {
-                    let _ = open::that(&url_state.0);
+                    let url = url_state.0.read().unwrap().clone();
+                    if !url.is_empty() {
+                        let _ = open::that(&url);
+                    }
                 } else if let Some(port) = app.try_state::<crate::PortState>() {
                     // Fallback for backward compatibility
-                    let url = format!("http://127.0.0.1:{}", port.0);
-                    let _ = open::that(&url);
+                    if let Some(p) = *port.0.read().unwrap() {
+                        let url = format!("http://127.0.0.1:{p}");
+                        let _ = open::that(&url);
+                    }
                 }
             }
             "change_server" => {
+                // Shut down existing local server if running.
+                if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
+                    let mut guard = holder.0.lock().unwrap();
+                    if let Some(handle) = guard.take() {
+                        std::thread::spawn(move || handle.shutdown());
+                    }
+                }
+                // Clear local-mode state so commands report "not running".
+                if let Some(state) = app.try_state::<crate::PortState>() {
+                    *state.0.write().unwrap() = None;
+                }
+                if let Some(state) = app.try_state::<crate::KernelState>() {
+                    *state.0.write().unwrap() = None;
+                }
+
                 // Navigate back to the connection screen
                 if let Some(w) = app.get_webview_window("main") {
                     let html = crate::connection::connection_html();

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3239,6 +3239,50 @@ system_prompt = "You are a helpful assistant."
     ///
     /// The message is answered using the agent's system prompt and model, but in a
     /// **fresh temporary session** — no conversation history is loaded and the
+    /// Lightweight LLM call for classification tasks (reply-intent, routing, etc.).
+    ///
+    /// Resolves the agent's LLM driver and sends a minimal completion request
+    /// with NO tools, NO history, NO agent loop — just a system prompt and a
+    /// user message. Returns the raw LLM text response.
+    ///
+    /// Cost: ~100-200 tokens (system + user + response). Orders of magnitude
+    /// cheaper than `send_message` which runs the full agent loop.
+    pub async fn classify_text(
+        &self,
+        agent_id: AgentId,
+        system_prompt: &str,
+        user_message: &str,
+        max_tokens: u32,
+    ) -> KernelResult<String> {
+        let entry = self.registry.get(agent_id).ok_or_else(|| {
+            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
+        })?;
+        let driver = self.resolve_driver(&entry.manifest)?;
+        let request = librefang_runtime::llm_driver::CompletionRequest {
+            model: entry.manifest.model.model.clone(),
+            messages: vec![librefang_types::message::Message {
+                role: librefang_types::message::Role::User,
+                content: librefang_types::message::MessageContent::Text(user_message.to_string()),
+                pinned: false,
+            }],
+            tools: vec![],
+            max_tokens,
+            temperature: 0.0, // Deterministic for classification
+            system: Some(system_prompt.to_string()),
+            thinking: None,
+            extra_body: None,
+            response_format: None,
+            prompt_caching: false,
+            timeout_secs: Some(10),
+        };
+        let response = driver.complete(request).await.map_err(|e| {
+            KernelError::LibreFang(LibreFangError::Internal(format!(
+                "classify_text LLM call failed: {e}"
+            )))
+        })?;
+        Ok(response.text())
+    }
+
     /// exchange is **not persisted** to the real session. This lets users ask quick
     /// throwaway questions without polluting the ongoing conversation context.
     pub async fn send_message_ephemeral(

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -3310,6 +3310,9 @@ system_prompt = "You are a helpful assistant."
                 channel_type: None,
                 sender_display_name: None,
                 sender_user_id: None,
+                sender_username: None,
+                bot_username: None,
+                group_members: Vec::new(),
                 is_subagent: false,
                 is_autonomous: manifest.autonomous.is_some(),
                 agents_md: ws_meta.as_ref().and_then(|m| m.agents_md.clone()),
@@ -3920,8 +3923,24 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
+                sender_username: sender_context.and_then(|s| s.sender_username.clone()),
                 is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
                 was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
+                bot_username: sender_context.and_then(|s| s.bot_username.clone()),
+                group_members: sender_context
+                    .map(|s| {
+                        s.group_members
+                            .iter()
+                            .map(|m| {
+                                (
+                                    m.user_id.clone(),
+                                    m.display_name.clone(),
+                                    m.username.clone(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")
@@ -5030,8 +5049,24 @@ system_prompt = "You are a helpful assistant."
                 channel_type: sender_context.map(|s| s.channel.clone()),
                 sender_display_name: sender_context.map(|s| s.display_name.clone()),
                 sender_user_id: sender_context.map(|s| s.user_id.clone()),
+                sender_username: sender_context.and_then(|s| s.sender_username.clone()),
                 is_group: sender_context.map(|s| s.is_group).unwrap_or(false),
                 was_mentioned: sender_context.map(|s| s.was_mentioned).unwrap_or(false),
+                bot_username: sender_context.and_then(|s| s.bot_username.clone()),
+                group_members: sender_context
+                    .map(|s| {
+                        s.group_members
+                            .iter()
+                            .map(|m| {
+                                (
+                                    m.user_id.clone(),
+                                    m.display_name.clone(),
+                                    m.username.clone(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
                 is_subagent: manifest
                     .metadata
                     .get("is_subagent")

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -41,10 +41,20 @@ pub struct PromptContext {
     pub sender_display_name: Option<String>,
     /// Sender's platform user ID (from channel message).
     pub sender_user_id: Option<String>,
+    /// Sender's `@handle` on the platform (Telegram/Discord/Slack, when available).
+    pub sender_username: Option<String>,
     /// Whether the current message originated from a group chat.
     pub is_group: bool,
     /// Whether the bot was @mentioned in a group message.
     pub was_mentioned: bool,
+    /// The bot's own platform `@handle` (e.g. `fandangorodelo_bot` on Telegram).
+    /// Injected into the system prompt so the LLM recognises mentions of itself
+    /// as a valid alias, not as a reference to some other entity.
+    pub bot_username: Option<String>,
+    /// Known members of the current group chat, accumulated from past
+    /// messages. Empty in DMs and on the first message of a fresh group.
+    /// Each entry is `(user_id, display_name, username)`.
+    pub group_members: Vec<(String, String, Option<String>)>,
     /// Whether this agent was spawned as a subagent.
     pub is_subagent: bool,
     /// Whether this agent has autonomous config.
@@ -164,8 +174,11 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
                 channel,
                 ctx.sender_display_name.as_deref(),
                 ctx.sender_user_id.as_deref(),
+                ctx.sender_username.as_deref(),
                 ctx.is_group,
                 ctx.was_mentioned,
+                ctx.bot_username.as_deref(),
+                &ctx.group_members,
             ));
         }
     }
@@ -466,12 +479,16 @@ fn build_user_section(user_name: Option<&str>) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_channel_section(
     channel: &str,
     sender_name: Option<&str>,
     sender_id: Option<&str>,
+    sender_username: Option<&str>,
     is_group: bool,
     was_mentioned: bool,
+    bot_username: Option<&str>,
+    group_members: &[(String, String, Option<String>)],
 ) -> String {
     let (limit, hints) = match channel {
         "telegram" => (
@@ -506,22 +523,45 @@ fn build_channel_section(
          You are responding via {channel}. Keep messages under {limit} chars.\n\
          {hints}"
     );
+
+    // Self-awareness: tell the agent its own platform handle so it recognises
+    // mentions of itself as a valid alias, not as a reference to another entity.
+    if let Some(handle) = bot_username {
+        let clean = sanitize_identity(handle);
+        section.push_str(&format!(
+            "\nYour own `@{clean}` handle on {channel} is a valid alias for you. \
+             When users address you with it, they are talking TO you — do not \
+             interpret it as a reference to some other user or agent."
+        ));
+    }
+
     // Append sender identity when available from channel bridge.
     // Both fields originate from the channel platform's user profile —
     // they are attacker-controlled in any public-facing deployment,
     // so sanitize before interpolating into the system prompt.
+    let sender_handle = sender_username.map(sanitize_identity);
     match (sender_name, sender_id) {
         (Some(name), Some(id)) => {
+            let handle_bit = sender_handle
+                .as_ref()
+                .map(|h| format!(", @{h}"))
+                .unwrap_or_default();
             section.push_str(&format!(
-                "\nThe current message is from user \"{}\" (platform ID: {}).",
+                "\nThe current message is from user \"{}\"{} (platform ID: {}).",
                 sanitize_identity(name),
+                handle_bit,
                 sanitize_identity(id)
             ));
         }
         (Some(name), None) => {
+            let handle_bit = sender_handle
+                .as_ref()
+                .map(|h| format!(" (@{h})"))
+                .unwrap_or_default();
             section.push_str(&format!(
-                "\nThe current message is from user \"{}\".",
-                sanitize_identity(name)
+                "\nThe current message is from user \"{}\"{}.",
+                sanitize_identity(name),
+                handle_bit
             ));
         }
         (None, Some(id)) => {
@@ -532,12 +572,42 @@ fn build_channel_section(
         }
         (None, None) => {}
     }
+
     if is_group {
         section.push_str("\nThis message is from a group chat.");
         if was_mentioned {
             section.push_str(" You were @mentioned directly.");
         }
+
+        // Group roster: list the known members so the agent can distinguish
+        // the current sender from other humans mentioned by `@handle` in the
+        // message text. Without this, a message like `dile a @jose ...` looks
+        // like a reference to an internal agent.
+        if !group_members.is_empty() {
+            section.push_str("\n\n### Known members of this group");
+            for (user_id, display_name, username) in group_members {
+                let name_clean = sanitize_identity(display_name);
+                let id_clean = sanitize_identity(user_id);
+                let handle = match username {
+                    Some(u) => format!(" (@{}, id={})", sanitize_identity(u), id_clean),
+                    None => format!(" (id={id_clean})"),
+                };
+                section.push_str(&format!("\n- {name_clean}{handle}"));
+            }
+            section.push_str(
+                "\n\nWhen a message contains an `@handle` or a user name, look it up \
+                 in the list above. Those are real humans in this chat. They are \
+                 NEVER agents or other LibreFang entities — if you need to reach \
+                 another agent you use the `agent_send` tool (by name), not an \
+                 `@` mention in the reply text. If the referenced name is not in \
+                 the list above, say so plainly — do not invent an identity. \
+                 Address replies to the actual sender of the current message, \
+                 not to other members unless explicitly asked to pass a message \
+                 along.",
+            );
+        }
     }
+
     section
 }
 
@@ -996,44 +1066,129 @@ mod tests {
 
     #[test]
     fn test_channel_telegram() {
-        let section = build_channel_section("telegram", None, None, false, false);
+        let section = build_channel_section("telegram", None, None, None, false, false, None, &[]);
         assert!(section.contains("4096"));
         assert!(section.contains("Telegram"));
     }
 
     #[test]
     fn test_channel_discord() {
-        let section = build_channel_section("discord", None, None, false, false);
+        let section = build_channel_section("discord", None, None, None, false, false, None, &[]);
         assert!(section.contains("2000"));
         assert!(section.contains("Discord"));
     }
 
     #[test]
     fn test_channel_irc() {
-        let section = build_channel_section("irc", None, None, false, false);
+        let section = build_channel_section("irc", None, None, None, false, false, None, &[]);
         assert!(section.contains("512"));
         assert!(section.contains("plain text"));
     }
 
     #[test]
     fn test_channel_unknown_gets_default() {
-        let section = build_channel_section("smoke_signal", None, None, false, false);
+        let section =
+            build_channel_section("smoke_signal", None, None, None, false, false, None, &[]);
         assert!(section.contains("4096"));
         assert!(section.contains("smoke_signal"));
     }
 
     #[test]
     fn test_channel_group_chat_context() {
-        let section = build_channel_section("whatsapp", Some("Alice"), None, true, false);
+        let section = build_channel_section(
+            "whatsapp",
+            Some("Alice"),
+            None,
+            None,
+            true,
+            false,
+            None,
+            &[],
+        );
         assert!(section.contains("group chat"));
         assert!(!section.contains("@mentioned"));
     }
 
     #[test]
     fn test_channel_group_mentioned() {
-        let section = build_channel_section("whatsapp", Some("Bob"), None, true, true);
+        let section =
+            build_channel_section("whatsapp", Some("Bob"), None, None, true, true, None, &[]);
         assert!(section.contains("group chat"));
         assert!(section.contains("@mentioned"));
+    }
+
+    #[test]
+    fn test_channel_bot_handle_self_awareness() {
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("123"),
+            Some("pakman"),
+            true,
+            true,
+            Some("fandangorodelo_bot"),
+            &[],
+        );
+        assert!(section.contains("@fandangorodelo_bot"));
+        assert!(section.contains("valid alias"));
+        // Current sender rendered with its @handle
+        assert!(section.contains("Pakman"));
+        assert!(section.contains("@pakman"));
+    }
+
+    #[test]
+    fn test_channel_group_roster_rendered() {
+        let members = vec![
+            (
+                "1".to_string(),
+                "Pakman".to_string(),
+                Some("pakman".to_string()),
+            ),
+            (
+                "2".to_string(),
+                "Jorge Pablo".to_string(),
+                Some("jorgepablo".to_string()),
+            ),
+            ("3".to_string(), "dvpablo".to_string(), None),
+        ];
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("1"),
+            Some("pakman"),
+            true,
+            true,
+            Some("fandangorodelo_bot"),
+            &members,
+        );
+        assert!(section.contains("### Known members of this group"));
+        assert!(section.contains("Pakman"));
+        assert!(section.contains("Jorge Pablo"));
+        assert!(section.contains("dvpablo"));
+        assert!(section.contains("@jorgepablo"));
+        assert!(section.contains("real humans"));
+        assert!(section.contains("NOT agents"));
+    }
+
+    #[test]
+    fn test_channel_dm_has_no_roster() {
+        // DMs should never get a roster block even if one is passed.
+        let members = vec![(
+            "1".to_string(),
+            "Solo".to_string(),
+            Some("solo".to_string()),
+        )];
+        let section = build_channel_section(
+            "telegram",
+            Some("Pakman"),
+            Some("1"),
+            Some("pakman"),
+            false, // is_group = false
+            false,
+            Some("fandangorodelo_bot"),
+            &members,
+        );
+        assert!(!section.contains("### Known members of this group"));
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -160,6 +160,11 @@ pub struct ChannelOverrides {
     /// re-classification in `sticky_heuristic` mode.
     #[serde(default = "default_auto_route_divergence")]
     pub auto_route_divergence_count: u32,
+    /// When `true`, run a lightweight LLM precheck before the full agent loop
+    /// to decide whether the agent should reply at all.  Only active for group
+    /// messages; DMs always reply.  Default: `false` (opt-in).
+    #[serde(default)]
+    pub reply_precheck: bool,
 }
 
 impl Default for ChannelOverrides {
@@ -188,6 +193,7 @@ impl Default for ChannelOverrides {
             auto_route_confidence_threshold: default_auto_route_confidence(),
             auto_route_sticky_bonus: default_auto_route_bonus(),
             auto_route_divergence_count: default_auto_route_divergence(),
+            reply_precheck: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Two features for smarter group chat behavior, addressing a common pain point: bots either respond to everything (noisy) or only to formal @mentions (misses natural conversation).

Fixes #2291 and #2292.

## Feature 1: Alias-based triggering (#2292)

When `group_policy = mention_only`, the bot now also responds to messages containing its routing aliases from `[metadata.routing].aliases` in agent.toml.

Example: if aliases include "oye fandango", a message "oye fandango, búscame esto" triggers a response — no need for the formal `@fandangorodelo_bot` mention.

- Case-insensitive substring match
- Aliases fetched via new `get_agent_aliases()` trait method
- Checked after agent resolution (post-routing)
- Alias match skips the reply-intent precheck (treated as implicit mention)

## Feature 2: LLM reply-intent precheck (#2291)

When `reply_precheck = true` in channel overrides, group messages that are NOT explicitly addressed (no @mention, no command, no alias) go through a lightweight LLM classification call before the full agent loop.

The classifier returns REPLY or NO_REPLY (~100-200 tokens via new `Kernel::classify_text()`). Falls back to heuristic on LLM failure.

- **New `Kernel::classify_text()`**: direct LLM call without agent loop — no tools, no history, no streaming. Orders of magnitude cheaper than `send_message()`.
- **Fail-open**: LLM errors default to heuristic fallback (questions, greetings → reply; short messages → no reply)
- **DMs always reply**: precheck only for groups
- **Opt-in**: `reply_precheck = false` by default

### Priority chain

```
@mention → always reply
/command → always reply  
alias match → always reply (NEW)
reply_precheck=true → LLM decides (NEW)
reply_precheck=false → existing group_policy applies
```

### Configuration

```toml
[channels.telegram.overrides]
group_policy = "all"
reply_precheck = true
```

## Changes

- `bridge.rs`: `aliases_to_trigger_patterns()`, `agent_aliases` param in `should_process_group_message`, post-resolution alias+precheck block, `classify_reply_intent` + `get_agent_aliases` trait methods
- `config/types.rs`: `reply_precheck: bool` on `ChannelOverrides`
- `channel_bridge.rs`: `get_agent_aliases` reads from manifest metadata, `classify_reply_intent` uses `kernel.classify_text()` with heuristic fallback
- `kernel.rs`: new `classify_text()` — lightweight LLM call for classification tasks

## Prior art

Ported from ZeroClaw's `classify_channel_reply_intent()` pattern, adapted for librefang's architecture.

## Test plan

- [x] `cargo test -p librefang-channels` — all pass including new alias tests
- [x] `cargo clippy` — clean
- [x] `cargo check --workspace` — clean