### PR TITLE
fix(ci): draft PR handling, bot filtering, issue author self-reply

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -75,16 +75,41 @@ jobs:
             esac
           }
 
+          is_bot() {
+            case "$1" in
+              *\[bot\]) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
           if [ "${{ github.event_name }}" = "issues" ]; then
             # Issue closed — clean up state labels
             remove_label "$LABEL_WAITING"
             remove_label "$LABEL_ATTENTION"
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            COMMENTER="${{ github.event.comment.user.login }}"
             ASSOC="${{ github.event.comment.author_association }}"
+            ISSUE_AUTHOR="${{ github.event.issue.user.login }}"
+
+            # Skip bot comments (stale, github-actions, etc.)
+            if is_bot "$COMMENTER"; then
+              echo "Skipping bot comment from $COMMENTER"
+              exit 0
+            fi
+
             if is_maintainer "$ASSOC"; then
               remove_label "$LABEL_ATTENTION"
               add_label "$LABEL_WAITING"
             else
+              # Skip if the issue author is just adding more context
+              # before any maintainer has responded (no awaiting-response yet)
+              if [ "$COMMENTER" = "$ISSUE_AUTHOR" ]; then
+                gh issue view "$ISSUE" --repo "$REPO" --json labels --jq ".labels[].name" \
+                  | grep -qx "$LABEL_WAITING" 2>/dev/null || {
+                    echo "Issue author adding context before maintainer response — skipping"
+                    exit 0
+                  }
+              fi
               remove_label "$LABEL_WAITING"
               add_label "$LABEL_ATTENTION"
             fi

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -2,7 +2,7 @@ name: PR Labels
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, synchronize, closed, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted]
   issue_comment:
@@ -57,15 +57,33 @@ jobs:
             esac
           }
 
-          # ── PR opened / reopened / synchronize / closed ───────────
+          is_bot() {
+            case "$1" in
+              *\[bot\]) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # ── PR opened / reopened / synchronize / closed / draft ───
           if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             PR="${{ github.event.pull_request.number }}"
             ACTION="${{ github.event.action }}"
+            DRAFT="${{ github.event.pull_request.draft }}"
 
             case "$ACTION" in
               opened|reopened)
-                add_label "$LABEL_REVIEW"
+                if [ "$DRAFT" = "false" ]; then
+                  add_label "$LABEL_REVIEW"
+                fi
                 remove_label "$LABEL_CHANGES"
+                ;;
+              ready_for_review)
+                # Draft → ready
+                add_label "$LABEL_REVIEW"
+                ;;
+              converted_to_draft)
+                # Ready → draft
+                remove_label "$LABEL_REVIEW"
                 ;;
               synchronize)
                 if has_label "$LABEL_CHANGES"; then
@@ -101,7 +119,14 @@ jobs:
           # ── Comment on a PR ───────────────────────────────────────
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
             PR="${{ github.event.issue.number }}"
+            COMMENTER="${{ github.event.comment.user.login }}"
             ASSOC="${{ github.event.comment.author_association }}"
+
+            # Skip bot comments (codecov, github-actions, etc.)
+            if is_bot "$COMMENTER"; then
+              echo "Skipping bot comment from $COMMENTER"
+              exit 0
+            fi
 
             if is_maintainer "$ASSOC"; then
               if has_label "$LABEL_REVIEW"; then


### PR DESCRIPTION
## Summary

Follow-up to #2471 — closes gaps in the review/response state machine:

- **Draft PR**: `opened` with `draft=true` skips `ready-for-review`; new `ready_for_review` / `converted_to_draft` events handle draft toggle
- **Bot filtering**: comments from `*[bot]` users (codecov, github-actions, stale) skip state transitions entirely
- **Issue author self-reply**: if the issue author adds more context before any maintainer has responded (`awaiting-response` not present), `needs-attention` is not applied

## Test plan
- [ ] Open draft PR → no `ready-for-review`
- [ ] Mark draft as ready → `ready-for-review` added
- [ ] Convert back to draft → `ready-for-review` removed
- [ ] Bot comment on PR/issue → no label change
- [ ] Issue author adds context before maintainer reply → no `needs-attention`
- [ ] Issue author replies after `awaiting-response` → flips to `needs-attention`