### PR TITLE
fix(dashboard): repair mobile layout breakage across pages

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/A2APage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.tsx
@@ -113,7 +113,7 @@ export function A2APage() {
       {showDiscover && (
         <Card padding="md" className="animate-fade-in-scale">
           <h3 className="text-sm font-black mb-3">{t("a2a.discover_agent")}</h3>
-          <div className="flex gap-3">
+          <div className="flex flex-col sm:flex-row gap-3">
             <input
               type="url"
               value={discoverUrl}

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -49,7 +49,7 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
               <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.level")}</label>
               <select
@@ -227,7 +227,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
             {/* Embedding */}
             <div>
               <h4 className="text-xs font-bold mb-3">Embedding</h4>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <span className={labelCls}>Provider</span>
                   <select value={form.embedding_provider ?? ""} onChange={e => setForm({ ...form, embedding_provider: e.target.value })} className={inputCls}>
@@ -269,7 +269,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
                   </label>
                 ))}
               </div>
-              <div className="grid grid-cols-2 gap-3 mt-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
                 <div>
                   <span className={labelCls}>Extraction Model</span>
                   <input value={form.pm_extraction_model ?? ""} onChange={e => setForm({ ...form, pm_extraction_model: e.target.value })}

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -344,7 +344,7 @@ export function ModelsPage() {
       {/* Add Model Modal */}
       <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">
         <form onSubmit={handleAdd} className="p-5 space-y-4 max-h-[70vh] overflow-y-auto">
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div className="col-span-2">
                   <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.model_id")} *</label>
                   <input value={formId} onChange={e => setFormId(e.target.value)} placeholder={t("models.model_id_placeholder")} className={inputClass} required />

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -345,7 +345,7 @@ export function ModelsPage() {
       <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">
         <form onSubmit={handleAdd} className="p-5 space-y-4 max-h-[70vh] overflow-y-auto">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div className="col-span-2">
+                <div className="sm:col-span-2">
                   <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.model_id")} *</label>
                   <input value={formId} onChange={e => setFormId(e.target.value)} placeholder={t("models.model_id_placeholder")} className={inputClass} required />
                 </div>

--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
@@ -289,13 +289,13 @@ function TotpSection() {
         {/* Setup flow */}
         <div className="py-4">
           {showResetPrompt && !setupData ? (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2">
               <input
                 type="text"
                 value={resetCode}
                 onChange={(e) => setResetCode(e.target.value)}
                 placeholder={t("settings.totp_reset_placeholder", "Current TOTP or recovery code")}
-                className="w-48 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
+                className="w-full sm:w-48 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
                 onKeyDown={(e) => e.key === "Enter" && resetCode && handleSetup(resetCode)}
               />
               <Button
@@ -312,13 +312,13 @@ function TotpSection() {
               </Button>
             </div>
           ) : showRevokePrompt && !setupData ? (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2">
               <input
                 type="text"
                 value={revokeCode}
                 onChange={(e) => setRevokeCode(e.target.value)}
                 placeholder={t("settings.totp_revoke_placeholder", "TOTP or recovery code")}
-                className="w-48 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
+                className="w-full sm:w-48 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
                 onKeyDown={(e) => e.key === "Enter" && revokeCode && handleRevoke()}
               />
               <Button variant="danger" size="sm" onClick={handleRevoke} disabled={!revokeCode || loading} isLoading={loading}>
@@ -357,7 +357,7 @@ function TotpSection() {
               </p>
               {setupData.qr_code && (
                 <div className="flex justify-center p-4 bg-white rounded-xl border border-border-subtle">
-                  <img src={setupData.qr_code} alt="TOTP QR Code" className="w-48 h-48" />
+                  <img src={setupData.qr_code} alt="TOTP QR Code" className="w-40 h-40 sm:w-48 sm:h-48" />
                 </div>
               )}
               <code className="block text-sm font-mono bg-main border border-border-subtle rounded-lg px-3 py-2 break-all select-all">

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -258,7 +258,7 @@ export function TerminalPage() {
           <div className="h-full min-h-[400px] flex flex-col">
             <div
               ref={containerRef}
-              className="flex-1 bg-[#1a1a2e] rounded-b-lg p-2 overflow-hidden h-full min-[1001px]:h-[70%]"
+              className="flex-1 bg-[#1a1a2e] rounded-b-lg p-2 overflow-hidden h-full lg:h-[70%]"
             />
           </div>
         </Card>


### PR DESCRIPTION
## Summary
Targeted fixes for layout regressions that break or cramp content on phones / small tablets. Audit-driven, narrow scope — no breakpoint tuning here, just real overflow / collapse bugs.

- **SettingsPage**: TOTP reset/revoke rows were `flex` with a fixed `w-48` input, so the input + 2 buttons overflowed phones. Now stack with `flex-col sm:flex-row` and `w-full sm:w-48`.
- **SettingsPage**: TOTP QR code was hard-coded `w-48 h-48` and got cropped on narrow screens. Shrunk to `w-40 h-40 sm:w-48 sm:h-48`.
- **MemoryPage**: Two-column form grids (add-memory dialog and config sections) were `grid-cols-2` with no mobile fallback, leaving inputs too narrow on phones. Now `grid-cols-1 sm:grid-cols-2`.
- **ModelsPage**: Add-custom-model modal form had `grid-cols-2` with no fallback. Now `grid-cols-1 sm:grid-cols-2`.
- **A2APage**: Discover overlay had `flex gap-3` for input + button, overflowing on phones. Now `flex-col sm:flex-row`.
- **TerminalPage**: Used a one-off `min-[1001px]:h-[70%]` breakpoint that left the terminal at full height below 1001px. Replaced with the standard `lg:h-[70%]`.

## Test plan
- [ ] Visit `/settings` on a phone-width viewport and walk through TOTP setup / reset / revoke — inputs and buttons should stack, no horizontal scroll, QR code fits the modal
- [ ] Visit `/memory` and open the add-memory dialog and the config section on a phone-width viewport — form fields stack to one column
- [ ] Visit `/models` and open "Add custom model" on a phone-width viewport — form fields stack to one column
- [ ] Visit `/a2a` and open the discover overlay on a phone-width viewport — input and button stack
- [ ] Visit `/terminal` at 800px and 1280px viewport widths — terminal fills the card without layout jumps