### PR TITLE
fix(ci): always strip ready-for-review when conflicts exist

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -82,15 +82,18 @@ jobs:
                 }
               };
 
-              if (mergeable === false && !hasLabel) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  labels: [LABEL],
-                });
+              if (mergeable === false) {
+                if (!hasLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: [LABEL],
+                  });
+                  core.info(`#${pr.number}: +${LABEL}`);
+                }
+                // Always enforce: conflicts → no ready-for-review
                 await rmLabel('ready-for-review');
-                core.info(`#${pr.number}: +${LABEL} -ready-for-review`);
               } else if (mergeable !== false && hasLabel) {
                 await rmLabel(LABEL);
                 core.info(`#${pr.number}: -${LABEL}`);


### PR DESCRIPTION
## Summary

`ready-for-review` and `has-conflicts` could coexist on a PR due to a race condition between the `conflicts` and `review-state` jobs running in parallel on `synchronize` events.

**Root cause:** `rmLabel('ready-for-review')` was only called when *adding* `has-conflicts` for the first time (`mergeable === false && !hasLabel`). If `ready-for-review` was added after `has-conflicts` was already present, nothing would clean it up.

**Fix:** Whenever `mergeable === false`, unconditionally remove `ready-for-review` — regardless of whether the conflict label was just added or was already there.

## Test plan

- [ ] PR with `has-conflicts` + `ready-for-review` coexisting → trigger workflow → `ready-for-review` removed
- [ ] Normal conflict detection still works (label added/removed correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)