### PR TITLE
fix(terminal): wire ConPTY resize on Windows

### DIFF
--- a/crates/librefang-api/src/terminal.rs
+++ b/crates/librefang-api/src/terminal.rs
@@ -103,14 +103,10 @@ impl PtySession {
         Ok(())
     }
 
-    #[cfg(windows)]
-    pub fn resize(&mut self, _cols: u16, _rows: u16) -> std::io::Result<()> {
-        // Windows ConPTY resize is not yet implemented via portable-pty on this platform.
-        // TODO: investigate ConPTY resize support.
-        Ok(())
-    }
-
-    #[cfg(not(windows))]
+    /// Resize the underlying PTY. portable-pty 0.9 implements
+    /// `MasterPty::resize` on every backend it supports, including the
+    /// Windows ConPTY path (`ConPtyMasterPty`), so the same call works
+    /// cross-platform. Closes #2303.
     pub fn resize(&mut self, cols: u16, rows: u16) -> std::io::Result<()> {
         self._master
             .resize(PtySize {


### PR DESCRIPTION
Closes #2303.

The Windows branch of \`PtySession::resize\` was a no-op with a \`TODO: investigate ConPTY resize support\` comment (terminal.rs:109). The TODO was stale — portable-pty 0.9 (which librefang already depends on) implements \`MasterPty::resize\` on every supported backend, including the Windows \`ConPtyMasterPty\` that wraps the \`ResizePseudoConsole\` Win32 API.

Drop the \`#[cfg(windows)]\` split and share the same \`self._master.resize(PtySize {...})\` call on both platforms.

## Notes

- Upstream portable-pty 0.9.0 does not set \`PSEUDOCONSOLE_RESIZE_QUIRK\` (which fixes some cursor artifacts on Win10/11 after resize). If users report weird redraws after resize specifically on Windows, that would be the next place to look, but it's not a blocker for wiring the call up — the previous behavior was strictly worse (no resize at all).

## Test plan

- [x] \`cargo check -p librefang-api\` locally on Linux
- [ ] CI builds green on Windows
- [ ] Manual: open \`/terminal\` in the dashboard on Windows, resize the browser window, confirm the shell reflows (\`tput cols\` / \`tput lines\` report the new size)