### PR TITLE
release: v2026.4.15-beta21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.15] - 2026-04-15
+
+### Added
+
+- Add terminal websocket access controls and documentation (Terminal Phase 2) (#2332) (@leszek3737)
+- Show hand agents in chat picker, grouped by hand (#2458) (@neo-wanderer)
+- Group models by provider when showing all providers (#2509) (@houko)
+- Conditionally show thinking toggles based on model capability (#2511) (@houko)
+- Add Registry tab to MCP Servers page (#2515) (@houko)
+- Add TOTP second-factor verification to dashboard login (#2517) (@houko)
+
+### Fixed
+
+- Atomic tool-use turn commit — closes #2381 (follow-up to #2065) (#2387) (@DaBlitzStein)
+- Spawn pnpm via sh to resolve mise shim PATH (#2504) (@houko)
+- Retry mergeability check on synchronize to clear stale conflict label (#2505) (@houko)
+- Always strip ready-for-review when conflicts exist (#2506) (@houko)
+- Scaffold hand workspaces on first boot instead of activate+pause (#2507) (@houko)
+- Probe ollama before fallback, default to gemma4 (#2508) (@houko)
+- Collapsible provider groups in models page (#2510) (@houko)
+- Read SKILL.md for FangHub registry listing (#2512) (@houko)
+- Clear ci-failed label on new push and fallback PR lookup (#2513) (@houko)
+- Complete i18n for config page + switch to browser history routing (#2514) (@houko)
+- I18n remaining hardcoded strings across all pages (#2516) (@houko)
+
+### Changed
+
+- Centralize JID normalization in lib/identity.js (#2503) (@f-liva)
+
+
 ## [2026.4.14] - 2026-04-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "aes",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "clap",
  "clap_complete",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "axum",
  "clap",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "axum",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10979,7 +10979,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32160",
+  "version": "26.4.32171",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.14-beta20",
+  "version": "2026.4.15-beta21",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.14-beta20",
+  "version": "2026.4.15-beta21",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.14b20",
+    version="2026.4.15b21",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.14-beta20"
+version = "2026.4.15-beta21"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.15-beta21 -->
## Release v2026.4.15-beta21

### Added

- Add terminal websocket access controls and documentation (Terminal Phase 2) (#2332) (@leszek3737)
- Show hand agents in chat picker, grouped by hand (#2458) (@neo-wanderer)
- Group models by provider when showing all providers (#2509) (@houko)
- Conditionally show thinking toggles based on model capability (#2511) (@houko)
- Add Registry tab to MCP Servers page (#2515) (@houko)
- Add TOTP second-factor verification to dashboard login (#2517) (@houko)

### Fixed

- Atomic tool-use turn commit — closes #2381 (follow-up to #2065) (#2387) (@DaBlitzStein)
- Spawn pnpm via sh to resolve mise shim PATH (#2504) (@houko)
- Retry mergeability check on synchronize to clear stale conflict label (#2505) (@houko)
- Always strip ready-for-review when conflicts exist (#2506) (@houko)
- Scaffold hand workspaces on first boot instead of activate+pause (#2507) (@houko)
- Probe ollama before fallback, default to gemma4 (#2508) (@houko)
- Collapsible provider groups in models page (#2510) (@houko)
- Read SKILL.md for FangHub registry listing (#2512) (@houko)
- Clear ci-failed label on new push and fallback PR lookup (#2513) (@houko)
- Complete i18n for config page + switch to browser history routing (#2514) (@houko)
- I18n remaining hardcoded strings across all pages (#2516) (@houko)

### Changed

- Centralize JID normalization in lib/identity.js (#2503) (@f-liva)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.14-beta20...v2026.4.15-beta21