### PR TITLE
fix(api): GCRA rate limiter never honoured per-key token exhaustion

### DIFF
--- a/crates/librefang-api/src/rate_limiter.rs
+++ b/crates/librefang-api/src/rate_limiter.rs
@@ -72,7 +72,27 @@ pub async fn gcra_rate_limit(
     let path = request.uri().path().to_string();
     let cost = operation_cost(&method, &path);
 
-    if state.limiter.check_key_n(&ip, cost).is_err() {
+    // `check_key_n` returns a nested `Result<Result<(), NotUntil>, InsufficientCapacity>`:
+    //   * outer `Err(InsufficientCapacity)` — the cost exceeds the configured
+    //     burst size; this request can never be served.
+    //   * outer `Ok(Err(NotUntil))`         — the key is out of tokens right
+    //     now; this is the **normal rate-limit trigger** we need to honour.
+    //   * outer `Ok(Ok(()))`                — a token was consumed, pass
+    //     through.
+    //
+    // The previous check — `state.limiter.check_key_n(&ip, cost).is_err()` —
+    // only caught `InsufficientCapacity`, so `NotUntil` (the normal "you've
+    // exhausted your quota" signal) was treated as OK and every request
+    // slid straight through. A burst of 200 `/api/health` calls (cost=1,
+    // quota=500/min) never returned 429 in practice, and heavier endpoints
+    // (POST /api/agents at cost=50) were equally unthrottled until the
+    // per-call cost itself grew larger than the burst size.
+    let rate_limited = match state.limiter.check_key_n(&ip, cost) {
+        Ok(Ok(())) => false,
+        Ok(Err(_not_until)) => true,
+        Err(_insufficient_capacity) => true,
+    };
+    if rate_limited {
         tracing::warn!(ip = %ip, cost = cost.get(), path = %path, "GCRA rate limit exceeded");
         let retry_after = state.retry_after_secs.to_string();
         return Response::builder()
@@ -91,6 +111,35 @@ pub async fn gcra_rate_limit(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: a small-quota limiter must actually start rejecting
+    /// after the burst is drained. Before this fix the nested-Result
+    /// destructuring only caught `InsufficientCapacity`, so the inner
+    /// `NotUntil` (the normal "out of tokens") path was treated as OK
+    /// and `check_key_n` silently passed everything.
+    #[test]
+    fn test_rate_limit_trips_after_quota_drained() {
+        let limiter = create_rate_limiter(5); // 5 tokens / minute
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let cost = NonZeroU32::new(1).unwrap();
+        // Drain the burst (5 tokens) — these must all pass.
+        for i in 0..5 {
+            let r = limiter.check_key_n(&ip, cost);
+            assert!(
+                matches!(r, Ok(Ok(()))),
+                "token {i} should pass but got {r:?}"
+            );
+        }
+        // The next call must hit the inner NotUntil arm that the old
+        // .is_err() missed. This is the precise shape the middleware
+        // now pattern-matches on.
+        let r = limiter.check_key_n(&ip, cost);
+        assert!(
+            matches!(r, Ok(Err(_))),
+            "post-burst call must surface the NotUntil variant, got {r:?}"
+        );
+    }
+
     #[test]
     fn test_costs() {
         assert_eq!(operation_cost("GET", "/api/health").get(), 1);


### PR DESCRIPTION
## Summary
\`gcra_rate_limit\` decided whether to return 429 with \`state.limiter.check_key_n(&ip, cost).is_err()\`. governor's \`check_key_n\` returns a **nested** \`Result<Result<(), NotUntil>, InsufficientCapacity>\`, so \`.is_err()\` only catches the outer \`InsufficientCapacity\` — the \"requested cost is larger than the configured burst\" corner case. The normal rate-limit signal is the inner \`Err(NotUntil)\` variant nested inside \`Ok(_)\`, which the old code always saw as \`Ok(..)\` and let straight through.

Net effect: the per-IP quota was a no-op for anything whose cost ≤ burst size. \`SECURITY.md\`'s \"GCRA rate limiter: Cost-aware token buckets per IP\" claim had no teeth in practice.

## Reproduction before fix
```bash
# daemon running with default 500 req/min quota
for i in $(seq 1 200); do
  curl -s -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:4545/api/health
done | sort | uniq -c
#    200 200        ← 0x 429 seen; burst should trip at request 500+
```

## Fix
Destructure the nested \`Result\` explicitly so both arms return 429:
```rust
let rate_limited = match state.limiter.check_key_n(&ip, cost) {
    Ok(Ok(()))              => false,
    Ok(Err(_not_until))     => true,  // <- previously leaked through
    Err(_insuff_capacity)   => true,
};
```
Add a regression test that drains a 5-token quota and asserts the post-burst call surfaces the inner \`NotUntil\` variant the middleware now pattern-matches on.

## Test plan
- [x] \`cargo test -p librefang-api --lib rate_limiter\` — 2 passed (1 new regression)
- [x] \`cargo clippy -p librefang-api --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build