### PR TITLE
perf(ci): shrink dev debug info to line-tables-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,10 @@ smallvec = "1"
 
 [profile.dev]
 split-debuginfo = "unpacked" # Speeds up incremental linking on macOS
+# Shrinks debug test binaries by ~60% to relieve Ubuntu CI memory pressure
+# (#1805, #1807, #2117). Panics and backtraces still carry file:line; only
+# interactive debugger (lldb/gdb) variable inspection is lost.
+debug = "line-tables-only"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## Summary
- Adds `debug = "line-tables-only"` to `[profile.dev]` in the workspace root `Cargo.toml`.
- Cuts debug test binary size dramatically (test binaries were the root cause of the Ubuntu SIGTERM loop in #1805 / #1807 / #2117).
- Panics, `RUST_BACKTRACE=1`, `tracing`, and `anyhow` backtraces still report file:line as before.
- Step 2 of the CI speed-up plan started in #2377. Doesn't yet touch the per-crate serial loop in `test-ubuntu` — that's step 3 and will become safer once binaries are smaller.

## Trade-off
Interactive debuggers (lldb / gdb / IDE debuggers) lose variable inspection in dev builds. Devs who need it can override locally:

```toml
# In a user-local config, e.g. .cargo/config.toml or a personal profile
[profile.dev]
debug = "full"
```

Most of the codebase uses `tracing` / `println` debugging, so expected impact is low. Worth calling out in review if anyone relies on IDE step-debugging.

## Test plan
- [ ] CI green on this PR.
- [ ] Locally: `cargo test -p librefang-runtime` passes and runs faster than before.
- [ ] Locally: verify a `panic!()` still shows file:line in backtrace.
- [ ] Eyeball test binary size before/after on Linux: `ls -lh target/debug/deps/librefang_runtime-*` — expect meaningful shrink.