### PR TITLE
fix(runtime): stop agent loop on pure-text max_tokens overflow

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2489,7 +2489,14 @@ pub async fn run_agent_loop(
             }
             StopReason::MaxTokens => {
                 consecutive_max_tokens += 1;
-                if consecutive_max_tokens >= MAX_CONTINUATIONS {
+                // If the LLM hit the token cap without emitting any tool
+                // calls, this is a pure-text overflow — continuing would
+                // only make the response longer without ever completing
+                // an action, and downstream channels (Telegram: 4096 char
+                // cap) will keep rejecting it. Return the partial text
+                // immediately instead of burning more tokens (#2286).
+                let pure_text_overflow = response.tool_calls.is_empty();
+                if pure_text_overflow || consecutive_max_tokens >= MAX_CONTINUATIONS {
                     // Return partial response instead of continuing forever
                     let text = max_tokens_response_text(&response);
                     let (cleaned_text, parsed_directives) =
@@ -2499,11 +2506,20 @@ pub async fn run_agent_loop(
                     if let Err(e) = memory.save_session_async(session).await {
                         warn!("Failed to save session on max continuations: {e}");
                     }
-                    warn!(
-                        iteration,
-                        consecutive_max_tokens,
-                        "Max continuations reached, returning partial response"
-                    );
+                    if pure_text_overflow {
+                        warn!(
+                            iteration,
+                            consecutive_max_tokens,
+                            text_len = text.len(),
+                            "Max tokens hit on pure-text response — returning partial (no tool calls to continue)"
+                        );
+                    } else {
+                        warn!(
+                            iteration,
+                            consecutive_max_tokens,
+                            "Max continuations reached, returning partial response"
+                        );
+                    }
                     // Fire AgentLoopEnd hook
                     let ctx = crate::hooks::HookContext {
                         agent_name: &manifest.name,
@@ -3448,7 +3464,9 @@ pub async fn run_agent_loop_streaming(
             }
             StopReason::MaxTokens => {
                 consecutive_max_tokens += 1;
-                if consecutive_max_tokens >= MAX_CONTINUATIONS {
+                // See non-streaming branch above — same logic for #2286.
+                let pure_text_overflow = response.tool_calls.is_empty();
+                if pure_text_overflow || consecutive_max_tokens >= MAX_CONTINUATIONS {
                     let text = max_tokens_response_text(&response);
                     let (cleaned_text, parsed_directives) =
                         crate::reply_directives::parse_directives(&text);
@@ -3457,11 +3475,20 @@ pub async fn run_agent_loop_streaming(
                     if let Err(e) = memory.save_session_async(session).await {
                         warn!("Failed to save session on max continuations: {e}");
                     }
-                    warn!(
-                        iteration,
-                        consecutive_max_tokens,
-                        "Max continuations reached (streaming), returning partial response"
-                    );
+                    if pure_text_overflow {
+                        warn!(
+                            iteration,
+                            consecutive_max_tokens,
+                            text_len = text.len(),
+                            "Max tokens hit on pure-text response (streaming) — returning partial (no tool calls to continue)"
+                        );
+                    } else {
+                        warn!(
+                            iteration,
+                            consecutive_max_tokens,
+                            "Max continuations reached (streaming), returning partial response"
+                        );
+                    }
                     // Fire AgentLoopEnd hook
                     let ctx = crate::hooks::HookContext {
                         agent_name: &manifest.name,


### PR DESCRIPTION
Closes #2286.

## Problem

When the LLM hits its output token cap with \`finish_reason=length\` AND the response contains zero tool calls, the agent loop was treating it as a legitimate tool-chain continuation and asking the model to \`\"Please continue\"\` up to \`MAX_CONTINUATIONS\` (5) times. Each continuation grew the accumulated text, and on streaming channels with a hard message cap (Telegram: 4096 chars) every send attempt was rejected.

The reporter observed **167,279 tokens burned on a single request that never reached the user** — the bot churned for ~17 minutes while the user saw nothing.

## Root cause

\`agent_loop.rs\` \`StopReason::MaxTokens\` branches (both streaming ~L3498 and non-streaming ~L2541) unconditionally pushed the partial text into the conversation and sent \`\"Please continue\"\`, regardless of whether the response contained any tool calls. The counter only bailed out after 5 iterations.

## Fix

Short-circuit the MaxTokens branch when \`response.tool_calls.is_empty()\` — that's a pure-text overflow, and no amount of continuation will finish it. Return the partial text immediately.

Tool-chain continuations stay correct: if the LLM cut off mid-tool-call (non-empty \`response.tool_calls\`), the old continuation behavior still applies.

\`\`\`rust
let pure_text_overflow = response.tool_calls.is_empty();
if pure_text_overflow || consecutive_max_tokens >= MAX_CONTINUATIONS {
    // return partial text now
}
\`\`\`

Both streaming and non-streaming paths get the same treatment.

## Scope note

This is the minimal targeted fix for #2286's pure-text explosion. Broader improvements suggested in the issue (channel-aware output budget, stream-then-split, stop iterating on channel send failures) are out of scope and should be separate PRs.

## Test plan

- [x] \`cargo check -p librefang-runtime\`
- [ ] CI green
- [ ] Regression: a tool-using agent whose LLM legitimately runs out of tokens mid-tool-call should still continue