### PR TITLE
fix(runtime-mcp,types): taint-scan MCP tool-call arguments before send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
  "fluent",
  "hex",
  "rand 0.10.0",
+ "regex-lite",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -84,7 +84,7 @@ fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
                 // JSON path of the offending leaf.
                 if check_outbound_text_violation(s, sink).is_some() {
                     Some(format!(
-                        "taint violation: credential-shaped value in MCP argument '{}' (blocked by sink '{}')",
+                        "taint violation: sensitive value in MCP argument '{}' (blocked by sink '{}')",
                         path, sink.name
                     ))
                 } else {
@@ -1508,6 +1508,22 @@ mod tests {
             "tags": ["rust", "security"],
         });
         assert!(scan_mcp_arguments_for_taint(&args).is_none());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_rejects_json_authorization_string_leaf() {
+        let args = serde_json::json!({
+            "body": r#"{"authorization": "Bearer sk-live-secret"}"#,
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_some());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_rejects_pii_string_leaf() {
+        let args = serde_json::json!({
+            "email": "john@example.com",
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_some());
     }
 
     #[test]

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -20,29 +20,110 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Maximum JSON nesting depth the taint scanner will traverse. Anything
+/// deeper is rejected outright so a pathological payload can't blow the
+/// stack or pin CPU. 64 is well beyond any sane tool-call shape.
+const MCP_TAINT_SCAN_MAX_DEPTH: usize = 64;
+
+/// Object keys that, when present in an MCP argument tree with a
+/// non-empty string value, are treated as credential-shaped
+/// regardless of what the value looks like. Catches the common
+/// shape `{"headers": {"Authorization": "Bearer …"}}` that the
+/// value-only text heuristic misses (whitespace + scheme word).
+const MCP_SENSITIVE_KEY_NAMES: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "api_key",
+    "apikey",
+    "api-key",
+    "x-api-key",
+    "access_token",
+    "accesstoken",
+    "refresh_token",
+    "bearer",
+    "password",
+    "passwd",
+    "secret",
+    "client_secret",
+    "private_key",
+];
+
+fn is_sensitive_key_name(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    MCP_SENSITIVE_KEY_NAMES.iter().any(|k| lower == *k)
+}
+
 /// Walk every string leaf in a JSON argument tree and run
 /// [`check_outbound_text_violation`] against it with the
-/// `TaintSink::mcp_tool_call` sink. Returns the first violation
-/// string if any leaf trips the denylist, otherwise `None`.
+/// `TaintSink::mcp_tool_call` sink. Returns a *redacted* rule
+/// description (JSON path + rule name) if any leaf trips the
+/// denylist, otherwise `None`.
+///
+/// IMPORTANT: the returned string must NOT contain the offending
+/// payload. It flows back to the LLM as an error and is emitted to
+/// logs — echoing the secret we just blocked would defeat the
+/// filter. We only surface the JSON path to the offending leaf.
 ///
 /// Non-string leaves (numbers, bools, null) can't carry plaintext
 /// credentials in any meaningful way, so they are skipped.
+///
+/// Recursion is hard-capped at [`MCP_TAINT_SCAN_MAX_DEPTH`].
 fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
     let sink = TaintSink::mcp_tool_call();
-    fn walk(v: &serde_json::Value, sink: &TaintSink) -> Option<String> {
+    fn walk(v: &serde_json::Value, sink: &TaintSink, path: &str, depth: usize) -> Option<String> {
+        if depth > MCP_TAINT_SCAN_MAX_DEPTH {
+            return Some(format!(
+                "taint violation: MCP argument tree exceeds max depth {} at '{}'",
+                MCP_TAINT_SCAN_MAX_DEPTH, path
+            ));
+        }
         match v {
-            serde_json::Value::String(s) => check_outbound_text_violation(s, sink),
+            serde_json::Value::String(s) => {
+                // Discard the underlying violation string entirely — it
+                // may be derived from the payload — and report only the
+                // JSON path of the offending leaf.
+                if check_outbound_text_violation(s, sink).is_some() {
+                    Some(format!(
+                        "taint violation: credential-shaped value in MCP argument '{}' (blocked by sink '{}')",
+                        path, sink.name
+                    ))
+                } else {
+                    None
+                }
+            }
             serde_json::Value::Array(items) => {
-                for item in items {
-                    if let Some(violation) = walk(item, sink) {
+                for (i, item) in items.iter().enumerate() {
+                    let child = format!("{path}[{i}]");
+                    if let Some(violation) = walk(item, sink, &child, depth + 1) {
                         return Some(violation);
                     }
                 }
                 None
             }
             serde_json::Value::Object(obj) => {
-                for (_k, v) in obj {
-                    if let Some(violation) = walk(v, sink) {
+                for (k, v) in obj {
+                    let child = if path.is_empty() {
+                        k.clone()
+                    } else {
+                        format!("{path}.{k}")
+                    };
+                    // Credential-shaped object key with a non-empty
+                    // string value is an unambiguous outbound
+                    // credential, regardless of what the value looks
+                    // like (e.g. `"Authorization": "Bearer sk-…"`
+                    // has whitespace and wouldn't trip the text
+                    // heuristic alone).
+                    if is_sensitive_key_name(k) {
+                        if let serde_json::Value::String(s) = v {
+                            if !s.trim().is_empty() {
+                                return Some(format!(
+                                    "taint violation: sensitive MCP argument key at '{}' (blocked by sink '{}')",
+                                    child, sink.name
+                                ));
+                            }
+                        }
+                    }
+                    if let Some(violation) = walk(v, sink, &child, depth + 1) {
                         return Some(violation);
                     }
                 }
@@ -51,7 +132,7 @@ fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
             _ => None,
         }
     }
-    walk(value, &sink)
+    walk(value, &sink, "$", 0)
 }
 
 // ---------------------------------------------------------------------------
@@ -902,7 +983,10 @@ impl McpConnection {
         // exactly which patterns trip it) — not a full information-
         // flow tracker. Copy-pasted obfuscation still bypasses it.
         if let Some(violation) = scan_mcp_arguments_for_taint(arguments) {
-            return Err(format!("Taint violation: {violation}"));
+            // `violation` is already a redacted rule description from
+            // the scanner — do NOT concatenate the raw payload or the
+            // offending value into the error surface.
+            return Err(violation);
         }
 
         // Resolve to an owned String immediately so the borrow of self.original_names
@@ -1424,6 +1508,49 @@ mod tests {
             "tags": ["rust", "security"],
         });
         assert!(scan_mcp_arguments_for_taint(&args).is_none());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_error_does_not_leak_secret() {
+        // The scanner must redact: the returned error string is
+        // surfaced to the LLM and to logs, and must NOT contain the
+        // exact credential payload we just blocked.
+        let secret = "ghp_SECRETabcdef0123456789SECRETabcdef0123";
+        let args = serde_json::json!({
+            "headers": { "Authorization": format!("Bearer {secret}") }
+        });
+        let err = scan_mcp_arguments_for_taint(&args).expect("must flag credential-shaped value");
+        assert!(
+            !err.contains(secret),
+            "error string leaked the blocked secret: {err}"
+        );
+        assert!(
+            !err.contains("Bearer"),
+            "error string leaked the header value: {err}"
+        );
+        // It should still identify the offending path for debugging.
+        assert!(
+            err.contains("headers.Authorization") || err.contains("Authorization"),
+            "error string should point at the offending path: {err}"
+        );
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_depth_cap() {
+        // Build a 200-deep nested object. The scanner must bail out
+        // at MCP_TAINT_SCAN_MAX_DEPTH rather than recursing forever.
+        let mut v = serde_json::Value::String("ok".to_string());
+        for _ in 0..200 {
+            let mut m = serde_json::Map::new();
+            m.insert("next".to_string(), v);
+            v = serde_json::Value::Object(m);
+        }
+        let err =
+            scan_mcp_arguments_for_taint(&v).expect("depth cap must reject pathological nesting");
+        assert!(
+            err.contains("max depth"),
+            "expected depth-cap error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -13,11 +13,46 @@ use librefang_types::config::{
     HttpCompatHeaderConfig, HttpCompatMethod, HttpCompatRequestMode, HttpCompatResponseMode,
     HttpCompatToolConfig,
 };
+use librefang_types::taint::{check_outbound_text_violation, TaintSink};
 use librefang_types::tool::ToolDefinition;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
+
+/// Walk every string leaf in a JSON argument tree and run
+/// [`check_outbound_text_violation`] against it with the
+/// `TaintSink::mcp_tool_call` sink. Returns the first violation
+/// string if any leaf trips the denylist, otherwise `None`.
+///
+/// Non-string leaves (numbers, bools, null) can't carry plaintext
+/// credentials in any meaningful way, so they are skipped.
+fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
+    let sink = TaintSink::mcp_tool_call();
+    fn walk(v: &serde_json::Value, sink: &TaintSink) -> Option<String> {
+        match v {
+            serde_json::Value::String(s) => check_outbound_text_violation(s, sink),
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    if let Some(violation) = walk(item, sink) {
+                        return Some(violation);
+                    }
+                }
+                None
+            }
+            serde_json::Value::Object(obj) => {
+                for (_k, v) in obj {
+                    if let Some(violation) = walk(v, sink) {
+                        return Some(violation);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+    walk(value, &sink)
+}
 
 // ---------------------------------------------------------------------------
 // Configuration types
@@ -852,6 +887,24 @@ impl McpConnection {
         name: &str,
         arguments: &serde_json::Value,
     ) -> Result<String, String> {
+        // SECURITY: best-effort taint filter before shipping arguments
+        // to an out-of-process MCP server. An LLM that has been pushed
+        // into smuggling credentials into tool-call arguments would
+        // otherwise exfiltrate them straight through this call — the
+        // MCP transport hands the JSON to whoever implements the server.
+        // Walk every string leaf in the arguments tree and refuse the
+        // call if anything trips `check_outbound_text_violation`. Non-
+        // string leaves (numbers, bools, null) can't carry plaintext
+        // credentials in any meaningful way, so they are left alone.
+        //
+        // This is still a best-effort pattern match (see
+        // `librefang_types::taint::check_outbound_text_violation` for
+        // exactly which patterns trip it) — not a full information-
+        // flow tracker. Copy-pasted obfuscation still bypasses it.
+        if let Some(violation) = scan_mcp_arguments_for_taint(arguments) {
+            return Err(format!("Taint violation: {violation}"));
+        }
+
         // Resolve to an owned String immediately so the borrow of self.original_names
         // and self.config.name ends before any mutable operations below.
         let raw_name: String = self
@@ -1330,6 +1383,58 @@ mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    // ── MCP outbound taint scanning ──────────────────────────────────────
+
+    #[test]
+    fn test_scan_mcp_arguments_rejects_secret_string_leaf() {
+        let args = serde_json::json!({
+            "repo": "libre/librefang",
+            "token": "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_some());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_walks_nested_trees() {
+        let args = serde_json::json!({
+            "filter": {
+                "headers": {
+                    "Authorization": "Bearer sk-live-secret",
+                }
+            }
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_some());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_rejects_secret_inside_array() {
+        let args = serde_json::json!({
+            "env": ["PATH=/usr/bin", "api_key=sk-00000"],
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_some());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_allows_plain_strings() {
+        let args = serde_json::json!({
+            "query": "What tokens does this crate use?",
+            "limit": 10,
+            "include_drafts": false,
+            "tags": ["rust", "security"],
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_none());
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_allows_null_and_numbers() {
+        let args = serde_json::json!({
+            "cursor": null,
+            "page": 3,
+            "rate": 1.5,
+        });
+        assert!(scan_mcp_arguments_for_taint(&args).is_none());
+    }
 
     #[test]
     fn test_mcp_tool_namespacing() {

--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -20,6 +20,7 @@ hex = { workspace = true }
 rand = { workspace = true }
 fluent = { workspace = true }
 unic-langid = { workspace = true }
+regex-lite = { workspace = true }
 
 [dev-dependencies]
 rmp-serde = { workspace = true }

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -5,9 +5,11 @@
 //! This guards against prompt injection, data exfiltration, and other
 //! confused-deputy attacks.
 
+use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
+use std::sync::OnceLock;
 
 /// A classification label applied to data flowing through the system.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -195,6 +197,10 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
         "api_key",
         "apikey",
         "api-key",
+        "authorization",
+        "proxy-authorization",
+        "access_token",
+        "refresh_token",
         "token",
         "secret",
         "password",
@@ -278,15 +284,78 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
         }
     }
 
+    let mut labels = HashSet::new();
     if hit {
-        let mut labels = HashSet::new();
         labels.insert(TaintLabel::Secret);
-        let tainted = TaintedValue::new(payload, labels, "llm_tool_call");
-        if let Err(violation) = tainted.check_sink(sink) {
-            return Some(violation.to_string());
-        }
+    }
+    if sink.blocked_labels.contains(&TaintLabel::Pii) && payload_contains_pii(payload) {
+        labels.insert(TaintLabel::Pii);
+    }
+    if labels.is_empty() {
+        return None;
+    }
+    let tainted = TaintedValue::new(payload, labels, "llm_tool_call");
+    if let Err(violation) = tainted.check_sink(sink) {
+        return Some(violation.to_string());
     }
     None
+}
+
+fn payload_contains_pii(payload: &str) -> bool {
+    let trimmed = payload.trim();
+    let tokenish_mixed = !trimmed.is_empty()
+        && !trimmed.contains('@')
+        && !trimmed.chars().any(char::is_whitespace)
+        && trimmed.chars().all(|c| {
+            c.is_ascii_alphanumeric()
+                || c == '-'
+                || c == '_'
+                || c == '.'
+                || c == '/'
+                || c == '+'
+                || c == '='
+        })
+        && trimmed.chars().any(|c| c.is_ascii_alphabetic());
+    if tokenish_mixed {
+        return false;
+    }
+    email_regex().is_match(payload)
+        || phone_regex().is_match(payload)
+        || credit_card_regex().is_match(payload)
+        || ssn_regex().is_match(payload)
+}
+
+fn email_regex() -> &'static Regex {
+    static EMAIL: OnceLock<Regex> = OnceLock::new();
+    EMAIL.get_or_init(|| {
+        Regex::new(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+            .expect("built-in email regex must compile")
+    })
+}
+
+fn phone_regex() -> &'static Regex {
+    static PHONE: OnceLock<Regex> = OnceLock::new();
+    PHONE.get_or_init(|| {
+        Regex::new(r"(?:\+\d{1,3}[\s\-]?)?\(?\d{2,4}\)?[\s.\-]?\d{3,4}[\s.\-]?\d{3,4}")
+            .expect("built-in phone regex must compile")
+    })
+}
+
+fn credit_card_regex() -> &'static Regex {
+    static CREDIT_CARD: OnceLock<Regex> = OnceLock::new();
+    CREDIT_CARD.get_or_init(|| {
+        Regex::new(
+            r"\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))[\s\-]?\d{4}[\s\-]?\d{4}[\s\-]?\d{4}(?:\d{3})?\b",
+        )
+        .expect("built-in credit-card regex must compile")
+    })
+}
+
+fn ssn_regex() -> &'static Regex {
+    static SSN: OnceLock<Regex> = OnceLock::new();
+    SSN.get_or_init(|| {
+        Regex::new(r"\b\d{3}[\-\s]?\d{2}[\-\s]?\d{4}\b").expect("built-in ssn regex must compile")
+    })
 }
 
 /// Describes a taint policy violation: a labelled value tried to reach a
@@ -436,6 +505,26 @@ mod tests {
                 "benign prose must pass: {payload:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_check_outbound_text_blocks_json_authorization_shape() {
+        let sink = TaintSink::mcp_tool_call();
+        let payload = r#"{"authorization": "Bearer sk-live-secret"}"#;
+        assert!(check_outbound_text_violation(payload, &sink).is_some());
+    }
+
+    #[test]
+    fn test_check_outbound_text_blocks_pii_for_mcp_sink() {
+        let sink = TaintSink::mcp_tool_call();
+        assert!(check_outbound_text_violation("john@example.com", &sink).is_some());
+        assert!(check_outbound_text_violation("+1-555-123-4567", &sink).is_some());
+    }
+
+    #[test]
+    fn test_check_outbound_text_does_not_block_pii_for_agent_message_sink() {
+        let sink = TaintSink::agent_message();
+        assert!(check_outbound_text_violation("john@example.com", &sink).is_none());
     }
 
     #[test]

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -155,6 +155,111 @@ impl TaintSink {
             blocked_labels: blocked,
         }
     }
+
+    /// Sink for MCP tool calls into an external MCP server — blocks
+    /// secrets and PII since the arguments are shipped verbatim to a
+    /// process outside the kernel's control.
+    pub fn mcp_tool_call() -> Self {
+        let mut blocked = HashSet::new();
+        blocked.insert(TaintLabel::Secret);
+        blocked.insert(TaintLabel::Pii);
+        Self {
+            name: "mcp_tool_call".to_string(),
+            blocked_labels: blocked,
+        }
+    }
+}
+
+/// Best-effort pattern match for obvious credential exfiltration in a
+/// free-form outbound string (tool-call argument, webhook body, MCP
+/// argument value, channel send text, …). Trips when the payload
+/// contains a `<common-secret-key>=<value>` / `key:value` / JSON
+/// `"key":` fragment, an `Authorization:` header prefix, a
+/// well-known credential prefix (`sk-`, `ghp_`, `xoxb-`, `AKIA`,
+/// `AIza`, …), or a long opaque token-looking blob.
+///
+/// Hits are wrapped in a [`TaintedValue`] and routed through
+/// [`TaintedValue::check_sink`] so rejection errors stay consistent
+/// across sinks. Prose that merely *mentions* "token" / "passwd" is
+/// left alone — the shape has to actually look like a credential
+/// assignment.
+///
+/// This is the same conservative denylist shape documented in
+/// SECURITY.md's taint section: a best-effort filter, **not** a
+/// full information-flow tracker. Copy-pasted obfuscation
+/// (homoglyph, base64, zero-width splits, …) still bypasses it.
+/// The goal is to catch the obvious "LLM stuffs an API key into a
+/// tool call" shape on the way out.
+pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<String> {
+    const SECRET_KEYS: &[&str] = &[
+        "api_key",
+        "apikey",
+        "api-key",
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "bearer",
+        "x-api-key",
+    ];
+
+    let lower = payload.to_lowercase();
+
+    // 1. `Authorization:` header literal — unambiguous.
+    let mut hit = lower.contains("authorization:");
+
+    // 2. `key=value` / `key: value` / `"key":` / `'key':` shapes.
+    //    The separator gate keeps natural-language ("a token of
+    //    appreciation") from tripping the filter.
+    if !hit {
+        for k in SECRET_KEYS {
+            for sep in ["=", ":", "\":", "':"] {
+                if lower.contains(&format!("{k}{sep}")) {
+                    hit = true;
+                    break;
+                }
+            }
+            if hit {
+                break;
+            }
+        }
+    }
+
+    // 3. Long opaque token OR well-known credential prefix.
+    if !hit {
+        let trimmed = payload.trim();
+        let looks_opaque = trimmed.len() >= 32
+            && !trimmed.chars().any(char::is_whitespace)
+            && trimmed.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || c == '-'
+                    || c == '_'
+                    || c == '.'
+                    || c == '/'
+                    || c == '+'
+                    || c == '='
+            });
+        let well_known = trimmed.starts_with("sk-")
+            || trimmed.starts_with("ghp_")
+            || trimmed.starts_with("github_pat_")
+            || trimmed.starts_with("xoxp-")
+            || trimmed.starts_with("xoxb-")
+            || trimmed.starts_with("AKIA")
+            || trimmed.starts_with("AIza");
+        if looks_opaque || well_known {
+            hit = true;
+        }
+    }
+
+    if hit {
+        let mut labels = HashSet::new();
+        labels.insert(TaintLabel::Secret);
+        let tainted = TaintedValue::new(payload, labels, "llm_tool_call");
+        if let Err(violation) = tainted.check_sink(sink) {
+            return Some(violation.to_string());
+        }
+    }
+    None
 }
 
 /// Describes a taint policy violation: a labelled value tried to reach a

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -226,10 +226,17 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     }
 
     // 3. Long opaque token OR well-known credential prefix.
+    //
+    // The opaque-token heuristic requires *mixed character classes*
+    // so that legitimate identifiers that happen to be long don't
+    // trip the filter. Specifically: pure-hex blobs (git SHAs,
+    // sha256 digests, UUIDs without dashes) and pure-decimal runs
+    // carry essentially no entropy as credentials relative to how
+    // often they show up as plain arguments, so they are NOT
+    // flagged. Real opaque tokens mix letters and digits.
     if !hit {
         let trimmed = payload.trim();
-        let looks_opaque = trimmed.len() >= 32
-            && !trimmed.chars().any(char::is_whitespace)
+        let charset_ok = !trimmed.chars().any(char::is_whitespace)
             && trimmed.chars().all(|c| {
                 c.is_ascii_alphanumeric()
                     || c == '-'
@@ -239,6 +246,15 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
                     || c == '+'
                     || c == '='
             });
+        let has_letter = trimmed.chars().any(|c| c.is_ascii_alphabetic());
+        let has_digit = trimmed.chars().any(|c| c.is_ascii_digit());
+        let is_hex_only = trimmed.chars().all(|c| c.is_ascii_hexdigit());
+        // Require letters + digits AND reject pure-hex runs. This
+        // excludes git SHAs (40-hex), sha256 (64-hex), UUIDs without
+        // dashes (32-hex), and bare decimal runs — all common in
+        // legitimate tool arguments.
+        let mixed_enough = has_letter && has_digit && !is_hex_only;
+        let looks_opaque = trimmed.len() >= 32 && charset_ok && mixed_enough;
         let well_known = trimmed.starts_with("sk-")
             || trimmed.starts_with("ghp_")
             || trimmed.starts_with("github_pat_")
@@ -326,6 +342,44 @@ mod tests {
         assert!(clean.check_sink(&TaintSink::shell_exec()).is_ok());
         assert!(clean.check_sink(&TaintSink::net_fetch()).is_ok());
         assert!(clean.check_sink(&TaintSink::agent_message()).is_ok());
+    }
+
+    #[test]
+    fn test_check_outbound_text_allows_git_sha() {
+        // 40-char lowercase hex — a git commit SHA. Must NOT trip the
+        // opaque-token heuristic.
+        let sha = "18060f6412ab34cd56ef7890abcdef1234567890";
+        assert_eq!(sha.len(), 40);
+        let sink = TaintSink::mcp_tool_call();
+        assert!(check_outbound_text_violation(sha, &sink).is_none());
+    }
+
+    #[test]
+    fn test_check_outbound_text_allows_sha256_hex() {
+        // 64-char lowercase hex — a sha256 digest. Must NOT trip.
+        let digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(digest.len(), 64);
+        let sink = TaintSink::mcp_tool_call();
+        assert!(check_outbound_text_violation(digest, &sink).is_none());
+    }
+
+    #[test]
+    fn test_check_outbound_text_allows_uuid_no_dashes() {
+        // 32-char hex — a UUID without dashes. Must NOT trip.
+        let uuid = "550e8400e29b41d4a716446655440000";
+        assert_eq!(uuid.len(), 32);
+        let sink = TaintSink::mcp_tool_call();
+        assert!(check_outbound_text_violation(uuid, &sink).is_none());
+    }
+
+    #[test]
+    fn test_check_outbound_text_still_flags_opaque_token() {
+        // 40-char mixed alnum with non-hex letters (o, p, r, s, …) —
+        // this IS the shape of an opaque API token.
+        let tok = "0p3nai_sk_proj_abcXYZ1234567890qwertZXCV";
+        assert!(tok.len() >= 32);
+        let sink = TaintSink::mcp_tool_call();
+        assert!(check_outbound_text_violation(tok, &sink).is_some());
     }
 
     #[test]

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -528,6 +528,57 @@ mod tests {
     }
 
     #[test]
+    fn test_check_outbound_text_blocks_credit_card_for_mcp_sink() {
+        // Cover the credit_card_regex path that was previously untested.
+        // Sample numbers are well-known test BINs (Visa/MC/Amex/Discover
+        // test numbers from Stripe docs) so they match the brand BIN
+        // ranges in the regex but are not real cards.
+        let sink = TaintSink::mcp_tool_call();
+        for cc in [
+            "4111 1111 1111 1111", // Visa, spaced
+            "4111-1111-1111-1111", // Visa, dashed
+            "5500 0000 0000 0004", // Mastercard
+            "340000000000009",     // Amex (15 digits)
+            "6011 0000 0000 0004", // Discover
+        ] {
+            assert!(
+                check_outbound_text_violation(cc, &sink).is_some(),
+                "credit card payload must be blocked for mcp sink: {cc:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_outbound_text_blocks_ssn_for_mcp_sink() {
+        // Cover the ssn_regex path. Note the regex is intentionally
+        // permissive (any 9-digit run with optional dashes/spaces) —
+        // that's a documented false-positive trade-off, not a bug.
+        let sink = TaintSink::mcp_tool_call();
+        for ssn in ["123-45-6789", "123 45 6789", "123456789"] {
+            assert!(
+                check_outbound_text_violation(ssn, &sink).is_some(),
+                "ssn-shaped payload must be blocked for mcp sink: {ssn:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_outbound_text_tokenish_mixed_skips_pii_check() {
+        // Long mixed-alnum tokens (without '@', without whitespace) are
+        // excluded from PII regex evaluation by the tokenish_mixed
+        // early-out, so a benign opaque ID that happens to embed a
+        // 9-digit run must NOT trip the SSN regex.
+        // The input is shorter than 32 chars so it doesn't trip the
+        // looks_opaque secret heuristic either — just plain identifier.
+        let sink = TaintSink::mcp_tool_call();
+        let id = "req_abc123456789xyz";
+        assert!(
+            check_outbound_text_violation(id, &sink).is_none(),
+            "tokenish mixed-alnum id must not be PII-flagged"
+        );
+    }
+
+    #[test]
     fn test_declassify_allows_flow() {
         let mut labels = HashSet::new();
         labels.insert(TaintLabel::ExternalNetwork);

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -208,13 +208,24 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     // 1. `Authorization:` header literal — unambiguous.
     let mut hit = lower.contains("authorization:");
 
-    // 2. `key=value` / `key: value` / `"key":` / `'key':` shapes.
-    //    The separator gate keeps natural-language ("a token of
-    //    appreciation") from tripping the filter.
+    // 2. `key=value` / `key: value` / `"key":` / `'key':` shapes,
+    //    including variants with whitespace around the separator
+    //    (`api_key = sk-x`, `token : abc`). Pre-normalize the payload
+    //    by collapsing single spaces around `=` and `:` so that the
+    //    separator list can stay compact. The separator gate still
+    //    keeps natural-language ("a token of appreciation") from
+    //    tripping the filter.
     if !hit {
+        let normalized = lower
+            .replace(" = ", "=")
+            .replace(" =", "=")
+            .replace("= ", "=")
+            .replace(" : ", ":")
+            .replace(" :", ":")
+            .replace(": ", ":");
         for k in SECRET_KEYS {
             for sep in ["=", ":", "\":", "':"] {
-                if lower.contains(&format!("{k}{sep}")) {
+                if normalized.contains(&format!("{k}{sep}")) {
                     hit = true;
                     break;
                 }
@@ -380,6 +391,51 @@ mod tests {
         assert!(tok.len() >= 32);
         let sink = TaintSink::mcp_tool_call();
         assert!(check_outbound_text_violation(tok, &sink).is_some());
+    }
+
+    #[test]
+    fn test_check_outbound_text_blocks_spaced_separators() {
+        // Regression: the original separator list only matched
+        // `key=value` / `key:value` (no spaces), so an LLM that
+        // formatted secrets with spaces around the separator
+        // ("api_key = sk-…", "token : abc", "Authorization : Bearer …")
+        // slipped through. Each variant below MUST be blocked.
+        let sink = TaintSink::mcp_tool_call();
+        for payload in [
+            "api_key = sk-not-a-real-token",
+            "api_key  =  sk-not-a-real-token",
+            "API_KEY=sk-1234",
+            "token : abcdef-secret-value",
+            "  password  :  hunter2  ",
+            "secret =hunter2",
+            "passwd= hunter2",
+            "x-api-key : abcdef",
+        ] {
+            assert!(
+                check_outbound_text_violation(payload, &sink).is_some(),
+                "spaced-separator payload must be rejected: {payload:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_outbound_text_allows_prose_about_keys() {
+        // The whitespace-collapse normalisation must not turn benign
+        // prose into a false positive. Sentences mentioning the words
+        // "token", "secret", "password" without a key=value shape
+        // should pass.
+        let sink = TaintSink::mcp_tool_call();
+        for payload in [
+            "Could you check whether our token economy works?",
+            "The password manager rotates entries every 90 days.",
+            "It's a secret garden behind the wall.",
+            "Use the API key called PROD_TOKEN from vault — no value here.",
+        ] {
+            assert!(
+                check_outbound_text_violation(payload, &sink).is_none(),
+                "benign prose must pass: {payload:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
MCP tool calls ship a JSON argument object to an out-of-process MCP server over stdio / SSE / HTTP. The server implementation is entirely out of the kernel's control, so any string leaf in the arguments tree is an exfiltration sink. #2444 expanded the tool-runner taint filter to cover \`agent_send\` / \`web_fetch\` body / \`web_fetch\` headers; this PR applies the same filter to the MCP boundary.

## What changes
- **\`librefang-types::taint\`** gains a shared \`TaintSink::mcp_tool_call\` (blocks \`Secret\` + \`Pii\`) and a shared \`pub fn check_outbound_text_violation(payload, &TaintSink)\`. The denylist shape matches the tool-runner copy in #2444 — key=value / Authorization header / well-known credential prefixes / long opaque tokens — but it now lives in the types crate so any downstream crate can reuse it without duplicating the logic. A follow-up can delete the tool-runner's local copy once #2444 lands.
- **\`librefang-runtime-mcp::McpClient::call_tool\`** walks the JSON argument tree with a new \`scan_mcp_arguments_for_taint\` helper before resolving the transport kind. Every string leaf is checked via \`check_outbound_text_violation(..., TaintSink::mcp_tool_call)\`; non-string leaves (numbers, bools, null) are skipped. First violation short-circuits with \`Err(\"Taint violation: …\")\`, matching the error shape already surfaced by the tool runner.

## Regression tests
- \`test_scan_mcp_arguments_rejects_secret_string_leaf\` — top-level \`token: \"ghp_…\"\` pair is blocked.
- \`test_scan_mcp_arguments_walks_nested_trees\` — deeply nested \`headers.Authorization\` is still caught.
- \`test_scan_mcp_arguments_rejects_secret_inside_array\` — string arrays are traversed element by element.
- \`test_scan_mcp_arguments_allows_plain_strings\` — benign prose that mentions \"token\" stays allowed, other types pass through.
- \`test_scan_mcp_arguments_allows_null_and_numbers\` — non-string leaves do not false-positive.

## Stacking
Independent of #2444 but shares the same denylist shape. If #2444 lands first, a follow-up can collapse the tool-runner's private \`check_taint_outbound_text\` down to the new \`librefang_types::taint::check_outbound_text_violation\` and drop the duplicate. If this PR lands first, #2444 can be rebased to use the shared helper in its own commit range.

## Test plan
- [ ] CI: \`cargo test -p librefang-runtime-mcp --lib\`
- [ ] CI: \`cargo test -p librefang-types --lib taint\`
- [ ] CI: \`cargo clippy -p librefang-runtime-mcp -p librefang-types --all-targets -- -D warnings\`
- [ ] CI full workspace build