### PR TITLE
fix(channels): preserve pending Telegram updates across daemon restart

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -824,6 +824,12 @@ impl ChannelAdapter for TelegramAdapter {
         // Clear any existing webhook to avoid 409 Conflict during getUpdates polling.
         // This is necessary when the daemon restarts — the old polling session may
         // still be active on Telegram's side for ~30s, causing 409 errors.
+        //
+        // IMPORTANT: do NOT set drop_pending_updates=true here. For a messaging
+        // adapter, silently discarding user messages queued while the daemon was
+        // down is a data-loss bug. The Telegram API default (false) preserves the
+        // backlog, and the first getUpdates call after startup will pick up every
+        // update that accumulated during downtime.
         {
             let delete_url = format!(
                 "{}/bot{}/deleteWebhook",
@@ -833,7 +839,7 @@ impl ChannelAdapter for TelegramAdapter {
             match self
                 .client
                 .post(&delete_url)
-                .json(&serde_json::json!({"drop_pending_updates": true}))
+                .json(&serde_json::json!({"drop_pending_updates": false}))
                 .send()
                 .await
             {


### PR DESCRIPTION
## Summary

Addresses the concern raised by @houko on #2248: `start()` in the Telegram adapter called `deleteWebhook` with `drop_pending_updates=true`, which silently discards every user message queued on Telegram's side while the daemon was down. For a messaging adapter this is a data-loss bug — users expect the backlog to be delivered once the bot comes back online.

## Historical note

This line is **not** a regression from #2223 / #2248. I traced it with `git log -L 827,843:crates/librefang-channels/src/telegram.rs` and the `.json({"drop_pending_updates": true})` call appears as a **context line** (unchanged) in every commit that touches the surrounding block, going all the way back to `cc93ef45` ("community fixes"). #2223 only changed the URL format (hardcoded `https://api.telegram.org` → `self.api_base_url`), which pulled the entire block into the diff and made the flag look newly added. The behavior predates both PRs.

The investigation is unchanged by that history — @houko is right that the current default is wrong, regardless of when it was introduced.

## Fix

- `crates/librefang-channels/src/telegram.rs`: flip `drop_pending_updates` from `true` to `false` in the `deleteWebhook` request body.
- Add an inline `IMPORTANT:` comment explaining why the flag must stay `false`, so the next person who edits this block does not reintroduce the bug.

## Why not just drop the field?

`false` is the Telegram API default, so passing it explicitly is technically redundant. Keeping the field with an explicit `false` makes the intent visible at the call site — future readers see immediately that the choice was deliberate, not forgotten. The `IMPORTANT:` comment reinforces this.

## Why keep the `deleteWebhook` call at all?

It clears any stale webhook registration that would otherwise cause a 409 Conflict on `getUpdates` during daemon restart (webhooks and long-polling are mutually exclusive in the Telegram Bot API). That part is still needed — it's only the `drop_pending_updates` flag that was wrong.

## Test plan

- [x] `cargo build -p librefang-channels --lib` passes
- [x] `cargo clippy -p librefang-channels --all-targets -- -D warnings` passes
- [ ] (maintainer) Live verification: stop the daemon, send 2-3 messages to the bot from Telegram, restart the daemon, confirm all 2-3 messages are delivered to the agent