### PR TITLE
chore: sync Cargo.lock with librefang-api toml_edit dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,6 +3944,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tower",
  "tower-http",
  "tracing",


### PR DESCRIPTION
## Summary

`crates/librefang-api/Cargo.toml` declares `toml_edit = "0.25"` but the committed `Cargo.lock` was missing the corresponding dependency entry under `librefang-api`. Any `cargo` invocation on a fresh checkout regenerates the lock and produces a one-line dirty diff, churning every developer's working tree.

Commit the regenerated entry so the lock is in sync.

## Diff

```
@@ -3944,6 +3944,7 @@ name = "librefang-api"
  "tokio-stream",
  "tokio-test",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tower",
  "tower-http",
```

## Test plan
- [x] Diff is the same one cargo regenerates on a clean tree
- No code/behavior change