### PR TITLE
docs(security): describe prompt-injection scanner as a heuristic

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,17 @@ LibreFang implements defense-in-depth with the following security controls:
 - **Path traversal protection**: `safe_resolve_path()` / `safe_resolve_parent()` on all file operations
 - **SSRF protection**: Private IP blocking, DNS resolution checks, cloud metadata endpoint filtering
 - **Image validation**: Media type whitelist (png/jpeg/gif/webp), 5MB size limit
-- **Prompt injection scanning**: Skill content scanned for override attempts and data exfiltration
+- **Prompt injection heuristics** *(best-effort, not a security boundary)*: Skill content is
+  scanned for a short hard-coded list of English override phrases and exfiltration keywords
+  (`ignore previous instructions`, `exfiltrate`, `post to https`, …) via case-insensitive
+  substring match. Matches emit warnings and block installation of ClawHub skills whose
+  `prompt_context` contains a *critical* pattern. This is a warning layer for obviously
+  malicious content, **not** a defence against a motivated attacker: Unicode homoglyphs,
+  zero-width separators, line-split keywords, Base64/other encodings, markdown/link
+  obfuscation, and non-English phrasing all bypass it. The actual runtime safety of
+  installed skills comes from the capability system and the WASM / subprocess sandbox
+  (see **Runtime Isolation**), which bound what a skill can do regardless of what its
+  prompt text says.
 
 ### Cryptographic Security
 - **Ed25519 signed manifests**: Agent identity verification


### PR DESCRIPTION
## Summary
Rewords the "Prompt injection scanning" bullet in SECURITY.md so it
accurately reflects what `crates/librefang-skills/src/verify.rs` does:
a case-insensitive substring match against 19 hard-coded English
phrases. It is a best-effort warning layer, not a security boundary —
a motivated attacker can bypass it trivially, and the real defence for
malicious skills comes from the capability system + WASM / subprocess
sandbox described under **Runtime Isolation**.

## Why
Audit of the current scanner (exact logic copied into Python for
reproducibility) against 10 attacker inputs:

| input                                    | blocked? |
| ---------------------------------------- | -------- |
| plain baseline                           | YES      |
| Cyrillic homoglyph `р`                   | no       |
| zero-width space `\u200b` inside phrase  | no       |
| line-split (`Ign\nore previous`)         | no       |
| semantic rewrite, no blacklisted phrase  | no       |
| Base64 encoded instruction               | no       |
| Chinese translation                      | no       |
| leetspeak                                | no       |
| HTML comment + mixed punctuation wrap    | no       |
| markdown link obfuscation                | no       |
| emoji separators between words           | no       |

Only the baseline trips a `critical`. Every other form slides through
because the check is `content.to_lowercase().contains(pattern)` with
no NFKC, no zero-width stripping, no whitespace/line normalisation,
no decoding, and no multilingual patterns.

Rather than growing the blacklist (which is a losing arms race), this
PR matches the doc to the implementation and points readers at the
parts of the system that actually bound what a malicious skill can do
at runtime.

## Test plan
- [x] doc-only change, no code or tests affected