### PR TITLE
fix(xtask): fall back to npm when pnpm is unavailable in dev command

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -73,15 +73,27 @@ pub fn run(args: DevArgs) -> Result<(), Box<dyn std::error::Error>> {
     let dashboard_dir = root.join("crates/librefang-api/dashboard");
     let mut _dashboard_child = None;
     if !args.no_dashboard && dashboard_dir.join("package.json").exists() {
-        println!("Installing dashboard dependencies...");
+        // Detect available package manager: prefer pnpm, fall back to npm.
+        let pm = if Command::new("pnpm")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            "pnpm"
+        } else {
+            "npm"
+        };
+
+        println!("Installing dashboard dependencies (using {pm})...");
         let _ = Command::new("sh")
-            .args(["-c", "pnpm install"])
+            .args(["-c", &format!("{pm} install")])
             .current_dir(&dashboard_dir)
             .status();
 
-        println!("Starting dashboard dev server...");
+        println!("Starting dashboard dev server (using {pm})...");
         let child = Command::new("sh")
-            .args(["-c", "pnpm dev"])
+            .args(["-c", &format!("{pm} run dev")])
             .current_dir(&dashboard_dir)
             .spawn();
         match child {


### PR DESCRIPTION
## Summary
- `just dev` silently failed to start the Vite dashboard dev server on systems where `pnpm` is not installed
- The xtask dev command now detects the available package manager at runtime: prefers `pnpm`, falls back to `npm`

## Test plan
- [ ] On a system with `pnpm`: `just dev` uses pnpm as before
- [ ] On a system without `pnpm` (only `npm`): `just dev` starts both daemon (4545) and Vite dev server (5173)