### PR TITLE
feat(config): add audit.anchor_path to redirect the tip-anchor file

### DIFF
--- a/crates/librefang-kernel/src/kernel.rs
+++ b/crates/librefang-kernel/src/kernel.rs
@@ -2478,16 +2478,21 @@ impl LibreFangKernel {
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
         let trigger_config = config.triggers.clone();
-        // Default audit anchor lives next to the SQLite file so operators
-        // who do nothing still get a tip-anchored log that detects full
-        // `audit_entries` rewrites. The anchor file path is intentionally
-        // derived from `data_dir` rather than a new config knob — if an
-        // operator needs to put the anchor somewhere the daemon can write
-        // to but unprivileged code cannot (chmod-0400 file, systemd
-        // ReadOnlyPaths mount, syslog pipe) they can symlink it. A first-
-        // class `audit.anchor_path` config field can land in a follow-up
-        // once the shape of the hardening story is settled.
-        let audit_anchor_path = config.data_dir.join("audit.anchor");
+        // Resolve the audit anchor path from `[audit].anchor_path`. When
+        // unset, the default is `data_dir/audit.anchor` — good enough to
+        // catch most casual tampering since it sits next to the SQLite
+        // file. When the operator points it somewhere the daemon can
+        // write to but unprivileged code cannot (chmod-0400 file, systemd
+        // `ReadOnlyPaths=` mount, NFS share, pipe to `logger`), the same
+        // rewrite check becomes a real supply-chain boundary. Relative
+        // paths resolve against `data_dir` so operators can write
+        // `anchor_path = "audit/tip.anchor"` without hard-coding an
+        // absolute path in config.toml.
+        let audit_anchor_path = match config.audit.anchor_path.as_ref() {
+            Some(path) if path.is_absolute() => path.clone(),
+            Some(path) => config.data_dir.join(path),
+            None => config.data_dir.join("audit.anchor"),
+        };
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2981,17 +2981,36 @@ fn default_max_request_body_bytes() -> usize {
 /// ```toml
 /// [audit]
 /// retention_days = 90
+/// # Optional override for the external tip-anchor path. Relative
+/// # paths resolve against `data_dir`. Leave unset for the default
+/// # `data_dir/audit.anchor`.
+/// anchor_path = "/var/log/librefang/audit.anchor"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AuditConfig {
     /// How many days to retain audit log entries. Default: 90. Set to 0 for unlimited.
     pub retention_days: u32,
+    /// Optional override for the external Merkle-tip anchor file that
+    /// `AuditLog::with_db_anchored` uses to detect full rewrites of
+    /// `audit_entries`. When unset the daemon writes to
+    /// `data_dir/audit.anchor`, which catches most casual tampering but
+    /// sits in the same filesystem namespace as the SQLite file it is
+    /// meant to verify. Operators who want a stronger boundary can
+    /// point this at a path the daemon can write to but unprivileged
+    /// code cannot — a chmod-0400 file owned by a dedicated user, a
+    /// `systemd ReadOnlyPaths=` mount, an NFS share, or a pipe to
+    /// `logger`. Relative paths are resolved against `data_dir`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor_path: Option<PathBuf>,
 }
 
 impl Default for AuditConfig {
     fn default() -> Self {
-        Self { retention_days: 90 }
+        Self {
+            retention_days: 90,
+            anchor_path: None,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
#2436 landed the kernel audit log wiring through \`AuditLog::with_db_anchored\` with a hard-coded \`data_dir/audit.anchor\` path. That catches casual tampering, but the anchor file still sits in the same filesystem namespace as the SQLite database it is supposed to verify — an attacker with write access to \`data_dir\` can rewrite both in one breath. Operators who want a stronger boundary need to point the anchor at a path the daemon can write to but unprivileged code cannot.

## Fix
Introduce \`AuditConfig.anchor_path: Option<PathBuf>\`. When set, \`Kernel::boot\` uses it instead of the default:
- Absolute paths are used verbatim — operators can target \`/var/log/librefang/audit.anchor\` (chmod-0400, owned by a dedicated user), \`/mnt/ro-witness/audit.anchor\` (systemd \`ReadOnlyPaths=\` mount), an NFS share, or a FIFO piped to \`logger\`.
- Relative paths resolve against \`data_dir\`, so operators can write \`anchor_path = \"audit/tip.anchor\"\` without pinning the config to a specific deployment layout.
- Unset (the default) keeps the \`data_dir/audit.anchor\` behaviour introduced in #2436, so existing deployments are unaffected.

## Example config.toml
```toml
[audit]
retention_days = 90
# Put the anchor on a read-only mount the daemon writes to but the
# agent sandbox cannot touch. Rewriting audit_entries still breaks
# /api/audit/verify.
anchor_path = \"/var/log/librefang/audit.anchor\"
```

## Test plan
- [x] \`cargo check -p librefang-kernel\` — clean
- [x] \`cargo clippy -p librefang-kernel -p librefang-types --all-targets -- -D warnings\` — clean
- [ ] CI full workspace build + kernel integration tests