### PR TITLE
chore: sync Cargo.lock after librefang-llm-driver dep addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4155,6 +4155,7 @@ dependencies = [
  "librefang-hands",
  "librefang-kernel-metering",
  "librefang-kernel-router",
+ "librefang-llm-driver",
  "librefang-memory",
  "librefang-runtime",
  "librefang-skills",


### PR DESCRIPTION
## Summary
- Sync `Cargo.lock` to reflect `librefang-llm-driver` dependency added to `librefang-kernel`

## Test plan
- [x] `cargo build --workspace --lib` passes