### PR TITLE
chore(skills): fix rustfmt on upsert_mcp_server test assert

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -4309,7 +4309,11 @@ mod tests {
         }
         let raw = std::fs::read_to_string(&config_path).unwrap();
         let parsed: Wrapper = toml::from_str(&raw).unwrap();
-        assert_eq!(parsed.mcp_servers.len(), 1, "upsert must replace, not append");
+        assert_eq!(
+            parsed.mcp_servers.len(),
+            1,
+            "upsert must replace, not append"
+        );
         assert_eq!(parsed.mcp_servers[0].timeout_secs, 60);
         match &parsed.mcp_servers[0].transport {
             Some(McpTransportEntry::Http { url }) => assert_eq!(url, "http://new:9090/mcp"),


### PR DESCRIPTION
The three-arg `assert_eq!` added in #2327 exceeded rustfmt's line-width threshold, so `cargo fmt --check` fails on every PR branched from main (e.g. #2331). Wrap the call to multi-line form to unblock Quality CI.