### PR TITLE
feat(dashboard): group models by provider when showing all providers

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -152,6 +152,18 @@ export function ModelsPage() {
 
   const hiddenCount = useMemo(() => allModels.filter(m => hiddenSet.has(modelKey(m))).length, [allModels, hiddenSet]);
 
+  // Group by provider when showing all providers
+  const grouped = useMemo(() => {
+    if (providerFilter !== "all") return null;
+    const map = new Map<string, typeof filtered>();
+    for (const m of filtered) {
+      const list = map.get(m.provider);
+      if (list) list.push(m);
+      else map.set(m.provider, [m]);
+    }
+    return new Map([...map.entries()].sort(([a], [b]) => a.localeCompare(b)));
+  }, [filtered, providerFilter]);
+
   const tierColor = (tier?: string) => {
     switch (tier) {
       case "basic": return "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400";
@@ -279,65 +291,80 @@ export function ModelsPage() {
             <span></span>
           </div>
 
-          {filtered.map((m, i) => {
-            const isCustom = m.tier === "custom";
-            return (
-              <div key={`${m.provider}:${m.id}`}
-                className={`grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors ${
-                  !m.available ? "opacity-40" : ""
-                } ${i % 2 === 0 ? "" : "bg-main/30"}`}>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-1.5">
-                    <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
-                    {m.available ? (
-                      <span className="w-2 h-2 rounded-full bg-success shrink-0" />
-                    ) : (
-                      <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
-                        <Lock className="w-3 h-3" /> {t("models.no_key")}
-                      </span>
-                    )}
-                    {isCustom && (
-                      <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />
+          {(() => {
+            const renderRow = (m: (typeof filtered)[0], i: number) => {
+              const isCustom = m.tier === "custom";
+              return (
+                <div key={`${m.provider}:${m.id}`}
+                  className={`grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors ${
+                    !m.available ? "opacity-40" : ""
+                  } ${i % 2 === 0 ? "" : "bg-main/30"}`}>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-1.5">
+                      <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
+                      {m.available ? (
+                        <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                      ) : (
+                        <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
+                          <Lock className="w-3 h-3" /> {t("models.no_key")}
+                        </span>
+                      )}
+                      {isCustom && (
+                        <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />
+                      )}
+                    </div>
+                    {m.display_name && m.display_name !== m.id && (
+                      <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
                     )}
                   </div>
-                  {m.display_name && m.display_name !== m.id && (
-                    <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
-                  )}
-                </div>
-                <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
-                <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
-                  {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
-                </span>
-                <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
-                <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
-                <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                <span className="flex items-center justify-center gap-1">
-                  {showHidden ? (
-                    <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
-                      className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
-                      <Eye className="w-3.5 h-3.5" />
-                    </button>
-                  ) : (
-                    <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
-                      className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
-                      <EyeOff className="w-3.5 h-3.5" />
-                    </button>
-                  )}
-                  {isCustom && !showHidden && (
-                    confirmDeleteId === m.id ? (
-                      <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
-                    ) : (
-                      <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
-                        <Trash2 className="w-3.5 h-3.5" />
+                  <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
+                  <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
+                    {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
+                  </span>
+                  <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
+                  <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
+                  <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+                  <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+                  <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+                  <span className="flex items-center justify-center gap-1">
+                    {showHidden ? (
+                      <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
+                        className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
+                        <Eye className="w-3.5 h-3.5" />
                       </button>
-                    )
-                  )}
-                </span>
-              </div>
-            );
-          })}
+                    ) : (
+                      <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
+                        className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
+                        <EyeOff className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                    {isCustom && !showHidden && (
+                      confirmDeleteId === m.id ? (
+                        <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
+                      ) : (
+                        <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      )
+                    )}
+                  </span>
+                </div>
+              );
+            };
+
+            if (grouped) {
+              return Array.from(grouped.entries()).map(([provider, models]) => (
+                <div key={provider}>
+                  <div className="flex items-center gap-2 px-5 py-2 bg-surface border-t border-border-subtle min-w-[780px] sticky top-0 z-10">
+                    <span className="text-xs font-bold text-text">{provider}</span>
+                    <span className="px-1.5 py-0.5 rounded-full bg-brand/10 text-brand text-[10px] font-bold">{models.length}</span>
+                  </div>
+                  {models.map((m, i) => renderRow(m, i))}
+                </div>
+              ));
+            }
+            return filtered.map((m, i) => renderRow(m, i));
+          })()}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- When provider filter is "all", models are grouped under provider headers (sorted alphabetically) with model count badges
- Selecting a specific provider keeps the flat list unchanged
- All existing filters (search, tier, available only, hidden) work correctly with grouping