### PR TITLE
fix(dashboard): collapsible provider groups in models page

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -13,7 +13,7 @@ import { Modal } from "../components/ui/Modal";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { useUIStore } from "../lib/store";
 import {
-  Cpu, Search, Check, X, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2, Sparkles
+  Cpu, Search, Check, X, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2, Sparkles, ChevronDown, ChevronRight
 } from "lucide-react";
 import { modelKey } from "../lib/hiddenModels";
 
@@ -30,6 +30,7 @@ export function ModelsPage() {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   useCreateShortcut(() => setShowAdd(true));
   const [showHidden, setShowHidden] = useState(false);
+  const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
   const hiddenModelKeys = useUIStore((s) => s.hiddenModelKeys);
   const hideModelAction = useUIStore((s) => s.hideModel);
   const unhideModelAction = useUIStore((s) => s.unhideModel);
@@ -277,8 +278,8 @@ export function ModelsPage() {
           icon={<Cpu className="w-7 h-7" />}
           title={allModels.length === 0 ? t("models.no_models") : t("models.no_results")}
         />
-      ) : (
-        <div className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
+      ) : (() => {
+        const colHeader = (
           <div className="grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 bg-main text-[11px] font-bold text-text-dim/60 uppercase">
             <span>{t("models.col_model")}</span>
             <span>{t("models.col_provider")}</span>
@@ -290,83 +291,118 @@ export function ModelsPage() {
             <span className="text-center" title={t("models.col_streaming")}><Zap className="w-3.5 h-3.5 inline" /></span>
             <span></span>
           </div>
+        );
 
-          {(() => {
-            const renderRow = (m: (typeof filtered)[0], i: number) => {
-              const isCustom = m.tier === "custom";
-              return (
-                <div key={`${m.provider}:${m.id}`}
-                  className={`grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors ${
-                    !m.available ? "opacity-40" : ""
-                  } ${i % 2 === 0 ? "" : "bg-main/30"}`}>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1.5">
-                      <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
-                      {m.available ? (
-                        <span className="w-2 h-2 rounded-full bg-success shrink-0" />
-                      ) : (
-                        <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
-                          <Lock className="w-3 h-3" /> {t("models.no_key")}
-                        </span>
+        const renderRow = (m: (typeof filtered)[0], i: number) => {
+          const isCustom = m.tier === "custom";
+          return (
+            <div key={`${m.provider}:${m.id}`}
+              className={`grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors ${
+                !m.available ? "opacity-40" : ""
+              } ${i % 2 === 0 ? "" : "bg-main/30"}`}>
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
+                  {m.available ? (
+                    <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                  ) : (
+                    <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
+                      <Lock className="w-3 h-3" /> {t("models.no_key")}
+                    </span>
+                  )}
+                  {isCustom && (
+                    <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />
+                  )}
+                </div>
+                {m.display_name && m.display_name !== m.id && (
+                  <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
+                )}
+              </div>
+              <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
+              <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
+                {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
+              </span>
+              <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
+              <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
+              <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+              <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+              <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+              <span className="flex items-center justify-center gap-1">
+                {showHidden ? (
+                  <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
+                    className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
+                    <Eye className="w-3.5 h-3.5" />
+                  </button>
+                ) : (
+                  <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
+                    className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
+                    <EyeOff className="w-3.5 h-3.5" />
+                  </button>
+                )}
+                {isCustom && !showHidden && (
+                  confirmDeleteId === m.id ? (
+                    <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
+                  ) : (
+                    <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  )
+                )}
+              </span>
+            </div>
+          );
+        };
+
+        const toggleProvider = (p: string) => {
+          setCollapsedProviders(prev => {
+            const next = new Set(prev);
+            if (next.has(p)) next.delete(p); else next.add(p);
+            return next;
+          });
+        };
+
+        if (grouped) {
+          return (
+            <div className="flex flex-col gap-3">
+              {Array.from(grouped.entries()).map(([provider, models]) => {
+                const collapsed = collapsedProviders.has(provider);
+                const availCount = models.filter(m => m.available).length;
+                return (
+                  <div key={provider} className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
+                    <button
+                      type="button"
+                      onClick={() => toggleProvider(provider)}
+                      className="flex items-center gap-3 w-full px-5 py-3.5 bg-surface hover:bg-main/60 transition-colors cursor-pointer select-none min-w-[780px]"
+                    >
+                      {collapsed
+                        ? <ChevronRight className="w-4 h-4 text-text-dim shrink-0" />
+                        : <ChevronDown className="w-4 h-4 text-text-dim shrink-0" />}
+                      <span className="text-sm font-bold text-text">{provider}</span>
+                      <span className="px-2 py-0.5 rounded-full bg-brand/10 text-brand text-[11px] font-bold">{models.length}</span>
+                      {availCount > 0 && availCount < models.length && (
+                        <span className="text-[11px] text-text-dim">{availCount} {t("models.available")}</span>
                       )}
-                      {isCustom && (
-                        <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />
-                      )}
-                    </div>
-                    {m.display_name && m.display_name !== m.id && (
-                      <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
+                    </button>
+                    {!collapsed && (
+                      <>
+                        {colHeader}
+                        {models.map((m, i) => renderRow(m, i))}
+                      </>
                     )}
                   </div>
-                  <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
-                  <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
-                    {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
-                  </span>
-                  <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
-                  <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
-                  <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                  <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                  <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-                  <span className="flex items-center justify-center gap-1">
-                    {showHidden ? (
-                      <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
-                        className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
-                        <Eye className="w-3.5 h-3.5" />
-                      </button>
-                    ) : (
-                      <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
-                        className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
-                        <EyeOff className="w-3.5 h-3.5" />
-                      </button>
-                    )}
-                    {isCustom && !showHidden && (
-                      confirmDeleteId === m.id ? (
-                        <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
-                      ) : (
-                        <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </button>
-                      )
-                    )}
-                  </span>
-                </div>
-              );
-            };
+                );
+              })}
+            </div>
+          );
+        }
 
-            if (grouped) {
-              return Array.from(grouped.entries()).map(([provider, models]) => (
-                <div key={provider}>
-                  <div className="flex items-center gap-2 px-5 py-2 bg-surface border-t border-border-subtle min-w-[780px] sticky top-0 z-10">
-                    <span className="text-xs font-bold text-text">{provider}</span>
-                    <span className="px-1.5 py-0.5 rounded-full bg-brand/10 text-brand text-[10px] font-bold">{models.length}</span>
-                  </div>
-                  {models.map((m, i) => renderRow(m, i))}
-                </div>
-              ));
-            }
-            return filtered.map((m, i) => renderRow(m, i));
-          })()}
-        </div>
-      )}
+        return (
+          <div className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
+            {colHeader}
+            {filtered.map((m, i) => renderRow(m, i))}
+          </div>
+        );
+      })()}
 
       {/* Add Model Modal */}
       <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">


### PR DESCRIPTION
## Summary
- Replace flat provider group headers with collapsible card-style groups
- Each provider gets its own rounded card with a clickable header (chevron + name + count + available count)
- Click header to expand/collapse the model list under that provider
- Selecting a specific provider in the filter reverts to the original flat table