### PR TITLE
docs(security): audit chain is tamper-evident only against partial edits

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,8 +88,8 @@ LibreFang implements defense-in-depth with the following security controls:
 - **CORS policy**: Restricted to localhost when no API key configured
 
 ### Audit
-- **Merkle hash chain**: Tamper-evident audit trail for all agent actions
-- **Tamper detection**: Chain integrity verification via `/api/audit/verify`
+- **Hash-linked audit log**: Each entry's hash covers its fields plus the previous entry's hash, and `/api/audit/verify` recomputes the chain from the genesis sentinel. This detects **in-place edits** (flip a byte in one entry and the chain breaks at that row) and **row deletions** (the successor's `prev_hash` no longer matches).
+- **Limitation — no external tip anchor**: the chain is only self-consistent, it is not anchored to a trust root outside the SQLite database. An attacker with write access to `~/.librefang/data/librefang.db` can delete every row, insert a fabricated history, and recompute every hash from genesis forward — `/api/audit/verify` will return `valid: true` because it has nothing to compare the tip against. Treat the audit log as tamper-*evident against casual or partial edits*, **not** as a cryptographic supply-chain proof. If you need the stronger property, mirror the tip hash to an append-only store you control (signed systemd-journald entry, transparency log, offsite append-only file) and reconcile on startup; this is not built in.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
\`SECURITY.md\` advertises *\"Merkle hash chain: Tamper-evident audit trail for all agent actions\"*. In practice \`AuditLog::verify_integrity\` only walks the chain from a hard-coded genesis sentinel and checks that each entry's \`prev_hash\` matches the previous entry's \`hash\`. That catches in-place edits and row deletions, but it does not anchor the tip to any trust root outside the SQLite database, so an attacker with write access to \`~/.librefang/data/librefang.db\` can wipe every row, insert a fabricated history, and recompute every hash from genesis forward — the endpoint still returns \`valid: true\`.

Reword the section so the threat model is explicit and point readers at the stronger property (external append-only mirror / transparency log) if they need supply-chain-grade tamper evidence. No behaviour change.

## Reproduction
```bash
# 1. Stop the daemon so SQLite is unlocked.
./target/debug/librefang stop

# 2. Wipe the audit table and plant a fake history whose hashes chain
#    forward from the genesis sentinel.
python3 <<'PY'
import sqlite3, hashlib
db = sqlite3.connect('~/.librefang/data/librefang.db')
c = db.cursor()
c.execute(\"DELETE FROM audit_entries\")
def h(seq, ts, aid, action, detail, outcome, prev):
    m = hashlib.sha256()
    for s in (str(seq), ts, aid, action, detail, outcome, prev): m.update(s.encode())
    return m.hexdigest()
prev = '0' * 64
rows = [
    (1, '2026-04-14T00:00:00+00:00', 'innocent', 'AgentMessage', 'everything was fine', 'ok'),
    (2, '2026-04-14T00:00:01+00:00', 'innocent', 'ToolInvoke',   'read-only access',    'ok'),
]
for seq, ts, aid, action, detail, outcome in rows:
    my = h(seq, ts, aid, action, detail, outcome, prev)
    c.execute(\"INSERT INTO audit_entries VALUES (?,?,?,?,?,?,?,?)\",
              (seq, ts, aid, action, detail, outcome, prev, my))
    prev = my
db.commit()
PY

# 3. Restart and verify.
./target/debug/librefang start
curl -H \"Authorization: Bearer \$KEY\" http://127.0.0.1:4545/api/audit/verify
# -> {\"entries\":2,\"tip_hash\":\"…\",\"valid\":true}
```

## Test plan
- [x] doc-only change, no code or tests touched