### PR TITLE
docs(security): narrow the secret-zeroization claim to its actual scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,23 @@ LibreFang implements defense-in-depth with the following security controls:
 ### Cryptographic Security
 - **Ed25519 signed manifests**: Agent identity verification
 - **HMAC-SHA256 wire protocol**: Mutual authentication with nonce-based replay protection
-- **Secret zeroization**: `Zeroizing<String>` on all API key fields, wiped on drop
+- **Secret zeroization** *(scoped to the credential vault)*: the encrypted
+  credential vault in `librefang-extensions/src/vault.rs` stores every
+  entry as `Zeroizing<String>`, so individual vault reads drop plaintext
+  immediately after use and the vault master key is also held in
+  `Zeroizing<[u8; 32]>`. The embedding driver re-wraps its API key with
+  `Zeroizing::new` after reading it from config. Other secret-carrying
+  fields on `KernelConfig` (`api_key`, `dashboard_pass`,
+  `dashboard_pass_hash`) are still plain `String`: adding a destructor to
+  `KernelConfig` breaks partial-move patterns across ~700 call sites,
+  and switching every field to `Zeroizing<String>` requires a
+  serde-compatible newtype rollout that is not yet in place. The
+  in-process copy of these fields therefore persists in heap memory
+  until the owning `Arc<KernelConfig>` is dropped, which is
+  good-enough against post-exit forensics on most platforms but is
+  **not** the "wiped on every drop" guarantee the previous bullet
+  implied. If you need stronger memory hygiene, run the daemon inside
+  a memory-encrypted VM or disable core dumps for the process.
 
 ### Runtime Isolation
 - **WASM dual metering**: Fuel limits + epoch interruption with watchdog thread


### PR DESCRIPTION
## Summary
\`SECURITY.md\`'s *\"Zeroizing<String> on all API key fields, wiped on drop\"* is not what the code does today:

- \`librefang-extensions/src/vault.rs\` holds every credential as \`Zeroizing<String>\` (and the master key as \`Zeroizing<[u8; 32]>\`), so vault reads clear plaintext on scope exit ✅
- \`librefang-runtime/src/embedding.rs\` re-wraps the embedding API key with \`Zeroizing::new\` after reading it out of config ✅
- **Everything else** on \`KernelConfig\` — \`api_key\`, \`dashboard_pass\`, \`dashboard_pass_hash\` — is still plain \`String\`. Adding a \`Drop\` impl to \`KernelConfig\` breaks the \`config.thinking.unwrap()\` / \`config.X\` partial-move patterns used in roughly 720 call sites (I tried), and switching each field to \`Zeroizing<String>\` requires a serde-compatible newtype rollout that is not yet in place.

Reword the bullet so readers planning a threat model don't assume a guarantee the current implementation can't deliver, and point them at the operational mitigations (memory-encrypted VM, disabled core dumps) if they need more.

This is a docs-only change; a follow-up code PR can land the newtype once we pick a pattern that survives partial-move sites.

## Test plan
- [x] doc-only change