### PR TITLE
feat(dashboard): improve models and providers page UX

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -48,6 +48,9 @@ export interface ProviderItem {
   key_required?: boolean;
   health?: string;
   media_capabilities?: string[];
+  is_custom?: boolean;
+  error_message?: string;
+  last_tested?: string;
 }
 
 export interface MediaProvider {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -412,7 +412,13 @@
     "wizard_create": "Create Provider",
     "wizard_creating": "Creating...",
     "wizard_id_required": "Provider ID is required",
-    "wizard_base_url_required": "Base URL is required"
+    "wizard_base_url_required": "Base URL is required",
+    "wizard_auto_derived": "Auto-derived",
+    "wizard_env_var": "Env Var",
+    "provider_models": "Models",
+    "no_models_for_provider": "No models registered",
+    "remove_key_confirm_title": "Remove API Key",
+    "remove_key_confirm_message": "This will remove the stored API key and move the provider back to unconfigured."
   },
   "channels": {
     "title": "Channels",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -412,7 +412,13 @@
     "wizard_create": "创建供应商",
     "wizard_creating": "创建中...",
     "wizard_id_required": "供应商 ID 不能为空",
-    "wizard_base_url_required": "Base URL 不能为空"
+    "wizard_base_url_required": "Base URL 不能为空",
+    "wizard_auto_derived": "自动推导",
+    "wizard_env_var": "环境变量",
+    "provider_models": "模型",
+    "no_models_for_provider": "暂无注册模型",
+    "remove_key_confirm_title": "移除 API Key",
+    "remove_key_confirm_message": "这将移除已存储的 API Key，并将该供应商标记为未配置。"
   },
   "channels": {
     "title": "通道",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1,15 +1,16 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { listProviders, testProvider, setProviderKey, deleteProviderKey, setProviderUrl, createRegistryContent, setDefaultProvider, getStatus } from "../api";
+import { listProviders, listModels, testProvider, setProviderKey, deleteProviderKey, setProviderUrl, createRegistryContent, setDefaultProvider, getStatus } from "../api";
+import type { ProviderItem } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
-import { Badge } from "../components/ui/Badge";
+import { Badge, type BadgeVariant } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
 import { Select } from "../components/ui/Select";
 import { Modal } from "../components/ui/Modal";
@@ -52,34 +53,139 @@ function getLatencyColor(ms?: number) {
   return "text-error";
 }
 
+function getAuthBadge(status?: string): { variant: BadgeVariant; label: string } {
+  switch (status) {
+    case "configured":
+    case "validated_key":
+      return { variant: "success", label: "KEY" };
+    case "configured_cli":
+      return { variant: "default", label: "CLI" };
+    case "auto_detected":
+      return { variant: "warning", label: "AUTO" };
+    case "not_required":
+      return { variant: "success", label: "LOCAL" };
+    case "invalid_key":
+      return { variant: "error", label: "INVALID" };
+    case "cli_not_installed":
+      return { variant: "error", label: "CLI N/A" };
+    case "missing":
+    default:
+      return { variant: "warning", label: "SETUP" };
+  }
+}
 
 type SortField = "name" | "models" | "latency";
 type SortOrder = "asc" | "desc";
 type ViewMode = "grid" | "list";
 type FilterStatus = "all" | "reachable" | "unreachable";
 
-interface Provider {
-  id: string;
-  display_name?: string;
-  auth_status?: string;
-  reachable?: boolean;
-  model_count?: number;
-  latency_ms?: number;
-  api_key_env?: string;
-  base_url?: string;
-  key_required?: boolean;
-  health?: string;
-  last_tested?: string;
-  error_message?: string;
-  media_capabilities?: string[];
-  /** True for providers added by the user at runtime; false for ones shipped
-   *  by the registry. Only custom providers can actually be deleted — built-ins
-   *  are recreated by the next registry sync, so we hide the delete control. */
-  is_custom?: boolean;
+// ── useProviderConfig hook ────────────────────────────────────────
+
+interface ProviderConfigState {
+  provider: ProviderItem | null;
+  keyInput: string;
+  urlInput: string;
+  hasStoredKey: boolean;
+  saving: boolean;
+  error: string | null;
+  testing: boolean;
+  testResult: { ok: boolean; message: string } | null;
 }
 
+function useProviderConfig(
+  refetchProviders: () => void,
+  testMutation: ReturnType<typeof useMutation<any, any, string>>,
+  addToast: (msg: string, type?: "success" | "error" | "info") => void,
+  t: (key: string, opts?: any) => string,
+  activeTab: string,
+  setActiveTab: (tab: "configured" | "unconfigured") => void,
+) {
+  const [state, setState] = useState<ProviderConfigState>({
+    provider: null, keyInput: "", urlInput: "", hasStoredKey: false,
+    saving: false, error: null, testing: false, testResult: null,
+  });
+
+  const open = useCallback((p: ProviderItem) => {
+    setState({
+      provider: p, keyInput: "", urlInput: p.base_url || "",
+      hasStoredKey: p.auth_status === "configured" || p.auth_status === "validated_key" || p.auth_status === "invalid_key" || p.auth_status === "auto_detected",
+      saving: false, error: null, testing: false, testResult: null,
+    });
+  }, []);
+
+  const close = useCallback(() => setState(s => ({ ...s, provider: null })), []);
+
+  const setKeyInput = useCallback((v: string) => setState(s => ({ ...s, keyInput: v })), []);
+  const setUrlInput = useCallback((v: string) => setState(s => ({ ...s, urlInput: v })), []);
+
+  const saveKey = useCallback(async () => {
+    if (!state.provider) return;
+    setState(s => ({ ...s, saving: true, error: null }));
+    try {
+      if (state.urlInput.trim() && state.urlInput !== state.provider.base_url) {
+        await setProviderUrl(state.provider.id, state.urlInput.trim());
+      }
+      if (state.keyInput.trim()) {
+        await setProviderKey(state.provider.id, state.keyInput.trim());
+      }
+      refetchProviders();
+      setState(s => ({ ...s, provider: null }));
+      if (activeTab === "unconfigured") setActiveTab("configured");
+      addToast(t("providers.key_saved"), "success");
+    } catch (e: any) {
+      setState(s => ({ ...s, error: e?.message || String(e) }));
+    } finally {
+      setState(s => ({ ...s, saving: false }));
+    }
+  }, [state.provider, state.keyInput, state.urlInput, refetchProviders, addToast, t, activeTab, setActiveTab]);
+
+  const removeKey = useCallback(async () => {
+    if (!state.provider) return;
+    setState(s => ({ ...s, saving: true }));
+    try {
+      await deleteProviderKey(state.provider.id);
+      refetchProviders();
+      setState(s => ({ ...s, provider: null, hasStoredKey: false }));
+      addToast(t("providers.key_removed"), "success");
+    } catch (e: any) {
+      setState(s => ({ ...s, error: e?.message || String(e) }));
+    } finally {
+      setState(s => ({ ...s, saving: false }));
+    }
+  }, [state.provider, refetchProviders, addToast, t]);
+
+  const testKey = useCallback(async () => {
+    if (!state.provider) return;
+    setState(s => ({ ...s, testing: true, testResult: null }));
+    try {
+      if (state.keyInput.trim()) {
+        await setProviderKey(state.provider.id, state.keyInput.trim());
+        setState(s => ({ ...s, hasStoredKey: true, keyInput: "" }));
+      }
+      if (state.urlInput.trim() && state.urlInput !== state.provider.base_url) {
+        await setProviderUrl(state.provider.id, state.urlInput.trim());
+      }
+      const result = await testMutation.mutateAsync(state.provider.id);
+      if (result.status === "error") {
+        setState(s => ({ ...s, testResult: { ok: false, message: String(result.error_message || result.error || t("providers.unreachable")) } }));
+      } else {
+        setState(s => ({ ...s, testResult: { ok: true, message: t("providers.reachable") } }));
+      }
+      refetchProviders();
+    } catch (e: any) {
+      setState(s => ({ ...s, testResult: { ok: false, message: e?.message || t("common.error") } }));
+    } finally {
+      setState(s => ({ ...s, testing: false }));
+    }
+  }, [state.provider, state.keyInput, state.urlInput, testMutation, refetchProviders, t]);
+
+  return { ...state, open, close, setKeyInput, setUrlInput, saveKey, removeKey, testKey };
+}
+
+// ── ProviderCard ─────────────────────────────────────────────────
+
 interface ProviderCardProps {
-  provider: Provider;
+  provider: ProviderItem;
   isSelected: boolean;
   isDefault: boolean;
   pendingId: string | null;
@@ -87,16 +193,16 @@ interface ProviderCardProps {
   onSelect: (id: string, checked: boolean) => void;
   onTest: (id: string) => void;
   onSetDefault: (id: string) => void;
-  onViewDetails: (provider: Provider) => void;
-  onQuickConfig: (provider: Provider) => void;
-  onEdit: (provider: Provider) => void;
-  onDelete: (provider: Provider) => void;
+  onViewDetails: (provider: ProviderItem) => void;
+  onConfigure: (provider: ProviderItem) => void;
+  onDelete: (provider: ProviderItem) => void;
   t: (key: string) => string;
 }
 
-function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onQuickConfig, onEdit, onDelete, t }: ProviderCardProps) {
+function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onConfigure, onDelete, t }: ProviderCardProps) {
   const isConfigured = isProviderAvailable(p.auth_status);
   const isCli = p.auth_status === "configured_cli" || p.auth_status === "cli_not_installed" || (!p.base_url && !p.key_required);
+  const authBadge = getAuthBadge(p.auth_status);
 
   if (viewMode === "list") {
     return (
@@ -161,36 +267,34 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               <Star className="w-3 h-3 mr-1 inline" />{t("providers.is_default")}
             </Badge>
           )}
-          {!isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onQuickConfig(p)} leftIcon={<Key className="w-3 h-3" />}>
+          {isConfigured ? (
+            <>
+              {!isDefault && (
+                <Button variant="ghost" size="sm" onClick={() => onSetDefault(p.id)} leftIcon={<Star className="w-3 h-3" />}>
+                  <span className="hidden sm:inline">{t("providers.set_as_default")}</span>
+                </Button>
+              )}
+              <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+                <span className="hidden sm:inline">{t("common.edit")}</span>
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+                <span className="hidden sm:inline text-error">{p.is_custom ? t("common.delete") : t("providers.remove_key")}</span>
+              </Button>
+              <Button
+                variant="secondary" size="sm"
+                onClick={() => onTest(p.id)}
+                disabled={pendingId === p.id}
+                leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
+                className="whitespace-nowrap"
+              >
+                <span className="hidden sm:inline">{pendingId === p.id ? t("providers.analyzing") : t("providers.test")}</span>
+              </Button>
+            </>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Key className="w-3 h-3" />}>
               <span className="hidden sm:inline">{t("providers.config")}</span>
             </Button>
           )}
-          {isConfigured && !isDefault && (
-            <Button variant="ghost" size="sm" onClick={() => onSetDefault(p.id)} leftIcon={<Star className="w-3 h-3" />}>
-              <span className="hidden sm:inline">{t("providers.set_as_default")}</span>
-            </Button>
-          )}
-          {isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onEdit(p)} leftIcon={<Pencil className="w-3 h-3" />}>
-              <span className="hidden sm:inline">{t("common.edit")}</span>
-            </Button>
-          )}
-          {isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
-              <span className="hidden sm:inline text-error">{p.is_custom ? t("common.delete") : t("providers.remove_key")}</span>
-            </Button>
-          )}
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => onTest(p.id)}
-            disabled={pendingId === p.id}
-            leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
-            className="whitespace-nowrap"
-          >
-            <span className="hidden sm:inline">{pendingId === p.id ? t("providers.analyzing") : t("providers.test")}</span>
-          </Button>
           <Button variant="ghost" size="sm" onClick={() => onViewDetails(p)}>
             <ChevronRight className="w-4 h-4" />
           </Button>
@@ -335,162 +439,168 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
 
         {/* Actions */}
         <div className="flex gap-2 mt-auto">
-          {!isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onQuickConfig(p)} leftIcon={<Key className="w-3 h-3" />} className="flex-1 whitespace-nowrap">
+          {isConfigured ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+                {t("common.edit")}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+                {p.is_custom ? t("common.delete") : t("providers.remove_key")}
+              </Button>
+              <Button
+                variant="secondary" size="sm"
+                onClick={() => onTest(p.id)}
+                disabled={pendingId === p.id}
+                leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
+                className="flex-1 whitespace-nowrap"
+              >
+                {pendingId === p.id ? t("providers.analyzing") : t("providers.test")}
+              </Button>
+            </>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Key className="w-3 h-3" />} className="flex-1 whitespace-nowrap">
               {t("providers.config")}
             </Button>
           )}
-          {isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onEdit(p)} leftIcon={<Pencil className="w-3 h-3" />}>
-              {t("common.edit")}
-            </Button>
-          )}
-          {isConfigured && (
-            <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
-              {p.is_custom ? t("common.delete") : t("providers.remove_key")}
-            </Button>
-          )}
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => onTest(p.id)}
-            disabled={pendingId === p.id}
-            leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
-            className="flex-1 whitespace-nowrap"
-          >
-            {pendingId === p.id ? t("providers.analyzing") : t("providers.test")}
-          </Button>
         </div>
       </div>
     </Card>
   );
 }
 
-// Details Modal
+// ── Details Modal ────────────────────────────────────────────────
+
 function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
-  provider: Provider;
+  provider: ProviderItem;
   onClose: () => void;
   onTest: (id: string) => void;
   pendingId: string | null;
-  t: (key: string) => string
+  t: (key: string, opts?: any) => string;
 }) {
   const isConfigured = isProviderAvailable(provider.auth_status);
+  const authBadge = getAuthBadge(provider.auth_status);
+
+  const modelsQuery = useQuery({
+    queryKey: ["models", "provider", provider.id],
+    queryFn: () => listModels({ provider: provider.id }),
+  });
+  const models = modelsQuery.data?.models ?? [];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
-      <div className="bg-surface rounded-2xl border border-border-subtle w-full sm:max-w-lg shadow-2xl rounded-t-2xl sm:rounded-2xl max-h-[90vh] overflow-y-auto animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-        {/* Header */}
-        <div className={`h-2 bg-gradient-to-r ${isConfigured ? "from-success via-success/60 to-success/30" : "from-brand via-brand/60 to-brand/30"} rounded-t-2xl`} />
-        <div className="p-6 border-b border-border-subtle">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className={`w-12 h-12 rounded-xl flex items-center justify-center text-2xl ${isConfigured ? "bg-success/10 border border-success/20" : "bg-brand/10 border border-brand/20"}`}>
-                {getProviderIcon(provider.id)}
-              </div>
-              <div>
-                <h2 className="text-xl font-black">{provider.display_name || provider.id}</h2>
-                <p className="text-xs font-black uppercase tracking-widest text-text-dim/60">{provider.id}</p>
-              </div>
-            </div>
-            <button onClick={onClose} className="p-2 hover:bg-main/30 rounded-lg transition-colors" aria-label={t("common.close")}>
-              <X className="w-5 h-5 text-text-dim" />
-            </button>
+    <Modal isOpen onClose={onClose} title={provider.display_name || provider.id} size="lg">
+      <div className="p-6 space-y-4">
+        {/* Header info */}
+        <div className="flex items-center gap-3">
+          <div className={`w-12 h-12 rounded-xl flex items-center justify-center text-2xl ${isConfigured ? "bg-success/10 border border-success/20" : "bg-brand/10 border border-brand/20"}`}>
+            {getProviderIcon(provider.id)}
+          </div>
+          <div className="flex-1">
+            <p className="text-xs font-black uppercase tracking-widest text-text-dim/60">{provider.id}</p>
+          </div>
+          <Badge variant={authBadge.variant}>{authBadge.label}</Badge>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="p-4 rounded-xl bg-main/30">
+            <p className="text-[10px] font-black uppercase tracking-wider text-text-dim/70 mb-1">{t("providers.models")}</p>
+            <p className="text-2xl font-black">{provider.model_count ?? 0}</p>
+          </div>
+          <div className="p-4 rounded-xl bg-main/30">
+            <p className="text-[10px] font-black uppercase tracking-wider text-text-dim/70 mb-1">{t("providers.latency")}</p>
+            <p className={`text-2xl font-black ${getLatencyColor(provider.latency_ms)}`}>
+              {provider.latency_ms ? `${provider.latency_ms}ms` : "-"}
+            </p>
           </div>
         </div>
 
-        {/* Content */}
-        <div className="p-6 space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="p-4 rounded-xl bg-main/30">
-              <p className="text-[10px] font-black uppercase tracking-wider text-text-dim/70 mb-1">{t("providers.models")}</p>
-              <p className="text-2xl font-black">{provider.model_count ?? 0}</p>
-            </div>
-            <div className="p-4 rounded-xl bg-main/30">
-              <p className="text-[10px] font-black uppercase tracking-wider text-text-dim/70 mb-1">{t("providers.latency")}</p>
-              <p className={`text-2xl font-black ${getLatencyColor(provider.latency_ms)}`}>
-                {provider.latency_ms ? `${provider.latency_ms}ms` : "-"}
-              </p>
-            </div>
-          </div>
-
-          <div className="space-y-3">
-            <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("common.properties")}</h3>
-            <div className="space-y-2">
-              {provider.base_url && (
-                <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                  <span className="text-xs font-bold text-text-dim">{t("providers.base_url")}</span>
-                  <span className="text-xs font-mono text-text-main truncate max-w-[200px]">{provider.base_url}</span>
-                </div>
-              )}
-              {provider.api_key_env && (
-                <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                  <span className="text-xs font-bold text-text-dim">{t("providers.api_key")}</span>
-                  <span className="text-xs font-mono text-text-main">{provider.api_key_env}</span>
-                </div>
-              )}
+        {/* Properties */}
+        <div className="space-y-3">
+          <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("common.properties")}</h3>
+          <div className="space-y-2">
+            {provider.base_url && (
               <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                <span className="text-xs font-bold text-text-dim">{t("common.status")}</span>
-                <Badge variant={isConfigured ? "success" : "warning"}>
-                  {isConfigured ? t("common.active") : t("common.setup")}
+                <span className="text-xs font-bold text-text-dim">{t("providers.base_url")}</span>
+                <span className="text-xs font-mono text-text-main truncate max-w-[200px]">{provider.base_url}</span>
+              </div>
+            )}
+            {provider.api_key_env && (
+              <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
+                <span className="text-xs font-bold text-text-dim">{t("providers.api_key")}</span>
+                <span className="text-xs font-mono text-text-main">{provider.api_key_env}</span>
+              </div>
+            )}
+            <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
+              <span className="text-xs font-bold text-text-dim">{t("common.status")}</span>
+              <Badge variant={authBadge.variant}>{authBadge.label}</Badge>
+            </div>
+            <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
+              <span className="text-xs font-bold text-text-dim">{t("providers.health")}</span>
+              {provider.reachable !== undefined ? (
+                <Badge variant={provider.reachable === true ? "success" : "error"}>
+                  {provider.reachable === true ? t("providers.reachable") : t("providers.unreachable")}
                 </Badge>
-              </div>
-              <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                <span className="text-xs font-bold text-text-dim">{t("providers.health")}</span>
-                {provider.reachable !== undefined ? (
-                  <Badge variant={provider.reachable === true ? "success" : "error"}>
-                    {provider.reachable === true ? t("providers.reachable") : t("providers.unreachable")}
-                  </Badge>
-                ) : <Badge variant="default">{t("providers.not_checked")}</Badge>}
-              </div>
-              {provider.key_required !== undefined && (
-                <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                  <span className="text-xs font-bold text-text-dim">{t("providers.key_required")}</span>
-                  <span className="text-xs font-bold">{provider.key_required ? t("common.yes") : t("common.no")}</span>
-                </div>
-              )}
-              {provider.last_tested && (
-                <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
-                  <span className="text-xs font-bold text-text-dim">{t("providers.last_test")}</span>
-                  <span className="text-xs font-mono text-text-main">{formatDateTime(provider.last_tested)}</span>
-                </div>
-              )}
+              ) : <Badge variant="default">{t("providers.not_checked")}</Badge>}
             </div>
+            {provider.key_required !== undefined && (
+              <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
+                <span className="text-xs font-bold text-text-dim">{t("providers.key_required")}</span>
+                <span className="text-xs font-bold">{provider.key_required ? t("common.yes") : t("common.no")}</span>
+              </div>
+            )}
+            {provider.last_tested && (
+              <div className="flex justify-between items-center p-3 rounded-lg bg-main/20">
+                <span className="text-xs font-bold text-text-dim">{t("providers.last_test")}</span>
+                <span className="text-xs font-mono text-text-main">{formatDateTime(provider.last_tested)}</span>
+              </div>
+            )}
           </div>
+        </div>
 
-          {provider.error_message && (
-            <div className="p-4 rounded-xl bg-error/10 border border-error/20">
-              <h3 className="text-xs font-black uppercase tracking-wider text-error mb-2">{t("providers.error")}</h3>
-              <p className="text-xs font-mono text-error">{provider.error_message}</p>
+        {/* Model list */}
+        <div className="space-y-3">
+          <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("providers.provider_models")}</h3>
+          {modelsQuery.isLoading ? (
+            <p className="text-xs text-text-dim">{t("common.loading")}</p>
+          ) : models.length === 0 ? (
+            <p className="text-xs text-text-dim">{t("providers.no_models_for_provider")}</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 max-h-48 overflow-y-auto">
+              {models.map(m => (
+                <div key={m.id} className="flex items-center gap-2 p-2 rounded-lg bg-main/20 text-xs">
+                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${m.available ? "bg-success" : "bg-text-dim/30"}`} />
+                  <span className="truncate font-mono">{m.display_name || m.id}</span>
+                </div>
+              ))}
             </div>
           )}
-
-          {/* Quick Actions */}
-          <div className="flex gap-2 pt-2">
-            <Button
-              variant="primary"
-              className="flex-1"
-              onClick={() => onTest(provider.id)}
-              disabled={pendingId === provider.id}
-              leftIcon={pendingId === provider.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Zap className="w-4 h-4" />}
-            >
-              {pendingId === provider.id ? t("providers.analyzing") : t("providers.test_connection")}
-            </Button>
-            <Button variant="secondary" leftIcon={<ExternalLink className="w-4 h-4" />}>
-              {t("providers.open_settings")}
-            </Button>
-          </div>
         </div>
 
-        {/* Footer */}
-        <div className="p-4 border-t border-border-subtle flex justify-end">
-          <Button variant="ghost" onClick={onClose}>{t("common.close")}</Button>
+        {provider.error_message && (
+          <div className="p-4 rounded-xl bg-error/10 border border-error/20">
+            <h3 className="text-xs font-black uppercase tracking-wider text-error mb-2">{t("providers.error")}</h3>
+            <p className="text-xs font-mono text-error">{provider.error_message}</p>
+          </div>
+        )}
+
+        {/* Quick Actions */}
+        <div className="flex gap-2 pt-2">
+          <Button
+            variant="primary" className="flex-1"
+            onClick={() => onTest(provider.id)}
+            disabled={pendingId === provider.id}
+            leftIcon={pendingId === provider.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Zap className="w-4 h-4" />}
+          >
+            {pendingId === provider.id ? t("providers.analyzing") : t("providers.test_connection")}
+          </Button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }
 
-// Filter Chips
+// ── Filter Chips ─────────────────────────────────────────────────
+
 function FilterChips({ activeFilter, onChange, t }: {
   activeFilter: FilterStatus;
   onChange: (filter: FilterStatus) => void;
@@ -522,7 +632,7 @@ function FilterChips({ activeFilter, onChange, t }: {
   );
 }
 
-// ── Create Provider Wizard ──────────────────────────────────────────────
+// ── Create Provider Wizard ──────────────────────────────────────
 
 interface ModelEntry {
   id: string;
@@ -535,10 +645,7 @@ interface ModelEntry {
 }
 
 function toTitleCase(id: string): string {
-  return id
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
+  return id.split("-").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
 }
 
 function toEnvVar(id: string): string {
@@ -546,13 +653,9 @@ function toEnvVar(id: string): string {
 }
 
 const EMPTY_MODEL: ModelEntry = {
-  id: "",
-  display_name: "",
-  tier: "balanced",
-  context_window: "",
-  max_output_tokens: "",
-  input_cost_per_m: "",
-  output_cost_per_m: "",
+  id: "", display_name: "", tier: "balanced",
+  context_window: "", max_output_tokens: "",
+  input_cost_per_m: "", output_cost_per_m: "",
 };
 
 const TIER_OPTIONS = [
@@ -574,24 +677,18 @@ function CreateProviderWizard({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  // Step 1 fields
   const [id, setId] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
 
-  // Step 2 fields (auto-derived, user can override)
   const [displayName, setDisplayName] = useState("");
   const [apiKeyEnv, setApiKeyEnv] = useState("");
   const [keyRequired, setKeyRequired] = useState(true);
   const [derivedOverridden, setDerivedOverridden] = useState(false);
 
-  // Step 3 fields
   const [models, setModels] = useState<ModelEntry[]>([]);
-
-  // Validation
   const [errors, setErrors] = useState<string[]>([]);
 
-  // Sync derived values when id changes (unless user has manually overridden)
   const derivedDisplayName = toTitleCase(id);
   const derivedApiKeyEnv = toEnvVar(id);
   const effectiveDisplayName = derivedOverridden ? displayName : derivedDisplayName;
@@ -614,7 +711,6 @@ function CreateProviderWizard({
 
   const handleNext = () => {
     if (step === 0 && !validateStep0()) return;
-    // When entering step 2 for the first time, sync derived values
     if (step === 0 && !derivedOverridden) {
       setDisplayName(derivedDisplayName);
       setApiKeyEnv(derivedApiKeyEnv);
@@ -637,9 +733,7 @@ function CreateProviderWizard({
       base_url: baseUrl.trim(),
       key_required: effectiveKeyRequired,
     };
-    if (apiKey.trim()) {
-      values.api_key = apiKey.trim();
-    }
+    if (apiKey.trim()) values.api_key = apiKey.trim();
     if (models.length > 0) {
       values.models = models
         .filter((m) => m.id.trim())
@@ -669,9 +763,7 @@ function CreateProviderWizard({
   };
 
   const updateModel = (idx: number, field: keyof ModelEntry, value: unknown) => {
-    setModels((prev) =>
-      prev.map((m, i) => (i === idx ? { ...m, [field]: value } : m)),
-    );
+    setModels((prev) => prev.map((m, i) => (i === idx ? { ...m, [field]: value } : m)));
   };
 
   const removeModel = (idx: number) => {
@@ -680,28 +772,15 @@ function CreateProviderWizard({
 
   return (
     <div>
-      {/* Header */}
-      <div className="px-5 py-3 border-b border-border-subtle flex items-center justify-between">
-        <h3 className="text-sm font-bold">{t("providers.add")}</h3>
-        <button onClick={onCancel} className="p-1 rounded hover:bg-main" aria-label={t("common.close")}>
-          <X className="w-4 h-4" />
-        </button>
-      </div>
-
       {/* Step indicator */}
       <div className="px-5 pt-4 pb-2">
         <div className="flex items-center gap-1">
           {steps.map((label, i) => (
-            <button
-              key={i}
-              className="flex items-center gap-1 flex-1 group"
-              onClick={() => { if (i < step) setStep(i); }}
-              disabled={i > step}
-            >
-              <div className={`
-                w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 transition-colors
-                ${i < step ? "bg-success text-white cursor-pointer" : i === step ? "bg-brand text-white" : "bg-main text-text-dim"}
-              `}>
+            <button key={i} className="flex items-center gap-1 flex-1 group"
+              onClick={() => { if (i < step) setStep(i); }} disabled={i > step}>
+              <div className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 transition-colors ${
+                i < step ? "bg-success text-white cursor-pointer" : i === step ? "bg-brand text-white" : "bg-main text-text-dim"
+              }`}>
                 {i < step ? <Check className="w-3 h-3" /> : i + 1}
               </div>
               <span className={`text-[10px] font-bold uppercase tracking-wider truncate ${i === step ? "text-text-main" : "text-text-dim"}`}>
@@ -717,55 +796,30 @@ function CreateProviderWizard({
         {/* Step 1: Basics */}
         {step === 0 && (
           <>
-            <Input
-              label={t("providers.wizard_id_label") + " *"}
-              value={id}
-              onChange={(e) => {
-                const v = e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "");
-                setId(v);
-                setErrors((prev) => prev.filter((e) => e !== "id"));
-              }}
-              placeholder={t("providers.wizard_id_placeholder")}
-              className={errors.includes("id") ? "border-error" : ""}
-            />
-            {errors.includes("id") && (
-              <p className="text-[10px] text-error -mt-2">{t("providers.wizard_id_required")}</p>
-            )}
+            <Input label={t("providers.wizard_id_label") + " *"} value={id}
+              onChange={(e) => { setId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "")); setErrors(prev => prev.filter(e2 => e2 !== "id")); }}
+              placeholder={t("providers.wizard_id_placeholder")} className={errors.includes("id") ? "border-error" : ""} />
+            {errors.includes("id") && <p className="text-[10px] text-error -mt-2">{t("providers.wizard_id_required")}</p>}
             <p className="text-[10px] text-text-dim/60 -mt-2">{t("providers.wizard_id_hint")}</p>
 
-            <Input
-              label={t("providers.wizard_base_url_label") + " *"}
-              value={baseUrl}
-              onChange={(e) => {
-                setBaseUrl(e.target.value);
-                setErrors((prev) => prev.filter((e) => e !== "base_url"));
-              }}
-              placeholder={t("providers.wizard_base_url_placeholder")}
-              className={errors.includes("base_url") ? "border-error" : ""}
-            />
-            {errors.includes("base_url") && (
-              <p className="text-[10px] text-error -mt-2">{t("providers.wizard_base_url_required")}</p>
-            )}
+            <Input label={t("providers.wizard_base_url_label") + " *"} value={baseUrl}
+              onChange={(e) => { setBaseUrl(e.target.value); setErrors(prev => prev.filter(e2 => e2 !== "base_url")); }}
+              placeholder={t("providers.wizard_base_url_placeholder")} className={errors.includes("base_url") ? "border-error" : ""} />
+            {errors.includes("base_url") && <p className="text-[10px] text-error -mt-2">{t("providers.wizard_base_url_required")}</p>}
 
-            <Input
-              label={t("providers.wizard_api_key_label")}
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={t("providers.wizard_api_key_placeholder")}
-            />
+            <Input label={t("providers.wizard_api_key_label")} type="password" value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)} placeholder={t("providers.wizard_api_key_placeholder")} />
             <p className="text-[10px] text-text-dim/60 -mt-2">{t("providers.wizard_api_key_hint")}</p>
 
-            {/* Preview derived values */}
             {id.trim() && (
               <div className="p-3 rounded-xl bg-main/40 border border-border-subtle/50 space-y-1.5">
-                <p className="text-[9px] font-bold uppercase tracking-wider text-text-dim/60">Auto-derived</p>
+                <p className="text-[9px] font-bold uppercase tracking-wider text-text-dim/60">{t("providers.wizard_auto_derived")}</p>
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-text-dim w-24 shrink-0">Display Name</span>
+                  <span className="text-text-dim w-24 shrink-0">{t("providers.wizard_display_name_label")}</span>
                   <span className="font-mono text-text-main">{derivedDisplayName}</span>
                 </div>
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-text-dim w-24 shrink-0">Env Var</span>
+                  <span className="text-text-dim w-24 shrink-0">{t("providers.wizard_env_var")}</span>
                   <span className="font-mono text-text-main">{derivedApiKeyEnv}</span>
                 </div>
               </div>
@@ -777,41 +831,18 @@ function CreateProviderWizard({
         {step === 1 && (
           <>
             <p className="text-[10px] text-text-dim/60">{t("providers.wizard_advanced_hint")}</p>
-
-            <Input
-              label={t("providers.wizard_display_name_label")}
-              value={displayName}
-              onChange={(e) => { setDisplayName(e.target.value); setDerivedOverridden(true); }}
-              placeholder={derivedDisplayName}
-            />
-
-            <Input
-              label={t("providers.wizard_api_key_env_label")}
-              value={apiKeyEnv}
-              onChange={(e) => { setApiKeyEnv(e.target.value); setDerivedOverridden(true); }}
-              placeholder={derivedApiKeyEnv}
-            />
-
+            <Input label={t("providers.wizard_display_name_label")} value={displayName}
+              onChange={(e) => { setDisplayName(e.target.value); setDerivedOverridden(true); }} placeholder={derivedDisplayName} />
+            <Input label={t("providers.wizard_api_key_env_label")} value={apiKeyEnv}
+              onChange={(e) => { setApiKeyEnv(e.target.value); setDerivedOverridden(true); }} placeholder={derivedApiKeyEnv} />
             <div className="space-y-1">
               <label className="flex items-center gap-3 cursor-pointer">
-                <button
-                  type="button"
-                  role="checkbox"
-                  aria-checked={keyRequired}
+                <button type="button" role="checkbox" aria-checked={keyRequired}
                   onClick={() => { setKeyRequired(!keyRequired); setDerivedOverridden(true); }}
-                  className={`
-                    relative w-10 h-5 rounded-full transition-colors duration-200 shrink-0
-                    ${keyRequired ? "bg-brand" : "bg-main border border-border-subtle"}
-                  `}
-                >
-                  <span className={`
-                    absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform duration-200
-                    ${keyRequired ? "translate-x-5" : "translate-x-0"}
-                  `} />
+                  className={`relative w-10 h-5 rounded-full transition-colors duration-200 shrink-0 ${keyRequired ? "bg-brand" : "bg-main border border-border-subtle"}`}>
+                  <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform duration-200 ${keyRequired ? "translate-x-5" : "translate-x-0"}`} />
                 </button>
-                <span className="text-xs font-bold text-text-main">
-                  {t("providers.wizard_key_required_label")}
-                </span>
+                <span className="text-xs font-bold text-text-main">{t("providers.wizard_key_required_label")}</span>
               </label>
             </div>
           </>
@@ -821,7 +852,6 @@ function CreateProviderWizard({
         {step === 2 && (
           <>
             <p className="text-[10px] text-text-dim/60">{t("providers.wizard_models_hint")}</p>
-
             {models.map((m, idx) => (
               <div key={idx} className="p-3 rounded-xl border border-border-subtle/50 bg-main/20 space-y-3">
                 <div className="flex items-center justify-between">
@@ -831,72 +861,32 @@ function CreateProviderWizard({
                   </button>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
-                  <Input
-                    label={t("providers.wizard_model_id") + " *"}
-                    value={m.id}
-                    onChange={(e) => updateModel(idx, "id", e.target.value)}
-                    placeholder="gpt-4o"
-                  />
-                  <Input
-                    label={t("providers.wizard_model_name")}
-                    value={m.display_name}
-                    onChange={(e) => updateModel(idx, "display_name", e.target.value)}
-                    placeholder="GPT-4o"
-                  />
+                  <Input label={t("providers.wizard_model_id") + " *"} value={m.id} onChange={(e) => updateModel(idx, "id", e.target.value)} placeholder="gpt-4o" />
+                  <Input label={t("providers.wizard_model_name")} value={m.display_name} onChange={(e) => updateModel(idx, "display_name", e.target.value)} placeholder="GPT-4o" />
                 </div>
                 <div className="grid grid-cols-3 gap-3">
-                  <Select
-                    label={t("providers.wizard_model_tier")}
-                    options={TIER_OPTIONS}
-                    value={m.tier}
-                    onChange={(e) => updateModel(idx, "tier", e.target.value)}
-                  />
-                  <Input
-                    label={t("providers.wizard_model_context")}
-                    type="number"
-                    value={m.context_window === "" ? "" : String(m.context_window)}
-                    onChange={(e) => updateModel(idx, "context_window", e.target.value === "" ? "" : Number(e.target.value))}
-                    placeholder="128000"
-                  />
-                  <Input
-                    label={t("providers.wizard_model_max_output")}
-                    type="number"
-                    value={m.max_output_tokens === "" ? "" : String(m.max_output_tokens)}
-                    onChange={(e) => updateModel(idx, "max_output_tokens", e.target.value === "" ? "" : Number(e.target.value))}
-                    placeholder="4096"
-                  />
+                  <Select label={t("providers.wizard_model_tier")} options={TIER_OPTIONS} value={m.tier} onChange={(e) => updateModel(idx, "tier", e.target.value)} />
+                  <Input label={t("providers.wizard_model_context")} type="number" value={m.context_window === "" ? "" : String(m.context_window)}
+                    onChange={(e) => updateModel(idx, "context_window", e.target.value === "" ? "" : Number(e.target.value))} placeholder="128000" />
+                  <Input label={t("providers.wizard_model_max_output")} type="number" value={m.max_output_tokens === "" ? "" : String(m.max_output_tokens)}
+                    onChange={(e) => updateModel(idx, "max_output_tokens", e.target.value === "" ? "" : Number(e.target.value))} placeholder="4096" />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
-                  <Input
-                    label={t("providers.wizard_model_input_cost")}
-                    type="number"
-                    value={m.input_cost_per_m === "" ? "" : String(m.input_cost_per_m)}
-                    onChange={(e) => updateModel(idx, "input_cost_per_m", e.target.value === "" ? "" : Number(e.target.value))}
-                    placeholder="2.5"
-                  />
-                  <Input
-                    label={t("providers.wizard_model_output_cost")}
-                    type="number"
-                    value={m.output_cost_per_m === "" ? "" : String(m.output_cost_per_m)}
-                    onChange={(e) => updateModel(idx, "output_cost_per_m", e.target.value === "" ? "" : Number(e.target.value))}
-                    placeholder="10.0"
-                  />
+                  <Input label={t("providers.wizard_model_input_cost")} type="number" value={m.input_cost_per_m === "" ? "" : String(m.input_cost_per_m)}
+                    onChange={(e) => updateModel(idx, "input_cost_per_m", e.target.value === "" ? "" : Number(e.target.value))} placeholder="2.5" />
+                  <Input label={t("providers.wizard_model_output_cost")} type="number" value={m.output_cost_per_m === "" ? "" : String(m.output_cost_per_m)}
+                    onChange={(e) => updateModel(idx, "output_cost_per_m", e.target.value === "" ? "" : Number(e.target.value))} placeholder="10.0" />
                 </div>
               </div>
             ))}
-
-            <button
-              type="button"
-              onClick={() => setModels((prev) => [...prev, { ...EMPTY_MODEL }])}
-              className="w-full py-2 rounded-xl border border-dashed border-border-subtle text-xs font-bold text-text-dim hover:text-brand hover:border-brand transition-colors flex items-center justify-center gap-1.5"
-            >
+            <button type="button" onClick={() => setModels(prev => [...prev, { ...EMPTY_MODEL }])}
+              className="w-full py-2 rounded-xl border border-dashed border-border-subtle text-xs font-bold text-text-dim hover:text-brand hover:border-brand transition-colors flex items-center justify-center gap-1.5">
               <Plus className="w-3.5 h-3.5" />
               {t("schema_form.add_item")}
             </button>
           </>
         )}
 
-        {/* Submit error */}
         {submitError && (
           <div className="flex items-center gap-2 text-error text-xs">
             <AlertCircle className="w-4 h-4 shrink-0" />
@@ -950,11 +940,14 @@ function CreateProviderWizard({
   );
 }
 
+// ── Main Page ────────────────────────────────────────────────────
+
 type TabType = "configured" | "unconfigured";
 
 export function ProvidersPage() {
   const { t } = useTranslation();
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
   const [activeTab, setActiveTab] = useState<TabType>("configured");
   const [search, setSearch] = useState("");
   const [sortField, setSortField] = useState<SortField>("name");
@@ -962,18 +955,10 @@ export function ProvidersPage() {
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [detailsProvider, setDetailsProvider] = useState<Provider | null>(null);
-  const [configProvider, setConfigProvider] = useState<Provider | null>(null);
+  const [detailsProvider, setDetailsProvider] = useState<ProviderItem | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   useCreateShortcut(() => setShowCreateForm(true));
-  const [keyInput, setKeyInput] = useState("");
-  const [urlInput, setUrlInput] = useState("");
-  const [hasStoredKey, setHasStoredKey] = useState(false);
-  const [keySaving, setKeySaving] = useState(false);
-  const [keyError, setKeyError] = useState<string | null>(null);
-  const [keyTesting, setKeyTesting] = useState(false);
-  const [keyTestResult, setKeyTestResult] = useState<{ ok: boolean; message: string } | null>(null);
-  const [deleteConfirmProvider, setDeleteConfirmProvider] = useState<Provider | null>(null);
+  const [deleteConfirmProvider, setDeleteConfirmProvider] = useState<ProviderItem | null>(null);
   const addToast = useUIStore((s) => s.addToast);
 
   const providersQuery = useQuery({ queryKey: ["providers", "list"], queryFn: listProviders, refetchInterval: REFRESH_MS });
@@ -981,26 +966,31 @@ export function ProvidersPage() {
   const testMutation = useMutation({ mutationFn: testProvider });
   const defaultProviderMutation = useMutation({ mutationFn: setDefaultProvider });
 
+  const config = useProviderConfig(
+    () => void providersQuery.refetch(),
+    testMutation,
+    addToast,
+    t,
+    activeTab,
+    setActiveTab,
+  );
+
   const providers = providersQuery.data ?? [];
   const currentDefaultProvider = statusQuery.data?.default_provider ?? "";
   const configuredCount = useMemo(() => providers.filter(p => isProviderAvailable(p.auth_status)).length, [providers]);
   const unconfiguredCount = useMemo(() => providers.filter(p => !isProviderAvailable(p.auth_status)).length, [providers]);
 
-  // Filter, search, and sort
   const filteredProviders = useMemo(
     () => [...providers]
       .filter(p => {
         const tabMatch = activeTab === "configured" ? isProviderAvailable(p.auth_status) : !isProviderAvailable(p.auth_status);
         const searchMatch = !search || (p.display_name || p.id).toLowerCase().includes(search.toLowerCase()) || p.id.toLowerCase().includes(search.toLowerCase());
-
         let statusMatch = true;
         if (filterStatus === "reachable") statusMatch = p.reachable === true;
         else if (filterStatus === "unreachable") statusMatch = p.reachable === false;
-
         return tabMatch && searchMatch && statusMatch;
       })
       .sort((a, b) => {
-        // CLI providers always sort after non-CLI
         const aCli = a.auth_status === "configured_cli" || a.auth_status === "cli_not_installed" || (!a.base_url && !a.key_required) ? 1 : 0;
         const bCli = b.auth_status === "configured_cli" || b.auth_status === "cli_not_installed" || (!b.base_url && !b.key_required) ? 1 : 0;
         if (aCli !== bCli) return aCli - bCli;
@@ -1013,62 +1003,36 @@ export function ProvidersPage() {
     [providers, activeTab, search, filterStatus, sortField, sortOrder],
   );
 
-  const paginatedProviders = filteredProviders;
-
-  // Reset page when filters change
-  const handleTabChange = (tab: TabType) => {
-    setActiveTab(tab);
-    setSelectedIds(new Set());
-    setFilterStatus("all");
-  };
-
-  const handleSearch = (value: string) => {
-    setSearch(value);
-    setSelectedIds(new Set());
-  };
-
-  const handleFilterChange = (filter: FilterStatus) => {
-    setFilterStatus(filter);
-    setSelectedIds(new Set());
-  };
+  const handleTabChange = (tab: TabType) => { setActiveTab(tab); setSelectedIds(new Set()); setFilterStatus("all"); };
+  const handleSearch = (value: string) => { setSearch(value); setSelectedIds(new Set()); };
+  const handleFilterChange = (filter: FilterStatus) => { setFilterStatus(filter); setSelectedIds(new Set()); };
 
   const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
-    } else {
-      setSortField(field);
-      setSortOrder("desc");
-    }
+    if (sortField === field) setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    else { setSortField(field); setSortOrder("desc"); }
   };
 
   const handleSelect = (id: string, checked: boolean) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev);
-      if (checked) next.add(id);
-      else next.delete(id);
-      return next;
-    });
+    setSelectedIds(prev => { const next = new Set(prev); if (checked) next.add(id); else next.delete(id); return next; });
   };
 
   const handleSelectAll = () => {
-    if (selectedIds.size === paginatedProviders.length) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(paginatedProviders.map(p => p.id)));
-    }
+    if (selectedIds.size === filteredProviders.length) setSelectedIds(new Set());
+    else setSelectedIds(new Set(filteredProviders.map(p => p.id)));
   };
 
   const handleBatchTest = async () => {
     const ids = Array.from(selectedIds);
-    for (const id of ids) {
-      setPendingId(id);
+    setTestingIds(new Set(ids));
+    await Promise.all(ids.map(async (id) => {
       try {
         await testMutation.mutateAsync(id);
-      } catch (e: any) {
-        // Continue testing others
+      } catch {
+        // continue
+      } finally {
+        setTestingIds(prev => { const next = new Set(prev); next.delete(id); return next; });
       }
-    }
-    setPendingId(null);
+    }));
     addToast(t("common.success"), "success");
     void providersQuery.refetch();
   };
@@ -1077,112 +1041,14 @@ export function ProvidersPage() {
     setPendingId(id);
     try {
       const result = await testMutation.mutateAsync(id);
-      if (result.status === "error") {
-        addToast(String(result.error_message || result.error || t("common.error")), "error");
-      } else {
-        addToast(t("common.success"), "success");
-      }
+      if (result.status === "error") addToast(String(result.error_message || result.error || t("common.error")), "error");
+      else addToast(t("common.success"), "success");
       await providersQuery.refetch();
     } catch (e: any) {
       addToast(e.message || t("common.error"), "error");
       await providersQuery.refetch();
     } finally {
       setPendingId(null);
-    }
-  };
-
-  const handleQuickConfig = (provider: Provider) => {
-    setConfigProvider(provider);
-    setKeyInput("");
-    setUrlInput(provider.base_url || "");
-    setHasStoredKey(provider.auth_status === "configured" || provider.auth_status === "validated_key" || provider.auth_status === "invalid_key" || provider.auth_status === "auto_detected");
-    setKeyError(null);
-    setKeyTestResult(null);
-  };
-
-  const handleSaveKey = async () => {
-    if (!configProvider) return;
-    setKeySaving(true);
-    setKeyError(null);
-    try {
-      if (urlInput.trim() && urlInput !== configProvider.base_url) {
-        await setProviderUrl(configProvider.id, urlInput.trim());
-      }
-      if (keyInput.trim()) {
-        await setProviderKey(configProvider.id, keyInput.trim());
-        setHasStoredKey(true);
-        setKeyInput("");
-      }
-      await providersQuery.refetch();
-      setConfigProvider(null);
-      // Auto-switch to "configured" tab so the user sees the newly configured provider
-      if (activeTab === "unconfigured") setActiveTab("configured");
-      addToast(t("providers.key_saved"), "success");
-    } catch (e: any) {
-      setKeyError(e?.message || String(e));
-    } finally {
-      setKeySaving(false);
-    }
-  };
-
-  const handleDeleteKey = async () => {
-    if (!configProvider) return;
-    setKeySaving(true);
-    try {
-      await deleteProviderKey(configProvider.id);
-      await providersQuery.refetch();
-      setHasStoredKey(false);
-      setConfigProvider(null);
-      addToast(t("providers.key_removed"), "success");
-    } catch (e: any) {
-      setKeyError(e?.message || String(e));
-    } finally {
-      setKeySaving(false);
-    }
-  };
-
-  const handleEdit = (provider: Provider) => handleQuickConfig(provider);
-
-  const handleDeleteConfirm = async () => {
-    if (!deleteConfirmProvider) return;
-    setKeySaving(true);
-    try {
-      await deleteProviderKey(deleteConfirmProvider.id);
-      await providersQuery.refetch();
-      setDeleteConfirmProvider(null);
-      addToast(t("providers.key_removed"), "success");
-    } catch (e: any) {
-      addToast(e?.message || t("common.error"), "error");
-    } finally {
-      setKeySaving(false);
-    }
-  };
-
-  const handleTestKey = async () => {
-    if (!configProvider) return;
-    setKeyTesting(true);
-    setKeyTestResult(null);
-    try {
-      // Save any pending key/url input before testing so the backend uses the new value
-      if (keyInput.trim()) {
-        await setProviderKey(configProvider.id, keyInput.trim());
-        setHasStoredKey(true);
-        setKeyInput("");
-      }
-      if (urlInput.trim() && urlInput !== configProvider.base_url) {
-        await setProviderUrl(configProvider.id, urlInput.trim());
-      }
-      const result = await testMutation.mutateAsync(configProvider.id);
-      if (result.status === "error") {
-        setKeyTestResult({ ok: false, message: String(result.error_message || result.error || t("providers.unreachable")) });
-      } else {
-        setKeyTestResult({ ok: true, message: t("providers.reachable") });
-      }
-      await providersQuery.refetch();
-    } catch (e: any) {
-      setKeyTestResult({ ok: false, message: e?.message || t("common.error") });
-    } finally {
-      setKeyTesting(false);
     }
   };
 
@@ -1196,7 +1062,20 @@ export function ProvidersPage() {
     }
   };
 
-  const allSelected = paginatedProviders.length > 0 && selectedIds.size === paginatedProviders.length;
+  const handleDeleteConfirm = async () => {
+    if (!deleteConfirmProvider) return;
+    try {
+      await deleteProviderKey(deleteConfirmProvider.id);
+      await providersQuery.refetch();
+      setDeleteConfirmProvider(null);
+      addToast(t("providers.key_removed"), "success");
+    } catch (e: any) {
+      addToast(e?.message || t("common.error"), "error");
+    }
+  };
+
+  const effectivePendingId = pendingId || (testingIds.size > 0 ? Array.from(testingIds)[0] : null);
+  const allSelected = filteredProviders.length > 0 && selectedIds.size === filteredProviders.length;
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -1215,7 +1094,7 @@ export function ProvidersPage() {
               <kbd className="hidden sm:inline-flex h-4 min-w-[16px] items-center justify-center rounded border border-white/30 bg-white/10 px-1 text-[8px] font-mono font-semibold ml-1.5">n</kbd>
             </Button>
             <div className="hidden rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-[10px] font-bold uppercase text-text-dim sm:block">
-              {t("providers.configured_count", { configured: configuredCount, total: providers.length })}
+              {configuredCount} / {providers.length} {t("providers.configured")}
             </div>
           </div>
         }
@@ -1224,57 +1103,31 @@ export function ProvidersPage() {
       {/* Search & Controls */}
       <div className="flex flex-col sm:flex-row gap-3">
         <div className="flex-1">
-          <Input
-            value={search}
-            onChange={(e) => handleSearch(e.target.value)}
-            placeholder={t("common.search")}
+          <Input value={search} onChange={(e) => handleSearch(e.target.value)} placeholder={t("common.search")}
             leftIcon={<Search className="w-4 h-4" />}
             rightIcon={search && (
-              <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search", { defaultValue: "Clear search" })}>
+              <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search")}>
                 <X className="w-3 h-3" />
               </button>
-            )}
-          />
+            )} />
         </div>
 
         <div className="flex gap-2 items-center flex-wrap">
-          {/* Sort buttons */}
           <div className="flex gap-1 p-1 bg-main/30 rounded-lg">
-            <button
-              onClick={() => handleSort("name")}
-              className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${sortField === "name" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
-              {sortField === "name" && (sortOrder === "asc" ? <SortAsc className="w-3 h-3" /> : <SortDesc className="w-3 h-3" />)}
-              {t("providers.name")}
-            </button>
-            <button
-              onClick={() => handleSort("models")}
-              className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${sortField === "models" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
-              {sortField === "models" && (sortOrder === "asc" ? <SortAsc className="w-3 h-3" /> : <SortDesc className="w-3 h-3" />)}
-              {t("providers.models")}
-            </button>
-            <button
-              onClick={() => handleSort("latency")}
-              className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${sortField === "latency" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
-              {sortField === "latency" && (sortOrder === "asc" ? <SortAsc className="w-3 h-3" /> : <SortDesc className="w-3 h-3" />)}
-              {t("providers.latency")}
-            </button>
+            {(["name", "models", "latency"] as SortField[]).map(field => (
+              <button key={field} onClick={() => handleSort(field)}
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${sortField === field ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}>
+                {sortField === field && (sortOrder === "asc" ? <SortAsc className="w-3 h-3" /> : <SortDesc className="w-3 h-3" />)}
+                {t(`providers.${field === "name" ? "name" : field}`)}
+              </button>
+            ))}
           </div>
 
-          {/* View toggle */}
           <div className="flex gap-1 p-1 bg-main/30 rounded-lg">
-            <button
-              onClick={() => setViewMode("grid")}
-              className={`p-1.5 rounded-md transition-colors ${viewMode === "grid" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
+            <button onClick={() => setViewMode("grid")} className={`p-1.5 rounded-md transition-colors ${viewMode === "grid" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}>
               <Grid3X3 className="w-4 h-4" />
             </button>
-            <button
-              onClick={() => setViewMode("list")}
-              className={`p-1.5 rounded-md transition-colors ${viewMode === "list" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
+            <button onClick={() => setViewMode("list")} className={`p-1.5 rounded-md transition-colors ${viewMode === "list" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}>
               <List className="w-4 h-4" />
             </button>
           </div>
@@ -1284,38 +1137,22 @@ export function ProvidersPage() {
       {/* Tabs & Filter */}
       <div className="flex items-center justify-between gap-3 flex-wrap overflow-x-auto">
         <div className="flex gap-1 p-1 bg-main/30 rounded-xl w-fit">
-          <button
-            onClick={() => handleTabChange("configured")}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-colors ${
-              activeTab === "configured" ? "bg-surface text-success shadow-sm" : "text-text-dim hover:text-text-main"
-            }`}
-          >
+          <button onClick={() => handleTabChange("configured")}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-colors ${activeTab === "configured" ? "bg-surface text-success shadow-sm" : "text-text-dim hover:text-text-main"}`}>
             <CheckCircle2 className="w-4 h-4" />
             {t("providers.configured")}
-            <span className={`ml-1 px-1.5 py-0.5 rounded-full text-[10px] ${activeTab === "configured" ? "bg-success/20 text-success" : "bg-border-subtle text-text-dim"}`}>
-              {configuredCount}
-            </span>
+            <span className={`ml-1 px-1.5 py-0.5 rounded-full text-[10px] ${activeTab === "configured" ? "bg-success/20 text-success" : "bg-border-subtle text-text-dim"}`}>{configuredCount}</span>
           </button>
-          <button
-            onClick={() => handleTabChange("unconfigured")}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-colors ${
-              activeTab === "unconfigured" ? "bg-surface text-brand shadow-sm" : "text-text-dim hover:text-text-main"
-            }`}
-          >
+          <button onClick={() => handleTabChange("unconfigured")}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-colors ${activeTab === "unconfigured" ? "bg-surface text-brand shadow-sm" : "text-text-dim hover:text-text-main"}`}>
             <XCircle className="w-4 h-4" />
             {t("providers.unconfigured")}
-            <span className={`ml-1 px-1.5 py-0.5 rounded-full text-[10px] ${activeTab === "unconfigured" ? "bg-brand/20 text-brand" : "bg-border-subtle text-text-dim"}`}>
-              {unconfiguredCount}
-            </span>
+            <span className={`ml-1 px-1.5 py-0.5 rounded-full text-[10px] ${activeTab === "unconfigured" ? "bg-brand/20 text-brand" : "bg-border-subtle text-text-dim"}`}>{unconfiguredCount}</span>
           </button>
         </div>
 
-        {/* Filter chips - only show for configured tab */}
-        {activeTab === "configured" && (
-          <FilterChips activeFilter={filterStatus} onChange={handleFilterChange} t={t} />
-        )}
+        {activeTab === "configured" && <FilterChips activeFilter={filterStatus} onChange={handleFilterChange} t={t} />}
 
-        {/* Batch actions */}
         {selectedIds.size > 0 && (
           <div className="flex items-center gap-2">
             <span className="text-xs font-bold text-text-dim">{selectedIds.size} selected</span>
@@ -1339,37 +1176,29 @@ export function ProvidersPage() {
         />
       ) : (
         <>
-          {/* Select all */}
           <div className="flex items-center gap-2">
-            <button
-              onClick={handleSelectAll}
-              className="flex items-center gap-2 text-xs font-bold text-text-dim hover:text-text-main transition-colors"
-            >
+            <button onClick={handleSelectAll} className="flex items-center gap-2 text-xs font-bold text-text-dim hover:text-text-main transition-colors">
               {allSelected ? <CheckSquare className="w-4 h-4 text-brand" /> : <Square className="w-4 h-4" />}
               {t("providers.select_all")}
             </button>
             {(search || filterStatus !== "all") && (
-              <span className="text-xs text-text-dim">
-                ({filteredProviders.length} {t("providers.results")})
-              </span>
+              <span className="text-xs text-text-dim">({filteredProviders.length} {t("providers.results")})</span>
             )}
           </div>
 
           <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
-            {paginatedProviders.map((p) => (
+            {filteredProviders.map((p) => (
               <ProviderCard
-                key={p.id}
-                provider={p}
+                key={p.id} provider={p}
                 isSelected={selectedIds.has(p.id)}
                 isDefault={p.id === currentDefaultProvider}
-                pendingId={pendingId}
+                pendingId={testingIds.has(p.id) ? p.id : pendingId}
                 viewMode={viewMode}
                 onSelect={handleSelect}
                 onTest={handleTest}
                 onSetDefault={handleSetDefault}
                 onViewDetails={setDetailsProvider}
-                onQuickConfig={handleQuickConfig}
-                onEdit={handleEdit}
+                onConfigure={config.open}
                 onDelete={setDeleteConfirmProvider}
                 t={t}
               />
@@ -1389,125 +1218,116 @@ export function ProvidersPage() {
         />
       )}
 
-      {/* API Key Config Modal */}
-      <Modal isOpen={!!configProvider} onClose={() => setConfigProvider(null)} title={t("providers.configure_provider")} size="md">
-        {configProvider && (
+      {/* Config Modal */}
+      <Modal isOpen={!!config.provider} onClose={config.close} title={t("providers.configure_provider")} size="md">
+        {config.provider && (
           <div className="p-5 space-y-4">
-              <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
-                <div className="w-10 h-10 rounded-xl bg-brand/10 flex items-center justify-center">
-                  {providerIcons[configProvider.id] || <Server className="w-5 h-5 text-brand" />}
-                </div>
-                <div>
-                  <p className="text-sm font-bold">{configProvider.display_name || configProvider.id}</p>
-                  <p className="text-[10px] text-text-dim font-mono">{configProvider.id}</p>
-                </div>
-                <Badge variant={isProviderAvailable(configProvider.auth_status) ? "success" : "error"} className="ml-auto">
-                  {configProvider.auth_status}
-                </Badge>
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
+              <div className="w-10 h-10 rounded-xl bg-brand/10 flex items-center justify-center">
+                {providerIcons[config.provider.id] || <Server className="w-5 h-5 text-brand" />}
               </div>
+              <div>
+                <p className="text-sm font-bold">{config.provider.display_name || config.provider.id}</p>
+                <p className="text-[10px] text-text-dim font-mono">{config.provider.id}</p>
+              </div>
+              <Badge variant={getAuthBadge(config.provider.auth_status).variant} className="ml-auto">
+                {getAuthBadge(config.provider.auth_status).label}
+              </Badge>
+            </div>
 
-              {configProvider.key_required !== false && (
+            {config.provider.key_required !== false && (
               <div>
                 <label className="text-[10px] font-bold text-text-dim uppercase">API Key</label>
-                <input type="password" value={keyInput} onChange={e => setKeyInput(e.target.value)}
-                  placeholder={hasStoredKey ? t("providers.key_placeholder_existing") : t("providers.key_placeholder")}
+                <input type="password" value={config.keyInput} onChange={e => config.setKeyInput(e.target.value)}
+                  placeholder={config.hasStoredKey ? t("providers.key_placeholder_existing") : t("providers.key_placeholder")}
                   className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
               </div>
-              )}
+            )}
 
-              <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">Base URL <span className="normal-case font-normal text-text-dim/50">({t("providers.optional")})</span></label>
-                <input type="text" value={urlInput} onChange={e => setUrlInput(e.target.value)}
-                  placeholder="https://api.example.com/v1"
-                  className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">Base URL <span className="normal-case font-normal text-text-dim/50">({t("providers.optional")})</span></label>
+              <input type="text" value={config.urlInput} onChange={e => config.setUrlInput(e.target.value)}
+                placeholder="https://api.example.com/v1"
+                className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
+            </div>
+
+            {config.error && (
+              <div className="flex items-center gap-2 text-error text-xs">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {config.error}
               </div>
+            )}
 
-              {keyError && (
-                <div className="flex items-center gap-2 text-error text-xs">
-                  <AlertCircle className="w-4 h-4 shrink-0" />
-                  {keyError}
-                </div>
-              )}
-
-              {keyTestResult && (
-                <div className={`flex items-center gap-2 text-xs p-3 rounded-xl ${keyTestResult.ok ? "bg-success/10 border border-success/20 text-success" : "bg-error/10 border border-error/20 text-error"}`}>
-                  {keyTestResult.ok ? <CheckCircle2 className="w-4 h-4 shrink-0" /> : <XCircle className="w-4 h-4 shrink-0" />}
-                  {keyTestResult.message}
-                </div>
-              )}
-
-              <div className="flex gap-2 pt-2">
-                <Button variant="primary" className="flex-1" onClick={handleSaveKey} disabled={keySaving || keyTesting || (!keyInput.trim() && urlInput === (configProvider.base_url || ""))}>
-                  {keySaving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Key className="w-4 h-4 mr-1" />}
-                  {t("common.save")}
-                </Button>
-                <Button variant="secondary" onClick={handleTestKey} disabled={keySaving || keyTesting || (!hasStoredKey && !keyInput.trim())}>
-                  {keyTesting ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
-                  {t("providers.test")}
-                </Button>
-                {hasStoredKey && (
-                  <Button variant="secondary" onClick={handleDeleteKey} disabled={keySaving || keyTesting}>
-                    <XCircle className="w-4 h-4 mr-1 text-error" />
-                    {t("providers.remove_key")}
-                  </Button>
-                )}
+            {config.testResult && (
+              <div className={`flex items-center gap-2 text-xs p-3 rounded-xl ${config.testResult.ok ? "bg-success/10 border border-success/20 text-success" : "bg-error/10 border border-error/20 text-error"}`}>
+                {config.testResult.ok ? <CheckCircle2 className="w-4 h-4 shrink-0" /> : <XCircle className="w-4 h-4 shrink-0" />}
+                {config.testResult.message}
               </div>
+            )}
+
+            <div className="flex gap-2 pt-2">
+              <Button variant="primary" className="flex-1" onClick={config.saveKey}
+                disabled={config.saving || config.testing || (!config.keyInput.trim() && config.urlInput === (config.provider.base_url || ""))}>
+                {config.saving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Key className="w-4 h-4 mr-1" />}
+                {t("common.save")}
+              </Button>
+              <Button variant="secondary" onClick={config.testKey} disabled={config.saving || config.testing || (!config.hasStoredKey && !config.keyInput.trim())}>
+                {config.testing ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
+                {t("providers.test")}
+              </Button>
+              {config.hasStoredKey && (
+                <Button variant="secondary" onClick={config.removeKey} disabled={config.saving || config.testing}>
+                  <XCircle className="w-4 h-4 mr-1 text-error" />
+                  {t("providers.remove_key")}
+                </Button>
+              )}
+            </div>
           </div>
         )}
       </Modal>
 
       {/* Delete Confirmation Modal */}
-      {deleteConfirmProvider && (
-        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm" onClick={() => setDeleteConfirmProvider(null)}>
-          <div className="bg-surface rounded-2xl shadow-2xl border border-border-subtle w-[400px] max-w-[90vw] animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle">
-              <div className="flex items-center gap-2">
-                <Trash2 className="w-4 h-4 text-error" />
-                <h3 className="text-sm font-bold">{deleteConfirmProvider.is_custom ? t("providers.delete_confirm_title") : t("providers.remove_key_confirm_title", { defaultValue: "Remove API Key" })}</h3>
+      <Modal isOpen={!!deleteConfirmProvider} onClose={() => setDeleteConfirmProvider(null)}
+        title={deleteConfirmProvider?.is_custom ? t("providers.delete_confirm_title") : t("providers.remove_key_confirm_title")} size="sm">
+        {deleteConfirmProvider && (
+          <div className="p-5 space-y-4">
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
+              <div className="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
+                {providerIcons[deleteConfirmProvider.id] || <Server className="w-5 h-5 text-error" />}
               </div>
-              <button onClick={() => setDeleteConfirmProvider(null)} className="p-1 rounded hover:bg-main" aria-label={t("common.close", { defaultValue: "Close" })}><X className="w-4 h-4" /></button>
+              <div>
+                <p className="text-sm font-bold">{deleteConfirmProvider.display_name || deleteConfirmProvider.id}</p>
+                <p className="text-[10px] text-text-dim font-mono">{deleteConfirmProvider.id}</p>
+              </div>
             </div>
-            <div className="p-5 space-y-4">
-              <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
-                <div className="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
-                  {providerIcons[deleteConfirmProvider.id] || <Server className="w-5 h-5 text-error" />}
-                </div>
-                <div>
-                  <p className="text-sm font-bold">{deleteConfirmProvider.display_name || deleteConfirmProvider.id}</p>
-                  <p className="text-[10px] text-text-dim font-mono">{deleteConfirmProvider.id}</p>
-                </div>
-              </div>
-              <p className="text-sm text-text-dim">{deleteConfirmProvider.is_custom ? t("providers.delete_confirm_message") : t("providers.remove_key_confirm_message", { defaultValue: "This will remove the stored API key and move the provider back to unconfigured." })}</p>
-              <div className="flex gap-2 pt-2">
-                <Button variant="ghost" className="flex-1" onClick={() => setDeleteConfirmProvider(null)}>
-                  {t("common.cancel")}
-                </Button>
-                <Button variant="primary" className="flex-1 !bg-error hover:!bg-error/80" onClick={handleDeleteConfirm} disabled={keySaving}>
-                  {keySaving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Trash2 className="w-4 h-4 mr-1" />}
-                  {deleteConfirmProvider.is_custom ? t("common.delete") : t("providers.remove_key")}
-                </Button>
-              </div>
+            <p className="text-sm text-text-dim">
+              {deleteConfirmProvider.is_custom ? t("providers.delete_confirm_message") : t("providers.remove_key_confirm_message")}
+            </p>
+            <div className="flex gap-2 pt-2">
+              <Button variant="ghost" className="flex-1" onClick={() => setDeleteConfirmProvider(null)}>
+                {t("common.cancel")}
+              </Button>
+              <Button variant="primary" className="flex-1 !bg-error hover:!bg-error/80" onClick={handleDeleteConfirm}>
+                <Trash2 className="w-4 h-4 mr-1" />
+                {deleteConfirmProvider.is_custom ? t("common.delete") : t("providers.remove_key")}
+              </Button>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </Modal>
 
       {/* Create Provider Wizard */}
-      {showCreateForm && (
-        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm" onClick={() => setShowCreateForm(false)}>
-          <div className="bg-surface rounded-2xl shadow-2xl border border-border-subtle w-[540px] max-w-[90vw] max-h-[85vh] overflow-y-auto animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-            <CreateProviderWizard
-              onSubmit={async (values) => {
-                await createRegistryContent("provider", values);
-                setShowCreateForm(false);
-                setActiveTab("configured");
-                void providersQuery.refetch();
-              }}
-              onCancel={() => setShowCreateForm(false)}
-            />
-          </div>
-        </div>
-      )}
+      <Modal isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton>
+        <CreateProviderWizard
+          onSubmit={async (values) => {
+            await createRegistryContent("provider", values);
+            setShowCreateForm(false);
+            setActiveTab("configured");
+            void providersQuery.refetch();
+          }}
+          onCancel={() => setShowCreateForm(false)}
+        />
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

### Models Page
- Add column sorting (click headers to sort by model, provider, tier, context, input/output cost)
- Add output cost and thinking columns
- Add inline model detail panel (click row to expand: aliases, max output, full ID)
- Add expand/collapse all button for provider groups
- Show tier badges and cost range in collapsed provider headers
- Search now matches model aliases
- Persist "Available Only" filter across sessions
- Mobile card layout below 768px
- Default collapsed groups + available-only filter
- Backend: include aliases in model list API response

### Providers Page
- Merge Config/Edit buttons (they were identical functions)
- Unify all 3 hand-rolled modals to shared Modal component
- Remove non-functional "Open Settings" button
- Show friendly auth badges (KEY/AUTO/CLI/LOCAL) instead of raw `auth_status`
- Hide Test button for unconfigured providers
- Add model list to details modal
- Extract `useProviderConfig` hook (6 `useState` → 1 hook)
- Parallel batch testing with per-provider spinner
- Fix wizard hardcoded English → i18n
- Delete duplicate Provider interface, use `ProviderItem` from api.ts
- Net -165 lines

## Test plan
- [ ] Models: click column headers → sort toggles
- [ ] Models: click row → detail panel with aliases
- [ ] Models: search by alias
- [ ] Models: Expand/Collapse All works
- [ ] Models: mobile card layout below 768px
- [ ] Providers: configured → Edit + Test buttons only
- [ ] Providers: unconfigured → Configure button only, no Test
- [ ] Providers: config modal shows KEY/AUTO/CLI badge
- [ ] Providers: details modal shows model list
- [ ] Providers: batch test runs in parallel with spinners
- [ ] Providers: wizard "Auto-derived" label changes with language
- [ ] Providers: all modals use consistent Modal component
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`