### PR TITLE
fix(api): lock Owner-only writes away from Admin-role API keys

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -56,9 +56,37 @@ pub struct AuthenticatedApiUser {
     pub role: UserRole,
 }
 
+/// Endpoints that mutate kernel-wide configuration, user accounts, or
+/// daemon lifecycle. `librefang_kernel::auth::Action::{ModifyConfig,
+/// ManageUsers}` requires `UserRole::Owner` at the kernel layer; the
+/// HTTP surface must agree, otherwise an Admin API key can change
+/// configuration / rotate the bearer token / reload the daemon that a
+/// Owner is responsible for.
+fn is_owner_only_write(method: &axum::http::Method, path: &str) -> bool {
+    // Only non-GET methods are candidates — reads are handled separately.
+    if *method == axum::http::Method::GET {
+        return false;
+    }
+    // Exact-match list. These are the only routes the current codebase
+    // exposes that cross the "Owner action" line; add here rather than
+    // matching a prefix so a new Admin-write endpoint doesn't silently
+    // get locked to Owner by accident.
+    matches!(
+        path,
+        "/api/config"
+            | "/api/config/set"
+            | "/api/config/reload"
+            | "/api/auth/change-password"
+            | "/api/shutdown"
+    )
+}
+
 /// Whitelist check for per-user API-key access.
 ///
-/// - `Admin` and above: full access to all methods and paths.
+/// - `Owner`: full access.
+/// - `Admin`: full access **except** Owner-only writes (see
+///   [`is_owner_only_write`]) — kernel-wide config, user management,
+///   daemon lifecycle, and the bearer-token change endpoint.
 /// - `User`: GET everything + POST to a limited set of endpoints
 ///   (agent messages, clone, approval actions).
 /// - `Viewer`: GET only.
@@ -67,6 +95,11 @@ pub struct AuthenticatedApiUser {
 /// The `path` must already be normalized (no trailing slash, version prefix
 /// stripped) before calling this function.
 fn user_role_allows_request(role: UserRole, method: &axum::http::Method, path: &str) -> bool {
+    // Owner-only writes: even Admin cannot touch these.
+    if is_owner_only_write(method, path) {
+        return role >= UserRole::Owner;
+    }
+
     if role >= UserRole::Admin || *method == axum::http::Method::GET {
         return true;
     }
@@ -573,6 +606,85 @@ mod tests {
     #[test]
     fn test_request_id_header_constant() {
         assert_eq!(REQUEST_ID_HEADER, "x-request-id");
+    }
+
+    #[test]
+    fn test_user_role_admin_cannot_modify_config() {
+        // Admin must be blocked from kernel-wide config mutations.
+        let post = axum::http::Method::POST;
+        for path in [
+            "/api/config",
+            "/api/config/set",
+            "/api/config/reload",
+            "/api/auth/change-password",
+            "/api/shutdown",
+        ] {
+            assert!(
+                !user_role_allows_request(UserRole::Admin, &post, path),
+                "Admin must NOT be allowed to POST {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_role_owner_still_allowed_on_config_writes() {
+        let post = axum::http::Method::POST;
+        for path in [
+            "/api/config",
+            "/api/config/set",
+            "/api/config/reload",
+            "/api/auth/change-password",
+            "/api/shutdown",
+        ] {
+            assert!(
+                user_role_allows_request(UserRole::Owner, &post, path),
+                "Owner must be allowed to POST {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_role_admin_can_still_spawn_agents_and_install_skills() {
+        let post = axum::http::Method::POST;
+        for path in ["/api/agents", "/api/skills/install"] {
+            assert!(
+                user_role_allows_request(UserRole::Admin, &post, path),
+                "Admin must still be allowed to POST {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_role_user_still_limited_to_message_endpoints() {
+        let post = axum::http::Method::POST;
+        assert!(user_role_allows_request(
+            UserRole::User,
+            &post,
+            "/api/agents/123/message"
+        ));
+        // Users still can't touch spawn, skill install, or config.
+        for path in ["/api/agents", "/api/skills/install", "/api/config/set"] {
+            assert!(
+                !user_role_allows_request(UserRole::User, &post, path),
+                "User must NOT be allowed to POST {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_role_viewer_still_get_only() {
+        let get = axum::http::Method::GET;
+        let post = axum::http::Method::POST;
+        assert!(user_role_allows_request(
+            UserRole::Viewer,
+            &get,
+            "/api/agents"
+        ));
+        assert!(!user_role_allows_request(
+            UserRole::Viewer,
+            &post,
+            "/api/agents/123/message"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
SECURITY.md advertises a four-tier RBAC — Owner / Admin / User / Viewer — and \`librefang_kernel::auth::Action::{ModifyConfig, ManageUsers}\` is pinned to \`UserRole::Owner\` at the kernel layer. The HTTP side disagreed: \`user_role_allows_request\` in \`crates/librefang-api/src/middleware.rs\` short-circuited with

```rust
if role >= UserRole::Admin || *method == axum::http::Method::GET {
    return true;
}
```

so any Admin API key could POST to *every* non-read endpoint, including the routes that replace or rotate kernel state the Owner is responsible for:

- \`POST /api/config\` — replace kernel config
- \`POST /api/config/set\` — targeted config mutation
- \`POST /api/config/reload\` — hot-reload from disk
- \`POST /api/auth/change-password\` — rotates the bearer token / dashboard password
- \`POST /api/shutdown\` — daemon lifecycle

Effectively, the HTTP surface treated Admin as if it were Owner for writes — a silent privilege escalation.

## Fix
Add \`is_owner_only_write\` as an exact-match list (no prefix tricks, so a new Admin-write endpoint can't get silently locked to Owner by accident) and gate it before the existing Admin shortcut. Admin retains every other write endpoint — spawn agents, install skills, approve requests, etc. — so existing Admin workflows are unaffected.

## Regression tests (\`middleware::tests\`)
- \`test_user_role_admin_cannot_modify_config\` — Admin POST to each Owner-only path is blocked
- \`test_user_role_owner_still_allowed_on_config_writes\` — Owner still passes the same gates
- \`test_user_role_admin_can_still_spawn_agents_and_install_skills\` — Admin's non-Owner writes untouched
- \`test_user_role_user_still_limited_to_message_endpoints\` — User role unchanged
- \`test_user_role_viewer_still_get_only\` — Viewer unchanged

## Test plan
- [x] \`cargo test -p librefang-api --lib user_role\` — 5 passed
- [x] \`cargo clippy -p librefang-api --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build