### PR TITLE
fix(dashboard): move TOTP scope to ConfigPage via schema

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
@@ -9,7 +9,7 @@ import {
   Shield, CheckCircle, XCircle, Download,
 } from "lucide-react";
 import { useUIStore } from "../lib/store";
-import { totpSetup, totpConfirm, totpStatus, totpRevoke, setConfigValue } from "../api";
+import { totpSetup, totpConfirm, totpStatus, totpRevoke } from "../api";
 
 interface SegmentOption<T extends string> {
   value: T;
@@ -272,33 +272,6 @@ function TotpSection() {
           </div>
         </SettingRow>
 
-        {status?.confirmed && (
-          <SettingRow
-            icon={Shield}
-            iconColor="text-blue-500"
-            label={t("settings.totp_scope_title", "TOTP Scope")}
-            description={t("settings.totp_scope_desc", "Where to require TOTP verification")}
-          >
-            <select
-              value={status.scope ?? "none"}
-              onChange={async (e) => {
-                try {
-                  await setConfigValue("approvals.second_factor", e.target.value);
-                  statusQuery.refetch();
-                  setSuccess(t("settings.totp_scope_saved", "TOTP scope updated. Restart may be required."));
-                } catch (err: any) {
-                  setError(err.message || "Failed to update scope");
-                }
-              }}
-              className="rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-bold outline-none focus:border-brand"
-            >
-              <option value="none">{t("settings.totp_scope_none", "Disabled")}</option>
-              <option value="totp">{t("settings.totp_scope_approval", "Approvals only")}</option>
-              <option value="login">{t("settings.totp_scope_login", "Login only")}</option>
-              <option value="both">{t("settings.totp_scope_both", "Approvals + Login")}</option>
-            </select>
-          </SettingRow>
-        )}
 
         {status?.confirmed && status.remaining_recovery_codes <= 2 && (
           <div className="px-1 py-2 text-sm text-warning flex items-center gap-2">

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -918,6 +918,8 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
         "timeout_secs": config.approval.timeout_secs,
         "auto_approve_autonomous": config.approval.auto_approve_autonomous,
         "auto_approve": config.approval.auto_approve,
+        "second_factor": serde_json::to_value(&config.approval.second_factor).unwrap_or(serde_json::json!("none")),
+        "totp_issuer": config.approval.totp_issuer,
     });
 
     set!("exec_policy", {
@@ -1649,7 +1651,9 @@ pub async fn config_schema(State(state): State<Arc<AppState>>) -> impl IntoRespo
     }});
     sec!("approval", { "hot_reloadable": true, "fields": {
         "require_approval": "string[]", "timeout_secs": "number",
-        "auto_approve_autonomous": "boolean", "auto_approve": "boolean"
+        "auto_approve_autonomous": "boolean", "auto_approve": "boolean",
+        "second_factor": { "type": "select", "options": ["none", "totp", "login", "both"] },
+        "totp_issuer": "string"
     }});
     sec!("exec_policy", { "fields": {
         "mode": { "type": "select", "options": ["deny", "allowlist", "full"] },


### PR DESCRIPTION
## Summary
- Expose `second_factor` (select: none/totp/login/both) and `totp_issuer` in the approval config schema
- They now appear automatically in ConfigPage alongside other approval settings
- Remove the hand-written scope selector from SettingsPage — config.toml fields belong in ConfigPage