### PR TITLE
fix: remove orphaned doc comment causing clippy failure on main

### DIFF
--- a/crates/librefang-runtime/src/media_understanding.rs
+++ b/crates/librefang-runtime/src/media_understanding.rs
@@ -265,8 +265,6 @@ fn detect_vision_provider() -> Option<&'static str> {
     None
 }
 
-/// Map a known audio MIME type to the extension Whisper expects.
-/// Returns `None` for MIME types that aren't in Whisper's supported set so
 // ── STT provider helpers ──────────────────────────────────────────────
 
 /// Resolve Whisper-compatible API URL and key for a provider.


### PR DESCRIPTION
## Summary

- Remove two orphaned `///` doc comment lines in `media_understanding.rs` that were left behind from a previous refactor
- These lines caused `clippy::empty_line_after_doc_comments` error on main, failing the Quality CI job

## Root cause

Lines 268-269 had `///` doc comments (`Map a known audio MIME type...`) that weren't attached to any function — the function they documented was removed but the comments remained. Combined with the section separator comment and blank line before `whisper_provider_config`, clippy flagged it as an empty line after doc comments.

## Test plan

- [x] `cargo clippy -p librefang-runtime -- -D warnings` passes with zero warnings