### PR TITLE
docs(security): describe taint tracking as a two-sink pattern match

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,7 +100,26 @@ LibreFang implements defense-in-depth with the following security controls:
 ### Runtime Isolation
 - **WASM dual metering**: Fuel limits + epoch interruption with watchdog thread
 - **Subprocess sandbox**: Environment isolation (`env_clear()`), restricted PATH
-- **Taint tracking**: Information flow labels prevent untrusted data in privileged operations
+- **Tool-sink heuristics** *(pattern match, not full information-flow tracking)*:
+  `crates/librefang-types/src/taint.rs` defines `TaintLabel`, `TaintedValue`,
+  and `TaintSink`, and the LLM tool runner checks two sinks before
+  executing risky tool calls:
+  `check_taint_shell_exec` refuses commands matching `curl `, `wget `,
+  `| sh`, `| bash`, `base64 -d`, `eval ` (plus the shell-metacharacter
+  denylist), and `check_taint_net_fetch` refuses URLs whose query string
+  or percent-decoded parameter names contain `api_key`, `apikey`,
+  `token`, `secret`, `password`, or an `authorization:` header fragment.
+  Values that hit a pattern are wrapped in `TaintedValue` and run
+  through `check_sink`, which is where the refusal originates.
+
+  This is **not** a general information-flow control system: labels are
+  attached at the call site the moment a pattern matches, they do not
+  propagate across function boundaries, LLM tool outputs are not
+  automatically labelled, and there is no compiler/type-level
+  enforcement — code that never constructs a `TaintedValue` is
+  entirely outside the check. Treat it as a targeted denylist for two
+  specific exfiltration / injection shapes in the tool runner, not as
+  a lattice that covers all untrusted data in the process.
 
 ### Network Security
 - **GCRA rate limiter**: Cost-aware token buckets per IP


### PR DESCRIPTION
## Summary
The \"Taint tracking: Information flow labels prevent untrusted data in privileged operations\" bullet reads like a general IFC lattice — compile-time labels, propagation across call boundaries, label-aware types for every value. In practice the runtime only uses the taint module from two places:

- \`check_taint_shell_exec\` — substring-scans the tool-call \`command\` for \`curl \`, \`wget \`, \`| sh\`, \`| bash\`, \`base64 -d\`, \`eval \` (on top of the shell-metacharacter denylist). If any pattern hits, it constructs a fresh \`TaintedValue\` with \`TaintLabel::ExternalNetwork\` and immediately runs \`check_sink(shell_exec())\`.
- \`check_taint_net_fetch\` — scans the URL for \`api_key\`, \`apikey\`, \`token\`, \`secret\`, \`password\` (literal and percent-decoded) and the \`authorization:\` substring. On hit it constructs a \`TaintedValue\` with \`TaintLabel::Secret\` and runs \`check_sink(net_fetch())\`.

Labels never propagate across function boundaries, LLM tool outputs are not automatically labelled, and any call site that never constructs a \`TaintedValue\` is outside the check — there is no type-level enforcement. It is effectively a two-sink pattern denylist dressed in IFC vocabulary.

Reword the bullet so readers planning a threat model know exactly which two shapes are filtered and don't assume a lattice that covers arbitrary data flows. No behaviour change.

## Test plan
- [x] doc-only change