### PR TITLE
fix(dashboard): use full viewport width for page content

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -707,7 +707,7 @@ export function App() {
 
         {/* Main Content */}
         <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden bg-main" tabIndex={-1}>
-          <div className="mx-auto max-w-7xl p-3 sm:p-4 lg:p-8">
+          <div className="w-full p-3 sm:p-4 lg:p-8">
             <Outlet />
           </div>
         </main>

--- a/crates/librefang-api/dashboard/src/components/ui/SkillOutputPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/SkillOutputPanel.tsx
@@ -16,7 +16,7 @@ export function SkillOutputPanel() {
 
   return (
     <div className={`fixed bottom-0 left-0 right-0 pointer-events-none ${isMobileMenuOpen ? "z-[30]" : "z-[90]"} ${isSidebarCollapsed ? "lg:left-[72px]" : "lg:left-[280px]"}`}>
-      <div className="mx-auto max-w-7xl px-3 sm:px-4 lg:px-8 pb-[env(safe-area-inset-bottom,8px)]">
+      <div className="w-full px-3 sm:px-4 lg:px-8 pb-[env(safe-area-inset-bottom,8px)]">
         <div className="pointer-events-auto rounded-t-xl border border-b-0 border-border-subtle bg-surface shadow-2xl">
           {/* Header */}
           <div className="flex items-center justify-between px-3 sm:px-4 py-2 border-b border-border-subtle/50">

--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -16,6 +16,13 @@
   --color-surface-hover: var(--bg-surface-hover);
   --color-border-subtle: var(--border-color);
   --color-text-dim: var(--text-muted);
+
+  /* Custom breakpoints for wide displays.
+     Tailwind v4 defaults stop at 2xl (1536px), which leaves 2K / 4K monitors
+     stuck at the same density as a 1536px laptop. These let card grids go
+     5-wide on QHD (1920+) and 6-wide on UHD / 4K (2560+). */
+  --breakpoint-3xl: 1920px;
+  --breakpoint-4xl: 2560px;
 }
 
 :root {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -400,7 +400,7 @@ export function AgentsPage() {
       </div>
 
       {agentsQuery.isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : filteredAgents.length === 0 ? (
@@ -431,7 +431,7 @@ export function AgentsPage() {
           />
         )
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 stagger-children">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 stagger-children">
           {coreAgents.map(agent => renderAgentCard(agent))}
         </div>
       )}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -400,7 +400,7 @@ export function AgentsPage() {
       </div>
 
       {agentsQuery.isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : filteredAgents.length === 0 ? (
@@ -431,7 +431,7 @@ export function AgentsPage() {
           />
         )
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 stagger-children">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6 stagger-children">
           {coreAgents.map(agent => renderAgentCard(agent))}
         </div>
       )}

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -796,7 +796,7 @@ export function ChannelsPage() {
       </div>
 
       {channelsQuery.isLoading ? (
-        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
+        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
           {[1, 2, 3].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : channels.length === 0 ? (
@@ -819,7 +819,7 @@ export function ChannelsPage() {
             )}
           </div>
 
-          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
+          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
             {paginatedChannels.map((c) => (
               <ChannelCard
                 key={c.name}

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -796,7 +796,7 @@ export function ChannelsPage() {
       </div>
 
       {channelsQuery.isLoading ? (
-        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3" : "flex flex-col gap-2"}>
+        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
           {[1, 2, 3].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : channels.length === 0 ? (
@@ -819,7 +819,7 @@ export function ChannelsPage() {
             )}
           </div>
 
-          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3" : "flex flex-col gap-2"}>
+          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
             {paginatedChannels.map((c) => (
               <ChannelCard
                 key={c.name}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1613,7 +1613,7 @@ export function ChatPage() {
 
           {/* Message area */}
           <div className="flex-1 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
-            <div className="w-full space-y-4 sm:space-y-6">
+            <div className="mx-auto w-full space-y-4 sm:space-y-6 max-w-4xl xl:max-w-5xl 2xl:max-w-6xl 3xl:max-w-[1600px] 4xl:max-w-[2000px]">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
                 <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-main/50" />
@@ -1661,13 +1661,15 @@ export function ChatPage() {
 
           {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
-            <ChatInput
-              onSend={sendMessage}
-              disabled={isLoading}
-              placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
-              authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
-              providerName={selectedAgent?.model_provider}
-            />
+            <div className="mx-auto w-full max-w-4xl xl:max-w-5xl 2xl:max-w-6xl 3xl:max-w-[1600px] 4xl:max-w-[2000px]">
+              <ChatInput
+                onSend={sendMessage}
+                disabled={isLoading}
+                placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
+                authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
+                providerName={selectedAgent?.model_provider}
+              />
+            </div>
           </div>
         </main>
       </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1613,7 +1613,7 @@ export function ChatPage() {
 
           {/* Message area */}
           <div className="flex-1 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
-            <div className="mx-auto w-full max-w-4xl space-y-4 sm:space-y-6">
+            <div className="w-full space-y-4 sm:space-y-6">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
                 <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-main/50" />
@@ -1661,15 +1661,13 @@ export function ChatPage() {
 
           {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
-            <div className="mx-auto w-full max-w-4xl">
-              <ChatInput
-                onSend={sendMessage}
-                disabled={isLoading}
-                placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
-                authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
-                providerName={selectedAgent?.model_provider}
-              />
-            </div>
+            <ChatInput
+              onSend={sendMessage}
+              disabled={isLoading}
+              placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
+              authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
+              providerName={selectedAgent?.model_provider}
+            />
           </div>
         </main>
       </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1612,7 +1612,8 @@ export function ChatPage() {
           )}
 
           {/* Message area */}
-          <div className="flex-1 overflow-y-auto p-3 sm:p-6 space-y-4 sm:space-y-6 scrollbar-thin">
+          <div className="flex-1 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
+            <div className="mx-auto w-full max-w-4xl space-y-4 sm:space-y-6">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
                 <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-main/50" />
@@ -1655,17 +1656,20 @@ export function ChatPage() {
                 <div ref={messagesEndRef} />
               </div>
             )}
+            </div>
           </div>
 
           {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
-            <ChatInput
-              onSend={sendMessage}
-              disabled={isLoading}
-              placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
-              authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
-              providerName={selectedAgent?.model_provider}
-            />
+            <div className="mx-auto w-full max-w-4xl">
+              <ChatInput
+                onSend={sendMessage}
+                disabled={isLoading}
+                placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
+                authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
+                providerName={selectedAgent?.model_provider}
+              />
+            </div>
           </div>
         </main>
       </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1613,7 +1613,7 @@ export function ChatPage() {
 
           {/* Message area */}
           <div className="flex-1 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
-            <div className="mx-auto w-full space-y-4 sm:space-y-6 max-w-4xl xl:max-w-5xl 2xl:max-w-6xl 3xl:max-w-[1600px] 4xl:max-w-[2000px]">
+            <div className="w-full space-y-4 sm:space-y-6">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
                 <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-main/50" />
@@ -1661,15 +1661,13 @@ export function ChatPage() {
 
           {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
-            <div className="mx-auto w-full max-w-4xl xl:max-w-5xl 2xl:max-w-6xl 3xl:max-w-[1600px] 4xl:max-w-[2000px]">
-              <ChatInput
-                onSend={sendMessage}
-                disabled={isLoading}
-                placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
-                authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
-                providerName={selectedAgent?.model_provider}
-              />
-            </div>
+            <ChatInput
+              onSend={sendMessage}
+              disabled={isLoading}
+              placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
+              authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
+              providerName={selectedAgent?.model_provider}
+            />
           </div>
         </main>
       </div>

--- a/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
@@ -274,13 +274,13 @@ export function CommsPage() {
 
           {/* Channels Grid */}
           {isLoading ? (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
               {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
             </div>
           ) : filteredChannels.length === 0 ? (
             <EmptyState title={t("common.no_data")} icon={<Radio className="h-6 w-6" />} />
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
               {filteredChannels.map((c) => (
                 <Card key={c.name} hover padding="md">
                   <div className="flex items-center justify-between mb-3">

--- a/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
@@ -274,13 +274,13 @@ export function CommsPage() {
 
           {/* Channels Grid */}
           {isLoading ? (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
               {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
             </div>
           ) : filteredChannels.length === 0 ? (
             <EmptyState title={t("common.no_data")} icon={<Radio className="h-6 w-6" />} />
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
               {filteredChannels.map((c) => (
                 <Card key={c.name} hover padding="md">
                   <div className="flex items-center justify-between mb-3">

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1158,7 +1158,7 @@ function ActiveHandChip({
 
 function HandCardGridSkeleton() {
   return (
-    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="flex flex-col rounded-2xl border border-border-subtle bg-surface">
           <div className="flex items-start gap-3 p-4 pb-3">
@@ -1692,7 +1692,7 @@ export function HandsPage() {
           }
         />
       ) : (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 stagger-children">
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 stagger-children">
           {filtered.map((h) => {
             const isActive = activeHandIds.has(h.id);
             const instance = instanceByHandId.get(h.id);

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1158,7 +1158,7 @@ function ActiveHandChip({
 
 function HandCardGridSkeleton() {
   return (
-    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="flex flex-col rounded-2xl border border-border-subtle bg-surface">
           <div className="flex items-start gap-3 p-4 pb-3">
@@ -1692,7 +1692,7 @@ export function HandsPage() {
           }
         />
       ) : (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 stagger-children">
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6 stagger-children">
           {filtered.map((h) => {
             const isActive = activeHandIds.has(h.id);
             const instance = instanceByHandId.get(h.id);

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -386,7 +386,7 @@ export function McpServersPage() {
 
       {/* Server cards */}
       {configured.length > 0 && (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
           {configured.map((server) => {
             const conn = connectedMap.get(server.name);
             const isConnected = conn?.connected ?? false;

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -386,7 +386,7 @@ export function McpServersPage() {
 
       {/* Server cards */}
       {configured.length > 0 && (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
           {configured.map((server) => {
             const conn = connectedMap.get(server.name);
             const isConnected = conn?.connected ?? false;

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -896,7 +896,7 @@ export function ProvidersPage() {
       </div>
 
       {providersQuery.isLoading ? (
-        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3" : "flex flex-col gap-2"}>
+        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : providers.length === 0 ? (
@@ -924,7 +924,7 @@ export function ProvidersPage() {
             )}
           </div>
 
-          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3" : "flex flex-col gap-2"}>
+          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
             {paginatedProviders.map((p) => (
               <ProviderCard
                 key={p.id}

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -896,7 +896,7 @@ export function ProvidersPage() {
       </div>
 
       {providersQuery.isLoading ? (
-        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
+        <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : providers.length === 0 ? (
@@ -924,7 +924,7 @@ export function ProvidersPage() {
             )}
           </div>
 
-          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" : "flex flex-col gap-2"}>
+          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
             {paginatedProviders.map((p) => (
               <ProviderCard
                 key={p.id}

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -715,13 +715,13 @@ export function SkillsPage() {
       {/* Content */}
       {viewMode === "installed" ? (
         skillsQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : installedSkills.length === 0 ? (
           <EmptyState title={t("skills.no_skills")} icon={<Package className="h-6 w-6" />} />
         ) : (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
             {installedSkills.map(s => (
               <InstalledSkillCard key={s.name} skill={s} onUninstall={handleUninstall} t={t} />
             ))}
@@ -729,7 +729,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "marketplace" ? (
         isMarketplaceLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isRateLimited ? (
@@ -740,7 +740,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} description={search ? t("skills.try_different_search", { defaultValue: "Try a different search term." }) : t("skills.browse_unavailable", { defaultValue: "Browse is temporarily unavailable. Try searching above." })} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
               {filteredMarketplace.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "clawhub")}
@@ -752,7 +752,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "skillhub" ? (
         isSkillhubLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isSkillhubRateLimited ? (
@@ -763,7 +763,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
               {filteredSkillhub.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "skillhub")}
@@ -776,12 +776,12 @@ export function SkillsPage() {
       ) : (
         /* viewMode === "fanghub" — official LibreFang registry skills */
         fanghubQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
         ) : filteredFanghub.length === 0 ? (
           <EmptyState title={t("skills.no_results")} icon={<Zap className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
             {filteredFanghub.map((skill: FangHubSkill) => (
               <FangHubSkillCard
                 key={skill.name}

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -715,13 +715,13 @@ export function SkillsPage() {
       {/* Content */}
       {viewMode === "installed" ? (
         skillsQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : installedSkills.length === 0 ? (
           <EmptyState title={t("skills.no_skills")} icon={<Package className="h-6 w-6" />} />
         ) : (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {installedSkills.map(s => (
               <InstalledSkillCard key={s.name} skill={s} onUninstall={handleUninstall} t={t} />
             ))}
@@ -729,7 +729,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "marketplace" ? (
         isMarketplaceLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isRateLimited ? (
@@ -740,7 +740,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} description={search ? t("skills.try_different_search", { defaultValue: "Try a different search term." }) : t("skills.browse_unavailable", { defaultValue: "Browse is temporarily unavailable. Try searching above." })} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
               {filteredMarketplace.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "clawhub")}
@@ -752,7 +752,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "skillhub" ? (
         isSkillhubLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isSkillhubRateLimited ? (
@@ -763,7 +763,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
               {filteredSkillhub.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "skillhub")}
@@ -776,12 +776,12 @@ export function SkillsPage() {
       ) : (
         /* viewMode === "fanghub" — official LibreFang registry skills */
         fanghubQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
         ) : filteredFanghub.length === 0 ? (
           <EmptyState title={t("skills.no_results")} icon={<Zap className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {filteredFanghub.map((skill: FangHubSkill) => (
               <FangHubSkillCard
                 key={skill.name}

--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2478,6 +2478,16 @@ impl LibreFangKernel {
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
         let trigger_config = config.triggers.clone();
+        // Default audit anchor lives next to the SQLite file so operators
+        // who do nothing still get a tip-anchored log that detects full
+        // `audit_entries` rewrites. The anchor file path is intentionally
+        // derived from `data_dir` rather than a new config knob — if an
+        // operator needs to put the anchor somewhere the daemon can write
+        // to but unprivileged code cannot (chmod-0400 file, systemd
+        // ReadOnlyPaths mount, syslog pipe) they can symlink it. A first-
+        // class `audit.anchor_path` config field can land in a follow-up
+        // once the shape of the hardening story is settled.
+        let audit_anchor_path = config.data_dir.join("audit.anchor");
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),
@@ -2494,7 +2504,10 @@ impl LibreFangKernel {
             template_registry: WorkflowTemplateRegistry::new(),
             triggers: TriggerEngine::with_config(&trigger_config),
             background,
-            audit_log: Arc::new(AuditLog::with_db(memory.usage_conn())),
+            audit_log: Arc::new(AuditLog::with_db_anchored(
+                memory.usage_conn(),
+                audit_anchor_path,
+            )),
             metering,
             default_driver: driver,
             wasm_sandbox,

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -414,8 +414,27 @@ fn run_watch(
         let _ = Command::new("stty").arg("sane").status();
     });
 
+    // Watch the Rust workspace only. The dashboard lives under
+    // `crates/librefang-api/dashboard/` but has its own vite HMR via
+    // `pnpm dev`, so changes there must NOT trigger a Rust rebuild +
+    // daemon restart. Ignore the dashboard directory and any editor
+    // scratch files that could otherwise bounce cargo-watch in a loop.
     let cargo_watch_status = Command::new("cargo")
-        .args(["watch", "--watch", "crates", "-s", &rebuild_and_restart])
+        .args([
+            "watch",
+            "--watch",
+            "crates",
+            "--ignore",
+            "crates/librefang-api/dashboard/**",
+            "--ignore",
+            "**/node_modules/**",
+            "--ignore",
+            "**/target/**",
+            "--ignore",
+            "**/*.md",
+            "-s",
+            &rebuild_and_restart,
+        ])
         .current_dir(root)
         .status()?;
 


### PR DESCRIPTION
## Summary

The global page wrapper in \`App.tsx\` capped every route at \`max-w-7xl\` (1280px), which leaves very large blank margins on wide monitors (1920px+). This removes the cap so pages fill the viewport, and keeps chat readable with an inner \`max-w-4xl\` reading column.

## Changes

- \`App.tsx\` main content wrapper: \`max-w-7xl mx-auto\` → \`w-full\`
- \`SkillOutputPanel.tsx\` bottom panel: same fix to stay aligned with the new layout
- \`ChatPage.tsx\` message list and input: wrapped the inner content in \`mx-auto w-full max-w-4xl\` so text stays readable even when the chat pane grows; the scroll container and the bottom input bar still fill the full pane

## Test plan

- [x] \`pnpm typecheck\` (dashboard)
- [ ] Visually verify at 1366px / 1920px / 2560px that pages fill the viewport and chat messages stay readable