### PR TITLE
fix(api): mark manifest mut in parse_manifest

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -275,7 +275,7 @@ async fn resolve_manifest(
     }
 
     // Parse TOML
-    let manifest: AgentManifest = match toml::from_str(&manifest_toml) {
+    let mut manifest: AgentManifest = match toml::from_str(&manifest_toml) {
         Ok(m) => m,
         Err(e) => {
             let _ = e;


### PR DESCRIPTION
## Summary

Main is red. The recently-merged \"allow custom name when spawning agent from template\" change added an assignment to \`manifest.name\` in \`parse_manifest\` but left the binding as \`let manifest\`, so rustc rejects it with:

\`\`\`
error[E0594]: cannot assign to \`manifest.name\`, as \`manifest\` is not declared as mutable
   --> crates/librefang-api/src/routes/agents.rs:293:13
\`\`\`

Every open PR that merges main now fails Quality + all three Test platforms on the same error (seen on #2299, #2300, #2294 at minimum).

## Fix

One character:

\`\`\`diff
-    let manifest: AgentManifest = match toml::from_str(&manifest_toml) {
+    let mut manifest: AgentManifest = match toml::from_str(&manifest_toml) {
\`\`\`

## Test plan

- [x] Obvious-fix: the same assignment already exists unchanged, only the binding needs \`mut\`
- [ ] CI green