### PR TITLE
fix(runtime-wasm): strip parent env before host_shell_exec spawns child

### DIFF
--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -377,6 +377,45 @@ fn extract_host_from_url(url: &str) -> String {
 // Shell (capability-checked)
 // ---------------------------------------------------------------------------
 
+/// Environment variables re-added after `env_clear` on a sandboxed child
+/// process. Mirrors the list in `librefang-runtime/src/subprocess_sandbox.rs`
+/// so that WASM guests invoking `shell_exec` get the same stripped-down
+/// environment as the top-level shell tool. Keeping the list inline (rather
+/// than taking a dependency on `librefang-runtime`) avoids a crate cycle.
+const WASM_SHELL_SAFE_ENV_VARS: &[&str] = &[
+    "PATH", "HOME", "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL", "TERM",
+];
+
+/// Clear the child's environment and re-add only the safe allowlist. The
+/// WASM sandbox path used to skip this, so an agent whose `ShellExec`
+/// capability was granted inherited the entire daemon environment — every
+/// LLM provider API key, vault master key override, cloud metadata token,
+/// etc. — regardless of how tightly its Wasm fuel and epoch budget were
+/// capped. This closes that exfiltration hole while leaving the capability
+/// gate above untouched.
+fn sanitize_shell_env(cmd: &mut std::process::Command) {
+    cmd.env_clear();
+    for var in WASM_SHELL_SAFE_ENV_VARS {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
+    }
+    #[cfg(windows)]
+    for var in [
+        "USERPROFILE",
+        "SYSTEMROOT",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "COMSPEC",
+        "WINDIR",
+        "PATHEXT",
+    ] {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
+    }
+}
+
 fn host_shell_exec(state: &GuestState, params: &serde_json::Value) -> serde_json::Value {
     let command = match params.get("command").and_then(|c| c.as_str()) {
         Some(c) => c,
@@ -399,6 +438,7 @@ fn host_shell_exec(state: &GuestState, params: &serde_json::Value) -> serde_json
     // Each argument is passed directly to the process.
     let mut cmd = std::process::Command::new(command);
     cmd.args(&args);
+    sanitize_shell_env(&mut cmd);
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -601,6 +641,51 @@ mod tests {
         let result = host_shell_exec(&state, &json!({"command": "ls"}));
         let err = result["error"].as_str().unwrap();
         assert!(err.contains("denied"));
+    }
+
+    /// Regression: a WASM guest with an explicit `ShellExec("*")` capability
+    /// used to inherit the daemon's full environment, including every LLM
+    /// provider API key. The fix strips the env before exec so only the
+    /// hard-coded safe allowlist (PATH, HOME, LANG, …) survives. Stamp a
+    /// fake secret into the parent environment, drive the host call, and
+    /// verify that the child's `env` output does not contain it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_shell_exec_strips_parent_env_secrets() {
+        // Use a unique key per run so concurrent tests don't collide.
+        let key = format!("LF_WASM_FAKE_SECRET_{}", std::process::id());
+        let value = "sk-should-not-reach-child";
+        std::env::set_var(&key, value);
+
+        let state = test_state(vec![Capability::ShellExec("*".to_string())]);
+        let result = host_shell_exec(
+            &state,
+            &json!({
+                "command": "/usr/bin/env",
+                "args": [],
+            }),
+        );
+
+        // Tidy up the parent env regardless of assertion outcome.
+        std::env::remove_var(&key);
+
+        let ok = result
+            .get("ok")
+            .expect("shell_exec should succeed with ShellExec(*) capability");
+        let stdout = ok
+            .get("stdout")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default();
+        assert!(
+            !stdout.contains(&key) && !stdout.contains(value),
+            "WASM shell_exec child must not inherit parent secrets; got stdout:\n{stdout}"
+        );
+        // And PATH (on the safe allowlist) should still be present so
+        // legitimate shell invocations keep working.
+        assert!(
+            stdout.contains("PATH="),
+            "WASM shell_exec child must still see PATH; got stdout:\n{stdout}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
\`host_shell_exec\` in the WASM host-function table called \`std::process::Command::new(command)\` without touching the environment, so any Wasm guest holding a \`ShellExec\` capability inherited the daemon's full env on the child process. That includes every LLM provider API key (\`OPENAI_API_KEY\`, \`ANTHROPIC_API_KEY\`, \`GEMINI_API_KEY\`, \`MINIMAX_API_KEY\`, …), vault master-key overrides, and any cloud metadata tokens. \`SECURITY.md\` advertises *\"Subprocess sandbox: Environment isolation (env_clear()), restricted PATH\"*, but this path skipped it entirely — the only existing caller of \`subprocess_sandbox::sandbox_command\` is the top-level \`tool_runner.rs\` shell tool.

Importing \`librefang-runtime::subprocess_sandbox\` here would create a dependency cycle (\`runtime → runtime-wasm → runtime\`), so the fix mirrors the allowlist inline as \`sanitize_shell_env\` and calls it on every \`host_shell_exec\` spawn. The allowlist matches \`subprocess_sandbox::SAFE_ENV_VARS\` (\`PATH\`, \`HOME\`, \`TMPDIR\`, \`TMP\`, \`TEMP\`, \`LANG\`, \`LC_ALL\`, \`TERM\`, plus the Windows extras) so legitimate commands keep working.

## Regression test
\`test_shell_exec_strips_parent_env_secrets\`:
1. stamps a uniquely-named fake secret into the parent environment
2. drives \`host_shell_exec\` with \`ShellExec(\"*\")\` to run \`/usr/bin/env\`
3. asserts the child's stdout contains \`PATH=\` but does *not* contain the fake secret name or value

## Test plan
- [x] \`cargo test -p librefang-runtime-wasm --lib shell_exec\` — 2 passed (1 new)
- [x] \`cargo clippy -p librefang-runtime-wasm --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build