### PR TITLE
fix(agents): refuse direct DELETE on hand-spawned agents + clarify revert warning

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -197,7 +197,7 @@
     "hands": "Hands",
     "hand_badge": "HAND",
     "show_hand_agents": "Show hand agents",
-    "hand_agent_hint": "You are editing the active runtime agent created by a hand.",
+    "hand_agent_hint": "You are editing the active runtime agent created by a hand. Changes live in memory only and will revert to the hand's configuration when the daemon restarts or the hand is reloaded.",
     "tools_cap": "Tools",
     "network": "Network",
     "help": "Manage all agents in the system. Create, suspend, resume, and delete agents. View their status and configuration.",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -197,7 +197,7 @@
     "hands": "Hands",
     "hand_badge": "HAND",
     "show_hand_agents": "显示 Hands 智能体",
-    "hand_agent_hint": "你正在编辑由 Hand 创建的活动运行时智能体。",
+    "hand_agent_hint": "你正在编辑由 Hand 创建的活动运行时智能体。改动仅在内存中生效；守护进程重启或 Hand 重新加载后会回退到 Hand 的配置。",
     "tools_cap": "工具",
     "network": "网络",
     "help": "管理系统中的所有智能体。可以创建、暂停、恢复和删除智能体，查看其状态和配置。",

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -503,6 +503,21 @@ pub async fn bulk_delete_agents(
                 continue;
             }
         };
+        // Same guard as the single-agent kill path: hand-spawned agents
+        // must be removed by deactivating their owning hand, not directly.
+        if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
+            if entry.is_hand {
+                results.push(BulkActionResult {
+                    agent_id: id_str.clone(),
+                    success: false,
+                    message: None,
+                    error: Some(
+                        "Cannot delete a hand-spawned agent directly; deactivate or uninstall the owning hand instead.".to_string(),
+                    ),
+                });
+                continue;
+            }
+        }
         match state.kernel.kill_agent(agent_id) {
             Ok(()) => {
                 results.push(BulkActionResult {
@@ -1507,6 +1522,22 @@ pub async fn kill_agent(
             );
         }
     };
+
+    // Hand-spawned runtime agents are owned by their hand instance. Killing
+    // one directly leaves the hand registry pointing at a dangling id that
+    // can respawn or produce stale instance state — require callers to
+    // deactivate or uninstall the owning hand instead. The dashboard hides
+    // Delete for hand agents already; this closes the direct-API loophole.
+    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
+        if entry.is_hand {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "Cannot delete a hand-spawned agent directly; deactivate or uninstall the owning hand instead."
+                })),
+            );
+        }
+    }
 
     match state.kernel.kill_agent(agent_id) {
         Ok(()) => (


### PR DESCRIPTION
Follow-up to #2335 closing two small gaps.

## 1. Direct-DELETE loophole on hand-spawned agents

\`AgentsPage\` hides the Delete button for hand agents, but \`DELETE /api/agents/{id}\` and \`DELETE /api/agents/bulk\` were both still happy to \`state.kernel.kill_agent(agent_id)\` them directly. That leaves the hand registry pointing at an id the kernel registry no longer has — the hand can respawn into a new id, double-register, or produce stale audit state. Any tool hitting the API directly (curl, integration test, MCP client) bypassed the UX guard.

Both handlers now look up the agent, check \`entry.is_hand\`, and return **409 Conflict** with a message telling the caller to deactivate or uninstall the owning hand. For bulk deletes the hand-owned entries are reported as per-id failures; well-formed non-hand ids in the same request still go through.

## 2. Modal hint didn't warn about revert

The original copy said \"You are editing the active runtime agent created by a hand.\" — technically true, but silent on the part that actually bites:

- \`update_model_and_provider\` / \`update_max_tokens\` / \`update_temperature\` all mutate \`AgentEntry.manifest.model\` in the in-memory registry.
- None of them persist back to the hand's HAND.toml on disk.
- On daemon restart or hand reload, kernel.rs rebuilds every hand-spawned agent from the hand's on-disk config, silently discarding the UI edit.

So an operator could change \`qwen3-coder\` → \`qwen-vl-max\` from the modal, see the field update, then wake up to find it reverted after the next restart. The new copy (EN + ZH) spells that out.

## Test plan

- [x] \`cargo check -p librefang-api --lib\` — clean
- [x] \`cargo clippy -p librefang-api --lib -- -D warnings\` — clean
- [x] \`cargo fmt --check -p librefang-api\` — clean
- [ ] Live: \`curl -X DELETE /api/agents/<hand-agent-id>\` → 409 with the guard message
- [ ] Live: \`curl -X DELETE /api/agents/bulk\` with a mix of hand and non-hand ids → per-id results, hand entries marked \`success: false\` with the guard message, non-hand entries deleted
- [ ] Dashboard: open a hand agent in the Agents tab → hint now warns about revert on daemon restart / hand reload