### PR TITLE
fix: improve provider auto-detection accuracy and UX

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/status.ts
+++ b/crates/librefang-api/dashboard/src/lib/status.ts
@@ -14,5 +14,5 @@ export function getStatusVariant(status?: string): BadgeVariant {
 /** Check if a provider auth_status indicates the provider is usable.
  *  Mirrors the Rust AuthStatus::is_available() variants. */
 export function isProviderAvailable(status?: string): boolean {
-  return status === "configured" || status === "validated_key" || status === "not_required" || status === "configured_cli";
+  return status === "configured" || status === "validated_key" || status === "not_required" || status === "configured_cli" || status === "auto_detected";
 }

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -22,7 +22,7 @@ import { Typewriter_v2 } from "../components/Typewriter_v2";
 import "katex/dist/katex.min.css";
 
 const isAuthUnavailable = (status?: string) =>
-  !!status && status !== "configured" && status !== "validated_key" && status !== "configured_cli" && status !== "not_required";
+  !!status && status !== "configured" && status !== "validated_key" && status !== "configured_cli" && status !== "not_required" && status !== "auto_detected";
 
 interface ChatToolCall extends AgentTool {
   _call_id?: string;
@@ -1611,6 +1611,7 @@ export function ChatPage() {
           </p>
           {(agent.auth_status === "configured" || agent.auth_status === "validated_key") && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-brand/10 text-brand"}`}>KEY</span>}
           {agent.auth_status === "configured_cli" && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-accent/10 text-accent"}`}>CLI</span>}
+          {agent.auth_status === "auto_detected" && <span className={`flex-shrink-0 px-1 py-0.5 rounded text-[8px] font-bold uppercase leading-none ${selectedAgentId === agent.id ? "bg-white/20" : "bg-warning/10 text-warning"}`}>AUTO</span>}
           {isAuthUnavailable(agent.auth_status) && <AlertCircle className="h-3 w-3 text-warning flex-shrink-0" />}
         </div>
         {isCoordinator ? (

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -666,7 +666,7 @@ export function ProvidersPage() {
     setConfigProvider(provider);
     setKeyInput("");
     setUrlInput(provider.base_url || "");
-    setHasStoredKey(provider.auth_status === "configured" || provider.auth_status === "validated_key" || provider.auth_status === "invalid_key");
+    setHasStoredKey(provider.auth_status === "configured" || provider.auth_status === "validated_key" || provider.auth_status === "invalid_key" || provider.auth_status === "auto_detected");
     setKeyError(null);
     setKeyTestResult(null);
   };

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -977,12 +977,14 @@ export function ProvidersPage() {
                 </Badge>
               </div>
 
+              {configProvider.key_required !== false && (
               <div>
                 <label className="text-[10px] font-bold text-text-dim uppercase">API Key</label>
                 <input type="password" value={keyInput} onChange={e => setKeyInput(e.target.value)}
                   placeholder={hasStoredKey ? t("providers.key_placeholder_existing") : t("providers.key_placeholder")}
                   className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
               </div>
+              )}
 
               <div>
                 <label className="text-[10px] font-bold text-text-dim uppercase">Base URL <span className="normal-case font-normal text-text-dim/50">({t("providers.optional")})</span></label>

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -760,6 +760,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                 librefang_types::model_catalog::AuthStatus::CliNotInstalled => "CLI not installed",
                 librefang_types::model_catalog::AuthStatus::ValidatedKey => "key validated",
                 librefang_types::model_catalog::AuthStatus::InvalidKey => "invalid key",
+                librefang_types::model_catalog::AuthStatus::AutoDetected => "auto-detected",
             };
             msg.push_str(&format!(
                 "  {} — {} [{}, {} model(s)]\n",

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -879,19 +879,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
         "path": config.vault.path.as_ref().map(|p| p.to_string_lossy().to_string()),
     });
 
-    let stt_available = config.media.audio_provider.is_some() || {
-        let has_key = |var: &str| std::env::var(var).is_ok_and(|v| !v.trim().is_empty());
-        has_key("GROQ_API_KEY")
-            || has_key("OPENAI_API_KEY")
-            || has_key("GEMINI_API_KEY")
-            || has_key("GOOGLE_API_KEY")
-            || has_key("ELEVENLABS_API_KEY")
-            || has_key("MINIMAX_API_KEY")
-            || has_key("MINIMAX_CN_API_KEY")
-            || has_key("FIREWORKS_API_KEY")
-            || has_key("TOGETHER_API_KEY")
-            || has_key("SILICONFLOW_API_KEY")
-    };
+    let stt_available = config.media.audio_provider.is_some();
     set!("media", {
         "image_description": config.media.image_description,
         "audio_transcription": config.media.audio_transcription,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -717,10 +717,20 @@ impl LibreFangKernel {
                 .map(|(id, base_url, key_env)| {
                     let kernel = Arc::clone(&self);
                     tokio::spawn(async move {
-                        let key = match std::env::var(&key_env) {
-                            Ok(k) if !k.trim().is_empty() => k,
-                            _ => return,
-                        };
+                        // Resolve the actual key via primary env var, alt env var,
+                        // and credential files. This is needed for AutoDetected
+                        // providers whose key lives in a fallback env var (e.g.
+                        // GOOGLE_API_KEY for gemini, not GEMINI_API_KEY).
+                        let key = librefang_runtime::drivers::resolve_provider_api_key(&id)
+                            .or_else(|| {
+                                std::env::var(&key_env)
+                                    .ok()
+                                    .filter(|k| !k.trim().is_empty())
+                            })
+                            .unwrap_or_default();
+                        if key.is_empty() {
+                            return;
+                        }
                         let result =
                             librefang_runtime::model_catalog::probe_api_key(&id, &base_url, &key)
                                 .await;

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -928,6 +928,32 @@ pub fn is_cli_provider(name: &str) -> bool {
     )
 }
 
+/// Resolve the API key for a provider by checking all known sources:
+/// primary env var → alt env var → Codex credential file (for openai).
+///
+/// Returns `None` if no key is found through any source.
+pub fn resolve_provider_api_key(provider: &str) -> Option<String> {
+    let entry = find_provider(provider)?;
+    let non_empty = |v: String| if v.trim().is_empty() { None } else { Some(v) };
+
+    std::env::var(entry.api_key_env)
+        .ok()
+        .and_then(non_empty)
+        .or_else(|| {
+            entry
+                .alt_api_key_env
+                .and_then(|v| std::env::var(v).ok())
+                .and_then(non_empty)
+        })
+        .or_else(|| {
+            if entry.name == "openai" {
+                read_codex_credential()
+            } else {
+                None
+            }
+        })
+}
+
 /// Read an OpenAI API key from the Codex CLI credential file.
 ///
 /// Checks `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.

--- a/crates/librefang-runtime/src/media_understanding.rs
+++ b/crates/librefang-runtime/src/media_understanding.rs
@@ -66,14 +66,23 @@ impl MediaEngine {
             return Err("Expected audio attachment".into());
         }
 
+        let explicit = self.config.audio_provider.is_some();
         let provider = self
             .config
             .audio_provider
             .as_deref()
             .or_else(|| detect_audio_provider())
             .ok_or(
-                "No audio transcription provider configured. Set one of: GROQ_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, ELEVENLABS_API_KEY, MINIMAX_API_KEY, FIREWORKS_API_KEY, TOGETHER_API_KEY, SILICONFLOW_API_KEY",
+                "No audio transcription provider configured. Set [media] audio_provider in config.toml.",
             )?;
+
+        if !explicit {
+            tracing::warn!(
+                detected_provider = provider,
+                "Audio provider auto-detected from env var — may not match actual service. \
+                 Set [media] audio_provider in config.toml for reliable STT."
+            );
+        }
 
         let _permit = self.semaphore.acquire().await.map_err(|e| e.to_string())?;
 

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -214,8 +214,10 @@ impl ModelCatalog {
                 _ => false,
             };
 
-            provider.auth_status = if has_key || has_key_fallback {
+            provider.auth_status = if has_key {
                 AuthStatus::Configured
+            } else if has_key_fallback {
+                AuthStatus::AutoDetected
             } else if has_cli_fallback {
                 AuthStatus::ConfiguredCli
             } else {

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -241,7 +241,9 @@ impl ModelCatalog {
     pub fn providers_needing_validation(&self) -> Vec<(String, String, String)> {
         self.providers
             .iter()
-            .filter(|p| p.auth_status == AuthStatus::Configured)
+            .filter(|p| {
+                p.auth_status == AuthStatus::Configured || p.auth_status == AuthStatus::AutoDetected
+            })
             .map(|p| (p.id.clone(), p.base_url.clone(), p.api_key_env.clone()))
             .collect()
     }

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -351,6 +351,7 @@ mod tests {
         assert_eq!(AuthStatus::ConfiguredCli.to_string(), "configured_cli");
         assert_eq!(AuthStatus::Missing.to_string(), "missing");
         assert_eq!(AuthStatus::NotRequired.to_string(), "not_required");
+        assert_eq!(AuthStatus::AutoDetected.to_string(), "auto_detected");
         assert_eq!(AuthStatus::CliNotInstalled.to_string(), "cli_not_installed");
     }
 

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -46,6 +46,9 @@ pub enum AuthStatus {
     Configured,
     /// No API key, but a CLI tool (e.g. claude-code) is available as fallback.
     ConfiguredCli,
+    /// Key detected via fallback env var — may not match the actual provider.
+    /// Functionally usable but user should verify.
+    AutoDetected,
     /// API key is present but was rejected by the provider (HTTP 401/403).
     InvalidKey,
     /// API key is missing.
@@ -66,6 +69,7 @@ impl AuthStatus {
             self,
             AuthStatus::ValidatedKey
                 | AuthStatus::Configured
+                | AuthStatus::AutoDetected
                 | AuthStatus::ConfiguredCli
                 | AuthStatus::NotRequired
         )
@@ -78,6 +82,7 @@ impl fmt::Display for AuthStatus {
             AuthStatus::ValidatedKey => write!(f, "validated_key"),
             AuthStatus::Configured => write!(f, "configured"),
             AuthStatus::ConfiguredCli => write!(f, "configured_cli"),
+            AuthStatus::AutoDetected => write!(f, "auto_detected"),
             AuthStatus::InvalidKey => write!(f, "invalid_key"),
             AuthStatus::Missing => write!(f, "missing"),
             AuthStatus::NotRequired => write!(f, "not_required"),


### PR DESCRIPTION
## Summary

- Add `AuthStatus::AutoDetected` for providers detected via fallback env var (e.g. `GOOGLE_API_KEY` → gemini). Shows **AUTO** badge (yellow) in dashboard to warn users the detection may not match the actual service
- `stt_available` now only returns `true` when `audio_provider` is explicitly set in config — no more env var guessing for the mic button
- Hide API Key input field for providers with `key_required=false` (e.g. ollama)
- Add warning log when STT provider is auto-detected

Fixes #2541

## Changes

| File | What |
|------|------|
| `crates/librefang-types/src/model_catalog.rs` | New `AuthStatus::AutoDetected` variant |
| `crates/librefang-runtime/src/model_catalog.rs` | `detect_auth` uses `AutoDetected` for fallback key paths |
| `crates/librefang-runtime/src/media_understanding.rs` | Warning log for auto-detected STT provider |
| `crates/librefang-api/src/routes/config.rs` | `stt_available` only checks explicit config |
| `crates/librefang-api/dashboard/src/lib/status.ts` | `isProviderAvailable` includes `auto_detected` |
| `crates/librefang-api/dashboard/src/pages/ChatPage.tsx` | AUTO badge + `isAuthUnavailable` update |
| `crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx` | Hide API Key input when `key_required=false` |

## Test plan

- [ ] Provider with direct key (`GROQ_API_KEY` for groq) → shows `KEY` badge
- [ ] Provider with fallback key (`GOOGLE_API_KEY` for gemini) → shows `AUTO` badge
- [ ] No `audio_provider` in config → mic button disabled
- [ ] `audio_provider = "groq"` in config → mic button enabled
- [ ] Ollama provider config modal → no API Key input field
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`