### PR TITLE
fix(ci): match camelCase/snake_case keywords in issue auto-label

### DIFF
--- a/.github/scripts/auto-label-issue.sh
+++ b/.github/scripts/auto-label-issue.sh
@@ -71,13 +71,20 @@ add_label_if_match() {
   fi
 }
 
+# Keyword regexes use a left-anchored \b only (no trailing \b) for words
+# that commonly appear glued to a suffix in librefang's domain vocabulary
+# — `MemoryUpdate`, `EventBus`, `TaskBoard`, `tool_use`, `tool_result`,
+# `EmbeddingStore`, etc. The leading \b still prevents substring hits
+# like `remembered` (no \b before `mem`) or `subtask` (no \b before
+# `task`). Words with high suffix FP risk (`hand`, `auth`) keep the
+# trailing \b.
 add_label_if_match 'channel|telegram|discord|slack|whatsapp|feishu|webhook|messaging' 'area/channels'
 add_label_if_match 'skill|fanghub|marketplace' 'area/skills'
-add_label_if_match 'kernel|scheduler|cron|rbac|workflow|trigger|\bevent\b|\btask\b|session|\bhand\b|spawn' 'area/kernel'
-add_label_if_match 'runtime|agent.?loop|\bllm\b|wasm|sandbox|driver|provider|\bmcp\b|tool.?call|prompt' 'area/runtime'
+add_label_if_match 'kernel|scheduler|cron|rbac|workflow|trigger|\bevent|\btask|session|\bhand\b|spawn' 'area/kernel'
+add_label_if_match 'runtime|agent.?loop|\bllm\b|wasm|sandbox|driver|provider|\bmcp\b|\btool[._ -]?(call|use|result)|prompt' 'area/runtime'
 add_label_if_match '\bapi\b|endpoint|dashboard|frontend|\bui\b|react|http|rest|websocket|\broute\b' 'area/api'
 add_label_if_match '\bsdk\b|python|javascript|typescript|\bnpm\b|\bpip\b' 'area/sdk'
-add_label_if_match '\bmemory\b|knowledge|vector|embedding|sqlite' 'area/memory'
+add_label_if_match '\bmemory|knowledge|vector|embedding|sqlite' 'area/memory'
 add_label_if_match 'security|\bauth\b|\btoken\b|vulnerability|audit|taint|capability|approval|totp|\bcve\b|sandbox.escape' 'area/security'
 add_label_if_match 'docker|deploy|github.?action|gh.?action|pipeline|\bbuild\b' 'area/ci'
 add_label_if_match 'documentation|readme|\bguide\b|tutorial|translat|i18n' 'area/docs'


### PR DESCRIPTION
## Why
The keyword regexes from #2455 / #2457 were double-anchored with `\b`, so glued-suffix forms common in librefang's domain vocabulary silently fell through:

| Title | Old labels | Should have been |
|---|---|---|
| #2438 \"Trigger event wiring: **MemoryUpdate** never emitted…\" | `area/kernel` only | `area/kernel` + `area/memory` |
| #2344 \"session_repair misses orphaned **tool_use** IDs when **ToolResult** is misplaced…\" | `area/kernel` only | `area/kernel` + `area/runtime` |

`\bmemory\b` has no word boundary inside `memoryupdate` (no transition between `y` and `u`), and `tool.?call` doesn't cover `tool_use` / `tool_result`.

## What
- Drop the trailing `\b` on the keywords most prone to legitimate suffixing in this codebase: `memory`, `event`, `task`. They now match `MemoryUpdate`, `EventBus`, `TaskBoard`, `task_queue`, `event_loop`, etc.
- Replace `tool.?call` with `\btool[._ -]?(call|use|result)` so all three tool-* forms (and `tool-call`, `tool_call`, `toolcall`) hit `area/runtime`.
- Keep both `\b` anchors on words with high FP risk (`hand`, `auth`).
- The leading `\b` is preserved everywhere — that's what actually prevents substring matches like `remembered` → `memory` or `subtask` → `task`.

## Smoke test
```
─ camelCase / snake_case targets ─
#2438 (MemoryUpdate):              area/kernel,area/memory     ✓
#2344 (tool_use, ToolResult):      area/kernel,area/runtime    ✓
#2333 (TriggerPattern::Task*):     area/kernel                  ✓

─ regression check ─
#2368 (provider):                  area/runtime                 unchanged ✓
\"feat: add a thing\":               enhancement                  unchanged ✓
\"fix(channels): telegram polls\":   area/channels,bug            unchanged ✓
\"Something is broken please help\": needs-triage                 unchanged ✓

─ FP guards (must NOT match the loosened keywords) ─
\"agent remembered too much\":       needs-triage                 ✓
\"preventive maintenance docs\":     needs-triage                 ✓
\"subtask hierarchy bug\":           needs-triage                 ✓
\"client connection drops\":         needs-triage                 ✓
\"wrong handler chosen for /api\":   area/api                     ✓ (api hit, not hand)
```

## Test plan
- [ ] After merge, re-run \`gh workflow run issue-auto-label.yml -f backfill=true\` — should be a no-op since there are no unlabeled open issues right now, but verifies the script doesn't blow up
- [ ] Open a test issue titled \`Test MemoryUpdate event\` and confirm it auto-tags \`area/memory,area/kernel\`