### PR TITLE
feat(dashboard): improve models page UX

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -882,6 +882,7 @@ export interface ModelItem {
   supports_vision?: boolean;
   supports_streaming?: boolean;
   supports_thinking?: boolean;
+  aliases?: string[];
   available?: boolean;
 }
 

--- a/crates/librefang-api/dashboard/src/lib/store.ts
+++ b/crates/librefang-api/dashboard/src/lib/store.ts
@@ -28,8 +28,10 @@ interface UIState {
   skillOutputs: SkillOutput[];
   hiddenModelKeys: string[];
   terminalEnabled: boolean | null;
+  modelsAvailableOnly: boolean;
   deepThinking: boolean;
   showThinkingProcess: boolean;
+  setModelsAvailableOnly: (value: boolean) => void;
   setDeepThinking: (value: boolean) => void;
   setShowThinkingProcess: (value: boolean) => void;
   toggleTheme: () => void;
@@ -62,8 +64,10 @@ export const useUIStore = create<UIState>()(
       skillOutputs: [],
       hiddenModelKeys: [],
       terminalEnabled: null,
+      modelsAvailableOnly: true,
       deepThinking: false,
       showThinkingProcess: true,
+      setModelsAvailableOnly: (value) => set({ modelsAvailableOnly: value }),
       setDeepThinking: (value) => set({ deepThinking: value }),
       setShowThinkingProcess: (value) => set({ showThinkingProcess: value }),
       toggleTheme: () =>
@@ -119,6 +123,7 @@ export const useUIStore = create<UIState>()(
         language: state.language,
         navLayout: state.navLayout,
         hiddenModelKeys: state.hiddenModelKeys,
+        modelsAvailableOnly: state.modelsAvailableOnly,
         deepThinking: state.deepThinking,
         showThinkingProcess: state.showThinkingProcess,
       }),

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1635,9 +1635,11 @@
     "col_tier": "Tier",
     "col_context": "Context",
     "col_input": "Input $/M",
+    "col_output": "Output $/M",
     "col_tools": "Tools",
     "col_vision": "Vision",
     "col_streaming": "Streaming",
+    "col_thinking": "Thinking",
     "help": "Browse all available LLM models across providers. Filter by tier, provider, and availability. Compare capabilities and pricing.",
     "add_model": "Add Model",
     "add_custom_model": "Add Custom Model",
@@ -1663,7 +1665,12 @@
     "show_hidden": "Hidden",
     "hidden_count": "{{count}} hidden",
     "model_hidden": "Model hidden",
-    "model_unhidden": "Model unhidden"
+    "model_unhidden": "Model unhidden",
+    "expand_all": "Expand All",
+    "collapse_all": "Collapse All",
+    "aliases": "Aliases",
+    "max_output_tokens": "Max Output",
+    "cost_range": "Cost"
   },
   "media": {
     "section": "Media",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1610,9 +1610,11 @@
     "col_tier": "等级",
     "col_context": "上下文",
     "col_input": "输入 $/M",
+    "col_output": "输出 $/M",
     "col_tools": "工具",
     "col_vision": "视觉",
     "col_streaming": "流式",
+    "col_thinking": "思考",
     "help": "浏览所有供应商的可用 LLM 模型。按等级、供应商和可用性筛选，比较模型能力和价格。",
     "add_model": "添加模型",
     "add_custom_model": "添加自定义模型",
@@ -1638,7 +1640,12 @@
     "show_hidden": "已隐藏",
     "hidden_count": "{{count}} 个已隐藏",
     "model_hidden": "模型已隐藏",
-    "model_unhidden": "模型已取消隐藏"
+    "model_unhidden": "模型已取消隐藏",
+    "expand_all": "全部展开",
+    "collapse_all": "全部折叠",
+    "aliases": "别名",
+    "max_output_tokens": "最大输出",
+    "cost_range": "价格"
   },
   "media": {
     "section": "媒体生成",

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatCompact, formatCost as formatCostUtil } from "../lib/format";
+import type { ModelItem } from "../api";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { listModels, addCustomModel, removeCustomModel } from "../api";
@@ -13,9 +14,16 @@ import { Modal } from "../components/ui/Modal";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { useUIStore } from "../lib/store";
 import {
-  Cpu, Search, Check, X, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2, Sparkles, ChevronDown, ChevronRight
+  Cpu, Search, Check, X, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2, Sparkles,
+  ChevronDown, ChevronRight, Brain, ArrowUpDown, ChevronsUpDown, Tag,
 } from "lucide-react";
 import { modelKey } from "../lib/hiddenModels";
+
+type SortField = "model" | "provider" | "tier" | "context" | "input_cost" | "output_cost";
+type SortDir = "asc" | "desc";
+
+const GRID_COLS = "grid-cols-[minmax(140px,1fr)_90px_70px_70px_70px_70px_40px_40px_40px_40px_70px]";
+const GRID_MIN_W = "min-w-[860px]";
 
 const REFRESH_MS = 60000;
 export function ModelsPage() {
@@ -25,16 +33,29 @@ export function ModelsPage() {
   const [search, setSearch] = useState("");
   const [tierFilter, setTierFilter] = useState<string>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
-  const [availableOnly, setAvailableOnly] = useState(true);
+  const availableOnly = useUIStore((s) => s.modelsAvailableOnly);
+  const setAvailableOnly = useUIStore((s) => s.setModelsAvailableOnly);
   const [showAdd, setShowAdd] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   useCreateShortcut(() => setShowAdd(true));
   const [showHidden, setShowHidden] = useState(false);
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
+  const [expandedModelId, setExpandedModelId] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<SortField>("model");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [isMobile, setIsMobile] = useState(false);
   const hiddenModelKeys = useUIStore((s) => s.hiddenModelKeys);
   const hideModelAction = useUIStore((s) => s.hideModel);
   const unhideModelAction = useUIStore((s) => s.unhideModel);
   const pruneHiddenKeys = useUIStore((s) => s.pruneHiddenKeys);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
 
   // Form state
   const [formId, setFormId] = useState("");
@@ -142,7 +163,12 @@ export function ModelsPage() {
   const filtered = useMemo(
     () => allModels.filter(m => {
       const q = search.toLowerCase();
-      if (search && !m.id.toLowerCase().includes(q) && !(m.display_name || "").toLowerCase().includes(q) && !m.provider.toLowerCase().includes(q)) return false;
+      if (search
+        && !m.id.toLowerCase().includes(q)
+        && !(m.display_name || "").toLowerCase().includes(q)
+        && !m.provider.toLowerCase().includes(q)
+        && !(m.aliases ?? []).some(a => a.toLowerCase().includes(q))
+      ) return false;
       if (tierFilter !== "all" && m.tier !== tierFilter) return false;
       if (providerFilter !== "all" && m.provider !== providerFilter) return false;
       if (availableOnly && !m.available) return false;
@@ -153,17 +179,44 @@ export function ModelsPage() {
 
   const hiddenCount = useMemo(() => allModels.filter(m => hiddenSet.has(modelKey(m))).length, [allModels, hiddenSet]);
 
+  // Sort
+  const sortedFiltered = useMemo(() => {
+    const sorted = [...filtered];
+    const dir = sortDir === "asc" ? 1 : -1;
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case "model": cmp = (a.display_name || a.id).localeCompare(b.display_name || b.id); break;
+        case "provider": cmp = a.provider.localeCompare(b.provider); break;
+        case "tier": cmp = (a.tier || "").localeCompare(b.tier || ""); break;
+        case "context": cmp = (a.context_window ?? 0) - (b.context_window ?? 0); break;
+        case "input_cost": cmp = (a.input_cost_per_m ?? 0) - (b.input_cost_per_m ?? 0); break;
+        case "output_cost": cmp = (a.output_cost_per_m ?? 0) - (b.output_cost_per_m ?? 0); break;
+      }
+      return cmp * dir;
+    });
+    return sorted;
+  }, [filtered, sortField, sortDir]);
+
   // Group by provider when showing all providers
   const grouped = useMemo(() => {
     if (providerFilter !== "all") return null;
-    const map = new Map<string, typeof filtered>();
-    for (const m of filtered) {
+    const map = new Map<string, ModelItem[]>();
+    for (const m of sortedFiltered) {
       const list = map.get(m.provider);
       if (list) list.push(m);
       else map.set(m.provider, [m]);
     }
     return new Map([...map.entries()].sort(([a], [b]) => a.localeCompare(b)));
-  }, [filtered, providerFilter]);
+  }, [sortedFiltered, providerFilter]);
+
+  const allGroupedProviders = useMemo(() => grouped ? Array.from(grouped.keys()) : [], [grouped]);
+  const allExpanded = allGroupedProviders.length > 0 && allGroupedProviders.every(p => expandedProviders.has(p));
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) setSortDir(d => d === "asc" ? "desc" : "asc");
+    else { setSortField(field); setSortDir("asc"); }
+  };
 
   const tierColor = (tier?: string) => {
     switch (tier) {
@@ -192,7 +245,214 @@ export function ModelsPage() {
     return formatCompact(tokens);
   };
 
+  const SortHeader = ({ field, children, className = "" }: { field: SortField; children: React.ReactNode; className?: string }) => (
+    <button type="button" onClick={() => toggleSort(field)}
+      className={`group flex items-center gap-0.5 cursor-pointer hover:text-text transition-colors select-none ${className}`}>
+      {children}
+      {sortField === field
+        ? <ArrowUpDown className="w-3 h-3 text-brand" />
+        : <ArrowUpDown className="w-3 h-3 opacity-0 group-hover:opacity-30" />}
+    </button>
+  );
+
   const inputClass = "w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand";
+
+  // Collapsed provider summary: tier badges + cheapest cost
+  const providerSummary = (models: ModelItem[]) => {
+    const tierSet = new Set(models.map(m => m.tier).filter(Boolean));
+    const tiers = Array.from(tierSet).sort();
+    const costs = models.map(m => m.input_cost_per_m ?? 0).filter(c => c > 0);
+    const minCost = costs.length > 0 ? Math.min(...costs) : null;
+    return (
+      <div className="flex items-center gap-1.5 ml-auto mr-2">
+        {tiers.slice(0, 4).map(tier => (
+          <span key={tier} className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${tierColor(tier)}`}>{tier}</span>
+        ))}
+        {tiers.length > 4 && <span className="text-[9px] text-text-dim">+{tiers.length - 4}</span>}
+        {minCost !== null && (
+          <span className="text-[10px] text-text-dim font-mono ml-1">{t("models.cost_range")} {formatCostUtil(minCost)}+</span>
+        )}
+      </div>
+    );
+  };
+
+  // Mobile card for a single model
+  const renderMobileCard = (m: ModelItem) => {
+    const isCustom = m.tier === "custom";
+    const mKey = `${m.provider}:${m.id}`;
+    const isExpanded = expandedModelId === mKey;
+    return (
+      <div key={mKey} className={`rounded-xl border border-border-subtle p-3 space-y-2 ${!m.available ? "opacity-40" : ""}`}>
+        <div className="flex items-start justify-between gap-2">
+          <button type="button" onClick={() => setExpandedModelId(isExpanded ? null : mKey)} className="text-left min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
+              {m.available ? <span className="w-2 h-2 rounded-full bg-success shrink-0" /> : <Lock className="w-3 h-3 text-text-dim/60 shrink-0" />}
+              {isCustom && <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />}
+            </div>
+            {m.display_name && m.display_name !== m.id && (
+              <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
+            )}
+          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            {showHidden ? (
+              <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
+                className="p-1 rounded text-text-dim/40 hover:text-success" title={t("models.unhide_model")}><Eye className="w-3.5 h-3.5" /></button>
+            ) : (
+              <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
+                className="p-1 rounded text-text-dim/40 hover:text-warning" title={t("models.hide_model")}><EyeOff className="w-3.5 h-3.5" /></button>
+            )}
+            {isCustom && !showHidden && (
+              confirmDeleteId === m.id
+                ? <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
+                : <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error" title={t("models.delete_model")}><Trash2 className="w-3.5 h-3.5" /></button>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-1.5 items-center">
+          <span className="text-[10px] font-semibold text-text-dim bg-surface px-1.5 py-0.5 rounded">{m.provider}</span>
+          <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${tierColor(m.tier)}`}>{m.tier === "custom" ? t("models.custom") : m.tier || "-"}</span>
+          <span className="text-[10px] font-mono text-text-dim">{formatCtx(m.context_window)}</span>
+          <span className="text-[10px] font-mono text-text">{formatCost(m.input_cost_per_m)}/{formatCost(m.output_cost_per_m)}</span>
+        </div>
+        <div className="flex gap-2 items-center">
+          {m.supports_tools && <Wrench className="w-3 h-3 text-success" />}
+          {m.supports_vision && <Eye className="w-3 h-3 text-success" />}
+          {m.supports_streaming && <Zap className="w-3 h-3 text-success" />}
+          {m.supports_thinking && <Brain className="w-3 h-3 text-success" />}
+        </div>
+        {isExpanded && (
+          <div className="pt-2 border-t border-border-subtle/50 space-y-1 text-[11px] text-text-dim">
+            <p><span className="font-bold">{t("models.model_id")}:</span> <span className="font-mono">{m.id}</span></p>
+            <p><span className="font-bold">{t("models.max_output_tokens")}:</span> {formatCtx(m.max_output_tokens)}</p>
+            {(m.aliases ?? []).length > 0 && (
+              <div className="flex items-center gap-1 flex-wrap">
+                <Tag className="w-3 h-3" />
+                <span className="font-bold">{t("models.aliases")}:</span>
+                {m.aliases!.map(a => <span key={a} className="font-mono bg-surface px-1 rounded">{a}</span>)}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Desktop table row
+  const renderRow = (m: ModelItem, i: number) => {
+    const isCustom = m.tier === "custom";
+    const mKey = `${m.provider}:${m.id}`;
+    const isExpanded = expandedModelId === mKey;
+    return (
+      <div key={mKey}>
+        <div
+          className={`grid ${GRID_COLS} ${GRID_MIN_W} gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors cursor-pointer ${
+            !m.available ? "opacity-40" : ""
+          } ${i % 2 === 0 ? "" : "bg-main/30"}`}
+          onClick={() => setExpandedModelId(isExpanded ? null : mKey)}
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
+              {m.available ? (
+                <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+              ) : (
+                <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
+                  <Lock className="w-3 h-3" /> {t("models.no_key")}
+                </span>
+              )}
+              {isCustom && <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />}
+            </div>
+            {m.display_name && m.display_name !== m.id && (
+              <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
+            )}
+          </div>
+          <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
+          <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
+            {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
+          </span>
+          <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
+          <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
+          <span className="text-xs font-mono text-text">{formatCost(m.output_cost_per_m)}</span>
+          <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+          <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+          <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+          <span className="text-center">{m.supports_thinking ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
+          <span className="flex items-center justify-center gap-1" onClick={e => e.stopPropagation()}>
+            {showHidden ? (
+              <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
+                className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
+                <Eye className="w-3.5 h-3.5" />
+              </button>
+            ) : (
+              <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
+                className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
+                <EyeOff className="w-3.5 h-3.5" />
+              </button>
+            )}
+            {isCustom && !showHidden && (
+              confirmDeleteId === m.id ? (
+                <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
+              ) : (
+                <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              )
+            )}
+          </span>
+        </div>
+        {/* Inline detail panel */}
+        {isExpanded && (
+          <div className={`px-5 py-3 bg-surface/50 border-t border-border-subtle/30 ${GRID_MIN_W}`}>
+            <div className="flex flex-wrap gap-x-6 gap-y-1 text-[11px] text-text-dim">
+              <span><span className="font-bold">{t("models.model_id")}:</span> <span className="font-mono">{m.id}</span></span>
+              <span><span className="font-bold">{t("models.max_output_tokens")}:</span> {formatCtx(m.max_output_tokens)}</span>
+              <span><span className="font-bold">{t("models.col_output")}:</span> {formatCost(m.output_cost_per_m)}</span>
+              {(m.aliases ?? []).length > 0 && (
+                <span className="flex items-center gap-1">
+                  <Tag className="w-3 h-3" />
+                  <span className="font-bold">{t("models.aliases")}:</span>
+                  {m.aliases!.map(a => <span key={a} className="font-mono bg-main px-1 rounded">{a}</span>)}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const toggleProvider = (p: string) => {
+    setExpandedProviders(prev => {
+      const next = new Set(prev);
+      if (next.has(p)) next.delete(p); else next.add(p);
+      return next;
+    });
+  };
+
+  const toggleAllProviders = () => {
+    if (allExpanded) {
+      setExpandedProviders(new Set());
+    } else {
+      setExpandedProviders(new Set(allGroupedProviders));
+    }
+  };
+
+  const colHeader = (
+    <div className={`grid ${GRID_COLS} ${GRID_MIN_W} gap-3 px-5 py-3 bg-main text-[11px] font-bold text-text-dim/60 uppercase`}>
+      <SortHeader field="model">{t("models.col_model")}</SortHeader>
+      <SortHeader field="provider">{t("models.col_provider")}</SortHeader>
+      <SortHeader field="tier">{t("models.col_tier")}</SortHeader>
+      <SortHeader field="context">{t("models.col_context")}</SortHeader>
+      <SortHeader field="input_cost">{t("models.col_input")}</SortHeader>
+      <SortHeader field="output_cost">{t("models.col_output")}</SortHeader>
+      <span className="text-center" title={t("models.col_tools")}><Wrench className="w-3.5 h-3.5 inline" /></span>
+      <span className="text-center" title={t("models.col_vision")}><Eye className="w-3.5 h-3.5 inline" /></span>
+      <span className="text-center" title={t("models.col_streaming")}><Zap className="w-3.5 h-3.5 inline" /></span>
+      <span className="text-center" title={t("models.col_thinking")}><Brain className="w-3.5 h-3.5 inline" /></span>
+      <span></span>
+    </div>
+  );
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -237,7 +497,7 @@ export function ModelsPage() {
           {providers.map(p => <option key={p} value={p}>{p === "all" ? t("models.all_providers") : p}</option>)}
         </select>
 
-        <div className="flex gap-0.5 rounded-xl border border-border-subtle bg-surface p-0.5 flex-wrap overflow-x-auto">
+        <div className="hidden sm:flex gap-0.5 rounded-xl border border-border-subtle bg-surface p-0.5 flex-wrap overflow-x-auto">
           {tiers.map(tier => (
             <button key={tier} onClick={() => setTierFilter(tier || "all")}
               className={`px-2.5 py-1.5 rounded-lg text-[10px] font-bold transition-colors ${
@@ -266,6 +526,14 @@ export function ModelsPage() {
             <span className="ml-1 px-1.5 py-0.5 rounded-full bg-warning/20 text-warning text-[9px] font-bold">{hiddenCount}</span>
           )}
         </button>
+
+        {grouped && allGroupedProviders.length > 1 && (
+          <button onClick={toggleAllProviders}
+            className="flex items-center gap-1.5 px-3 py-2.5 rounded-xl border border-border-subtle text-xs font-bold text-text-dim hover:border-brand/30 transition-colors">
+            <ChevronsUpDown className="w-3 h-3" />
+            {allExpanded ? t("models.collapse_all") : t("models.expand_all")}
+          </button>
+        )}
       </div>
 
       <p className="text-xs text-text-dim">{filtered.length} {t("models.results")}</p>
@@ -278,131 +546,49 @@ export function ModelsPage() {
           icon={<Cpu className="w-7 h-7" />}
           title={allModels.length === 0 ? t("models.no_models") : t("models.no_results")}
         />
-      ) : (() => {
-        const colHeader = (
-          <div className="grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 bg-main text-[11px] font-bold text-text-dim/60 uppercase">
-            <span>{t("models.col_model")}</span>
-            <span>{t("models.col_provider")}</span>
-            <span>{t("models.col_tier")}</span>
-            <span>{t("models.col_context")}</span>
-            <span>{t("models.col_input")}</span>
-            <span className="text-center" title={t("models.col_tools")}><Wrench className="w-3.5 h-3.5 inline" /></span>
-            <span className="text-center" title={t("models.col_vision")}><Eye className="w-3.5 h-3.5 inline" /></span>
-            <span className="text-center" title={t("models.col_streaming")}><Zap className="w-3.5 h-3.5 inline" /></span>
-            <span></span>
-          </div>
-        );
-
-        const renderRow = (m: (typeof filtered)[0], i: number) => {
-          const isCustom = m.tier === "custom";
-          return (
-            <div key={`${m.provider}:${m.id}`}
-              className={`grid grid-cols-[minmax(160px,1fr)_100px_80px_80px_80px_50px_50px_50px_80px] min-w-[780px] gap-3 px-5 py-3 items-center border-t border-border-subtle/50 hover:bg-surface transition-colors ${
-                !m.available ? "opacity-40" : ""
-              } ${i % 2 === 0 ? "" : "bg-main/30"}`}>
-              <div className="min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <p className="text-sm font-bold truncate">{m.display_name || m.id}</p>
-                  {m.available ? (
-                    <span className="w-2 h-2 rounded-full bg-success shrink-0" />
-                  ) : (
-                    <span className="flex items-center gap-0.5 text-[9px] text-text-dim/60 shrink-0">
-                      <Lock className="w-3 h-3" /> {t("models.no_key")}
-                    </span>
+      ) : isMobile ? (
+        /* Mobile card layout */
+        <div className="flex flex-col gap-2">
+          {sortedFiltered.map(m => renderMobileCard(m))}
+        </div>
+      ) : grouped ? (
+        <div className="flex flex-col gap-3">
+          {Array.from(grouped.entries()).map(([provider, models]) => {
+            const collapsed = !expandedProviders.has(provider);
+            const availCount = models.filter(m => m.available).length;
+            return (
+              <div key={provider} className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
+                <button
+                  type="button"
+                  onClick={() => toggleProvider(provider)}
+                  className="flex items-center gap-3 w-full px-5 py-3.5 bg-surface hover:bg-main/60 transition-colors cursor-pointer select-none min-w-[780px]"
+                >
+                  {collapsed
+                    ? <ChevronRight className="w-4 h-4 text-text-dim shrink-0" />
+                    : <ChevronDown className="w-4 h-4 text-text-dim shrink-0" />}
+                  <span className="text-sm font-bold text-text">{provider}</span>
+                  <span className="px-2 py-0.5 rounded-full bg-brand/10 text-brand text-[11px] font-bold">{models.length}</span>
+                  {availCount > 0 && availCount < models.length && (
+                    <span className="text-[11px] text-text-dim">{availCount} {t("models.available")}</span>
                   )}
-                  {isCustom && (
-                    <Sparkles className="w-3 h-3 text-violet-500 shrink-0" />
-                  )}
-                </div>
-                {m.display_name && m.display_name !== m.id && (
-                  <p className="text-[10px] text-text-dim/40 font-mono truncate">{m.id}</p>
+                  {collapsed && providerSummary(models)}
+                </button>
+                {!collapsed && (
+                  <>
+                    {colHeader}
+                    {models.map((m, i) => renderRow(m, i))}
+                  </>
                 )}
               </div>
-              <span className="text-xs font-semibold text-text truncate">{m.provider}</span>
-              <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md w-fit ${tierColor(m.tier)}`}>
-                {m.tier === "custom" ? t("models.custom") : m.tier || "-"}
-              </span>
-              <span className="text-xs font-mono text-text">{formatCtx(m.context_window)}</span>
-              <span className="text-xs font-mono text-text">{formatCost(m.input_cost_per_m)}</span>
-              <span className="text-center">{m.supports_tools ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-              <span className="text-center">{m.supports_vision ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-              <span className="text-center">{m.supports_streaming ? <Check className="w-4 h-4 text-success inline" /> : <X className="w-4 h-4 text-text-dim/15 inline" />}</span>
-              <span className="flex items-center justify-center gap-1">
-                {showHidden ? (
-                  <button onClick={() => { unhideModelAction(modelKey(m)); addToast(t("models.model_unhidden"), "success"); }}
-                    className="p-1 rounded text-text-dim/40 hover:text-success hover:bg-success/10 transition-colors" title={t("models.unhide_model")} aria-label={t("models.unhide_model")}>
-                    <Eye className="w-3.5 h-3.5" />
-                  </button>
-                ) : (
-                  <button onClick={() => { hideModelAction(modelKey(m)); addToast(t("models.model_hidden"), "success"); }}
-                    className="p-1 rounded text-text-dim/40 hover:text-warning hover:bg-warning/10 transition-colors" title={t("models.hide_model")} aria-label={t("models.hide_model")}>
-                    <EyeOff className="w-3.5 h-3.5" />
-                  </button>
-                )}
-                {isCustom && !showHidden && (
-                  confirmDeleteId === m.id ? (
-                    <button onClick={() => handleDelete(m.id)} className="px-1.5 py-0.5 rounded bg-error text-white text-[9px] font-bold">{t("common.confirm")}</button>
-                  ) : (
-                    <button onClick={() => handleDelete(m.id)} className="p-1 rounded text-text-dim/20 hover:text-error hover:bg-error/10 transition-colors" title={t("models.delete_model")}>
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
-                  )
-                )}
-              </span>
-            </div>
-          );
-        };
-
-        const toggleProvider = (p: string) => {
-          setExpandedProviders(prev => {
-            const next = new Set(prev);
-            if (next.has(p)) next.delete(p); else next.add(p);
-            return next;
-          });
-        };
-
-        if (grouped) {
-          return (
-            <div className="flex flex-col gap-3">
-              {Array.from(grouped.entries()).map(([provider, models]) => {
-                const collapsed = !expandedProviders.has(provider);
-                const availCount = models.filter(m => m.available).length;
-                return (
-                  <div key={provider} className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
-                    <button
-                      type="button"
-                      onClick={() => toggleProvider(provider)}
-                      className="flex items-center gap-3 w-full px-5 py-3.5 bg-surface hover:bg-main/60 transition-colors cursor-pointer select-none min-w-[780px]"
-                    >
-                      {collapsed
-                        ? <ChevronRight className="w-4 h-4 text-text-dim shrink-0" />
-                        : <ChevronDown className="w-4 h-4 text-text-dim shrink-0" />}
-                      <span className="text-sm font-bold text-text">{provider}</span>
-                      <span className="px-2 py-0.5 rounded-full bg-brand/10 text-brand text-[11px] font-bold">{models.length}</span>
-                      {availCount > 0 && availCount < models.length && (
-                        <span className="text-[11px] text-text-dim">{availCount} {t("models.available")}</span>
-                      )}
-                    </button>
-                    {!collapsed && (
-                      <>
-                        {colHeader}
-                        {models.map((m, i) => renderRow(m, i))}
-                      </>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          );
-        }
-
-        return (
-          <div className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
-            {colHeader}
-            {filtered.map((m, i) => renderRow(m, i))}
-          </div>
-        );
-      })()}
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">
+          {colHeader}
+          {sortedFiltered.map((m, i) => renderRow(m, i))}
+        </div>
+      )}
 
       {/* Add Model Modal */}
       <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -30,7 +30,7 @@ export function ModelsPage() {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   useCreateShortcut(() => setShowAdd(true));
   const [showHidden, setShowHidden] = useState(false);
-  const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
+  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
   const hiddenModelKeys = useUIStore((s) => s.hiddenModelKeys);
   const hideModelAction = useUIStore((s) => s.hideModel);
   const unhideModelAction = useUIStore((s) => s.unhideModel);
@@ -354,7 +354,7 @@ export function ModelsPage() {
         };
 
         const toggleProvider = (p: string) => {
-          setCollapsedProviders(prev => {
+          setExpandedProviders(prev => {
             const next = new Set(prev);
             if (next.has(p)) next.delete(p); else next.add(p);
             return next;
@@ -365,7 +365,7 @@ export function ModelsPage() {
           return (
             <div className="flex flex-col gap-3">
               {Array.from(grouped.entries()).map(([provider, models]) => {
-                const collapsed = collapsedProviders.has(provider);
+                const collapsed = !expandedProviders.has(provider);
                 const availCount = models.filter(m => m.available).length;
                 return (
                   <div key={provider} className="rounded-2xl border border-border-subtle overflow-hidden overflow-x-auto">

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -25,7 +25,7 @@ export function ModelsPage() {
   const [search, setSearch] = useState("");
   const [tierFilter, setTierFilter] = useState<string>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
-  const [availableOnly, setAvailableOnly] = useState(false);
+  const [availableOnly, setAvailableOnly] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   useCreateShortcut(() => setShowAdd(true));

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -128,6 +128,7 @@ pub async fn list_models(
                 "supports_vision": m.supports_vision,
                 "supports_streaming": m.supports_streaming,
                 "supports_thinking": m.supports_thinking,
+                "aliases": m.aliases,
                 "available": available,
             })
         })


### PR DESCRIPTION
## Summary

- Add column sorting (click headers to sort by model, provider, tier, context, input/output cost)
- Add output cost and thinking columns to the table
- Add inline model detail panel (click any row to expand: aliases, max output tokens, full ID)
- Add expand/collapse all button for provider groups
- Show tier badges and cost range in collapsed provider headers
- Search now matches model aliases
- Persist "Available Only" filter preference across sessions
- Mobile responsive: card layout below 768px
- Backend: include aliases in model list API response
- Default to collapsed provider groups and available-only filter

## Test plan
- [ ] Click column headers → sort toggles asc/desc
- [ ] Click model row → detail panel expands with aliases, max output
- [ ] Search by alias name (e.g. "sonnet") → finds matching models
- [ ] Expand All / Collapse All button works
- [ ] Collapsed provider shows tier badges + cost range
- [ ] Toggle Available Only → refresh page → preference persists
- [ ] Resize browser below 768px → card layout
- [ ] Output cost and thinking columns display correctly
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`