### PR TITLE
fix: clippy regressions from refactor splits (#2404, #2406)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,10 +4208,12 @@ version = "2026.4.13-beta19"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
+ "librefang-runtime",
  "librefang-types",
  "regex-lite",
  "serde",
  "serde_json",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]

--- a/crates/librefang-kernel-router/Cargo.toml
+++ b/crates/librefang-kernel-router/Cargo.toml
@@ -14,3 +14,7 @@ regex-lite = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+librefang-runtime = { path = "../librefang-runtime" }

--- a/crates/librefang-runtime-drivers/src/drivers/mod.rs
+++ b/crates/librefang-runtime-drivers/src/drivers/mod.rs
@@ -922,6 +922,52 @@ pub fn is_cli_provider(name: &str) -> bool {
     )
 }
 
+/// Read an OpenAI API key from the Codex CLI credential file.
+///
+/// Checks `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.
+/// Returns `Some(api_key)` if the file exists and contains a valid, non-expired token.
+fn read_codex_credential() -> Option<String> {
+    let codex_home = std::env::var("CODEX_HOME")
+        .map(std::path::PathBuf::from)
+        .ok()
+        .or_else(|| {
+            #[cfg(target_os = "windows")]
+            {
+                std::env::var("USERPROFILE")
+                    .ok()
+                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                std::env::var("HOME")
+                    .ok()
+                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
+            }
+        })?;
+
+    let auth_path = codex_home.join("auth.json");
+    let content = std::fs::read_to_string(&auth_path).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    if let Some(expires_at) = parsed.get("expires_at").and_then(|v| v.as_i64()) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        if now >= expires_at {
+            return None;
+        }
+    }
+
+    parsed
+        .get("api_key")
+        .or_else(|| parsed.get("token"))
+        .or_else(|| parsed.get("tokens").and_then(|t| t.get("id_token")))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1334,50 +1380,4 @@ mod tests {
         cache.clear();
         assert!(cache.is_empty());
     }
-}
-
-/// Read an OpenAI API key from the Codex CLI credential file.
-///
-/// Checks `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.
-/// Returns `Some(api_key)` if the file exists and contains a valid, non-expired token.
-fn read_codex_credential() -> Option<String> {
-    let codex_home = std::env::var("CODEX_HOME")
-        .map(std::path::PathBuf::from)
-        .ok()
-        .or_else(|| {
-            #[cfg(target_os = "windows")]
-            {
-                std::env::var("USERPROFILE")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-        })?;
-
-    let auth_path = codex_home.join("auth.json");
-    let content = std::fs::read_to_string(&auth_path).ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    if let Some(expires_at) = parsed.get("expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-        if now >= expires_at {
-            return None;
-        }
-    }
-
-    parsed
-        .get("api_key")
-        .or_else(|| parsed.get("token"))
-        .or_else(|| parsed.get("tokens").and_then(|t| t.get("id_token")))
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
 }


### PR DESCRIPTION
## Summary

Two clippy errors that landed in main but only surface under full \`cargo clippy --workspace --all-targets\` (not \`cargo check\`). They block every new PR's Quality CI job (first surfaced on #2407).

## Errors

### 1. \`librefang-kernel-router\` — missing dev-dependencies (from #2406)

\`\`\`
error[E0432]: unresolved import \`tempfile\`
    --> crates/librefang-kernel-router/src/lib.rs:1200:9
1200 |     use tempfile::tempdir;

error[E0433]: failed to resolve: use of unresolved module or unlinked crate \`librefang_runtime\`
    --> crates/librefang-kernel-router/src/lib.rs:1206:29
1206 |     let test_home = librefang_runtime::registry_sync::resolve_home_dir_for_tests();
\`\`\`

The embedded test module references \`tempfile::tempdir\` and \`librefang_runtime::registry_sync::resolve_home_dir_for_tests\`, but neither was added as a dev-dependency when the file moved from \`librefang-kernel/src/router.rs\` (where the parent kernel crate already had those deps) to its own crate.

**Fix:** add \`tempfile\` and \`librefang-runtime\` to \`[dev-dependencies]\` in the new crate's Cargo.toml.

### 2. \`librefang-runtime-drivers\` — \`items_after_test_module\` (from #2404)

\`\`\`
error: items after a test module
    --> crates/librefang-runtime-drivers/src/drivers/mod.rs:926:1
 926 | mod tests {
1343 | fn read_codex_credential() -> Option<String> {
\`\`\`

\`read_codex_credential\` was inlined into \`drivers/mod.rs\` (in #2404) to break the reverse dependency on \`librefang_runtime::model_catalog\`, but it was appended to the end of the file — after the \`#[cfg(test)] mod tests\` block. Clippy's \`items_after_test_module\` lint rejects this.

**Fix:** move the function to its natural location, just after \`is_cli_provider\`, before the test module.

## Verification

\`\`\`
cargo clippy -p librefang-runtime-drivers -p librefang-kernel-router --all-targets -- -D warnings
\`\`\`

Clean, 3m 38s cold.

## Why CI didn't catch this earlier

The PRs that introduced these were merged via \`--admin\` after passing \`cargo check\` locally. \`cargo check\` does NOT run clippy lints, so neither the missing dev-deps nor the lint violation showed up until #2407 ran the full workspace clippy in CI.

Lesson: the post-merge \`Quality\` job on main should be watched after stacked PR landings.