### PR TITLE
fix(dashboard): copy button silently failing in non-secure contexts

### DIFF
--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -148,6 +148,21 @@ body {
   animation: fade-in-scale 0.5s var(--apple-bounce);
 }
 
+/* Chat message entrance — lighter than page transition: 220ms, no blur. */
+@keyframes message-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 6px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+.animate-message-in {
+  animation: message-in 0.22s var(--apple-ease);
+}
+
 /* ── Staggered children (Apple cascade) ─────────── */
 .stagger-children > * {
   opacity: 0;

--- a/crates/librefang-api/dashboard/src/lib/clipboard.ts
+++ b/crates/librefang-api/dashboard/src/lib/clipboard.ts
@@ -1,0 +1,31 @@
+// `navigator.clipboard` is only defined in secure contexts (HTTPS or
+// localhost). When the dashboard is served over plain HTTP on a LAN IP
+// (`http://192.168.x.x:4545`) the clipboard API is `undefined`, so a bare
+// `navigator.clipboard.writeText(...)` call throws with no feedback to the
+// user. Fall back to the legacy `document.execCommand('copy')` path via a
+// detached textarea so LAN-exposed dashboards still work.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to execCommand
+    }
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -44,6 +44,8 @@
     "skip_to_content": "Skip to content"
   },
   "common": {
+    "copied": "Copied",
+    "copy_failed": "Copy failed",
     "refresh": "Refresh",
     "status": "Status",
     "daemon_online": "Daemon Online",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -44,6 +44,8 @@
     "skip_to_content": "跳转到内容"
   },
   "common": {
+    "copied": "已复制",
+    "copy_failed": "复制失败",
     "refresh": "刷新",
     "status": "状态",
     "daemon_online": "守护进程在线",

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { listChannels, configureChannel, testChannel, reloadChannels, wechatQrStart, wechatQrStatus, whatsappQrStart, whatsappQrStatus, type ChannelItem } from "../api";
 import { useUIStore } from "../lib/store";
+import { copyToClipboard } from "../lib/clipboard";
 import QRCode from "qrcode";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -406,7 +407,10 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
                       className="flex-1 rounded-lg border border-border-subtle bg-main/50 px-3 py-2 text-xs text-text-dim font-mono"
                     />
                     <button
-                      onClick={() => navigator.clipboard.writeText(field.value || field.placeholder || "")}
+                      onClick={async () => {
+                        const ok = await copyToClipboard(field.value || field.placeholder || "");
+                        addToast(ok ? t("common.copied") : t("common.copy_failed"), ok ? "success" : "error");
+                      }}
                       className="px-3 py-2 rounded-lg bg-brand/10 text-brand text-xs hover:bg-brand/20 transition-colors shrink-0"
                       title="Copy"
                     >

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -592,12 +592,12 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
   }, [message.content, isUser]);
 
   return (
-    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-      <div className={`flex flex-col max-w-[90%] sm:max-w-[75%] ${isUser ? "items-end" : "items-start"}`}>
+    <div className={`flex animate-message-in ${isUser ? "justify-end" : "justify-start"}`}>
+      <div className={`flex flex-col w-fit max-w-[90%] sm:max-w-[75%] ${isUser ? "items-end" : "items-start"}`}>
         {/* Avatar + name */}
         <div className={`flex items-center gap-2 mb-1.5 ${isUser ? "self-end flex-row-reverse" : "self-start"}`}>
           <div className={`h-7 w-7 rounded-lg flex items-center justify-center ${
-            isUser ? "bg-gradient-to-br from-brand to-accent text-white shadow-md" : "bg-surface border border-border-subtle"
+            isUser ? "bg-brand text-white shadow-sm" : "bg-surface border border-border-subtle"
           }`}>
             {isUser ? <User className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5 text-brand" />}
           </div>
@@ -617,9 +617,9 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 
         {/* Message content */}
         {(displayContent || isUser || message.isStreaming || message.error) && (
-        <div className={`relative px-4 py-3 rounded-2xl text-sm leading-relaxed shadow-sm transition-colors ${
+        <div className={`relative px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed shadow-sm ${
           isUser
-            ? "bg-gradient-to-br from-brand to-brand/90 text-white rounded-tr-md"
+            ? "bg-brand text-white rounded-tr-md"
             : message.error
               ? "bg-error/10 border border-error/20 text-error rounded-tl-md"
               : "bg-surface border border-border-subtle rounded-tl-md"
@@ -628,7 +628,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
             displayContent ? (
               <Typewriter_v2 text={displayContent} speed={10} />
             ) : (
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 py-0.5">
                 <span className="w-1.5 h-1.5 bg-brand/60 rounded-full animate-bounce" style={{ animationDelay: "0ms" }} />
                 <span className="w-1.5 h-1.5 bg-brand/60 rounded-full animate-bounce" style={{ animationDelay: "150ms" }} />
                 <span className="w-1.5 h-1.5 bg-brand/60 rounded-full animate-bounce" style={{ animationDelay: "300ms" }} />
@@ -640,7 +640,12 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
               <span>{message.error}</span>
             </div>
           ) : isUser ? (
-            <p className="whitespace-pre-line break-words">{displayContent}</p>
+            // `break-words` only splits on spaces, so a bare URL/token
+            // long enough to overflow its parent used to push the whole
+            // 75%-wide bubble out of frame. `overflow-wrap: anywhere` is
+            // the standard safe-wrap value that only kicks in when the
+            // word would otherwise overflow, so normal text is untouched.
+            <p className="whitespace-pre-line [overflow-wrap:anywhere]">{displayContent}</p>
           ) : (
             <MarkdownContent
               remarkPlugins={[remarkMath]}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ import { MessageCircle, Send, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles,
 import { Badge } from "../components/ui/Badge";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { useUIStore } from "../lib/store";
+import { copyToClipboard } from "../lib/clipboard";
 import { ToolCallCard } from "../components/ui/ToolCallCard";
 import { filterVisible } from "../lib/hiddenModels";
 import { Typewriter_v2 } from "../components/Typewriter_v2";
@@ -1229,6 +1230,7 @@ export function ChatPage() {
   const [selectedAgentId, setSelectedAgentId] = useState(initialAgentId);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
+  const addToast = useUIStore((s) => s.addToast);
 
   // Sync agent selection to URL search params
   const selectAgent = useCallback((id: string) => {
@@ -1248,14 +1250,13 @@ export function ChatPage() {
   );
 
   const handleCopy = useCallback(async (messageId: string, content: string) => {
-    try {
-      await navigator.clipboard.writeText(content);
+    if (await copyToClipboard(content)) {
       setCopiedMessageId(messageId);
       setTimeout(() => setCopiedMessageId(null), 1500);
-    } catch {
-      // Clipboard API not available
+    } else {
+      addToast(t("common.copy_failed"), "error");
     }
-  }, []);
+  }, [addToast, t]);
 
   const configQuery = useQuery({ queryKey: ["config"], queryFn: getFullConfig, staleTime: 60000 });
   const usageFooter = (configQuery.data as Record<string, unknown>)?.usage_footer as string | undefined ?? "full";

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -678,11 +678,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
             {!message.isStreaming && !message.error && message.role === "assistant" && ttsAvailable && onSpeak && (
               <button
                 onClick={() => onSpeak(message.id, message.content)}
-                className={`h-6 w-6 rounded-md flex items-center justify-center transition-colors ${
-                  isUser
-                    ? "bg-gradient-to-br from-brand to-accent text-white shadow-sm hover:shadow-md"
-                    : "bg-surface border border-border-subtle text-brand hover:bg-surface-hover"
-                }`}
+                className="h-6 w-6 rounded-md flex items-center justify-center text-text-dim/60 hover:text-brand hover:bg-surface-hover transition-colors"
                 title={
                   ttsStatus === "loading" ? t("chat.tts_generating") :
                   isSpeaking && ttsStatus === "playing" ? t("chat.pause") :
@@ -704,9 +700,9 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
               <button
                 onClick={() => onCopy(message.id, message.content)}
                 className={`h-6 w-6 rounded-md flex items-center justify-center transition-colors ${
-                  isUser
-                    ? "bg-gradient-to-br from-brand to-accent text-white shadow-sm hover:shadow-md"
-                    : "bg-surface border border-border-subtle text-brand hover:bg-surface-hover"
+                  copied
+                    ? "text-success"
+                    : "text-text-dim/60 hover:text-brand hover:bg-surface-hover"
                 }`}
                 title={copied ? t("chat.copied") : t("chat.copy")}
               >


### PR DESCRIPTION
## Summary

\`navigator.clipboard\` is only defined in secure contexts (HTTPS or \`localhost\`). When the LibreFang dashboard is served over plain HTTP on a LAN IP (\`http://192.168.x.x:4545\`) the clipboard API is \`undefined\`, so:

- \`ChatPage.tsx:1252\` — \`await navigator.clipboard.writeText(...)\` threw into an empty \`catch {}\`. Clicking the copy button on a chat message did nothing — no success icon flip, no error, no toast. Silent.
- \`ChannelsPage.tsx:409\` — called \`navigator.clipboard.writeText(...)\` with no guard at all. Clicking Copy on a readonly channel config field threw an unhandled \`TypeError\` and the button looked dead.

## Fix

Extract \`lib/clipboard.ts::copyToClipboard(text)\` which:

1. Tries \`navigator.clipboard?.writeText\` when available and catches any rejection.
2. Falls back to \`document.execCommand('copy')\` via a detached readonly textarea — the standard pre-Clipboard-API technique, still works in insecure contexts.
3. Returns a boolean so callers can decide their own success/failure UI.

Both call sites now route through this helper and show a toast (\`common.copied\` / \`common.copy_failed\`) on failure. \`ChatPage\` additionally keeps its existing 1.5s check-icon flip on success. \`common.copied\` / \`common.copy_failed\` added to both \`en.json\` and \`zh.json\` (\`chat.*\` already has \`copied\` but it's the button label, not a toast string — kept as-is).

## Reproduction before fix

1. Start the daemon with \`api_listen = \"0.0.0.0:4545\"\`.
2. Open the dashboard from another machine via \`http://<lan-ip>:4545\`.
3. Chat with an agent, click the Copy button on any message → nothing happens.
4. Open Channels → configure a readonly webhook URL field → click Copy → DevTools console shows \`TypeError: Cannot read property 'writeText' of undefined\`.

After the fix both flows work via the execCommand fallback, or surface a toast error if even that fails.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [ ] Manual: LAN HTTP access (the actual repro scenario)
- [ ] CI full workspace build