### PR TITLE
feat(ws) harden terminal websocket follow-ups after #2229

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -39,6 +39,12 @@ export function TerminalPage() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const sendCloseMessage = useCallback((ws: WebSocket | null) => {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "close" }));
+    }
+  }, []);
+
   const connect = useCallback(() => {
     if (wsRef.current) {
       wsRef.current.close();
@@ -46,8 +52,12 @@ export function TerminalPage() {
 
     setError(null);
     setIsConnecting(true);
-    const url = buildAuthenticatedWebSocketUrl("/api/terminal/ws");
-    const ws = new WebSocket(url);
+    const url = new URL(buildAuthenticatedWebSocketUrl("/api/terminal/ws"));
+    if (terminalRef.current) {
+      url.searchParams.set("cols", String(terminalRef.current.cols));
+      url.searchParams.set("rows", String(terminalRef.current.rows));
+    }
+    const ws = new WebSocket(url.toString());
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -151,13 +161,13 @@ export function TerminalPage() {
 
     if (wsRef.current) {
       intentionalDisconnectRef.current = true;
-      wsRef.current.send(JSON.stringify({ type: "close" }));
+      sendCloseMessage(wsRef.current);
       wsRef.current.close();
       wsRef.current = null;
     }
     setIsConnected(false);
     setIsConnecting(false);
-  }, []);
+  }, [sendCloseMessage]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -205,7 +215,7 @@ export function TerminalPage() {
       }
       if (wsRef.current) {
         intentionalDisconnectRef.current = true;
-        wsRef.current.send(JSON.stringify({ type: "close" }));
+        sendCloseMessage(wsRef.current);
         wsRef.current.close();
         wsRef.current = null;
       }
@@ -213,7 +223,7 @@ export function TerminalPage() {
       setIsConnecting(false);
       term.dispose();
     };
-  }, []);
+  }, [sendCloseMessage]);
 
   return (
     <div className="flex flex-col h-full">

--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -22,8 +22,7 @@ use tracing::{info, warn};
 
 use super::AppState;
 use crate::terminal::PtySession;
-use crate::ws::send_json;
-use crate::ws::TerminalWsGuard;
+use crate::ws::{send_json, try_acquire_ws_slot, ws_auth_token, ws_query_param, WsConnectionGuard};
 
 pub const MAX_WS_MSG_SIZE: usize = 64 * 1024;
 
@@ -130,20 +129,10 @@ pub async fn terminal_ws(
     headers: axum::http::HeaderMap,
     uri: axum::http::Uri,
 ) -> impl IntoResponse {
-    // Extract token from header or query string.
-    let header_token = headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "));
-
-    let query_token = uri
-        .query()
-        .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")));
-
-    let provided_token = header_token.or(query_token);
+    let provided_token = ws_auth_token(&headers, &uri);
 
     // No token at all → immediate reject.
-    let token_str = match provided_token {
+    let token_str = match provided_token.as_deref() {
         Some(t) => t,
         None => {
             warn!("Terminal WebSocket rejected — no auth token provided");
@@ -153,6 +142,7 @@ pub async fn terminal_ws(
 
     // 1. Check against configured API tokens (constant-time compare).
     let valid_tokens = crate::server::valid_api_tokens(state.kernel.as_ref());
+    let user_api_keys = crate::server::configured_user_api_keys(state.kernel.as_ref());
     let api_auth = {
         use subtle::ConstantTimeEq;
         valid_tokens.iter().any(|key| {
@@ -172,16 +162,24 @@ pub async fn terminal_ws(
         });
         sessions.contains_key(token_str)
     };
+    let mut user_key_auth = false;
+    if !session_auth {
+        user_key_auth = user_api_keys
+            .iter()
+            .any(|user| crate::password_hash::verify_password(token_str, &user.api_key_hash));
+    }
 
-    if !api_auth && !session_auth {
+    if !api_auth && !session_auth && !user_key_auth {
         warn!("Terminal WebSocket upgrade rejected: invalid auth");
         return axum::http::StatusCode::UNAUTHORIZED.into_response();
     }
 
     let ip = addr.ip();
     let max_ws_per_ip = state.kernel.config_ref().rate_limit.max_ws_per_ip;
+    let initial_cols = initial_terminal_dimension(&uri, "cols", MAX_COLS);
+    let initial_rows = initial_terminal_dimension(&uri, "rows", MAX_ROWS);
 
-    let _terminal_guard = match crate::ws::try_acquire_terminal_ws_slot(ip, max_ws_per_ip) {
+    let _terminal_guard = match try_acquire_ws_slot(ip, max_ws_per_ip) {
         Some(g) => g,
         None => {
             warn!(ip = %ip, max_ws_per_ip, "Terminal WebSocket rejected: too many connections from IP");
@@ -191,21 +189,29 @@ pub async fn terminal_ws(
 
     ws.on_upgrade(move |socket| {
         let guard = _terminal_guard;
-        handle_terminal_ws(socket, state, ip, guard)
+        handle_terminal_ws(socket, state, ip, guard, initial_cols, initial_rows)
     })
     .into_response()
+}
+
+fn initial_terminal_dimension(uri: &axum::http::Uri, key: &str, max: u16) -> Option<u16> {
+    ws_query_param(uri, key)
+        .and_then(|raw| raw.parse::<u16>().ok())
+        .filter(|value| (1..=max).contains(value))
 }
 
 async fn handle_terminal_ws(
     socket: WebSocket,
     state: Arc<AppState>,
     _client_ip: IpAddr,
-    _guard: TerminalWsGuard,
+    _guard: WsConnectionGuard,
+    initial_cols: Option<u16>,
+    initial_rows: Option<u16>,
 ) {
     let (sender, mut receiver) = socket.split();
     let sender = Arc::new(Mutex::new(sender));
 
-    let (mut pty, mut pty_rx) = match PtySession::spawn(None, None) {
+    let (mut pty, mut pty_rx) = match PtySession::spawn(initial_cols, initial_rows) {
         Ok((pty, rx)) => (pty, rx),
         Err(e) => {
             let _ = send_json(
@@ -446,7 +452,9 @@ async fn handle_terminal_ws(
 
 #[cfg(test)]
 mod tests {
-    use crate::routes::terminal::{router, ClientMessage, ServerMessage};
+    use crate::routes::terminal::{
+        initial_terminal_dimension, router, ClientMessage, ServerMessage, MAX_COLS, MAX_ROWS,
+    };
     use crate::terminal::shell_for_current_os;
 
     #[test]
@@ -500,6 +508,23 @@ mod tests {
         let ok = "x".repeat(64 * 1024);
         let msg = ClientMessage::Input { data: ok };
         assert!(msg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_initial_terminal_dimension_parses_valid_query_values() {
+        let uri: axum::http::Uri = "/api/terminal/ws?cols=132&rows=43".parse().unwrap();
+        assert_eq!(
+            initial_terminal_dimension(&uri, "cols", MAX_COLS),
+            Some(132)
+        );
+        assert_eq!(initial_terminal_dimension(&uri, "rows", MAX_ROWS), Some(43));
+    }
+
+    #[test]
+    fn test_initial_terminal_dimension_rejects_invalid_query_values() {
+        let uri: axum::http::Uri = "/api/terminal/ws?cols=2000&rows=0".parse().unwrap();
+        assert_eq!(initial_terminal_dimension(&uri, "cols", MAX_COLS), None);
+        assert_eq!(initial_terminal_dimension(&uri, "rows", MAX_ROWS), None);
     }
 
     #[test]

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -15,6 +15,7 @@
 use crate::routes::AppState;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{ConnectInfo, Path, State, WebSocketUpgrade};
+use axum::http::{HeaderMap, Uri};
 use axum::response::IntoResponse;
 use dashmap::DashMap;
 use futures::stream::SplitSink;
@@ -116,44 +117,24 @@ pub fn try_acquire_ws_slot(ip: IpAddr, max_ws_per_ip: usize) -> Option<WsConnect
     Some(WsConnectionGuard { ip })
 }
 
-// ---------------------------------------------------------------------------
-// Terminal Connection Tracking
-// ---------------------------------------------------------------------------
-
-/// Global connection tracker for terminal WebSocket connections.
-pub fn terminal_ws_tracker() -> &'static DashMap<IpAddr, AtomicUsize> {
-    static TRACKER: std::sync::OnceLock<DashMap<IpAddr, AtomicUsize>> = std::sync::OnceLock::new();
-    TRACKER.get_or_init(DashMap::new)
-}
-
-/// RAII guard that decrements the terminal connection count on drop.
-pub struct TerminalWsGuard {
-    ip: IpAddr,
-}
-
-impl Drop for TerminalWsGuard {
-    fn drop(&mut self) {
-        if let Some(entry) = terminal_ws_tracker().get(&self.ip) {
-            let prev = entry.value().fetch_sub(1, Ordering::Relaxed);
-            if prev <= 1 {
-                drop(entry);
-                terminal_ws_tracker().remove(&self.ip);
-            }
+pub fn ws_query_param(uri: &Uri, key: &str) -> Option<String> {
+    let query = uri.query()?;
+    url::form_urlencoded::parse(query.as_bytes()).find_map(|(param, value)| {
+        if param == key {
+            Some(value.into_owned())
+        } else {
+            None
         }
-    }
+    })
 }
 
-/// Try to acquire a terminal WS connection slot for the given IP.
-pub fn try_acquire_terminal_ws_slot(ip: IpAddr, max_per_ip: usize) -> Option<TerminalWsGuard> {
-    let entry = terminal_ws_tracker()
-        .entry(ip)
-        .or_insert_with(|| AtomicUsize::new(0));
-    let current = entry.value().fetch_add(1, Ordering::Relaxed);
-    if current >= max_per_ip {
-        entry.value().fetch_sub(1, Ordering::Relaxed);
-        return None;
-    }
-    Some(TerminalWsGuard { ip })
+pub fn ws_auth_token(headers: &HeaderMap, uri: &Uri) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(ToOwned::to_owned)
+        .or_else(|| ws_query_param(uri, "token"))
 }
 
 // ---------------------------------------------------------------------------
@@ -187,22 +168,12 @@ pub async fn agent_ws(
             })
         };
 
-        let header_token = headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "));
-
-        let query_token = uri
-            .query()
-            .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")));
-
-        let header_auth = header_token.map(&matches_any).unwrap_or(false);
-        let query_auth = query_token.map(&matches_any).unwrap_or(false);
-
+        let provided_token = ws_auth_token(&headers, &uri);
         let mut session_auth = false;
         let mut user_key_auth = false;
-        let provided_token = header_token.or(query_token);
-        if let Some(token_str) = provided_token {
+        let mut api_auth = false;
+        if let Some(token_str) = provided_token.as_deref() {
+            api_auth = matches_any(token_str);
             let mut sessions = state.active_sessions.write().await;
             sessions.retain(|_, st| {
                 !crate::password_hash::is_token_expired(
@@ -221,7 +192,7 @@ pub async fn agent_ws(
             }
         }
 
-        if !header_auth && !query_auth && !session_auth && !user_key_auth {
+        if !api_auth && !session_auth && !user_key_auth {
             warn!("WebSocket upgrade rejected: invalid auth");
             return axum::http::StatusCode::UNAUTHORIZED.into_response();
         }
@@ -1455,6 +1426,29 @@ mod tests {
         assert_eq!(
             extract_status_code("API error (401): invalid api key"),
             Some(401)
+        );
+    }
+
+    #[test]
+    fn test_ws_query_param_decodes_percent_encoded_values() {
+        let uri: Uri = "/api/terminal/ws?token=abc%2Bdef%2Fghi%3D&cols=120"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            ws_query_param(&uri, "token").as_deref(),
+            Some("abc+def/ghi=")
+        );
+        assert_eq!(ws_query_param(&uri, "cols").as_deref(), Some("120"));
+    }
+
+    #[test]
+    fn test_ws_auth_token_prefers_bearer_header() {
+        let uri: Uri = "/api/terminal/ws?token=query-token".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer header-token".parse().unwrap());
+        assert_eq!(
+            ws_auth_token(&headers, &uri).as_deref(),
+            Some("header-token")
         );
     }
 


### PR DESCRIPTION
## What changed
- reuse the shared WebSocket per-IP connection guard for terminal sessions so terminal connections count against the same limit as other WS endpoints
- centralize WebSocket auth/query parsing and URL-decode query parameters before validating `token=` values
- pass initial terminal `cols` and `rows` through the WebSocket URL so the PTY is spawned with the client size instead of always starting at `120x40`
- only send the terminal `close` message from the dashboard when the socket is actually open, avoiding close/unmount race errors in the browser
- allow terminal WebSocket auth via per-user API keys in addition to global API tokens and dashboard sessions

## Why
PR #2229 added the terminal feature, but it still left a few follow-up issues:
- terminal WebSockets used a separate per-IP tracker, which effectively doubled the allowed WS count for a single client IP
- browser WebSocket tokens were query-encoded, but the server compared the raw encoded value instead of the decoded token
- the PTY always started with a hardcoded size before the first client resize arrived
- the dashboard tried to send a `close` frame even when the socket was no longer open

## Impact
- terminal auth now behaves the same way as the other browser WebSocket paths for query token handling
- terminal sessions no longer bypass the shared WS connection cap
- the first terminal render uses the client terminal dimensions more reliably
- disconnecting or unmounting the terminal page no longer throws on already-closed sockets

## Validation
- ran `cargo fmt --all`
- attempted `cargo test -p librefang-api --lib`
- test run is currently blocked by a pre-existing compile error on `main` in `crates/librefang-api/src/routes/agents.rs:293` (`manifest.name` assignment requires a mutable binding), not by these terminal follow-up changes
