### PR TITLE
fix(api,runtime): extend IPv4-mapped IPv6 SSRF guard to remaining call sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ dependencies = [
  "librefang-extensions",
  "librefang-hands",
  "librefang-kernel-metering",
+ "librefang-kernel-router",
  "librefang-memory",
  "librefang-runtime",
  "librefang-skills",
@@ -4179,6 +4180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "librefang-kernel-handle"
+version = "2026.4.13-beta19"
+dependencies = [
+ "async-trait",
+ "librefang-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "librefang-kernel-metering"
 version = "2026.4.13-beta19"
 dependencies = [
@@ -4186,6 +4200,32 @@ dependencies = [
  "librefang-runtime",
  "librefang-types",
  "serde",
+]
+
+[[package]]
+name = "librefang-kernel-router"
+version = "2026.4.13-beta19"
+dependencies = [
+ "dirs 6.0.0",
+ "librefang-hands",
+ "librefang-types",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "librefang-llm-driver"
+version = "2026.4.13-beta19"
+dependencies = [
+ "async-trait",
+ "librefang-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4248,9 +4288,13 @@ dependencies = [
  "landlock",
  "librefang-channels",
  "librefang-http",
+ "librefang-kernel-handle",
+ "librefang-llm-driver",
  "librefang-memory",
+ "librefang-runtime-drivers",
  "librefang-runtime-mcp",
  "librefang-runtime-oauth",
+ "librefang-runtime-wasm",
  "librefang-skills",
  "librefang-types",
  "once_cell",
@@ -4280,6 +4324,37 @@ dependencies = [
  "uuid",
  "wasmtime",
  "webpki-roots",
+ "zeroize",
+]
+
+[[package]]
+name = "librefang-runtime-drivers"
+version = "2026.4.13-beta19"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "futures",
+ "hex",
+ "hmac",
+ "librefang-http",
+ "librefang-llm-driver",
+ "librefang-runtime-oauth",
+ "librefang-types",
+ "rand 0.10.0",
+ "regex-lite",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -4320,6 +4395,23 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "librefang-runtime-wasm"
+version = "2026.4.13-beta19"
+dependencies = [
+ "anyhow",
+ "librefang-http",
+ "librefang-kernel-handle",
+ "librefang-types",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtime",
 ]
 
 [[package]]

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -493,14 +493,22 @@ fn is_url_safe_for_ssrf(raw_url: &str, allowed_hosts: &[String]) -> Result<(), S
     };
 
     for ip in &addrs {
-        if is_private_ip(ip) {
+        // Canonicalise IPv4-mapped IPv6 (::ffff:X.X.X.X) before any safety
+        // check. The OS transparently connects these to the embedded IPv4
+        // target, so leaving them as IPv6 lets an attacker reach loopback /
+        // private / cloud-metadata IPs via the v6 form (e.g.
+        // [::ffff:169.254.169.254]) which the v6-only branches of
+        // is_private_ip / is_cloud_metadata_ip do not recognise.
+        let canonical = canonical_ip(ip);
+        if is_private_ip(&canonical) {
             // Cloud metadata ranges are unconditionally blocked even when
             // the host appears in the allowlist.
-            if !is_cloud_metadata_ip(ip) && is_host_allowed(host, ip, allowed_hosts) {
+            if !is_cloud_metadata_ip(&canonical) && is_host_allowed(host, &canonical, allowed_hosts)
+            {
                 continue;
             }
             return Err(format!(
-                "Requests to private/internal IP addresses are not allowed ({ip})"
+                "Requests to private/internal IP addresses are not allowed ({canonical})"
             ));
         }
     }
@@ -508,10 +516,22 @@ fn is_url_safe_for_ssrf(raw_url: &str, allowed_hosts: &[String]) -> Result<(), S
     Ok(())
 }
 
+/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// addresses are returned unchanged.
+fn canonical_ip(ip: &IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(*v6),
+        },
+        IpAddr::V4(_) => *ip,
+    }
+}
+
 /// Returns true if the IP is in a cloud metadata / CGNAT range that must be
 /// blocked unconditionally (`169.254.0.0/16` or `100.64.0.0/10`).
 fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
-    match ip {
+    match canonical_ip(ip) {
         IpAddr::V4(v4) => {
             let o = v4.octets();
             (o[0] == 169 && o[1] == 254) || (o[0] == 100 && (o[1] & 0xC0) == 64)
@@ -597,7 +617,7 @@ fn cidr_contains(cidr: &str, ip: &IpAddr) -> Result<bool, ()> {
 /// Returns true if the IP address is in a private, loopback, link-local, or
 /// otherwise internal range that should not be reachable from user-supplied URLs.
 fn is_private_ip(ip: &IpAddr) -> bool {
-    match ip {
+    match canonical_ip(ip) {
         IpAddr::V4(v4) => {
             v4.is_loopback()              // 127.0.0.0/8
                 || v4.is_private()         // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
@@ -1430,4 +1450,48 @@ pub(crate) fn remove_toml_section(content: &str, section: &str) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_ip, is_cloud_metadata_ip, is_private_ip};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn canonical_ip_unwraps_ipv4_mapped_v6() {
+        let mapped: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
+        assert_eq!(
+            canonical_ip(&mapped),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))
+        );
+        // Real IPv6 is left alone.
+        let real_v6: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(canonical_ip(&real_v6), real_v6);
+    }
+
+    #[test]
+    fn is_private_ip_recognises_ipv4_mapped_v6() {
+        // Without canonicalisation the V6 arms only cover fc00::/7 + fe80::/10,
+        // letting ::ffff:X.X.X.X slip past as "public". These must be blocked.
+        assert!(is_private_ip(&"::ffff:10.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:169.254.169.254".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:192.168.1.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:100.64.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn is_cloud_metadata_ip_recognises_ipv4_mapped_v6() {
+        // AWS IMDS + Alibaba IMDS (CGNAT) expressed as IPv4-mapped IPv6 must
+        // unconditionally be blocked — this is the exact reproduction from
+        // PR #2396 but exercising the network.rs copy of the guard.
+        assert!(is_cloud_metadata_ip(
+            &"::ffff:169.254.169.254".parse().unwrap()
+        ));
+        assert!(is_cloud_metadata_ip(&"::ffff:a9fe:a9fe".parse().unwrap()));
+        assert!(is_cloud_metadata_ip(&"::ffff:100.64.0.1".parse().unwrap()));
+        assert!(is_cloud_metadata_ip(
+            &"::ffff:100.100.100.200".parse().unwrap()
+        ));
+    }
 }

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -120,30 +120,65 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
         }
     }
 
-    // Block private/link-local IPs to mitigate SSRF
-    if let Some(host) = parsed.host_str() {
-        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+    // Block private/link-local IPs to mitigate SSRF.
+    //
+    // Use the typed `url::Host` enum rather than `host_str().parse::<IpAddr>()`:
+    // `host_str()` returns IPv6 literals wrapped in brackets (e.g.
+    // `"[::ffff:7f00:1]"`), which `IpAddr::from_str` rejects — meaning the
+    // string-parse path silently skipped every IPv6 URL. `parsed.host()`
+    // returns `Host::Ipv6(Ipv6Addr)` / `Host::Ipv4(Ipv4Addr)` directly, with
+    // the url crate already having normalised the address.
+    match parsed.host() {
+        Some(url::Host::Ipv4(v4)) => {
+            let ip = std::net::IpAddr::V4(v4);
             if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
                 return Err(
                     "url must not point to a private, loopback, or link-local address".to_string(),
                 );
             }
         }
-        // Also block common internal hostnames
-        let lower = host.to_lowercase();
-        if lower == "localhost"
-            || lower == "metadata.google.internal"
-            || lower.ends_with(".internal")
-        {
-            return Err("url must not point to an internal/localhost address".to_string());
+        Some(url::Host::Ipv6(v6)) => {
+            // Canonicalise IPv4-mapped IPv6 (::ffff:X.X.X.X) so the OS-level
+            // transparent connect to the embedded IPv4 target can't bypass
+            // these checks — ip.is_loopback() and the V6 arms of
+            // is_private_ip / is_link_local do not recognise the mapped form.
+            let ip = canonical_ip(std::net::IpAddr::V6(v6));
+            if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
+                return Err(
+                    "url must not point to a private, loopback, or link-local address".to_string(),
+                );
+            }
         }
+        Some(url::Host::Domain(host)) => {
+            // Also block common internal hostnames
+            let lower = host.to_lowercase();
+            if lower == "localhost"
+                || lower == "metadata.google.internal"
+                || lower.ends_with(".internal")
+            {
+                return Err("url must not point to an internal/localhost address".to_string());
+            }
+        }
+        None => {}
     }
 
     Ok(())
 }
 
-fn is_private_ip(ip: std::net::IpAddr) -> bool {
+/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// addresses are returned unchanged.
+fn canonical_ip(ip: std::net::IpAddr) -> std::net::IpAddr {
     match ip {
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => std::net::IpAddr::V4(v4),
+            None => std::net::IpAddr::V6(v6),
+        },
+        std::net::IpAddr::V4(_) => ip,
+    }
+}
+
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    match canonical_ip(ip) {
         std::net::IpAddr::V4(v4) => {
             v4.is_private() || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
             // 100.64.0.0/10
@@ -153,7 +188,7 @@ fn is_private_ip(ip: std::net::IpAddr) -> bool {
 }
 
 fn is_link_local(ip: std::net::IpAddr) -> bool {
-    match ip {
+    match canonical_ip(ip) {
         std::net::IpAddr::V4(v4) => v4.is_link_local() || v4.octets()[0] == 169,
         std::net::IpAddr::V6(_) => false,
     }
@@ -444,6 +479,28 @@ mod tests {
         let wh = store.create(valid_create_req()).unwrap();
         assert_eq!(wh.name, "test-hook");
         assert_eq!(store.list().len(), 1);
+    }
+
+    #[test]
+    fn validate_webhook_url_blocks_ipv4_mapped_ipv6_loopback() {
+        // OS-level transparent connect means ::ffff:127.0.0.1 reaches
+        // loopback, but ip.is_loopback() + the V6 _ => false arms of
+        // is_private_ip / is_link_local miss it. canonical_ip must unwrap
+        // these before the guard runs.
+        assert!(validate_webhook_url("http://[::ffff:127.0.0.1]/hook").is_err());
+        assert!(validate_webhook_url("http://[::ffff:7f00:1]/hook").is_err());
+    }
+
+    #[test]
+    fn validate_webhook_url_blocks_ipv4_mapped_ipv6_metadata() {
+        assert!(validate_webhook_url("http://[::ffff:169.254.169.254]/hook").is_err());
+        assert!(validate_webhook_url("http://[::ffff:a9fe:a9fe]/hook").is_err());
+    }
+
+    #[test]
+    fn validate_webhook_url_blocks_ipv4_mapped_ipv6_private() {
+        assert!(validate_webhook_url("http://[::ffff:10.0.0.1]/hook").is_err());
+        assert!(validate_webhook_url("http://[::ffff:192.168.1.1]/hook").is_err());
     }
 
     #[test]

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -157,7 +157,9 @@ fn is_ssrf_target(url: &str) -> Result<SsrfResolved, serde_json::Value> {
     match socket_addr.to_socket_addrs() {
         Ok(addrs) => {
             for addr in addrs {
-                let ip = addr.ip();
+                // Canonicalise IPv4-mapped IPv6 (::ffff:X.X.X.X) before any
+                // safety check — see canonical_ip below.
+                let ip = canonical_ip(&addr.ip());
                 if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
                     return Err(json!({"error": format!(
                         "SSRF blocked: {hostname} resolves to private IP {ip}"
@@ -183,8 +185,21 @@ fn is_ssrf_target(url: &str) -> Result<SsrfResolved, serde_json::Value> {
     })
 }
 
-fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// addresses are returned unchanged. Keeps downstream IP checks operating on
+/// the address the OS will actually connect to.
+fn canonical_ip(ip: &std::net::IpAddr) -> std::net::IpAddr {
     match ip {
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => std::net::IpAddr::V4(v4),
+            None => std::net::IpAddr::V6(*v6),
+        },
+        std::net::IpAddr::V4(_) => *ip,
+    }
+}
+
+fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+    match canonical_ip(ip) {
         std::net::IpAddr::V4(v4) => {
             let octets = v4.octets();
             matches!(
@@ -686,6 +701,25 @@ mod tests {
         assert!(is_private_ip(&"169.254.169.254".parse::<IpAddr>().unwrap()));
         assert!(!is_private_ip(&"8.8.8.8".parse::<IpAddr>().unwrap()));
         assert!(!is_private_ip(&"1.1.1.1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_recognises_ipv4_mapped_v6() {
+        use std::net::IpAddr;
+        // IPv4-mapped IPv6 (::ffff:X.X.X.X) must be canonicalised to its
+        // IPv4 form so the private-range checks actually fire. Without
+        // canonicalisation, the V6 branch only catches fc00::/7 + fe80::/10
+        // and leaves ::ffff:10.0.0.1, ::ffff:169.254.169.254 etc. as
+        // "public" — the exact bypass fixed in web_fetch.rs.
+        assert!(is_private_ip(&"::ffff:10.0.0.1".parse::<IpAddr>().unwrap()));
+        assert!(is_private_ip(
+            &"::ffff:169.254.169.254".parse::<IpAddr>().unwrap()
+        ));
+        assert!(is_private_ip(
+            &"::ffff:192.168.1.1".parse::<IpAddr>().unwrap()
+        ));
+        // Real IPv6 still takes the V6 branch.
+        assert!(!is_private_ip(&"2001:db8::1".parse::<IpAddr>().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2396. Self-review against the full codebase found that **the original PR only fixed 1 of 4 call sites** with the IPv4-mapped IPv6 SSRF bypass. This PR covers the other three.

## The gap #2396 left

`check_ssrf` in `web_fetch.rs` was patched. These three copies of the same guard pattern were **unchanged and still exploitable**:

| File | Handler | Same bypass |
|---|---|---|
| `librefang-runtime-wasm/src/host_functions.rs` | WASM plugins' `host_http_get` | V6 arm of `is_private_ip` checked only `fc00::/7` + `fe80::/10`, missing `::ffff:*` |
| `librefang-api/src/routes/network.rs` | A2A `/api/discover` and related | Same gap. Also `is_cloud_metadata_ip` returned `false` unconditionally for every V6 address, so `[::ffff:169.254.169.254]` slipped the IMDS block through this code path too. The exact reproduction from #2396 applied here verbatim. |
| `librefang-api/src/webhook_store.rs::validate_webhook_url` | POST `/api/webhooks` URL validation | Two bugs: (1) V6 arms of `is_private_ip` / `is_link_local` returned `false` with a `// Simplified` TODO, so `::ffff:*` bypassed; (2) more critical — `parsed.host_str().parse::<IpAddr>()` rejected **every** IPv6 literal because `url::Url` wraps IPv6 hosts in brackets (e.g. `"[::ffff:7f00:1]"`) and `IpAddr::from_str` refuses brackets. Result: no V6 URL — not `::1`, not `::ffff:*`, not `fe80::1` — was ever inspected by the IP guard. |

The webhook_store bracket bug is worth emphasising: **`http://[::1]/hook` has been bypassing webhook URL validation from day one** because the guard never ran on IPv6 literals at all. Switched to `parsed.host()` which returns the typed `url::Host` enum directly.

## Fix

Each site gets a local `canonical_ip` helper that unwraps `::ffff:X.X.X.X` to its IPv4 form via `Ipv6Addr::to_ipv4_mapped`. Every downstream check (`is_loopback` / `is_unspecified` / `is_private_ip` / `is_cloud_metadata_ip` / `is_link_local`) now canonicalises before matching.

## Tests added

- `host_functions::tests::test_is_private_ip_recognises_ipv4_mapped_v6`
- `routes::network::tests::canonical_ip_unwraps_ipv4_mapped_v6`
- `routes::network::tests::is_private_ip_recognises_ipv4_mapped_v6`
- `routes::network::tests::is_cloud_metadata_ip_recognises_ipv4_mapped_v6`
- `webhook_store::tests::validate_webhook_url_blocks_ipv4_mapped_ipv6_loopback`
- `webhook_store::tests::validate_webhook_url_blocks_ipv4_mapped_ipv6_metadata`
- `webhook_store::tests::validate_webhook_url_blocks_ipv4_mapped_ipv6_private`

## Verified locally

- `cargo test -p librefang-runtime-wasm --lib host_functions::tests` — 20 passed
- `cargo test -p librefang-api --lib routes::network::tests webhook_store::tests` — 29 passed
- `cargo check -p librefang-runtime-wasm -p librefang-api` — clean

## Out of scope (follow-up)

`webhook_store.rs` still has V6 arms of `is_private_ip` / `is_link_local` that return `false` for non-mapped IPv6, so `fe80::1` / `fc00::1` literals bypass webhook URL validation. That's a pre-existing gap flagged by the existing `// Simplified` comment — same bug class but different inputs, not introduced or fixed here. Happy to take that as a follow-up PR.

## Test plan

- [x] `cargo test -p librefang-runtime-wasm --lib host_functions::tests`
- [x] `cargo test -p librefang-api --lib routes::network::tests webhook_store::tests`
- [x] `cargo clippy -p librefang-runtime -p librefang-api --all-targets -- -D warnings`
- [ ] CI full workspace build