### PR TITLE
docs(runtime): document additive penalty assumption in fallback recover

### DIFF
--- a/crates/librefang-runtime-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-runtime-drivers/src/drivers/fallback.rs
@@ -136,6 +136,12 @@ impl FallbackDriver {
             .is_ok()
         {
             let cur = entry.ewma_latency_ms.load(Ordering::Relaxed);
+            // Strip the accumulated error penalty. This subtraction is only
+            // correct as long as `ERROR_PENALTY_MS` is added once per error
+            // *additively* on the failure path (see line ~205). If the
+            // penalty formula ever becomes multiplicative, exponential, or
+            // otherwise non-linear in `errors`, this restore math will
+            // silently under- or over-correct — change both sites together.
             let restored = cur.saturating_sub(ERROR_PENALTY_MS.saturating_mul(errors));
             entry.ewma_latency_ms.store(restored, Ordering::Relaxed);
             info!(


### PR DESCRIPTION
Follow-up to #2367 (merged) addressing the single non-blocking observation in [houko's review](https://github.com/librefang/librefang/pull/2367#pullrequestreview-4098928994):

> EWMA penalty strip assumes additive penalty accumulation — worth a comment near the subtraction so future formula changes don't silently break the recovery math.

Adds a 6-line comment immediately above the \`restored = cur - ERROR_PENALTY_MS * errors\` subtraction in \`maybe_recover\`, calling out that the restore math is only correct while the failure path adds the penalty additively, and that any non-linear change to the failure-side formula must change both sites together.

No behavior change, no new tests needed (the assumption is unchanged).

\`cargo check -p librefang-runtime-drivers\` clean.