### PR TITLE
test(runtime): replace cat with sleep in process_manager tests to fix flake

### DIFF
--- a/crates/librefang-runtime/src/process_manager.rs
+++ b/crates/librefang-runtime/src/process_manager.rs
@@ -267,17 +267,33 @@ impl Default for ProcessManager {
 mod tests {
     use super::*;
 
+    /// Long-running, IO-quiet placeholder process for tests that need
+    /// "something alive in the registry until we kill it". Using `cat`
+    /// here used to flake the Ubuntu CI job — a stdin-blocked child
+    /// somehow caused the runner to receive SIGTERM mid-test (exit 143).
+    /// `sleep` doesn't touch stdin/stdout, has a bounded lifetime, and
+    /// behaves identically across platforms via Windows' `timeout`.
+    fn long_running_proc() -> (&'static str, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd",
+                vec![
+                    "/C".to_string(),
+                    "timeout".to_string(),
+                    "/t".to_string(),
+                    "30".to_string(),
+                ],
+            )
+        } else {
+            ("sleep", vec!["30".to_string()])
+        }
+    }
+
     #[tokio::test]
     async fn test_start_and_list() {
         let pm = ProcessManager::new(5);
 
-        let cmd = if cfg!(windows) { "cmd" } else { "cat" };
-        let args: Vec<String> = if cfg!(windows) {
-            vec!["/C".to_string(), "echo".to_string(), "hello".to_string()]
-        } else {
-            vec![]
-        };
-
+        let (cmd, args) = long_running_proc();
         let id = pm.start("agent1", cmd, &args).await.unwrap();
         assert!(id.starts_with("proc_"));
 
@@ -293,18 +309,7 @@ mod tests {
     async fn test_per_agent_limit() {
         let pm = ProcessManager::new(1);
 
-        let cmd = if cfg!(windows) { "cmd" } else { "cat" };
-        let args: Vec<String> = if cfg!(windows) {
-            vec![
-                "/C".to_string(),
-                "timeout".to_string(),
-                "/t".to_string(),
-                "10".to_string(),
-            ]
-        } else {
-            vec![]
-        };
-
+        let (cmd, args) = long_running_proc();
         let id1 = pm.start("agent1", cmd, &args).await.unwrap();
         let result = pm.start("agent1", cmd, &args).await;
         assert!(result.is_err());


### PR DESCRIPTION
## Symptom

The Ubuntu Test job has been intermittently failing on `process_manager::tests::test_per_agent_limit` with **exit code 143** (SIGTERM, runner shutdown signal). Reproduced on at least two unrelated runs:

- `24333639158` on PR #2365 (`fix/skills-prompt-deterministic-order`) — touches only `kernel.rs` + `prompt_builder.rs`.
- `24333049210` on `main` itself.

Both kills happen **within 6ms of the test starting**, with the runner reporting:

```
##[error]Process completed with exit code 143.
##[error]The runner has received a shutdown signal.
```

macOS and Windows always pass — only `ubuntu-latest` hits this.

## Root cause

The two tests that need a "keep something alive in the registry until I kill it" placeholder were using `cat` (no args) on Unix. `ProcessManager::start` spawns it with `Stdio::piped()`, so the parent owns the stdin pipe and `cat` blocks reading on it until the parent closes it. Some interaction between that blocked child and the GitHub Actions runner's process management causes the runner to receive SIGTERM mid-step.

I don't have a definitive diagnosis of *why* the actions runner kills itself — the most plausible guesses are stdin/IO inheritance hazards or a runner-internal "child still alive" sweep — but the fix doesn't depend on knowing the exact mechanism, just on removing the offending pattern.

## Fix

Replace `cat` with `sleep 30` on Unix:

- `sleep` doesn't read stdin, doesn't write stdout, and self-terminates after 30 seconds.
- The Windows side already used `cmd /C timeout /t 10` which has the same shape; bumped to 30s for parity.
- Extracted as a tiny `long_running_proc()` helper so both `test_start_and_list` and `test_per_agent_limit` share the same definition, with a comment explaining the history.

## Test plan

- [x] `cargo test -p librefang-runtime --lib process_manager` — 5/5 green locally
- [x] `cargo fmt --check -p librefang-runtime` — clean
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean
- [ ] Watch the next few CI runs on `main` and unrelated PRs to confirm the SIGTERM stops happening