### PR TITLE
fix(cron): default delivery to LastChannel instead of None (#2338)

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -10966,7 +10966,13 @@ impl KernelHandle for LibreFangKernel {
             serde_json::from_value(job_json["delivery"].clone())
                 .map_err(|e| format!("Invalid delivery: {e}"))?
         } else {
-            CronDelivery::None
+            // Default to LastChannel so cron jobs created by an agent in
+            // a channel context actually deliver their output back to
+            // that channel. The previous default (`None`) silently
+            // dropped every result and gave users no way to recover the
+            // originating channel without explicit `delivery` config.
+            // Issue #2338.
+            CronDelivery::LastChannel
         };
         let one_shot = job_json["one_shot"].as_bool().unwrap_or(false);
 


### PR DESCRIPTION
Closes #2338.

## Bug

\`cron_create\` defaulted to \`CronDelivery::None\` when the caller didn't specify \`delivery\`, so every agent-created cron job **silently discarded its result**. There was no way to make a cron job deliver back to the channel where it was scheduled without explicit config.

Reporter saw cron jobs running successfully in logs but no output ever reached the channel.

## Fix

One-line default change: \`CronDelivery::None\` → \`CronDelivery::LastChannel\`.

The agent's most recent channel interaction is the most useful default — it matches user expectation that a cron job created in a chat sends results back to that chat, and degrades gracefully (no delivery) when no last channel is recorded.

Callers that want the old "fire and forget" behaviour can still pass \`delivery: { kind: "none" }\` explicitly.

## Verification

\`cargo check -p librefang-kernel\` ✅ (3m 41s cold)