### PR TITLE
fix(runtime): stop killing unrelated process groups in tree-kill path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,7 @@ dependencies = [
  "hmac",
  "http",
  "landlock",
+ "libc",
  "librefang-channels",
  "librefang-http",
  "librefang-kernel-handle",

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -59,6 +59,9 @@ tempfile = { workspace = true }
 landlock = { version = "0.4", optional = true }
 seccompiler = { version = "0.4", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 landlock-sandbox = ["dep:landlock"]
 seccomp-sandbox = ["dep:seccompiler"]

--- a/crates/librefang-runtime/src/process_manager.rs
+++ b/crates/librefang-runtime/src/process_manager.rs
@@ -89,6 +89,15 @@ impl ProcessManager {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        // Put the child in its own process group so `kill_process_tree`
+        // can safely use `kill(-pgid, ...)` to reach the whole subtree.
+        // Without this the child inherits the parent's pgid and the
+        // tree-kill path would target whichever unrelated process group
+        // happens to have the child's PID as its PGID — see
+        // `is_process_group_leader` in subprocess_sandbox.rs for why
+        // that matters on long-lived runners like GitHub Actions.
+        #[cfg(unix)]
+        cmd.process_group(0);
         #[cfg(windows)]
         cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
         let mut child = cmd
@@ -268,11 +277,18 @@ mod tests {
     use super::*;
 
     /// Long-running, IO-quiet placeholder process for tests that need
-    /// "something alive in the registry until we kill it". Using `cat`
-    /// here used to flake the Ubuntu CI job — a stdin-blocked child
-    /// somehow caused the runner to receive SIGTERM mid-test (exit 143).
-    /// `sleep` doesn't touch stdin/stdout, has a bounded lifetime, and
-    /// behaves identically across platforms via Windows' `timeout`.
+    /// "something alive in the registry until we kill it". The earlier
+    /// history of this helper is a cautionary tale: it used `cat`,
+    /// which blocked on stdin and exposed a latent bug where
+    /// `kill_process_tree` sent `kill -TERM -<pid>` to a non-leader
+    /// (because `ProcessManager::start` didn't put the child in its
+    /// own pgid). On Ubuntu CI the resulting signal would occasionally
+    /// land on the actions-runner session leader, killing the whole
+    /// job mid-test. Moving to `sleep` narrowed the window but didn't
+    /// fix the root cause — that took
+    /// (a) spawning children with `process_group(0)` and
+    /// (b) gating the negative-PID kill on `is_process_group_leader`
+    /// in `subprocess_sandbox::kill_tree_unix`.
     fn long_running_proc() -> (&'static str, Vec<String>) {
         if cfg!(windows) {
             (

--- a/crates/librefang-runtime/src/subprocess_sandbox.rs
+++ b/crates/librefang-runtime/src/subprocess_sandbox.rs
@@ -318,21 +318,43 @@ pub async fn kill_process_tree(pid: u32, grace_ms: u64) -> Result<bool, String> 
     }
 }
 
+/// Return true iff `pid` is the leader of its own process group
+/// (i.e. `getpgid(pid) == pid`). Only group leaders are safe targets
+/// for the `kill(-pgid, ...)` syntax — calling it on a non-leader
+/// would blindly send the signal to whatever unrelated process group
+/// happens to have `pid` as its PGID, which on shared runners can be
+/// the actions-runner session itself.
+#[cfg(unix)]
+fn is_process_group_leader(pid: u32) -> bool {
+    // SAFETY: `getpgid` is always safe to call; it only reads kernel
+    // state and returns -1 with errno on error (which we map to false).
+    let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+    pgid >= 0 && pgid as u32 == pid
+}
+
 #[cfg(unix)]
 async fn kill_tree_unix(pid: u32, grace_ms: u64) -> Result<bool, String> {
     use tokio::process::Command;
 
     let pid_i32 = pid as i32;
+    let is_group_leader = is_process_group_leader(pid);
 
-    // Try to kill the process group first (negative PID).
-    // This kills the process and all its children.
-    let group_kill = Command::new("kill")
-        .args(["-TERM", &format!("-{pid_i32}")])
-        .output()
-        .await;
-
-    if group_kill.is_err() {
-        // Fallback: kill just the process.
+    // Send SIGTERM. When `pid` is its own pgid we can safely use the
+    // negative-PID syntax to cover the whole group (the process plus
+    // any children that inherited the pgid). When it isn't, we MUST
+    // NOT use that syntax: `kill -TERM -<pid>` would target whichever
+    // unrelated process group happens to have `pid` as its PGID, which
+    // on long-lived runners (GitHub Actions' ubuntu-latest in
+    // particular) can easily coincide with the actions-runner session
+    // leader and bring the whole job down with a SIGTERM originating
+    // from inside a test. See librefang/librefang#2464 for the
+    // investigation that turned this up.
+    if is_group_leader {
+        let _ = Command::new("kill")
+            .args(["-TERM", &format!("-{pid_i32}")])
+            .output()
+            .await;
+    } else {
         let _ = Command::new("kill")
             .args(["-TERM", &pid.to_string()])
             .output()
@@ -350,19 +372,21 @@ async fn kill_tree_unix(pid: u32, grace_ms: u64) -> Result<bool, String> {
 
     match check {
         Ok(output) if output.status.success() => {
-            // Still alive — force kill.
+            // Still alive — force kill. Same pgid rule applies: never
+            // SIGKILL by pgid unless we've confirmed the target is the
+            // group leader.
             tracing::warn!(
                 pid,
+                is_group_leader,
                 "Process still alive after grace period, sending SIGKILL"
             );
 
-            // Try group kill first.
-            let _ = Command::new("kill")
-                .args(["-9", &format!("-{pid_i32}")])
-                .output()
-                .await;
-
-            // Also try direct kill.
+            if is_group_leader {
+                let _ = Command::new("kill")
+                    .args(["-9", &format!("-{pid_i32}")])
+                    .output()
+                    .await;
+            }
             let _ = Command::new("kill")
                 .args(["-9", &pid.to_string()])
                 .output()
@@ -686,6 +710,68 @@ mod tests {
         // Now try to kill — should return Ok(false) since already exited.
         let result = kill_child_tree(&mut child, 100).await;
         assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_is_process_group_leader_distinguishes_own_group_from_inherited_group() {
+        // Regression for the ubuntu-CI flake investigated in
+        // librefang/librefang#2464: `kill_tree_unix` used to blindly
+        // call `kill(-pid, SIGTERM)` which only makes sense for
+        // process-group leaders. When the child inherited the test
+        // binary's pgid, that negative-PID form targeted whichever
+        // unrelated process group happened to be led by a process
+        // whose PID equalled the child's — occasionally the actions-
+        // runner session leader itself, killing the whole job.
+        //
+        // This test exercises both branches of the helper:
+        //  (a) child spawned WITHOUT `process_group(0)` — inherits the
+        //      test binary's pgid, so `pgid != pid` and the helper
+        //      must return false;
+        //  (b) child spawned WITH `process_group(0)` — becomes its own
+        //      group leader, so `pgid == pid` and the helper must
+        //      return true.
+        use tokio::process::Command;
+
+        let mut inherited = Command::new("sleep")
+            .arg("10")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn inherited-pgid sleep");
+        let inherited_pid = inherited.id().expect("inherited pid");
+        assert!(
+            !is_process_group_leader(inherited_pid),
+            "a child that inherits the parent pgid must NOT look like a group leader"
+        );
+        inherited.kill().await.ok();
+        inherited.wait().await.ok();
+
+        let mut owned = Command::new("sleep")
+            .arg("10")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .process_group(0)
+            .spawn()
+            .expect("spawn own-pgid sleep");
+        let owned_pid = owned.id().expect("owned pid");
+        assert!(
+            is_process_group_leader(owned_pid),
+            "a child spawned with process_group(0) must be its own group leader"
+        );
+        owned.kill().await.ok();
+        owned.wait().await.ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_is_process_group_leader_rejects_nonexistent_pid() {
+        // Very high PID guaranteed not to exist — `getpgid` returns -1,
+        // helper must say "not a leader" so the caller falls back to
+        // the single-PID kill path.
+        assert!(!is_process_group_leader(999_999));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Root-cause fix for the ubuntu-latest CI flake where random PRs fail with

```
##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
##[error]The operation was canceled.
```

…almost always landing in `process_manager::tests` (`test_per_agent_limit` / `test_start_and_list`). Despite the message, nothing was actually cancelling the runner externally — **the SIGTERM was originating from inside our own code**.

## The bug

`subprocess_sandbox::kill_tree_unix` opens with:

```rust
let group_kill = Command::new("kill")
    .args(["-TERM", &format!("-{pid_i32}")])
    .output()
    .await;
```

`kill -TERM -<pid>` is process-*group* syntax: it signals the pgid equal to `<pid>`. That is only safe when `<pid>` is the leader of its own process group — i.e. `getpgid(pid) == pid`. None of our spawn sites guaranteed that.

`ProcessManager::start` spawned via plain `tokio::process::Command::new(...)`, so children inherited the parent's pgid. Their PIDs, and the pgid of whatever ambient group they landed in, had no relationship. Whenever the child's PID happened to equal the PGID of some unrelated long-lived group on the runner, `kill -TERM -<pid>` delivered SIGTERM into *that* group. On GitHub's ubuntu-latest runners, the long-lived group most likely to collide is the actions-runner session leader itself — so the entire job died mid-test with `"The runner has received a shutdown signal."`

This is why the flake looked infrastructural (the cancellation arrived from "outside"), why it was Ubuntu-only (Windows goes through `taskkill /T /PID`, which is strictly PID-scoped), and why it kept reproducing across reruns (PID allocation on a stable runner image is deterministic enough that the collision condition repeats).

An earlier workaround swapped the test helper's `cat` for `sleep 30`, and the comment block in `process_manager.rs:270-275` even captures the symptom:

> Using `cat` here used to flake the Ubuntu CI job — a stdin-blocked child somehow caused the runner to receive SIGTERM mid-test (exit 143).

The helper change narrowed the window but left the root cause untouched.

## The fix

Two layers, both small:

### 1. Gate the `-<pgid>` kill on an actual pgid check

New helper in `subprocess_sandbox.rs`:

```rust
#[cfg(unix)]
fn is_process_group_leader(pid: u32) -> bool {
    let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
    pgid >= 0 && pgid as u32 == pid
}
```

`kill_tree_unix` now decides up front whether `<pid>` is a pgid leader. If it is, the old fast path fires (`kill -TERM -<pid>` then `kill -9 -<pid>` on escalation). If it isn't, we fall straight through to the single-PID form — **never signalling an unrelated group**.

This is the real protection: it applies to *every* caller of `kill_process_tree`, regardless of how their child was spawned. The rest of the function (grace wait, `kill -0` liveness probe, SIGKILL escalation) is unchanged.

### 2. Make `ProcessManager::start` a well-behaved caller

```rust
#[cfg(unix)]
cmd.process_group(0);
```

…so children become their own pgid leaders, their descendants inherit the same pgid, and the fast path in `kill_tree_unix` can safely reach the whole subtree. This is defence-in-depth on top of (1), not a substitute for it — the `is_process_group_leader` check still protects any other current or future spawn site that forgets to set `process_group(0)`.

### 3. Regression tests

- `test_is_process_group_leader_distinguishes_own_group_from_inherited_group` spawns `sleep` twice — once **without** `process_group(0)` and once **with** — and asserts `is_process_group_leader` returns `false` then `true`. This pins both branches of the helper against actual kernel behaviour rather than a mocked-out proxy, which is the whole point of the fix.
- `test_is_process_group_leader_rejects_nonexistent_pid` covers the `getpgid == -1` / ESRCH path.

Both are `#[cfg(unix)]` — Windows goes through a separate `taskkill /T /PID` path that was never affected.

### 4. House-keeping

Updated the cautionary comment on `long_running_proc()` in `process_manager.rs` to stop blaming `cat` / `sleep` and record the actual root cause, so the next person reading that file does not chase the same ghost.

## What's intentionally not in this PR

- No changes to the many other `tokio::process::Command::new` sites in `tool_runner.rs`, `media_understanding.rs`, `docker_sandbox.rs`, etc. They don't need fixing because layer (1) now makes `kill_tree_unix` safe for all of them. Selectively adding `process_group(0)` at each call site can happen incrementally as a follow-up if someone wants the fast-path behaviour there too — but it is no longer load-bearing for correctness.
- No `libc` version bump — we pick up the existing `0.2` line already used by `librefang-cli` and `librefang-kernel`.

## Test plan

- [x] `cargo check -p librefang-runtime` — clean
- [ ] `cargo test -p librefang-runtime --lib -- process_manager subprocess_sandbox` — ran locally but cancelled mid-compile to free disk; CI will re-verify
- [ ] CI Test/Ubuntu must go green. **If this PR merges and the next few PRs stop hitting the "runner received a shutdown signal" flake, the fix is confirmed.**

## Related

Investigated while unblocking #2464 (which was stably failing on Ubuntu with this exact symptom, despite touching only memory/session code — completely unrelated to process_manager). Once this lands, #2464 just needs a rebase.
