### PR TITLE
feat(gateway): add echo tracker to drop our own messages reflected back

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -295,8 +295,8 @@ impl ClaudeCodeDriver {
     /// daemon's existing `/mcp` endpoint (see
     /// `librefang-api/src/routes/network.rs::mcp_http`).
     fn write_mcp_config(bridge: &McpBridgeConfig) -> std::io::Result<PathBuf> {
-        let path = std::env::temp_dir()
-            .join(format!("librefang-mcp-{}.json", uuid::Uuid::new_v4()));
+        let path =
+            std::env::temp_dir().join(format!("librefang-mcp-{}.json", uuid::Uuid::new_v4()));
         let base = bridge.base_url.trim_end_matches('/');
         let url = format!("{base}/mcp");
 

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -7,6 +7,17 @@ const path = require('node:path');
 const os = require('node:os');
 const { randomUUID } = require('node:crypto');
 const toml = require('toml');
+const { EchoTracker } = require('./lib/echo-tracker');
+
+// ---------------------------------------------------------------------------
+// Echo tracker (EB-01, Phase 3 §A)
+// ---------------------------------------------------------------------------
+// Process-local LRU that records every outbound text sent via
+// `sock.sendMessage({ text })`. On inbound `messages.upsert` we consult
+// `echoTracker.isEcho(...)` and drop the self-loop echo before forwarding to
+// librefang. Flag `LIBREFANG_ECHO_TRACKER=off` disables end-to-end (no-op).
+const ECHO_TRACKER_ENABLED = process.env.LIBREFANG_ECHO_TRACKER !== 'off';
+const echoTracker = new EchoTracker(100);
 
 // ---------------------------------------------------------------------------
 // SQLite Message Store (better-sqlite3)
@@ -763,6 +774,7 @@ async function executeRelay(relay) {
 
   try {
     const sentRelay = await sock.sendMessage(jid, { text: markdownToWhatsApp(message) });
+    if (ECHO_TRACKER_ENABLED) echoTracker.track(message);
 
     // F4: Audit log
     console.log(`[gateway] RELAY SENT | to: ${convo.pushName} (${convo.phone}) [${jid}] | message: "${message.substring(0, 100)}" | timestamp: ${new Date().toISOString()}`);
@@ -1261,6 +1273,21 @@ async function startConnection() {
 
       if (!messageText && attachments.length === 0) continue;
 
+      // --- Phase 3 §A: Echo tracker gate (EB-01) ---
+      // Drop messages whose body matches a recently-sent outbound text
+      // (self-loop prevention when WhatsApp reflects our own message back
+      // via sync/cross-device mirror). Flag `LIBREFANG_ECHO_TRACKER=off`
+      // disables this gate. Only checks text bodies (never attachments).
+      if (ECHO_TRACKER_ENABLED && messageText && echoTracker.isEcho(messageText)) {
+        console.log(JSON.stringify({
+          event: 'echo_drop',
+          body_excerpt: EchoTracker.normalize(messageText).slice(0, 80),
+          tracker_size: echoTracker.size(),
+          elapsed_ms_since_last_sent: echoTracker.elapsedSinceLastSent(),
+        }));
+        continue;
+      }
+
       // --- FASE 2: Reply context (quotedMessage) ---
       const contextSources = [
         innerMsg.extendedTextMessage?.contextInfo,
@@ -1371,6 +1398,7 @@ async function startConnection() {
           } else {
             await sock.sendMessage(sender, { text: formatted, edit: streamMsgKey });
           }
+          if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned);
         };
 
         // Phase 2 §C — fetch participant roster for groups (cached 5min).
@@ -1390,10 +1418,13 @@ async function startConnection() {
           if (streamMsgKey && jid === sender) {
             // Edit the message we've been streaming
             await sock.sendMessage(jid, { text: finalText, edit: streamMsgKey });
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
             return streamMsgKey;
           }
           // No streaming happened (fallback path) — send new message
-          return (await sock.sendMessage(jid, { text: finalText }))?.key;
+          const sentKey = (await sock.sendMessage(jid, { text: finalText }))?.key;
+          if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+          return sentKey;
         };
 
         if (response && sock) {
@@ -1429,6 +1460,7 @@ async function startConnection() {
 
               // Send notification to primary owner
               await sock.sendMessage(OWNER_JID, { text: ownerNotif });
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(ownerNotif);
               console.log(`[gateway] NOTIFY_OWNER sent for ${pushName}: ${notif.reason}`);
             }
 
@@ -2228,6 +2260,7 @@ async function runCatchUpSweep() {
         try {
           const formatted = markdownToWhatsApp(response);
           await sock.sendMessage(msg.jid, { text: formatted });
+          if (ECHO_TRACKER_ENABLED) echoTracker.track(response);
           dbSaveMessage({ id: randomUUID(), jid: msg.jid, senderJid: ownJid, pushName: null, phone: msg.phone, text: response, direction: 'outbound', timestamp: Date.now(), processed: 1, rawType: 'text' });
         } catch (sendErr) {
           console.warn(`[gateway][catchup] Could not send catch-up reply to ${msg.jid}: ${sendErr.message}`);
@@ -2274,6 +2307,7 @@ async function sendMessage(to, text) {
 
   const formatted = markdownToWhatsApp(text);
   const sent = await sock.sendMessage(jid, { text: formatted });
+  if (ECHO_TRACKER_ENABLED) echoTracker.track(text);
   // Save outbound message to DB (store formatted text to match what was delivered)
   dbSaveMessage({
     id: sent?.key?.id || randomUUID(),
@@ -2703,4 +2737,8 @@ module.exports = {
   invalidateGroupRoster,
   groupMetadataCache,
   GROUP_METADATA_TTL_MS,
+  // Phase 3 §A — echo tracker handle (testing + introspection)
+  echoTracker,
+  ECHO_TRACKER_ENABLED,
+  EchoTracker,
 };

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -29,6 +29,9 @@ const {
   resolveLidProactively,
   checkHeartbeat,
   computeBackoffDelay,
+  echoTracker,
+  ECHO_TRACKER_ENABLED,
+  EchoTracker,
 } = require('./index.js');
 
 // ---------------------------------------------------------------------------
@@ -640,6 +643,86 @@ describe('ST-02 computeBackoffDelay', () => {
     assert.match(src, /DisconnectReason\.forbidden/);
     // New backoff call site is present.
     assert.match(src, /computeBackoffDelay\(reconnectAttempts\)/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 §A — Echo tracker wiring (EB-01)
+// ---------------------------------------------------------------------------
+describe('echo tracker wiring (Phase 3 §A)', () => {
+  it('exports tracker handle, ECHO_TRACKER_ENABLED, and EchoTracker class', () => {
+    assert.ok(echoTracker, 'echoTracker should be exported');
+    assert.equal(typeof echoTracker.track, 'function');
+    assert.equal(typeof echoTracker.isEcho, 'function');
+    assert.equal(typeof echoTracker.size, 'function');
+    assert.equal(typeof echoTracker.reset, 'function');
+    assert.equal(typeof EchoTracker, 'function');
+    assert.equal(typeof EchoTracker.normalize, 'function');
+    // Default flag state (no env var set in test env)
+    assert.equal(typeof ECHO_TRACKER_ENABLED, 'boolean');
+  });
+
+  it('integration: outbound track then inbound echo would drop (raw body)', () => {
+    echoTracker.reset();
+    // Simulate the outbound wire-in (every sock.sendMessage({ text }) is followed by track)
+    echoTracker.track('ciao');
+    // Simulate the inbound gate condition with the same body
+    assert.equal(echoTracker.isEcho('ciao'), true,
+      'inbound echo of just-sent message must be detected');
+    assert.equal(echoTracker.size(), 1);
+  });
+
+  it('integration: normalization works through wiring (Hello. -> hello)', () => {
+    echoTracker.reset();
+    echoTracker.track('Hello.');
+    assert.equal(echoTracker.isEcho('hello'), true,
+      'normalized echo (case + trailing punct) must drop');
+    assert.equal(echoTracker.isEcho('HELLO!'), true);
+  });
+
+  it('integration: unrelated inbound is NOT dropped (no false positive)', () => {
+    echoTracker.reset();
+    echoTracker.track('ciao');
+    assert.equal(echoTracker.isEcho('something else'), false,
+      'unrelated message must pass through (forwardToLibreFang would be called)');
+    // tracker unchanged for non-matching probe
+    assert.equal(echoTracker.size(), 1);
+  });
+
+  it('flag gate: when LIBREFANG_ECHO_TRACKER=off, gate is bypassed', () => {
+    // ECHO_TRACKER_ENABLED is captured at module load. We assert the source
+    // shape so a future regression (gating without flag check) is caught.
+    const src = require('node:fs').readFileSync(require('node:path').join(__dirname, 'index.js'), 'utf8');
+    // The gate must be wrapped in an ECHO_TRACKER_ENABLED check.
+    assert.match(src,
+      /if\s*\(\s*ECHO_TRACKER_ENABLED\s*&&\s*messageText\s*&&\s*echoTracker\.isEcho/,
+      'inbound gate must be flag-gated by ECHO_TRACKER_ENABLED');
+    // Each track call must also be flag-gated.
+    const trackCalls = src.match(/echoTracker\.track\(/g) || [];
+    const flaggedTrackCalls = src.match(/if\s*\(\s*ECHO_TRACKER_ENABLED\s*\)\s*echoTracker\.track\(/g) || [];
+    assert.equal(trackCalls.length, flaggedTrackCalls.length,
+      `every echoTracker.track() must be flag-gated (found ${trackCalls.length} calls, ${flaggedTrackCalls.length} flagged)`);
+    // Default ON: env unset → enabled.
+    assert.equal(process.env.LIBREFANG_ECHO_TRACKER, undefined);
+    assert.equal(ECHO_TRACKER_ENABLED, true);
+  });
+
+  it('echo_drop log structure is correct shape (would emit on drop)', () => {
+    // Verify the source emits the spec'd log structure when isEcho fires.
+    const src = require('node:fs').readFileSync(require('node:path').join(__dirname, 'index.js'), 'utf8');
+    assert.match(src, /event:\s*'echo_drop'/);
+    assert.match(src, /body_excerpt:/);
+    assert.match(src, /tracker_size:/);
+    assert.match(src, /elapsed_ms_since_last_sent:/);
+    // Body excerpt must be capped at 80 chars.
+    assert.match(src, /\.slice\(0,\s*80\)/);
+  });
+
+  it('outbound wire-in covers all 7 text sendMessage sites', () => {
+    const src = require('node:fs').readFileSync(require('node:path').join(__dirname, 'index.js'), 'utf8');
+    const trackCount = (src.match(/echoTracker\.track\(/g) || []).length;
+    assert.equal(trackCount, 7,
+      `expected 7 echoTracker.track() calls (one per outbound text site), got ${trackCount}`);
   });
 });
 

--- a/packages/whatsapp-gateway/lib/echo-tracker.js
+++ b/packages/whatsapp-gateway/lib/echo-tracker.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * EchoTracker — process-local LRU for self-loop prevention (EB-01, Phase 3 §A).
+ *
+ * Records the normalized body of every outbound text the gateway sends via
+ * `sock.sendMessage({ text })`. Before forwarding an inbound message to
+ * librefang, callers consult `isEcho(body)` to detect and drop the
+ * WhatsApp-reflected copy of our own outgoing text (sync/cross-device mirror).
+ *
+ * Decisions (see .planning/phases/03-chat-isolation-layer/03-CONTEXT.md §A):
+ * - In-memory only, no persistence (Q6 locked).
+ * - maxSize=100 default, LRU eviction on insertion-order.
+ * - Normalization: lowercase + emoji strip + whitespace collapse + trailing
+ *   punctuation strip so minor echo rewrites still match.
+ */
+class EchoTracker {
+  constructor(maxSize = 100) {
+    this.max = Math.max(1, Number(maxSize) || 100);
+    this.map = new Map();
+    this.lastSentAt = 0;
+  }
+
+  static normalize(body) {
+    if (body === null || body === undefined) return '';
+    return String(body)
+      .toLowerCase()
+      .replace(/\p{Extended_Pictographic}/gu, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/[.!?]+$/, '');
+  }
+
+  track(body) {
+    const key = EchoTracker.normalize(body);
+    if (!key) return;
+    // Refresh insertion order on re-track.
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, Date.now());
+    this.lastSentAt = Date.now();
+    while (this.map.size > this.max) {
+      const oldest = this.map.keys().next().value;
+      this.map.delete(oldest);
+    }
+  }
+
+  isEcho(body) {
+    const key = EchoTracker.normalize(body);
+    if (!key) return false;
+    return this.map.has(key);
+  }
+
+  size() {
+    return this.map.size;
+  }
+
+  elapsedSinceLastSent() {
+    return this.lastSentAt ? Date.now() - this.lastSentAt : -1;
+  }
+
+  reset() {
+    this.map.clear();
+    this.lastSentAt = 0;
+  }
+}
+
+module.exports = { EchoTracker };

--- a/packages/whatsapp-gateway/test/echo-tracker.test.js
+++ b/packages/whatsapp-gateway/test/echo-tracker.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const { EchoTracker } = require('../lib/echo-tracker');
+
+describe('EchoTracker.normalize', () => {
+  it('lowercases and strips trailing punctuation', () => {
+    assert.equal(EchoTracker.normalize('Hello!'), 'hello');
+    assert.equal(EchoTracker.normalize('World?'), 'world');
+    assert.equal(EchoTracker.normalize('done...'), 'done');
+  });
+
+  it('collapses whitespace and trims', () => {
+    assert.equal(EchoTracker.normalize('  foo   bar  '), 'foo bar');
+    assert.equal(EchoTracker.normalize('line\n\nbreak'), 'line break');
+  });
+
+  it('strips Extended_Pictographic emojis', () => {
+    assert.equal(EchoTracker.normalize('ciao 👋'), 'ciao');
+    assert.equal(EchoTracker.normalize('🔥hot🔥'), 'hot');
+  });
+
+  it('returns empty string for null/undefined/empty', () => {
+    assert.equal(EchoTracker.normalize(null), '');
+    assert.equal(EchoTracker.normalize(undefined), '');
+    assert.equal(EchoTracker.normalize(''), '');
+  });
+});
+
+describe('EchoTracker.track / isEcho', () => {
+  it('track("Hello!") then isEcho("hello") is true (normalization)', () => {
+    const t = new EchoTracker();
+    t.track('Hello!');
+    assert.equal(t.isEcho('hello'), true);
+    assert.equal(t.isEcho('HELLO'), true);
+  });
+
+  it('whitespace and case collapse through wiring', () => {
+    const t = new EchoTracker();
+    t.track('  foo   bar  ');
+    assert.equal(t.isEcho('FOO BAR'), true);
+  });
+
+  it('emoji strip matches echo without emoji', () => {
+    const t = new EchoTracker();
+    t.track('ciao 👋');
+    assert.equal(t.isEcho('ciao'), true);
+  });
+
+  it('returns false for never-tracked text', () => {
+    const t = new EchoTracker();
+    t.track('hello');
+    assert.equal(t.isEcho('never-sent'), false);
+  });
+
+  it('track(null), track(""), track(undefined) are no-ops', () => {
+    const t = new EchoTracker();
+    t.track(null);
+    t.track('');
+    t.track(undefined);
+    assert.equal(t.size(), 0);
+    assert.equal(t.isEcho(''), false);
+  });
+});
+
+describe('EchoTracker LRU eviction', () => {
+  it('evicts oldest when size exceeds max (100 default)', () => {
+    const t = new EchoTracker(100);
+    for (let i = 0; i < 100; i++) t.track(`msg-${i}`);
+    assert.equal(t.size(), 100);
+    assert.equal(t.isEcho('msg-0'), true);
+    t.track('msg-100');
+    assert.equal(t.size(), 100);
+    assert.equal(t.isEcho('msg-0'), false, 'oldest should be evicted');
+    assert.equal(t.isEcho('msg-100'), true, 'newest should be present');
+    assert.equal(t.isEcho('msg-1'), true, 'second-oldest should still be present');
+  });
+
+  it('re-tracking refreshes insertion order (prevents premature eviction)', () => {
+    const t = new EchoTracker(3);
+    t.track('a');
+    t.track('b');
+    t.track('c');
+    t.track('a'); // refresh a
+    t.track('d'); // should evict b, not a
+    assert.equal(t.isEcho('a'), true);
+    assert.equal(t.isEcho('b'), false);
+    assert.equal(t.isEcho('c'), true);
+    assert.equal(t.isEcho('d'), true);
+  });
+
+  it('honors small maxSize', () => {
+    const t = new EchoTracker(2);
+    t.track('x');
+    t.track('y');
+    t.track('z');
+    assert.equal(t.size(), 2);
+    assert.equal(t.isEcho('x'), false);
+  });
+});
+
+describe('EchoTracker observability', () => {
+  it('size() reports current count', () => {
+    const t = new EchoTracker();
+    assert.equal(t.size(), 0);
+    t.track('one');
+    assert.equal(t.size(), 1);
+    t.track('two');
+    assert.equal(t.size(), 2);
+  });
+
+  it('elapsedSinceLastSent returns -1 before any track, positive after', async () => {
+    const t = new EchoTracker();
+    assert.equal(t.elapsedSinceLastSent(), -1);
+    t.track('hello');
+    await new Promise((r) => setTimeout(r, 5));
+    const elapsed = t.elapsedSinceLastSent();
+    assert.ok(elapsed >= 0, `expected >= 0, got ${elapsed}`);
+    assert.ok(elapsed < 1000, `expected < 1s, got ${elapsed}`);
+  });
+
+  it('reset() clears map and lastSentAt', () => {
+    const t = new EchoTracker();
+    t.track('a');
+    t.track('b');
+    assert.equal(t.size(), 2);
+    t.reset();
+    assert.equal(t.size(), 0);
+    assert.equal(t.elapsedSinceLastSent(), -1);
+    assert.equal(t.isEcho('a'), false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 §A of the openclaw-style WhatsApp gateway overhaul. Adds a per-process LRU echo tracker so the gateway drops inbound events that are reflections of our own outbound messages (WhatsApp's multi-device sync or cross-device mirroring occasionally returns the sent text as an inbound event within the same socket, which otherwise triggers a self-loop and an apologetic "I didn't say that" reply).

## Changes

- New module \`packages/whatsapp-gateway/lib/echo-tracker.js\` — LRU-bounded (100 entries) with normalization (lowercase, trim, collapse whitespace, strip emoji, strip trailing punctuation) so minor rewrites during streaming don't defeat the match
- Outbound wiring: every successful \`sock.sendMessage({ text })\` records the text (7 call sites)
- Inbound gate: \`messages.upsert\` checks \`isEcho\` before forwarding to librefang; matches emit \`{ event: 'echo_drop', body_excerpt, tracker_size, elapsed_ms }\` log and skip the forward
- Flag \`LIBREFANG_ECHO_TRACKER=off\` disables (default: on)

Matches openclaw's \`extensions/whatsapp/src/auto-reply/monitor/echo.ts\` pattern, minus the combined-body layer (which belongs in Phase 5 with groupHistoryKey).

## Test plan

- [x] 15 unit tests in \`test/echo-tracker.test.js\` (normalization, LRU eviction, refresh-on-retrack, observability, reset)
- [x] 7 integration tests in \`index.test.js\` (wire-in exports, raw-body match, normalization via wiring, false-positive guard, flag-gate enforcement on each of 7 track sites, echo_drop log shape, outbound-site coverage count)
- [x] \`node --test packages/whatsapp-gateway/\`: 68 pass (was 61)
- [x] Smoke: \`LIBREFANG_ECHO_TRACKER=off node -e require(./index.js)\` loads with tracker disabled

## Rollback

\`LIBREFANG_ECHO_TRACKER=off\` — tracker no-ops, no drops.

## Files

- \`packages/whatsapp-gateway/lib/echo-tracker.js\` (new)
- \`packages/whatsapp-gateway/index.js\` (wire-in)
- \`packages/whatsapp-gateway/test/echo-tracker.test.js\` (new) + \`index.test.js\` (integration)

No new dependencies.