### PR TITLE
feat: group addressee detection — stop responding when not actually spoken to

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1299,6 +1299,11 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
         was_mentioned: req.was_mentioned,
         thread_id: None,
         account_id: None,
+        // Phase 2 §C — forward the optional group participant roster from the
+        // gateway POST body so the addressee guard can fire downstream. Empty
+        // when the caller (Telegram, direct API) doesn't populate it; the
+        // guard then becomes a no-op and cannot produce false positives.
+        group_participants: req.group_participants.clone().unwrap_or_default(),
         ..Default::default()
     })
 }
@@ -4558,6 +4563,7 @@ pub async fn push_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use librefang_channels::types::ParticipantRef;
 
     /// The pre-fix prefix-match (`"image/"`) let SVG, BMP, TIFF, HEIC and
     /// friends through. Post-fix the allowlist is exact-match over the
@@ -4722,6 +4728,7 @@ mod tests {
             ephemeral: false,
             thinking: None,
             show_thinking: None,
+            group_participants: None,
         };
         assert!(request_sender_context(&req).is_none());
     }
@@ -4739,11 +4746,13 @@ mod tests {
             ephemeral: false,
             thinking: None,
             show_thinking: None,
+            group_participants: None,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert_eq!(sender.user_id, "u-123");
         assert_eq!(sender.display_name, "u-123");
         assert_eq!(sender.channel, "api");
+        assert!(sender.group_participants.is_empty());
     }
 
     #[test]
@@ -4759,10 +4768,77 @@ mod tests {
             ephemeral: false,
             thinking: None,
             show_thinking: None,
+            group_participants: None,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert!(sender.is_group);
         assert!(sender.was_mentioned);
+    }
+
+    #[test]
+    fn test_request_sender_context_threads_group_participants() {
+        let roster = vec![
+            ParticipantRef {
+                jid: "111@s.whatsapp.net".to_string(),
+                display_name: "Alice".to_string(),
+            },
+            ParticipantRef {
+                jid: "222@s.whatsapp.net".to_string(),
+                display_name: "Bob".to_string(),
+            },
+        ];
+        let req = MessageRequest {
+            message: "Bob, ciao".to_string(),
+            attachments: Vec::new(),
+            sender_id: Some("111@s.whatsapp.net".to_string()),
+            sender_name: Some("Alice".to_string()),
+            channel_type: Some("whatsapp".to_string()),
+            is_group: true,
+            was_mentioned: false,
+            ephemeral: false,
+            thinking: None,
+            show_thinking: None,
+            group_participants: Some(roster.clone()),
+        };
+        let sender = request_sender_context(&req).expect("sender context");
+        assert_eq!(sender.group_participants, roster);
+    }
+
+    #[test]
+    fn test_message_request_group_participants_default_when_missing() {
+        // Backward compat: callers (Telegram, direct API) that omit
+        // `group_participants` must still deserialize cleanly.
+        let json = serde_json::json!({
+            "message": "hi",
+            "sender_id": "u-1",
+            "channel_type": "telegram",
+            "is_group": false,
+        });
+        let req: MessageRequest =
+            serde_json::from_value(json).expect("deserialize without group_participants");
+        assert!(req.group_participants.is_none());
+        let sender = request_sender_context(&req).expect("sender context");
+        assert!(sender.group_participants.is_empty());
+    }
+
+    #[test]
+    fn test_message_request_group_participants_deserializes_from_json() {
+        let json = serde_json::json!({
+            "message": "hey Bob",
+            "sender_id": "111@s.whatsapp.net",
+            "sender_name": "Alice",
+            "channel_type": "whatsapp:group-jid@g.us",
+            "is_group": true,
+            "group_participants": [
+                {"jid": "111@s.whatsapp.net", "display_name": "Alice"},
+                {"jid": "222@s.whatsapp.net", "display_name": "Bob"}
+            ]
+        });
+        let req: MessageRequest =
+            serde_json::from_value(json).expect("deserialize with group_participants");
+        let sender = request_sender_context(&req).expect("sender context");
+        assert_eq!(sender.group_participants.len(), 2);
+        assert_eq!(sender.group_participants[1].display_name, "Bob");
     }
 
     #[test]

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -143,6 +143,21 @@ pub struct SpawnResponse {
     pub name: String,
 }
 
+/// OpenAPI schema stand-in for `librefang_channels::types::ParticipantRef`.
+///
+/// The real type lives in `librefang-channels`, which does not depend on
+/// utoipa. This mirror struct exists only so `#[schema(value_type = ...)]`
+/// on `MessageRequest.group_participants` can expose the shape to the
+/// generated OpenAPI document.
+#[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[allow(dead_code)]
+pub struct ParticipantRefSchema {
+    /// Platform JID (e.g. `1234567890@s.whatsapp.net`).
+    pub jid: String,
+    /// Human-readable name (push-name, contact name, or first part of JID).
+    pub display_name: String,
+}
+
 /// A file attachment reference (from a prior upload).
 #[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct AttachmentRef {
@@ -175,6 +190,17 @@ pub struct MessageRequest {
     /// Whether the bot was @mentioned in a group message.
     #[serde(default)]
     pub was_mentioned: bool,
+    /// Optional group participant roster (Phase 2 §C addressee guard).
+    ///
+    /// Forwarded by the WhatsApp gateway for group messages so the kernel's
+    /// addressee guard (`is_addressed_to_other_participant`) can detect when
+    /// a turn is addressed to a named participant other than the agent.
+    ///
+    /// `#[serde(default)]` ensures backward compatibility for callers (Telegram,
+    /// direct API) that don't populate this field.
+    #[serde(default)]
+    #[schema(value_type = Option<Vec<ParticipantRefSchema>>)]
+    pub group_participants: Option<Vec<librefang_channels::types::ParticipantRef>>,
     /// If true, this is an ephemeral "side question" (`/btw`).
     /// The message is answered using the agent's system prompt but WITHOUT
     /// loading or saving session history — the real conversation is untouched.

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -9,7 +9,7 @@ use crate::router::AgentRouter;
 use crate::sanitizer::{InputSanitizer, SanitizeResult};
 use crate::types::{
     default_phase_emoji, truncate_utf8, AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage,
-    ChannelUser, InteractiveButton, LifecycleReaction, SenderContext,
+    ChannelUser, InteractiveButton, LifecycleReaction, ParticipantRef, SenderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -18,7 +18,7 @@ use librefang_types::config::{
     AutoRouteStrategy, ChannelOverrides, DmPolicy, GroupPolicy, OutputFormat,
 };
 use librefang_types::message::ContentBlock;
-use regex::RegexSet;
+use regex::{Regex, RegexSet};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
@@ -1321,6 +1321,120 @@ fn matches_group_trigger_pattern(
     matched
 }
 
+// ---------------------------------------------------------------------------
+// Phase 2 §C — Positional vocative trigger + addressee guard (OB-04, OB-05)
+// ---------------------------------------------------------------------------
+
+/// Truncate `text` to `max` chars (UTF-8 safe) for log excerpts.
+fn truncate_excerpt(text: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (i, ch) in text.chars().enumerate() {
+        if i >= max {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Returns true when `LIBREFANG_GROUP_ADDRESSEE_GUARD=on`.
+///
+/// Per D-§C-6 the guard is shipped default-off for a 1-week observation
+/// window. While off, the legacy substring matcher remains authoritative
+/// and the new positional/addressee functions are bypassed in
+/// `should_process_group_message`.
+fn addressee_guard_enabled() -> bool {
+    std::env::var("LIBREFANG_GROUP_ADDRESSEE_GUARD")
+        .ok()
+        .as_deref()
+        == Some("on")
+}
+
+/// Detect a leading-vocative `<Capitalized>[,!]` token in `text`.
+///
+/// Returns the captured name (without the punctuation) when the turn opens
+/// with a vocative form like "Caterina,". The match is anchored at the start
+/// of the string after optional whitespace; only ASCII-style capitalized
+/// names are recognized (Italian/English vocatives — sufficient for §C).
+fn leading_vocative_name(text: &str) -> Option<String> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // ^\s* <Capitalized name (1+ letters)> followed by , or !
+        Regex::new(r"^\s*([A-ZÀ-Ý][A-Za-zÀ-ÿ]+)[,!]").expect("leading_vocative regex compiles")
+    });
+    re.captures(text)
+        .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+}
+
+/// Strict positional vocative-trigger match for `pattern` in `text`.
+///
+/// True iff the (whole-word, case-sensitive — pattern is expected to be a
+/// proper name like "Signore") `pattern` appears either:
+///  * at the start of the turn after optional whitespace, or
+///  * immediately after a `[.!?]` punctuation boundary followed by whitespace.
+///
+/// Additionally REJECTED when another capitalized vocative appears BEFORE
+/// the matched pattern — this captures the Beeper-screenshot case
+/// `"Caterina, chiedi al Signore..."` where "Signore" is mentioned but the
+/// turn is addressed to Caterina.
+pub fn is_vocative_trigger(text: &str, pattern: &str) -> bool {
+    if text.is_empty() || pattern.is_empty() {
+        return false;
+    }
+    // Build a per-call regex (patterns vary per-agent and tests cover several).
+    // Pattern is a literal proper name; escape to avoid regex-meta surprises.
+    let escaped = regex::escape(pattern);
+    let combined = format!(r"(?:^|[.!?])\s*({escaped})\b", escaped = escaped);
+    let re = match Regex::new(&combined) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let Some(m) = re.find(text) else { return false };
+
+    // Heuristic: reject if any *other* capitalized vocative (`<Name>,`) appears
+    // BEFORE the pattern position. We scan only the prefix [0..match_start].
+    let prefix = &text[..m.start()];
+    static OTHER_VOCATIVE: OnceLock<Regex> = OnceLock::new();
+    let other = OTHER_VOCATIVE.get_or_init(|| {
+        Regex::new(r"\b([A-ZÀ-Ý][A-Za-zÀ-ÿ]+),\s").expect("other_vocative regex compiles")
+    });
+    for cap in other.captures_iter(prefix) {
+        if let Some(name) = cap.get(1) {
+            // If the prefix vocative IS the pattern itself we'd have matched at
+            // start; getting here means it's a *different* name → reject.
+            if !name.as_str().eq_ignore_ascii_case(pattern) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// True when the turn opens with a vocative addressed to a participant other
+/// than the agent (e.g. `"Caterina, chiedi..."` in a group containing
+/// Caterina + the Bot).
+///
+/// Heuristic: extract a leading `<Capitalized>[,!]` token and look it up
+/// (case-insensitively) in the participant roster. If found and not equal
+/// to `agent_name`, the turn is addressed to someone else.
+pub fn is_addressed_to_other_participant(
+    text: &str,
+    participants: &[ParticipantRef],
+    agent_name: &str,
+) -> bool {
+    let Some(name) = leading_vocative_name(text) else {
+        return false;
+    };
+    if name.eq_ignore_ascii_case(agent_name) {
+        return false;
+    }
+    participants.iter().any(|p| {
+        p.display_name.eq_ignore_ascii_case(&name)
+            && !p.display_name.eq_ignore_ascii_case(agent_name)
+    })
+}
+
 fn is_group_command(message: &ChannelMessage) -> bool {
     matches!(&message.content, ChannelContent::Command { .. })
         || matches!(&message.content, ChannelContent::Text(text) if text.starts_with('/'))
@@ -1389,23 +1503,114 @@ fn should_process_group_message(
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let is_command = is_group_command(message);
-            let regex_triggered = !was_mentioned
-                && !is_command
-                && matches_group_trigger_pattern(
+            let text = text_content(message).unwrap_or("");
+            let sender_excerpt: &str = &message.sender.display_name;
+            let guard_on = addressee_guard_enabled();
+
+            // OB-04/OB-05 — addressee guard. When the turn opens with a vocative
+            // matching another participant in the group roster, abstain even if
+            // a substring of `group_trigger_patterns` matches mid-turn.
+            // (No owner short-circuit here: per OB-06 audit no `is_owner` branch
+            // exists in librefang-channels — owner is treated as any participant.)
+            if guard_on {
+                let participants = extract_group_participants(message);
+                let agent_name = extract_agent_name(message);
+                if is_addressed_to_other_participant(text, &participants, &agent_name) {
+                    info!(
+                        event = "group_gating_skip",
+                        reason = "addressed_to_other_participant",
+                        channel = ct_str,
+                        sender = %sender_excerpt,
+                        text_excerpt = %truncate_excerpt(text, 80),
+                        "OB-04: vocative addressed to other participant"
+                    );
+                    return false;
+                }
+            }
+
+            // Trigger-pattern check. Under guard-on we additionally require
+            // `is_vocative_trigger` (positional) on top of the substring match,
+            // so "Caterina, chiedi al Signore..." with pattern "Signore" no
+            // longer triggers (the substring matches but the position is wrong
+            // AND another vocative precedes it).
+            let regex_triggered = if !was_mentioned && !is_command {
+                let mut hit = matches_group_trigger_pattern(
                     ct_str,
                     message,
                     &overrides.group_trigger_patterns,
                 );
+                if hit && guard_on {
+                    let positional_ok = overrides
+                        .group_trigger_patterns
+                        .iter()
+                        .any(|p| is_vocative_trigger(text, p));
+                    if !positional_ok {
+                        info!(
+                            event = "group_gating_skip",
+                            reason = "vocative_position_mismatch",
+                            channel = ct_str,
+                            sender = %sender_excerpt,
+                            text_excerpt = %truncate_excerpt(text, 80),
+                            "OB-05: substring matched but not at vocative position"
+                        );
+                        hit = false;
+                    }
+                }
+                hit
+            } else {
+                false
+            };
+
             if !was_mentioned && !is_command && !regex_triggered {
-                debug!(
-                    "Ignoring group message on {ct_str} (group_policy=mention_only, not mentioned)"
+                info!(
+                    event = "group_gating_skip",
+                    reason = "mention_only_no_mention",
+                    channel = ct_str,
+                    sender = %sender_excerpt,
+                    text_excerpt = %truncate_excerpt(text, 80),
+                    "OB-06: mention_only and bot was not mentioned"
                 );
                 return false;
             }
+            info!(
+                event = "group_gating_pass",
+                channel = ct_str,
+                sender = %sender_excerpt,
+                was_mentioned,
+                is_command,
+                regex_triggered,
+                "Group message accepted for processing"
+            );
             true
         }
         GroupPolicy::All => true,
     }
+}
+
+/// Read `group_participants` from the inbound message metadata payload
+/// (populated gateway-side by `sock.groupMetadata`). Returns empty when the
+/// channel doesn't supply a roster — the addressee guard then becomes a no-op
+/// (cannot fire false positives).
+fn extract_group_participants(message: &ChannelMessage) -> Vec<ParticipantRef> {
+    message
+        .metadata
+        .get("group_participants")
+        .and_then(|v| serde_json::from_value::<Vec<ParticipantRef>>(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Read the canonical agent display name from message metadata when the
+/// caller provides it (gateway/runtime injects so the addressee guard knows
+/// "this name == us"). Empty string when absent — `eq_ignore_ascii_case("")`
+/// then never matches a real participant name, so the guard simply checks
+/// whether the leading vocative belongs to another roster member.
+fn extract_agent_name(message: &ChannelMessage) -> String {
+    message
+        .metadata
+        .get("agent_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Build a `SenderContext` from an incoming `ChannelMessage`.
@@ -1453,6 +1658,10 @@ fn build_sender_context(
         auto_route_confidence_threshold,
         auto_route_sticky_bonus,
         auto_route_divergence_count,
+        // §C: forward roster from inbound payload (gateway populates via
+        // sock.groupMetadata). Empty for non-WhatsApp channels — addressee
+        // guard then becomes a no-op (BC-01).
+        group_participants: extract_group_participants(message),
     }
 }
 
@@ -4421,6 +4630,316 @@ mod tests {
             assert!(result.is_some());
             let (drained_msg, _) = result.unwrap();
             assert_content_eq(&drained_msg.content, "1\n2");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Phase 2 §C — Vocative trigger + addressee guard tests (OB-04, OB-05)
+    // ---------------------------------------------------------------------
+
+    mod vocative_tests {
+        use super::super::is_vocative_trigger;
+
+        #[test]
+        fn matches_at_start_of_turn_with_comma() {
+            assert!(is_vocative_trigger("Signore, dimmi", "Signore"));
+        }
+
+        #[test]
+        fn matches_at_start_of_turn_with_space() {
+            assert!(is_vocative_trigger("Signore chiedi al bot", "Signore"));
+        }
+
+        #[test]
+        fn matches_after_strong_punctuation() {
+            assert!(is_vocative_trigger("ciao. Signore, come va?", "Signore"));
+        }
+
+        #[test]
+        fn matches_with_leading_whitespace() {
+            assert!(is_vocative_trigger("  Signore, ...", "Signore"));
+        }
+
+        #[test]
+        fn rejects_other_capitalized_vocative_before_pattern() {
+            // The Beeper-screenshot case (user directive).
+            assert!(!is_vocative_trigger(
+                "Caterina, chiedi al Signore il pagamento",
+                "Signore"
+            ));
+        }
+
+        #[test]
+        fn rejects_when_not_at_vocative_position() {
+            assert!(!is_vocative_trigger(
+                "Ieri il Signore ha detto di...",
+                "Signore"
+            ));
+        }
+
+        #[test]
+        fn rejects_lowercase_substring() {
+            // Pattern is "Signore" (proper-name); lowercase should not match.
+            assert!(!is_vocative_trigger("il signore è arrivato", "Signore"));
+        }
+
+        #[test]
+        fn rejects_with_alessandro_then_signore() {
+            assert!(!is_vocative_trigger(
+                "Alessandro, dopo chiama il Signore",
+                "Signore"
+            ));
+        }
+
+        #[test]
+        fn word_boundary_signori_not_signore() {
+            assert!(!is_vocative_trigger("Signori, ascoltate", "Signore"));
+        }
+
+        #[test]
+        fn empty_text_returns_false() {
+            assert!(!is_vocative_trigger("", "Signore"));
+        }
+
+        #[test]
+        fn dammi_il_signore_rejected() {
+            assert!(!is_vocative_trigger("dammi il Signore", "Signore"));
+        }
+    }
+
+    mod addressee_tests {
+        use super::super::is_addressed_to_other_participant;
+        use crate::types::ParticipantRef;
+
+        fn roster(names: &[&str]) -> Vec<ParticipantRef> {
+            names
+                .iter()
+                .enumerate()
+                .map(|(i, n)| ParticipantRef {
+                    jid: format!("{}@s.whatsapp.net", i),
+                    display_name: (*n).to_string(),
+                })
+                .collect()
+        }
+
+        #[test]
+        fn caterina_with_caterina_in_roster_returns_true() {
+            let r = roster(&["Caterina", "Ambrogio"]);
+            assert!(is_addressed_to_other_participant(
+                "Caterina, chiedi...",
+                &r,
+                "Ambrogio"
+            ));
+        }
+
+        #[test]
+        fn agent_addressed_returns_false() {
+            let r = roster(&["Caterina", "Ambrogio"]);
+            assert!(!is_addressed_to_other_participant(
+                "Ambrogio, vieni qui",
+                &r,
+                "Ambrogio"
+            ));
+        }
+
+        #[test]
+        fn no_vocative_returns_false() {
+            let r = roster(&["Caterina", "Ambrogio"]);
+            assert!(!is_addressed_to_other_participant(
+                "stamattina è bello",
+                &r,
+                "Ambrogio"
+            ));
+        }
+
+        #[test]
+        fn exclamation_vocative_recognized() {
+            let r = roster(&["Caterina", "Bot"]);
+            assert!(is_addressed_to_other_participant("Caterina!", &r, "Bot"));
+        }
+
+        #[test]
+        fn beeper_screenshot_full_turn() {
+            let r = roster(&["Caterina", "Bot"]);
+            assert!(is_addressed_to_other_participant(
+                "Caterina, chiedi al Signore il pagamento",
+                &r,
+                "Bot"
+            ));
+        }
+
+        #[test]
+        fn name_not_in_roster_returns_false() {
+            // "Marco," is a vocative but Marco isn't a participant — guard
+            // does not fire (avoids false positives on names that happen to
+            // start a sentence but aren't in the group).
+            let r = roster(&["Caterina", "Bot"]);
+            assert!(!is_addressed_to_other_participant(
+                "Marco, dove sei?",
+                &r,
+                "Bot"
+            ));
+        }
+
+        #[test]
+        fn case_insensitive_match() {
+            let r = roster(&["caterina", "Bot"]);
+            assert!(is_addressed_to_other_participant(
+                "Caterina, vieni qui",
+                &r,
+                "Bot"
+            ));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // §C wiring tests — should_process_group_message + guard flag behavior
+    // ---------------------------------------------------------------------
+
+    mod should_process_group_message_v2 {
+        use super::super::{should_process_group_message, ParticipantRef};
+        use super::group_text_message;
+        use librefang_types::config::{ChannelOverrides, GroupPolicy};
+        use serde_json::json;
+        use std::sync::Mutex;
+
+        // Serialize tests that mutate the LIBREFANG_GROUP_ADDRESSEE_GUARD env
+        // var — env mutation is process-global.
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+        fn with_guard_on<F: FnOnce()>(f: F) {
+            let _g = ENV_LOCK.lock().unwrap();
+            std::env::set_var("LIBREFANG_GROUP_ADDRESSEE_GUARD", "on");
+            f();
+            std::env::remove_var("LIBREFANG_GROUP_ADDRESSEE_GUARD");
+        }
+
+        fn with_guard_off<F: FnOnce()>(f: F) {
+            let _g = ENV_LOCK.lock().unwrap();
+            std::env::remove_var("LIBREFANG_GROUP_ADDRESSEE_GUARD");
+            f();
+        }
+
+        fn inject_roster(msg: &mut crate::types::ChannelMessage, names: &[&str], agent: &str) {
+            let participants: Vec<ParticipantRef> = names
+                .iter()
+                .enumerate()
+                .map(|(i, n)| ParticipantRef {
+                    jid: format!("{i}@s.whatsapp.net"),
+                    display_name: (*n).to_string(),
+                })
+                .collect();
+            msg.metadata.insert(
+                "group_participants".to_string(),
+                serde_json::to_value(&participants).unwrap(),
+            );
+            msg.metadata.insert("agent_name".to_string(), json!(agent));
+        }
+
+        #[test]
+        fn caterina_chiedi_al_signore_rejected_under_guard() {
+            with_guard_on(|| {
+                let mut msg = group_text_message("Caterina, chiedi al Signore il pagamento");
+                inject_roster(&mut msg, &["Caterina", "Ambrogio"], "Ambrogio");
+                let overrides = ChannelOverrides {
+                    group_policy: GroupPolicy::MentionOnly,
+                    group_trigger_patterns: vec!["Signore".to_string()],
+                    ..Default::default()
+                };
+                assert!(!should_process_group_message("whatsapp", &overrides, &msg));
+            });
+        }
+
+        #[test]
+        fn signore_at_start_passes_under_guard() {
+            with_guard_on(|| {
+                let mut msg = group_text_message("Signore, conferma il prossimo appuntamento");
+                inject_roster(&mut msg, &["Caterina", "Ambrogio"], "Ambrogio");
+                let overrides = ChannelOverrides {
+                    group_policy: GroupPolicy::MentionOnly,
+                    group_trigger_patterns: vec!["Signore".to_string()],
+                    ..Default::default()
+                };
+                assert!(should_process_group_message("whatsapp", &overrides, &msg));
+            });
+        }
+
+        #[test]
+        fn owner_no_mention_no_pattern_rejected() {
+            // OB-06: "owner-in-group" doesn't bypass mention_only — there's
+            // no owner short-circuit in librefang-channels (audit confirms).
+            // A plain "ciao a tutti" with no mention is rejected.
+            with_guard_on(|| {
+                let mut msg = group_text_message("ciao a tutti, come va?");
+                inject_roster(&mut msg, &["Caterina", "Ambrogio"], "Ambrogio");
+                let overrides = ChannelOverrides {
+                    group_policy: GroupPolicy::MentionOnly,
+                    group_trigger_patterns: vec!["Signore".to_string()],
+                    ..Default::default()
+                };
+                assert!(!should_process_group_message("whatsapp", &overrides, &msg));
+            });
+        }
+
+        #[test]
+        fn owner_explicit_mention_passes() {
+            with_guard_on(|| {
+                let mut msg = group_text_message("@Bot rispondimi");
+                inject_roster(&mut msg, &["Caterina", "Ambrogio"], "Ambrogio");
+                msg.metadata
+                    .insert("was_mentioned".to_string(), json!(true));
+                let overrides = ChannelOverrides {
+                    group_policy: GroupPolicy::MentionOnly,
+                    ..Default::default()
+                };
+                assert!(should_process_group_message("whatsapp", &overrides, &msg));
+            });
+        }
+
+        #[test]
+        fn legacy_substring_still_works_with_guard_off() {
+            // Backward compat: with the flag default-off (rollback path)
+            // the pre-Phase-2 substring matcher remains authoritative.
+            with_guard_off(|| {
+                let msg = group_text_message("Caterina, chiedi al Signore il pagamento");
+                let overrides = ChannelOverrides {
+                    group_policy: GroupPolicy::MentionOnly,
+                    group_trigger_patterns: vec!["(?i)\\bSignore\\b".to_string()],
+                    ..Default::default()
+                };
+                // Legacy behavior: substring matches → returns true.
+                assert!(should_process_group_message("whatsapp", &overrides, &msg));
+            });
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // BC-02 — SenderContext serde-default for group_participants
+    // ---------------------------------------------------------------------
+
+    mod bc02_tests {
+        use crate::types::SenderContext;
+
+        #[test]
+        fn old_blob_without_group_participants_parses() {
+            // Stored canonical blob from before Phase 2 §C — no
+            // `group_participants` key. Must deserialize cleanly.
+            let json = r#"{
+                "channel": "whatsapp",
+                "user_id": "u1",
+                "display_name": "Alice",
+                "is_group": false,
+                "was_mentioned": false,
+                "thread_id": null,
+                "account_id": null,
+                "auto_route": "off",
+                "auto_route_ttl_minutes": 0,
+                "auto_route_confidence_threshold": 0,
+                "auto_route_sticky_bonus": 0,
+                "auto_route_divergence_count": 0
+            }"#;
+            let ctx: SenderContext = serde_json::from_str(json).expect("BC-02 parse");
+            assert!(ctx.group_participants.is_empty());
         }
     }
 }

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -297,6 +297,30 @@ pub struct SenderContext {
     /// Divergence count threshold for `sticky_heuristic` strategy.
     #[serde(default)]
     pub auto_route_divergence_count: u32,
+    /// Group participant roster (Phase 2 §C OB-04/OB-05/GS-01).
+    ///
+    /// Populated by the WhatsApp gateway via `sock.groupMetadata(groupJid)`
+    /// (5min TTL cache) for group messages. Empty for DMs and for non-WhatsApp
+    /// channels that don't yet expose roster info. Used by the addressee guard
+    /// in `should_process_group_message` to detect when a turn is addressed
+    /// to a named participant other than the agent.
+    ///
+    /// `#[serde(default)]` ensures BC-02: stored canonical blobs that predate
+    /// this field still deserialize cleanly.
+    #[serde(default)]
+    pub group_participants: Vec<ParticipantRef>,
+}
+
+/// Reference to a participant in a group chat.
+///
+/// Minimal shape required by the §C addressee guard. Full roster persistence
+/// (with phone-number resolution, role, etc.) is deferred to Phase 5.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParticipantRef {
+    /// Platform JID (e.g. `1234567890@s.whatsapp.net` or `lid@lid`).
+    pub jid: String,
+    /// Human-readable name (push-name, contact name, or first part of JID).
+    pub display_name: String,
 }
 
 /// Agent lifecycle phase for UX indicators.

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -291,6 +291,51 @@ let ownJid = null;
 const lidToPnJid = new Map();    // '<digits>@lid' → '<digits>@s.whatsapp.net'
 const ownerLidJids = new Set();  // '<digits>@lid'
 
+// ---------------------------------------------------------------------------
+// Phase 2 §C — Group participant roster cache (GS-01 minimal)
+// ---------------------------------------------------------------------------
+// Populated lazily by `getGroupParticipants(sock, groupJid)` on first inbound
+// from a group; subsequent inbounds within GROUP_METADATA_TTL_MS reuse the
+// cached roster (no Baileys network call). The Baileys
+// `group-participants.update` event invalidates the matching entry so adds /
+// removes / promotions become visible at the next message.
+//
+// The roster is forwarded to the kernel inside the inbound payload's
+// `sender_context.metadata.group_participants` field; librefang-channels'
+// `should_process_group_message` consults it to decide whether the turn is
+// addressed to the bot or to another participant (OB-04, OB-05).
+const GROUP_METADATA_TTL_MS = 5 * 60 * 1000;
+const groupMetadataCache = new Map(); // groupJid -> { participants: [...], fetchedAt }
+
+async function getGroupParticipants(sock, groupJid) {
+  if (!groupJid || !groupJid.endsWith('@g.us')) return [];
+  const cached = groupMetadataCache.get(groupJid);
+  if (cached && (Date.now() - cached.fetchedAt) < GROUP_METADATA_TTL_MS) {
+    console.log(JSON.stringify({ event: 'group_roster_cache_hit', groupJid, size: cached.participants.length }));
+    return cached.participants;
+  }
+  try {
+    const meta = await sock.groupMetadata(groupJid);
+    const participants = (meta && Array.isArray(meta.participants) ? meta.participants : []).map(p => ({
+      jid: p.id || p.jid || '',
+      display_name: p.notify || p.name || (p.id ? String(p.id).split('@')[0] : ''),
+    }));
+    groupMetadataCache.set(groupJid, { participants, fetchedAt: Date.now() });
+    console.log(JSON.stringify({ event: 'group_roster_fetched', groupJid, size: participants.length }));
+    return participants;
+  } catch (err) {
+    console.log(JSON.stringify({ event: 'group_roster_fetch_failed', groupJid, error: String(err && err.message || err) }));
+    return [];
+  }
+}
+
+function invalidateGroupRoster(groupJid) {
+  if (!groupJid) return;
+  if (groupMetadataCache.delete(groupJid)) {
+    console.log(JSON.stringify({ event: 'group_roster_invalidated', groupJid }));
+  }
+}
+
 // CS-02: proactive LID→PN resolution for first-seen LIDs. Races
 // sock.onWhatsApp([lid]) against a timeout; on success, populates the cache
 // so subsequent messages in the same burst find it synchronously. On
@@ -858,6 +903,13 @@ async function startConnection() {
   // Save credentials whenever they update
   sock.ev.on('creds.update', saveCreds);
 
+  // Phase 2 §C / GS-01 — invalidate cached group roster on membership change
+  // so adds/removes/promotions become visible at the next inbound message.
+  sock.ev.on('group-participants.update', (update) => {
+    const id = update && update.id;
+    if (id) invalidateGroupRoster(id);
+  });
+
   // Connection state changes (QR code, connected, disconnected)
   sock.ev.on('connection.update', async (update) => {
     const { connection, lastDisconnect, qr } = update;
@@ -1321,8 +1373,13 @@ async function startConnection() {
           }
         };
 
+        // Phase 2 §C — fetch participant roster for groups (cached 5min).
+        // Empty for DMs and on fetch failure (graceful degradation per
+        // GS-01 minimal: addressee guard simply can't fire without roster).
+        const groupParticipants = isGroup ? await getGroupParticipants(sock, sender) : [];
+
         const rawResponse = await forwardToLibreFangStreaming(
-          messageToSend, systemPrefix, phone, pushName, isOwner, attachments, onProgress, sender, { isGroup, wasMentioned },
+          messageToSend, systemPrefix, phone, pushName, isOwner, attachments, onProgress, sender, { isGroup, wasMentioned, groupParticipants },
         );
         // Scrub NO_REPLY before markdown conversion — if the model emitted it
         // trailing or glued to an emoji it would otherwise reach WhatsApp.
@@ -1787,7 +1844,7 @@ function buildRelaySystemInstruction() {
 // ---------------------------------------------------------------------------
 const MAX_FORWARD_RETRIES = 1;
 
-async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup = false, wasMentioned = false, chatJid = '' } = {}, retryCount = 0) {
+async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup = false, wasMentioned = false, chatJid = '', groupParticipants = [] } = {}, retryCount = 0) {
   // CS-01: fail-fast — refuse to forward with an empty chatJid. A bare
   // `whatsapp` channel loses per-conversation session isolation; the kernel
   // would merge unrelated chats into the same session.
@@ -1826,6 +1883,13 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
   // Include attachments if present
   if (attachments && attachments.length > 0) {
     payload.attachments = attachments;
+  }
+
+  // Phase 2 §C — forward the group participant roster so the kernel's
+  // addressee guard (`is_addressed_to_other_participant`) can fire.
+  // Empty for DMs and for the catch-up path (no live `sock` to query).
+  if (isGroup && Array.isArray(groupParticipants) && groupParticipants.length > 0) {
+    payload.group_participants = groupParticipants;
   }
 
   const payloadStr = JSON.stringify(payload);
@@ -1917,7 +1981,7 @@ const STREAMING_EDIT_INTERVAL_MS = 2000;
  * @param {(text: string) => Promise<void>} onProgress
  * @returns {Promise<string>} complete response
  */
-async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, isOwner, attachments, onProgress, chatJid = '', { isGroup = false, wasMentioned = false } = {}) {
+async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, isOwner, attachments, onProgress, chatJid = '', { isGroup = false, wasMentioned = false, groupParticipants = [] } = {}) {
   // CS-01: fail-fast — refuse to forward with an empty chatJid (same
   // rationale as `forwardToLibreFang`). Keeps streaming parity.
   if (!chatJid) {
@@ -1950,6 +2014,14 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
 
   if (attachments && attachments.length > 0) {
     payload.attachments = attachments;
+  }
+
+  // Phase 2 §C — see forwardToLibreFang. Streaming path also forwards roster
+  // for parity (kernel-side wiring still required to thread it into
+  // ChannelMessage.metadata — tracked as a follow-up; gating tests at the
+  // bridge layer cover the receive side).
+  if (isGroup && Array.isArray(groupParticipants) && groupParticipants.length > 0) {
+    payload.group_participants = groupParticipants;
   }
 
   const payloadStr = JSON.stringify(payload);
@@ -2627,4 +2699,8 @@ module.exports = {
   resolveLidProactively,
   checkHeartbeat,
   computeBackoffDelay,
+  getGroupParticipants,
+  invalidateGroupRoster,
+  groupMetadataCache,
+  GROUP_METADATA_TTL_MS,
 };

--- a/packages/whatsapp-gateway/test/group-roster.test.js
+++ b/packages/whatsapp-gateway/test/group-roster.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// Phase 2 §C — group participant roster cache + invalidation tests (GS-01).
+//
+// Run via `node --test packages/whatsapp-gateway/test/group-roster.test.js`
+// or, from inside the package, `node --test test/group-roster.test.js`.
+
+const assert = require('node:assert/strict');
+const { describe, it, beforeEach } = require('node:test');
+
+// Override DB path before requiring the module — same pattern as index.test.js.
+process.env.WHATSAPP_DB_PATH =
+  '/tmp/test-wa-gateway-roster-' + process.pid + '.db';
+
+const {
+  getGroupParticipants,
+  invalidateGroupRoster,
+  groupMetadataCache,
+} = require('../index.js');
+
+const GROUP_JID = '120363000000000000@g.us';
+
+function fixtureMeta() {
+  return {
+    id: GROUP_JID,
+    participants: [
+      { id: '391112223333@s.whatsapp.net', notify: 'Caterina' },
+      { id: '391999888777@s.whatsapp.net', notify: 'Ambrogio' },
+      { id: '393334445555@s.whatsapp.net', name: 'Marco' },
+    ],
+  };
+}
+
+function makeSock(throwsAfter = -1) {
+  let calls = 0;
+  return {
+    calls() {
+      return calls;
+    },
+    groupMetadata: async (jid) => {
+      calls += 1;
+      if (throwsAfter >= 0 && calls > throwsAfter) {
+        throw new Error('socket disconnected');
+      }
+      assert.equal(jid, GROUP_JID);
+      return fixtureMeta();
+    },
+  };
+}
+
+describe('group roster cache', () => {
+  beforeEach(() => {
+    groupMetadataCache.clear();
+  });
+
+  it('caches roster across 3 inbounds (1 network call)', async () => {
+    const sock = makeSock();
+    const r1 = await getGroupParticipants(sock, GROUP_JID);
+    const r2 = await getGroupParticipants(sock, GROUP_JID);
+    const r3 = await getGroupParticipants(sock, GROUP_JID);
+    assert.equal(sock.calls(), 1, 'only first call hits the network');
+    assert.equal(r1.length, 3);
+    assert.deepEqual(r1, r2);
+    assert.deepEqual(r1, r3);
+    // Display-name resolution: notify > name > id-prefix
+    assert.equal(r1[0].display_name, 'Caterina');
+    assert.equal(r1[2].display_name, 'Marco');
+  });
+
+  it('re-fetches after invalidation', async () => {
+    const sock = makeSock();
+    await getGroupParticipants(sock, GROUP_JID);
+    await getGroupParticipants(sock, GROUP_JID);
+    invalidateGroupRoster(GROUP_JID);
+    await getGroupParticipants(sock, GROUP_JID);
+    assert.equal(sock.calls(), 2, 'invalidation forces a 2nd network call');
+  });
+
+  it('returns empty array on fetch failure (graceful degradation)', async () => {
+    const sock = {
+      groupMetadata: async () => {
+        throw new Error('not connected');
+      },
+    };
+    const r = await getGroupParticipants(sock, GROUP_JID);
+    assert.deepEqual(r, []);
+    assert.equal(
+      groupMetadataCache.has(GROUP_JID),
+      false,
+      'failed fetch must not poison cache',
+    );
+  });
+
+  it('returns empty array for non-group JID without calling the network', async () => {
+    const sock = makeSock();
+    const r = await getGroupParticipants(sock, '391112223333@s.whatsapp.net');
+    assert.deepEqual(r, []);
+    assert.equal(sock.calls(), 0);
+  });
+
+  it('returns empty array for falsy JID', async () => {
+    const sock = makeSock();
+    assert.deepEqual(await getGroupParticipants(sock, ''), []);
+    assert.deepEqual(await getGroupParticipants(sock, null), []);
+    assert.equal(sock.calls(), 0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 §C of the openclaw-style output-boundary overhaul. Stops the agent from responding in group chats when the turn is addressed to **another** participant, and closes an implicit owner-in-group bypass that sidestepped the \`mention_only\` gating.

Original bug from production (observed in a family group chat): user A addresses user B by name (\"<B-name>, do something with <owner-title>\") — the bot replied as though it had been summoned by the mere mention of its owner-trigger pattern (\"<owner-title>\"), even though the turn's syntactic addressee was user B, not the bot. Group gating matched the trigger pattern anywhere in the turn, with no notion of vocative position or other-participant addressee detection.

## Changes

1. **\`is_vocative_trigger(text, pattern)\`** in \`crates/librefang-channels/src/bridge.rs\` — matches only at the start of the turn or after strong punctuation (\`.!?\`), and rejects if a capitalized vocative-like token precedes the pattern in the same turn. Replaces the previous \`regex.is_match\` logic.
2. **\`is_addressed_to_other_participant(text, roster, agent_name)\`** — if the turn starts with \`<Name>,\` and \`Name\` is in the group roster but not the agent's canonical name, returns true → \`should_process_group_message\` abstains.
3. **\`SenderContext.group_participants: Vec<ParticipantRef>\`** (\`#[serde(default)]\`) — populated from the gateway via \`sock.groupMetadata(jid)\` cached 5min with invalidation on Baileys \`group-participants.update\` events. Threaded through \`request_sender_context\` in \`crates/librefang-api/src/routes/agents.rs\`. Non-WhatsApp adapters are unaffected (default empty Vec).
4. **Owner-in-group audit** — grepped \`is_owner\`, \`owner_jid\`, etc. across \`crates/librefang-channels/src/\`: zero short-circuits to remove. OB-06 is satisfied by absence of bypass; regression guarded by integration test \`owner_no_mention_no_pattern_rejected\`.
5. **Flag \`LIBREFANG_GROUP_ADDRESSEE_GUARD=on\`** default-off for 1 week of observation, then on by default.

## Test plan

- [x] 11 \`vocative_tests\` (start-of-turn, post-punctuation, reject other-vocative-before-pattern, case-insensitivity)
- [x] 7 \`addressee_tests\` (other-participant vocative, agent-addressed, non-vocative text)
- [x] 5 \`should_process_group_message_v2\` integration tests (owner-no-mention rejected, owner-with-mention accepted, legacy-flag-off backward compat)
- [x] 1 \`bc02_tests\` serde backward compat on \`group_participants\`
- [x] 5 gateway \`group-roster.test.js\` (cache + invalidation + fetch-failure fallback + non-group + falsy)
- [x] 3 new route tests for \`MessageRequest.group_participants\` (threaded into SenderContext, default-when-missing, deserialize-from-json)
- [x] \`cargo test -p librefang-channels\`: 716 pass
- [x] \`cargo test -p librefang-api --lib\`: 308 pass
- [x] gateway \`node --test\`: 61 pass baseline + 5 new roster

## Known follow-up (not in this PR)

The addressee guard reads group participants from \`ChannelMessage.metadata\` inside \`bridge.rs\`. HTTP-ingested messages from the WhatsApp gateway take the \`routes/agents.rs → kernel.send_message_with_sender_context\` path, which populates \`SenderContext.group_participants\` but does NOT construct a \`ChannelMessage\` for the bridge. A sibling PR will either:

- Extend the kernel dispatch path to evaluate the addressee guard against \`SenderContext.group_participants\` directly, or
- Construct a synthetic \`ChannelMessage\` so the existing bridge gating applies uniformly.

Until that lands, the guard is active for in-process adapter-driven messages (Telegram/Discord) and the gateway carries the roster for observability. Feature flag \`LIBREFANG_GROUP_ADDRESSEE_GUARD\` will stay off in production for WhatsApp until the wiring closes.

## Rollback

Flag off restores the previous \`matches_group_trigger_pattern\` semantics.