### PR TITLE
fix(dashboard): show disabled mic button when STT not configured

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1433,6 +1433,7 @@
     "voice_stop": "Stop recording",
     "voice_recording": "Listening...",
     "voice_transcribing": "Transcribing...",
+    "voice_not_configured": "Voice input requires an STT provider. Configure one in Config → Tools → Media.",
     "deep_thinking": "Deep Thinking",
     "deep_thinking_hint": "Ask the model to reason step-by-step (reasoning models only)",
     "show_thinking": "Show Thinking",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1408,6 +1408,7 @@
     "voice_stop": "停止录音",
     "voice_recording": "正在聆听...",
     "voice_transcribing": "正在转写...",
+    "voice_not_configured": "语音输入需要配置 STT 服务商，请在 配置 → Tools → Media 中配置",
     "deep_thinking": "深度思考",
     "deep_thinking_hint": "启用后请求模型进行深度推理（仅支持 reasoning 模型）",
     "show_thinking": "显示思考过程",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -889,12 +889,12 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, s
             className="w-full min-h-[44px] sm:min-h-[52px] max-h-[150px] rounded-2xl border border-border-subtle bg-surface px-3 sm:px-5 py-2.5 sm:py-3.5 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none resize-none placeholder:text-text-dim/40 shadow-sm"
           />
         </div>
-        {voiceInput.isSupported && sttAvailable && (
+        {voiceInput.isSupported && (
           <button
             type="button"
-            onClick={voiceInput.toggleRecording}
-            disabled={effectiveDisabled || voiceInput.isTranscribing}
-            title={voiceInput.isRecording ? t("chat.voice_stop") : t("chat.voice_input")}
+            onClick={sttAvailable ? voiceInput.toggleRecording : undefined}
+            disabled={!sttAvailable || effectiveDisabled || voiceInput.isTranscribing}
+            title={!sttAvailable ? t("chat.voice_not_configured") : voiceInput.isRecording ? t("chat.voice_stop") : t("chat.voice_input")}
             className={`group relative px-3 sm:px-3.5 py-2.5 sm:py-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed ${
               voiceInput.isRecording
                 ? "bg-error/10 text-error border border-error/30 animate-pulse"


### PR DESCRIPTION
## Summary

- Show the voice input mic button in a greyed-out disabled state (instead of hiding it) when no STT provider is configured
- Hover tooltip tells the user where to configure: "Config → Tools → Media"

Follows up on #2533.

## Test plan

- [ ] No STT keys set → mic button visible but greyed out, hover shows configuration hint
- [ ] Set any STT key → mic button becomes active