### PR TITLE
fix(cron): At schedules in the past no longer fire forever (#2337)

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -470,7 +470,18 @@ pub fn compute_next_run_after(
     after: chrono::DateTime<Utc>,
 ) -> chrono::DateTime<Utc> {
     match schedule {
-        CronSchedule::At { at } => *at,
+        // For `at` schedules, return the original time only if it's still
+        // in the future. Otherwise the scheduler would see `next_run <= now`
+        // forever and fire the job on every tick (every 15s) until the
+        // process restarts. Push it to the far future so the job never
+        // fires again. Issue #2337.
+        CronSchedule::At { at } => {
+            if *at > after {
+                *at
+            } else {
+                after + Duration::days(36500)
+            }
+        }
         CronSchedule::Every { every_secs } => after + Duration::seconds(*every_secs as i64),
         CronSchedule::Cron { expr, tz } => {
             // Convert standard 5/6-field cron to 7-field for the `cron` crate.
@@ -858,6 +869,28 @@ mod tests {
         let schedule = CronSchedule::At { at: target };
         let next = compute_next_run(&schedule);
         assert_eq!(next, target);
+    }
+
+    /// Regression: #2337 — `compute_next_run_after` for an `at` schedule
+    /// in the past must NOT return the past time, otherwise the scheduler
+    /// re-fires the job on every tick forever.
+    #[test]
+    fn test_compute_next_run_after_at_in_past_returns_far_future() {
+        let now = Utc::now();
+        let past = now - Duration::hours(1);
+        let schedule = CronSchedule::At { at: past };
+        let next = compute_next_run_after(&schedule, now);
+        // Should be far future, not the original past time.
+        assert!(next > now + Duration::days(1000));
+    }
+
+    #[test]
+    fn test_compute_next_run_after_at_in_future_unchanged() {
+        let now = Utc::now();
+        let future = now + Duration::hours(1);
+        let schedule = CronSchedule::At { at: future };
+        let next = compute_next_run_after(&schedule, now);
+        assert_eq!(next, future);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2337.

## Bug

\`compute_next_run_after\` for \`CronSchedule::At { at }\` always returned the original \`at\` regardless of whether it was in the past. The scheduler then saw \`next_run <= now\` on **every tick (every 15 seconds)** and fired the job forever until daemon restart.

Reporter saw a single \`recordarle_a_dvpablo\` job accumulate 91+ dropped events on a Raspberry Pi — event bus full, CPU thrashing, legitimate events lost.

## Fix

When \`at <= after\`, return a far-future date (today + 100 years) so the job never fires again after its scheduled time. Same shape, no schema change, no \"fired\" flag needed.

## Tests (2 new)

- \`test_compute_next_run_after_at_in_past_returns_far_future\` — regression
- \`test_compute_next_run_after_at_in_future_unchanged\` — forward path unaffected

\`cargo test -p librefang-kernel --lib cron::tests\` — 36 passed.