### PR TITLE
feat(api): add TOTP second-factor verification to dashboard login

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -17,8 +17,10 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
   const [authMethod, setAuthMethod] = useState<"credentials" | "api_key">(
     mode === "api_key" ? "api_key" : "credentials",
   );
-  const [errorKey, setErrorKey] = useState<"invalid_api_key" | "invalid_credentials" | null>(null);
+  const [errorKey, setErrorKey] = useState<"invalid_api_key" | "invalid_credentials" | "invalid_totp" | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [totpRequired, setTotpRequired] = useState(false);
+  const [totpCode, setTotpCode] = useState("");
 
   useEffect(() => {
     setAuthMethod(mode === "api_key" ? "api_key" : "credentials");
@@ -55,20 +57,36 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
     setErrorKey(null);
 
     try {
+      if (totpRequired) {
+        if (!totpCode || totpCode.length !== 6) {
+          setErrorKey("invalid_totp");
+          return;
+        }
+        const result = await dashboardLogin(username.trim(), password, totpCode);
+        if (!result.ok) {
+          setErrorKey("invalid_totp");
+          return;
+        }
+        onAuthenticated();
+        return;
+      }
+
       if (!username.trim() || !password) {
         setErrorKey("invalid_credentials");
         return;
       }
 
       const result = await dashboardLogin(username.trim(), password);
+      if (result.requires_totp) {
+        setTotpRequired(true);
+        setTotpCode("");
+        return;
+      }
       if (!result.ok) {
         setErrorKey("invalid_credentials");
         return;
       }
 
-      // The login response already proves the credential path succeeded.
-      // Avoid immediately probing session-backed auth before the new session
-      // is fully visible server-side.
       onAuthenticated();
     } finally {
       setSubmitting(false);
@@ -112,7 +130,26 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
             </div>
           )}
           <form onSubmit={isCredentials ? handleCredentialsSubmit : handleApiKeySubmit} className="space-y-4">
-            {isCredentials ? (
+            {isCredentials && totpRequired ? (
+              <>
+                <p className="text-sm text-text-dim text-center">{t("auth.totp_prompt")}</p>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                  value={totpCode}
+                  onChange={(e) => { setTotpCode(e.target.value.replace(/\D/g, "").slice(0, 6)); setErrorKey(null); }}
+                  placeholder="000000"
+                  autoFocus
+                  className={`w-full rounded-xl border px-4 py-3 text-center text-2xl font-mono tracking-[0.5em] focus:ring-2 outline-none transition-colors ${
+                    errorKey === "invalid_totp"
+                      ? "border-error focus:border-error focus:ring-error/10"
+                      : "border-border-subtle bg-main focus:border-brand focus:ring-brand/10"
+                  }`}
+                />
+              </>
+            ) : isCredentials ? (
               <>
                 <input
                   type="text"
@@ -157,10 +194,10 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
             )}
             <button
               type="submit"
-              disabled={submitting || (isCredentials ? !username.trim() || !password : !key.trim())}
+              disabled={submitting || (isCredentials ? (totpRequired ? totpCode.length !== 6 : !username.trim() || !password) : !key.trim())}
               className="w-full rounded-xl bg-brand py-3 text-sm font-bold text-white hover:bg-brand/90 transition-colors shadow-lg shadow-brand/20"
             >
-              {t("auth.submit")}
+              {totpRequired ? t("auth.verify_totp") : t("auth.submit")}
             </button>
           </form>
         </div>

--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -25,6 +25,8 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
   useEffect(() => {
     setAuthMethod(mode === "api_key" ? "api_key" : "credentials");
     setErrorKey(null);
+    setTotpRequired(false);
+    setTotpCode("");
   }, [mode]);
 
   async function handleApiKeySubmit(e: React.FormEvent) {
@@ -111,7 +113,7 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
             <div className="mb-4 grid grid-cols-2 gap-2 rounded-xl bg-main p-1">
               <button
                 type="button"
-                onClick={() => { setAuthMethod("credentials"); setErrorKey(null); setKey(""); }}
+                onClick={() => { setAuthMethod("credentials"); setErrorKey(null); setKey(""); setTotpRequired(false); setTotpCode(""); }}
                 className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
                   isCredentials ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-brand"
                 }`}
@@ -120,7 +122,7 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
               </button>
               <button
                 type="button"
-                onClick={() => { setAuthMethod("api_key"); setErrorKey(null); setUsername(""); setPassword(""); }}
+                onClick={() => { setAuthMethod("api_key"); setErrorKey(null); setUsername(""); setPassword(""); setTotpRequired(false); setTotpCode(""); }}
                 className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
                   !isCredentials ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-brand"
                 }`}

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2152,12 +2152,14 @@ export async function getDashboardUsername(): Promise<string> {
   }
 }
 
-export async function dashboardLogin(username: string, password: string): Promise<{ ok: boolean; token?: string; error?: string }> {
+export async function dashboardLogin(username: string, password: string, totpCode?: string): Promise<{ ok: boolean; token?: string; error?: string; requires_totp?: boolean }> {
   try {
+    const body: Record<string, string> = { username, password };
+    if (totpCode) body.totp_code = totpCode;
     const resp = await fetch("/api/auth/dashboard-login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify(body),
     });
     const data = await resp.json();
     if (data.ok && data.token) {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1648,9 +1648,12 @@
     "username_placeholder": "Enter username...",
     "password_placeholder": "Enter password...",
     "submit": "Authenticate",
+    "verify_totp": "Verify",
+    "totp_prompt": "Enter the 6-digit code from your authenticator app.",
     "invalid": "Authentication failed. Please try again.",
     "invalid_api_key": "Invalid API key. Please try again.",
-    "invalid_credentials": "Invalid username or password. Please try again."
+    "invalid_credentials": "Invalid username or password. Please try again.",
+    "invalid_totp": "Invalid TOTP code. Please try again."
   },
   "network": {
     "section": "OFP Network",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1623,9 +1623,12 @@
     "username_placeholder": "输入用户名...",
     "password_placeholder": "输入密码...",
     "submit": "认证",
+    "verify_totp": "验证",
+    "totp_prompt": "请输入验证器应用中的 6 位动态码。",
     "invalid": "认证失败，请重试。",
     "invalid_api_key": "无效的 API Key，请重试。",
-    "invalid_credentials": "用户名或密码无效，请重试。"
+    "invalid_credentials": "用户名或密码无效，请重试。",
+    "invalid_totp": "动态码无效，请重试。"
   },
   "network": {
     "section": "OFP 网络",

--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
@@ -177,7 +177,6 @@ function TotpSection() {
   const statusQuery = useQuery({
     queryKey: ["totp", "status"],
     queryFn: totpStatus,
-    staleTime: 30_000,
   });
 
   const status = statusQuery.data;

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2069,7 +2069,8 @@ pub async fn totp_status(State(state): State<Arc<AppState>>) -> impl IntoRespons
         .is_some_and(|s| !s.is_empty());
     let confirmed = state.kernel.vault_get("totp_confirmed").as_deref() == Some("true");
     let policy = state.kernel.approvals().policy();
-    let enforced = policy.second_factor == librefang_types::approval::SecondFactor::Totp;
+    let sf = policy.second_factor;
+    let enforced = sf != librefang_types::approval::SecondFactor::None;
 
     let remaining_recovery = state
         .kernel
@@ -2082,6 +2083,7 @@ pub async fn totp_status(State(state): State<Arc<AppState>>) -> impl IntoRespons
         "enrolled": has_secret,
         "confirmed": confirmed,
         "enforced": enforced,
+        "scope": serde_json::to_value(sf).unwrap_or(serde_json::json!("none")),
         "remaining_recovery_codes": remaining_recovery,
     }))
 }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -262,6 +262,57 @@ async fn dashboard_login(
                 );
             }
 
+            // TOTP second-factor check for login
+            let policy = state.kernel.approvals().policy();
+            if policy.second_factor.requires_login_totp() {
+                let totp_enrolled = state
+                    .kernel
+                    .vault_get("totp_secret")
+                    .is_some_and(|s| !s.is_empty());
+                let totp_confirmed =
+                    state.kernel.vault_get("totp_confirmed").as_deref() == Some("true");
+                if totp_enrolled && totp_confirmed {
+                    let totp_code = body.get("totp_code").and_then(|v| v.as_str()).unwrap_or("");
+                    if totp_code.is_empty() {
+                        // Password OK but TOTP required — ask frontend to prompt
+                        return axum::response::Json(serde_json::json!({
+                            "ok": false,
+                            "requires_totp": true,
+                        }))
+                        .into_response();
+                    }
+                    // Verify TOTP code
+                    let secret = state.kernel.vault_get("totp_secret").unwrap_or_default();
+                    let issuer = policy.totp_issuer.clone();
+                    match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                        &secret, totp_code, &issuer,
+                    ) {
+                        Ok(true) => { /* TOTP valid, proceed to session creation */ }
+                        Ok(false) => {
+                            return (
+                                axum::http::StatusCode::UNAUTHORIZED,
+                                axum::response::Json(serde_json::json!({
+                                    "ok": false,
+                                    "error": "Invalid TOTP code",
+                                })),
+                            )
+                                .into_response();
+                        }
+                        Err(e) => {
+                            tracing::warn!("TOTP verification error during login: {e}");
+                            return (
+                                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                axum::response::Json(serde_json::json!({
+                                    "ok": false,
+                                    "error": "TOTP verification failed",
+                                })),
+                            )
+                                .into_response();
+                        }
+                    }
+                }
+            }
+
             // Store the session token so the auth middleware can validate it.
             {
                 let mut sessions = state.active_sessions.write().await;

--- a/crates/librefang-types/src/approval.rs
+++ b/crates/librefang-types/src/approval.rs
@@ -47,18 +47,36 @@ const MAX_CHANNEL_RULE_TOOLS: usize = 50;
 // SecondFactor
 // ---------------------------------------------------------------------------
 
-/// Second-factor verification method for critical tool approvals.
+/// Second-factor verification scope.
 ///
-/// When set to `Totp`, approvals require a valid TOTP code from an
-/// authenticator app in addition to the normal approve action.
+/// Controls where TOTP verification is enforced:
+/// - `Totp` = approvals only (backward-compatible default when TOTP is enabled)
+/// - `Login` = dashboard login only
+/// - `Both` = approvals + dashboard login
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SecondFactor {
     /// No second factor required (default).
     #[default]
     None,
-    /// TOTP (RFC 6238) verification via authenticator app.
+    /// TOTP required for tool approvals only.
     Totp,
+    /// TOTP required for dashboard login only.
+    Login,
+    /// TOTP required for both approvals and dashboard login.
+    Both,
+}
+
+impl SecondFactor {
+    /// Whether TOTP is required for dashboard login.
+    pub fn requires_login_totp(self) -> bool {
+        matches!(self, SecondFactor::Login | SecondFactor::Both)
+    }
+
+    /// Whether TOTP is required for tool approvals.
+    pub fn requires_approval_totp(self) -> bool {
+        matches!(self, SecondFactor::Totp | SecondFactor::Both)
+    }
 }
 
 /// Maximum TOTP grace period in seconds (1 hour).
@@ -676,7 +694,7 @@ impl ApprovalPolicy {
     /// Returns `true` if `second_factor` is `Totp` AND (totp_tools is empty
     /// OR the tool matches a pattern in totp_tools).
     pub fn tool_requires_totp(&self, tool_name: &str) -> bool {
-        if self.second_factor != SecondFactor::Totp {
+        if !self.second_factor.requires_approval_totp() {
             return false;
         }
         if self.totp_tools.is_empty() {
@@ -768,8 +786,8 @@ impl ApprovalPolicy {
         }
 
         // -- totp_issuer --
-        if self.second_factor == SecondFactor::Totp && self.totp_issuer.is_empty() {
-            return Err("totp_issuer must not be empty when second_factor is totp".into());
+        if self.second_factor != SecondFactor::None && self.totp_issuer.is_empty() {
+            return Err("totp_issuer must not be empty when second_factor is enabled".into());
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- Extend `SecondFactor` enum: `None` | `Totp` (approval only, backward-compatible) | `Login` (login only) | `Both` (approval + login)
- `dashboard_login` checks TOTP after password when `second_factor` is `login` or `both`:
  - No `totp_code` in request -> returns `{ "ok": false, "requires_totp": true }`
  - Invalid code -> 401
  - Valid code -> session token
- Dashboard `AuthDialog` shows TOTP 6-digit input step after successful password
- Settings page: fix stale TOTP status display after login (removed `staleTime`)
- `totp_status` endpoint now returns `scope` field

## Config example
```toml
[approvals]
second_factor = "both"  # or "login" or "totp"
```