### PR TITLE
feat: add qwen3.6-plus from coding plan

### DIFF
--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -155,7 +155,7 @@ const PROVIDERS: &[ProviderInfo] = &[
     ProviderInfo {
         name: "alibaba-coding-plan",
         env_var: "ALIBABA_CODING_PLAN_API_KEY",
-        default_model: "alibaba-coding-plan/qwen3.5-plus",
+        default_model: "alibaba-coding-plan/qwen3.6-plus",
         needs_key: true,
     },
 ];

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1993,22 +1993,34 @@ supports_streaming = true
     #[test]
     fn test_alibaba_coding_plan_zero_cost() {
         let catalog = test_catalog();
-        let model = catalog
+        let qwen35plus = catalog
             .find_model("alibaba-coding-plan/qwen3.5-plus")
             .expect("qwen3.5-plus model should be registered");
-        assert_eq!(model.input_cost_per_m, 0.0);
-        assert_eq!(model.output_cost_per_m, 0.0);
+        assert_eq!(qwen35plus.input_cost_per_m, 0.0);
+        assert_eq!(qwen35plus.output_cost_per_m, 0.0);
+        let qwen36plus = catalog
+            .find_model("alibaba-coding-plan/qwen3.6-plus")
+            .expect("qwen3.6-plus model should be registered");
+        assert_eq!(qwen36plus.input_cost_per_m, 0.0);
+        assert_eq!(qwen36plus.output_cost_per_m, 0.0);
     }
 
     #[test]
     fn test_alibaba_coding_plan_vision_models() {
         let catalog = test_catalog();
-        let qwen_plus = catalog
+        let qwen35plus = catalog
             .find_model("alibaba-coding-plan/qwen3.5-plus")
             .expect("qwen3.5-plus model should be registered");
-        assert!(qwen_plus.supports_vision);
-        assert_eq!(qwen_plus.tier, ModelTier::Smart);
-        assert_eq!(qwen_plus.context_window, 1_000_000);
+        assert!(qwen35plus.supports_vision);
+        assert_eq!(qwen35plus.tier, ModelTier::Smart);
+        assert_eq!(qwen35plus.context_window, 1_000_000);
+
+        let qwen36plus = catalog
+            .find_model("alibaba-coding-plan/qwen3.6-plus")
+            .expect("qwen3.6-plus model should be registered");
+        assert!(qwen36plus.supports_vision);
+        assert_eq!(qwen36plus.tier, ModelTier::Smart);
+        assert_eq!(qwen36plus.context_window, 1_000_000);
 
         let kimi = catalog
             .find_model("alibaba-coding-plan/kimi-k2.5")

--- a/docs/src/app/configuration/providers/hosted/page.mdx
+++ b/docs/src/app/configuration/providers/hosted/page.mdx
@@ -448,6 +448,7 @@ This page covers internet-hosted model providers that authenticate with an API k
 | **Models** | 8 |
 
 **Available Models:**
+- `alibaba-coding-plan/qwen3.6-plus` (Smart) — vision support, 1M context
 - `alibaba-coding-plan/qwen3.5-plus` (Smart) — vision support, 1M context
 - `alibaba-coding-plan/qwen3-coder-plus` (Smart) — 1M context
 - `alibaba-coding-plan/qwen3-coder-next` (Frontier) — 262K context

--- a/docs/src/app/zh/configuration/providers/hosted/page.mdx
+++ b/docs/src/app/zh/configuration/providers/hosted/page.mdx
@@ -448,6 +448,7 @@
 | **模型数** | 8 |
 
 **可用模型：**
+- `alibaba-coding-plan/qwen3.6-plus` (智能) — 支持视觉，1M 上下文
 - `alibaba-coding-plan/qwen3.5-plus` (智能) — 支持视觉，1M 上下文
 - `alibaba-coding-plan/qwen3-coder-plus` (智能) — 1M 上下文
 - `alibaba-coding-plan/qwen3-coder-next` (旗舰) — 262K 上下文


### PR DESCRIPTION
<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [x] LLM provider
- [ ] Built-in tool
- [ ] Bug fix
- [ ] Feature (Rust)
- [x] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

Follows up the librefang-registry addition for model `qwen3.6-plus` within Alibaba Coding Plan. 

## Changes

* Documentation updates
* Default Alibaba Coding Plan to the latest and greatest `qwen3.6-plus`
* Add testing for new model addition

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
