### PR TITLE
fix(api,docs): tighten upload MIME allowlist to match SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,12 @@ LibreFang implements defense-in-depth with the following security controls:
 ### Input Validation
 - **Path traversal protection**: `safe_resolve_path()` / `safe_resolve_parent()` on all file operations
 - **SSRF protection**: Private IP blocking, DNS resolution checks, cloud metadata endpoint filtering
-- **Image validation**: Media type whitelist (png/jpeg/gif/webp), 5MB size limit
+- **Image upload validation**: exact-match MIME allowlist on
+  `/api/agents/{id}/upload` covers `image/png`, `image/jpeg`, `image/gif`,
+  `image/webp`; scriptable formats like `image/svg+xml` are rejected.
+  Upload size is capped by `KernelConfig.max_upload_size_bytes` (default
+  10 MiB — tighten it in `config.toml` if your threat model demands a
+  smaller limit).
 - **Prompt injection heuristics** *(best-effort, not a security boundary)*: Skill content is
   scanned for a short hard-coded list of English override phrases and exfiltration keywords
   (`ignore previous instructions`, `exfiltrate`, `post to https`, …) via case-insensitive

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4085,13 +4085,52 @@ pub(crate) static UPLOAD_REGISTRY: LazyLock<DashMap<String, UploadMeta>> =
 #[allow(dead_code)]
 const MAX_UPLOAD_SIZE: usize = 10 * 1024 * 1024;
 
-/// Allowed content type prefixes for upload.
-const ALLOWED_CONTENT_TYPES: &[&str] = &["image/", "text/", "application/pdf", "audio/"];
+/// Explicit MIME allowlist for `/api/agents/{id}/upload`.
+///
+/// Historically this was `["image/", "text/", "application/pdf", "audio/"]`,
+/// which is a **prefix match**: any `image/*` subtype passed, including
+/// `image/svg+xml` (scriptable → XSS / SSRF via `<use xlink:href>`),
+/// `image/x-icon`, `image/tiff`, `image/heic`, and anything else. That
+/// contradicts the SECURITY.md promise of *"Media type whitelist
+/// (png/jpeg/gif/webp)"*. The new list is exact-match, mirrors
+/// `librefang_types::media::ALLOWED_IMAGE_TYPES`, and covers only the
+/// formats the agent loop actually consumes, so a crafted SVG posted via
+/// browser drag-drop or API can no longer land in uploads/.
+const ALLOWED_UPLOAD_CONTENT_TYPES: &[&str] = &[
+    // Images — matches ALLOWED_IMAGE_TYPES exactly
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    // Audio — used by transcribe/STT paths
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+    "audio/mp4",
+    "audio/webm",
+    "audio/x-wav",
+    "audio/flac",
+    // Text + PDF passthrough
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/pdf",
+];
+
+/// Strip MIME parameters (`; charset=utf-8`) and lowercase before matching.
+fn normalise_upload_mime(ct: &str) -> String {
+    ct.split(';')
+        .next()
+        .unwrap_or(ct)
+        .trim()
+        .to_ascii_lowercase()
+}
 
 fn is_allowed_content_type(ct: &str) -> bool {
-    ALLOWED_CONTENT_TYPES
+    let base = normalise_upload_mime(ct);
+    ALLOWED_UPLOAD_CONTENT_TYPES
         .iter()
-        .any(|prefix| ct.starts_with(prefix))
+        .any(|allowed| *allowed == base)
 }
 
 /// POST /api/agents/{id}/upload — Upload a file attachment.
@@ -4516,6 +4555,60 @@ pub async fn push_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pre-fix prefix-match (`"image/"`) let SVG, BMP, TIFF, HEIC and
+    /// friends through. Post-fix the allowlist is exact-match over the
+    /// same four formats SECURITY.md advertises.
+    #[test]
+    fn test_upload_mime_allowlist_rejects_previously_accepted_types() {
+        // Previously accepted via prefix match, now explicitly rejected.
+        for bad in [
+            "image/svg+xml",
+            "image/svg+xml; charset=utf-8",
+            "image/bmp",
+            "image/tiff",
+            "image/x-icon",
+            "image/heic",
+            "image/heif",
+            "image/avif",
+            "image/vnd.microsoft.icon",
+            "text/html", // text/ prefix used to let this through
+            "text/xml",
+            "audio/vnd.rn-realaudio",
+            "application/octet-stream",
+            "application/javascript",
+        ] {
+            assert!(
+                !is_allowed_content_type(bad),
+                "{bad} must be rejected by the upload allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn test_upload_mime_allowlist_accepts_expected_formats() {
+        for good in [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "image/PNG",                 // case-insensitive
+            "image/png; charset=binary", // MIME params stripped
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+            "audio/flac",
+            "text/plain",
+            "text/markdown",
+            "text/csv",
+            "application/pdf",
+        ] {
+            assert!(
+                is_allowed_content_type(good),
+                "{good} must be accepted by the upload allowlist"
+            );
+        }
+    }
 
     #[test]
     fn test_clone_request_defaults() {

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4085,52 +4085,35 @@ pub(crate) static UPLOAD_REGISTRY: LazyLock<DashMap<String, UploadMeta>> =
 #[allow(dead_code)]
 const MAX_UPLOAD_SIZE: usize = 10 * 1024 * 1024;
 
-/// Explicit MIME allowlist for `/api/agents/{id}/upload`.
+/// Non-media MIME types also accepted on `/api/agents/{id}/upload` — text
+/// files and PDFs that the agent loop consumes directly. Media types are
+/// sourced from `librefang_types::media::{ALLOWED_IMAGE_TYPES,
+/// ALLOWED_AUDIO_TYPES}` so the upload endpoint, the channel bridge, and
+/// `MediaAttachment::validate()` can never drift.
+const EXTRA_ALLOWED_UPLOAD_TYPES: &[&str] =
+    &["text/plain", "text/markdown", "text/csv", "application/pdf"];
+
+/// Exact-match MIME allowlist for `/api/agents/{id}/upload`.
 ///
-/// Historically this was `["image/", "text/", "application/pdf", "audio/"]`,
-/// which is a **prefix match**: any `image/*` subtype passed, including
-/// `image/svg+xml` (scriptable → XSS / SSRF via `<use xlink:href>`),
-/// `image/x-icon`, `image/tiff`, `image/heic`, and anything else. That
-/// contradicts the SECURITY.md promise of *"Media type whitelist
-/// (png/jpeg/gif/webp)"*. The new list is exact-match, mirrors
-/// `librefang_types::media::ALLOWED_IMAGE_TYPES`, and covers only the
-/// formats the agent loop actually consumes, so a crafted SVG posted via
-/// browser drag-drop or API can no longer land in uploads/.
-const ALLOWED_UPLOAD_CONTENT_TYPES: &[&str] = &[
-    // Images — matches ALLOWED_IMAGE_TYPES exactly
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-    // Audio — used by transcribe/STT paths
-    "audio/mpeg",
-    "audio/wav",
-    "audio/ogg",
-    "audio/mp4",
-    "audio/webm",
-    "audio/x-wav",
-    "audio/flac",
-    // Text + PDF passthrough
-    "text/plain",
-    "text/markdown",
-    "text/csv",
-    "application/pdf",
-];
-
-/// Strip MIME parameters (`; charset=utf-8`) and lowercase before matching.
-fn normalise_upload_mime(ct: &str) -> String {
-    ct.split(';')
-        .next()
-        .unwrap_or(ct)
-        .trim()
-        .to_ascii_lowercase()
-}
-
+/// Historically this was the prefix list `["image/", "text/",
+/// "application/pdf", "audio/"]`, which accepted any `image/*` subtype —
+/// including `image/svg+xml` (scriptable → XSS / SSRF via `<use
+/// xlink:href>`), `image/x-icon`, `image/tiff`, `image/heic` — and every
+/// `text/*` subtype including `text/html` and `text/xml`. That
+/// contradicted the SECURITY.md promise of *"Media type whitelist
+/// (png/jpeg/gif/webp)"*.
+///
+/// The new check is exact-match against the canonical
+/// `librefang_types::media::ALLOWED_IMAGE_TYPES` +
+/// `ALLOWED_AUDIO_TYPES` constants, so the upload endpoint and
+/// `MediaAttachment::validate()` share a single source of truth and
+/// cannot drift.
 fn is_allowed_content_type(ct: &str) -> bool {
-    let base = normalise_upload_mime(ct);
-    ALLOWED_UPLOAD_CONTENT_TYPES
-        .iter()
-        .any(|allowed| *allowed == base)
+    use librefang_types::media::{mime_base, ALLOWED_AUDIO_TYPES, ALLOWED_IMAGE_TYPES};
+    let base = mime_base(ct);
+    ALLOWED_IMAGE_TYPES.contains(&base.as_str())
+        || ALLOWED_AUDIO_TYPES.contains(&base.as_str())
+        || EXTRA_ALLOWED_UPLOAD_TYPES.contains(&base.as_str())
 }
 
 /// POST /api/agents/{id}/upload — Upload a file attachment.

--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -147,7 +147,7 @@ pub const ALLOWED_VIDEO_TYPES: &[&str] = &["video/mp4", "video/quicktime", "vide
 
 /// Extract the bare `type/subtype` from a MIME string, discarding parameters
 /// and whitespace (RFC 2045). E.g. `"audio/ogg; codecs=opus"` → `"audio/ogg"`.
-fn mime_base(mime: &str) -> String {
+pub fn mime_base(mime: &str) -> String {
     mime.split(';')
         .next()
         .unwrap_or(mime)


### PR DESCRIPTION
## Summary
\`is_allowed_content_type\` on \`/api/agents/{id}/upload\` compared against the **prefix** list \`[\"image/\", \"text/\", \"application/pdf\", \"audio/\"]\`. Any \`image/*\` subtype passed through, including:

- \`image/svg+xml\` — scriptable; stored-XSS if rendered inline, SSRF via \`<use xlink:href>\` / \`<image href>\`
- \`image/bmp\`, \`image/tiff\`, \`image/x-icon\`, \`image/heic\`, \`image/avif\`, \`image/vnd.microsoft.icon\`
- every \`text/*\` subtype including \`text/html\` and \`text/xml\`

That directly contradicted SECURITY.md's *\"Media type whitelist (png/jpeg/gif/webp)\"* claim and would have been the entry point for a classic stored-XSS or SVG-based SSRF the moment the dashboard rendered an upload inline.

## Fix
- Replace the prefix list with \`ALLOWED_UPLOAD_CONTENT_TYPES\`, an exact set that mirrors \`librefang_types::media::ALLOWED_IMAGE_TYPES\` plus the audio / text / PDF subtypes actually consumed by the agent loop.
- Normalise (strip MIME params + lowercase) before comparing so \`image/PNG\` and \`image/png; charset=binary\` still work but \`image/svg+xml; charset=utf-8\` doesn't.
- Correct SECURITY.md: the old bullet claimed a 5 MiB size limit; the actual bound is \`KernelConfig.max_upload_size_bytes\` (default 10 MiB). Document that and point operators at the config knob if they need a smaller cap.

## Regression tests
Two new tests in \`routes::agents::tests\`:

- \`test_upload_mime_allowlist_rejects_previously_accepted_types\` — asserts every format the old prefix match would have accepted by accident (14 cases including SVG, HTML, TIFF, HEIC, BMP, AVIF, \`application/octet-stream\`, \`application/javascript\`, …) is now rejected.
- \`test_upload_mime_allowlist_accepts_expected_formats\` — asserts PNG/JPEG/GIF/WebP + the audio / text / PDF subtypes still pass, including \`image/PNG\` (case) and \`image/png; charset=binary\` (MIME parameters).

## Test plan
- [x] \`cargo test -p librefang-api --lib upload_mime\` — 2 passed (2 new)
- [x] \`cargo clippy -p librefang-api --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build