### PR TITLE
fix(kernel): wire audit log through with_db_anchored by default

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2478,6 +2478,16 @@ impl LibreFangKernel {
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
         let trigger_config = config.triggers.clone();
+        // Default audit anchor lives next to the SQLite file so operators
+        // who do nothing still get a tip-anchored log that detects full
+        // `audit_entries` rewrites. The anchor file path is intentionally
+        // derived from `data_dir` rather than a new config knob — if an
+        // operator needs to put the anchor somewhere the daemon can write
+        // to but unprivileged code cannot (chmod-0400 file, systemd
+        // ReadOnlyPaths mount, syslog pipe) they can symlink it. A first-
+        // class `audit.anchor_path` config field can land in a follow-up
+        // once the shape of the hardening story is settled.
+        let audit_anchor_path = config.data_dir.join("audit.anchor");
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),
@@ -2494,7 +2504,10 @@ impl LibreFangKernel {
             template_registry: WorkflowTemplateRegistry::new(),
             triggers: TriggerEngine::with_config(&trigger_config),
             background,
-            audit_log: Arc::new(AuditLog::with_db(memory.usage_conn())),
+            audit_log: Arc::new(AuditLog::with_db_anchored(
+                memory.usage_conn(),
+                audit_anchor_path,
+            )),
             metering,
             default_driver: driver,
             wasm_sandbox,


### PR DESCRIPTION
## Summary
#2431 landed \`AuditLog::with_db_anchored\`, which stores the latest \`seq:hash\` pair outside SQLite so a full rewrite of \`audit_entries\` can finally be detected. But nothing in the kernel called it — every \`Kernel::boot\` still went through the old \`AuditLog::with_db\` path, so the default deployment kept the gap documented in #2415.

Flip \`Kernel::boot\` to construct the audit log via \`with_db_anchored\` with the anchor file at \`data_dir/audit.anchor\`.

## Why derive the path from \`data_dir\` instead of adding a config knob
Operators who need the anchor somewhere the daemon can write to but unprivileged code cannot (chmod-0400 file, \`systemd ReadOnlyPaths=\` mount, pipe to \`logger\`) can symlink \`data_dir/audit.anchor\` to that target today. A first-class \`audit.anchor_path\` field would need the usual \`KernelConfig\` surgery (\`types::config::types\` + \`Default\` impl + \`strict_config\` allowlist) and land in a follow-up once the shape of the hardening story is settled. Getting the default on first matters more than owning the shape of the field.

## Upgrade path
\`with_db_anchored\` seeds the anchor file from the current in-DB tip when the file doesn't exist yet, so operators who upgrade to this release get the anchor for free on first boot without an explicit migration step. The linked-list check, the new anchor check, and \`/api/audit/verify\` will all start catching full-rewrite tampering from the next boot onward.

## Test plan
- [x] \`cargo check -p librefang-kernel\` — clean
- [x] \`cargo clippy -p librefang-kernel --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build + existing audit integration tests