### PR TITLE
fix(dashboard): cap chat message bubble width for readability

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/MarkdownContent.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/MarkdownContent.tsx
@@ -19,7 +19,11 @@ const defaultComponents: Record<string, ComponentType<any>> = {
       : <code className="px-1 py-0.5 rounded bg-main font-mono text-[11px]" {...props}>{children}</code>;
   },
   pre: ({ children }: { children: ReactNode }) => <>{children}</>,
-  table: ({ children }: { children: ReactNode }) => <table className="w-full text-xs border-collapse mb-1.5">{children}</table>,
+  table: ({ children }: { children: ReactNode }) => (
+    <div className="overflow-x-auto mb-1.5">
+      <table className="w-full text-xs border-collapse">{children}</table>
+    </div>
+  ),
   th: ({ children }: { children: ReactNode }) => <th className="border border-border-subtle px-2 py-1 bg-main font-bold text-left">{children}</th>,
   td: ({ children }: { children: ReactNode }) => <td className="border border-border-subtle px-2 py-1">{children}</td>,
   blockquote: ({ children }: { children: ReactNode }) => <blockquote className="border-l-2 border-brand pl-3 italic text-text-dim mb-1.5">{children}</blockquote>,

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -623,7 +623,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 
   return (
     <div className={`flex animate-message-in ${isUser ? "justify-end" : "justify-start"}`}>
-      <div className={`flex flex-col w-fit max-w-[90%] sm:max-w-[75%] ${isUser ? "items-end" : "items-start"}`}>
+      <div className={`flex flex-col min-w-0 w-fit max-w-[90%] sm:max-w-[min(75%,70ch)] ${isUser ? "items-end" : "items-start"}`}>
         {/* Avatar + name */}
         <div className={`flex items-center gap-2 mb-1.5 ${isUser ? "self-end flex-row-reverse" : "self-start"}`}>
           <div className={`h-7 w-7 rounded-lg flex items-center justify-center ${
@@ -669,7 +669,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 
         {/* Message content */}
         {(displayContent || isUser || message.isStreaming || message.error) && (
-        <div className={`relative px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed shadow-sm ${
+        <div className={`relative px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed shadow-sm min-w-0 [overflow-wrap:anywhere] ${
           isUser
             ? "bg-brand text-white rounded-tr-md"
             : message.error


### PR DESCRIPTION
## Summary
- Cap each chat bubble at `min(75%, 70ch)` so messages stay within a comfortable reading width on wide displays instead of stretching to 75% of the viewport
- Add `overflow-wrap:anywhere` + `min-w-0` so long URLs/tokens wrap inside the bubble
- Wrap markdown tables in `overflow-x-auto` (matching existing code-block behavior) so wide tables scroll instead of breaking the bubble

## Test plan
- [ ] Open `/chat`, send a short message — bubble hugs content
- [ ] Send a very long paragraph on a wide monitor — line length stays around ~70 characters, doesn't span the whole pane
- [ ] Send a message containing a long unbreakable URL — wraps inside the bubble
- [ ] Ask the agent for a markdown table wider than the bubble — table scrolls horizontally, bubble width unchanged
- [ ] Resize to mobile width — bubble falls back to 90% width