### PR TITLE
fix(http): add default connect/read timeouts to shared HTTP client (#2340)

### DIFF
--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -183,7 +183,20 @@ pub fn new_client() -> reqwest::Client {
 pub fn build_http_client(proxy: &ProxyConfig) -> reqwest::ClientBuilder {
     let mut builder = reqwest::Client::builder()
         .use_preconfigured_tls(tls_config())
-        .user_agent(USER_AGENT);
+        .user_agent(USER_AGENT)
+        // Default timeouts so the agent loop never hangs forever when an
+        // upstream stalls. These are per-request defaults that any caller
+        // may override via `.timeout()`, `.connect_timeout()`, etc. on the
+        // returned builder. Issue #2340.
+        //
+        // - `connect_timeout`: cap TCP / TLS handshake. 30s is generous
+        //   even for slow international links to LLM providers.
+        // - `read_timeout`: per-read inactivity timeout, NOT total request
+        //   time. Streaming LLM responses keep this alive as long as
+        //   tokens trickle in; a true upstream stall will fire it. 300s
+        //   gives slow models room while still bounding hangs.
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .read_timeout(std::time::Duration::from_secs(300));
 
     // Build the NoProxy filter from explicit config only.
     let no_proxy_filter = proxy


### PR DESCRIPTION
Closes #2340.

## Bug

\`build_http_client()\` had no default timeouts. If an LLM provider stalled mid-stream (no TCP RST, no graceful close, just silence) the agent loop hung forever. Reporter saw their agent permanently stuck on a dead provider — only a daemon restart unblocked it.

## Fix

Add per-request defaults so every \`reqwest::Client\` built from this helper has a bounded hang time:

\`\`\`rust
.connect_timeout(Duration::from_secs(30))
.read_timeout(Duration::from_secs(300))
\`\`\`

- **\`connect_timeout = 30s\`** caps TCP / TLS handshake. Generous for slow international links to LLM providers but still finite.
- **\`read_timeout = 300s\`** is per-read inactivity, **not** total request time. Streaming LLM responses keep it alive as long as tokens trickle in; only a true upstream stall fires it. Issue suggested 120s; I went 300s to be safer for very slow models, still bounded.

Both defaults can be overridden per-request via \`.timeout()\` / \`.connect_timeout()\` so callers needing longer limits (large registry tarball downloads, channel long-poll endpoints) are unaffected.

## Affects

Every consumer of \`librefang-http::proxied_client_builder/proxied_client/new_client\`:
- LLM drivers (anthropic, openai, gemini, claude_code, copilot, ...)
- \`web_fetch\` (agent web tool)
- MCP transports
- channel HTTP calls

## Verification

- \`cargo check -p librefang-http\` ✅ (1m 33s cold)