### PR TITLE
fix(runtime): session_repair phase 3 preserves tool-call boundaries (#2353)

### DIFF
--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -143,11 +143,30 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
     }
 
     // Phase 3: Merge consecutive same-role messages
+    //
+    // Anthropic's API requires each `ToolUse` block to be followed by its
+    // matching `ToolResult` block in the very next message — they cannot
+    // be separated by other text/tool blocks. A naive same-role merge can
+    // break that invariant: e.g. merging
+    //   Assistant[ToolUse#1] + Assistant[Text]   →   Assistant[ToolUse#1, Text]
+    // leaves ToolUse#1 with no immediately-following ToolResult, and the
+    // next API call returns 400 with no way to recover. Issue #2353.
+    //
+    // Skip the merge whenever it would splice across a tool-call boundary:
+    //   • `last` ends with a ToolUse — the next message MUST be a
+    //     same-shape ToolResult delivery, not a merged content blob.
+    //   • `msg` is a pure tool-result delivery — keep it as its own
+    //     message so the pairing stays intact.
     let pre_merge_len = cleaned.len();
     let mut merged: Vec<Message> = Vec::with_capacity(cleaned.len());
     for msg in cleaned {
         if let Some(last) = merged.last_mut() {
-            if last.role == msg.role {
+            if last.role == msg.role
+                && !message_has_tool_use(last)
+                && !message_is_only_tool_results(&msg)
+                && !message_has_tool_use(&msg)
+                && !message_is_only_tool_results(last)
+            {
                 merge_content(&mut last.content, msg.content);
                 stats.messages_merged += 1;
                 continue;


### PR DESCRIPTION
Closes #2353.

## Bug

\`session_repair\` Phase 3 (same-role merge) blindly concatenated content blocks of consecutive same-role messages. When an earlier phase removed an intermediate message, that left two assistants adjacent and the merge produced things like:

\`\`\`
[Assistant: ToolUse#1] + [Assistant: Text]
   →  [Assistant: ToolUse#1, Text]
\`\`\`

Anthropic requires every \`tool_use\` block be followed by its matching \`tool_result\` in the very next message, with no other content between them. The merged shape puts a Text block between ToolUse#1 and the ToolResult that should answer it → next API call fails with \`400 invalid_request_error\`, unretriable, **agent bricked**.

Same root cause class as #2381 (tool_use ↔ tool_result pairing).

## Fix

Skip the merge whenever it would splice across a tool-call boundary. Don't merge two same-role messages if any of these is true:

- \`last\` ends with a \`ToolUse\` (must be answered by a fresh same-shape \`ToolResult\` message)
- \`msg\` is a pure tool-result delivery (must stay its own message)
- either side already contains a \`ToolUse\` (defensive)

The unmerged path keeps both messages separate, which is always API-legal even if slightly more verbose.

## Verification

\`cargo check -p librefang-runtime\` ✅ (3m 25s cold)