### PR TITLE
fix(api): terminal WebSocket froze after ~10 keystrokes from per-message cap

### DIFF
--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -299,7 +299,12 @@ async fn handle_terminal_ws(
 
     let rl_cfg = state.kernel.config_ref().rate_limit.clone();
     let ws_idle_timeout = Duration::from_secs(rl_cfg.ws_idle_timeout_secs);
-    let max_input_per_min: usize = rl_cfg.ws_messages_per_minute as usize;
+    // Use the terminal-specific input budget: PTY sessions send one WS
+    // message per keystroke, so the generic `ws_messages_per_minute` (sized
+    // for chat where a "message" is a whole utterance) was two orders of
+    // magnitude too low and made interactive programs like vim appear to
+    // freeze after ~10 keys.
+    let max_input_per_min: usize = rl_cfg.ws_terminal_messages_per_minute as usize;
     let mut input_times: Vec<std::time::Instant> = Vec::new();
     let input_window: Duration = Duration::from_secs(60);
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -591,6 +591,18 @@ pub struct RateLimitConfig {
     /// Maximum WebSocket messages per minute per connection. Default: 10.
     #[serde(default = "default_ws_messages_per_minute")]
     pub ws_messages_per_minute: u32,
+    /// Maximum terminal WebSocket input messages per minute per connection.
+    /// Default: 3600.
+    ///
+    /// Terminal sessions send one WebSocket message per keystroke, so the
+    /// generic `ws_messages_per_minute = 10` (sized for chat WS where a
+    /// "message" is a whole utterance) is two orders of magnitude too low
+    /// for an interactive PTY — typing `vim` + `:wq` in vim already
+    /// exhausts the budget and the session appears to freeze. 3600/min
+    /// (60/sec ≈ 720 WPM) covers any human typing speed plus TUI
+    /// navigation bursts while still capping pathological floods.
+    #[serde(default = "default_ws_terminal_messages_per_minute")]
+    pub ws_terminal_messages_per_minute: u32,
     /// WebSocket idle timeout in seconds (close after inactivity). Default: 1800.
     #[serde(default = "default_ws_idle_timeout_secs")]
     pub ws_idle_timeout_secs: u64,
@@ -614,6 +626,9 @@ fn default_max_ws_per_ip() -> usize {
 fn default_ws_messages_per_minute() -> u32 {
     10
 }
+fn default_ws_terminal_messages_per_minute() -> u32 {
+    3600
+}
 fn default_ws_idle_timeout_secs() -> u64 {
     1800
 }
@@ -631,6 +646,7 @@ impl Default for RateLimitConfig {
             retry_after_secs: default_retry_after_secs(),
             max_ws_per_ip: default_max_ws_per_ip(),
             ws_messages_per_minute: default_ws_messages_per_minute(),
+            ws_terminal_messages_per_minute: default_ws_terminal_messages_per_minute(),
             ws_idle_timeout_secs: default_ws_idle_timeout_secs(),
             ws_debounce_ms: default_ws_debounce_ms(),
             ws_debounce_chars: default_ws_debounce_chars(),


### PR DESCRIPTION
## Summary

Right after #2441 let the terminal WebSocket upgrade succeed for local-dev daemons, the next failure mode is that the session freezes mid-interaction. Symptom: type a short command, the first ~10 characters echo normally, then every subsequent keystroke is dropped and the screen looks dead.

## Root cause

\`terminal_ws\` read its per-input budget from \`rate_limit.ws_messages_per_minute\`, whose default is \`10\` (\`crates/librefang-types/src/config/types.rs:615\`). That value is sized for chat WebSockets where a "message" is a whole utterance — one user sends ≤10 full chat messages per minute just fine. But a **PTY** session sends one WebSocket message **per keystroke**: typing \`vim\` + \`:wq\` is already 5 keystrokes, and any interactive TUI navigation blows past 10/minute within seconds.

Once the budget is exhausted the server returns \`{"type":"error","content":"Rate limit exceeded. Max 10 inputs per minute."}\` for every subsequent keystroke. The dashboard's \`TerminalPage\` stores the error in page-header state but never writes it into the terminal, so the user just sees an unresponsive session.

## Fix

Add a dedicated \`rate_limit.ws_terminal_messages_per_minute\` field with a default of **3600** (60/sec ≈ 720 WPM — well above any human typing speed, still caps pathological floods) and use it from \`terminal_ws\`. Chat WS keeps the existing generic field and default.

## Reproduction before fix

\`\`\`bash
# 1. Start daemon with default config
./target/release/librefang start &
sleep 6

# 2. Open the dashboard terminal page
open http://127.0.0.1:4545/dashboard/#/terminal

# 3. Type \`ls -la ~/.librefang\` in the terminal — echo stops after 10 chars.
#    Daemon log spams:
#      Rate limit exceeded. Max 10 inputs per minute.
\`\`\`

After the fix the full command echoes and interactive programs (\`vim\`, \`htop\`) behave normally.

## Test plan

- [ ] CI full workspace build
- [ ] Manual: type a 50+ character command in the dashboard terminal
- [ ] Manual: \`vim\` → \`:wq\` round-trip