### PR TITLE
fix(whatsapp-gateway): restore /message/send-audio endpoint accidentally removed in #2217

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -2141,6 +2141,57 @@ async function sendImage(to, imageUrl, caption) {
   });
 }
 
+async function sendAudio(to, audioUrl, ptt = true) {
+  if (!sock || connStatus !== 'connected') {
+    throw new Error('WhatsApp not connected');
+  }
+
+  // Preserve group JIDs (@g.us) as-is; normalize phone → JID for individuals
+  const jid = to.includes('@g.us') ? to
+    : to.replace(/^\+/, '').replace(/@.*$/, '') + '@s.whatsapp.net';
+
+  // Fetch audio into buffer (Baileys needs buffer or local file)
+  const buffer = await new Promise((resolve, reject) => {
+    const MAX_REDIRECTS = 5;
+    const request = (url, redirectCount = 0) => {
+      if (redirectCount > MAX_REDIRECTS) {
+        return reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
+      }
+      const mod = url.startsWith('https') ? require('node:https') : require('node:http');
+      mod.get(url, (resp) => {
+        if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers.location) {
+          return request(resp.headers.location, redirectCount + 1);
+        }
+        if (resp.statusCode !== 200) {
+          return reject(new Error(`Failed to fetch audio: HTTP ${resp.statusCode}`));
+        }
+        const chunks = [];
+        resp.on('data', (c) => chunks.push(c));
+        resp.on('end', () => resolve(Buffer.concat(chunks)));
+        resp.on('error', reject);
+      }).on('error', reject);
+    };
+    request(audioUrl);
+  });
+
+  // ptt: true sends as a voice note (push-to-talk bubble); false sends as audio file
+  const audioMsg = { audio: buffer, mimetype: 'audio/ogg; codecs=opus', ptt };
+
+  const sent = await sock.sendMessage(jid, audioMsg);
+  dbSaveMessage({
+    id: sent?.key?.id || randomUUID(),
+    jid,
+    senderJid: ownJid || null,
+    pushName: null,
+    phone: to,
+    text: ptt ? '[Voice message]' : '[Audio]',
+    direction: 'outbound',
+    timestamp: Date.now(),
+    processed: 1,
+    rawType: 'audio',
+  });
+}
+
 // ---------------------------------------------------------------------------
 // HTTP server
 // ---------------------------------------------------------------------------
@@ -2269,6 +2320,20 @@ const server = http.createServer(async (req, res) => {
 
       await sendImage(to, image_url, caption || '');
       return jsonResponse(req, res, 200, { success: true, message: 'Image sent' });
+    }
+
+    // POST /message/send-audio — send audio file or voice note via URL
+    if (req.method === 'POST' && path === '/message/send-audio') {
+      const body = await parseBody(req);
+      const { to, audio_url, ptt } = body;
+
+      if (!to || !audio_url) {
+        return jsonResponse(req, res, 400, { error: 'Missing "to" or "audio_url" field' });
+      }
+
+      // ptt (push-to-talk) defaults to true — sends as voice note bubble
+      await sendAudio(to, audio_url, ptt !== false);
+      return jsonResponse(req, res, 200, { success: true, message: 'Audio sent' });
     }
 
     // GET /conversations — list active stranger conversations (Step B)


### PR DESCRIPTION
## Summary

Restores the `sendAudio()` helper and the `POST /message/send-audio` route that PR #2099 introduced and PR #2217 silently dropped during its rebase.

## Background

- **PR #2099** (commit `a7335cb1`, merged 2026-04-05) added voice-note / audio-file delivery to the WhatsApp gateway: a `sendAudio(to, audioUrl, ptt)` helper plus the HTTP route `POST /message/send-audio` accepting `{ to, audio_url, ptt }`. `ptt: true` produces a voice-note bubble (`audio/ogg; codecs=opus`); `ptt: false` produces a regular audio attachment.
- **PR #2217** (commit `855a0851`, merged 2026-04-09 — *fix(gateway): decryption retry, streaming tag leak, session isolation*) removed both. Not as part of its stated intent — the diff against the merge base contains 10 deletion lines for `sendAudio` / `send-audio` that have nothing to do with retries, tag leaks, or session isolation. The likely root cause is that `feat/wa-gateway-fixes` was branched off `upstream/main` *before* #2099 was merged, and the final rebase didn't preserve the additions of #2099 — they were silently overwritten because the same hunk in `index.js` was being rewritten.

The result is that since 2026-04-09 the gateway has no outbound channel for voice notes / audio files at all. Agents that produce audio (TTS-derived voice notes for WhatsApp) have a generation step that succeeds but a delivery step that has nowhere to go.

## What this PR does

Restores the deleted code **verbatim** from `a7335cb1`:

- `sendAudio(to, audioUrl, ptt = true)` — same buffer-fetch loop with `MAX_REDIRECTS = 5`, same `audio/ogg; codecs=opus` MIME, same `dbSaveMessage` shape (`rawType: 'audio'`, text `'[Voice message]'` or `'[Audio]'` depending on `ptt`).
- `POST /message/send-audio` route — same body shape (`{ to, audio_url, ptt }`), same defaulting (`ptt !== false` → voice note), same 400 on missing fields, same `{ success: true, message: 'Audio sent' }` response.

No behavioural changes vs. the original PR #2099. The code sits in the same place in `index.js` (right after `sendImage()` and after the `/message/send-image` route).

## Testing

- `node --check packages/whatsapp-gateway/index.js` passes.
- Verified against a live deployment: the route is reachable on `http://127.0.0.1:3009/message/send-audio` and Baileys `sock.sendMessage` accepts the payload.

## Attribution

- [x] Original work (restoration of #2099 by @f-liva)