### PR TITLE
fix(api): stop middleware path normalization from swallowing GET /

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -264,7 +264,15 @@ pub async fn auth(
     } else {
         raw_path.clone()
     };
-    let path: &str = after_version.strip_suffix('/').unwrap_or(&after_version);
+    // Strip a trailing slash for consistent ACL matching, but preserve the
+    // root path "/" itself — otherwise stripping turns it into the empty
+    // string, and `is_public` checks that compare against "/" (e.g. for the
+    // dashboard HTML) silently miss, returning 401 for GET /.
+    let path: &str = if after_version == "/" {
+        "/"
+    } else {
+        after_version.strip_suffix('/').unwrap_or(&after_version)
+    };
     if path == "/api/shutdown" {
         let is_loopback = request
             .extensions()
@@ -795,6 +803,40 @@ mod tests {
         // After normalization "/api/agents/" → "/api/agents", which User
         // role is not allowed to POST to → FORBIDDEN.
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Regression for #2305: GET / must stay public. Earlier path
+    /// normalization stripped the trailing slash from "/" producing an
+    /// empty string, so the `path == "/"` public-endpoint check missed
+    /// and the dashboard HTML returned 401 instead of the SPA.
+    #[tokio::test]
+    async fn test_root_path_is_public_even_with_api_key_set() {
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("somekey".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(vec![]),
+        };
+        let app = Router::new()
+            .route("/", get(|| async { "dashboard html" }))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "GET / must serve the dashboard HTML without auth so the SPA can render"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2305.

## Problem

\`GET /\` returns \`401 Unauthorized\` despite being listed as public at \`middleware.rs:285\`. With \`Authorization: Bearer <api_key>\` it works; without it the dashboard HTML never reaches the browser so the SPA never gets to show the login form.

## Root cause

The auth middleware strips a trailing slash from the request path before running the public-endpoint ACL check (so \`/api/foo/\` and \`/api/foo\` match identically). The stripping was unconditional:

\`\`\`rust
let path = after_version.strip_suffix('/').unwrap_or(&after_version);
\`\`\`

For the literal root path \`\"/\"\`, \`strip_suffix('/')\` returns \`Some(\"\")\`, so \`path\` became the empty string. Every subsequent public-endpoint check (including \`path == \"/\"\`) then missed, and \`GET /\` returned 401.

This matches the reporter's observation that \`/api/health\` (also listed as public) worked fine — the bug only trips on paths that are exactly the slash character.

## Fix

One branch: preserve \`\"/\"\` literally, only strip the trailing slash when there's actually something in front of it.

\`\`\`rust
let path: &str = if after_version == \"/\" {
    \"/\"
} else {
    after_version.strip_suffix('/').unwrap_or(&after_version)
};
\`\`\`

## Test

Added \`test_root_path_is_public_even_with_api_key_set\` — instantiates the middleware with a non-empty \`api_key_lock\` and asserts \`GET /\` returns 200 without an \`Authorization\` header.

## Test plan

- [x] \`cargo test -p librefang-api middleware\` locally
- [ ] \`curl http://127.0.0.1:4545/\` returns 200 HTML without auth header
- [ ] \`curl -H \"Authorization: Bearer somekey\" http://127.0.0.1:4545/\` still returns 200 (no regression for the auth'd path)