### PR TITLE
fix(dashboard): prevent auto-detection from overriding provider key removal

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { listProviders, testProvider, setProviderKey, deleteProviderKey, setProviderUrl, createRegistryContent, setDefaultProvider } from "../api";
+import { listProviders, testProvider, setProviderKey, deleteProviderKey, setProviderUrl, createRegistryContent, setDefaultProvider, getStatus } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -977,7 +977,7 @@ export function ProvidersPage() {
   const addToast = useUIStore((s) => s.addToast);
 
   const providersQuery = useQuery({ queryKey: ["providers", "list"], queryFn: listProviders, refetchInterval: REFRESH_MS });
-  const statusQuery = useQuery({ queryKey: ["status"], queryFn: () => fetch("/api/status").then(r => r.json()) as Promise<{ default_provider?: string }>, refetchInterval: REFRESH_MS });
+  const statusQuery = useQuery({ queryKey: ["status"], queryFn: getStatus, refetchInterval: REFRESH_MS });
   const testMutation = useMutation({ mutationFn: testProvider });
   const defaultProviderMutation = useMutation({ mutationFn: setDefaultProvider });
 

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -777,13 +777,18 @@ pub async fn set_provider_key(
     // Set env var in current process so detect_auth picks it up
     std::env::set_var(&env_var, &key);
 
-    // Refresh auth detection (sync, sets status to Configured if non-empty)
-    state
-        .kernel
-        .model_catalog_ref()
-        .write()
-        .unwrap_or_else(|e| e.into_inner())
-        .detect_auth();
+    // Re-enable fallback detection (user is adding a key, undo any prior suppress)
+    // and refresh auth status.
+    {
+        let mut catalog = state
+            .kernel
+            .model_catalog_ref()
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        catalog.unsuppress_provider(&name);
+        catalog.save_suppressed(&state.kernel.home_dir().join("suppressed_providers.json"));
+        catalog.detect_auth();
+    }
 
     // Kick off a background probe to validate the new key immediately so the
     // dashboard reflects ValidatedKey / InvalidKey without waiting for restart.
@@ -966,13 +971,17 @@ pub async fn delete_provider_key(
     // Remove from process environment
     std::env::remove_var(&env_var);
 
-    // Refresh auth detection
-    state
-        .kernel
-        .model_catalog_ref()
-        .write()
-        .unwrap_or_else(|e| e.into_inner())
-        .detect_auth();
+    // Suppress fallback/CLI detection for this provider and refresh auth
+    {
+        let mut catalog = state
+            .kernel
+            .model_catalog_ref()
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        catalog.suppress_provider(&name);
+        catalog.save_suppressed(&state.kernel.home_dir().join("suppressed_providers.json"));
+        catalog.detect_auth();
+    }
 
     (
         StatusCode::OK,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1728,6 +1728,7 @@ impl LibreFangKernel {
         // Initialize model catalog, detect provider auth, and apply URL overrides
         let mut model_catalog =
             librefang_runtime::model_catalog::ModelCatalog::new(&config.home_dir);
+        model_catalog.load_suppressed(&config.home_dir.join("suppressed_providers.json"));
         model_catalog.detect_auth();
         // Apply region selections first (lower priority than explicit provider_urls)
         if !config.provider_regions.is_empty() {

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -6,7 +6,7 @@
 use librefang_types::model_catalog::{
     AliasesCatalogFile, AuthStatus, ModelCatalogEntry, ModelCatalogFile, ModelTier, ProviderInfo,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tracing::warn;
 
 /// The model catalog — registry of all known models and providers.
@@ -14,6 +14,9 @@ pub struct ModelCatalog {
     models: Vec<ModelCatalogEntry>,
     aliases: HashMap<String, String>,
     providers: Vec<ProviderInfo>,
+    /// Providers whose fallback/CLI detection is suppressed by the user
+    /// (i.e. the user explicitly removed the key via the dashboard).
+    suppressed_providers: HashSet<String>,
 }
 
 impl ModelCatalog {
@@ -151,6 +154,7 @@ impl ModelCatalog {
             models,
             aliases,
             providers,
+            suppressed_providers: HashSet::new(),
         }
     }
 
@@ -192,26 +196,40 @@ impl ModelCatalog {
             // Primary: check the provider's declared env var (non-empty after trim)
             let has_key = std::env::var(&provider.api_key_env).is_ok_and(|v| !v.trim().is_empty());
 
+            // If the user explicitly removed this provider's key, skip
+            // fallback/CLI detection — only honour the primary env var.
+            let suppressed = self.suppressed_providers.contains(&provider.id);
+
             // Secondary: provider-specific fallback keys (still API-key-based auth)
-            let has_key_fallback = match provider.id.as_str() {
-                "gemini" => std::env::var("GOOGLE_API_KEY").is_ok_and(|v| !v.trim().is_empty()),
-                "openai" | "codex" => {
-                    std::env::var("OPENAI_API_KEY").is_ok_and(|v| !v.trim().is_empty())
-                        || read_codex_credential().is_some()
+            let has_key_fallback = if suppressed {
+                false
+            } else {
+                match provider.id.as_str() {
+                    "gemini" => std::env::var("GOOGLE_API_KEY").is_ok_and(|v| !v.trim().is_empty()),
+                    "openai" | "codex" => {
+                        std::env::var("OPENAI_API_KEY").is_ok_and(|v| !v.trim().is_empty())
+                            || read_codex_credential().is_some()
+                    }
+                    _ => false,
                 }
-                _ => false,
             };
 
             // Tertiary: CLI tools that can serve as fallback for API providers
-            let aider_ok = || crate::drivers::cli_provider_available("aider");
-            let has_cli_fallback = match provider.id.as_str() {
-                "anthropic" => crate::drivers::cli_provider_available("claude-code") || aider_ok(),
-                "gemini" => crate::drivers::cli_provider_available("gemini-cli") || aider_ok(),
-                "openai" | "codex" => {
-                    crate::drivers::cli_provider_available("codex-cli") || aider_ok()
+            let has_cli_fallback = if suppressed {
+                false
+            } else {
+                let aider_ok = || crate::drivers::cli_provider_available("aider");
+                match provider.id.as_str() {
+                    "anthropic" => {
+                        crate::drivers::cli_provider_available("claude-code") || aider_ok()
+                    }
+                    "gemini" => crate::drivers::cli_provider_available("gemini-cli") || aider_ok(),
+                    "openai" | "codex" => {
+                        crate::drivers::cli_provider_available("codex-cli") || aider_ok()
+                    }
+                    "qwen" => crate::drivers::cli_provider_available("qwen-code") || aider_ok(),
+                    _ => false,
                 }
-                "qwen" => crate::drivers::cli_provider_available("qwen-code") || aider_ok(),
-                _ => false,
             };
 
             provider.auth_status = if has_key {
@@ -395,6 +413,34 @@ impl ModelCatalog {
     /// Returns `true` if the alias was found and removed.
     pub fn remove_alias(&mut self, alias: &str) -> bool {
         self.aliases.remove(&alias.to_lowercase()).is_some()
+    }
+
+    /// Mark a provider as suppressed — fallback/CLI detection will be skipped
+    /// for this provider until `unsuppress_provider` is called.
+    pub fn suppress_provider(&mut self, id: &str) {
+        self.suppressed_providers.insert(id.to_string());
+    }
+
+    /// Remove a provider from the suppressed set, re-enabling fallback/CLI detection.
+    pub fn unsuppress_provider(&mut self, id: &str) {
+        self.suppressed_providers.remove(id);
+    }
+
+    /// Load the suppressed-providers list from a JSON file.
+    pub fn load_suppressed(&mut self, path: &std::path::Path) {
+        if let Ok(data) = std::fs::read_to_string(path) {
+            if let Ok(list) = serde_json::from_str::<Vec<String>>(&data) {
+                self.suppressed_providers = list.into_iter().collect();
+            }
+        }
+    }
+
+    /// Persist the suppressed-providers list to a JSON file.
+    pub fn save_suppressed(&self, path: &std::path::Path) {
+        let list: Vec<&String> = self.suppressed_providers.iter().collect();
+        if let Ok(json) = serde_json::to_string_pretty(&list) {
+            let _ = std::fs::write(path, json);
+        }
     }
 
     /// Set a custom base URL for a provider, overriding the default.

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -436,8 +436,14 @@ impl ModelCatalog {
     }
 
     /// Persist the suppressed-providers list to a JSON file.
+    /// Removes the file when the set is empty.
     pub fn save_suppressed(&self, path: &std::path::Path) {
-        let list: Vec<&String> = self.suppressed_providers.iter().collect();
+        if self.suppressed_providers.is_empty() {
+            let _ = std::fs::remove_file(path);
+            return;
+        }
+        let mut list: Vec<&String> = self.suppressed_providers.iter().collect();
+        list.sort();
         if let Ok(json) = serde_json::to_string_pretty(&list) {
             let _ = std::fs::write(path, json);
         }


### PR DESCRIPTION
## Summary
- When removing an API key via the dashboard, `detect_auth()` would immediately re-detect CLI tools or fallback env vars, making the removal appear to fail
- Add `suppressed_providers` set to `ModelCatalog` that skips fallback/CLI detection for providers the user has explicitly removed
- Persisted to `suppressed_providers.json`; cleared per-provider when a new key is added via `set_provider_key`

## Test plan
- [ ] `cargo build --workspace --lib` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [ ] Dashboard: remove a provider key → status should show Missing, not ConfiguredCli/AutoDetected
- [ ] Dashboard: add a key back → suppress is cleared, fallback detection re-enabled
- [ ] Restart daemon → suppressed state persists from `suppressed_providers.json`