### PR TITLE
fix(runtime): relax brittle alibaba-coding-plan model count assertion

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1978,13 +1978,15 @@ supports_streaming = true
     }
 
     #[test]
-    fn test_alibaba_coding_plan_models_count() {
+    fn test_alibaba_coding_plan_has_models() {
+        // Smoke check only — the exact model set is owned by the upstream
+        // librefang-registry repo and changes over time. Specific model
+        // coverage is asserted by name in the sibling tests below.
         let catalog = test_catalog();
         let models = catalog.models_by_provider("alibaba-coding-plan");
-        assert_eq!(
-            models.len(),
-            8,
-            "alibaba-coding-plan should have exactly 8 models"
+        assert!(
+            !models.is_empty(),
+            "alibaba-coding-plan should expose at least one model"
         );
     }
 


### PR DESCRIPTION
## Summary
- CI was failing across macOS / Ubuntu / Windows on `test_alibaba_coding_plan_models_count` because the test hardcoded an exact count of 8 models, but the model list is sourced from the upstream `librefang-registry` repo.
- Upstream added `qwen3.6-plus`, bringing the count to 9, which tripped the assertion.
- Replaced the exact-count assertion with a non-empty smoke check. Specific model coverage is already enforced by the sibling tests that look up models by name (`_vision_models`, `_zero_cost`, `_provider`, `_coder_models`).

## Notes
- Same anti-pattern exists at `model_catalog.rs:1641` for `claude-code` (`assert_eq!(models.len(), 3)`). Left alone to keep this PR focused — happy to do a follow-up if desired.

## Test plan
- [x] `cargo test -p librefang-runtime --lib model_catalog::tests::test_alibaba` — all 6 alibaba tests pass locally
- [ ] CI green on this branch