### PR TITLE
ci: skip security and install-smoke on unrelated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       docs: ${{ steps.filter.outputs.docs }}
       ci: ${{ steps.filter.outputs.ci }}
+      install: ${{ steps.filter.outputs.install }}
       crates: ${{ steps.crates.outputs.crates }}
     steps:
       - uses: actions/checkout@v6
@@ -48,6 +49,10 @@ jobs:
               - '*.md'
             ci:
               - '.github/workflows/**'
+            install:
+              - 'web/public/install.sh'
+              - 'web/public/install.ps1'
+              - 'scripts/tests/install_sh_test.sh'
       - name: Detect affected crates
         id: crates
         if: steps.filter.outputs.rust == 'true'
@@ -140,6 +145,8 @@ jobs:
   # ── Security audit (independent) ─────────────────────────────────────────────────────
   security:
     name: Security
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -191,6 +198,8 @@ jobs:
   # ── Installer smoke test (fast, independent) ────────────────────────────────────────
   install-smoke:
     name: Install Smoke
+    needs: changes
+    if: needs.changes.outputs.install == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds `needs: changes` gates to the `security` and `install-smoke` jobs so they only run when their inputs change, instead of firing on every PR (including docs-only ones).
- Adds a new `install` output to the `changes` paths-filter covering `web/public/install.{sh,ps1}` and `scripts/tests/install_sh_test.sh`.
- `secrets` scan is intentionally left always-on — trufflehog still needs to see markdown/config changes in case a key leaks there.

This is step 1 of a broader CI speed-up; follow-ups will address the Ubuntu test job's per-crate serial loop (the dominant wall-clock cost) without reopening the nextest SIGTERM saga from #1805 / #1807 / #2117.

## Test plan
- [ ] Open a docs-only PR — `Security` and `Install Smoke` should be skipped, `Secrets Scan` still runs.
- [ ] Touch `web/public/install.sh` — `Install Smoke` runs, `Security` skipped.
- [ ] Touch a Rust file — `Security` runs, `Install Smoke` skipped.
- [ ] Touch `.github/workflows/ci.yml` — both run (ci filter).