### PR TITLE
fix(api): remove needless borrow in serde_json::to_value call

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -918,7 +918,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
         "timeout_secs": config.approval.timeout_secs,
         "auto_approve_autonomous": config.approval.auto_approve_autonomous,
         "auto_approve": config.approval.auto_approve,
-        "second_factor": serde_json::to_value(&config.approval.second_factor).unwrap_or(serde_json::json!("none")),
+        "second_factor": serde_json::to_value(config.approval.second_factor).unwrap_or(serde_json::json!("none")),
         "totp_issuer": config.approval.totp_issuer,
     });
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `&` borrow on `config.approval.second_factor` in `serde_json::to_value()` call
- Fixes clippy `needless_borrows_for_generic_args` lint error that broke CI Quality job

## Root cause
`serde_json::to_value` is generic and `T: Serialize` is already implemented for the type directly; borrowing it is redundant and clippy (with `-D warnings`) treats this as an error.

Closes https://github.com/librefang/librefang/actions/runs/24433496969/job/71382669676