### PR TITLE
fix(dashboard): tighten card grid breakpoints across pages

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -400,7 +400,7 @@ export function AgentsPage() {
       </div>
 
       {agentsQuery.isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6">
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
         </div>
       ) : filteredAgents.length === 0 ? (
@@ -431,7 +431,7 @@ export function AgentsPage() {
           />
         )
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6 stagger-children">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 stagger-children">
           {coreAgents.map(agent => renderAgentCard(agent))}
         </div>
       )}

--- a/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
@@ -274,13 +274,13 @@ export function CommsPage() {
 
           {/* Channels Grid */}
           {isLoading ? (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6">
               {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
             </div>
           ) : filteredChannels.length === 0 ? (
             <EmptyState title={t("common.no_data")} icon={<Radio className="h-6 w-6" />} />
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6">
               {filteredChannels.map((c) => (
                 <Card key={c.name} hover padding="md">
                   <div className="flex items-center justify-between mb-3">

--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
@@ -190,7 +190,7 @@ export function GoalsPage() {
             <h3 className="text-lg font-black tracking-tight mb-1">{t("goals.pick_template")}</h3>
             <p className="text-sm text-text-dim">{t("goals.pick_template_desc")}</p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 stagger-children">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 stagger-children">
             {templates.map((tpl) => {
               const Icon = TEMPLATE_ICONS[tpl.icon] ?? Target;
               const isApplying = applyingTemplate === tpl.id;
@@ -231,7 +231,7 @@ export function GoalsPage() {
       ) : (
         <>
           {/* KPI row */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 xl:grid-cols-4 stagger-children">
+          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
             {[
               { label: t("goals.total"), value: stats.total, color: "text-brand", bg: "bg-brand/10", icon: Target },
               { label: t("goals.pending"), value: stats.pending, color: "text-text-dim", bg: "bg-main", icon: Clock },

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1158,7 +1158,7 @@ function ActiveHandChip({
 
 function HandCardGridSkeleton() {
   return (
-    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6">
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="flex flex-col rounded-2xl border border-border-subtle bg-surface">
           <div className="flex items-start gap-3 p-4 pb-3">
@@ -1692,7 +1692,7 @@ export function HandsPage() {
           }
         />
       ) : (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6 stagger-children">
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 stagger-children">
           {filtered.map((h) => {
             const isActive = activeHandIds.has(h.id);
             const instance = instanceByHandId.get(h.id);

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -210,7 +210,7 @@ export function RuntimePage() {
       ) : (
         <>
           {/* ── KPI Cards ── */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 xl:grid-cols-4 stagger-children">
+          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
             {[
               { icon: Timer, label: t("runtime.system_uptime"), value: uptimeStr, color: "text-success", bg: "bg-success/10" },
               { icon: Layers, label: t("runtime.active_agents"), value: `${status?.active_agent_count ?? 0} / ${status?.agent_count ?? 0}`, color: "text-brand", bg: "bg-brand/10" },

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -715,13 +715,13 @@ export function SkillsPage() {
       {/* Content */}
       {viewMode === "installed" ? (
         skillsQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : installedSkills.length === 0 ? (
           <EmptyState title={t("skills.no_skills")} icon={<Package className="h-6 w-6" />} />
         ) : (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {installedSkills.map(s => (
               <InstalledSkillCard key={s.name} skill={s} onUninstall={handleUninstall} t={t} />
             ))}
@@ -729,7 +729,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "marketplace" ? (
         isMarketplaceLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isRateLimited ? (
@@ -740,7 +740,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} description={search ? t("skills.try_different_search", { defaultValue: "Try a different search term." }) : t("skills.browse_unavailable", { defaultValue: "Browse is temporarily unavailable. Try searching above." })} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+            <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
               {filteredMarketplace.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "clawhub")}
@@ -752,7 +752,7 @@ export function SkillsPage() {
         )
       ) : viewMode === "skillhub" ? (
         isSkillhubLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {[1, 2, 3, 4, 5, 6].map(i => <CardSkeleton key={i} />)}
           </div>
         ) : isSkillhubRateLimited ? (
@@ -763,7 +763,7 @@ export function SkillsPage() {
           <EmptyState title={t("skills.no_results")} icon={<Search className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-            <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+            <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
               {filteredSkillhub.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
                   onInstall={(slug) => handleInstall(slug, "skillhub")}
@@ -776,12 +776,12 @@ export function SkillsPage() {
       ) : (
         /* viewMode === "fanghub" — official LibreFang registry skills */
         fanghubQuery.isLoading ? (
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">{[1, 2, 3].map(i => <CardSkeleton key={i} />)}</div>
         ) : filteredFanghub.length === 0 ? (
           <EmptyState title={t("skills.no_results")} icon={<Zap className="h-6 w-6" />} />
         ) : (
           <div className="overflow-y-auto max-h-[600px] pr-1">
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
+          <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {filteredFanghub.map((skill: FangHubSkill) => (
               <FangHubSkillCard
                 key={skill.name}

--- a/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
@@ -219,7 +219,7 @@ export function TelemetryPage() {
               <Badge variant="brand" className="ml-2">v{parsed.system.version}</Badge>
             )}
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 xl:grid-cols-8 stagger-children">
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4 xl:grid-cols-8 stagger-children">
             <Card hover padding="md">
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">{t("telemetry.uptime")}</span>
@@ -295,7 +295,7 @@ export function TelemetryPage() {
             <h2 className="text-sm font-black tracking-tight uppercase">{t("telemetry.llm_usage")}</h2>
             <Badge variant="default" className="ml-2">{t("telemetry.tokens_1h")}</Badge>
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-5 stagger-children">
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-5 stagger-children">
             <Card hover padding="md">
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">{t("telemetry.total_tokens")}</span>
@@ -334,7 +334,7 @@ export function TelemetryPage() {
           </div>
 
           {/* ── Per-Agent Table + HTTP Endpoints ── */}
-          <div className="grid gap-6 lg:grid-cols-2 stagger-children">
+          <div className="grid gap-6 md:grid-cols-2 stagger-children">
             {/* Per-Agent Token Usage */}
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -233,7 +233,7 @@ export function WorkflowsPage() {
       {/* Templates Tab */}
       {activeTab === "templates" && (
         apiTemplates.length > 0 ? (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
             {apiTemplates.map(tmpl => {
               const Icon = categoryIconMap[tmpl.category || ""] || Layers;
               const stepCount = tmpl.steps?.length ?? 0;


### PR DESCRIPTION
## Summary
Card grids on many pages were stuck at 1–2 columns until the `lg` (1024px) or `xl` (1280px) breakpoint, leaving cards stretched too wide on tablets and small laptops. This shifts the column jumps one breakpoint earlier so middle screen sizes (640–1280px) actually use the available width.

Pattern: where a grid went `md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 …`, it now goes `sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 …` (each step shifted down by one breakpoint).

Affected pages and grids:
- **AgentsPage** lines 403, 434 — agent card grid
- **HandsPage** lines 1161, 1695 — hand card grid + skeleton
- **SkillsPage** 8 grids in the marketplace/installed/skeleton sections
- **CommsPage** lines 277, 283 — channels grid + skeleton
- **WorkflowsPage** line 236 — templates grid
- **GoalsPage** line 193 — templates grid; line 234 — KPI row (was 2→4 at xl, now 2→4 at md)
- **RuntimePage** line 213 — KPI row (same fix)
- **TelemetryPage** line 222 — system stats (lg→md), line 298 — token KPIs (added md:grid-cols-3), line 337 — per-agent table (lg→md)

Not touched (already fine or risky):
- OverviewPage main grid (left col uses `lg:col-span-2` — would need paired bump, prefer to leave)
- Sidebar layouts (`lg:grid-cols-[1fr_300px]` in Workflows/Goals) — sidebar would be cramped at 768px
- AnalyticsPage, NetworkPage, A2APage grids — already use `md:` jumps, no improvement available

## Test plan
- [ ] Visit `/agents`, `/hands`, `/skills`, `/comms`, `/workflows`, `/goals` at viewport widths 640px / 768px / 1024px / 1280px / 1920px and confirm card counts per row increase progressively without overflow
- [ ] Visit `/runtime` and `/telemetry` at the same widths and confirm KPI rows fill the available width on tablets
- [ ] Spot-check that no card looks too narrow / clipped at any breakpoint