### PR TITLE
release: v2026.4.13-beta19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.13] - 2026-04-13
+
+### Added
+
+- Allow editing hand agent model settings from agents page (#2335) (@leszek3737)
+- Add config-driven session_mode for agent triggers (#2341) (@neo-wanderer)
+- Telegram rich media, polls, interactive commands, and channel_send tool (#2356) (@leszek3737)
+
+### Fixed
+
+- Decryption retry, streaming tag leak, session isolation (#2217) (@f-liva)
+- Inherit kernel default_model instead of hardcoded Anthropic (#2299) (@houko)
+- Per-agent loading state so streaming one agent doesn't block others (#2324) (@houko)
+- Write MCP server config as TOML table, not stringified JSON (#2327) (@houko)
+- Load secrets.env autonomously at boot time (#2359) (@f-liva)
+- Prevent zombie processes on shutdown (#2360) (@f-liva)
+- Refuse direct DELETE on hand-spawned agents + clarify revert warning (#2361) (@houko)
+- Normalize MIME type parameters before allowlist check (#2362) (@f-liva)
+- Resolve LID JIDs to phone numbers for owner detection (#2363) (@f-liva)
+- Harden poll_options parsing and poll context cleanup (#2364) (@houko)
+- Deterministic prompt context ordering and raise truncation cap (#2365) (@houko)
+- Stop Qwen driver from leaking raw JSON into chat (#2366) (@f-liva)
+- Let FallbackDriver recover from transient unhealthiness (#2367) (@f-liva)
+- Clear stale per-agent overrides on provider switch (#2371) (@neo-wanderer)
+- Scrub NO_REPLY sentinel in every reply path (#2373) (@f-liva)
+- Restore /message/send-audio endpoint accidentally removed in #2217 (#2376) (@f-liva)
+- Support "date" metric format and drop ureq from cli (#2382) (@houko)
+
+### Performance
+
+- Shrink dev debug info to line-tables-only (#2378) (@houko)
+
+### Maintenance
+
+- Split Docker image and deploy status (#2323) (@houko)
+- Fix max_tokens assertions after pure-text short-circuit (#2325) (@houko)
+- Strengthen telegram sanitizer coverage (#2334) (@leszek3737)
+- Fix rustfmt on upsert_mcp_server test assert (#2358) (@houko)
+- Replace cat with sleep in process_manager tests to fix flake (#2375) (@houko)
+- Skip security and install-smoke on unrelated PRs (#2377) (@houko)
+- Apply cargo fmt to runtime drivers (#2380) (@houko)
+
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "aes",
  "async-trait",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "clap",
  "clap_complete",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "axum",
  "clap",
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "async-trait",
  "axum",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10796,7 +10796,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32128",
+  "version": "26.4.32149",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.11-beta18",
+  "version": "2026.4.13-beta19",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.11-beta18",
+  "version": "2026.4.13-beta19",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.11b18",
+    version="2026.4.13b19",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.11-beta18"
+version = "2026.4.13-beta19"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.13-beta19 -->
## Release v2026.4.13-beta19

### Added

- Allow editing hand agent model settings from agents page (#2335) (@leszek3737)
- Add config-driven session_mode for agent triggers (#2341) (@neo-wanderer)
- Telegram rich media, polls, interactive commands, and channel_send tool (#2356) (@leszek3737)

### Fixed

- Decryption retry, streaming tag leak, session isolation (#2217) (@f-liva)
- Inherit kernel default_model instead of hardcoded Anthropic (#2299) (@houko)
- Per-agent loading state so streaming one agent doesn't block others (#2324) (@houko)
- Write MCP server config as TOML table, not stringified JSON (#2327) (@houko)
- Load secrets.env autonomously at boot time (#2359) (@f-liva)
- Prevent zombie processes on shutdown (#2360) (@f-liva)
- Refuse direct DELETE on hand-spawned agents + clarify revert warning (#2361) (@houko)
- Normalize MIME type parameters before allowlist check (#2362) (@f-liva)
- Resolve LID JIDs to phone numbers for owner detection (#2363) (@f-liva)
- Harden poll_options parsing and poll context cleanup (#2364) (@houko)
- Deterministic prompt context ordering and raise truncation cap (#2365) (@houko)
- Stop Qwen driver from leaking raw JSON into chat (#2366) (@f-liva)
- Let FallbackDriver recover from transient unhealthiness (#2367) (@f-liva)
- Clear stale per-agent overrides on provider switch (#2371) (@neo-wanderer)
- Scrub NO_REPLY sentinel in every reply path (#2373) (@f-liva)
- Restore /message/send-audio endpoint accidentally removed in #2217 (#2376) (@f-liva)
- Support "date" metric format and drop ureq from cli (#2382) (@houko)

### Performance

- Shrink dev debug info to line-tables-only (#2378) (@houko)

### Maintenance

- Split Docker image and deploy status (#2323) (@houko)
- Fix max_tokens assertions after pure-text short-circuit (#2325) (@houko)
- Strengthen telegram sanitizer coverage (#2334) (@leszek3737)
- Fix rustfmt on upsert_mcp_server test assert (#2358) (@houko)
- Replace cat with sleep in process_manager tests to fix flake (#2375) (@houko)
- Skip security and install-smoke on unrelated PRs (#2377) (@houko)
- Apply cargo fmt to runtime drivers (#2380) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.11-beta18...v2026.4.13-beta19