### PR TITLE
fix(kernel): scaffold hand workspaces on first boot instead of activate+pause

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -7623,29 +7623,30 @@ system_prompt = "You are a helpful assistant."
                 }
             }
         } else if !state_path.exists() {
-            // First boot: activate all registry hands then pause them (pre-install).
-            // This creates full workspace structure (AGENT.json, SOUL.md, memory/, etc.)
-            // without leaving agents running.
+            // First boot: scaffold workspace directories and identity files for all
+            // registry hands without activating them. Activation (DB entries, session
+            // spawning, agent registration) only happens when the user explicitly
+            // enables a hand — not unconditionally on every fresh install.
             let defs = self.hand_registry.list_definitions();
             if !defs.is_empty() {
                 info!(
-                    "First boot — pre-installing {} hand(s) (activate + pause)",
+                    "First boot — scaffolding {} hand workspace(s) (files only, no activation)",
                     defs.len()
                 );
+                let hands_ws_dir = cfg.effective_hands_workspaces_dir();
                 for def in &defs {
-                    match self.activate_hand(&def.id, std::collections::HashMap::new()) {
-                        Ok(inst) => {
-                            if let Err(e) = self.pause_hand(inst.instance_id) {
-                                warn!(hand = %def.id, error = %e, "Failed to pause pre-installed hand");
-                            } else {
-                                info!(hand = %def.id, "Pre-installed hand (paused)");
-                            }
+                    for (role, agent) in &def.agents {
+                        let safe_hand = safe_path_component(&def.id, "hand");
+                        let safe_role = safe_path_component(role, "agent");
+                        let workspace = hands_ws_dir.join(&safe_hand).join(&safe_role);
+                        if let Err(e) = ensure_workspace(&workspace) {
+                            warn!(hand = %def.id, role = %role, error = %e, "Failed to scaffold hand workspace");
+                            continue;
                         }
-                        Err(e) => {
-                            warn!(hand = %def.id, error = %e, "Failed to pre-install hand");
-                        }
+                        generate_identity_files(&workspace, &agent.manifest);
                     }
                 }
+                // Write an empty state file so subsequent boots skip this block.
                 self.persist_hand_state();
             }
         }


### PR DESCRIPTION
## Problem

On first boot, every registry hand was unconditionally activated (`activate_hand`) then immediately paused (`pause_hand`). This wrote all hands into `hand_state.json` as `Paused`, so every subsequent restart restored all 55+ agents — regardless of whether the user had ever used them.

`activate_hand` is a heavyweight operation: it creates DB entries, spawns role agents, allocates sessions, and registers schedulers. Running it for every hand on first boot (and on every restart) is wasteful.

## Fix

Replace the `activate_hand + pause_hand` loop with a lightweight scaffold:
- Call `ensure_workspace()` to create directory structure (`data/`, `output/`, `sessions/`, etc.)
- Call `generate_identity_files()` to write `SOUL.md`, `USER.md`, `TOOLS.md`, etc.
- No DB entries, no session creation, no agent spawning

An empty `hand_state.json` is still written so subsequent boots skip this block entirely.

**Hands are now activated on demand** — only when the user explicitly enables one. Restarts only restore hands the user has actually activated.

## Impact

- First boot: creates workspace files only (same files as before, none of the overhead)
- Subsequent restarts: 0 agents restored by default instead of 55+
- No behavior change for users who have already activated hands

🤖 Generated with [Claude Code](https://claude.com/claude-code)