### PR TITLE
fix(providers): hide delete button for built-in providers, flag custom

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -71,6 +71,10 @@ interface Provider {
   last_tested?: string;
   error_message?: string;
   media_capabilities?: string[];
+  /** True for providers added by the user at runtime; false for ones shipped
+   *  by the registry. Only custom providers can actually be deleted — built-ins
+   *  are recreated by the next registry sync, so we hide the delete control. */
+  is_custom?: boolean;
 }
 
 interface ProviderCardProps {
@@ -171,7 +175,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               <span className="hidden sm:inline">{t("common.edit")}</span>
             </Button>
           )}
-          {isConfigured && (
+          {isConfigured && p.is_custom && (
             <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
               <span className="hidden sm:inline text-error">{t("common.delete")}</span>
             </Button>
@@ -340,7 +344,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               {t("common.edit")}
             </Button>
           )}
-          {isConfigured && (
+          {isConfigured && p.is_custom && (
             <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
               {t("common.delete")}
             </Button>

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -373,6 +373,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             "api_key_env": p.api_key_env,
             "base_url": p.base_url,
             "media_capabilities": p.media_capabilities,
+            "is_custom": p.is_custom,
         });
 
         // Attach region map so the dashboard can show available regions
@@ -483,6 +484,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "api_key_env": p.api_key_env,
             "base_url": p.base_url,
             "media_capabilities": p.media_capabilities,
+            "is_custom": p.is_custom,
         });
         if let Some(probe) = probe_map.remove(&i) {
             attach_probe_result(&mut entry, &probe, &p.id, state.kernel.model_catalog_ref());

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -46,21 +46,34 @@ impl ModelCatalog {
         providers_dir: &std::path::Path,
         registry_providers_dir: Option<&std::path::Path>,
     ) -> Self {
-        let builtin_filenames: std::collections::HashSet<std::ffi::OsString> =
-            registry_providers_dir
-                .and_then(|d| std::fs::read_dir(d).ok())
-                .into_iter()
-                .flatten()
-                .flatten()
-                .filter_map(|e| {
-                    let path = e.path();
-                    if path.extension().is_some_and(|ext| ext == "toml") {
-                        path.file_name().map(|n| n.to_os_string())
-                    } else {
-                        None
-                    }
+        // Built-in filename set for custom classification.
+        //
+        // Tri-state semantics:
+        //   - `None` registry dir passed, or `read_dir` on it failed
+        //     (missing / corrupt / unreadable cache) → classification
+        //     unavailable, fall back to is_custom=false for every provider.
+        //     This keeps the delete button hidden, which is the safe
+        //     default — a user can always remove an API key via the edit
+        //     dialog's "Remove Key" control.
+        //   - `Some(set)` successful read, even if `set` is empty → trust
+        //     the classification. An empty registry dir genuinely means
+        //     every provider is user-added.
+        let builtin_filenames: Option<std::collections::HashSet<std::ffi::OsString>> =
+            registry_providers_dir.and_then(|dir| {
+                std::fs::read_dir(dir).ok().map(|entries| {
+                    entries
+                        .flatten()
+                        .filter_map(|e| {
+                            let path = e.path();
+                            if path.extension().is_some_and(|ext| ext == "toml") {
+                                path.file_name().map(|n| n.to_os_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
                 })
-                .collect();
+            });
 
         let mut sources: Vec<(String, bool)> = Vec::new();
         if let Ok(entries) = std::fs::read_dir(providers_dir) {
@@ -68,11 +81,10 @@ impl ModelCatalog {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "toml") {
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        let is_custom = registry_providers_dir.is_some()
-                            && path
-                                .file_name()
-                                .map(|n| !builtin_filenames.contains(n))
-                                .unwrap_or(false);
+                        let is_custom = match (&builtin_filenames, path.file_name()) {
+                            (Some(set), Some(name)) => !set.contains(name),
+                            _ => false,
+                        };
                         sources.push((content, is_custom));
                     }
                 }
@@ -899,6 +911,73 @@ mod tests {
     fn test_catalog_has_models() {
         let catalog = test_catalog();
         assert!(catalog.list_models().len() >= 30);
+    }
+
+    /// P2 regression: when registry classification is unavailable
+    /// (registry dir unreadable or missing), every provider must fall back
+    /// to is_custom=false so the dashboard does not re-enable the misleading
+    /// delete button on built-ins.
+    #[test]
+    fn test_is_custom_safe_fallback_on_missing_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers_dir = tmp.path().join("providers");
+        std::fs::create_dir_all(&providers_dir).unwrap();
+        std::fs::write(
+            providers_dir.join("acme.toml"),
+            r#"[provider]
+id = "acme"
+display_name = "Acme"
+api_key_env = "ACME_API_KEY"
+base_url = "https://acme.test"
+"#,
+        )
+        .unwrap();
+
+        // Case 1: registry dir argument is None → classification skipped.
+        let catalog = ModelCatalog::new_from_dir_with_registry(&providers_dir, None);
+        assert!(
+            !catalog.list_providers().iter().any(|p| p.is_custom),
+            "is_custom must be false when no registry dir is supplied"
+        );
+
+        // Case 2: registry dir points to a nonexistent path → read_dir
+        // fails, classification must degrade to false (not true).
+        let missing_registry = tmp.path().join("nonexistent-registry");
+        let catalog =
+            ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&missing_registry));
+        assert!(
+            !catalog.list_providers().iter().any(|p| p.is_custom),
+            "is_custom must be false when registry read_dir fails"
+        );
+
+        // Case 3: registry dir exists and does NOT contain acme.toml →
+        // acme is correctly flagged custom.
+        let registry_dir = tmp.path().join("registry");
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        let catalog =
+            ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
+        assert!(
+            catalog.list_providers().iter().any(|p| p.id == "acme" && p.is_custom),
+            "acme must be flagged custom when registry dir exists but does not list it"
+        );
+
+        // Case 4: registry dir lists acme.toml → acme is a built-in.
+        std::fs::write(
+            registry_dir.join("acme.toml"),
+            r#"[provider]
+id = "acme"
+"#,
+        )
+        .unwrap();
+        let catalog =
+            ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
+        assert!(
+            catalog
+                .list_providers()
+                .iter()
+                .any(|p| p.id == "acme" && !p.is_custom),
+            "acme must NOT be flagged custom when registry dir lists it"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -19,22 +19,61 @@ pub struct ModelCatalog {
 impl ModelCatalog {
     /// Create a new catalog by loading providers from `home_dir/providers/`
     /// and aliases from `home_dir/aliases.toml`.
+    ///
+    /// Providers whose TOML filename also exists in
+    /// `home_dir/registry/providers/` are marked as built-in; the rest are
+    /// flagged `is_custom = true` so the dashboard can show a real delete
+    /// control for them.
     pub fn new(home_dir: &std::path::Path) -> Self {
         let providers_dir = home_dir.join("providers");
-        Self::new_from_dir(&providers_dir)
+        let registry_providers_dir = home_dir.join("registry").join("providers");
+        Self::new_from_dir_with_registry(&providers_dir, Some(&registry_providers_dir))
     }
 
     /// Create a catalog by loading all `*.toml` files from a specific directory.
     ///
     /// Also loads `aliases.toml` from the parent of `providers_dir` if present.
+    /// All loaded providers are marked `is_custom = false` (safe default —
+    /// callers that want custom detection should use
+    /// [`Self::new_from_dir_with_registry`] or [`Self::new`]).
     pub fn new_from_dir(providers_dir: &std::path::Path) -> Self {
-        let mut sources = Vec::new();
+        Self::new_from_dir_with_registry(providers_dir, None)
+    }
+
+    /// Same as [`Self::new_from_dir`] but with a registry-providers directory
+    /// used to classify each loaded provider as built-in vs user-added.
+    pub fn new_from_dir_with_registry(
+        providers_dir: &std::path::Path,
+        registry_providers_dir: Option<&std::path::Path>,
+    ) -> Self {
+        let builtin_filenames: std::collections::HashSet<std::ffi::OsString> =
+            registry_providers_dir
+                .and_then(|d| std::fs::read_dir(d).ok())
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|e| {
+                    let path = e.path();
+                    if path.extension().is_some_and(|ext| ext == "toml") {
+                        path.file_name().map(|n| n.to_os_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+        let mut sources: Vec<(String, bool)> = Vec::new();
         if let Ok(entries) = std::fs::read_dir(providers_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "toml") {
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        sources.push(content);
+                        let is_custom = registry_providers_dir.is_some()
+                            && path
+                                .file_name()
+                                .map(|n| !builtin_filenames.contains(n))
+                                .unwrap_or(false);
+                        sources.push((content, is_custom));
                     }
                 }
             }
@@ -46,14 +85,19 @@ impl ModelCatalog {
     }
 
     /// Build a catalog from pre-loaded TOML source strings.
-    fn from_sources(sources: &[String], aliases_source: Option<&str>) -> Self {
+    ///
+    /// Each source is tagged with an `is_custom` flag that is copied onto
+    /// the corresponding [`ProviderInfo`].
+    fn from_sources(sources: &[(String, bool)], aliases_source: Option<&str>) -> Self {
         let mut models: Vec<ModelCatalogEntry> = Vec::new();
         let mut providers: Vec<ProviderInfo> = Vec::new();
-        for source in sources {
+        for (source, is_custom) in sources {
             if let Ok(file) = toml::from_str::<ModelCatalogFile>(source) {
                 let provider_id = file.provider.as_ref().map(|p| p.id.clone());
                 if let Some(p) = file.provider {
-                    providers.push(p.into());
+                    let mut info: ProviderInfo = p.into();
+                    info.is_custom = *is_custom;
+                    providers.push(info);
                 }
                 for mut model in file.models {
                     // Back-fill provider from the [provider] section when
@@ -1411,7 +1455,10 @@ supports_tools = false
 supports_vision = false
 supports_streaming = false
 "#;
-        let sources = vec![provider_a.to_string(), provider_b.to_string()];
+        let sources = vec![
+            (provider_a.to_string(), false),
+            (provider_b.to_string(), false),
+        ];
         ModelCatalog::from_sources(&sources, None)
     }
 
@@ -1792,7 +1839,7 @@ supports_tools = true
 supports_vision = false
 supports_streaming = true
 "#;
-        let catalog = ModelCatalog::from_sources(&[toml_content.to_string()], None);
+        let catalog = ModelCatalog::from_sources(&[(toml_content.to_string(), false)], None);
         let providers = catalog.list_providers();
         assert_eq!(providers.len(), 1);
         assert_eq!(providers[0].id, "testprov");
@@ -1827,7 +1874,7 @@ supports_tools = false
 supports_vision = false
 supports_streaming = true
 "#;
-        let catalog = ModelCatalog::from_sources(&[toml_content.to_string()], None);
+        let catalog = ModelCatalog::from_sources(&[(toml_content.to_string(), false)], None);
         let providers = catalog.list_providers();
         assert_eq!(providers.len(), 1);
         assert!(providers[0].media_capabilities.is_empty());

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -954,10 +954,12 @@ base_url = "https://acme.test"
         // acme is correctly flagged custom.
         let registry_dir = tmp.path().join("registry");
         std::fs::create_dir_all(&registry_dir).unwrap();
-        let catalog =
-            ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
+        let catalog = ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
         assert!(
-            catalog.list_providers().iter().any(|p| p.id == "acme" && p.is_custom),
+            catalog
+                .list_providers()
+                .iter()
+                .any(|p| p.id == "acme" && p.is_custom),
             "acme must be flagged custom when registry dir exists but does not list it"
         );
 
@@ -969,8 +971,7 @@ id = "acme"
 "#,
         )
         .unwrap();
-        let catalog =
-            ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
+        let catalog = ModelCatalog::new_from_dir_with_registry(&providers_dir, Some(&registry_dir));
         assert!(
             catalog
                 .list_providers()

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -403,6 +403,8 @@ impl ModelCatalog {
                 regions: std::collections::HashMap::new(),
                 media_capabilities: Vec::new(),
                 available_models: Vec::new(),
+                // Added at runtime via set_provider_url → always custom.
+                is_custom: true,
             });
             // Re-detect auth for the newly added provider
             self.detect_auth();

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -184,6 +184,14 @@ pub struct ProviderInfo {
     /// Empty until background validation completes successfully.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub available_models: Vec<String>,
+    /// True when the provider was added at runtime by the user (via the
+    /// dashboard "Add provider" flow), false when it was shipped by the
+    /// librefang-registry. Drives whether the dashboard shows a real
+    /// "Delete" control — built-in providers can only be deconfigured
+    /// (key removed), not deleted, because the registry sync would
+    /// re-create their TOML on the next boot anyway.
+    #[serde(default)]
+    pub is_custom: bool,
 }
 
 impl Default for ProviderInfo {
@@ -200,6 +208,7 @@ impl Default for ProviderInfo {
             regions: HashMap::new(),
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
+            is_custom: false,
         }
     }
 }
@@ -252,6 +261,9 @@ impl From<ProviderCatalogToml> for ProviderInfo {
             regions: p.regions,
             media_capabilities: p.media_capabilities,
             available_models: Vec::new(),
+            // Populated by the runtime catalog loader (classifies based on
+            // whether the file is also present in registry/providers/).
+            is_custom: false,
         }
     }
 }
@@ -414,6 +426,7 @@ mod tests {
             regions: HashMap::new(),
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
+            is_custom: false,
         };
         let json = serde_json::to_string(&info).unwrap();
         let parsed: ProviderInfo = serde_json::from_str(&json).unwrap();
@@ -627,6 +640,7 @@ aliases = []
             ]),
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
+            is_custom: false,
         };
 
         // Simulate region selection: if user picks "us", use that region's base_url


### PR DESCRIPTION
## Summary

Closes #2288.

The Providers dashboard shows a red \"Delete\" button on every configured provider, but clicking it calls \`deleteProviderKey\` — which only removes the \`*_API_KEY\` env var. The provider itself stays in the catalog because the next registry sync recreates its TOML from \`home/registry/providers/*.toml\`. From the user's POV, delete silently fails: confirmation dialog dismisses, a \"Key removed\" toast appears, the provider is still in the list.

The underlying issue is that the frontend had no way to tell built-in providers (shipped by librefang-registry, recreated on every sync) apart from custom ones (written via \`POST /api/registry/content/provider\` to \`home/providers/{id}.toml\`, with no counterpart in \`home/registry/providers/\`). The \`ProviderInfo\` struct had no classification field.

## Approach

- Add \`is_custom: bool\` to \`ProviderInfo\` (\`#[serde(default)]\` so older clients that don't send it stay compatible).
- \`ModelCatalog::new(home_dir)\` now computes \`is_custom\` by diffing the loaded providers directory against \`home_dir/registry/providers/\`: any file whose name is **not** present in the registry-side dir is flagged custom. This runs once at catalog load time — no per-request cost.
- Add \`ModelCatalog::new_from_dir_with_registry()\` for callers that have both dirs. The legacy \`new_from_dir()\` keeps its single-arg shape and defaults to \`is_custom = false\` (safe fallback — delete button hidden everywhere if classification can't be determined).
- \`from_sources\` signature updated to \`&[(String, bool)]\`; three test call-sites updated accordingly.
- Dashboard \`ProvidersPage.tsx\`: hide the Delete button in both list and grid view unless \`p.is_custom === true\`. Built-in providers can still be \"deconfigured\" by clearing the API key through the edit dialog's \"Remove Key\" control, which already does the right thing.

## Changes

- \`crates/librefang-types/src/model_catalog.rs\`: \`ProviderInfo.is_custom\` field + \`Default\` impl + \`From<ProviderCatalogToml>\` + two test literal initializers.
- \`crates/librefang-runtime/src/model_catalog.rs\`: new \`new_from_dir_with_registry\`, \`from_sources\` tuple signature, three test call-sites.
- \`crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx\`: \`Provider\` interface extended, delete button gated on \`p.is_custom\` in both views.

## Scope note

This is the minimal honest fix for the reported bug (the dishonest button on built-ins). A **true** DELETE endpoint for custom providers — one that removes the TOML file and the in-memory catalog entry — is intentionally out of scope and should land as a separate follow-up: the reporter's video almost certainly shows a built-in provider (OpenRouter / Groq / Anthropic), and fixing that path doesn't require a new backend route at all.

## Test plan

- [x] \`cargo check --workspace --tests\` — clean
- [ ] (maintainer) Dashboard smoke test: confirm Delete button **hidden** on built-in providers (openrouter, groq, anthropic, ...)
- [ ] (maintainer) If you have a custom provider added via the \"Add Provider\" dashboard form, confirm Delete button **still shows** on it
- [ ] (maintainer) Verify the existing \"Remove Key\" path inside the edit dialog still works for built-ins (should be unchanged)

Closes #2288