### PR TITLE
fix(runtime-wasm): stop leaking sandbox watchdog threads

### DIFF
--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -175,14 +175,64 @@ impl WasmSandbox {
                 .map_err(|e| SandboxError::Execution(e.to_string()))?;
         }
 
-        // Set epoch deadline (wall-clock metering)
+        // Set epoch deadline (wall-clock metering).
+        //
+        // The watchdog thread used to be fire-and-forget — it slept for the
+        // full timeout (30s by default) and then called `increment_epoch`
+        // whether or not the guest had already returned. That leaked a
+        // sleeping OS thread per invocation and also caused cross-store
+        // false interrupts, because `Engine::increment_epoch` is global to
+        // the Engine: every concurrently running guest observes the tick.
+        // Sustained workloads piled up thousands of sleeping threads and
+        // eventually exhausted the OS thread limit, and any fresh guest
+        // that happened to start right after a stale watchdog fired would
+        // trap on `Interrupt` even though it had used no wall-clock time.
+        //
+        // Instead, give the watchdog a `done` flag it polls on short
+        // intervals. When the main thread finishes it flips the flag and
+        // the watchdog exits without touching the engine epoch. Join the
+        // watchdog on the happy path so the thread is actually reclaimed.
+        // The legitimate timeout path is untouched: if the guest blows its
+        // wall-clock budget the flag is never flipped, the watchdog sleeps
+        // out the deadline and increments epoch as before.
         store.set_epoch_deadline(1);
         let engine_clone = engine.clone();
         let timeout = config.timeout_secs.unwrap_or(30);
-        let _watchdog = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_secs(timeout));
+        let watchdog_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let watchdog_done_for_thread = std::sync::Arc::clone(&watchdog_done);
+        let watchdog = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout);
+            while std::time::Instant::now() < deadline {
+                if watchdog_done_for_thread.load(std::sync::atomic::Ordering::Acquire) {
+                    return;
+                }
+                // Short sleep so we react to completion within ~50ms but
+                // still spend almost no CPU on the happy path.
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
             engine_clone.increment_epoch();
         });
+        // RAII guard so every early-return path (`?`, trap, ABI error,
+        // panic) signals the watchdog and joins the thread. Without this
+        // the `?` operators below would drop the JoinHandle silently and
+        // we'd leak a sleeping thread per error path just like the
+        // pre-fix code did on the happy path.
+        struct WatchdogGuard {
+            done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+            handle: Option<std::thread::JoinHandle<()>>,
+        }
+        impl Drop for WatchdogGuard {
+            fn drop(&mut self) {
+                self.done.store(true, std::sync::atomic::Ordering::Release);
+                if let Some(h) = self.handle.take() {
+                    let _ = h.join();
+                }
+            }
+        }
+        let _watchdog_guard = WatchdogGuard {
+            done: watchdog_done,
+            handle: Some(watchdog),
+        };
 
         // Build linker with host function imports
         let mut linker = Linker::new(engine);

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -188,13 +188,18 @@ impl WasmSandbox {
         // that happened to start right after a stale watchdog fired would
         // trap on `Interrupt` even though it had used no wall-clock time.
         //
-        // Instead, give the watchdog a `done` flag it polls on short
-        // intervals. When the main thread finishes it flips the flag and
-        // the watchdog exits without touching the engine epoch. Join the
-        // watchdog on the happy path so the thread is actually reclaimed.
-        // The legitimate timeout path is untouched: if the guest blows its
-        // wall-clock budget the flag is never flipped, the watchdog sleeps
-        // out the deadline and increments epoch as before.
+        // Instead, the watchdog blocks in `park_timeout(deadline - now)`
+        // and is woken via `Thread::unpark` the moment the main thread
+        // finishes. It re-checks the done flag on wake-up to distinguish
+        // "guest completed, go home" from "spurious wake-up, keep waiting".
+        // On the happy path the watchdog wakes within microseconds rather
+        // than a 50 ms poll interval, so a 5 ms sandbox call stays a 5 ms
+        // sandbox call. On the timeout path it sleeps out the remaining
+        // deadline exactly as before and trips the epoch.
+        //
+        // An RAII guard signals the flag and joins the thread on every
+        // early-return path (`?`, trap, ABI error, panic) so no error-path
+        // leak slips past either.
         store.set_epoch_deadline(1);
         let engine_clone = engine.clone();
         let timeout = config.timeout_secs.unwrap_or(30);
@@ -202,29 +207,45 @@ impl WasmSandbox {
         let watchdog_done_for_thread = std::sync::Arc::clone(&watchdog_done);
         let watchdog = std::thread::spawn(move || {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout);
-            while std::time::Instant::now() < deadline {
-                if watchdog_done_for_thread.load(std::sync::atomic::Ordering::Acquire) {
+            loop {
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    // Wall-clock budget blown — trip the epoch so the
+                    // running guest traps on `Interrupt` on its next
+                    // epoch check.
+                    engine_clone.increment_epoch();
                     return;
                 }
-                // Short sleep so we react to completion within ~50ms but
-                // still spend almost no CPU on the happy path.
-                std::thread::sleep(std::time::Duration::from_millis(50));
+                if watchdog_done_for_thread.load(std::sync::atomic::Ordering::Acquire) {
+                    // Main thread finished cleanly; leave the engine
+                    // untouched so concurrent stores aren't falsely
+                    // interrupted.
+                    return;
+                }
+                // park_timeout wakes on Thread::unpark (sent by the main
+                // thread via the RAII guard below) or when the budget
+                // expires, whichever comes first. The loop then re-checks
+                // the done flag — park/unpark is allowed to return
+                // spuriously, so the flag is the source of truth.
+                std::thread::park_timeout(deadline - now);
             }
-            engine_clone.increment_epoch();
         });
-        // RAII guard so every early-return path (`?`, trap, ABI error,
-        // panic) signals the watchdog and joins the thread. Without this
-        // the `?` operators below would drop the JoinHandle silently and
-        // we'd leak a sleeping thread per error path just like the
-        // pre-fix code did on the happy path.
         struct WatchdogGuard {
             done: std::sync::Arc<std::sync::atomic::AtomicBool>,
             handle: Option<std::thread::JoinHandle<()>>,
         }
         impl Drop for WatchdogGuard {
             fn drop(&mut self) {
+                // Flip the flag first (Release), then unpark so the
+                // watchdog wakes, re-reads the flag under Acquire, and
+                // observes the store-happens-before-load ordering. Finally
+                // join so the OS thread is actually reclaimed before we
+                // return to the caller — otherwise a tight invocation
+                // loop would still grow the thread table, just more
+                // slowly.
                 self.done.store(true, std::sync::atomic::Ordering::Release);
                 if let Some(h) = self.handle.take() {
+                    h.thread().unpark();
                     let _ = h.join();
                 }
             }


### PR DESCRIPTION
## Summary
\`WasmSandbox::execute_sync\` spawned a detached thread that slept for the entire configured timeout (30 s by default) before calling \`Engine::increment_epoch\`, regardless of whether the guest had already returned. Two problems follow:

1. **Thread leak → thread-table DoS.** The \`JoinHandle\` was bound to \`_watchdog\`, so it dropped without joining. Every successful (or error-returning, via \`?\`) invocation leaked a sleeping OS thread for the remainder of the timeout window. Sustained workloads piled up thousands of idle watchdogs and could exhaust the process thread table — a cheap DoS for any caller that can trigger sandbox execution.

2. **Cross-guest false interrupts.** \`Engine::increment_epoch\` is global to the \`Engine\`, which is reused across invocations. A stale watchdog firing after its guest had finished would still bump the engine epoch, and an unrelated fresh guest that started in that window would trap on \`Interrupt\` even though it had used no wall-clock time. That makes \`epoch_interruption\` unreliable as a wall-clock budget enforcer.

## Fix
- Give the watchdog an \`AtomicBool\` \"done\" flag it polls every 50 ms.
- Wrap the flag + \`JoinHandle\` in a small \`WatchdogGuard\` \`Drop\` impl so every exit path (happy path, \`?\` early return, panic) signals completion and joins the thread — no leaks and no interference with concurrent invocations.
- Legitimate wall-clock timeouts are untouched: if the guest blows its budget the flag is never flipped, the watchdog sleeps out the deadline and increments the epoch as before.

## Test plan
- [x] \`cargo test -p librefang-runtime-wasm --lib\` — 26 passed (fuel exhaustion, echo module, host_call dispatch, capability denied, …)
- [x] \`cargo clippy -p librefang-runtime-wasm --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build