### PR TITLE
fix(drivers): claude_code fails fast when agent has tools (#2314)

### DIFF
--- a/crates/librefang-runtime-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-runtime-drivers/src/drivers/claude_code.rs
@@ -425,6 +425,34 @@ fn detect_cli_error_in_text(text: &str) -> Option<LlmError> {
 #[async_trait]
 impl LlmDriver for ClaudeCodeDriver {
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        // Issue #2314: this driver does not (yet) bridge LibreFang tools
+        // through to the Claude Code CLI. Earlier code silently dropped
+        // `request.tools`, so users who configured tools on a Claude
+        // Code agent saw the agent ignore every tool call without any
+        // log line — the LLM ran but never executed anything.
+        //
+        // Fail fast with a clear, actionable error instead of silently
+        // dropping the tools. Users can either:
+        //   - remove tools from the agent manifest, or
+        //   - switch to a driver that supports tool calls (anthropic,
+        //     openai, gemini, ...).
+        //
+        // A real fix (bridging LibreFang tools via Claude Code's
+        // `--mcp-config` MCP-client support) is tracked separately;
+        // it requires a local MCP server implementation that exposes
+        // LibreFang tools as MCP tools.
+        if !request.tools.is_empty() {
+            return Err(LlmError::Api {
+                status: 400,
+                message: format!(
+                    "claude_code driver does not support tool calls yet \
+                     (agent has {} tools configured). Remove `tools` from \
+                     the agent manifest or use a different driver \
+                     (anthropic / openai / gemini). Tracking issue: #2314",
+                    request.tools.len()
+                ),
+            });
+        }
         let prepared = Self::build_prompt(&request);
         let model_flag = Self::model_flag(&request.model);
 


### PR DESCRIPTION
**Partial** fix for #2314.

## Bug

The \`claude_code\` driver silently dropped \`request.tools\`. Users who configured tools on a Claude Code agent saw the agent run normally but **never execute any tool**, with no log line explaining why. Reporter saw \"tools listed but never called\".

## Why this is only a partial fix

A real fix means bridging LibreFang tools through Claude Code's \`--mcp-config\` MCP-client support, which requires a **local MCP server** implementation that exposes LibreFang tools as MCP tools to the spawned \`claude\` subprocess. That's a multi-hundred-line feature build, not a one-line fix, and is tracked separately.

This PR fixes the **user-visible failure mode**: instead of silently dropping the tools, fail fast with a clear, actionable error.

## Fix

At the top of \`ClaudeCodeDriver::complete()\`, return \`LlmError::Api { status: 400, message: ... }\` if \`request.tools\` is non-empty. The message tells users exactly what to do:

> claude_code driver does not support tool calls yet (agent has N tools configured). Remove \`tools\` from the agent manifest or use a different driver (anthropic / openai / gemini). Tracking issue: #2314

The agent now stops with a clear error instead of running silently and ignoring every tool call.

## Verification

\`cargo check -p librefang-runtime-drivers\` ✅ (1m 35s cold)

## Issue earlier root-cause investigation

I had a sub-agent investigate this earlier and they reported \"Claude Code CLI does not support MCP integration\" — that is **factually wrong**. Real \`claude --help\` output shows \`--mcp-config <configs...>\` and \`--allowedTools / --disallowedTools\` flags. The real fix path (A) above is technically supported by the CLI; only the implementation work is still TODO.