### PR TITLE
fix(api): terminal WebSocket rejected local-dev daemons with no api_key

### DIFF
--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -129,49 +129,73 @@ pub async fn terminal_ws(
     headers: axum::http::HeaderMap,
     uri: axum::http::Uri,
 ) -> impl IntoResponse {
-    let provided_token = ws_auth_token(&headers, &uri);
-
-    // No token at all → immediate reject.
-    let token_str = match provided_token.as_deref() {
-        Some(t) => t,
-        None => {
-            warn!("Terminal WebSocket rejected — no auth token provided");
-            return axum::http::StatusCode::UNAUTHORIZED.into_response();
-        }
-    };
-
-    // 1. Check against configured API tokens (constant-time compare).
+    // Match `agent_ws` (`ws.rs::agent_ws`): when no authentication source is
+    // configured on the daemon at all — no `api_key`, no `user_api_keys`, no
+    // dashboard credentials — let the upgrade through. A local-dev daemon
+    // without an `api_key` cannot teach the dashboard to send a token, so
+    // every terminal WS upgrade used to be rejected with 401 before any of
+    // these code paths even ran. That broke the dashboard terminal page
+    // completely for anyone running `librefang start` without configuring
+    // auth, and diverged from how every other WS endpoint in this crate
+    // handles the same situation.
+    //
+    // When auth IS configured, the rejection semantics are unchanged:
+    // missing token → 401, mismatched token → 401. The terminal is no more
+    // or less sensitive than `agent_ws`, which can already invoke arbitrary
+    // tools including shell, so keeping the two in lock-step is the sane
+    // default. Operators who want a stricter stance for the terminal
+    // specifically can configure `api_key` or dashboard credentials.
     let valid_tokens = crate::server::valid_api_tokens(state.kernel.as_ref());
     let user_api_keys = crate::server::configured_user_api_keys(state.kernel.as_ref());
-    let api_auth = {
-        use subtle::ConstantTimeEq;
-        valid_tokens.iter().any(|key| {
-            token_str.len() == key.len() && token_str.as_bytes().ct_eq(key.as_bytes()).into()
-        })
-    };
+    let dashboard_auth = crate::server::has_dashboard_credentials(state.kernel.as_ref());
+    let auth_required = !valid_tokens.is_empty() || !user_api_keys.is_empty() || dashboard_auth;
 
-    // 2. Check against active dashboard sessions (handles the case where
-    //    no api_key is configured but the user logged in via dashboard).
-    let session_auth = {
-        let mut sessions = state.active_sessions.write().await;
-        sessions.retain(|_, st| {
-            !crate::password_hash::is_token_expired(
-                st,
-                crate::password_hash::DEFAULT_SESSION_TTL_SECS,
-            )
-        });
-        sessions.contains_key(token_str)
-    };
-    let mut user_key_auth = false;
-    if !session_auth {
-        user_key_auth = user_api_keys
-            .iter()
-            .any(|user| crate::password_hash::verify_password(token_str, &user.api_key_hash));
-    }
+    if auth_required {
+        let provided_token = ws_auth_token(&headers, &uri);
+        let token_str = match provided_token.as_deref() {
+            Some(t) => t,
+            None => {
+                warn!("Terminal WebSocket rejected — no auth token provided");
+                return axum::http::StatusCode::UNAUTHORIZED.into_response();
+            }
+        };
 
-    if !api_auth && !session_auth && !user_key_auth {
-        warn!("Terminal WebSocket upgrade rejected: invalid auth");
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        // 1. Check against configured API tokens (constant-time compare).
+        let api_auth = {
+            use subtle::ConstantTimeEq;
+            valid_tokens.iter().any(|key| {
+                token_str.len() == key.len() && token_str.as_bytes().ct_eq(key.as_bytes()).into()
+            })
+        };
+
+        // 2. Check against active dashboard sessions (handles the case where
+        //    no api_key is configured but the user logged in via dashboard).
+        let session_auth = {
+            let mut sessions = state.active_sessions.write().await;
+            sessions.retain(|_, st| {
+                !crate::password_hash::is_token_expired(
+                    st,
+                    crate::password_hash::DEFAULT_SESSION_TTL_SECS,
+                )
+            });
+            sessions.contains_key(token_str)
+        };
+        let mut user_key_auth = false;
+        if !session_auth {
+            user_key_auth = user_api_keys
+                .iter()
+                .any(|user| crate::password_hash::verify_password(token_str, &user.api_key_hash));
+        }
+
+        if !api_auth && !session_auth && !user_key_auth {
+            warn!("Terminal WebSocket upgrade rejected: invalid auth");
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+    } else {
+        warn!(
+            ip = %addr.ip(),
+            "Terminal WebSocket upgrade allowed without auth — no api_key, user_api_keys, or dashboard credentials configured"
+        );
     }
 
     let ip = addr.ip();


### PR DESCRIPTION
## Summary

The dashboard terminal page (\`/dashboard/#/terminal\`) fails to connect on any local-dev daemon that hasn't configured an \`api_key\`. Symptom:

1. Dashboard calls \`buildAuthenticatedWebSocketUrl(\"/api/terminal/ws\")\` which tries to read an API key from local storage.
2. No \`api_key\` configured → \`getStoredApiKey()\` returns null → the resulting WS URL has no \`?token=\` param.
3. \`terminal_ws\` (\`crates/librefang-api/src/routes/terminal.rs:132\`) unconditionally rejects any upgrade without a token: \`None => 401\`.
4. The browser sees the WebSocket close immediately and the terminal page surfaces "connection closed" with no further explanation.

Confirmed hitting this through a vite dev proxy (\`http://<lan-ip>:5173/dashboard/#/terminal\` → vite \`/api\` proxy → \`127.0.0.1:4545\`): the daemon logs \`Terminal WebSocket rejected — no auth token provided\` on every attempt.

This diverged from \`agent_ws\` in \`ws.rs::agent_ws\`, which gates its strict token check on an \`auth_required\` flag derived from \`!valid_tokens.is_empty() || !user_api_keys.is_empty() || dashboard_auth\`. When no auth source is configured, \`agent_ws\` allows the upgrade through — which is why the chat page has always worked for local dev.

## Fix

Mirror \`agent_ws\`'s gate exactly in \`terminal_ws\`: compute \`auth_required\` from the same three sources, and skip the strict token check when it's false. When auth **is** configured the existing semantics are preserved — missing token → 401, mismatched token → 401. When nothing is configured, emit a loud \`warn!\` with the client IP so operators can see what they're trading off and the upgrade proceeds.

Both endpoints can invoke shell-adjacent capabilities (the agent loop already runs user-granted tools), so keeping them in lock-step is the sane default. A stricter stance for the terminal specifically has to be earned via actual auth configuration, not by silently breaking local dev.

## Reproduction before fix

\`\`\`bash
# 1. Start the daemon with no api_key configured.
./target/release/librefang start &
sleep 6

# 2. Open the dashboard — vite dev or static build, doesn't matter.
open http://127.0.0.1:4545/dashboard/#/terminal

# 3. Browser DevTools Network tab shows the /api/terminal/ws upgrade
#    closing immediately; the daemon log shows:
#      Terminal WebSocket rejected — no auth token provided
\`\`\`

After the fix the upgrade completes and the PTY session starts, matching how the chat WebSocket already behaves.

## Test plan

- [ ] CI full workspace build
- [ ] Manual repro against a local-dev daemon with no \`api_key\`