### PR TITLE
fix(whatsapp-gateway): resolve LID JIDs to phone numbers for owner detection

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -244,6 +244,25 @@ let cachedAgentId = null;
 let ownJid = null;
 
 // ---------------------------------------------------------------------------
+// LID ↔ phone-number JID mapping
+// ---------------------------------------------------------------------------
+// WhatsApp assigns every account an opaque `<digits>@lid` identifier that is
+// unrelated to the phone number. The `remoteJid` of an inbound message may be
+// a LID rather than an `@s.whatsapp.net` JID, and in that case we can only
+// recognise the sender (owner vs. stranger, routing key, logging) once we have
+// resolved the LID back to a phone-number JID.
+//
+// We maintain two caches:
+//   - `lidToPnJid`    — populated from `msg.key.senderPn` whenever a message
+//                       arrives that carries both the LID and the real PN JID.
+//   - `ownerLidJids`  — LIDs known to belong to an OWNER_NUMBERS entry. We
+//                       resolve these once at connect via `sock.onWhatsApp()`
+//                       so that the very first LID-addressed message from the
+//                       owner is recognised, even before any senderPn event.
+const lidToPnJid = new Map();    // '<digits>@lid' → '<digits>@s.whatsapp.net'
+const ownerLidJids = new Set();  // '<digits>@lid'
+
+// ---------------------------------------------------------------------------
 // Message store for Baileys retry mechanism
 // ---------------------------------------------------------------------------
 // Baileys needs getMessage() to re-decrypt messages on retry.  We keep a
@@ -825,6 +844,28 @@ async function startConnection() {
       // Invalidate cached agent UUID on reconnect — the daemon may have
       // restarted and agents may have new UUIDs.
       cachedAgentId = null;
+
+      // Resolve LIDs for every OWNER_NUMBERS entry so that LID-addressed
+      // messages from the owner are recognised without waiting for the first
+      // senderPn event. Best-effort: if the call fails (old Baileys, no
+      // network, number not on WhatsApp) we log and continue — subsequent
+      // senderPn events will still populate `lidToPnJid`.
+      if (OWNER_JIDS.size > 0 && typeof sock.onWhatsApp === 'function') {
+        try {
+          const results = await sock.onWhatsApp(...[...OWNER_JIDS]);
+          for (const r of results || []) {
+            if (r && r.exists && r.lid) {
+              ownerLidJids.add(r.lid);
+              if (r.jid) lidToPnJid.set(r.lid, r.jid);
+            }
+          }
+          if (ownerLidJids.size > 0) {
+            console.log(`[gateway] Owner LIDs resolved → ${[...ownerLidJids].join(', ')}`);
+          }
+        } catch (err) {
+          console.warn(`[gateway] Failed to resolve owner LIDs: ${err.message}`);
+        }
+      }
     }
   });
 
@@ -928,20 +969,56 @@ async function startConnection() {
       if (!text && !downloadableMedia && !mediaDescriptor && !innerMsg._overrideMediaText) continue;
 
       // Extract real phone number
-      const isLidJid = sender.endsWith('@lid');
-      const senderPn = msg.key.senderPn || msg.key.participant || '';
-      let phone;
-      if (isLidJid && senderPn) {
-        phone = '+' + senderPn.replace(/@.*$/, '');
-      } else {
-        phone = '+' + sender.replace(/@.*$/, '');
-      }
-      const pushName = msg.pushName || phone;
-
-      // Determine sender type
+      //
+      // `sender` (= msg.key.remoteJid) may be:
+      //   - '<digits>@s.whatsapp.net' — standard phone-number JID
+      //   - '<digits>@lid'            — WhatsApp anonymous LID (opaque)
+      //   - '<digits>@g.us'           — group JID (we handle separately below)
+      //
+      // A LID by itself is NOT a phone number — using it as such produces
+      // bogus 15-digit phone strings and causes every LID-addressed message
+      // to be mis-classified as from a stranger. Resolve via, in order:
+      //   1. `msg.key.senderPn` (sometimes provided by Baileys directly)
+      //   2. `lidToPnJid` cache populated by previous (1)s or by onWhatsApp()
+      //   3. `msg.key.participant` (groups; the actual sender inside)
+      //   4. `sender` itself when it's already an `@s.whatsapp.net` JID
+      // If none of the above yields a phone-number JID, `phone` is left as
+      // a placeholder and we flag the sender as unresolved.
       const isGroup = sender.endsWith('@g.us');
-      const senderPnJid = senderPn ? senderPn.replace(/@.*$/, '') + '@s.whatsapp.net' : '';
-      const isOwner = OWNER_JIDS.size > 0 && (OWNER_JIDS.has(sender) || (senderPnJid && OWNER_JIDS.has(senderPnJid)));
+      const isLidJid = sender.endsWith('@lid');
+      const senderPnRaw = msg.key.senderPn || '';
+
+      // Cache LID → phone-number JID when we see both on the same message.
+      if (isLidJid && senderPnRaw) {
+        lidToPnJid.set(sender, senderPnRaw);
+      }
+
+      // Resolve to a phone-number JID (or empty string if we cannot).
+      let senderPnJid = '';
+      if (senderPnRaw) {
+        senderPnJid = senderPnRaw;
+      } else if (isLidJid && lidToPnJid.has(sender)) {
+        senderPnJid = lidToPnJid.get(sender);
+      } else if (!isLidJid && !isGroup) {
+        senderPnJid = sender;
+      } else if (msg.key.participant && !msg.key.participant.endsWith('@lid')) {
+        senderPnJid = msg.key.participant;
+      }
+
+      const phone = senderPnJid ? '+' + senderPnJid.replace(/@.*$/, '') : '';
+      const phoneResolved = phone !== '';
+      const pushName = msg.pushName || phone || sender;
+
+      if (!phoneResolved) {
+        console.warn(`[gateway] Could not resolve phone for sender=${sender} senderPn=${senderPnRaw || '∅'} participant=${msg.key.participant || '∅'} — treating as unknown`);
+      }
+
+      // Determine sender type. Owner check accepts either the resolved
+      // phone-number JID or a LID previously bound to an owner number.
+      const isOwner = OWNER_JIDS.size > 0 && (
+        (senderPnJid && OWNER_JIDS.has(senderPnJid)) ||
+        (isLidJid && ownerLidJids.has(sender))
+      );
       const isStranger = !isGroup && OWNER_JIDS.size > 0 && !isOwner;
 
       // Detect @mention: check if our JID is in the mentionedJid list
@@ -1896,9 +1973,16 @@ async function runCatchUpSweep() {
       // Ensure agent ID is resolved
       if (!cachedAgentId) await resolveAgentId();
 
-      // Determine if sender is owner or stranger
+      // Determine if sender is owner or stranger. Mirror the logic used in
+      // `messages.upsert`: a LID JID is not a phone number, so accept either
+      // a resolved phone-number JID or a known owner LID.
+      const isLidMsgJid = msg.jid && msg.jid.endsWith('@lid');
       const senderPnJid = msg.phone ? msg.phone.replace(/^\+/, '') + '@s.whatsapp.net' : '';
-      const isOwner = OWNER_JIDS.size > 0 && (OWNER_JIDS.has(msg.jid) || (senderPnJid && OWNER_JIDS.has(senderPnJid)));
+      const isOwner = OWNER_JIDS.size > 0 && (
+        (!isLidMsgJid && msg.jid && OWNER_JIDS.has(msg.jid)) ||
+        (senderPnJid && OWNER_JIDS.has(senderPnJid)) ||
+        (isLidMsgJid && ownerLidJids.has(msg.jid))
+      );
 
       // Never re-forward group messages — we cannot tell if the bot was
       // mentioned, so replaying them violates group_policy and can leak


### PR DESCRIPTION
## Problem

WhatsApp has rolled out **LID** (anonymous identifier) addressing for messaging. Instead of a message carrying the sender's phone-number JID (`<digits>@s.whatsapp.net`) in `msg.key.remoteJid`, it increasingly arrives with an opaque `<digits>@lid` identifier unrelated to the phone number.

The existing code in `messages.upsert` ignored this and fell back to using the LID itself as the phone number:

```js
const isLidJid = sender.endsWith('@lid');
const senderPn = msg.key.senderPn || msg.key.participant || '';
let phone;
if (isLidJid && senderPn) {
  phone = '+' + senderPn.replace(/@.*$/, '');
} else {
  phone = '+' + sender.replace(/@.*$/, '');   // ⚠️  LID treated as a phone number
}
```

Two consequences observed in production:

1. `[gateway] Incoming from +191856289808491 ...` — a 15-digit string that is obviously not a phone number but gets logged, stored, and passed downstream as if it were.
2. **The agent fails to recognise its own owner.** `OWNER_JIDS` contains `<ownerNumber>@s.whatsapp.net` and the sender is `<lidDigits>@lid`, so `isOwner` is always `false` for LID-addressed messages from the owner. The agent greets the owner as a stranger ("Buongiorno! Sono Ambrogio, l'assistente digitale di Federico Liva…").

The catch-up sweep path had the same bug: `OWNER_JIDS.has(msg.jid)` compared against a stored LID.

## Fix

Two new in-memory caches, populated by Baileys signals the gateway already has access to:

- **`lidToPnJid`** — opportunistic LID → phone-number JID mapping, populated every time a message carries both a LID `remoteJid` and a non-empty `msg.key.senderPn`.
- **`ownerLidJids`** — LIDs known to belong to an `OWNER_NUMBERS` entry. Resolved once at `connection === 'open'` via `sock.onWhatsApp([...OWNER_JIDS])`; best-effort (logs on failure, degrades gracefully — `lidToPnJid` will still populate from subsequent events).

Phone-number extraction in `messages.upsert` now resolves via, in order:

1. `msg.key.senderPn` (explicit from Baileys)
2. `lidToPnJid` cache (learned from earlier messages)
3. `sender` itself — only when it is already an `@s.whatsapp.net` JID
4. `msg.key.participant` — only when it is non-LID (useful in groups)

If none of those yields a phone-number JID, `phone` stays empty and a warning is logged. The LID is never again paraded as a phone number.

Owner detection (`messages.upsert` and the catch-up sweep) now accepts either a resolved phone-number JID **or** a known owner LID.

## Testing

- Manual: this is gateway-side code (`packages/whatsapp-gateway/index.js`) and does not ship with an automated test harness. It will be validated against production traffic on the NAS — both LID and classical `@s.whatsapp.net` messages from the owner must be recognised as such, and strangers must still be flagged correctly.
- `node --check packages/whatsapp-gateway/index.js` passes.
- Existing behaviour preserved for non-LID senders: the resolution path collapses to `senderPnJid = sender` and the owner check matches `OWNER_JIDS` directly, exactly as before.

## Attribution

- [x] Original work