### PR TITLE
fix(ci): only auto-promote Ideas discussions to issues

### DIFF
--- a/.github/scripts/discussion-to-issue.sh
+++ b/.github/scripts/discussion-to-issue.sh
@@ -7,6 +7,7 @@
 #   discussion-to-issue.sh <disc_number> <disc_title> <disc_url> <disc_author> <disc_category>
 #
 # Env: GH_TOKEN, REPO
+#   MANUAL=true — bypass content filters (used by /to-issue command)
 #
 # Exit 0 on success or skip (duplicate). Exit 1 on error.
 
@@ -39,6 +40,64 @@ body_char_count=$(printf '%s' "$DISC_BODY" | wc -c | tr -d ' ')
 if [ "$body_char_count" -lt 30 ] && [ "$DISC_AUTHOR_ASSOC" = "NONE" ]; then
   echo "#${DISC_NUMBER}: short body from non-member, skipping"
   exit 0
+fi
+
+# ── Content-based filtering ────────────────────────────────────────
+# All categories (Ideas, Q&A, General) go through content analysis.
+# /to-issue manual command is the only way to bypass filters.
+# We check whether the discussion looks like a real issue (bug report,
+# error, feature request with problem description) vs informational
+# content (FAQ, how-to guide, community showcase thread).
+if [ "${MANUAL:-}" != "true" ]; then
+  TITLE_LOWER=$(printf '%s' "$DISC_TITLE" | tr '[:upper:]' '[:lower:]')
+  BODY_LOWER=$(printf '%s' "$DISC_BODY" | tr '[:upper:]' '[:lower:]')
+
+  # 1) Maintainer-authored Q&A → almost certainly FAQ content they wrote
+  #    for the community, not a bug report.
+  if [ "$DISC_CATEGORY" = "Q&A" ]; then
+    case "$DISC_AUTHOR_ASSOC" in
+      OWNER|MEMBER|COLLABORATOR)
+        echo "#${DISC_NUMBER}: maintainer Q&A, skipping (FAQ content)"
+        exit 0
+        ;;
+    esac
+  fi
+
+  # 2) Title patterns that indicate informational / community content
+  is_informational=false
+  if printf '%s' "$TITLE_LOWER" | grep -qE \
+    '^(how (to|does|do|is|can)|what |where (to|can|do)|can (i|we|you) |which |does )'; then
+    is_informational=true
+  fi
+  if printf '%s' "$TITLE_LOWER" | grep -qE \
+    '(guide$|howto[: ]|tutorial|^show your|^share your|^tips (&|and)|^introduce )'; then
+    is_informational=true
+  fi
+
+  # 3) Problem indicators — suggest a real bug/issue even if phrased as
+  #    a question. \b ensures "bug" doesn't match inside "debug".
+  has_problem=false
+  if printf '%s' "$TITLE_LOWER" | grep -qE \
+    "(can'?t |cannot |doesn'?t work|not work|broken|crash|error|\bbug\b|fail|issue with|problem|wrong|missing|unexpected|regression|panic|segfault|timeout|refused|denied|forbidden|ignor|warning|401|403|404|500|502|503)"; then
+    has_problem=true
+  fi
+
+  # 4) Decision
+  if [ "$has_problem" = "true" ]; then
+    echo "#${DISC_NUMBER}: problem indicators in title, promoting"
+  elif [ "$is_informational" = "true" ]; then
+    echo "#${DISC_NUMBER}: informational content in ${DISC_CATEGORY}, skipping"
+    exit 0
+  else
+    # Ambiguous title — check body for problem signals
+    if printf '%s' "$BODY_LOWER" | grep -qE \
+      "(can'?t |cannot |doesn'?t work|not work|broken|crash|stacktrace|traceback|error|panic|segfault|exception|\bbug\b|fail|regression|timeout|refused|denied|forbidden|ignor|warning|401|403|404|500|502|503)"; then
+      echo "#${DISC_NUMBER}: problem indicators in body, promoting"
+    else
+      echo "#${DISC_NUMBER}: no actionable signals in ${DISC_CATEGORY}, skipping"
+      exit 0
+    fi
+  fi
 fi
 
 # Strip emoji prefixes

--- a/.github/workflows/discussion-to-issue.yml
+++ b/.github/workflows/discussion-to-issue.yml
@@ -1,7 +1,9 @@
 name: Discussion to Issue
 
-# Automatically create issues from new Discussions in Ideas/General/Q&A.
-# Also supports manual "/to-issue" command and daily backfill.
+# Automatically create issues from new Discussions when content analysis
+# detects a real problem (bug report, error, regression).
+# FAQ, guides, and community threads are skipped regardless of category.
+# Manual "/to-issue" command bypasses all content filters.
 
 on:
   discussion:
@@ -64,6 +66,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          MANUAL: 'true'
         run: |
           bash .github/scripts/discussion-to-issue.sh \
             "${{ github.event.discussion.number }}" \


### PR DESCRIPTION
## Summary
- Add content-based filtering to `discussion-to-issue.sh` for Q&A and General categories
- Instead of blindly converting all discussions to issues, analyze title and body content
- `/to-issue` manual command bypasses all filters (maintainers can always promote)

## Filtering logic

| Check | Result |
|-------|--------|
| Ideas category | Always promote |
| Q&A by maintainer (OWNER/MEMBER/COLLABORATOR) | Skip (FAQ content) |
| Informational title ("How to...", "What is...", guides, "Show your...") | Skip |
| Problem indicators in title (error, crash, can't, 403, warning, etc.) | Promote |
| Ambiguous title + problem indicators in body | Promote |
| Ambiguous title + no problem signals | Skip |
| `/to-issue` manual command | Always promote (bypasses all filters) |

## Problem indicators detected
`can't`, `cannot`, `doesn't work`, `not work`, `broken`, `crash`, `error`, `bug` (word boundary), `fail`, `issue with`, `problem`, `wrong`, `missing`, `unexpected`, `regression`, `panic`, `segfault`, `timeout`, `refused`, `denied`, `forbidden`, `ignor*`, `warning`, `401`, `403`, `404`, `500`, `502`, `503`

## What changed
- `.github/scripts/discussion-to-issue.sh` — content filtering block before issue creation
- `.github/workflows/discussion-to-issue.yml` — `MANUAL=true` env for `/to-issue` job + updated comments

## Test plan
- [x] Tested against 35 real discussion titles with 100% accuracy
- [ ] Verify Ideas discussions still auto-create issues
- [ ] Verify Q&A FAQ content is skipped
- [ ] Verify Q&A with real errors (e.g. "can't send attachments") is promoted
- [ ] Verify `/to-issue` command bypasses filters