### PR TITLE
fix(types): normalize MIME type parameters before allowlist check

### DIFF
--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -145,14 +145,26 @@ pub const ALLOWED_AUDIO_TYPES: &[&str] = &[
 /// Allowed video MIME types.
 pub const ALLOWED_VIDEO_TYPES: &[&str] = &["video/mp4", "video/quicktime", "video/webm"];
 
+/// Extract the bare `type/subtype` from a MIME string, discarding parameters
+/// and whitespace (RFC 2045). E.g. `"audio/ogg; codecs=opus"` → `"audio/ogg"`.
+fn mime_base(mime: &str) -> String {
+    mime.split(';')
+        .next()
+        .unwrap_or(mime)
+        .trim()
+        .to_ascii_lowercase()
+}
+
 impl MediaAttachment {
     /// Validate the attachment against security constraints.
     pub fn validate(&self) -> Result<(), String> {
-        // Check MIME type allowlist
+        // Check MIME type allowlist — normalize to bare type/subtype so that
+        // values like `audio/ogg; codecs=opus` (from WhatsApp) match the allowlist.
+        let base = mime_base(&self.mime_type);
         let allowed = match self.media_type {
-            MediaType::Image => ALLOWED_IMAGE_TYPES.contains(&self.mime_type.as_str()),
-            MediaType::Audio => ALLOWED_AUDIO_TYPES.contains(&self.mime_type.as_str()),
-            MediaType::Video => ALLOWED_VIDEO_TYPES.contains(&self.mime_type.as_str()),
+            MediaType::Image => ALLOWED_IMAGE_TYPES.contains(&base.as_str()),
+            MediaType::Audio => ALLOWED_AUDIO_TYPES.contains(&base.as_str()),
+            MediaType::Video => ALLOWED_VIDEO_TYPES.contains(&base.as_str()),
         };
         if !allowed {
             return Err(format!(
@@ -728,6 +740,33 @@ mod tests {
             mime_type: "image/png".to_string(),
             source: MediaSource::FilePath {
                 path: "test.png".to_string(),
+            },
+            size_bytes: 1024,
+        };
+        assert!(a.validate().is_ok());
+    }
+
+    #[test]
+    fn test_attachment_validate_mime_with_parameters() {
+        // WhatsApp voice notes arrive as `audio/ogg; codecs=opus`.
+        // The allowlist stores the bare `audio/ogg`, so validation must
+        // normalize parameters away before comparing.
+        let a = MediaAttachment {
+            media_type: MediaType::Audio,
+            mime_type: "audio/ogg; codecs=opus".to_string(),
+            source: MediaSource::FilePath {
+                path: "voice.ogg".to_string(),
+            },
+            size_bytes: 1024,
+        };
+        assert!(a.validate().is_ok());
+
+        // Uppercase type/subtype and spacing must also work.
+        let a = MediaAttachment {
+            media_type: MediaType::Audio,
+            mime_type: "Audio/OGG ;codecs=opus".to_string(),
+            source: MediaSource::FilePath {
+                path: "voice.ogg".to_string(),
             },
             size_bytes: 1024,
         };


### PR DESCRIPTION
## Problem

WhatsApp voice notes arrive with the MIME string `audio/ogg; codecs=opus`, but the media allowlist in `librefang-types/src/media.rs` stores bare `audio/ogg`. Since the check is a strict equality lookup, **every WhatsApp voice note is rejected** with:

```
WARN librefang_api::routes::agents: Audio transcription failed:
     Unsupported MIME type 'audio/ogg; codecs=opus' for Audio media
```

As a consequence, an agent receiving an audio attachment from WhatsApp gets no transcript and typically answers "I cannot listen to audio messages" — the attachment is silently dropped.

The same class of bug affects any sender that tacks on RFC 2045 parameters (`audio/mp4; codecs=mp4a.40.2`, `video/mp4; codecs=avc1`, etc.).

## Fix

Add a small `mime_base()` helper that extracts the bare `type/subtype` portion of a MIME string (everything before the first `;`), trims whitespace, and lowercases it. `MediaAttachment::validate()` now looks up this normalized form in the allowlist instead of the raw value.

- No allowlist changes — still only `audio/ogg`, `audio/mpeg`, etc. are accepted.
- Arbitrary parameters (`codecs`, `charset`, `boundary`, …) are simply discarded.
- Case-insensitive: `Audio/OGG` now matches, as required by RFC 2045.

## Testing

Added `test_attachment_validate_mime_with_parameters` covering:
- The exact WhatsApp voice-note MIME (`audio/ogg; codecs=opus`)
- A mixed-case + odd-spacing variant (`Audio/OGG ;codecs=opus`)

Existing tests (strict allowlist, bad MIME rejection, size limits) continue to pass.

## Attribution

- [x] Original work