### PR TITLE
fix(api): preserve root path "/" in auth middleware strip_suffix

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -264,7 +264,11 @@ pub async fn auth(
     } else {
         raw_path.clone()
     };
-    let path: &str = after_version.strip_suffix('/').unwrap_or(&after_version);
+    let path: &str = match after_version.strip_suffix('/') {
+        Some("") => "/", // preserve root path
+        Some(stripped) => stripped,
+        None => &after_version,
+    };
     if path == "/api/shutdown" {
         let is_loopback = request
             .extensions()


### PR DESCRIPTION
## Summary

- `strip_suffix('/')` on `"/"` produces `""`, so the `is_public` check never matches the root path
- `GET /` returns 401 instead of serving the dashboard HTML
- The React SPA never loads, so the login form never appears
- Simple fix: preserve `"/"` when strip_suffix would produce an empty string

## Root cause

```rust
// Before (bug): "/" → strip_suffix('/') → "" → is_public check fails
let path: &str = after_version.strip_suffix('/').unwrap_or(&after_version);

// After (fix): "/" → strip_suffix('/') → Some("") → preserved as "/"
let path: &str = match after_version.strip_suffix('/') {
    Some("") => "/",
    Some(stripped) => stripped,
    None => &after_version,
};
```

## Test plan

- [ ] `curl http://127.0.0.1:4545/` without auth header → should return HTML (200)
- [ ] `curl http://127.0.0.1:4545/api/health` → should still return 200
- [ ] `curl -X POST http://127.0.0.1:4545/api/agents` → should still return 401
- [ ] Dashboard login flow works in browser

Fixes #2305