### PR TITLE
fix(kernel): probe ollama before fallback, default to gemma4

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1369,6 +1369,15 @@ impl LibreFangKernel {
 
         let memory = Arc::new(substrate);
 
+        // Check if Ollama is reachable on localhost:11434 (TCP probe, 500ms timeout).
+        fn is_ollama_reachable() -> bool {
+            std::net::TcpStream::connect_timeout(
+                &std::net::SocketAddr::from(([127, 0, 0, 1], 11434)),
+                std::time::Duration::from_millis(500),
+            )
+            .is_ok()
+        }
+
         // Resolve "auto" provider: scan environment for the first available API key.
         if config.default_model.provider == "auto" || config.default_model.provider.is_empty() {
             if let Some((provider, model_hint, env_var)) = drivers::detect_available_provider() {
@@ -1394,7 +1403,10 @@ impl LibreFangKernel {
                 // Ollama is running locally — use the catalog's default model, not a hardcoded one.
                 let model = librefang_runtime::model_catalog::ModelCatalog::default()
                     .default_model_for_provider("ollama")
-                    .unwrap_or_else(|| "llama3.2".to_string());
+                    .unwrap_or_else(|| {
+                        warn!("Model catalog has no default for ollama — falling back to gemma4");
+                        "gemma4".to_string()
+                    });
                 info!(
                     model = %model,
                     "No API keys detected — Ollama is running locally, using as default"

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1390,10 +1390,17 @@ impl LibreFangKernel {
                 config.default_model.provider = provider.to_string();
                 config.default_model.model = model;
                 config.default_model.api_key_env = env_var.to_string();
-            } else {
-                warn!("No API keys detected in environment — defaulting to ollama (local)");
+            } else if is_ollama_reachable() {
+                // Ollama is running locally — use the catalog's default model, not a hardcoded one.
+                let model = librefang_runtime::model_catalog::ModelCatalog::default()
+                    .default_model_for_provider("ollama")
+                    .unwrap_or_else(|| "llama3.2".to_string());
+                info!(
+                    model = %model,
+                    "No API keys detected — Ollama is running locally, using as default"
+                );
                 config.default_model.provider = "ollama".to_string();
-                config.default_model.model = "llama3.2".to_string();
+                config.default_model.model = model;
                 config.default_model.api_key_env = String::new();
                 if !config.provider_urls.contains_key("ollama") {
                     config.provider_urls.insert(
@@ -1401,6 +1408,11 @@ impl LibreFangKernel {
                         "http://localhost:11434/v1".to_string(),
                     );
                 }
+            } else {
+                warn!(
+                    "No API keys detected and Ollama is not running. \
+                     Set an API key or start Ollama to enable LLM features."
+                );
             }
         }
 

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -11,6 +11,15 @@ use librefang_types::error::LibreFangError;
 use std::path::{Component, Path, PathBuf};
 use tracing::info;
 
+/// Check if Ollama is reachable on localhost:11434 (TCP probe with 500ms timeout).
+pub(super) fn is_ollama_reachable() -> bool {
+    std::net::TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], 11434)),
+        std::time::Duration::from_millis(500),
+    )
+    .is_ok()
+}
+
 /// Ensure workspaces directory structure exists.
 pub(super) fn ensure_workspaces_layout(home_dir: &Path) -> KernelResult<()> {
     let workspaces_dir = home_dir.join("workspaces");

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -11,15 +11,6 @@ use librefang_types::error::LibreFangError;
 use std::path::{Component, Path, PathBuf};
 use tracing::info;
 
-/// Check if Ollama is reachable on localhost:11434 (TCP probe with 500ms timeout).
-pub(super) fn is_ollama_reachable() -> bool {
-    std::net::TcpStream::connect_timeout(
-        &std::net::SocketAddr::from(([127, 0, 0, 1], 11434)),
-        std::time::Duration::from_millis(500),
-    )
-    .is_ok()
-}
-
 /// Ensure workspaces directory structure exists.
 pub(super) fn ensure_workspaces_layout(home_dir: &Path) -> KernelResult<()> {
     let workspaces_dir = home_dir.join("workspaces");


### PR DESCRIPTION
## Summary

- When `provider = "auto"` or empty and no API keys are detected, the kernel previously hardcoded `ollama` + `llama3.2` as the default — even when Ollama isn't installed or running
- This causes the dashboard ChatPage to show `llama3.2` as the selected model and produce confusing "model not found" errors on first message
- Now the fallback probes `localhost:11434` before using Ollama, resolves the model from the catalog instead of hardcoding, and logs a clear warning if nothing is available

## Test plan

- [ ] Start kernel with no API keys and Ollama **not running** → verify no `llama3.2` default is set, warning logged
- [ ] Start kernel with no API keys and Ollama **running** → verify Ollama is used with catalog-resolved model
- [ ] Start kernel with a valid API key → verify auto-detection picks the keyed provider (unchanged behavior)
- [ ] `cargo check -p librefang-kernel` passes