### PR TITLE
test(runtime): fix max_tokens assertions after pure-text short-circuit

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -5672,7 +5672,8 @@ mod tests {
         .expect("Loop should complete without error");
 
         assert_eq!(result.response, "Partial answer");
-        assert_eq!(result.iterations, MAX_CONTINUATIONS);
+        // Pure-text max_tokens overflow short-circuits on iter 1 (#2310).
+        assert_eq!(result.iterations, 1);
         assert_eq!(result.directives.reply_to.as_deref(), Some("msg_999"));
         assert!(result.directives.current_thread);
         assert!(!result.directives.silent);
@@ -5728,7 +5729,8 @@ mod tests {
             result.response,
             "[Partial response — token limit reached with no text output.]"
         );
-        assert_eq!(result.iterations, MAX_CONTINUATIONS);
+        // Pure-text max_tokens overflow short-circuits on iter 1 (#2310).
+        assert_eq!(result.iterations, 1);
         assert!(result.directives.reply_to.is_none());
         assert!(!result.directives.current_thread);
         assert!(!result.directives.silent);
@@ -5784,7 +5786,8 @@ mod tests {
         .expect("Streaming loop should complete without error");
 
         assert_eq!(result.response, "Partial answer");
-        assert_eq!(result.iterations, MAX_CONTINUATIONS);
+        // Pure-text max_tokens overflow short-circuits on iter 1 (#2310).
+        assert_eq!(result.iterations, 1);
         assert_eq!(result.directives.reply_to.as_deref(), Some("msg_999"));
         assert!(result.directives.current_thread);
         assert!(!result.directives.silent);


### PR DESCRIPTION
## Summary

Main CI has been red since #2310 merged. The pure-text overflow short-circuit added in #2310 makes `MaxTokens` with zero tool calls return on iteration **1** instead of running to `MAX_CONTINUATIONS` (5), but the three existing tests from #2135 still assert `result.iterations == MAX_CONTINUATIONS`.

Every merge since has inherited the red build: #2311, #2312, and the version bump #2315.

This PR updates those three assertions to match the new semantics. The rest of each test (partial response text, reply directives, current-thread flags) is unchanged — the contract under test is the same, only the iteration count is different.

## Test plan
- [x] `cargo test -p librefang-runtime --lib preserves_reply_directives` — 4/4 green locally
- [ ] CI turns green on main again after merge