### PR TITLE
fix(dashboard): tighten recent agents grid and widen running hand chips

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1096,7 +1096,7 @@ function ActiveHandChip({
 
   return (
     <div
-      className={`group relative flex flex-col gap-2 p-3 rounded-2xl border cursor-pointer transition-colors shrink-0 w-[260px] ${
+      className={`group relative flex flex-col gap-2 p-3 rounded-2xl border cursor-pointer transition-colors shrink-0 w-[320px] sm:w-[360px] ${
         warnState
           ? "border-warning/40 bg-warning/[0.06] hover:border-warning/60"
           : "border-success/40 bg-success/[0.06] hover:border-success/60"

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -266,13 +266,13 @@ export function OverviewPage() {
               </button>
             </div>
             {isLoading ? (
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {[1, 2].map(i => (
                   <div key={i} className="h-16 rounded-xl bg-gradient-to-r from-main via-surface-hover to-main bg-[length:200%_100%]" style={{ animation: "shimmer 1.5s ease-in-out infinite" }} />
                 ))}
               </div>
             ) : snapshot?.agents && snapshot.agents.length > 0 ? (
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {snapshot.agents.filter(a => !a.is_hand && !a.name.includes(":")).slice(0, 4).map(agent => (
                   <div
                     key={agent.id}


### PR DESCRIPTION
## Summary
- The Recent Agents grid on the Overview page stayed at 2 columns on every screen ≥640px, leaving each card too wide on large displays — bump to 4 columns at `xl`
- Running hand chips on `/hands` were fixed at `w-[260px]`, which felt cramped — widen to `w-[320px] sm:w-[360px]`

## Test plan
- [ ] Visit `/` at ≥1280px and confirm the Recent Agents section renders 4 cards per row
- [ ] Visit `/hands` with at least one running hand and confirm each chip is noticeably wider with no horizontal overflow on the strip