### PR TITLE
fix(ci): ignore RUSTSEC-2026-0098 (rustls-webpki)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           # - GTK/webkit: transitive from Tauri 2.x
           # - lexical-core: transitive through imap (imap 3.x is alpha, nom 8+ required)
           # - rsa: Marvin Attack timing side-channel, no fix available (transitive from librefang-channels)
-          # - rustls-webpki 0.102.x: transitive from rumqttc, no compatible upgrade available
+          # - rustls-webpki 0.102.x/0.103.x: transitive from rumqttc, no compatible upgrade available
           cargo xtask deps --audit \
             --ignore RUSTSEC-2024-0384 \
             --ignore RUSTSEC-2024-0385 \
@@ -174,7 +174,8 @@ jobs:
             --ignore RUSTSEC-2023-0086 \
             --ignore RUSTSEC-2024-0370 \
             --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2026-0049
+            --ignore RUSTSEC-2026-0049 \
+            --ignore RUSTSEC-2026-0098
 
   # ── Secrets scanning (independent) ────────────────────────────────────────────────────
   secrets:


### PR DESCRIPTION
## Summary
- Add `RUSTSEC-2026-0098` to the security audit ignore list
- rustls-webpki URI name constraints vulnerability, transitive from `rumqttc → rustls-webpki 0.102.8/0.103.10`
- No compatible upgrade available until rumqttc bumps its rustls stack

Unblocks #2616 and other open PRs.