### PR TITLE
fix(api): honour silent flag in KernelBridgeAdapter sender methods (#2521)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -551,7 +551,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .send_message_with_sender_context(agent_id, message, sender)
             .await
             .map_err(|e| format!("{e}"))?;
-        Ok(result.response)
+        if result.silent {
+            Ok(String::new())
+        } else {
+            Ok(result.response)
+        }
     }
 
     async fn send_message_with_blocks_and_sender(
@@ -578,7 +582,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .send_message_with_blocks_and_sender(agent_id, &text, blocks, sender)
             .await
             .map_err(|e| format!("{e}"))?;
-        Ok(result.response)
+        if result.silent {
+            Ok(String::new())
+        } else {
+            Ok(result.response)
+        }
     }
 
     async fn send_message_ephemeral(


### PR DESCRIPTION
## Summary

Closes #2521. Follow-up to #976 / PR #1143.

PR #1143 added the `result.silent` guard to the REST (`routes.rs`) and WebSocket (`ws.rs`) paths so that an agent returning the `NO_REPLY` / `[no reply needed]` sentinel is silently suppressed instead of leaking the sentinel text as a visible message. Two sibling methods in `KernelBridgeAdapter` were missed, and those are exactly the methods the Telegram channel inbound path uses.

The result is that when the agent intentionally returns `NO_REPLY` in a group chat, users see the literal `NO_REPLY` (or `[no reply needed]`) string in Telegram instead of the bot silently abstaining.

## Root cause

`crates/librefang-api/src/channel_bridge.rs`:

- `send_message_with_sender` (around line 554) returns `Ok(result.response)` with no `result.silent` guard.
- `send_message_with_blocks_and_sender` (around line 581) does the same.

The three sibling methods in the same `impl` block (`send_message`, `send_message_with_blocks`, `send_message_ephemeral`) correctly apply:

```rust
if result.silent { Ok(String::new()) } else { Ok(result.response) }
```

`is_no_reply` in `crates/librefang-runtime/src/agent_loop.rs:77-85` is case-accurate for `NO_REPLY` and covers both `[no reply needed]` and `no reply needed` via trimmed `ends_with`, so the kernel sets `silent: true` correctly — the flag is simply dropped by the two adapter methods on the way out.

## Changes

One-file change. Copy the `silent` guard pattern from the three working sibling methods into the two defective ones. Four net lines of code.

## Compatibility

No API or signature changes. Callers already expect an empty string on silent responses (that is how the three other methods behave and the Telegram adapter path already handles empty-string responses as no-op via `if !response.is_empty()` in `channel_bridge.rs` around line 2960). No behaviour change for non-silent responses.

## Test plan

- [x] `cargo check -p librefang-api --lib` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --lib` — clean, zero warnings
- [ ] CI matrix
- [ ] Live verification: trigger a `NO_REPLY` via Telegram and confirm the user sees nothing instead of the literal sentinel string.
