### PR TITLE
fix(kernel): hot-reload of agent.toml updates ResourceQuota immediately (#2317)

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -6212,11 +6212,16 @@ system_prompt = "You are a helpful assistant."
         if let Some(refreshed) = self.registry.get(agent_id) {
             // Re-grant capabilities in case caps/profile changed in the TOML.
             // Uses insert() so it replaces any existing grants for this agent.
-            // NOTE: we deliberately do NOT re-register with the scheduler,
-            // because that would wipe the agent's accumulated usage tracker.
-            // If resource quotas change, they take effect at next window reset.
             let caps = manifest_to_capabilities(&refreshed.manifest);
             self.capabilities.grant(agent_id, caps);
+            // Refresh the scheduler's quota cache so changes to
+            // `max_llm_tokens_per_hour` and friends take effect on the
+            // next message instead of waiting for daemon restart.
+            // Uses `update_quota` (not `register`) to preserve the
+            // accumulated usage tracker — switching the limit shouldn't
+            // wipe the running window. Issue #2317.
+            self.scheduler
+                .update_quota(agent_id, refreshed.manifest.resources.clone());
             let _ = self.memory.save_agent(&refreshed);
         }
 

--- a/crates/librefang-kernel/src/scheduler.rs
+++ b/crates/librefang-kernel/src/scheduler.rs
@@ -129,6 +129,14 @@ impl AgentScheduler {
         self.usage.insert(agent_id, UsageTracker::default());
     }
 
+    /// Update an agent's resource quota **without** resetting its usage
+    /// tracker. Use this when hot-reloading `agent.toml` so accumulated
+    /// LLM-token / tool-call counts stay accurate but the new limits
+    /// take effect immediately. Issue #2317.
+    pub fn update_quota(&self, agent_id: AgentId, quota: ResourceQuota) {
+        self.quotas.insert(agent_id, quota);
+    }
+
     /// Record token usage for an agent.
     pub fn record_usage(&self, agent_id: AgentId, usage: &TokenUsage) {
         if let Some(mut tracker) = self.usage.get_mut(&agent_id) {


### PR DESCRIPTION
Closes #2317.

## Bug

\`reload_agent_from_disk\` deliberately skipped \`scheduler.register()\` because re-registering wiped the per-agent usage tracker — but the trade-off was that **new resource quotas only took effect at the next window reset** (up to 1 hour). After editing \`max_llm_tokens_per_hour\` users saw the agent stay stuck on the OLD limit indefinitely. Only a daemon restart unblocked them.

Reporter:
\`\`\`
Agent has max_llm_tokens_per_hour = 300000
Hits limit: Token limit exceeded: 379817 / 300000
Edit agent.toml: max_llm_tokens_per_hour = 1200000
Send message → still gets 379817 / 300000
Restart daemon → works fine
\`\`\`

## Fix

New \`AgentScheduler::update_quota(agent_id, quota)\` that replaces the cached quota **without** touching the usage tracker. The hot-reload path calls this instead of \`register\`, so:

- new limits take effect on the very next message
- accumulated usage stays accurate (no fake "fresh budget" from reloads)
- existing window-reset semantics unchanged

The original \`register\` API stays for spawn / wizard / restore paths that legitimately need a clean tracker.

## Verification

\`cargo check -p librefang-kernel\` ✅ (4m 06s cold)