### PR TITLE
fix(dashboard): save API key on provider creation and show remove button for all providers

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -175,9 +175,9 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               <span className="hidden sm:inline">{t("common.edit")}</span>
             </Button>
           )}
-          {isConfigured && p.is_custom && (
+          {isConfigured && (
             <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
-              <span className="hidden sm:inline text-error">{t("common.delete")}</span>
+              <span className="hidden sm:inline text-error">{p.is_custom ? t("common.delete") : t("providers.remove_key")}</span>
             </Button>
           )}
           <Button
@@ -344,9 +344,9 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               {t("common.edit")}
             </Button>
           )}
-          {isConfigured && p.is_custom && (
+          {isConfigured && (
             <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
-              {t("common.delete")}
+              {p.is_custom ? t("common.delete") : t("providers.remove_key")}
             </Button>
           )}
           <Button
@@ -1032,7 +1032,7 @@ export function ProvidersPage() {
             <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle">
               <div className="flex items-center gap-2">
                 <Trash2 className="w-4 h-4 text-error" />
-                <h3 className="text-sm font-bold">{t("providers.delete_confirm_title")}</h3>
+                <h3 className="text-sm font-bold">{deleteConfirmProvider.is_custom ? t("providers.delete_confirm_title") : t("providers.remove_key_confirm_title", { defaultValue: "Remove API Key" })}</h3>
               </div>
               <button onClick={() => setDeleteConfirmProvider(null)} className="p-1 rounded hover:bg-main" aria-label={t("common.close", { defaultValue: "Close" })}><X className="w-4 h-4" /></button>
             </div>
@@ -1046,14 +1046,14 @@ export function ProvidersPage() {
                   <p className="text-[10px] text-text-dim font-mono">{deleteConfirmProvider.id}</p>
                 </div>
               </div>
-              <p className="text-sm text-text-dim">{t("providers.delete_confirm_message")}</p>
+              <p className="text-sm text-text-dim">{deleteConfirmProvider.is_custom ? t("providers.delete_confirm_message") : t("providers.remove_key_confirm_message", { defaultValue: "This will remove the stored API key and move the provider back to unconfigured." })}</p>
               <div className="flex gap-2 pt-2">
                 <Button variant="ghost" className="flex-1" onClick={() => setDeleteConfirmProvider(null)}>
                   {t("common.cancel")}
                 </Button>
                 <Button variant="primary" className="flex-1 !bg-error hover:!bg-error/80" onClick={handleDeleteConfirm} disabled={keySaving}>
                   {keySaving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Trash2 className="w-4 h-4 mr-1" />}
-                  {t("common.delete")}
+                  {deleteConfirmProvider.is_custom ? t("common.delete") : t("providers.remove_key")}
                 </Button>
               </div>
             </div>
@@ -1072,6 +1072,7 @@ export function ProvidersPage() {
               onSubmit={async (values) => {
                 await createRegistryContent("provider", values);
                 setShowCreateForm(false);
+                setActiveTab("configured");
                 void providersQuery.refetch();
               }}
               onCancel={() => setShowCreateForm(false)}

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1,6 +1,7 @@
 //! Audit, logging, tools, profiles, templates, memory, approvals,
 //! bindings, pairing, webhooks, and miscellaneous system handlers.
 
+use super::skills::write_secret_env;
 use super::AppState;
 
 /// Build routes for the system miscellaneous domain (audit, logs, tools, sessions, approvals, pairing, etc.).
@@ -3988,15 +3989,45 @@ async fn create_registry_content(
         .into_response();
     }
 
+    // For providers: extract the `api_key` value (if present) before writing TOML.
+    // The actual key is stored in secrets.env, NOT in the provider TOML file.
+    let api_key_to_save: Option<(String, String)> = if content_type == "provider" {
+        let obj = body.as_object();
+        let api_key = obj
+            .and_then(|m| m.get("api_key"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.trim().to_string());
+        let api_key_env = obj
+            .and_then(|m| m.get("api_key_env"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("{}_API_KEY", identifier.to_uppercase().replace('-', "_")));
+        api_key.map(|k| (api_key_env, k))
+    } else {
+        None
+    };
+
     // Convert JSON values to TOML.
     // For providers: the catalog TOML format requires a `[provider]` section header.
     // If the body is a flat object (fields at the top level), restructure it so that
     // non-`models` fields are nested under a `"provider"` key, producing the correct
     // `[provider] … [[models]] …` layout that `ModelCatalogFile` expects.
-    let body_for_toml = if content_type == "provider" {
-        normalize_provider_body(&body)
+    // Strip `api_key` from the body so the secret is not written to the TOML file.
+    let body_without_secret = if content_type == "provider" {
+        let mut b = body.clone();
+        if let Some(obj) = b.as_object_mut() {
+            obj.remove("api_key");
+        }
+        b
     } else {
         body.clone()
+    };
+    let body_for_toml = if content_type == "provider" {
+        normalize_provider_body(&body_without_secret)
+    } else {
+        body_without_secret
     };
     let toml_value = json_to_toml_value(&body_for_toml);
     let toml_string = match toml::to_string_pretty(&toml_value) {
@@ -4025,6 +4056,16 @@ async fn create_registry_content(
     // For provider files, refresh the in-memory model catalog so new models
     // and provider config changes are available immediately.
     if content_type == "provider" {
+        // Save the API key to secrets.env before detect_auth so the provider
+        // is immediately recognized as configured.
+        if let Some((env_var, key_value)) = &api_key_to_save {
+            let secrets_path = state.kernel.home_dir().join("secrets.env");
+            if let Err(e) = write_secret_env(&secrets_path, env_var, key_value) {
+                tracing::warn!("Failed to write API key to secrets.env: {e}");
+            }
+            std::env::set_var(env_var, key_value);
+        }
+
         let mut catalog = state
             .kernel
             .model_catalog_ref()
@@ -4037,6 +4078,10 @@ async fn create_registry_content(
         // Invalidate cached LLM drivers — URLs/keys may have changed.
         drop(catalog);
         state.kernel.clear_driver_cache();
+
+        if api_key_to_save.is_some() {
+            state.kernel.clone().spawn_key_validation();
+        }
     }
 
     Json(serde_json::json!({

--- a/crates/librefang-runtime/src/media_understanding.rs
+++ b/crates/librefang-runtime/src/media_understanding.rs
@@ -265,8 +265,6 @@ fn detect_vision_provider() -> Option<&'static str> {
     None
 }
 
-/// Map a known audio MIME type to the extension Whisper expects.
-/// Returns `None` for MIME types that aren't in Whisper's supported set so
 // ── STT provider helpers ──────────────────────────────────────────────
 
 /// Resolve Whisper-compatible API URL and key for a provider.


### PR DESCRIPTION
## Summary

- **Step-by-step provider creation wizard**: Replaces the flat SchemaForm with a 3-step wizard:
  - **Step 1 — Basics**: Only requires Provider ID, Base URL, and optional API Key
  - **Step 2 — Advanced**: Auto-derived display name, env var name, and key_required toggle (can override)
  - **Step 3 — Models**: Optional model configuration with skip option
- **Smart defaults**: Entering provider ID auto-derives `display_name` (title case), `api_key_env` (UPPERCASE_API_KEY), and `key_required`
- **Skip & Create**: Users can skip advanced options and model config to create a provider with minimal input
- **Fix ChatPage TS error**: Added missing `useTranslation()` call in `useChatMessages` hook

## Test plan

- [ ] Click "Add Provider" — verify 3-step wizard appears
- [ ] Enter provider ID (e.g. `my-provider`) — verify auto-derived values shown in preview
- [ ] Click Next — verify Step 2 shows pre-filled display name and env var
- [ ] Click "Skip & Create" on Step 2 — verify provider is created
- [ ] Full flow with models: complete all 3 steps with a model entry
- [ ] Verify `tsc --noEmit` passes with zero errors
- [ ] Verify `vite build` succeeds