### PR TITLE
fix(dashboard): make overview stats cards responsive at md breakpoint

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -185,7 +185,7 @@ export function OverviewPage() {
       )}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 stagger-children">
+      <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4 stagger-children">
         {isLoading ? (
           // Loading skeletons
           <>


### PR DESCRIPTION
## Summary
- The 4 overview stats cards stayed at 2 columns in the 768–1023px (md) range, leaving each card stretched too wide and hard to read
- Move the grid breakpoint from `lg:grid-cols-4` to `md:grid-cols-4` so tablets in landscape and small laptops switch to 4 columns
- Phones (<640px) still render 2 columns; the main content grid below (`lg:grid-cols-3`) is unaffected

## Test plan
- [ ] Visit `/` at <640px / 768px / 1024px / 1440px widths and confirm the stats cards render as 2 / 4 / 4 / 4 columns with no horizontal overflow
- [ ] Confirm quick actions, recent agents, and system status sections below remain unaffected