### PR TITLE
fix(test): add missing cli_profile_dirs to DefaultModelConfig literals

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4656,6 +4656,7 @@ mod tests {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         };
         let override_dm = librefang_types::config::DefaultModelConfig {
             provider: "deepseek".to_string(),
@@ -4664,6 +4665,7 @@ mod tests {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         };
 
         let effective = effective_default_model(&base, Some(&override_dm));
@@ -4682,6 +4684,7 @@ mod tests {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         };
 
         let effective = effective_default_model(&base, None);

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -82,6 +82,7 @@ async fn start_test_server_with_provider(
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };
@@ -214,6 +215,7 @@ async fn start_full_router(api_key: &str) -> FullRouterHarness {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };
@@ -1331,6 +1333,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -100,6 +100,7 @@ async fn test_full_daemon_lifecycle() {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };
@@ -240,6 +241,7 @@ async fn test_server_immediate_responsiveness() {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -44,6 +44,7 @@ async fn start_test_server() -> TestServer {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     };

--- a/crates/librefang-kernel/tests/integration_test.rs
+++ b/crates/librefang-kernel/tests/integration_test.rs
@@ -21,6 +21,7 @@ fn test_config() -> KernelConfig {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -27,6 +27,7 @@ fn test_config(name: &str) -> KernelConfig {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
+++ b/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
@@ -117,6 +117,7 @@ fn test_config(tmp: &tempfile::TempDir) -> KernelConfig {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     }

--- a/crates/librefang-kernel/tests/workflow_integration_test.rs
+++ b/crates/librefang-kernel/tests/workflow_integration_test.rs
@@ -26,6 +26,7 @@ fn test_config(provider: &str, model: &str, api_key_env: &str) -> KernelConfig {
             base_url: None,
             message_timeout_secs: 300,
             extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
         },
         ..KernelConfig::default()
     }


### PR DESCRIPTION
## Summary

Commit e246464d (`feat(runtime): Claude Code CLI profile rotation via CLAUDE_CONFIG_DIR`) added a new required field `cli_profile_dirs: Vec<String>` to `DefaultModelConfig`, but only updated the `Default` impl. Every literal `DefaultModelConfig { ... }` initializer across tests and routes was left without the field, so they all fail with E0063 on `cargo check --tests`.

This was invisible on `main` because every commit after e246464d has been either docs-only or docker-only, and the path-filter on the Test/Ubuntu job skips those. Main is green on paper but red on reality — any substantive PR immediately fails CI (e.g. #2277 hit this in run 24228487836).

## Changes

Added `cli_profile_dirs: Vec::new(),` to 11 sites across 8 files:

- `crates/librefang-api/src/routes/agents.rs` — 3 unit-test literals
- `crates/librefang-api/tests/api_integration_test.rs` — 3 sites
- `crates/librefang-api/tests/daemon_lifecycle_test.rs` — 2 sites
- `crates/librefang-api/tests/load_test.rs` — 1 site
- `crates/librefang-kernel/tests/integration_test.rs` — 1 site
- `crates/librefang-kernel/tests/multi_agent_test.rs` — 1 site
- `crates/librefang-kernel/tests/wasm_agent_integration_test.rs` — 1 site
- `crates/librefang-kernel/tests/workflow_integration_test.rs` — 1 site

## Test plan

- [x] `cargo check -p librefang-api -p librefang-kernel --tests` — passes locally
- [ ] CI Test/Ubuntu — will now actually run (this PR touches runtime-adjacent files)