### PR TITLE
refactor(runtime): extract mcp into librefang-runtime-mcp subcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "librefang-channels",
  "librefang-http",
  "librefang-memory",
+ "librefang-runtime-mcp",
  "librefang-skills",
  "librefang-types",
  "once_cell",
@@ -4268,6 +4269,21 @@ dependencies = [
  "wasmtime",
  "webpki-roots",
  "zeroize",
+]
+
+[[package]]
+name = "librefang-runtime-mcp"
+version = "2026.4.13-beta19"
+dependencies = [
+ "http",
+ "librefang-http",
+ "librefang-types",
+ "reqwest 0.13.2",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/librefang-types",
     "crates/librefang-memory",
     "crates/librefang-runtime",
+    "crates/librefang-runtime-mcp",
     "crates/librefang-http",
     "crates/librefang-wire",
     "crates/librefang-api",

--- a/crates/librefang-runtime-mcp/Cargo.toml
+++ b/crates/librefang-runtime-mcp/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "librefang-runtime-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "MCP (Model Context Protocol) client for LibreFang runtime"
+
+[dependencies]
+librefang-types = { path = "../librefang-types" }
+librefang-http = { path = "../librefang-http" }
+rmcp = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+http = "1"

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -388,7 +388,7 @@ impl McpConnection {
     async fn connect_sse(url: &str) -> Result<(McpInner, Option<Vec<rmcp::model::Tool>>), String> {
         Self::check_ssrf(url, "SSE")?;
 
-        let client = crate::http_client::proxied_client_builder()
+        let client = librefang_http::proxied_client_builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
@@ -599,7 +599,7 @@ impl McpConnection {
     ) -> Result<(McpInner, Option<Vec<rmcp::model::Tool>>), String> {
         Self::check_ssrf(base_url, "HTTP compatibility backend")?;
 
-        let client = crate::http_client::proxied_client_builder()
+        let client = librefang_http::proxied_client_builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
@@ -1427,7 +1427,7 @@ mod tests {
             tools: Vec::new(),
             original_names: HashMap::new(),
             inner: McpInner::HttpCompat {
-                client: crate::http_client::proxied_client(),
+                client: librefang_http::proxied_client(),
             },
         };
 

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -8,6 +8,7 @@ description = "Agent runtime and execution environment for LibreFang"
 [dependencies]
 librefang-types = { path = "../librefang-types" }
 librefang-http = { path = "../librefang-http" }
+librefang-runtime-mcp = { path = "../librefang-runtime-mcp" }
 librefang-channels = { path = "../librefang-channels" }
 librefang-memory = { path = "../librefang-memory" }
 librefang-skills = { path = "../librefang-skills" }

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -35,7 +35,7 @@ pub mod link_understanding;
 pub mod llm_driver;
 pub mod llm_errors;
 pub mod loop_guard;
-pub mod mcp;
+pub use librefang_runtime_mcp as mcp;
 pub mod mcp_server;
 pub mod media;
 pub mod media_understanding;


### PR DESCRIPTION
## Summary

Split the 1625-line MCP (Model Context Protocol) client module into a dedicated crate. Depends on \`librefang-http\` (from PR #2389) instead of reaching back into runtime for the HTTP client.

**Stacked on #2389 (http-client).** Base will update to main once #2389 merges.

## Changes

- New crate \`librefang-runtime-mcp\` (deps: types, http, rmcp, reqwest, tokio, serde, serde_json, tracing, http)
- \`librefang-runtime\` re-exports via \`pub use librefang_runtime_mcp as mcp\` so all internal \`crate::mcp::*\` paths (agent_loop, tool_runner) and external \`librefang_runtime::mcp::*\` paths (kernel.rs) keep working
- 3 \`crate::http_client::*\` call sites rewritten to \`librefang_http::*\`

## Verification

- \`cargo check -p librefang-runtime\` ✅ (3m 56s cold)

## Test plan

- [ ] CI: \`cargo check --workspace\`
- [ ] CI: \`cargo test --workspace\`
- [ ] CI: clippy clean
- [ ] Verify MCP stdio/SSE/HTTP transports still connect to external servers