### PR TITLE
fix(dashboard): i18n remaining hardcoded strings across all pages

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -111,7 +111,8 @@
       "hours_short": "h",
       "minutes_short": "m",
       "seconds_short": "s"
-    }
+    },
+    "copy": "Copy"
   },
   "status": {
     "running": "Running",
@@ -417,7 +418,9 @@
     "test_success": "Channel test passed",
     "test_failed": "Channel test failed",
     "reload": "Reload",
-    "reload_success": "Channels reloaded"
+    "reload_success": "Channels reloaded",
+    "qr_failed": "Failed to get QR code",
+    "login_success": "Login successful! Saving configuration..."
   },
   "skills": {
     "title": "Skills",
@@ -453,7 +456,17 @@
     "builtin": "FangHub",
     "official": "Official",
     "install_to": "Install to",
-    "global": "Global (all agents)"
+    "global": "Global (all agents)",
+    "cat_coding": "Coding",
+    "cat_git": "Git",
+    "cat_web": "Web",
+    "cat_devops": "DevOps",
+    "cat_browser": "Browser",
+    "cat_ai": "AI",
+    "cat_data": "Data",
+    "cat_productivity": "Productivity",
+    "cat_security": "Security",
+    "cat_cli": "CLI"
   },
   "hands": {
     "title": "Hands",
@@ -535,7 +548,12 @@
     "no_trend_data": "No trend data available yet",
     "cost_per_call": "Cost per Call",
     "cheapest_call": "Cheapest/Call",
-    "help": "View usage statistics and cost analytics. Monitor API calls, token consumption, and set budget limits to control spending."
+    "help": "View usage statistics and cost analytics. Monitor API calls, token consumption, and set budget limits to control spending.",
+    "cost": "Cost",
+    "avg": "Avg",
+    "min": "Min",
+    "max": "Max",
+    "cost_per_call_label": "Cost/Call"
   },
   "memory": {
     "title": "Memory",
@@ -719,7 +737,19 @@
       "respond_desc": "Send response",
       "agent": "Agent",
       "agent_desc": "Run agent task"
-    }
+    },
+    "ungroup": "Ungroup",
+    "delete_group": "Delete group and children",
+    "group": "Group",
+    "fit_view": "Fit View (Cmd+1)",
+    "export": "Export (Cmd+E)",
+    "import": "Import (Cmd+I)",
+    "shortcuts": "Shortcuts (?)",
+    "dry_run_hint": "Dry Run — validate without calling LLMs",
+    "dry_run": "Dry Run",
+    "dry_run_desc": "Validate agents and preview resolved prompts without calling any LLMs.",
+    "fullscreen": "Fullscreen",
+    "exit_fullscreen": "Exit fullscreen"
   },
   "workflows": {
     "title": "Workflows",
@@ -789,7 +819,11 @@
       "organizer_desc": "Categorize and structure",
       "report_writer": "Report Writer",
       "report_writer_desc": "Generate polished report"
-    }
+    },
+    "dry_run": "Dry Run",
+    "dry_run_hint": "Dry Run — validate without calling LLMs",
+    "dry_run_valid": "Valid — all agents resolved",
+    "dry_run_warning": "Warning — some agents not found"
   },
   "scheduler": {
     "title": "Scheduler",
@@ -1375,7 +1409,8 @@
     "save_all": "Save All",
     "no_results": "No fields match your search",
     "reset_default": "Reset to default",
-    "unsaved_warning": "You have unsaved changes. Discard them?"
+    "unsaved_warning": "You have unsaved changes. Discard them?",
+    "save_failed": "Save failed"
   },
   "chat": {
     "title": "Chat",
@@ -1418,7 +1453,30 @@
     "tts_unavailable": "No TTS provider configured",
     "tts_generating": "Generating speech...",
     "tts_error": "Speech generation failed",
-    "tts_empty": "No readable text"
+    "tts_empty": "No readable text",
+    "cmd_help": "Show available commands",
+    "cmd_clear": "Clear chat history",
+    "cmd_agents": "List available agents",
+    "cmd_info": "Show current agent info",
+    "cmd_new": "Reset session (clear history)",
+    "cmd_compact": "Compress context to save space",
+    "cmd_reset": "Reset session (clear history)",
+    "cmd_reboot": "Reboot session (clear context)",
+    "cmd_stop": "Cancel current run",
+    "cmd_model": "Show or switch model",
+    "cmd_usage": "Show session token usage",
+    "cmd_context": "Show context pressure",
+    "cmd_verbose": "Toggle verbose level",
+    "cmd_budget": "Show budget status",
+    "cmd_peers": "Show connected peers",
+    "cmd_a2a": "Show A2A agents",
+    "cmd_queue": "Show agent queue status",
+    "no_agents_available": "No agents available.",
+    "no_agent_selected": "No agent selected.",
+    "info_model": "Model",
+    "info_provider": "Provider",
+    "info_state": "State",
+    "ws_not_connected": "WebSocket not connected. Please refresh the page."
   },
   "goals": {
     "title": "Goals",
@@ -1502,7 +1560,8 @@
       "noEntries": "No audit entries found.",
       "showing": "Showing {{from}}-{{to}} of {{total}}"
     },
-    "loadError": "Failed to load approvals. Check your connection."
+    "loadError": "Failed to load approvals. Check your connection.",
+    "batch_disabled_totp": "Batch approve disabled when TOTP is enforced"
   },
   "wizard": {
     "welcome": "Welcome",
@@ -1791,6 +1850,9 @@
     "auth_revoke": "Revoke",
     "auth_started": "Authorization started — complete in the new tab",
     "auth_revoked": "Authorization revoked",
+    "auth_failed": "Auth failed",
+    "auth_start_failed": "Failed to start auth",
+    "auth_revoke_failed": "Failed to revoke auth",
     "tab_my_servers": "My Servers",
     "tab_registry": "Registry",
     "registry_subtitle": "Pre-configured MCP server templates from the registry",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -111,7 +111,8 @@
       "hours_short": "时",
       "minutes_short": "分",
       "seconds_short": "秒"
-    }
+    },
+    "copy": "复制"
   },
   "status": {
     "running": "运行中",
@@ -417,7 +418,9 @@
     "test_success": "通道测试通过",
     "test_failed": "通道测试失败",
     "reload": "重新加载",
-    "reload_success": "通道已重新加载"
+    "reload_success": "通道已重新加载",
+    "qr_failed": "获取二维码失败",
+    "login_success": "登录成功！正在保存配置..."
   },
   "skills": {
     "title": "技能",
@@ -453,7 +456,17 @@
     "builtin": "FangHub",
     "official": "官方",
     "install_to": "安装到",
-    "global": "全局（所有 Agent）"
+    "global": "全局（所有 Agent）",
+    "cat_coding": "编程",
+    "cat_git": "Git",
+    "cat_web": "Web",
+    "cat_devops": "DevOps",
+    "cat_browser": "浏览器",
+    "cat_ai": "AI",
+    "cat_data": "数据",
+    "cat_productivity": "效率",
+    "cat_security": "安全",
+    "cat_cli": "CLI"
   },
   "hands": {
     "title": "Hands",
@@ -535,7 +548,12 @@
     "no_trend_data": "暂无趋势数据",
     "cost_per_call": "单次调用成本",
     "cheapest_call": "最低单次成本",
-    "help": "查看使用统计和成本分析。监控 API 调用次数、Token 消耗量，设置预算限额控制支出。"
+    "help": "查看使用统计和成本分析。监控 API 调用次数、Token 消耗量，设置预算限额控制支出。",
+    "cost": "费用",
+    "avg": "平均",
+    "min": "最小",
+    "max": "最大",
+    "cost_per_call_label": "每次调用费用"
   },
   "memory": {
     "title": "记忆",
@@ -722,7 +740,19 @@
       "respond_desc": "发送响应",
       "agent": "智能体",
       "agent_desc": "运行智能体任务"
-    }
+    },
+    "ungroup": "取消分组",
+    "delete_group": "删除分组及子节点",
+    "group": "分组",
+    "fit_view": "适应视图 (Cmd+1)",
+    "export": "导出 (Cmd+E)",
+    "import": "导入 (Cmd+I)",
+    "shortcuts": "快捷键 (?)",
+    "dry_run_hint": "Dry Run — 验证但不调用 LLM",
+    "dry_run": "Dry Run",
+    "dry_run_desc": "验证 Agent 并预览解析后的提示词，不调用任何 LLM。",
+    "fullscreen": "全屏",
+    "exit_fullscreen": "退出全屏"
   },
   "workflows": {
     "title": "工作流",
@@ -793,7 +823,11 @@
       "organizer_desc": "分类和结构化",
       "report_writer": "周报撰写",
       "report_writer_desc": "生成专业周报"
-    }
+    },
+    "dry_run": "Dry Run",
+    "dry_run_hint": "Dry Run — 验证但不调用 LLM",
+    "dry_run_valid": "验证通过 — 所有 Agent 已解析",
+    "dry_run_warning": "警告 — 部分 Agent 未找到"
   },
   "scheduler": {
     "title": "调度器",
@@ -1350,7 +1384,8 @@
     "save_all": "全部保存",
     "no_results": "没有匹配的字段",
     "reset_default": "恢复默认值",
-    "unsaved_warning": "有未保存的修改，确定要丢弃吗？"
+    "unsaved_warning": "有未保存的修改，确定要丢弃吗？",
+    "save_failed": "保存失败"
   },
   "chat": {
     "title": "对话",
@@ -1393,7 +1428,30 @@
     "tts_unavailable": "未配置 TTS 供应商",
     "tts_generating": "正在生成语音...",
     "tts_error": "语音生成失败",
-    "tts_empty": "没有可朗读的文本"
+    "tts_empty": "没有可朗读的文本",
+    "cmd_help": "显示可用命令",
+    "cmd_clear": "清除聊天记录",
+    "cmd_agents": "列出可用 Agent",
+    "cmd_info": "显示当前 Agent 信息",
+    "cmd_new": "重置会话（清除历史）",
+    "cmd_compact": "压缩上下文以节省空间",
+    "cmd_reset": "重置会话（清除历史）",
+    "cmd_reboot": "重启会话（清除上下文）",
+    "cmd_stop": "取消当前运行",
+    "cmd_model": "显示或切换模型",
+    "cmd_usage": "显示会话 Token 使用量",
+    "cmd_context": "显示上下文压力",
+    "cmd_verbose": "切换详细日志级别",
+    "cmd_budget": "显示预算状态",
+    "cmd_peers": "显示已连接节点",
+    "cmd_a2a": "显示 A2A Agent",
+    "cmd_queue": "显示 Agent 队列状态",
+    "no_agents_available": "没有可用的 Agent。",
+    "no_agent_selected": "未选择 Agent。",
+    "info_model": "模型",
+    "info_provider": "提供商",
+    "info_state": "状态",
+    "ws_not_connected": "WebSocket 未连接，请刷新页面。"
   },
   "goals": {
     "title": "目标",
@@ -1477,7 +1535,8 @@
       "noEntries": "暂无审计记录。",
       "showing": "显示第 {{from}}-{{to}} 条，共 {{total}} 条"
     },
-    "loadError": "加载审批列表失败，请检查网络连接。"
+    "loadError": "加载审批列表失败，请检查网络连接。",
+    "batch_disabled_totp": "TOTP 强制启用时不可批量审批"
   },
   "wizard": {
     "welcome": "欢迎",
@@ -1798,6 +1857,9 @@
     "auth_revoke": "撤销",
     "auth_started": "授权已开始 — 请在新标签页中完成",
     "auth_revoked": "授权已撤销",
+    "auth_failed": "认证失败",
+    "auth_start_failed": "启动认证失败",
+    "auth_revoke_failed": "撤销认证失败",
     "tab_my_servers": "我的服务器",
     "tab_registry": "Registry",
     "registry_subtitle": "来自 Registry 的预配置 MCP 服务器模板",

--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -148,7 +148,7 @@ export function AnalyticsPage() {
                     <CartesianGrid strokeDasharray="3 3" opacity={0.2} horizontal={false} />
                     <XAxis type="number" tick={{ fontSize: 10 }} tickFormatter={v => `$${v}`} axisLine={false} tickLine={false} />
                     <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={100} axisLine={false} tickLine={false} />
-                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [formatCost(v), "Cost"]} />
+                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [formatCost(v), t("analytics.cost")]} />
                     <Bar dataKey="cost" radius={[0, 6, 6, 0]} fill="#3b82f6" />
                   </BarChart>
                 </ResponsiveContainer>
@@ -167,7 +167,7 @@ export function AnalyticsPage() {
                     <CartesianGrid strokeDasharray="3 3" opacity={0.2} horizontal={false} />
                     <XAxis type="number" tick={{ fontSize: 10 }} tickFormatter={v => `$${v}`} axisLine={false} tickLine={false} />
                     <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={120} axisLine={false} tickLine={false} />
-                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [formatCost(v), "Cost"]} />
+                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [formatCost(v), t("analytics.cost")]} />
                     <Bar dataKey="cost" radius={[0, 6, 6, 0]} fill="#a855f7" />
                   </BarChart>
                 </ResponsiveContainer>
@@ -234,7 +234,7 @@ export function AnalyticsPage() {
                   </h2>
                   <ResponsiveContainer width="100%" height={Math.max(modelPerformance.slice(0, 8).length * 40, 120)}>
                     <BarChart data={modelPerformance.slice(0, 8).map(m => ({ 
-                      name: m.model?.slice(0, 18) ?? "Unknown", 
+                      name: m.model?.slice(0, 18) ?? t("common.unknown"), 
                       avg: m.avg_latency_ms ?? 0,
                       min: m.min_latency_ms ?? 0,
                       max: m.max_latency_ms ?? 0,
@@ -244,9 +244,9 @@ export function AnalyticsPage() {
                       <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={120} axisLine={false} tickLine={false} />
                       <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any, name: any) => [`${v}ms`, name]} />
                       <Legend />
-                      <Bar dataKey="avg" name="Avg" radius={[0, 4, 4, 0]} fill="#3b82f6" />
-                      <Bar dataKey="min" name="Min" radius={[0, 4, 4, 0]} fill="#22c55e" />
-                      <Bar dataKey="max" name="Max" radius={[0, 4, 4, 0]} fill="#ef4444" />
+                      <Bar dataKey="avg" name={t("analytics.avg")} radius={[0, 4, 4, 0]} fill="#3b82f6" />
+                      <Bar dataKey="min" name={t("analytics.min")} radius={[0, 4, 4, 0]} fill="#22c55e" />
+                      <Bar dataKey="max" name={t("analytics.max")} radius={[0, 4, 4, 0]} fill="#ef4444" />
                     </BarChart>
                   </ResponsiveContainer>
                 </Card>
@@ -257,14 +257,14 @@ export function AnalyticsPage() {
                   </h2>
                   <ResponsiveContainer width="100%" height={Math.max(modelPerformance.slice(0, 8).length * 40, 120)}>
                     <BarChart data={modelPerformance.slice(0, 8).map(m => ({ 
-                      name: m.model?.slice(0, 18) ?? "Unknown", 
+                      name: m.model?.slice(0, 18) ?? t("common.unknown"), 
                       costPerCall: m.cost_per_call ?? 0,
                     }))} layout="vertical" margin={{ left: 0, right: 20 }}>
                       <CartesianGrid strokeDasharray="3 3" opacity={0.2} horizontal={false} />
                       <XAxis type="number" tick={{ fontSize: 10 }} tickFormatter={v => `$${v.toFixed(4)}`} axisLine={false} tickLine={false} />
                       <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={120} axisLine={false} tickLine={false} />
-                      <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [`$${v.toFixed(4)}`, "Cost/Call"]} />
-                      <Bar dataKey="costPerCall" name="Cost/Call" radius={[0, 4, 4, 0]} fill="#a855f7" />
+                      <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12 }} formatter={(v: any) => [`$${v.toFixed(4)}`, t("analytics.cost_per_call_label")]} />
+                      <Bar dataKey="costPerCall" name={t("analytics.cost_per_call_label")} radius={[0, 4, 4, 0]} fill="#a855f7" />
                     </BarChart>
                   </ResponsiveContainer>
                 </Card>

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -415,7 +415,7 @@ export function ApprovalsPage() {
                     onClick={() => handleBatchAction("approve")}
                     disabled={pendingId === "batch" || totpEnforced}
                     isLoading={pendingId === "batch"}
-                    title={totpEnforced ? "Batch approve disabled when TOTP is enforced" : undefined}
+                    title={totpEnforced ? t("approvals.batch_disabled_totp") : undefined}
                   >
                     {t("approvals.approveSelected")}
                   </Button>

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -141,6 +141,7 @@ function CustomNode({ data, type: nodeTypeKey, t }: { data: any; type: string; t
 
 // Group node component
 function GroupNodeComponent({ data, id }: { data: any; id: string }) {
+  const { t } = useTranslation();
   const expanded = data._expanded !== false;
   return (
     <div
@@ -160,20 +161,20 @@ function GroupNodeComponent({ data, id }: { data: any; id: string }) {
             ? <ChevronDown className="w-3.5 h-3.5 text-brand shrink-0" />
             : <ChevronRight className="w-3.5 h-3.5 text-brand shrink-0" />}
           <Group className="w-3.5 h-3.5 text-brand shrink-0" />
-          <span className="text-xs font-bold text-brand truncate">{data.label || "Group"}</span>
+          <span className="text-xs font-bold text-brand truncate">{data.label || t("canvas.group")}</span>
           {!expanded && data._childCount > 0 && (
             <span className="text-[9px] text-brand/50">{data._childCount}</span>
           )}
         </div>
         {/* Ungroup (keep child nodes) */}
         <button onClick={(e) => { e.stopPropagation(); data._onUngroup?.(id); }}
-          title="Ungroup"
+          title={t("canvas.ungroup")}
           className="p-0.5 rounded hover:bg-brand/20 text-brand/50 hover:text-brand shrink-0">
           <X className="w-3 h-3" />
         </button>
         {/* Delete group + child nodes */}
         <button onClick={(e) => { e.stopPropagation(); data._onDeleteGroup?.(id); }}
-          title="Delete group and children"
+          title={t("canvas.delete_group")}
           className="p-0.5 rounded hover:bg-error/20 text-text-dim/30 hover:text-error shrink-0">
           <Trash2 className="w-3 h-3" />
         </button>
@@ -1703,10 +1704,10 @@ function CanvasPageInner() {
 
           {/* View tools */}
           <div className="flex items-center gap-0.5 px-0.5 sm:px-1">
-            <Button variant="secondary" onClick={() => setIsFullscreen(!isFullscreen)} title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}>
+            <Button variant="secondary" onClick={() => setIsFullscreen(!isFullscreen)} title={isFullscreen ? t("canvas.exit_fullscreen") : t("canvas.fullscreen")}>
               {isFullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
             </Button>
-            <Button variant="secondary" onClick={() => fitView({ padding: 0.2, duration: 300 })} title="Fit View (Cmd+1)">
+            <Button variant="secondary" onClick={() => fitView({ padding: 0.2, duration: 300 })} title={t("canvas.fit_view")}>
               <Scan className="w-4 h-4" />
             </Button>
           </div>
@@ -1721,10 +1722,10 @@ function CanvasPageInner() {
             <Button variant="secondary" onClick={() => setShowTemplateBrowser(true)} title={t("canvas.browse_templates")}>
               <LayoutTemplate className="w-4 h-4" />
             </Button>
-            <Button variant="secondary" onClick={exportWorkflow} title="Export (Cmd+E)">
+            <Button variant="secondary" onClick={exportWorkflow} title={t("canvas.export")}>
               <Download className="w-4 h-4" />
             </Button>
-            <Button variant="secondary" onClick={importWorkflow} title="Import (Cmd+I)" className="hidden sm:flex">
+            <Button variant="secondary" onClick={importWorkflow} title={t("canvas.import")} className="hidden sm:flex">
               <Upload className="w-4 h-4" />
             </Button>
           </div>
@@ -1736,7 +1737,7 @@ function CanvasPageInner() {
             <Button variant="secondary" onClick={() => { setNodes([]); setEdges([]); setEditingNode(null); }} title={t("common.clear")}>
               <Trash2 className="w-4 h-4" />
             </Button>
-            <Button variant="secondary" onClick={() => setShowHelp(true)} title="Shortcuts (?)" className="hidden sm:flex">
+            <Button variant="secondary" onClick={() => setShowHelp(true)} title={t("canvas.shortcuts")} className="hidden sm:flex">
               <HelpCircle className="w-4 h-4" />
             </Button>
           </div>
@@ -1761,7 +1762,7 @@ function CanvasPageInner() {
             </Button>
             <Button variant="secondary" onClick={() => handleRunClick("dry")}
               disabled={(!selectedWorkflow && agentStepCount === 0) || !!runningWorkflowId || isDryRunning}
-              title="Dry Run — validate without calling LLMs">
+              title={t("canvas.dry_run_hint")}>
               {isDryRunning ? <Loader2 className="w-4 h-4 animate-spin" /> : <FlaskConical className="w-4 h-4" />}
               <span className="hidden sm:inline ml-1">Dry Run</span>
             </Button>
@@ -1866,7 +1867,7 @@ function CanvasPageInner() {
               <div className="p-3 space-y-3">
                 <p className="text-[10px] text-text-dim">
                   {showRunInput === "dry"
-                    ? "Validate agents and preview resolved prompts without calling any LLMs."
+                    ? t("canvas.dry_run_desc")
                     : t("canvas.run_input_hint")}
                 </p>
                 <textarea value={runInput} onChange={e => setRunInput(e.target.value)}
@@ -1891,7 +1892,7 @@ function CanvasPageInner() {
                       </Button>
                       <Button variant="ghost" size="sm" onClick={() => handleDryRun()}
                         disabled={isDryRunning || !!runningWorkflowId}
-                        title="Dry Run">
+                        title={t("canvas.dry_run")}>
                         <FlaskConical className="w-3.5 h-3.5" />
                       </Button>
                     </>

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -412,9 +412,9 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
                         addToast(ok ? t("common.copied") : t("common.copy_failed"), ok ? "success" : "error");
                       }}
                       className="px-3 py-2 rounded-lg bg-brand/10 text-brand text-xs hover:bg-brand/20 transition-colors shrink-0"
-                      title="Copy"
+                      title={t("common.copy")}
                     >
-                      Copy
+                      {t("common.copy")}
                     </button>
                   </div>
                 ) : field.type === "select" && field.options ? (
@@ -485,7 +485,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
       const res = await qrStart();
       if (!res.available || !res.qr_code) {
         setPhase("error");
-        setMessage(res.message || "Failed to get QR code");
+        setMessage(res.message || t("channels.qr_failed"));
         return;
       }
       setPhase("scanning");
@@ -508,7 +508,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
             if (status.connected && status.bot_token) {
               cancelledRef.current = true;
               setPhase("success");
-              setMessage("Login successful! Saving configuration...");
+              setMessage(t("channels.login_success"));
               await configureChannel(channel.name, { bot_token_env: status.bot_token });
               queryClient.invalidateQueries({ queryKey: ["channels", "list"] });
               setTimeout(onClose, 1500);

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -44,25 +44,25 @@ interface ChatMessage {
   thinkingCollapsed?: boolean;
 }
 
-// Slash commands
+// Slash commands — desc is an i18n key under "chat.cmd_*"
 const SLASH_COMMANDS = [
-  { cmd: "/help", desc: "Show available commands" },
-  { cmd: "/clear", desc: "Clear chat history" },
-  { cmd: "/agents", desc: "List available agents" },
-  { cmd: "/info", desc: "Show current agent info" },
-  { cmd: "/new", desc: "Reset session (clear history)" },
-  { cmd: "/compact", desc: "Compress context to save space" },
-  { cmd: "/reset", desc: "Reset session (clear history)" },
-  { cmd: "/reboot", desc: "Reboot session (clear context)" },
-  { cmd: "/stop", desc: "Cancel current run" },
-  { cmd: "/model", desc: "Show or switch model" },
-  { cmd: "/usage", desc: "Show session token usage" },
-  { cmd: "/context", desc: "Show context pressure" },
-  { cmd: "/verbose", desc: "Toggle verbose level" },
-  { cmd: "/budget", desc: "Show budget status" },
-  { cmd: "/peers", desc: "Show connected peers" },
-  { cmd: "/a2a", desc: "Show A2A agents" },
-  { cmd: "/queue", desc: "Show agent queue status" },
+  { cmd: "/help", descKey: "cmd_help" },
+  { cmd: "/clear", descKey: "cmd_clear" },
+  { cmd: "/agents", descKey: "cmd_agents" },
+  { cmd: "/info", descKey: "cmd_info" },
+  { cmd: "/new", descKey: "cmd_new" },
+  { cmd: "/compact", descKey: "cmd_compact" },
+  { cmd: "/reset", descKey: "cmd_reset" },
+  { cmd: "/reboot", descKey: "cmd_reboot" },
+  { cmd: "/stop", descKey: "cmd_stop" },
+  { cmd: "/model", descKey: "cmd_model" },
+  { cmd: "/usage", descKey: "cmd_usage" },
+  { cmd: "/context", descKey: "cmd_context" },
+  { cmd: "/verbose", descKey: "cmd_verbose" },
+  { cmd: "/budget", descKey: "cmd_budget" },
+  { cmd: "/peers", descKey: "cmd_peers" },
+  { cmd: "/a2a", descKey: "cmd_a2a" },
+  { cmd: "/queue", descKey: "cmd_queue" },
 ];
 
 // Commands that require backend processing via WebSocket command protocol
@@ -298,18 +298,18 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
         ]);
       };
       if (trimmed === "/help") {
-        sysMsg(SLASH_COMMANDS.map(c => `**${c.cmd}** — ${c.desc}`).join("\n"));
+        sysMsg(SLASH_COMMANDS.map(c => `**${c.cmd}** — ${t(`chat.${c.descKey}`)}`).join("\n"));
         return;
       }
       if (trimmed === "/clear") { setMessages([]); return; }
       if (trimmed === "/agents") {
         const names = agents.map(a => `- **${a.name}** (${a.state || "unknown"})`).join("\n");
-        sysMsg(names || "No agents available.");
+        sysMsg(names || t("chat.no_agents_available"));
         return;
       }
       if (trimmed === "/info") {
         const a = agents.find(a => a.id === agentId);
-        sysMsg(a ? `**${a.name}**\nModel: ${a.model_name || "-"}\nProvider: ${a.model_provider || "-"}\nState: ${a.state}` : "No agent selected.");
+        sysMsg(a ? `**${a.name}**\n${t("chat.info_model")}: ${a.model_name || "-"}\n${t("chat.info_provider")}: ${a.model_provider || "-"}\n${t("chat.info_state")}: ${a.state}` : t("chat.no_agent_selected"));
         return;
       }
 
@@ -344,7 +344,7 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
           ws.current.addEventListener("message", handleCmdResponse);
           ws.current.send(JSON.stringify({ type: "command", command: cmd, args: cmdArgs }));
         } else {
-          sysMsg("WebSocket not connected. Please refresh the page.");
+          sysMsg(t("chat.ws_not_connected"));
         }
         return;
       }
@@ -829,7 +829,7 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, s
               onClick={() => { setMessage(c.cmd); onSend(c.cmd); setMessage(""); }}
               className="w-full flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-main text-left transition-colors">
               <span className="text-xs font-mono font-bold text-brand">{c.cmd}</span>
-              <span className="text-[10px] text-text-dim">{c.desc}</span>
+              <span className="text-[10px] text-text-dim">{t(`chat.${c.descKey}`)}</span>
             </button>
           ))}
         </div>
@@ -1015,7 +1015,7 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
           <button
             onClick={() => setModelOpen(v => !v)}
             className="flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-mono text-text-dim/50 hover:text-text hover:bg-surface-hover transition-colors truncate max-w-[200px]"
-            title="Switch model"
+            title={t("chat.switch_model")}
           >
             <span className="truncate">{optimisticModel ?? modelName ?? t("chat.no_model")}</span>
             <ChevronDown className={`h-2.5 w-2.5 shrink-0 transition-transform ${modelOpen ? "rotate-180" : ""}`} />

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -277,7 +277,7 @@ export function ConfigPage({ category }: { category: string }) {
             : t("common.saved", "Saved");
         setSaveStatus((s) => ({ ...s, [path]: { ok: !reloadFailed, msg } }));
       } catch (err: any) {
-        setSaveStatus((s) => ({ ...s, [path]: { ok: false, msg: err.message || "Save failed" } }));
+        setSaveStatus((s) => ({ ...s, [path]: { ok: false, msg: err.message || t("config.save_failed") } }));
         errors++;
       }
     }

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -136,7 +136,7 @@ function AuthBadge({
             onAuthSuccess();
           } else if (status.auth.state === "error") {
             setPolling(false);
-            addToast(status.auth.message || "Auth failed", "error");
+            addToast(status.auth.message || t("mcp.auth_failed"), "error");
           }
         } catch {
           // ignore transient errors during polling
@@ -168,7 +168,7 @@ function AuthBadge({
       if (authWindow && !authWindow.closed) {
         authWindow.close();
       }
-      addToast(e?.message || "Failed to start auth", "error");
+      addToast(e?.message || t("mcp.auth_start_failed"), "error");
     }
   }, [server.name, addToast, t]);
 
@@ -178,7 +178,7 @@ function AuthBadge({
       onAuthSuccess(); // refresh
       addToast(t("mcp.auth_revoked"), "success");
     } catch (e: any) {
-      addToast(e?.message || "Failed to revoke auth", "error");
+      addToast(e?.message || t("mcp.auth_revoke_failed"), "error");
     }
   }, [server.name, onAuthSuccess, addToast, t]);
 

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -36,16 +36,16 @@ const USE_SKILLHUB = (() => {
 
 // Categories with icons and search keywords
 const categories = [
-  { id: "coding", name: "Coding", icon: Code, keyword: "python javascript code" },
-  { id: "git", name: "Git", icon: GitBranch, keyword: "git github" },
-  { id: "web", name: "Web", icon: Globe, keyword: "web frontend html css" },
-  { id: "devops", name: "DevOps", icon: Cloud, keyword: "devops cloud aws docker kubernetes" },
-  { id: "browser", name: "Browser", icon: Monitor, keyword: "browser automation" },
-  { id: "ai", name: "AI", icon: Bot, keyword: "ai llm gpt openai" },
-  { id: "data", name: "Data", icon: Database, keyword: "data analytics python" },
-  { id: "productivity", name: "Productivity", icon: Briefcase, keyword: "productivity" },
-  { id: "security", name: "Security", icon: Shield, keyword: "security" },
-  { id: "cli", name: "CLI", icon: Terminal, keyword: "cli bash shell" },
+  { id: "coding", nameKey: "skills.cat_coding", icon: Code, keyword: "python javascript code" },
+  { id: "git", nameKey: "skills.cat_git", icon: GitBranch, keyword: "git github" },
+  { id: "web", nameKey: "skills.cat_web", icon: Globe, keyword: "web frontend html css" },
+  { id: "devops", nameKey: "skills.cat_devops", icon: Cloud, keyword: "devops cloud aws docker kubernetes" },
+  { id: "browser", nameKey: "skills.cat_browser", icon: Monitor, keyword: "browser automation" },
+  { id: "ai", nameKey: "skills.cat_ai", icon: Bot, keyword: "ai llm gpt openai" },
+  { id: "data", nameKey: "skills.cat_data", icon: Database, keyword: "data analytics python" },
+  { id: "productivity", nameKey: "skills.cat_productivity", icon: Briefcase, keyword: "productivity" },
+  { id: "security", nameKey: "skills.cat_security", icon: Shield, keyword: "security" },
+  { id: "cli", nameKey: "skills.cat_cli", icon: Terminal, keyword: "cli bash shell" },
 ];
 
 function getCategoryIcon(category: string) {
@@ -676,7 +676,7 @@ export function SkillsPage() {
               }`}
             >
               {getCategoryIcon(cat.id)}
-              {cat.name}
+              {t(cat.nameKey)}
             </button>
           ))}
         </div>
@@ -687,7 +687,7 @@ export function SkillsPage() {
         <Input
           value={search}
           onChange={(e) => { setSearch(e.target.value); setSelectedCategory(null); }}
-          placeholder={selectedCategory ? categories.find(c => c.id === selectedCategory)?.name + "..." : t("skills.search_placeholder")}
+          placeholder={selectedCategory ? t(categories.find(c => c.id === selectedCategory)?.nameKey ?? "") + "..." : t("skills.search_placeholder")}
           leftIcon={<Search className="w-4 h-4" />}
           rightIcon={search ? (
             <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search", { defaultValue: "Clear search" })}>

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -365,9 +365,9 @@ export function WorkflowsPage() {
                     {t("canvas.run_now")}
                   </Button>
                   <Button variant="secondary" disabled={runMutation.isPending || dryRunMutation.isPending} onClick={handleDryRun}
-                    title="Dry Run — validate without calling LLMs">
+                    title={t("workflows.dry_run_hint")}>
                     {dryRunMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <FlaskConical className="w-4 h-4" />}
-                    <span className="hidden sm:inline ml-1.5">Dry Run</span>
+                    <span className="hidden sm:inline ml-1.5">{t("workflows.dry_run")}</span>
                   </Button>
                 </div>
 
@@ -379,7 +379,7 @@ export function WorkflowsPage() {
                         ? <CheckCircle2 className="w-3.5 h-3.5 text-success" />
                         : <AlertCircle className="w-3.5 h-3.5 text-warning" />}
                       <p className={`text-[10px] font-bold ${dryRunResult.valid ? "text-success" : "text-warning"}`}>
-                        {dryRunResult.valid ? "Valid — all agents resolved" : "Warning — some agents not found"}
+                        {dryRunResult.valid ? t("workflows.dry_run_valid") : t("workflows.dry_run_warning")}
                       </p>
                     </div>
                     <div className="space-y-2">


### PR DESCRIPTION
## Summary

Replace all remaining hardcoded English strings with `t()` i18n calls across 9 dashboard pages:

| Page | Changes |
|------|---------|
| ChatPage | 17 slash command descriptions, system messages, model switch tooltip |
| AnalyticsPage | Chart tooltip/legend labels (Cost, Avg, Min, Max, Cost/Call, Unknown) |
| CanvasPage | Toolbar buttons, group node labels, dry run text, fullscreen toggle |
| ChannelsPage | QR code error, login success message |
| WorkflowsPage | Dry run button, validation result text |
| McpServersPage | Auth error messages (3) |
| ApprovalsPage | Batch approve TOTP disabled tooltip |
| SkillsPage | 10 category names (Coding, Git, Web, etc.) |
| ConfigPage | Save failed message |

Added 60+ new i18n keys in both `en.json` and `zh.json`.

## Test plan

- [ ] Switch to Chinese → all pages show Chinese labels
- [ ] Switch to English → all show English
- [ ] Chat `/help` shows translated command descriptions
- [ ] Analytics charts show translated legends
- [ ] Canvas toolbar buttons show translated tooltips
- [ ] Skills marketplace categories show translated names