### PR TITLE
fix(api): derive require_auth_for_reads from api_key when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 - Config-driven session mode for agent triggers (`session_mode = "new" | "persistent"`) — per-agent default with per-trigger override
 
+### Security
+
+- **BREAKING**: `require_auth_for_reads` now defaults to *enabled* whenever any form of authentication is configured (`api_key`, `user_api_keys`, or dashboard credentials). Previously the flag had to be set explicitly, leaving read endpoints open even on instances with an `api_key`. Operators who deliberately want open reads on an authenticated instance (e.g. behind a trusted reverse proxy) must now set `require_auth_for_reads = false` in `config.toml`. A boot-time INFO log records when the flag is auto-enabled. (#2448)
+
 ## [2026.4.11] - 2026-04-11
 
 ### Added

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -691,18 +691,41 @@ pub async fn build_router(
     // AuthState shares api_key_lock with AppState so change_password can update it live.
     let user_api_keys_vec = configured_user_api_keys(state.kernel.as_ref());
     let dashboard_auth_enabled = has_dashboard_credentials(state.kernel.as_ref());
-    let require_auth_for_reads = state.kernel.config_ref().require_auth_for_reads;
-    if require_auth_for_reads {
-        let api_key_set = !state.kernel.config_ref().api_key.trim().is_empty();
-        let any_auth = api_key_set || !user_api_keys_vec.is_empty() || dashboard_auth_enabled;
-        if !any_auth {
-            tracing::warn!(
-                "require_auth_for_reads = true but no authentication is configured \
-                 (api_key, user_api_keys, and dashboard credentials are all empty). \
-                 The flag will have no effect — set an api_key or configure dashboard \
-                 credentials to lock down read endpoints."
-            );
-        }
+    let api_key_set = !state.kernel.config_ref().api_key.trim().is_empty();
+    let any_auth = api_key_set || !user_api_keys_vec.is_empty() || dashboard_auth_enabled;
+
+    // Resolve the effective value of `require_auth_for_reads`.
+    // - Explicit `Some(true)`  → operators are forcing the allowlist
+    //   closed even if auth is misconfigured (catches an accidental
+    //   `api_key = ""` redeploy).
+    // - Explicit `Some(false)` → operators are deliberately keeping the
+    //   reads allowlist open even when an `api_key` is set; typical
+    //   for deployments fronted by an external auth proxy.
+    // - `None` (default)       → derive from whether *any* authentication
+    //   is configured. This makes the safe default "set an api_key and
+    //   the reads allowlist closes automatically", instead of forcing
+    //   operators to remember a separate flag before reads stop leaking
+    //   agent IDs to the LAN.
+    let configured_require_auth_for_reads = state.kernel.config_ref().require_auth_for_reads;
+    let require_auth_for_reads = match configured_require_auth_for_reads {
+        Some(explicit) => explicit,
+        None => any_auth,
+    };
+    if require_auth_for_reads && !any_auth {
+        tracing::warn!(
+            "require_auth_for_reads = true but no authentication is configured \
+             (api_key, user_api_keys, and dashboard credentials are all empty). \
+             The flag will have no effect — set an api_key or configure dashboard \
+             credentials to lock down read endpoints."
+        );
+    }
+    if require_auth_for_reads && configured_require_auth_for_reads.is_none() && any_auth {
+        tracing::info!(
+            "require_auth_for_reads auto-enabled because authentication is configured \
+             (api_key / user_api_keys / dashboard credentials). Dashboard reads now \
+             require a bearer token. Set `require_auth_for_reads = false` in config.toml \
+             to restore the legacy public reads allowlist."
+        );
     }
     let auth_state = middleware::AuthState {
         api_key_lock: api_key_lock.clone(),

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -707,10 +707,8 @@ pub async fn build_router(
     //   operators to remember a separate flag before reads stop leaking
     //   agent IDs to the LAN.
     let configured_require_auth_for_reads = state.kernel.config_ref().require_auth_for_reads;
-    let require_auth_for_reads = match configured_require_auth_for_reads {
-        Some(explicit) => explicit,
-        None => any_auth,
-    };
+    let require_auth_for_reads =
+        derive_require_auth_for_reads(configured_require_auth_for_reads, any_auth);
     if require_auth_for_reads && !any_auth {
         tracing::warn!(
             "require_auth_for_reads = true but no authentication is configured \
@@ -719,7 +717,7 @@ pub async fn build_router(
              credentials to lock down read endpoints."
         );
     }
-    if require_auth_for_reads && configured_require_auth_for_reads.is_none() && any_auth {
+    if require_auth_for_reads && configured_require_auth_for_reads.is_none() {
         tracing::info!(
             "require_auth_for_reads auto-enabled because authentication is configured \
              (api_key / user_api_keys / dashboard credentials). Dashboard reads now \
@@ -1340,6 +1338,20 @@ fn is_process_alive(pid: u32) -> bool {
     }
 }
 
+/// Resolve the effective value of `require_auth_for_reads` from the explicit
+/// config option and whether any authentication method is configured.
+///
+/// - `Some(explicit)` preserves the operator's stated intent verbatim.
+/// - `None` derives the value from `any_auth` so that setting any form of
+///   auth (api_key / user keys / dashboard credentials) automatically closes
+///   the dashboard reads allowlist.
+fn derive_require_auth_for_reads(configured: Option<bool>, any_auth: bool) -> bool {
+    match configured {
+        Some(explicit) => explicit,
+        None => any_auth,
+    }
+}
+
 /// Check if an LibreFang daemon is actually responding at the given address.
 /// This avoids false positives where a different process reused the same PID
 /// after a system reboot.
@@ -1357,5 +1369,30 @@ fn is_daemon_responding(addr: &str) -> bool {
         std::net::TcpStream::connect(addr_only)
             .map(|_| true)
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod derive_require_auth_for_reads_tests {
+    use super::derive_require_auth_for_reads;
+
+    #[test]
+    fn none_with_auth_enables() {
+        assert!(derive_require_auth_for_reads(None, true));
+    }
+
+    #[test]
+    fn none_without_auth_disables() {
+        assert!(!derive_require_auth_for_reads(None, false));
+    }
+
+    #[test]
+    fn some_false_is_preserved_even_when_auth_configured() {
+        assert!(!derive_require_auth_for_reads(Some(false), true));
+    }
+
+    #[test]
+    fn some_true_is_preserved_even_when_no_auth_configured() {
+        assert!(derive_require_auth_for_reads(Some(true), false));
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1788,17 +1788,23 @@ pub struct KernelConfig {
     /// config, budget, sessions, approvals, hands, skills, workflows, …)
     /// requires a bearer token.
     ///
-    /// * `None` (default, or `auto` / unset in config.toml) — **derive
-    ///   from `api_key`**: the reads allowlist is collapsed *automatically*
+    /// * `None` (default, unset in config.toml) — **derive from
+    ///   configured auth**: the reads allowlist is collapsed *automatically*
     ///   whenever any authentication is configured (non-empty `api_key`,
     ///   per-user keys, or dashboard credentials). This is the safe
     ///   default: operators who already set an `api_key` shouldn't also
     ///   have to remember a separate flag before their read endpoints
     ///   stop leaking agent IDs to the LAN.
-    /// * `Some(true)` — force the allowlist closed even when auth is
-    ///   misconfigured (the middleware will still refuse the read). Used
-    ///   to catch an accidental `api_key = ""` redeploy rather than
-    ///   silently exposing reads.
+    /// * `Some(true)` — state the intent explicitly. The daemon logs a
+    ///   boot-time warning if no authentication is actually configured
+    ///   (so an accidental `api_key = ""` redeploy is visible in the
+    ///   logs), but the middleware itself only enforces the closed
+    ///   allowlist when some form of auth is also configured: with no
+    ///   `api_key`, user keys, or dashboard credentials there is nothing
+    ///   to authenticate against and reads fall through to the
+    ///   unauthenticated local-development bypass. Configure an
+    ///   `api_key` (or per-user keys / dashboard credentials) alongside
+    ///   this flag to actually close the allowlist.
     /// * `Some(false)` — force the allowlist open even when `api_key`
     ///   is set. Provided as an explicit escape hatch for deployments
     ///   that front the daemon with an external auth proxy and want the

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1784,17 +1784,31 @@ pub struct KernelConfig {
     /// require a `Authorization: Bearer <key>` header.
     /// If empty, the API is unauthenticated (local development only).
     pub api_key: String,
-    /// When `true` AND `api_key` is configured, the dashboard read-endpoint
-    /// allowlist is collapsed to just static assets, OAuth entry points, and
-    /// `/api/health*`. Every other GET (agents, config, budget, sessions,
-    /// approvals, hands, skills, workflows, …) requires a valid bearer token.
+    /// Controls whether the dashboard read-endpoint allowlist (agents,
+    /// config, budget, sessions, approvals, hands, skills, workflows, …)
+    /// requires a bearer token.
     ///
-    /// Default is `false` to preserve the pre-flag behaviour where the
-    /// unauthenticated dashboard SPA could render before the user supplied
-    /// credentials. Operators exposing the daemon beyond loopback should
-    /// enable this to stop remote enumeration of agents, config, and spend.
-    #[serde(default)]
-    pub require_auth_for_reads: bool,
+    /// * `None` (default, or `auto` / unset in config.toml) — **derive
+    ///   from `api_key`**: the reads allowlist is collapsed *automatically*
+    ///   whenever any authentication is configured (non-empty `api_key`,
+    ///   per-user keys, or dashboard credentials). This is the safe
+    ///   default: operators who already set an `api_key` shouldn't also
+    ///   have to remember a separate flag before their read endpoints
+    ///   stop leaking agent IDs to the LAN.
+    /// * `Some(true)` — force the allowlist closed even when auth is
+    ///   misconfigured (the middleware will still refuse the read). Used
+    ///   to catch an accidental `api_key = ""` redeploy rather than
+    ///   silently exposing reads.
+    /// * `Some(false)` — force the allowlist open even when `api_key`
+    ///   is set. Provided as an explicit escape hatch for deployments
+    ///   that front the daemon with an external auth proxy and want the
+    ///   in-tree dashboard to keep rendering before the reverse proxy
+    ///   has attached its own credentials.
+    ///
+    /// Unauthenticated static assets, OAuth flow endpoints, and
+    /// `/api/health*` stay reachable in every mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_auth_for_reads: Option<bool>,
     /// Hex-encoded Ed25519 public keys (32 bytes → 64 hex chars) allowed to
     /// sign agent manifests. `verify_signed_manifest` requires the envelope's
     /// `signer_public_key` to be on this list before accepting a signature —
@@ -3399,7 +3413,7 @@ impl Default for KernelConfig {
             network: NetworkConfig::default(),
             channels: ChannelsConfig::default(),
             api_key: String::new(),
-            require_auth_for_reads: false,
+            require_auth_for_reads: None,
             trusted_manifest_signers: Vec::new(),
             dashboard_user: String::new(),
             dashboard_pass: String::new(),


### PR DESCRIPTION
## Summary
#2398 added \`require_auth_for_reads\` as an opt-in flag that collapses the dashboard public-read allowlist when set to \`true\`. In practice that meant an operator who set \`api_key = \"…\"\` but forgot the *separate* \`require_auth_for_reads = true\` was still leaking agent IDs, config, budget, sessions, and pending approvals to any host on the LAN — because the default was \`false\` and the flag name wasn't obvious.

The dashboard SPA already handles 401 via its existing login flow (\`setOnUnauthorized\` / \`getStoredApiKey\` / \`Authorization: Bearer\` injection), so the safe default is **\"close the allowlist whenever auth is configured\"**, not \"closed only when two separate knobs agree\".

## Fix
Switch \`KernelConfig.require_auth_for_reads\` from \`bool\` to \`Option<bool>\`:

- **\`None\` (default)** → derive from whether any authentication is configured (non-empty \`api_key\`, per-user API keys, or dashboard credentials). Setting an \`api_key\` now auto-collapses the reads allowlist, matching operator expectations.
- **\`Some(true)\`** → force closed even if auth looks misconfigured. Catches an accidental \`api_key = \"\"\` redeploy.
- **\`Some(false)\`** → explicit escape hatch for deployments fronted by an external auth proxy that want the in-tree dashboard to keep rendering before the reverse proxy attaches credentials.

The middleware allowlist itself is unchanged — \`/\` static assets, OAuth flow endpoints, and \`/api/health*\` stay reachable in every mode. When the auto-enable path kicks in the daemon logs an \`info!\` line so operators see reads have been locked.

## Dashboard impact
**None.** The SPA in \`crates/librefang-api/dashboard\` already reads a \`librefang-api-key\` entry from \`localStorage\`, injects \`Authorization: Bearer\` on every request, and intercepts 401 through \`setOnUnauthorized\` to trigger the login screen. An unauthenticated visitor lands on the login form, types their key, and resumes — same flow operators already use today with \`require_auth_for_reads = true\`.

## Migration
Operators who explicitly *want* open reads with an \`api_key\` set (reverse-proxy auth in front of the daemon, say) must now add \`require_auth_for_reads = false\` to \`config.toml\`. Previously they didn't need any flag at all. The one \`info!\` line on boot makes the transition discoverable.

## Test plan
- [x] \`cargo check -p librefang-api\` — clean (verifies the \`Option<bool>\` lands without breaking other readers)
- [ ] CI: \`cargo test -p librefang-api --lib middleware\` (tests still construct \`AuthState { require_auth_for_reads: false }\` directly — those stay compatible because \`AuthState\` still carries a plain \`bool\`; only the config-level type changed)
- [ ] CI: \`cargo clippy -p librefang-api -p librefang-types --all-targets -- -D warnings\`
- [ ] CI full workspace build