### PR TITLE
fix(runtime): replace map_or(true, ...) with is_none_or in token_rotation

### DIFF
--- a/crates/librefang-runtime/src/drivers/token_rotation.rs
+++ b/crates/librefang-runtime/src/drivers/token_rotation.rs
@@ -263,7 +263,7 @@ impl LlmDriver for TokenRotationDriver {
                     // user sees when the first profile becomes available.
                     if last_error
                         .as_ref()
-                        .map_or(true, |cur| Self::resets_sooner(cur, &err))
+                        .is_none_or(|cur| Self::resets_sooner(cur, &err))
                     {
                         last_error = Some(err);
                     }
@@ -326,7 +326,7 @@ impl LlmDriver for TokenRotationDriver {
                     // user sees when the first profile becomes available.
                     if last_error
                         .as_ref()
-                        .map_or(true, |cur| Self::resets_sooner(cur, &err))
+                        .is_none_or(|cur| Self::resets_sooner(cur, &err))
                     {
                         last_error = Some(err);
                     }


### PR DESCRIPTION
## Summary

Un-blocks Quality CI on every open PR.

Rust 1.94 (pulled in by the 2026-04-09 toolchain bump) flags \`opt.map_or(true, f)\` as \`clippy::unnecessary_map_or\` and suggests \`opt.is_none_or(f)\` instead. \`token_rotation.rs\` has the anti-pattern at two sites:

- **line 264** in \`complete()\` — rate-limit fallback loop that tracks the error with the earliest reset time across all exhausted slots
- **line 327** in \`stream()\` — same pattern in the streaming path

Both are inside the \`while tried < slot_count\` error-aggregation loop. The two expressions are semantically identical — \`is_none_or(f)\` is literally defined as \`self.map_or(true, f)\` in stdlib — so this is a zero-behaviour-change rename that just satisfies the stricter lint.

## Impact

Quality has been red on every open PR since the toolchain bump landed on main (#2296, #2298, #2299, #2300 all show \`✗ Quality\`). Fixing it here un-blocks all of them without each having to rebase and tolerate a red Quality job. Once this merges, their next CI run will flip Quality to green.

## Changes

- \`crates/librefang-runtime/src/drivers/token_rotation.rs\`: two identical \`map_or(true, |cur| Self::resets_sooner(cur, &err))\` → \`is_none_or(|cur| Self::resets_sooner(cur, &err))\` rewrites.

## Test plan

- [x] \`cargo clippy -p librefang-runtime --all-targets -- -D warnings\` — clean
- [ ] (maintainer) Confirm Quality goes green on this PR's own CI run
- [ ] (maintainer) Rebase one open PR (e.g. #2298) on merged main and confirm its Quality also flips to green