### PR TITLE
ci: broaden issue auto-label coverage and add backfill

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -62,6 +62,9 @@
   description: "New or updated LLM provider driver"
 
 # Status
+- name: "needs-triage"
+  color: "ededed"
+  description: "Auto-applied when the issue title/body matched no area label — needs maintainer review"
 - name: "needs-rfc"
   color: "d876e3"
   description: "Requires an RFC before implementation"

--- a/.github/scripts/auto-label-issue.sh
+++ b/.github/scripts/auto-label-issue.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Compute area / type labels for a librefang issue based on its title and
+# body. Used by .github/workflows/issue-auto-label.yml — both the
+# event-driven path (single new/edited issue) and the workflow_dispatch
+# backfill path (re-label all unlabeled open issues).
+#
+# Usage:
+#   auto-label-issue.sh <issue_number> <title> <body_file>
+#
+# Output (stdout): a comma-separated list of label names, no leading
+# comma, no trailing newline. Empty output means "no labels to apply".
+#
+# Design notes
+# - Both title and body are scanned. Body is read from a file so newlines
+#   and shell metacharacters survive the env -> arg boundary.
+# - Each rule sets a `matched` flag. If nothing matched after every rule
+#   has run, the script falls back to `needs-triage` so maintainers can
+#   spot orphaned issues in the list view.
+# - Conventional-commit-style title prefixes are matched as well, but
+#   chore: / refactor: / test: only set the matched flag without adding
+#   a label (they're meta, not category).
+# - Keyword regexes use `\b` word boundaries where the keyword is short
+#   enough to false-positive on substrings (e.g. `\bcli\b` so it doesn't
+#   trip on `client`).
+
+set -euo pipefail
+
+issue_number="${1:-}"
+title="${2:-}"
+body_file="${3:-/dev/null}"
+
+if [ -z "$issue_number" ] || [ -z "$title" ]; then
+  echo "usage: $0 <issue_number> <title> <body_file>" >&2
+  exit 2
+fi
+
+title_lower=$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]')
+body_lower=$(tr '[:upper:]' '[:lower:]' < "$body_file" 2>/dev/null || true)
+combined=$(printf '%s\n%s' "$title_lower" "$body_lower")
+
+labels=""
+matched=0
+
+# ── Conventional commit prefix → type label (title only) ─────────────
+case "$title_lower" in
+  feat:*|'feat('*|feat!:*)
+    labels="$labels,enhancement"; matched=1 ;;
+  fix:*|'fix('*|fix!:*)
+    labels="$labels,bug"; matched=1 ;;
+  perf:*|'perf('*)
+    labels="$labels,enhancement"; matched=1 ;;
+  docs:*|doc:*|'docs('*)
+    labels="$labels,area/docs"; matched=1 ;;
+  ci:*|build:*|'ci('*|'build('*)
+    labels="$labels,area/ci"; matched=1 ;;
+  refactor:*|chore:*|test:*|'refactor('*|'chore('*|'test('*)
+    matched=1 ;;
+esac
+
+# ── Keyword → area label (title + body) ──────────────────────────────
+add_label_if_match() {
+  local pattern="$1"
+  local label="$2"
+  if printf '%s' "$combined" | grep -qiE -- "$pattern"; then
+    labels="$labels,$label"
+    matched=1
+  fi
+}
+
+add_label_if_match 'channel|telegram|discord|slack|whatsapp|feishu|webhook|messaging' 'area/channels'
+add_label_if_match 'skill|fanghub|marketplace' 'area/skills'
+add_label_if_match 'kernel|scheduler|cron|rbac|workflow|trigger|\bevent\b|\btask\b|session|\bhand\b|spawn' 'area/kernel'
+add_label_if_match 'runtime|agent.?loop|\bllm\b|wasm|sandbox|driver|provider|\bmcp\b|tool.?call|prompt' 'area/runtime'
+add_label_if_match '\bapi\b|endpoint|dashboard|frontend|\bui\b|react|http|rest|websocket|\broute\b' 'area/api'
+add_label_if_match '\bsdk\b|python|javascript|typescript|\bnpm\b|\bpip\b' 'area/sdk'
+add_label_if_match '\bmemory\b|knowledge|vector|embedding|sqlite' 'area/memory'
+add_label_if_match 'security|\bauth\b|\btoken\b|vulnerability|audit|taint|capability|approval|totp|\bcve\b|sandbox.escape' 'area/security'
+add_label_if_match 'docker|deploy|github.?action|gh.?action|pipeline|\bbuild\b' 'area/ci'
+add_label_if_match 'documentation|readme|\bguide\b|tutorial|translat|i18n' 'area/docs'
+add_label_if_match '\bcli\b|\btui\b' 'area/cli'
+add_label_if_match 'tauri|desktop.?app' 'area/desktop'
+add_label_if_match 'translat|i18n|chinese|japanese|korean' 'no-rust-required'
+
+# ── Fallback ────────────────────────────────────────────────────────
+if [ "$matched" -eq 0 ]; then
+  labels="needs-triage"
+fi
+
+# ── Strip leading comma + dedupe + drop empties ─────────────────────
+printf '%s' "${labels#,}" \
+  | tr ',' '\n' \
+  | grep -v '^$' \
+  | sort -u \
+  | paste -sd, -

--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -2,48 +2,78 @@ name: Issue Auto Label
 
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: 'Re-label all open issues currently missing labels'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
-  label:
+  label-event:
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
-      - name: Label issue by title keywords
+      - uses: actions/checkout@v4
+      - name: Compute and apply labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          TITLE=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]')
-          ISSUE="${{ github.event.issue.number }}"
-          REPO="${{ github.repository }}"
-          LABELS=""
-
-          # By type prefix
-          case "$TITLE" in
-            feat:*|'feat('*) LABELS="$LABELS,enhancement" ;;
-            fix:*|'fix('*)   LABELS="$LABELS,bug" ;;
-            docs:*|doc:*)    LABELS="$LABELS,area/docs" ;;
-            ci:*|build:*)    LABELS="$LABELS,area/ci" ;;
-          esac
-
-          # By keyword
-          echo "$TITLE" | grep -qiE 'channel|telegram|discord|slack|whatsapp' && LABELS="$LABELS,area/channels"
-          echo "$TITLE" | grep -qiE 'skill|fanghub|marketplace' && LABELS="$LABELS,area/skills"
-          echo "$TITLE" | grep -qiE 'kernel|scheduler|cron|rbac' && LABELS="$LABELS,area/kernel"
-          echo "$TITLE" | grep -qiE 'runtime|llm|wasm|sandbox|driver' && LABELS="$LABELS,area/runtime"
-          echo "$TITLE" | grep -qiE 'sdk|python|javascript|typescript' && LABELS="$LABELS,area/sdk"
-          echo "$TITLE" | grep -qiE 'security|auth|token|vulnerability' && LABELS="$LABELS,area/security"
-          echo "$TITLE" | grep -qiE 'docker|deploy|ci|workflow|action' && LABELS="$LABELS,area/ci"
-          echo "$TITLE" | grep -qiE 'translat|i18n|chinese|japanese|korean' && LABELS="$LABELS,area/docs,no-rust-required"
-
-          # Clean leading comma and apply
-          LABELS=$(echo "$LABELS" | sed 's/^,//')
-          if [ -n "$LABELS" ]; then
-            gh issue edit "$ISSUE" --repo "$REPO" --add-label "$LABELS"
-            echo "Applied labels: $LABELS"
+          set -euo pipefail
+          body_file=$(mktemp)
+          # ISSUE_BODY may be unset / null on minimal issues; printf
+          # tolerates an empty value and writes nothing.
+          printf '%s' "${ISSUE_BODY:-}" > "$body_file"
+          labels=$(bash .github/scripts/auto-label-issue.sh "$ISSUE_NUMBER" "$ISSUE_TITLE" "$body_file")
+          rm -f "$body_file"
+          if [ -n "$labels" ]; then
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$labels"
+            echo "#$ISSUE_NUMBER → $labels"
           else
-            echo "No labels matched"
+            echo "#$ISSUE_NUMBER → no labels (script returned empty)"
           fi
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.backfill == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Re-label every unlabeled open issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Pull every open issue with zero labels. base64-encode each
+          # row so titles / bodies with newlines or quotes survive the
+          # while-read boundary.
+          gh issue list --repo "$REPO" --state open --limit 1000 \
+            --json number,title,body,labels \
+            --jq '.[] | select(.labels | length == 0) | @base64' \
+            | while IFS= read -r row; do
+                decoded=$(printf '%s' "$row" | base64 -d)
+                num=$(printf '%s' "$decoded" | jq -r '.number')
+                title=$(printf '%s' "$decoded" | jq -r '.title')
+                body=$(printf '%s' "$decoded" | jq -r '.body // ""')
+                body_file=$(mktemp)
+                printf '%s' "$body" > "$body_file"
+                labels=$(bash .github/scripts/auto-label-issue.sh "$num" "$title" "$body_file")
+                rm -f "$body_file"
+                if [ -n "$labels" ]; then
+                  gh issue edit "$num" --repo "$REPO" --add-label "$labels" \
+                    && echo "#$num → $labels" \
+                    || echo "#$num → FAILED to apply $labels"
+                else
+                  echo "#$num → no labels"
+                fi
+              done


### PR DESCRIPTION
## Why
Looking at recent open issues, four out of the most recent unlabeled batch (#2438, #2368, #2344, #2333) were going through with **zero** labels even though each one clearly belongs to an existing `area/*`. The current `issue-auto-label.yml` had three blind spots:

1. **Title-only matching, narrow keyword list.** It scans only the title, and only for `channel|kernel|runtime|sdk|security|docker|translat`. Issues mentioning `memory`, `api`, `mcp`, `provider`, `session`, `task`, `trigger`, `event`, `dashboard`, `cli` all slip through — even though `area/memory`, `area/api`, `area/cli`, `area/desktop` already exist in `labels.yml`.
2. **Conventional-commit prefix is the only path to a type label.** Bug reports almost never start with `fix:`, so they never get the `bug` label.
3. **`opened`-only trigger.** Reopened / edited issues never re-run, and there's no way to clean up historical orphans.

## What
- Extract the labelling rules to `.github/scripts/auto-label-issue.sh` so the same code drives both the event-driven path and the new backfill path.
- Scan **title AND body**, with `\b...\b` word-boundary regexes where the keyword is short enough to false-positive (`\bcli\b`, `\bapi\b`, `\bevent\b`, `\bauth\b`).
- Add patterns for `area/api`, `area/memory`, `area/cli`, `area/desktop`, plus `feishu`/`webhook` channels, `mcp`/`provider`/`prompt` runtime, and more conventional-commit prefixes (`perf`, `refactor`, `chore`, `test`).
- Fall back to a new **`needs-triage`** label (added to `labels.yml`) when no rule matches, so orphan issues stay visible.
- Trigger on `[opened, reopened, edited]`.
- Add a `workflow_dispatch` input `backfill: true` that re-runs the labeller against every open issue currently missing labels — one-shot history cleanup plus a knob for future rule iterations.

## Smoke test
Ran the script locally against the four issues that motivated this PR:

| Issue | Title (truncated) | Old labels | New labels |
|---|---|---|---|
| #2438 | "Trigger event wiring: MemoryUpdate never emitted…" | — | `area/kernel` |
| #2368 | "Kimi/Moonshot provider: Rate limited after 3 retries…" | — | `area/runtime` |
| #2344 | "session_repair misses orphaned tool_use IDs…" | — | `area/kernel` |
| #2333 | "Emit Task Board events… expose TriggerPattern::Task*…" | — | `area/kernel` |

Plus a few synthetic cases:
- Random title with no signal → `needs-triage` ✓
- `feat: add a thing` → `enhancement` ✓
- `fix(channels): telegram polls leak` → `area/channels,bug` ✓

## Test plan
- [ ] After merge, `Label Sync` job picks up the new `needs-triage` label (or just runs `gh workflow run label-sync.yml`)
- [ ] Run `gh workflow run issue-auto-label.yml -f backfill=true` to backfill the historical orphans, then spot-check a few of the previously unlabeled issues to confirm they got area labels
- [ ] Open a fresh test issue with title `Test memory leak` and confirm it gets `area/memory` automatically
- [ ] Edit an existing issue's title and confirm the workflow re-runs and applies new labels