### PR TITLE
fix(channels): harden poll_options parsing and poll context cleanup

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -667,8 +667,17 @@ impl TelegramAdapter {
         items: &[crate::types::MediaGroupItem],
         thread_id: Option<i64>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Telegram sendMediaGroup requires 2–10 items. Validate locally so
+        // callers get a readable error instead of an HTTP 400 from the API.
         if items.is_empty() {
             return Ok(());
+        }
+        if !(2..=10).contains(&items.len()) {
+            return Err(format!(
+                "Telegram sendMediaGroup requires 2–10 items, got {}",
+                items.len()
+            )
+            .into());
         }
         let url = format!(
             "{}/bot{}/sendMediaGroup",
@@ -1473,19 +1482,30 @@ impl ChannelAdapter for TelegramAdapter {
 
         // Spawn background cleanup task for poll_contexts
         let poll_contexts_cleanup = poll_contexts.clone();
-        let shutdown_cleanup = shutdown.clone();
+        let mut shutdown_cleanup = shutdown.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(300)); // Every 5 minutes
+            interval.tick().await; // consume the immediate first tick
             loop {
+                // Race tick against shutdown so a stop() call doesn't wait up
+                // to 5 minutes for the next tick before exiting the loop.
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = shutdown_cleanup.changed() => {
+                        if *shutdown_cleanup.borrow() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
                 if *shutdown_cleanup.borrow() {
                     break;
                 }
-                interval.tick().await;
                 let now = Instant::now();
                 let mut removed = 0;
                 poll_contexts_cleanup.retain(|_k, v| {
                     if now.duration_since(v.last_accessed) > Duration::from_secs(1800) {
-                        // 30 minutes
+                        // 30 minutes since last interaction — drop.
                         removed += 1;
                         false
                     } else {
@@ -1700,7 +1720,14 @@ impl ChannelAdapter for TelegramAdapter {
                                     .insert("account_id".to_string(), serde_json::json!(aid));
                             }
 
-                            if let Some(ctx) = poll_contexts.get(&msg.platform_message_id) {
+                            // Use `get_mut` so each answer bumps `last_accessed`.
+                            // Without this refresh, a poll's question/options
+                            // metadata fell out of the cache exactly 30 minutes
+                            // after send, regardless of whether users were still
+                            // actively answering — long-running surveys lost
+                            // their context silently.
+                            if let Some(mut ctx) = poll_contexts.get_mut(&msg.platform_message_id) {
+                                ctx.last_accessed = Instant::now();
                                 msg.metadata.insert(
                                     "poll_question".to_string(),
                                     serde_json::json!(ctx.question),

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -2762,6 +2762,46 @@ async fn tool_cron_cancel(
 // Channel send tool (proactive outbound messaging via configured adapters)
 // ---------------------------------------------------------------------------
 
+/// Parse and validate `poll_options` for the `channel_send` tool.
+///
+/// Telegram requires 2–10 string options per poll. A previous version used
+/// `filter_map(as_str)` which silently dropped non-string entries — e.g.
+/// `["a", 42, "c"]` became `["a", "c"]`, slipped past the min-2 check, and
+/// sent a poll missing the user's third option. This helper fails fast
+/// when any entry is the wrong type so the agent can surface the mistake
+/// instead of producing a malformed poll.
+fn parse_poll_options(raw: Option<&serde_json::Value>) -> Result<Vec<String>, String> {
+    let arr = raw
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "poll_options must be an array of strings".to_string())?;
+    let mut out: Vec<String> = Vec::with_capacity(arr.len());
+    for (idx, v) in arr.iter().enumerate() {
+        match v.as_str() {
+            Some(s) => out.push(s.to_string()),
+            None => {
+                return Err(format!(
+                    "poll_options[{idx}] must be a string, got {}",
+                    match v {
+                        serde_json::Value::Null => "null",
+                        serde_json::Value::Bool(_) => "boolean",
+                        serde_json::Value::Number(_) => "number",
+                        serde_json::Value::Array(_) => "array",
+                        serde_json::Value::Object(_) => "object",
+                        serde_json::Value::String(_) => unreachable!(),
+                    }
+                ));
+            }
+        }
+    }
+    if !(2..=10).contains(&out.len()) {
+        return Err(format!(
+            "poll_options must have between 2 and 10 options, got {}",
+            out.len()
+        ));
+    }
+    Ok(out)
+}
+
 async fn tool_channel_send(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
@@ -2876,19 +2916,7 @@ async fn tool_channel_send(
             }
         }
 
-        let poll_options: Vec<String> = input
-            .get("poll_options")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        if poll_options.len() < 2 || poll_options.len() > 10 {
-            return Err("poll_options must have between 2 and 10 options".to_string());
-        }
+        let poll_options = parse_poll_options(input.get("poll_options"))?;
 
         let is_quiz = input
             .get("poll_is_quiz")
@@ -6316,5 +6344,69 @@ mod tests {
         ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
             Err("not used".to_string())
         }
+    }
+
+    #[test]
+    fn parse_poll_options_accepts_2_to_10_strings() {
+        let raw = serde_json::json!(["red", "green", "blue"]);
+        let opts = parse_poll_options(Some(&raw)).expect("valid options");
+        assert_eq!(opts, vec!["red", "green", "blue"]);
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_non_string_entry() {
+        // Regression: a previous version used filter_map(as_str) which
+        // silently dropped non-string entries, letting a malformed poll
+        // slip past the min-2 validation.
+        let raw = serde_json::json!(["a", 42, "c"]);
+        let err = parse_poll_options(Some(&raw)).expect_err("should reject number");
+        assert!(
+            err.contains("poll_options[1]"),
+            "error mentions index: {err}"
+        );
+        assert!(err.contains("number"), "error mentions type: {err}");
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_bool_entry() {
+        let raw = serde_json::json!(["a", true]);
+        let err = parse_poll_options(Some(&raw)).expect_err("should reject bool");
+        assert!(err.contains("poll_options[1]"));
+        assert!(err.contains("boolean"));
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_null_entry() {
+        let raw = serde_json::json!(["a", null, "c"]);
+        let err = parse_poll_options(Some(&raw)).expect_err("should reject null");
+        assert!(err.contains("poll_options[1]"));
+        assert!(err.contains("null"));
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_too_few() {
+        let raw = serde_json::json!(["only one"]);
+        let err = parse_poll_options(Some(&raw)).expect_err("should reject single option");
+        assert!(err.contains("between 2 and 10"));
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_too_many() {
+        let raw = serde_json::json!(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]);
+        let err = parse_poll_options(Some(&raw)).expect_err("should reject 11 options");
+        assert!(err.contains("between 2 and 10"));
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_missing() {
+        let err = parse_poll_options(None).expect_err("None should fail");
+        assert!(err.contains("must be an array"));
+    }
+
+    #[test]
+    fn parse_poll_options_rejects_non_array() {
+        let raw = serde_json::json!("not an array");
+        let err = parse_poll_options(Some(&raw)).expect_err("string should fail");
+        assert!(err.contains("must be an array"));
     }
 }


### PR DESCRIPTION
Follow-up to #2356 — four gaps that would silently misbehave in production.

## 1. `channel_send` silently dropped non-string poll options

The previous `filter_map(as_str)` turned `["a", 42, "c"]` into `["a", "c"]`, slipped past the min-2 bound, and sent a poll with the user's third option missing. The LLM thinks there are three choices but the user only sees two — no error surfaces anywhere.

Extracted a `parse_poll_options` helper that fails fast with a typed, per-index message (e.g. `poll_options[1] must be a string, got number`) and returns the length check as part of the same error path.

Eight new unit tests pin the behavior: happy path, number/bool/null rejection, missing array, non-array, 1-option, 11-option.

## 2. `PollContext.last_accessed` was never updated on access

`poll_contexts.get(&poll_id)` returned an immutable ref, so the background cleanup stripped entries exactly 30 minutes after *send*, regardless of whether users were still answering. A long survey (e.g. "vote by end of week") would silently lose its `poll_question` / `poll_options` metadata from late answers — the agent would only see `[User answered poll <id>: options [0]]` with no context.

Switched to `get_mut` so each answer bumps `last_accessed` — makes the field honest and keeps active polls alive as long as people are answering.

## 3. Cleanup task shutdown latency up to 5 minutes

The cleanup task body was `loop { if shutdown { break }; interval.tick().await; ... }`. Once it entered `tick().await`, a `stop()` call had to wait up to the full 5-minute interval before the loop would notice. Wrapped the tick in a `tokio::select!` against `shutdown.changed()` so the task exits promptly.

## 4. `api_send_media_group` didn't bound item count

Telegram's `sendMediaGroup` requires 2–10 items. The previous code only rejected empty input and let 1-item or 11+-item payloads hit the API, which returned an opaque HTTP 400. Validate locally up front with a clear error.

## Test plan

- [x] `cargo test -p librefang-runtime parse_poll_options` — 8/8 green
- [x] `cargo test -p librefang-channels --lib` — 675/675 green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p librefang-runtime -p librefang-channels --all-targets -- -D warnings` — clean
- [ ] Live: send a poll with 2 real options and confirm answers >30min later still carry metadata
- [ ] Live: `channel_send` with `poll_options: ["a", 42, "c"]` returns an actionable error to the agent instead of silently sending 2 options