### PR TITLE
fix(hands): scan workspaces/ dir to persist locally-installed hands across boot

### DIFF
--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -146,7 +146,19 @@ fn scan_agent_skill_files(dir: &Path) -> HashMap<String, String> {
     skills
 }
 
-/// Scan `home_dir/registry/hands/` for subdirectories containing HAND.toml.
+/// Scan for subdirectories containing HAND.toml across both the read-only
+/// registry (`home_dir/registry/hands/`) and the user-writable workspaces
+/// directory (`home_dir/workspaces/`), where `install_from_content_persisted`
+/// writes locally-installed hands.
+///
+/// Both locations are scanned because registry hands come from the shared
+/// librefang-registry tarball (reset on every sync) while workspaces hands
+/// come from the dashboard "install from content" flow and must survive
+/// daemon restarts. Registry entries take precedence when an id collides
+/// (the `seen` set drops duplicates after the first hit).
+///
+/// Subdirectories of `workspaces/` that are not hands (e.g. agent workspace
+/// directories) are naturally filtered out by the `HAND.toml` existence check.
 ///
 /// Returns `(hand_id, toml_content, shared_skill_content, per_agent_skill_content)`.
 /// Per-agent skill files follow the pattern `SKILL-{role}.md` (e.g. `SKILL-pm.md`).
@@ -154,7 +166,10 @@ fn scan_hands_dir(home_dir: &Path) -> Vec<(String, String, String, HashMap<Strin
     let mut seen = std::collections::HashSet::new();
     let mut results = Vec::new();
 
-    let dirs = [home_dir.join("registry").join("hands")];
+    let dirs = [
+        home_dir.join("registry").join("hands"),
+        home_dir.join("workspaces"),
+    ];
 
     for hands_dir in &dirs {
         if let Ok(entries) = std::fs::read_dir(hands_dir) {


### PR DESCRIPTION
## Summary

Closes #2282.

`install_from_content_persisted()` in \`librefang-hands/src/registry.rs\` writes locally-installed hands to \`\$LIBREFANG_HOME/workspaces/{hand_id}/\`, but \`scan_hands_dir()\` only scans \`\$LIBREFANG_HOME/registry/hands/\` on kernel boot. The two directories never overlap, so any hand the user installs via the dashboard \"Install from Content\" flow is silently dropped after \`docker compose down\` + \`docker compose up\`.

Custom skills do not have this bug — they are written to \`\$LIBREFANG_HOME/skills/\` and the skill scanner reads the same path — which is exactly the asymmetry the reporter described (\"custom skill not gone, but custom hand gone\").

Both \`workspaces/\` and \`registry/\` sit inside the \`/data\` docker volume, so the files were never actually deleted — the boot scanner just could not find them.

## Changes

- \`crates/librefang-hands/src/registry.rs\`: \`scan_hands_dir()\` now walks both \`home_dir.join(\"registry\").join(\"hands\")\` **and** \`home_dir.join(\"workspaces\")\`. Registry entries keep priority when an id collides thanks to the existing \`seen\` de-duplication set.

Non-hand subdirectories under \`workspaces/\` (e.g. agent workspace directories) are naturally filtered out by the existing \`HAND.toml\` existence check.

## Test plan

- [x] \`cargo check -p librefang-hands --tests\` — compiles clean
- [ ] (maintainer) Docker repro: install a hand via dashboard → \`docker compose down && docker compose up\` → confirm hand reappears in \`/hands\` tab

Closes #2282