### PR TITLE
feat(dashboard): conditionally show thinking toggles based on model capability

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -191,6 +191,7 @@ export interface AgentItem {
   model_name?: string;
   model_tier?: string;
   auth_status?: string;
+  supports_thinking?: boolean;
   ready?: boolean;
   profile?: string;
   identity?: AgentIdentity;
@@ -865,6 +866,7 @@ export interface ModelItem {
   supports_tools?: boolean;
   supports_vision?: boolean;
   supports_streaming?: boolean;
+  supports_thinking?: boolean;
   available?: boolean;
 }
 

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -783,7 +783,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 });
 
 // Input box - with shortcut hints
-function ChatInput({ onSend, disabled, placeholder, authMissing, providerName }: { onSend: (msg: string) => void; disabled: boolean; placeholder: string; authMissing?: boolean; providerName?: string }) {
+function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, supportsThinking }: { onSend: (msg: string) => void; disabled: boolean; placeholder: string; authMissing?: boolean; providerName?: string; supportsThinking?: boolean }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -834,7 +834,8 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName }:
           ))}
         </div>
       )}
-      {/* Thinking mode toggles */}
+      {/* Thinking mode toggles — only shown when the model supports thinking */}
+      {supportsThinking && (
       <div className="flex items-center gap-2 flex-wrap">
         <button
           type="button"
@@ -863,6 +864,7 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName }:
           <span>{t("chat.show_thinking")}</span>
         </button>
       </div>
+      )}
       <div className="flex gap-2 sm:gap-3 items-end">
         <div className="flex-1">
           <textarea
@@ -1667,6 +1669,7 @@ export function ChatPage() {
               placeholder={selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
               authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
               providerName={selectedAgent?.model_provider}
+              supportsThinking={selectedAgent?.supports_thinking}
             />
           </div>
         </main>

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -723,20 +723,21 @@ pub(crate) fn enrich_agent_json(
         e.manifest.model.model.as_str()
     };
 
-    let (tier, auth_status) = catalog
+    let (tier, auth_status, supports_thinking) = catalog
         .as_ref()
         .map(|cat| {
-            let tier = cat
-                .find_model(model)
+            let model_entry = cat.find_model(model);
+            let tier = model_entry
                 .map(|m| format!("{:?}", m.tier).to_lowercase())
                 .unwrap_or_else(|| "unknown".to_string());
+            let thinking = model_entry.map(|m| m.supports_thinking).unwrap_or(false);
             let auth = cat
                 .get_provider(provider)
                 .map(|p| p.auth_status.to_string())
                 .unwrap_or_else(|| "unknown".to_string());
-            (tier, auth)
+            (tier, auth, thinking)
         })
-        .unwrap_or(("unknown".to_string(), "unknown".to_string()));
+        .unwrap_or(("unknown".to_string(), "unknown".to_string(), false));
 
     let ready =
         matches!(e.state, librefang_types::agent::AgentState::Running) && auth_status != "missing";
@@ -753,6 +754,7 @@ pub(crate) fn enrich_agent_json(
         "model_name": model,
         "model_tier": tier,
         "auth_status": auth_status,
+        "supports_thinking": supports_thinking,
         "ready": ready,
         "profile": e.manifest.profile,
         "identity": {

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -127,6 +127,7 @@ pub async fn list_models(
                 "supports_tools": m.supports_tools,
                 "supports_vision": m.supports_vision,
                 "supports_streaming": m.supports_streaming,
+                "supports_thinking": m.supports_thinking,
                 "available": available,
             })
         })
@@ -655,6 +656,10 @@ pub async fn add_custom_model(
             .get("supports_streaming")
             .and_then(|v| v.as_bool())
             .unwrap_or(true),
+        supports_thinking: body
+            .get("supports_thinking")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
         aliases: vec![],
     };
 

--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -611,6 +611,7 @@ mod tests {
                 supports_tools: true,
                 supports_vision: false,
                 supports_streaming: true,
+                supports_thinking: false,
                 aliases: vec![],
             }],
         });

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -552,6 +552,7 @@ impl ModelCatalog {
                 supports_tools: true,
                 supports_vision: false,
                 supports_streaming: true,
+                supports_thinking: false,
                 aliases: Vec::new(),
             });
             added += 1;
@@ -1240,6 +1241,7 @@ id = "acme"
             supports_tools: true,
             supports_vision: false,
             supports_streaming: true,
+            supports_thinking: false,
             aliases: vec!["custom-qwen".to_string()],
         });
 
@@ -1267,6 +1269,7 @@ id = "acme"
             supports_tools: true,
             supports_vision: false,
             supports_streaming: true,
+            supports_thinking: false,
             aliases: Vec::new(),
         }));
 
@@ -1282,6 +1285,7 @@ id = "acme"
             supports_tools: true,
             supports_vision: false,
             supports_streaming: true,
+            supports_thinking: false,
             aliases: Vec::new(),
         }));
 
@@ -1324,6 +1328,7 @@ id = "acme"
             supports_tools: true,
             supports_vision: false,
             supports_streaming: true,
+            supports_thinking: false,
             aliases: Vec::new(),
         }));
 

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -118,6 +118,9 @@ pub struct ModelCatalogEntry {
     /// Whether the model supports streaming responses.
     #[serde(default)]
     pub supports_streaming: bool,
+    /// Whether the model supports extended thinking / reasoning.
+    #[serde(default)]
+    pub supports_thinking: bool,
     /// Aliases for this model (e.g. ["sonnet", "claude-sonnet"]).
     #[serde(default)]
     pub aliases: Vec<String>,
@@ -137,6 +140,7 @@ impl Default for ModelCatalogEntry {
             supports_tools: false,
             supports_vision: false,
             supports_streaming: false,
+            supports_thinking: false,
             aliases: Vec::new(),
         }
     }
@@ -403,6 +407,7 @@ mod tests {
             supports_tools: true,
             supports_vision: true,
             supports_streaming: true,
+            supports_thinking: true,
             aliases: vec!["sonnet".to_string(), "claude-sonnet".to_string()],
         };
         let json = serde_json::to_string(&entry).unwrap();


### PR DESCRIPTION
## Summary

- Add `supports_thinking` field to `ModelCatalogEntry` so the dashboard can determine whether a model supports extended thinking
- `/api/models` and `/api/agents` now include `supports_thinking` in their responses
- ChatPage thinking toggles ("deep thinking" / "show thinking process") are only rendered when the current agent's model has `supports_thinking = true`
- Custom model creation (`POST /api/models/custom`) accepts `supports_thinking` from the request body

Previously these buttons were always visible, which was confusing when using models that don't support thinking (e.g. local Ollama models).

## Follow-up

Provider TOML files in [librefang-registry](https://github.com/librefang/librefang-registry) need `supports_thinking = true` added to models that support it (Anthropic Claude, OpenAI o-series, DeepSeek-R1, Gemini 2.5+/3.x). `#[serde(default)]` ensures backward compatibility with existing TOMLs.

## Test plan

- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Dashboard: select Claude agent → thinking buttons visible
- [ ] Dashboard: select ollama/local agent → thinking buttons hidden
- [ ] Dashboard: switch model on agent → buttons update dynamically