### PR TITLE
fix(xtask): spawn pnpm via sh to resolve mise shim PATH

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -74,14 +74,14 @@ pub fn run(args: DevArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut _dashboard_child = None;
     if !args.no_dashboard && dashboard_dir.join("package.json").exists() {
         println!("Installing dashboard dependencies...");
-        let _ = Command::new("pnpm")
-            .arg("install")
+        let _ = Command::new("sh")
+            .args(["-c", "pnpm install"])
             .current_dir(&dashboard_dir)
             .status();
 
         println!("Starting dashboard dev server...");
-        let child = Command::new("pnpm")
-            .arg("dev")
+        let child = Command::new("sh")
+            .args(["-c", "pnpm dev"])
             .current_dir(&dashboard_dir)
             .spawn();
         match child {


### PR DESCRIPTION
## Summary

- `just dev` runs `cargo xtask dev`, whose inherited PATH contains direct mise install dirs but **not** the mise shims directory (`~/.local/share/mise/shims`)
- `Command::new("pnpm")` therefore fails to find pnpm and silently errors (warning printed to stderr, easy to miss)
- The dashboard Vite dev server never starts, leaving port 5173 with nothing listening → 502
- Fix: use `Command::new("sh").args(["-c", "pnpm ..."])` so the shell resolves pnpm through its own PATH

## Test plan

- [ ] Run `just dev` and confirm a Vite process is listening on port 5173
- [ ] Verify `http://localhost:5173/dashboard/` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)