### PR TITLE
feat(api): add LIBREFANG_DASHBOARD_EMBEDDED_ONLY env var to pin dashboard to embedded assets

### DIFF
--- a/crates/librefang-api/src/webchat.rs
+++ b/crates/librefang-api/src/webchat.rs
@@ -6,6 +6,21 @@
 //!
 //! This allows the dashboard to be updated without recompiling, while still
 //! providing a working dashboard in single-binary distributions.
+//!
+//! ## Opt-out: embedded-only mode
+//!
+//! Setting `LIBREFANG_DASHBOARD_EMBEDDED_ONLY=1` pins the resolver to the
+//! compile-time-embedded assets and short-circuits [`sync_dashboard`]. This is
+//! the right setting when you want the dashboard served by the daemon to
+//! exactly match the binary you built, e.g.:
+//!
+//! - Iterating on the dashboard locally against your own `cargo build`.
+//! - Running in a packaged environment where the dashboard is intentionally
+//!   frozen to the build artifact and must not mutate at runtime.
+//!
+//! Accepted truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Any
+//! other value — or the absence of the variable — leaves the default
+//! runtime-sync behavior intact.
 
 use axum::extract::{Path, State};
 use axum::http::{header, StatusCode};
@@ -77,8 +92,32 @@ const LOCALE_JA: &str = include_str!("../static/locales/ja.json");
 
 const DASHBOARD_SYNC_ERROR_FILE: &str = ".sync-error";
 
+/// Environment variable that, when set to a truthy value, forces the dashboard
+/// resolver to serve the compile-time-embedded assets and skips the release
+/// sync entirely. See the module-level docs for details.
+const EMBEDDED_ONLY_ENV: &str = "LIBREFANG_DASHBOARD_EMBEDDED_ONLY";
+
 fn embedded_dashboard_available() -> bool {
     REACT_DIST.get_file("index.html").is_some()
+}
+
+/// Returns `true` when the operator has opted into embedded-only dashboard
+/// mode via [`EMBEDDED_ONLY_ENV`]. Any of `1`, `true`, `yes`, `on` (case
+/// insensitive) counts as truthy.
+fn embedded_only_mode() -> bool {
+    is_embedded_only_value(std::env::var(EMBEDDED_ONLY_ENV).ok().as_deref())
+}
+
+/// Pure parser split out so tests can exercise the value grammar without
+/// touching process-global environment state.
+fn is_embedded_only_value(raw: Option<&str>) -> bool {
+    match raw {
+        Some(v) => {
+            let normalized = v.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        }
+        None => false,
+    }
 }
 
 fn dashboard_sync_error_path(home_dir: &std::path::Path) -> std::path::PathBuf {
@@ -86,15 +125,34 @@ fn dashboard_sync_error_path(home_dir: &std::path::Path) -> std::path::PathBuf {
 }
 
 /// Resolve a dashboard file: try runtime dir first, then embedded fallback.
+///
+/// In embedded-only mode (see [`embedded_only_mode`]) the runtime directory
+/// is skipped entirely so the compile-time assets win regardless of whatever
+/// stale copy may still be sitting in `$LIBREFANG_HOME/dashboard/` from a
+/// previous sync.
 fn resolve_dashboard_file(
     home_dir: Option<&std::path::Path>,
     relative_path: &str,
 ) -> Option<Vec<u8>> {
-    // 1. Try runtime directory
-    if let Some(home) = home_dir {
-        let runtime_path = home.join("dashboard").join(relative_path);
-        if let Ok(data) = std::fs::read(&runtime_path) {
-            return Some(data);
+    resolve_dashboard_file_with_mode(home_dir, relative_path, embedded_only_mode())
+}
+
+/// Testable variant of [`resolve_dashboard_file`] that takes the
+/// embedded-only decision as a parameter instead of reading it from the
+/// environment. Keeps the public entry point ergonomic while letting unit
+/// tests exercise both branches deterministically.
+fn resolve_dashboard_file_with_mode(
+    home_dir: Option<&std::path::Path>,
+    relative_path: &str,
+    embedded_only: bool,
+) -> Option<Vec<u8>> {
+    // 1. Try runtime directory (skipped when embedded-only mode is on).
+    if !embedded_only {
+        if let Some(home) = home_dir {
+            let runtime_path = home.join("dashboard").join(relative_path);
+            if let Ok(data) = std::fs::read(&runtime_path) {
+                return Some(data);
+            }
         }
     }
 
@@ -222,7 +280,7 @@ pub async fn react_asset(
             let has_ext = asset_path
                 .rsplit('/')
                 .next()
-                .map_or(false, |s| s.contains('.'));
+                .is_some_and(|s| s.contains('.'));
             if !has_ext {
                 if let Some(index) = resolve_dashboard_file(home_dir.as_deref(), "index.html") {
                     return ([(header::CONTENT_TYPE, "text/html; charset=utf-8")], index)
@@ -260,7 +318,17 @@ fn content_type_for(path: &str) -> &'static str {
 ///
 /// Downloads the dashboard-dist branch tarball and extracts it.
 /// Called during daemon startup (non-blocking).
+///
+/// Short-circuits when [`EMBEDDED_ONLY_ENV`] is truthy so local builds and
+/// frozen deployments aren't silently replaced by the release artifact.
 pub async fn sync_dashboard(home_dir: &std::path::Path) {
+    if embedded_only_mode() {
+        tracing::info!(
+            "{EMBEDDED_ONLY_ENV} is set; skipping dashboard sync and serving embedded assets only"
+        );
+        return;
+    }
+
     let dashboard_dir = home_dir.join("dashboard");
     let version_file = dashboard_dir.join(".version");
     let sync_error_file = dashboard_sync_error_path(home_dir);
@@ -398,4 +466,82 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_only_unset_is_false() {
+        assert!(!is_embedded_only_value(None));
+    }
+
+    #[test]
+    fn embedded_only_truthy_values() {
+        for v in [
+            "1", "true", "TRUE", "True", "yes", "YES", "on", "ON", " 1 ", "\tTrue\n",
+        ] {
+            assert!(
+                is_embedded_only_value(Some(v)),
+                "expected {v:?} to be truthy"
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_only_falsy_values() {
+        for v in [
+            "",
+            "0",
+            "false",
+            "no",
+            "off",
+            "FALSE",
+            "nope",
+            "anything-else",
+        ] {
+            assert!(
+                !is_embedded_only_value(Some(v)),
+                "expected {v:?} to be falsy"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_dashboard_prefers_runtime_dir_when_not_embedded_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dashboard = tmp.path().join("dashboard");
+        std::fs::create_dir_all(&dashboard).unwrap();
+        let marker = b"runtime-dir-wins";
+        std::fs::write(dashboard.join("test-marker.txt"), marker).unwrap();
+
+        let got = resolve_dashboard_file_with_mode(Some(tmp.path()), "test-marker.txt", false);
+        assert_eq!(got.as_deref(), Some(marker.as_slice()));
+    }
+
+    #[test]
+    fn resolve_dashboard_skips_runtime_dir_in_embedded_only_mode() {
+        // Put a file in the runtime dir that does NOT exist in the embedded
+        // bundle — in embedded-only mode the resolver must ignore it and
+        // return `None` instead of serving the stale runtime copy.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dashboard = tmp.path().join("dashboard");
+        std::fs::create_dir_all(&dashboard).unwrap();
+        std::fs::write(
+            dashboard.join("definitely-not-in-embedded-bundle.bin"),
+            b"stale-runtime",
+        )
+        .unwrap();
+
+        let got = resolve_dashboard_file_with_mode(
+            Some(tmp.path()),
+            "definitely-not-in-embedded-bundle.bin",
+            true,
+        );
+        assert!(
+            got.is_none(),
+            "embedded-only mode must not consult runtime dir"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #2519.

## Summary

- New env var `LIBREFANG_DASHBOARD_EMBEDDED_ONLY` — when truthy, the daemon short-circuits `webchat::sync_dashboard` and makes `resolve_dashboard_file` skip the runtime-dir lookup, so the compile-time `include_dir!` bundle is always served.
- Default behaviour is unchanged for existing deployments that rely on the hot-update flow.
- Drive-by: fix a pre-existing `clippy::unnecessary_map_or` in the same file (stable `rustc 1.94` promoted it to a warning and was blocking `cargo clippy --workspace --all-targets -- -D warnings`).

## Why

Today, any binary built locally against a modified `crates/librefang-api/dashboard/` is silently overridden at runtime: `sync_dashboard` downloads the release `dashboard-dist.tar.gz` into `$LIBREFANG_HOME/dashboard/` on every boot, and `resolve_dashboard_file` always consults the runtime directory **before** the embedded bundle. The effect is that the compile-time dashboard is dead code after first boot, and any local UI change is masked.

The same pathway also means a failed sync (404 / offline / transient) leaves a *stale* cached dashboard winning over the embedded fallback indefinitely, since the resolver never checks `.version` or `.sync-error`. A binary compiled against one crate version can happily serve the dashboard from an older one. See #2519 for the full repro.

The minimal, mergeable fix is an opt-in escape hatch. This PR adds it without touching the default path, so existing production deployments that deliberately rely on release-channel updates are unaffected.

## Design notes

- Env var grammar: `1`, `true`, `yes`, `on` (case-insensitive, trimmed) are truthy; anything else — including the variable being unset — is falsy. This matches the ad-hoc convention already used for other boolean env vars in the codebase.
- Helper split: `resolve_dashboard_file` delegates to a pure `resolve_dashboard_file_with_mode(..., embedded_only: bool)` so the branching logic is unit-testable without touching process-global env state (which would race between parallel tests).
- Parser split: `embedded_only_mode()` reads the env and delegates to a pure `is_embedded_only_value(Option<&str>)` that tests can call directly.
- `sync_dashboard` logs its reason when it short-circuits so operators can confirm from logs why the runtime dir is empty.

Not in scope for this PR (but mentioned in #2519 for follow-up): making the resolver compare `dashboard/.version` against `CARGO_PKG_VERSION` and fall back to embedded on mismatch. That's a default-behaviour change and deserves its own discussion.

## Test plan

New unit tests in `crates/librefang-api/src/webchat.rs`:

- [x] `embedded_only_unset_is_false` — unset env var → resolver uses runtime-dir path.
- [x] `embedded_only_truthy_values` — every accepted truthy string, including whitespace trimming and mixed case.
- [x] `embedded_only_falsy_values` — empty string, `0`, `false`, `no`, `off`, unexpected values.
- [x] `resolve_dashboard_prefers_runtime_dir_when_not_embedded_only` — verifies default behaviour on a temp `$LIBREFANG_HOME` that has a runtime file not present in the embedded bundle.
- [x] `resolve_dashboard_skips_runtime_dir_in_embedded_only_mode` — same temp dir, embedded-only on, resolver must return `None` rather than serving the stale runtime copy.

Full crate suite:

```
$ cargo test -p librefang-api
test result: ok. 365 passed; 0 failed; 0 ignored
test result: ok.  35 passed; 0 failed; 0 ignored
test result: ok.   7 passed; 0 failed; 0 ignored
test result: ok.   5 passed; 0 failed; 2 ignored
test result: ok.   1 passed; 0 failed; 0 ignored
```

```
$ cargo clippy -p librefang-api --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Manual verification

```bash
# default behaviour: runtime dir still wins, existing users unaffected
cargo run -p librefang-cli -- start &
# → logs: "Syncing dashboard assets from release..."
# → /data/dashboard/ is populated with the release tarball

# new opt-in: embedded-only, sync short-circuits
LIBREFANG_DASHBOARD_EMBEDDED_ONLY=1 cargo run -p librefang-cli -- start &
# → logs: "LIBREFANG_DASHBOARD_EMBEDDED_ONLY is set; skipping dashboard sync and serving embedded assets only"
# → /data/dashboard/ is not touched
# → the dashboard served at :4545 exactly matches the binary's bundled static/react/
```