### PR TITLE
fix(ci): ignore RUSTSEC-2026-0098 (rustls-webpki)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,8 @@ jobs:
             --ignore RUSTSEC-2023-0086 \
             --ignore RUSTSEC-2024-0370 \
             --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2026-0049
+            --ignore RUSTSEC-2026-0049 \
+            --ignore RUSTSEC-2026-0098
 
   # ── Secrets scanning (independent) ────────────────────────────────────────────────────
   secrets:


### PR DESCRIPTION
## Summary
- Add `RUSTSEC-2026-0098` to security audit ignore list
- `rustls-webpki` 0.102.8 URI name constraints vulnerability
- Transitive from `rumqttc 0.25.1` (latest stable), no upgrade path available

Unblocks all open PRs failing the Security check.