### PR TITLE
fix(dashboard): fix stale state bugs in provider config modal

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -666,7 +666,7 @@ export function ProvidersPage() {
     setConfigProvider(provider);
     setKeyInput("");
     setUrlInput(provider.base_url || "");
-    setHasStoredKey(provider.auth_status === "configured" || provider.auth_status === "validated_key");
+    setHasStoredKey(provider.auth_status === "configured" || provider.auth_status === "validated_key" || provider.auth_status === "invalid_key");
     setKeyError(null);
     setKeyTestResult(null);
   };
@@ -686,6 +686,8 @@ export function ProvidersPage() {
       }
       await providersQuery.refetch();
       setConfigProvider(null);
+      // Auto-switch to "configured" tab so the user sees the newly configured provider
+      if (activeTab === "unconfigured") setActiveTab("configured");
       addToast(t("providers.key_saved"), "success");
     } catch (e: any) {
       setKeyError(e?.message || String(e));
@@ -978,7 +980,7 @@ export function ProvidersPage() {
               <div>
                 <label className="text-[10px] font-bold text-text-dim uppercase">API Key</label>
                 <input type="password" value={keyInput} onChange={e => setKeyInput(e.target.value)}
-                  placeholder={isProviderAvailable(configProvider.auth_status) ? t("providers.key_placeholder_existing") : t("providers.key_placeholder")}
+                  placeholder={hasStoredKey ? t("providers.key_placeholder_existing") : t("providers.key_placeholder")}
                   className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
               </div>
 


### PR DESCRIPTION
## Summary

- **Remove-key button hidden on built-in providers**: the card-level delete button was gated on `is_custom`, so built-in providers had no way to remove their API key from the card view. Now all configured providers show a remove/delete button — built-in ones say "Remove Key", custom ones say "Delete". Both go through a confirmation dialog with appropriate wording.
- **hasStoredKey missed `invalid_key` status**: when a stored key failed validation, the edit modal's "Remove Key" button disappeared because `hasStoredKey` only checked `configured` and `validated_key`.
- **Newly configured provider invisible**: after saving a key the tab stayed on "unconfigured" — the provider vanished from the list without appearing in "configured". Now auto-switches to the "configured" tab on save.
- **Key appears cleared after test**: the key input placeholder used the stale `configProvider.auth_status` snapshot instead of the live `hasStoredKey` state, showing "Enter API key" even though the key was already saved.
- **Custom provider creation didn't switch tab**: after creating a provider the tab stayed on the current view instead of switching to "configured".
- **Custom provider created without API key**: the creation form only collected `api_key_env` (env var name) but not the actual key value. The backend now extracts an optional `api_key` field from the request body, saves it to `secrets.env`, and sets the env var before `detect_auth()` — so the provider is immediately configured. The key value is stripped from the TOML file. Requires companion registry PR: librefang/librefang-registry#57.

## Test plan

- [ ] Click "Remove Key" on a built-in configured provider card — confirm the confirmation dialog appears and key is removed
- [ ] Configure an unconfigured provider — after save, tab auto-switches to "configured"
- [ ] Enter an invalid key and test — confirm "Remove Key" button is still visible in the edit modal
- [ ] Enter a key and click Test — confirm placeholder shows "Key already saved" instead of "Enter API key"
- [ ] Create a custom provider with an API key via the add form — verify it appears in "configured" tab immediately
- [ ] Create a custom provider without an API key — verify it appears in "unconfigured" tab