### PR TITLE
fix(whatsapp-gateway): scrub NO_REPLY sentinel in every reply path

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -559,6 +559,31 @@ function extractNotifyOwner(responseText) {
 }
 
 // ---------------------------------------------------------------------------
+// NO_REPLY sentinel — agent-side convention to silently decline to answer.
+// ---------------------------------------------------------------------------
+// The agent prompts instruct the LLM to emit a bare `NO_REPLY` token when it
+// decides a message doesn't warrant a reply. Ideally it is the entire
+// response, but in practice we see two leaks:
+//   1. Trailing token:  "Tutto bene, Signore.\nNO_REPLY"
+//   2. Concatenated:    "...a Sua disposizione. 🎩NO_REPLY"   ← no separator
+// Both must be scrubbed before the text hits WhatsApp. The helper returns
+// the cleaned text, or `''` when the entire response was a NO_REPLY sentinel
+// and the caller should suppress delivery entirely.
+function stripNoReply(text) {
+  if (typeof text !== 'string' || !text) return text || '';
+  if (text.trim() === 'NO_REPLY') return '';
+  // `\bNO_REPLY\b` matches even when glued to an emoji (🎩NO_REPLY) because
+  // emoji code points are not word characters. Strip every standalone
+  // occurrence, collapse the whitespace it leaves behind.
+  const stripped = text
+    .replace(/\bNO_REPLY\b/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return stripped === 'NO_REPLY' ? '' : stripped;
+}
+
+// ---------------------------------------------------------------------------
 // Step E: Parse relay commands from agent response
 // ---------------------------------------------------------------------------
 
@@ -1109,6 +1134,10 @@ async function startConnection() {
               .replace(RELAY_RE, '')
               .replace(/\[no reply needed\]/gi, '');
           }
+          // Also scrub the plain `NO_REPLY` sentinel — it leaks mid-stream,
+          // trailing, and glued to emojis. When the whole chunk is a
+          // NO_REPLY (or strips down to empty), skip the edit entirely.
+          cleaned = stripNoReply(cleaned);
           cleaned = cleaned.trim();
           if (!cleaned) return;
           const formatted = markdownToWhatsApp(cleaned);
@@ -1123,7 +1152,9 @@ async function startConnection() {
         const rawResponse = await forwardToLibreFangStreaming(
           messageToSend, systemPrefix, phone, pushName, isOwner, attachments, onProgress, sender, { isGroup, wasMentioned },
         );
-        const response = markdownToWhatsApp(rawResponse);
+        // Scrub NO_REPLY before markdown conversion — if the model emitted it
+        // trailing or glued to an emoji it would otherwise reach WhatsApp.
+        const response = markdownToWhatsApp(stripNoReply(rawResponse));
 
         // Helper: send a new message or edit the streamed one for final delivery
         const sendOrEdit = async (jid, finalText) => {
@@ -1659,21 +1690,12 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
             }
             // The /api/agents/{id}/message endpoint returns { response: "..." }
             const responseText = data.response || data.message || data.text || '';
-            // Safety net: strip NO_REPLY token if it leaked through as text
-            const trimmed = responseText.trim();
-            if (trimmed === 'NO_REPLY' || trimmed.endsWith('\nNO_REPLY')) {
-              resolve('');
-              return;
-            }
-            resolve(responseText);
+            // Scrub NO_REPLY wherever it appears (isolated, trailing, or
+            // glued to an emoji / punctuation without a separator).
+            resolve(stripNoReply(responseText));
           } catch {
-            // Non-JSON fallback — still check for NO_REPLY
-            const fallback = body.trim() || '';
-            if (fallback === 'NO_REPLY' || fallback.endsWith('\nNO_REPLY')) {
-              resolve('');
-              return;
-            }
-            resolve(fallback);
+            // Non-JSON fallback — still scrub NO_REPLY for the same reason.
+            resolve(stripNoReply(body || ''));
           }
         });
       },


### PR DESCRIPTION
## Problem

The agent-side prompt convention is to emit a bare `NO_REPLY` token when the model decides a message doesn't warrant an answer. The WhatsApp gateway already trapped the *clean* case — the entire response equals `NO_REPLY`, or it trails a reply after a newline — but two real-world leak shapes still reached WhatsApp verbatim:

**Leak 1 — glued to an emoji or punctuation (observed in production):**

```
Perfetto, Signore! Sono a Sua disposizione per qualsiasi altra cosa. 🎩NO_REPLY
```

The existing check was `trimmed === 'NO_REPLY' || trimmed.endsWith('\nNO_REPLY')`. Neither matches here: the response has meaningful content, the sentinel is concatenated to an emoji with no separator, and the last character is `Y`, not a newline preceded by `NO_REPLY`. The token is sent as part of the user-visible message.

**Leak 2 — mid-stream partial edits:**

During `forwardToLibreFangStreaming` the `onProgress` callback publishes incremental WhatsApp message edits as chunks accumulate. That callback already strips `[NOTIFY_OWNER]`, `[RELAY_TO_STRANGER]`, and `[no reply needed]` but not the plain-token `NO_REPLY`, so if the model emits the sentinel before emitting the full answer (or during a nudge retry), the streamed WhatsApp message briefly shows it.

## Fix

New helper:

```javascript
function stripNoReply(text) {
  if (typeof text !== 'string' || !text) return text || '';
  if (text.trim() === 'NO_REPLY') return '';
  const stripped = text
    .replace(/\bNO_REPLY\b/g, '')
    .replace(/[ \t]+\n/g, '\n')
    .replace(/\n{3,}/g, '\n\n')
    .trim();
  return stripped === 'NO_REPLY' ? '' : stripped;
}
```

- `\b` matches between a word character and a non-word character. Emoji code points and punctuation are non-word, so `\bNO_REPLY\b` matches `"🎩NO_REPLY"` → strip works exactly where the old check failed.
- Whole-input match returns `''` so the caller can skip the `sendMessage` entirely (full suppression).
- Post-strip cleanup: trailing spaces/tabs before a newline collapse, and runs of 3+ blank lines collapse to 2 (so removing a trailing `NO_REPLY` on its own line doesn't leave a visual gap).

Applied at every reply boundary in `packages/whatsapp-gateway/index.js`:

1. `forwardToLibreFang` — JSON response path: replaces the two narrow trim-equality checks.
2. `forwardToLibreFang` — non-JSON fallback path: same treatment.
3. `forwardToLibreFangStreaming` — `onProgress` callback: so streamed edits never render the sentinel mid-flight.
4. `forwardToLibreFangStreaming` — post-stream `rawResponse` before markdown conversion.

## Testing

Manual: the production deployment that surfaced the glued-emoji leak now sends clean replies. The `data.silent` short-circuit and the existing bracket-tag strips (`[NOTIFY_OWNER]`, `[RELAY_TO_STRANGER]`, `[no reply needed]`) are unchanged.

This is gateway-side JS (no Rust test harness). Running `node --check packages/whatsapp-gateway/index.js` passes.

## Attribution

- [x] Original work