### PR TITLE
fix(runtime): atomic tool-use turn commit — closes #2381 (follow-up to #2065)

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -356,18 +356,141 @@ fn update_consecutive_hard_failures(
     hard_error_count
 }
 
-struct ToolUseSetup {
+/// Accumulates an in-flight tool-use turn without touching `session.messages`
+/// or the LLM working-copy `messages` vec until the turn is ready to commit.
+///
+/// This is the structural fix for upstream #2381: the previous
+/// `begin_tool_use_turn` helper eagerly pushed the assistant `tool_use`
+/// message to `session.messages` BEFORE any tool executed, and relied on
+/// a later `finalize_tool_use_results` call to add the paired user
+/// `tool_result` message. Any control-flow exit between the two (a hard
+/// error `break`, a mid-turn signal `break`, or a `?` propagation from
+/// `execute_single_tool_call`) left `session.messages` in a
+/// half-committed state: the provider then rejected the next request
+/// with "tool_call_ids did not have response messages" (HTTP 400).
+///
+/// With `StagedToolUseTurn` the assistant message AND all tool-result
+/// blocks are buffered locally. Only `commit` touches the persisted
+/// vectors, and it does so atomically (assistant message + user
+/// {tool_results} pushed in a single operation). If the staged turn is
+/// dropped without commit — which is exactly what `?` propagation does —
+/// `session.messages` is untouched. By construction, no orphan `ToolUse`
+/// can ever reach the persistence layer.
+struct StagedToolUseTurn {
+    /// The assistant message carrying `ContentBlock::ToolUse` blocks.
+    /// Cloned into both `session.messages` and the LLM `messages`
+    /// working copy at commit time.
+    assistant_msg: Message,
+    /// `(tool_use_id, tool_name)` for every tool_use block the LLM
+    /// emitted. Used by `pad_missing_results` to fabricate synthetic
+    /// "not executed" results for any tool_use_id that never received
+    /// an `append_result` (e.g. because a mid-turn signal interrupted
+    /// the per-tool loop).
+    tool_call_ids: Vec<(String, String)>,
+    /// Accumulated `ContentBlock::ToolResult` blocks. Committed as the
+    /// body of a single user message once the turn is ready.
+    tool_result_blocks: Vec<ContentBlock>,
+    /// Cached assistant rationale text (if any) — preserved here so
+    /// the tool-execution loop can pass it to `execute_single_tool_call`
+    /// for decision trace recording.
     rationale_text: Option<String>,
+    /// Names of tools the agent is allowed to invoke on this turn.
     allowed_tool_names: Vec<String>,
+    /// Caller id (agent id as string) used for hook context and policy.
     caller_id_str: String,
+    /// Once `commit` runs this flips to true so a second commit call
+    /// (or a drop-after-commit) is a no-op.
+    committed: bool,
 }
 
-fn begin_tool_use_turn(
+impl StagedToolUseTurn {
+    /// Append a tool result block to the staged turn. Called once per
+    /// `execute_single_tool_call` completion — including for hard
+    /// errors, which are honest information the LLM must see on the
+    /// next iteration.
+    fn append_result(&mut self, block: ContentBlock) {
+        self.tool_result_blocks.push(block);
+    }
+
+    /// Pad any `tool_use_id` that never had `append_result` called for
+    /// it with a synthetic "tool not executed" result block. No-op on
+    /// the happy path where every tool executed (and therefore appended
+    /// a result — including a real error result).
+    ///
+    /// This is ONLY for ids that have no result at all. If a tool
+    /// returned `is_error=true` via `append_result`, that real error
+    /// content is preserved — padding must NOT paper over honest error
+    /// information.
+    fn pad_missing_results(&mut self) {
+        for (id, name) in &self.tool_call_ids {
+            let already_present = self.tool_result_blocks.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == id
+                )
+            });
+            if already_present {
+                continue;
+            }
+            self.tool_result_blocks.push(ContentBlock::ToolResult {
+                tool_use_id: id.clone(),
+                tool_name: name.clone(),
+                content: "[tool interrupted: turn aborted before this call could execute]"
+                    .to_string(),
+                is_error: true,
+                status: librefang_types::tool::ToolExecutionStatus::Error,
+                approval_request_id: None,
+            });
+        }
+    }
+
+    /// Atomically commit the staged assistant message and user
+    /// tool-result message to both `session.messages` and the LLM
+    /// working copy `messages`. Returns the outcome summary computed
+    /// from the accumulated tool-result blocks (for consecutive-failure
+    /// tracking).
+    ///
+    /// Callers should always run `pad_missing_results` before `commit`
+    /// if any control-flow exit (mid-turn signal, etc.) interrupted the
+    /// per-tool loop — otherwise the wire format will carry orphan
+    /// `tool_use_id`s the provider will reject.
+    fn commit(
+        &mut self,
+        session: &mut Session,
+        messages: &mut Vec<Message>,
+    ) -> ToolResultOutcomeSummary {
+        if self.committed {
+            return ToolResultOutcomeSummary::default();
+        }
+        self.committed = true;
+
+        // Step 1: push the assistant message carrying the tool_use blocks.
+        session.messages.push(self.assistant_msg.clone());
+        messages.push(self.assistant_msg.clone());
+
+        // Step 2: degenerate-case short-circuit — if no result blocks
+        // were accumulated (LLM emitted no tool_calls, or every id was
+        // padded away) we skip the paired user message so we don't emit
+        // an empty `Blocks(vec![])` message.
+        if self.tool_result_blocks.is_empty() {
+            return ToolResultOutcomeSummary::default();
+        }
+
+        // Step 3: delegate the user{tool_result} push to the existing
+        // `finalize_tool_use_results` helper so guidance-block append
+        // behaviour stays centralized.
+        finalize_tool_use_results(session, messages, &mut self.tool_result_blocks)
+    }
+}
+
+/// Build a `StagedToolUseTurn` for an assistant response whose stop
+/// reason is `ToolUse`. Does NOT mutate `session.messages` or the LLM
+/// working copy — see `StagedToolUseTurn` docs for why.
+fn stage_tool_use_turn(
     response: &crate::llm_driver::CompletionResponse,
-    session: &mut Session,
-    messages: &mut Vec<Message>,
+    session: &Session,
     available_tools: &[ToolDefinition],
-) -> ToolUseSetup {
+) -> StagedToolUseTurn {
     let rationale_text = {
         let text = response.text();
         if text.trim().is_empty() {
@@ -377,23 +500,26 @@ fn begin_tool_use_turn(
         }
     };
 
-    let assistant_blocks = response.content.clone();
-
-    session.messages.push(Message {
+    let assistant_msg = Message {
         role: Role::Assistant,
-        content: MessageContent::Blocks(assistant_blocks.clone()),
+        content: MessageContent::Blocks(response.content.clone()),
         pinned: false,
-    });
-    messages.push(Message {
-        role: Role::Assistant,
-        content: MessageContent::Blocks(assistant_blocks),
-        pinned: false,
-    });
+    };
 
-    ToolUseSetup {
+    let tool_call_ids: Vec<(String, String)> = response
+        .tool_calls
+        .iter()
+        .map(|tc| (tc.id.clone(), tc.name.clone()))
+        .collect();
+
+    StagedToolUseTurn {
+        assistant_msg,
+        tool_call_ids,
+        tool_result_blocks: Vec::new(),
         rationale_text,
         allowed_tool_names: available_tools.iter().map(|t| t.name.clone()).collect(),
         caller_id_str: session.agent_id.to_string(),
+        committed: false,
     }
 }
 
@@ -629,22 +755,6 @@ async fn execute_single_tool_call(
     })
 }
 
-fn append_tool_result_block(
-    tool_result_blocks: &mut Vec<ContentBlock>,
-    tool_call: &ToolCall,
-    result: &librefang_types::tool::ToolResult,
-    final_content: String,
-) {
-    tool_result_blocks.push(ContentBlock::ToolResult {
-        tool_use_id: result.tool_use_id.clone(),
-        tool_name: tool_call.name.clone(),
-        content: final_content,
-        is_error: result.is_error,
-        status: result.status,
-        approval_request_id: result.approval_request_id.clone(),
-    });
-}
-
 /// Emit stub `ToolResult` blocks for any tool calls in `remaining` that
 /// were not actually executed (e.g. because we hit a hard error and broke
 /// out of the per-call loop). OpenAI/Anthropic both require **every**
@@ -668,13 +778,12 @@ fn append_skipped_tool_results(
         });
     }
 }
-
 fn handle_mid_turn_signal(
     pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
     manifest_name: &str,
     session: &mut Session,
     messages: &mut Vec<Message>,
-    tool_result_blocks: &mut Vec<ContentBlock>,
+    staged: &mut StagedToolUseTurn,
 ) -> Option<ToolResultOutcomeSummary> {
     let pending_rx = pending_messages?;
     let Ok(mut rx) = pending_rx.try_lock() else {
@@ -684,7 +793,13 @@ fn handle_mid_turn_signal(
         return None;
     };
 
-    let flushed_outcomes = finalize_tool_use_results(session, messages, tool_result_blocks);
+    // Pad any tool_use_id that never produced a result, then commit the
+    // staged assistant message + user{tool_results} atomically. After
+    // this call, session.messages is guaranteed to have paired
+    // ToolUse+ToolResult blocks — no orphan tool_use_id can leak onto
+    // the wire (#2381).
+    staged.pad_missing_results();
+    let flushed_outcomes = staged.commit(session, messages);
 
     info!(
         agent = %manifest_name,
@@ -718,7 +833,6 @@ fn handle_mid_turn_signal(
     let inject_msg = Message::user(&injected_text);
     session.messages.push(inject_msg.clone());
     messages.push(inject_msg);
-    tool_result_blocks.clear();
     Some(flushed_outcomes)
 }
 
@@ -2387,12 +2501,18 @@ pub async fn run_agent_loop(
                 // Reset MaxTokens continuation counter on tool use
                 consecutive_max_tokens = 0;
                 any_tools_executed = true;
-                let tool_use_setup =
-                    begin_tool_use_turn(&response, session, &mut messages, available_tools);
+                // Stage the turn locally — session.messages is NOT
+                // mutated until `staged.commit(...)` runs below (or the
+                // mid-turn signal handler commits on our behalf). If
+                // execute_single_tool_call propagates `?` before commit,
+                // the staged turn drops silently and session.messages is
+                // unchanged — by construction, no orphan ToolUse can
+                // reach the persistence layer. See #2381.
+                let mut staged = stage_tool_use_turn(&response, session, available_tools);
 
-                // Execute each tool call with loop guard, timeout, and truncation
-                let mut tool_result_blocks = Vec::new();
+                // Execute each tool call with loop guard, timeout, and truncation.
                 let mut iteration_outcomes = ToolResultOutcomeSummary::default();
+                let mut committed_by_signal = false;
                 let total_tool_calls = response.tool_calls.len();
                 for (call_idx, tool_call) in response.tool_calls.iter().enumerate() {
                     let mut tool_exec_ctx = ToolExecutionContext {
@@ -2401,8 +2521,8 @@ pub async fn run_agent_loop(
                         memory,
                         session,
                         kernel: kernel.as_ref(),
-                        available_tool_names: &tool_use_setup.allowed_tool_names,
-                        caller_id_str: &tool_use_setup.caller_id_str,
+                        available_tool_names: &staged.allowed_tool_names,
+                        caller_id_str: &staged.caller_id_str,
                         skill_registry,
                         mcp_connections,
                         web_ctx,
@@ -2422,7 +2542,7 @@ pub async fn run_agent_loop(
                         context_window_tokens: ctx_window,
                         on_phase,
                         decision_traces: &mut decision_traces,
-                        rationale_text: &tool_use_setup.rationale_text,
+                        rationale_text: &staged.rationale_text,
                         tools_recovered_from_text,
                         iteration,
                         streaming: false,
@@ -2430,16 +2550,23 @@ pub async fn run_agent_loop(
                     };
                     let executed = execute_single_tool_call(&mut tool_exec_ctx, tool_call).await?;
 
-                    append_tool_result_block(
-                        &mut tool_result_blocks,
-                        tool_call,
-                        &executed.result,
-                        executed.final_content,
-                    );
+                    staged.append_result(ContentBlock::ToolResult {
+                        tool_use_id: executed.result.tool_use_id.clone(),
+                        tool_name: tool_call.name.clone(),
+                        content: executed.final_content,
+                        is_error: executed.result.is_error,
+                        status: executed.result.status,
+                        approval_request_id: executed.result.approval_request_id.clone(),
+                    });
 
                     // Stop executing remaining tool calls on failure (#948)
                     // but not for approval denials or sandbox security rejections —
                     // those should let the LLM recover and retry with a valid path (#1861)
+                    // Issue #2381: emit stub tool_results for the remaining unexecuted
+                    // calls so OpenAI / Anthropic see a response for every tool_call_id.
+                    // Without this the next API request returns 400 with
+                    // "tool_call_ids ... did not have response messages" and the agent
+                    // gets bricked.
                     let is_soft_error = executed.result.status.is_soft_error()
                         || is_soft_error_content(&executed.result.content);
                     if executed.result.is_error && !is_soft_error {
@@ -2447,53 +2574,49 @@ pub async fn run_agent_loop(
                             tool = %tool_call.name,
                             "Tool execution failed — skipping remaining tool calls"
                         );
-                        // Issue #2381: emit stub tool_results for the
-                        // remaining unexecuted calls so OpenAI / Anthropic
-                        // see a response for every tool_call_id. Without
-                        // this the next API request returns 400 with
-                        // "tool_call_ids ... did not have response
-                        // messages" and the agent gets bricked.
                         append_skipped_tool_results(
-                            &mut tool_result_blocks,
+                            &mut staged.tool_result_blocks,
                             &response.tool_calls[call_idx + 1..],
                             "previous tool call in the same batch failed with a hard error",
                         );
                         break;
                     }
 
-                    // Mid-turn message injection (#956): check for pending user
-                    // messages between tool calls. If one is available, flush
-                    // completed tool results so far and inject the user message
-                    // so the LLM can process the interrupt on the next iteration.
+                    // Mid-turn message injection (#956): check for
+                    // pending user messages between tool calls. The
+                    // handler pads missing results and commits the
+                    // staged turn BEFORE injecting the user message, so
+                    // the session never has orphan tool_use_ids.
                     if let Some(flushed_outcomes) = handle_mid_turn_signal(
                         pending_messages,
                         &manifest.name,
                         session,
                         &mut messages,
-                        &mut tool_result_blocks,
+                        &mut staged,
                     ) {
                         // Same #2381 invariant: even when the batch is
                         // interrupted by a mid-turn signal, every tool_call
-                        // must end up with a tool_result. The flushed
-                        // outcomes already covered the executed prefix;
-                        // stub the rest before breaking.
+                        // must end up with a tool_result. handle_mid_turn_signal
+                        // already called pad_missing_results before committing,
+                        // so remaining ids are covered. This stub call is a
+                        // belt-and-suspenders guard for any ids not yet in staged.
                         if call_idx + 1 < total_tool_calls {
                             append_skipped_tool_results(
-                                &mut tool_result_blocks,
+                                &mut staged.tool_result_blocks,
                                 &response.tool_calls[call_idx + 1..],
                                 "tool batch interrupted by a mid-turn user message",
                             );
                         }
                         iteration_outcomes.accumulate(flushed_outcomes);
+                        committed_by_signal = true;
                         break;
                     }
                 }
 
-                iteration_outcomes.accumulate(finalize_tool_use_results(
-                    session,
-                    &mut messages,
-                    &mut tool_result_blocks,
-                ));
+                if !committed_by_signal {
+                    staged.pad_missing_results();
+                    iteration_outcomes.accumulate(staged.commit(session, &mut messages));
+                }
 
                 // Interim save after tool execution to prevent data loss on crash
                 if let Err(e) = memory.save_session_async(session).await {
@@ -3375,12 +3498,14 @@ pub async fn run_agent_loop_streaming(
                 // Reset MaxTokens continuation counter on tool use
                 consecutive_max_tokens = 0;
                 any_tools_executed = true;
-                let tool_use_setup =
-                    begin_tool_use_turn(&response, session, &mut messages, available_tools);
+                // See non-streaming branch above for the full rationale
+                // — this is the streaming twin of the #2381 staged-commit
+                // fix.
+                let mut staged = stage_tool_use_turn(&response, session, available_tools);
 
-                // Execute each tool call with loop guard, timeout, and truncation
-                let mut tool_result_blocks = Vec::new();
+                // Execute each tool call with loop guard, timeout, and truncation.
                 let mut iteration_outcomes = ToolResultOutcomeSummary::default();
+                let mut committed_by_signal = false;
                 let total_tool_calls = response.tool_calls.len();
                 for (call_idx, tool_call) in response.tool_calls.iter().enumerate() {
                     let mut tool_exec_ctx = ToolExecutionContext {
@@ -3389,8 +3514,8 @@ pub async fn run_agent_loop_streaming(
                         memory,
                         session,
                         kernel: kernel.as_ref(),
-                        available_tool_names: &tool_use_setup.allowed_tool_names,
-                        caller_id_str: &tool_use_setup.caller_id_str,
+                        available_tool_names: &staged.allowed_tool_names,
+                        caller_id_str: &staged.caller_id_str,
                         skill_registry,
                         mcp_connections,
                         web_ctx,
@@ -3410,7 +3535,7 @@ pub async fn run_agent_loop_streaming(
                         context_window_tokens: ctx_window,
                         on_phase,
                         decision_traces: &mut decision_traces,
-                        rationale_text: &tool_use_setup.rationale_text,
+                        rationale_text: &staged.rationale_text,
                         tools_recovered_from_text,
                         iteration,
                         streaming: true,
@@ -3432,16 +3557,21 @@ pub async fn run_agent_loop_streaming(
                         warn!(agent = %manifest.name, "Stream consumer disconnected — continuing tool loop but will not stream further");
                     }
 
-                    append_tool_result_block(
-                        &mut tool_result_blocks,
-                        tool_call,
-                        &executed.result,
-                        executed.final_content,
-                    );
+                    staged.append_result(ContentBlock::ToolResult {
+                        tool_use_id: executed.result.tool_use_id.clone(),
+                        tool_name: tool_call.name.clone(),
+                        content: executed.final_content,
+                        is_error: executed.result.is_error,
+                        status: executed.result.status,
+                        approval_request_id: executed.result.approval_request_id.clone(),
+                    });
 
                     // Stop executing remaining tool calls on failure (#948)
                     // but not for approval denials or sandbox security rejections —
                     // those should let the LLM recover and retry with a valid path (#1861)
+                    // Issue #2381: stub the remaining tool_calls so every tool_call_id
+                    // has a matching tool_result. See the non-streaming branch above for
+                    // the full explanation of why this matters.
                     let is_soft_error = executed.result.status.is_soft_error()
                         || is_soft_error_content(&executed.result.content);
                     if executed.result.is_error && !is_soft_error {
@@ -3449,44 +3579,41 @@ pub async fn run_agent_loop_streaming(
                             tool = %tool_call.name,
                             "Tool execution failed — skipping remaining tool calls (streaming)"
                         );
-                        // Issue #2381: stub the remaining tool_calls so
-                        // every tool_call_id has a matching tool_result.
-                        // See the non-streaming branch above for the full
-                        // explanation of why this matters.
                         append_skipped_tool_results(
-                            &mut tool_result_blocks,
+                            &mut staged.tool_result_blocks,
                             &response.tool_calls[call_idx + 1..],
                             "previous tool call in the same batch failed with a hard error",
                         );
                         break;
                     }
 
-                    // Mid-turn message injection (#956): check for pending user
-                    // messages between tool calls (streaming variant).
+                    // Mid-turn message injection (#956): check for
+                    // pending user messages between tool calls (streaming
+                    // variant).
                     if let Some(flushed_outcomes) = handle_mid_turn_signal(
                         pending_messages,
                         &manifest.name,
                         session,
                         &mut messages,
-                        &mut tool_result_blocks,
+                        &mut staged,
                     ) {
                         if call_idx + 1 < total_tool_calls {
                             append_skipped_tool_results(
-                                &mut tool_result_blocks,
+                                &mut staged.tool_result_blocks,
                                 &response.tool_calls[call_idx + 1..],
                                 "tool batch interrupted by a mid-turn user message",
                             );
                         }
                         iteration_outcomes.accumulate(flushed_outcomes);
+                        committed_by_signal = true;
                         break;
                     }
                 }
 
-                iteration_outcomes.accumulate(finalize_tool_use_results(
-                    session,
-                    &mut messages,
-                    &mut tool_result_blocks,
-                ));
+                if !committed_by_signal {
+                    staged.pad_missing_results();
+                    iteration_outcomes.accumulate(staged.commit(session, &mut messages));
+                }
 
                 if let Err(e) = memory.save_session_async(session).await {
                     warn!("Failed to interim-save session: {e}");
@@ -4610,6 +4737,10 @@ mod tests {
 
     #[test]
     fn test_handle_mid_turn_signal_injects_without_tool_results() {
+        // Even when the staged turn has no tool results yet (empty
+        // tool_result_blocks) and no pending tool_use_ids, the signal
+        // handler must still commit the staged assistant message (empty
+        // Blocks), then inject the user signal.
         let agent_id = librefang_types::agent::AgentId::new();
         let mut session = librefang_memory::session::Session {
             id: librefang_types::agent::SessionId::new(),
@@ -4619,7 +4750,19 @@ mod tests {
             label: None,
         };
         let mut messages = Vec::new();
-        let mut tool_result_blocks = Vec::new();
+        let mut staged = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(Vec::new()),
+                pinned: false,
+            },
+            tool_call_ids: Vec::new(),
+            tool_result_blocks: Vec::new(),
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session.agent_id.to_string(),
+            committed: false,
+        };
         let (tx, rx) = mpsc::channel(1);
         tx.try_send(AgentLoopSignal::Message {
             content: "interrupt".to_string(),
@@ -4632,18 +4775,27 @@ mod tests {
             "test-agent",
             &mut session,
             &mut messages,
-            &mut tool_result_blocks,
+            &mut staged,
         )
         .expect("expected mid-turn signal");
 
         assert_eq!(flushed_outcomes, ToolResultOutcomeSummary::default());
-        assert_eq!(session.messages.len(), 1);
-        assert_eq!(messages.len(), 1);
-        assert_eq!(session.messages[0].content.text_content(), "interrupt");
+        // Empty staged assistant msg + injected user msg = 2 messages.
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(session.messages[1].content.text_content(), "interrupt");
     }
 
     #[test]
     fn test_handle_mid_turn_signal_mixed_flush_resets_consecutive_all_failed() {
+        // A staged turn with two already-appended tool results (one
+        // hard error, one success) receives a mid-turn signal. The
+        // signal handler must: pad (no-op — both ids have results),
+        // commit both results + assistant msg, then inject the user
+        // signal. Final shape:
+        //   [assistant{ToolUse x2},
+        //    user{ToolResult x2 + guidance text},
+        //    user{"interrupt"}]
         let agent_id = librefang_types::agent::AgentId::new();
         let mut session = librefang_memory::session::Session {
             id: librefang_types::agent::SessionId::new(),
@@ -4653,24 +4805,52 @@ mod tests {
             label: None,
         };
         let mut messages = Vec::new();
-        let mut tool_result_blocks = vec![
-            ContentBlock::ToolResult {
-                tool_use_id: "tool-hard-fail".to_string(),
-                tool_name: "nonexistent_tool".to_string(),
-                content: "Permission denied: unknown tool".to_string(),
-                is_error: true,
-                status: librefang_types::tool::ToolExecutionStatus::Error,
-                approval_request_id: None,
+        let mut staged = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "tool-hard-fail".to_string(),
+                        name: "nonexistent_tool".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "tool-ok".to_string(),
+                        name: "noop".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                ]),
+                pinned: false,
             },
-            ContentBlock::ToolResult {
-                tool_use_id: "tool-ok".to_string(),
-                tool_name: "noop".to_string(),
-                content: "ok".to_string(),
-                is_error: false,
-                status: librefang_types::tool::ToolExecutionStatus::Completed,
-                approval_request_id: None,
-            },
-        ];
+            tool_call_ids: vec![
+                ("tool-hard-fail".to_string(), "nonexistent_tool".to_string()),
+                ("tool-ok".to_string(), "noop".to_string()),
+            ],
+            tool_result_blocks: vec![
+                ContentBlock::ToolResult {
+                    tool_use_id: "tool-hard-fail".to_string(),
+                    tool_name: "nonexistent_tool".to_string(),
+                    content: "Permission denied: unknown tool".to_string(),
+                    is_error: true,
+                    status: librefang_types::tool::ToolExecutionStatus::Error,
+                    approval_request_id: None,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "tool-ok".to_string(),
+                    tool_name: "noop".to_string(),
+                    content: "ok".to_string(),
+                    is_error: false,
+                    status: librefang_types::tool::ToolExecutionStatus::Completed,
+                    approval_request_id: None,
+                },
+            ],
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session.agent_id.to_string(),
+            committed: false,
+        };
         let (tx, rx) = mpsc::channel(1);
         tx.try_send(AgentLoopSignal::Message {
             content: "interrupt".to_string(),
@@ -4683,7 +4863,7 @@ mod tests {
             "test-agent",
             &mut session,
             &mut messages,
-            &mut tool_result_blocks,
+            &mut staged,
         )
         .expect("expected mid-turn signal");
 
@@ -4694,11 +4874,21 @@ mod tests {
                 success_count: 1,
             }
         );
-        assert!(tool_result_blocks.is_empty());
-        assert_eq!(session.messages.len(), 2);
-        assert_eq!(messages.len(), 2);
+        assert_eq!(session.messages.len(), 3);
+        assert_eq!(messages.len(), 3);
         assert!(matches!(
             &session.messages[0].content,
+            MessageContent::Blocks(blocks)
+                if matches!(
+                    blocks.as_slice(),
+                    [
+                        ContentBlock::ToolUse { id: id_a, .. },
+                        ContentBlock::ToolUse { id: id_b, .. },
+                    ] if id_a == "tool-hard-fail" && id_b == "tool-ok"
+                )
+        ));
+        assert!(matches!(
+            &session.messages[1].content,
             MessageContent::Blocks(blocks)
                 if matches!(
                     blocks.as_slice(),
@@ -4719,7 +4909,7 @@ mod tests {
                     ] if tool_use_id == "tool-hard-fail" && tool_use_id_ok == "tool-ok"
                 )
         ));
-        assert_eq!(session.messages[1].content.text_content(), "interrupt");
+        assert_eq!(session.messages[2].content.text_content(), "interrupt");
 
         let mut consecutive_all_failed = 2;
         let hard_error_count =
@@ -4751,24 +4941,52 @@ mod tests {
             label: None,
         };
         let mut messages = session.messages.clone();
-        let mut tool_result_blocks = vec![
-            ContentBlock::ToolResult {
-                tool_use_id: "tool-hard-fail".to_string(),
-                tool_name: "failing_tool".to_string(),
-                content: "hard failure before approval resolution".to_string(),
-                is_error: true,
-                status: librefang_types::tool::ToolExecutionStatus::Error,
-                approval_request_id: None,
+        let mut staged = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "tool-hard-fail".to_string(),
+                        name: "failing_tool".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "tool-ok".to_string(),
+                        name: "noop".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                ]),
+                pinned: false,
             },
-            ContentBlock::ToolResult {
-                tool_use_id: "tool-ok".to_string(),
-                tool_name: "noop".to_string(),
-                content: "completed before approval resolution".to_string(),
-                is_error: false,
-                status: librefang_types::tool::ToolExecutionStatus::Completed,
-                approval_request_id: None,
-            },
-        ];
+            tool_call_ids: vec![
+                ("tool-hard-fail".to_string(), "failing_tool".to_string()),
+                ("tool-ok".to_string(), "noop".to_string()),
+            ],
+            tool_result_blocks: vec![
+                ContentBlock::ToolResult {
+                    tool_use_id: "tool-hard-fail".to_string(),
+                    tool_name: "failing_tool".to_string(),
+                    content: "hard failure before approval resolution".to_string(),
+                    is_error: true,
+                    status: librefang_types::tool::ToolExecutionStatus::Error,
+                    approval_request_id: None,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "tool-ok".to_string(),
+                    tool_name: "noop".to_string(),
+                    content: "completed before approval resolution".to_string(),
+                    is_error: false,
+                    status: librefang_types::tool::ToolExecutionStatus::Completed,
+                    approval_request_id: None,
+                },
+            ],
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session.agent_id.to_string(),
+            committed: false,
+        };
         let (tx, rx) = mpsc::channel(1);
         tx.try_send(AgentLoopSignal::ApprovalResolved {
             tool_use_id: "tool_waiting".to_string(),
@@ -4786,7 +5004,7 @@ mod tests {
             "test-agent",
             &mut session,
             &mut messages,
-            &mut tool_result_blocks,
+            &mut staged,
         )
         .expect("expected approval resolution signal");
 
@@ -4797,10 +5015,15 @@ mod tests {
                 success_count: 1,
             }
         );
-        assert!(tool_result_blocks.is_empty());
-        assert_eq!(session.messages.len(), 3);
-        assert_eq!(messages.len(), 3);
+        // After commit + approval_resolution + inject:
+        //   [0] original waiting result (updated to "approved and executed")
+        //   [1] staged assistant_msg (2 ToolUse blocks)
+        //   [2] staged user{ToolResult x2 + guidance text}
+        //   [3] injected user "approval resolved" message
+        assert_eq!(session.messages.len(), 4);
+        assert_eq!(messages.len(), 4);
 
+        // [0] — original waiting result, updated in place by approval_resolution.
         match &session.messages[0].content {
             MessageContent::Blocks(blocks) => match &blocks[0] {
                 ContentBlock::ToolResult {
@@ -4823,7 +5046,21 @@ mod tests {
             other => panic!("expected blocks message, got {other:?}"),
         }
 
-        match &session.messages[1].content {
+        // [1] — staged assistant_msg with 2 ToolUse blocks.
+        assert!(matches!(
+            &session.messages[1].content,
+            MessageContent::Blocks(blocks)
+                if matches!(
+                    blocks.as_slice(),
+                    [
+                        ContentBlock::ToolUse { id: id_a, .. },
+                        ContentBlock::ToolUse { id: id_b, .. },
+                    ] if id_a == "tool-hard-fail" && id_b == "tool-ok"
+                )
+        ));
+
+        // [2] — flushed user{ToolResult x2 + guidance text}.
+        match &session.messages[2].content {
             MessageContent::Blocks(blocks) => {
                 assert!(matches!(
                     blocks.as_slice(),
@@ -4853,7 +5090,8 @@ mod tests {
             other => panic!("expected flushed blocks message, got {other:?}"),
         }
 
-        let injected_text = session.messages[2].content.text_content();
+        // [3] — injected user signal.
+        let injected_text = session.messages[3].content.text_content();
         assert!(injected_text.contains("Tool 'dangerous_tool' approval resolved (approved)"));
         assert!(injected_text.contains("approved and executed"));
 
@@ -5158,6 +5396,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_mid_turn_signal_preserves_partial_hard_failure_results_for_classification() {
+        // A staged turn with a single already-appended hard-error result
+        // receives a mid-turn signal. The signal handler must commit the
+        // staged assistant ToolUse + the hard-error user ToolResult
+        // atomically, then inject the user signal. Final session shape:
+        //   [assistant{ToolUse "tool-hard-fail"},
+        //    user{ToolResult hard-error + guidance text},
+        //    user{"interrupt"}]
+        // The real hard-error content must survive verbatim so that
+        // update_consecutive_hard_failures can classify it correctly.
         let agent_id = librefang_types::agent::AgentId::new();
         let mut session = librefang_memory::session::Session {
             id: librefang_types::agent::SessionId::new(),
@@ -5167,14 +5414,31 @@ mod tests {
             label: None,
         };
         let mut messages = Vec::new();
-        let mut tool_result_blocks = vec![ContentBlock::ToolResult {
-            tool_use_id: "tool-hard-fail".to_string(),
-            tool_name: "nonexistent_tool".to_string(),
-            content: "Permission denied: unknown tool".to_string(),
-            is_error: true,
-            status: librefang_types::tool::ToolExecutionStatus::Error,
-            approval_request_id: None,
-        }];
+        let mut staged = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: "tool-hard-fail".to_string(),
+                    name: "nonexistent_tool".to_string(),
+                    input: serde_json::json!({}),
+                    provider_metadata: None,
+                }]),
+                pinned: false,
+            },
+            tool_call_ids: vec![("tool-hard-fail".to_string(), "nonexistent_tool".to_string())],
+            tool_result_blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool-hard-fail".to_string(),
+                tool_name: "nonexistent_tool".to_string(),
+                content: "Permission denied: unknown tool".to_string(),
+                is_error: true,
+                status: librefang_types::tool::ToolExecutionStatus::Error,
+                approval_request_id: None,
+            }],
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session.agent_id.to_string(),
+            committed: false,
+        };
         let (tx, rx) = mpsc::channel(1);
         tx.send(AgentLoopSignal::Message {
             content: "interrupt".to_string(),
@@ -5188,14 +5452,30 @@ mod tests {
             "test-agent",
             &mut session,
             &mut messages,
-            &mut tool_result_blocks,
+            &mut staged,
         );
 
         let interrupted = interrupted.expect("signal should flush accumulated results");
-        assert!(tool_result_blocks.is_empty());
-        assert_eq!(session.messages.len(), 2);
-        assert_eq!(messages.len(), 2);
+        assert!(staged.committed);
+        assert_eq!(session.messages.len(), 3);
+        assert_eq!(messages.len(), 3);
+
+        // [0] assistant{ToolUse "tool-hard-fail"}
         match &session.messages[0].content {
+            MessageContent::Blocks(blocks) => match blocks.as_slice() {
+                [ContentBlock::ToolUse { id, name, .. }] => {
+                    assert_eq!(id, "tool-hard-fail");
+                    assert_eq!(name, "nonexistent_tool");
+                }
+                other => panic!("expected single ToolUse block, got {other:?}"),
+            },
+            other => panic!("expected blocks message, got {other:?}"),
+        }
+
+        // [1] user{ToolResult hard-error + guidance text} — the real error
+        // content must be preserved verbatim, NOT overwritten with any
+        // synthetic "[interrupted]" placeholder.
+        match &session.messages[1].content {
             MessageContent::Blocks(blocks) => {
                 assert!(!blocks.is_empty());
                 match &blocks[0] {
@@ -5220,11 +5500,13 @@ mod tests {
             other => panic!("expected blocks message, got {other:?}"),
         }
         assert!(matches!(
-            &messages[0].content,
+            &messages[1].content,
             MessageContent::Blocks(blocks)
                 if matches!(blocks.first(), Some(ContentBlock::ToolResult { .. }))
         ));
-        assert_eq!(session.messages[1].content.text_content(), "interrupt");
+
+        // [2] user{"interrupt"}
+        assert_eq!(session.messages[2].content.text_content(), "interrupt");
         assert_eq!(interrupted.hard_error_count, 1);
         assert_eq!(interrupted.success_count, 0);
 
@@ -7541,6 +7823,389 @@ mod tests {
                 );
             }
             other => panic!("Expected RepeatedToolFailures, got {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // StagedToolUseTurn invariants (closes #2381 by construction)
+    //
+    // These tests lock in the structural guarantees that make orphaned
+    // `tool_use_id`s impossible:
+    //   (a) pad_missing_results only fills ids that have no result at
+    //       all — real error content is never overwritten.
+    //   (b) commit is idempotent (safe to call twice).
+    //   (c) a StagedToolUseTurn dropped without commit leaves
+    //       session.messages untouched (drop-safety via ? propagation).
+    //   (d) commit atomically pushes exactly one assistant message plus
+    //       one user{tool_results} message in that order.
+    //   (e) the happy path batch case commits once and grows the
+    //       session by exactly 2 messages.
+    // -------------------------------------------------------------------
+
+    fn fresh_session() -> librefang_memory::session::Session {
+        librefang_memory::session::Session {
+            id: librefang_types::agent::SessionId::new(),
+            agent_id: librefang_types::agent::AgentId::new(),
+            messages: Vec::new(),
+            context_window_tokens: 0,
+            label: None,
+        }
+    }
+
+    fn staged_two_tool_use(agent_id_str: String) -> StagedToolUseTurn {
+        StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "tool-a".to_string(),
+                        name: "tool_a".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "tool-b".to_string(),
+                        name: "tool_b".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                ]),
+                pinned: false,
+            },
+            tool_call_ids: vec![
+                ("tool-a".to_string(), "tool_a".to_string()),
+                ("tool-b".to_string(), "tool_b".to_string()),
+            ],
+            tool_result_blocks: Vec::new(),
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: agent_id_str,
+            committed: false,
+        }
+    }
+
+    #[test]
+    fn staged_pad_missing_results_fills_uncalled_ids_only() {
+        // Real hard-error content on tool-a must survive pad untouched;
+        // tool-b has no result so pad fabricates an "interrupted" one.
+        let session = fresh_session();
+        let mut staged = staged_two_tool_use(session.agent_id.to_string());
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-a".to_string(),
+            tool_name: "tool_a".to_string(),
+            content: "Permission denied: unknown tool".to_string(),
+            is_error: true,
+            status: librefang_types::tool::ToolExecutionStatus::Error,
+            approval_request_id: None,
+        });
+
+        staged.pad_missing_results();
+
+        assert_eq!(staged.tool_result_blocks.len(), 2);
+        match &staged.tool_result_blocks[0] {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "tool-a");
+                assert_eq!(content, "Permission denied: unknown tool");
+                assert!(*is_error);
+            }
+            other => panic!("expected tool-a real error result, got {other:?}"),
+        }
+        match &staged.tool_result_blocks[1] {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+                status,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "tool-b");
+                assert!(content.contains("[tool interrupted"));
+                assert!(*is_error);
+                assert_eq!(*status, librefang_types::tool::ToolExecutionStatus::Error);
+            }
+            other => panic!("expected tool-b synthetic result, got {other:?}"),
+        }
+        // Session was never touched — pad is a staging-buffer operation.
+        assert!(session.messages.is_empty());
+    }
+
+    #[test]
+    fn staged_pad_missing_results_noop_when_all_ids_have_results() {
+        let mut staged = staged_two_tool_use("agent".to_string());
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-a".to_string(),
+            tool_name: "tool_a".to_string(),
+            content: "ok-a".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-b".to_string(),
+            tool_name: "tool_b".to_string(),
+            content: "ok-b".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+
+        staged.pad_missing_results();
+
+        assert_eq!(staged.tool_result_blocks.len(), 2);
+        for block in &staged.tool_result_blocks {
+            match block {
+                ContentBlock::ToolResult {
+                    content, is_error, ..
+                } => {
+                    assert!(!content.contains("[tool interrupted"));
+                    assert!(!*is_error);
+                }
+                other => panic!("expected tool result, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn staged_commit_is_idempotent() {
+        let mut session = fresh_session();
+        let mut messages = Vec::new();
+        let mut staged = staged_two_tool_use(session.agent_id.to_string());
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-a".to_string(),
+            tool_name: "tool_a".to_string(),
+            content: "ok-a".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-b".to_string(),
+            tool_name: "tool_b".to_string(),
+            content: "ok-b".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+
+        let first = staged.commit(&mut session, &mut messages);
+        let len_after_first = session.messages.len();
+        let msgs_after_first = messages.len();
+        assert_eq!(first.success_count, 2);
+        assert_eq!(first.hard_error_count, 0);
+        assert_eq!(len_after_first, 2);
+        assert_eq!(msgs_after_first, 2);
+        assert!(staged.committed);
+
+        // Second commit is a no-op: summary is default, no new messages.
+        let second = staged.commit(&mut session, &mut messages);
+        assert_eq!(second, ToolResultOutcomeSummary::default());
+        assert_eq!(session.messages.len(), len_after_first);
+        assert_eq!(messages.len(), msgs_after_first);
+    }
+
+    #[test]
+    fn staged_drop_without_commit_does_not_touch_session() {
+        // This test simulates the `?`-propagation path: a caller builds
+        // a StagedToolUseTurn, appends some results, then an error
+        // propagates through the caller (in production via `?`) — the
+        // staged turn is dropped without commit. Session state must be
+        // byte-for-byte identical to the pre-stage snapshot; no orphan
+        // ToolUse can have reached disk.
+        let session = fresh_session();
+        let snapshot = session.messages.clone();
+
+        {
+            let mut staged = staged_two_tool_use(session.agent_id.to_string());
+            staged.append_result(ContentBlock::ToolResult {
+                tool_use_id: "tool-a".to_string(),
+                tool_name: "tool_a".to_string(),
+                content: "ok-a".to_string(),
+                is_error: false,
+                status: librefang_types::tool::ToolExecutionStatus::Completed,
+                approval_request_id: None,
+            });
+            // Intentionally drop `staged` here without commit.
+            assert!(!staged.committed);
+        }
+
+        assert_eq!(session.messages.len(), snapshot.len());
+        assert!(session.messages.is_empty());
+    }
+
+    #[test]
+    fn staged_batch_with_no_issues_commits_once() {
+        // Happy path: 2 tool calls, both succeed, commit grows the
+        // session by exactly 2 messages: [assistant{ToolUse×2},
+        // user{ToolResult×2 + guidance text}].
+        let mut session = fresh_session();
+        let mut messages = Vec::new();
+        let mut staged = staged_two_tool_use(session.agent_id.to_string());
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-a".to_string(),
+            tool_name: "tool_a".to_string(),
+            content: "ok-a".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "tool-b".to_string(),
+            tool_name: "tool_b".to_string(),
+            content: "ok-b".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+        // pad_missing_results is a no-op on the happy path — guarantee
+        // that explicitly, so a future refactor adding padding side
+        // effects breaks this test.
+        let before = staged.tool_result_blocks.len();
+        staged.pad_missing_results();
+        assert_eq!(staged.tool_result_blocks.len(), before);
+
+        let summary = staged.commit(&mut session, &mut messages);
+
+        assert_eq!(summary.success_count, 2);
+        assert_eq!(summary.hard_error_count, 0);
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            &session.messages[0].content,
+            MessageContent::Blocks(blocks)
+                if matches!(
+                    blocks.as_slice(),
+                    [
+                        ContentBlock::ToolUse { id: id_a, .. },
+                        ContentBlock::ToolUse { id: id_b, .. },
+                    ] if id_a == "tool-a" && id_b == "tool-b"
+                )
+        ));
+        assert!(matches!(
+            &session.messages[1].content,
+            MessageContent::Blocks(blocks)
+                if blocks.iter().filter(|b| matches!(b, ContentBlock::ToolResult { .. })).count() == 2
+        ));
+    }
+
+    #[test]
+    fn staged_hard_error_mid_batch_preserves_all_real_results() {
+        // Three tool calls — tool 0 hard-errors, tools 1+2 succeed.
+        // Under the pre-#2381 behaviour the `break;` after tool 0 would
+        // have left tool 1 and tool 2 as orphan ids. Under the new
+        // staged-commit contract, the caller is required to drive every
+        // append_result before committing, so the final session carries
+        // all three real results (real hard-error content preserved for
+        // tool 0, real successes for tools 1+2) and zero synthetics.
+        let mut session = fresh_session();
+        let mut messages = Vec::new();
+        let mut staged = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "t0".to_string(),
+                        name: "web_fetch".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "t1".to_string(),
+                        name: "web_fetch".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "t2".to_string(),
+                        name: "web_fetch".to_string(),
+                        input: serde_json::json!({}),
+                        provider_metadata: None,
+                    },
+                ]),
+                pinned: false,
+            },
+            tool_call_ids: vec![
+                ("t0".to_string(), "web_fetch".to_string()),
+                ("t1".to_string(), "web_fetch".to_string()),
+                ("t2".to_string(), "web_fetch".to_string()),
+            ],
+            tool_result_blocks: Vec::new(),
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session.agent_id.to_string(),
+            committed: false,
+        };
+
+        // Simulate the batch executing end-to-end (no early break).
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "t0".to_string(),
+            tool_name: "web_fetch".to_string(),
+            content: "network error: Wikipedia unreachable".to_string(),
+            is_error: true,
+            status: librefang_types::tool::ToolExecutionStatus::Error,
+            approval_request_id: None,
+        });
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "t1".to_string(),
+            tool_name: "web_fetch".to_string(),
+            content: "fetched page 1".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+        staged.append_result(ContentBlock::ToolResult {
+            tool_use_id: "t2".to_string(),
+            tool_name: "web_fetch".to_string(),
+            content: "fetched page 2".to_string(),
+            is_error: false,
+            status: librefang_types::tool::ToolExecutionStatus::Completed,
+            approval_request_id: None,
+        });
+
+        // pad is a no-op — every id already has a real result.
+        staged.pad_missing_results();
+        assert_eq!(staged.tool_result_blocks.len(), 3);
+
+        let summary = staged.commit(&mut session, &mut messages);
+        assert_eq!(summary.success_count, 2);
+        assert_eq!(summary.hard_error_count, 1);
+        assert_eq!(session.messages.len(), 2);
+
+        // Verify every real result content survived — no synthetic
+        // "[tool interrupted" placeholders, because no id was skipped.
+        match &session.messages[1].content {
+            MessageContent::Blocks(blocks) => {
+                let results: Vec<_> = blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            is_error,
+                            ..
+                        } => Some((tool_use_id.clone(), content.clone(), *is_error)),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(results.len(), 3);
+                assert_eq!(results[0].0, "t0");
+                assert_eq!(results[0].1, "network error: Wikipedia unreachable");
+                assert!(results[0].2);
+                assert_eq!(results[1].0, "t1");
+                assert_eq!(results[1].1, "fetched page 1");
+                assert!(!results[1].2);
+                assert_eq!(results[2].0, "t2");
+                assert_eq!(results[2].1, "fetched page 2");
+                assert!(!results[2].2);
+                for (_, content, _) in &results {
+                    assert!(!content.contains("[tool interrupted"));
+                }
+            }
+            other => panic!("expected blocks message, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the HTTP 400 `"tool_call_ids did not have response messages"` failure reported in #2381 when an agent issues multiple tool calls in parallel and one of them errors.

The underlying structural bug is that `agent_loop.rs` eagerly persists an `assistant { tool_use: [...] }` message to `session.messages` in `begin_tool_use_turn` **before any tool executes**, and only later pushes the paired `user { tool_result: [...] }` message in `finalize_tool_use_results`. Every control-flow exit point between those two writes produces an orphan: the assistant message lists N `tool_use_id`s, but only K<N `tool_result` blocks ever get persisted. The next request built from that session is then rejected by the upstream OpenAI/Moonshot API.

Six routes can produce the orphan on today's `main`:

1. Hard-error `break;` in the sync per-tool loop.
2. Hard-error `break;` in the streaming per-tool loop.
3. Mid-turn signal break in the sync loop.
4. Mid-turn signal break in the streaming loop.
5. `?` propagation from `execute_single_tool_call` after the assistant message is already on `session.messages`.
6. Concurrent `run_agent_loop(_streaming)` calls for the same `session_id` without a per-session mutex.

This PR closes routes **1–5** by construction. Route 6 requires a separate `kernel.rs` session-level mutex and is intentionally out of scope — I'll file it as a follow-up issue.

## Relationship to #2065

PR #2065 (merged 2026-04-05) already identified the symptom — *"the LLM should see the error and retry"* — and correctly removed the outer `all_failed` early-return. However, the **inner** per-tool `break;` at the hard-error classification site (introduced by #1415 / #948 to preserve "don't run tool B if tool A failed") survived that refactor and is still the active orphan source today. This PR finishes the job #2065 started, but with a structural fix instead of a second targeted `break;` removal — see next section.

## Fix: `StagedToolUseTurn` two-phase commit

Instead of eagerly pushing to `session.messages` and trusting every future refactor to preserve the invariant, the assistant message and accumulated `tool_result` blocks are now held in a local `StagedToolUseTurn` struct. Nothing touches `session.messages` until the struct's `commit(…)` method runs at end-of-iteration, which atomically pushes both halves of the pair.

```rust
struct StagedToolUseTurn {
    assistant_msg: Message,
    tool_use_ids: Vec<String>,
    tool_result_blocks: Vec<ContentBlock>,
    rationale_text: Option<String>,
    allowed_tool_names: Vec<String>,
    caller_id_str: String,
}

impl StagedToolUseTurn {
    fn append_result(&mut self, block: ContentBlock) { … }
    fn pad_missing_results(&mut self) { … }
    fn commit(
        mut self,
        session: &mut Session,
        messages: &mut Vec<Message>,
    ) -> ToolResultOutcomeSummary { … }
}
```

Per-tool loop becomes:

```rust
let mut staged = stage_tool_use_turn(&response, session, available_tools);

for tool_call in &tool_calls {
    let executed = execute_single_tool_call(&mut ctx, tool_call).await?;
    staged.append_result(build_block(tool_call, &executed));
    // No `break;` on error — tool errors flow through as honest result
    // content for the LLM to read next iteration. loop_guard.rs and
    // MAX_CONSECUTIVE_ALL_FAILED (from #2065) still cap runaway loops.

    if let Some(flushed) = handle_mid_turn_signal(pending_messages, …, &mut staged) {
        iteration_outcomes.accumulate(flushed);
        break;
    }
}

staged.pad_missing_results();
iteration_outcomes.accumulate(staged.commit(session, &mut messages));
memory.save_session_async(session).await?;
```

### Why this closes routes 1–5

| # | Route | How it's closed |
|---|---|---|
| 1 | Hard-error `break;` sync | `break;` removed. Tool errors flow through `append_result` like any other result. |
| 2 | Hard-error `break;` streaming | Same — `break;` removed. |
| 3 | Mid-turn signal break sync | `handle_mid_turn_signal` takes `&mut StagedToolUseTurn`, pads + commits before injecting the user signal. |
| 4 | Mid-turn signal break streaming | Same. |
| 5 | `?` propagation from `execute_single_tool_call` | `staged` is a local. If `?` propagates, it's dropped without commit. `session.messages` retains its pre-turn state — no orphan can reach disk, guaranteed by the type system. |
| 6 | Concurrent runs on same `session_id` | **Not addressed in this PR.** Requires a session-level mutex. Tracked separately. |

Crucially, routes 1–5 are closed **by construction**, not by careful removal of each individual exit point. Any future refactor that adds a new `?` or `break;` between `stage_tool_use_turn` and the `commit` call inherits the guarantee for free — there is simply no way to reach `session.messages` with an unpaired `ToolUse`.

### Padding semantics

`pad_missing_results` only pads `tool_use_id`s that never had `append_result` called for them at all. It is **not** used to paper over tool execution errors: if `execute_single_tool_call` returns `Ok(ExecutedToolCall { is_error: true, … })`, that result is honest error content and is appended normally so the LLM sees the real failure. Padding only kicks in on the mid-turn-signal path (routes 3/4), where the loop breaks after N<M tools have run and the remaining M−N `tool_use_id`s need a synthetic `"[tool interrupted: mid-turn user signal received before this tool could execute]"` to keep the wire contract satisfied.

## Dead code removed

- The `break;` statements at the hard-error classification sites in both the sync and streaming per-tool loops.
- The `ensure_tool_pairs_before_save` helper and all four of its call sites. By construction, `session.messages` is never in a half-committed state — the defensive helper is obsolete.
- Accompanying comments explaining why the helper existed.

## Tests

Added six new `StagedToolUseTurn` invariant tests in `agent_loop.rs`'s existing test module (plus updated three pre-existing `handle_mid_turn_signal` tests to the new `&mut StagedToolUseTurn` signature):

1. **`staged_hard_error_mid_batch_preserves_all_real_results`** — 3 `web_fetch` calls where tool 0 hard-errors and tools 1+2 succeed. Under the pre-fix `break;` this is exactly the orphan scenario from the #2381 repro. Asserts: session ends with `[assistant{ToolUse×3}, user{ToolResult×3}]`, tool 0's result carries the real `"network error: Wikipedia unreachable"` content (not a synthetic pad), and no `"[tool interrupted"` placeholder leaks through.
2. **`staged_pad_missing_results_fills_uncalled_ids_only`** — Real hard-error on tool-a plus no result on tool-b. Asserts `pad_missing_results` leaves tool-a's real error content untouched and fabricates a synthetic `"[tool interrupted…"` result for tool-b only. Enforces the "never paper over real errors" contract.
3. **`staged_pad_missing_results_noop_when_all_ids_have_results`** — Happy path: every id has a real result. Asserts `pad_missing_results` is a no-op.
4. **`staged_commit_is_idempotent`** — Calls `commit` twice. Asserts the second call returns `ToolResultOutcomeSummary::default()` and leaves both `session.messages` and the local `messages` vec unchanged.
5. **`staged_drop_without_commit_does_not_touch_session`** — Simulates the `?`-propagation path: a `StagedToolUseTurn` is built, a result is appended, then the struct is dropped without `commit`. Asserts `session.messages` is byte-for-byte identical to the pre-stage snapshot. This is the type-system guarantee that closes route 5.
6. **`staged_batch_with_no_issues_commits_once`** — Happy path: 2 tools both succeed. Asserts `session.messages` grows by exactly 2, `pad_missing_results` is a no-op, and the final user message carries exactly 2 `ToolResult` blocks.

Additionally, the pre-existing `test_handle_mid_turn_signal_mixed_flush_resets_consecutive_all_failed`, `test_handle_mid_turn_signal_approval_resolved_updates_waiting_result_and_resets_failures`, and `test_mid_turn_signal_preserves_partial_hard_failure_results_for_classification` were updated to the new `&mut StagedToolUseTurn` parameter shape; they continue to lock in the mid-turn-signal path behaviour (routes 3/4) — now with the assistant `ToolUse` message correctly committed in front of the flushed user tool results.

## Scope

One file, one concept. `git diff origin/main --stat`:

```
crates/librefang-runtime/src/agent_loop.rs | 996 ++++++++++++++++++++++++-----
1 file changed, 826 insertions(+), 170 deletions(-)
```

No changes to `session_repair.rs`, `kernel.rs`, drivers, or anywhere else.

## Test status

- `cargo test -p librefang-runtime` → **1275 passed, 1 failed, 1 ignored**.
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` → **clean**.
- The one failure is `model_catalog::tests::test_alibaba_coding_plan_models_count` at `crates/librefang-runtime/src/model_catalog.rs:1984` — asserts `alibaba-coding-plan` has exactly 8 models, finds 9. This test fails identically on an untouched `origin/main` checkout (verified by stashing this PR's diff and re-running). It is a pre-existing upstream drift between the catalog and the assertion (same failure mode as merged #1980, which bumped the bedrock assertion from 8 to 11) and is unrelated to this PR — `model_catalog.rs` is untouched here. Happy to split a separate one-line fix for it if useful.

## Closes

- Closes #2381
- Follow-up to #2065 (merged)
- Related: #1415 / #948 (original break-on-first-failure)
