### PR TITLE
fix(api): reject path traversal in agent template name param

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -290,6 +290,67 @@ pub async fn get_profile(
 // Template endpoints
 // ---------------------------------------------------------------------------
 
+/// Validate a template name supplied via URL path before joining it onto the
+/// templates directory. Only permits `[A-Za-z0-9_-]` to guarantee the result
+/// cannot escape the base directory through `..`, absolute paths, or platform
+/// separators (`/`, `\`). Rejects empty names and anything longer than 64
+/// chars to cap log noise.
+fn validate_template_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() || name.len() > 64 {
+        return Err("invalid template name");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err("invalid template name");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod template_name_validation_tests {
+    use super::validate_template_name;
+
+    #[test]
+    fn accepts_simple_names() {
+        assert!(validate_template_name("assistant").is_ok());
+        assert!(validate_template_name("customer-support").is_ok());
+        assert!(validate_template_name("coder_v2").is_ok());
+        assert!(validate_template_name("a1").is_ok());
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(validate_template_name("..").is_err());
+        assert!(validate_template_name("../../etc").is_err());
+        assert!(validate_template_name("foo/../bar").is_err());
+        assert!(validate_template_name("..\\..\\tmp").is_err());
+    }
+
+    #[test]
+    fn rejects_separators_and_absolute_paths() {
+        assert!(validate_template_name("foo/bar").is_err());
+        assert!(validate_template_name("foo\\bar").is_err());
+        assert!(validate_template_name("/etc/passwd").is_err());
+        assert!(validate_template_name("C:\\Windows").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_oversized() {
+        assert!(validate_template_name("").is_err());
+        assert!(validate_template_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn rejects_null_and_special_chars() {
+        assert!(validate_template_name("foo\0bar").is_err());
+        assert!(validate_template_name("foo bar").is_err());
+        assert!(validate_template_name("foo.bar").is_err());
+        assert!(validate_template_name("foo%2fbar").is_err());
+    }
+}
+
 /// GET /api/templates — List available agent templates.
 #[utoipa::path(get, path = "/api/templates", tag = "system", operation_id = "list_agent_templates", responses((status = 200, description = "List templates", body = Vec<serde_json::Value>)))]
 pub async fn list_agent_templates() -> impl IntoResponse {
@@ -338,6 +399,9 @@ pub async fn get_agent_template(
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    if validate_template_name(&name).is_err() {
+        return ApiErrorResponse::not_found(t.t("api-error-template-not-found")).into_json_tuple();
+    }
     let agents_dir = librefang_kernel::config::librefang_home()
         .join("workspaces")
         .join("agents");
@@ -390,6 +454,14 @@ pub async fn get_agent_template_toml(
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    if validate_template_name(&name).is_err() {
+        return (
+            StatusCode::NOT_FOUND,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            t.t("api-error-template-not-found"),
+        )
+            .into_response();
+    }
     let agents_dir = librefang_kernel::config::librefang_home()
         .join("workspaces")
         .join("agents");


### PR DESCRIPTION
## Summary
- `GET /api/templates/{name}` and `/api/templates/{name}/toml` joined the URL-decoded `name` directly onto the agents directory, so an authenticated caller could read any `agent.toml` on disk via e.g. `/api/templates/..%2F..%2F..%2Ftmp%2Ftarget/toml`. `name` is also a raw path component, so `/` or `\\` in the decoded value let the read cross directories without needing `..`.
- Add `validate_template_name()` allowing only `[A-Za-z0-9_-]` up to 64 chars and call it from both handlers before touching the filesystem. This matches the format that `list_agent_templates` returns (derived from directory entries), so legitimate callers are unaffected.
- Invalid names return 404 rather than 400 to avoid confirming whether a traversal target exists.

## Reproduction before fix
```bash
mkdir -p /tmp/lftrav
echo 'name = "pwned"
description = "traversal proof"
module = "core"' > /tmp/lftrav/agent.toml

curl -H "Authorization: Bearer \$KEY" \
  "http://127.0.0.1:4545/api/templates/..%2F..%2F..%2F..%2F..%2Ftmp%2Flftrav/toml"
# -> 200 returning the attacker-planted agent.toml
```

## Test plan
- [x] `cargo test -p librefang-api --lib template_name_validation_tests` — 5 passed
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean
- [ ] CI full workspace build