### PR TITLE
release: v2026.4.11-beta18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.11] - 2026-04-11
+
+### Added
+
+- Add WebSocket terminal with PTY backend and xterm frontend  (Phase 1) (#2229) (@leszek3737)
+- Claude Code CLI profile rotation for rate-limit resilience (#2249) (@f-liva)
+- Add MCP Servers management page (#2278) (@houko)
+- Raise MSRV to 1.94.1 and keep stable toolchain (#2302) (@houko)
+- Uninstall hand (#2312) (@houko)
+
+### Fixed
+
+- Change Docker setup to fix permissions for LIBREFANG_HOME (#2240) (@Cruel)
+- Also ignore secrets.env (dashboard-managed env file) (#2248) (@DaBlitzStein)
+- Localize agent template copy for zh users (#2257) (@houko)
+- Restore approval context and dashboard auth flows (#2272) (@houko)
+- Exclude Hand sub-agents from channel routing fallback (#2276) (@houko)
+- Accept claude-code (hyphen) in CLI profile rotation guard (#2284) (@f-liva)
+- Replace --verbose with --include-partial-messages for qwen driver (#2290) (@f-liva)
+- Add missing cli_profile_dirs to DefaultModelConfig literals (#2296) (@houko)
+- Delegate first-boot config to librefang init (#2297) (@houko)
+- Scan workspaces/ dir to persist locally-installed hands across boot (#2298) (@houko)
+- Hide delete button for built-in providers, flag custom (#2300) (@houko)
+- Mark manifest mut in parse_manifest (#2306) (@houko)
+- Stop middleware path normalization from swallowing GET / (#2307) (@houko)
+- Preserve pending Telegram updates across daemon restart (#2309) (@houko)
+- Stop agent loop on pure-text max_tokens overflow (#2310) (@houko)
+- Make Hands Settings tab actually editable (#2311) (@houko)
+- Wire ConPTY resize on Windows (#2313) (@houko)
+
+### Changed
+
+- Harden and optimize Telegram adapter (#2223) (@leszek3737)
+
+### Maintenance
+
+- Cover full-path context hook launchers (#2255) (@houko)
+- Cover wechat and wecom multi-account config parsing (#2258) (@houko)
+
+### Other
+
+- Feat(ws) harden terminal websocket follow-ups after #2229 (#2304) (@houko)
+
+
 ## [2026.4.10] - 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "aes",
  "async-trait",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "clap",
  "clap_complete",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "axum",
  "clap",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "async-trait",
  "axum",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10809,7 +10809,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32117",
+  "version": "26.4.32128",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.10-beta17",
+  "version": "2026.4.11-beta18",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.10-beta17",
+  "version": "2026.4.11-beta18",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.10b17",
+    version="2026.4.11b18",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.10-beta17"
+version = "2026.4.11-beta18"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.11-beta18 -->
## Release v2026.4.11-beta18

### Added

- Add WebSocket terminal with PTY backend and xterm frontend  (Phase 1) (#2229) (@leszek3737)
- Claude Code CLI profile rotation for rate-limit resilience (#2249) (@f-liva)
- Add MCP Servers management page (#2278) (@houko)
- Raise MSRV to 1.94.1 and keep stable toolchain (#2302) (@houko)
- Uninstall hand (#2312) (@houko)

### Fixed

- Change Docker setup to fix permissions for LIBREFANG_HOME (#2240) (@Cruel)
- Also ignore secrets.env (dashboard-managed env file) (#2248) (@DaBlitzStein)
- Localize agent template copy for zh users (#2257) (@houko)
- Restore approval context and dashboard auth flows (#2272) (@houko)
- Exclude Hand sub-agents from channel routing fallback (#2276) (@houko)
- Accept claude-code (hyphen) in CLI profile rotation guard (#2284) (@f-liva)
- Replace --verbose with --include-partial-messages for qwen driver (#2290) (@f-liva)
- Add missing cli_profile_dirs to DefaultModelConfig literals (#2296) (@houko)
- Delegate first-boot config to librefang init (#2297) (@houko)
- Scan workspaces/ dir to persist locally-installed hands across boot (#2298) (@houko)
- Hide delete button for built-in providers, flag custom (#2300) (@houko)
- Mark manifest mut in parse_manifest (#2306) (@houko)
- Stop middleware path normalization from swallowing GET / (#2307) (@houko)
- Preserve pending Telegram updates across daemon restart (#2309) (@houko)
- Stop agent loop on pure-text max_tokens overflow (#2310) (@houko)
- Make Hands Settings tab actually editable (#2311) (@houko)
- Wire ConPTY resize on Windows (#2313) (@houko)

### Changed

- Harden and optimize Telegram adapter (#2223) (@leszek3737)

### Maintenance

- Cover full-path context hook launchers (#2255) (@houko)
- Cover wechat and wecom multi-account config parsing (#2258) (@houko)

### Other

- Feat(ws) harden terminal websocket follow-ups after #2229 (#2304) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.10-beta17...v2026.4.11-beta18