### PR TITLE
fix: add missing entries to default .gitignore on workspace init

### DIFF
--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -104,7 +104,7 @@ pub(super) fn init_git_if_missing(home_dir: &Path) {
     if !gitignore.exists() {
         let _ = std::fs::write(
             &gitignore,
-            "secrets.env\nvault.enc\ndaemon.json\nlogs/\ncache/\nregistry/\ndata/\n*.db\n*.db-shm\n*.db-wal\n",
+            "secrets.env\nvault.enc\ndaemon.json\ndaemon.log\nhand_state.json\nsessions.json\nworkflow_runs.json\nlogs/\ncache/\nregistry/\ndata/\ndashboard/\nbackups/\ninbox/\n.vscode/\n*.db\n*.db-shm\n*.db-wal\n",
         );
     }
     let _ = std::process::Command::new("git")


### PR DESCRIPTION
## Summary
- Add `daemon.log`, `hand_state.json`, `sessions.json`, `workflow_runs.json` to default `.gitignore`
- Add `dashboard/`, `backups/`, `inbox/`, `.vscode/` directories to default `.gitignore`
- These are all runtime-generated files/directories that should not be tracked by git in `~/.librefang`

## Test plan
- [ ] `cargo build --workspace --lib` passes
- [ ] `cargo test -p librefang-kernel` passes
- [ ] Fresh `init` creates `.gitignore` with all new entries