### PR TITLE
feat(plugins): enrich registry cards with manifest metadata

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2183,11 +2183,20 @@ export interface PluginItem {
   hooks?: { ingest?: boolean; after_turn?: boolean };
 }
 
+export interface RegistryPluginListing {
+  name: string;
+  installed: boolean;
+  version?: string | null;
+  description?: string | null;
+  author?: string | null;
+  hooks?: string[];
+}
+
 export interface RegistryEntry {
   name: string;
   github_repo: string;
   error?: string | null;
-  plugins: Array<{ name: string; installed: boolean }>;
+  plugins: RegistryPluginListing[];
 }
 
 export async function listPlugins(): Promise<{ plugins: PluginItem[]; total: number; plugins_dir: string }> {

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -228,33 +228,90 @@ export function PluginsPage() {
             <div className="space-y-8">
               {registries.map(reg => (
                 <div key={reg.name}>
-                  <div className="flex items-center gap-2 mb-3">
+                  <div className="flex items-center gap-2 mb-3 flex-wrap">
                     <h3 className="text-sm font-bold">{reg.name}</h3>
-                    <span className="text-[10px] text-text-dim font-mono">{reg.github_repo}</span>
+                    <a
+                      href={`https://github.com/${reg.github_repo}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-[10px] text-text-dim font-mono hover:text-brand transition-colors"
+                    >
+                      {reg.github_repo}
+                    </a>
+                    {reg.plugins.length > 0 && (
+                      <Badge variant="default">{reg.plugins.length}</Badge>
+                    )}
                     {reg.error && <Badge variant="error">{reg.error}</Badge>}
                   </div>
                   {reg.plugins.length === 0 ? (
                     <p className="text-xs text-text-dim italic">{t("plugins.no_available")}</p>
                   ) : (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 stagger-children">
                       {reg.plugins.map(rp => (
-                        <Card key={rp.name} padding="sm" className="flex items-center justify-between">
-                          <div className="flex items-center gap-3">
-                            <div className="w-8 h-8 rounded-lg bg-brand/10 flex items-center justify-center">
+                        <Card
+                          key={rp.name}
+                          padding="md"
+                          className="flex flex-col gap-3 hover:border-brand/30 transition-colors"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="w-9 h-9 rounded-xl bg-brand/10 flex items-center justify-center shrink-0">
                               <Puzzle className="w-4 h-4 text-brand" />
                             </div>
-                            <span className="text-sm font-bold">{rp.name}</span>
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-1.5 flex-wrap">
+                                <h4 className="text-sm font-bold truncate">{rp.name}</h4>
+                                {rp.version && (
+                                  <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-main text-text-dim font-mono">
+                                    {rp.version}
+                                  </span>
+                                )}
+                              </div>
+                              {rp.author && (
+                                <p className="text-[10px] text-text-dim/70 mt-0.5 truncate">
+                                  {rp.author}
+                                </p>
+                              )}
+                            </div>
                           </div>
-                          {rp.installed ? (
-                            <Badge variant="success"><Check className="w-3 h-3 mr-1" />{t("plugins.installed")}</Badge>
-                          ) : (
-                            <Button variant="primary" size="sm"
-                              onClick={() => handleRegistryInstall(rp.name, reg.github_repo)}
-                              disabled={installingName === rp.name}>
-                              {installingName === rp.name ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Download className="w-3.5 h-3.5 mr-1" />}
-                              {t("plugins.install")}
-                            </Button>
-                          )}
+                          <p
+                            className="text-xs text-text-dim leading-relaxed overflow-hidden"
+                            style={{
+                              display: "-webkit-box",
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: "vertical",
+                              minHeight: "2.25rem",
+                            }}
+                          >
+                            {rp.description || t("plugins.no_description", { defaultValue: "No description provided." })}
+                          </p>
+                          <div className="flex items-center justify-between gap-2 mt-auto">
+                            <div className="flex items-center gap-1 flex-wrap min-w-0">
+                              {(rp.hooks ?? []).slice(0, 3).map(h => (
+                                <Badge key={h} variant="brand">{h}</Badge>
+                              ))}
+                              {(rp.hooks?.length ?? 0) > 3 && (
+                                <span className="text-[9px] text-text-dim">+{(rp.hooks?.length ?? 0) - 3}</span>
+                              )}
+                            </div>
+                            {rp.installed ? (
+                              <Badge variant="success">
+                                <Check className="w-3 h-3 mr-1" />
+                                {t("plugins.installed")}
+                              </Badge>
+                            ) : (
+                              <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={() => handleRegistryInstall(rp.name, reg.github_repo)}
+                                disabled={installingName === rp.name}
+                              >
+                                {installingName === rp.name
+                                  ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                                  : <Download className="w-3.5 h-3.5 mr-1" />}
+                                {t("plugins.install")}
+                              </Button>
+                            )}
+                          </div>
                         </Card>
                       ))}
                     </div>

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -654,6 +654,10 @@ pub async fn list_plugin_registries(State(state): State<Arc<AppState>>) -> impl 
                     serde_json::json!({
                         "name": e.name,
                         "installed": installed_names.contains(&e.name),
+                        "version": e.version,
+                        "description": e.description,
+                        "author": e.author,
+                        "hooks": e.hooks,
                     })
                 })
                 .collect::<Vec<_>>(),

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -876,21 +876,123 @@ async fn install_from_registry(
 }
 
 /// Lightweight entry returned when browsing a registry.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// Populated from each plugin's `plugin.toml` when available. Fields beyond
+/// `name`/`registry` are optional so that registries that fail to serve a
+/// manifest still degrade gracefully to a name-only listing.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct RegistryPluginEntry {
     pub name: String,
     pub registry: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Hook names declared by the plugin (e.g. `ingest`, `after_turn`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hooks: Vec<String>,
 }
 
-/// List available plugin directory names from a GitHub registry.
+/// Disk cache file for an enriched registry listing.
+///
+/// Stored separately from the `index.json` cache so that listings built from
+/// the GitHub Contents API + per-plugin manifest fetches do not clobber a
+/// signed index cache.
+fn registry_listing_cache_path(registry: &str) -> std::path::PathBuf {
+    let cache_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".librefang")
+        .join("registry_cache");
+    let safe_name: String = registry
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    cache_dir.join(format!("{safe_name}__listing.json"))
+}
+
+/// Fetch and parse `plugins/<name>/plugin.toml` from a registry, extracting the
+/// fields we care about for a browse-listing card. Network and parse errors
+/// degrade to `None` so a single bad plugin does not sink the whole listing.
+async fn fetch_registry_plugin_meta(
+    client: &reqwest::Client,
+    github_repo: &str,
+    name: &str,
+) -> RegistryPluginEntry {
+    let mut entry = RegistryPluginEntry {
+        name: name.to_string(),
+        registry: github_repo.to_string(),
+        ..Default::default()
+    };
+
+    let url =
+        format!("https://raw.githubusercontent.com/{github_repo}/main/plugins/{name}/plugin.toml");
+    let text = match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp.text().await.ok(),
+        _ => None,
+    };
+    let Some(text) = text else { return entry };
+
+    let Ok(value) = toml::from_str::<toml::Value>(&text) else {
+        return entry;
+    };
+    if let Some(v) = value.get("version").and_then(|v| v.as_str()) {
+        entry.version = Some(v.to_string());
+    }
+    if let Some(v) = value.get("description").and_then(|v| v.as_str()) {
+        entry.description = Some(v.to_string());
+    }
+    if let Some(v) = value.get("author").and_then(|v| v.as_str()) {
+        entry.author = Some(v.to_string());
+    }
+    if let Some(hooks) = value.get("hooks").and_then(|v| v.as_table()) {
+        entry.hooks = hooks.keys().cloned().collect();
+        entry.hooks.sort();
+    }
+    entry
+}
+
+/// List available plugins in a GitHub registry, enriched with manifest metadata.
+///
+/// Lists `plugins/` via the GitHub Contents API, then fetches each plugin's
+/// `plugin.toml` concurrently to populate `version/description/author/hooks`.
+/// Results are cached to disk with the same TTL as the signed index cache
+/// to avoid hammering GitHub on every dashboard reload.
 pub async fn list_registry_plugins(github_repo: &str) -> Result<Vec<RegistryPluginEntry>, String> {
     validate_github_repo(github_repo)?;
-    let url = format!("https://api.github.com/repos/{github_repo}/contents/plugins");
+
+    let ttl = std::env::var("LIBREFANG_REGISTRY_CACHE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(default_registry_cache_ttl_secs);
+    let skip_cache = std::env::var("LIBREFANG_REGISTRY_NO_CACHE").as_deref() == Ok("1");
+    let cache_path = registry_listing_cache_path(github_repo);
+
+    if !skip_cache {
+        if let Some(bytes) = load_registry_cache(&cache_path, ttl) {
+            if let Ok(cached) = serde_json::from_slice::<Vec<RegistryPluginEntry>>(&bytes) {
+                debug!(
+                    "Using cached registry listing for {github_repo} ({} plugins)",
+                    cached.len()
+                );
+                return Ok(cached);
+            }
+        }
+    }
+
     let client = crate::http_client::client_builder()
         .timeout(std::time::Duration::from_secs(15))
         .build()
         .map_err(|e| format!("HTTP client error: {e}"))?;
 
+    let url = format!("https://api.github.com/repos/{github_repo}/contents/plugins");
     let resp = client
         .get(&url)
         .header("Accept", "application/vnd.github.v3+json")
@@ -910,14 +1012,25 @@ pub async fn list_registry_plugins(github_repo: &str) -> Result<Vec<RegistryPlug
         .await
         .map_err(|e| format!("Failed to parse registry listing: {e}"))?;
 
-    Ok(entries
+    let names: Vec<String> = entries
         .into_iter()
         .filter(|e| e.content_type == "dir")
-        .map(|e| RegistryPluginEntry {
-            name: e.name,
-            registry: github_repo.to_string(),
-        })
-        .collect())
+        .map(|e| e.name)
+        .collect();
+
+    let futs = names
+        .iter()
+        .map(|n| fetch_registry_plugin_meta(&client, github_repo, n));
+    let mut plugins: Vec<RegistryPluginEntry> = futures::future::join_all(futs).await;
+    plugins.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if !skip_cache {
+        if let Ok(bytes) = serde_json::to_vec(&plugins) {
+            save_registry_cache(&cache_path, &bytes);
+        }
+    }
+
+    Ok(plugins)
 }
 
 /// Install from a git URL by cloning.
@@ -4017,6 +4130,33 @@ after_turn = "hooks/after_turn.py"
             ..Default::default()
         };
         assert!(!check_hooks_exist(&plugin_dir, &manifest_escape));
+    }
+
+    /// Live listing smoke test — ensures the enriched listing populates
+    /// `description`/`version`/`hooks` from at least one plugin's `plugin.toml`.
+    /// Ignored by default — requires network access to GitHub.
+    #[tokio::test]
+    #[ignore]
+    async fn test_list_registry_plugins_enriched() {
+        // Skip disk cache so a cached name-only listing from a previous run
+        // cannot mask a regression.
+        std::env::set_var("LIBREFANG_REGISTRY_NO_CACHE", "1");
+        let entries = list_registry_plugins("librefang/librefang-registry")
+            .await
+            .expect("registry listing should succeed");
+        assert!(!entries.is_empty(), "expected at least one plugin");
+        assert!(
+            entries.iter().any(|e| e.description.is_some()),
+            "expected at least one plugin with a description"
+        );
+        assert!(
+            entries.iter().any(|e| e.version.is_some()),
+            "expected at least one plugin with a version"
+        );
+        assert!(
+            entries.iter().any(|e| !e.hooks.is_empty()),
+            "expected at least one plugin declaring hooks"
+        );
     }
 
     /// Integration test: install from GitHub registry, run hook, then remove.


### PR DESCRIPTION
## Summary
- Before: `/api/plugins/registries` returned only `{name, installed}` per plugin, so the marketplace cards showed an icon, a name, and an install button — and nothing else.
- Now: `list_registry_plugins` fetches each `plugin.toml` from the registry concurrently and surfaces `version / description / author / hooks`. Results are disk-cached next to the signed index cache (`registry_cache/<repo>__listing.json`, 1h TTL) so the dashboard does not hammer GitHub on every reload.
- Registry card is redesigned: name + version chip, author, 2-line description, hook badges, source-repo link on the registry header, and the existing install / installed affordance.

## Test plan
- [x] `cargo clippy -p librefang-runtime -p librefang-api --all-targets -- -D warnings`
- [x] `cargo test -p librefang-runtime --lib plugin_manager` (8 passed)
- [x] `cargo test -p librefang-runtime --lib plugin_manager::tests::test_list_registry_plugins_enriched -- --ignored` (new live smoke test — asserts description/version/hooks populate against `librefang/librefang-registry`)
- [x] `npm run typecheck` in `crates/librefang-api/dashboard`
- [x] `npm run build` in `crates/librefang-api/dashboard`