### PR TITLE
feat(dashboard): model selection when setting default provider (#2548)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -929,8 +929,8 @@ export async function setProviderUrl(providerId: string, baseUrl: string): Promi
   return put<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/url`, { base_url: baseUrl });
 }
 
-export async function setDefaultProvider(providerId: string): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/default`, {});
+export async function setDefaultProvider(providerId: string, model?: string): Promise<ApiActionResponse> {
+  return post<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/default`, model ? { model } : {});
 }
 
 // ── Media generation API ──────────────────────────────────────────────

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -378,6 +378,8 @@
     "api_key": "API Key",
     "set_as_default": "Set as Default",
     "default_set": "Default provider updated",
+    "auto_select_model": "Auto-select best model",
+    "model_name_placeholder": "e.g. llama3.2, qwen2.5",
     "is_default": "Default",
     "add": "Add Provider",
     "delete_confirm_title": "Remove Provider Key",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -378,6 +378,8 @@
     "api_key": "API Key",
     "set_as_default": "设为默认",
     "default_set": "默认供应商已更新",
+    "auto_select_model": "自动选择最佳模型",
+    "model_name_placeholder": "例如 llama3.2, qwen2.5",
     "is_default": "默认",
     "add": "添加供应商",
     "delete_confirm_title": "移除供应商密钥",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -79,6 +79,71 @@ type SortOrder = "asc" | "desc";
 type ViewMode = "grid" | "list";
 type FilterStatus = "all" | "reachable" | "unreachable";
 
+// ── SetDefaultModelSection — model picker + "set as default" in config modal ──
+
+function SetDefaultModelSection({ providerId, currentDefault, onSetDefault, t }: {
+  providerId: string;
+  currentDefault?: string;
+  onSetDefault: (id: string, model?: string) => Promise<void>;
+  t: (key: string, opts?: any) => string;
+}) {
+  const [selectedModel, setSelectedModel] = useState("");
+  const [setting, setSetting] = useState(false);
+  const isDefault = currentDefault === providerId;
+
+  const modelsQuery = useQuery({
+    queryKey: ["models", "provider", providerId],
+    queryFn: () => listModels({ provider: providerId, available: true }),
+    staleTime: 60_000,
+  });
+
+  const models = modelsQuery.data?.models || [];
+
+  const handleSetDefault = async () => {
+    setSetting(true);
+    try {
+      await onSetDefault(providerId, selectedModel || undefined);
+    } finally {
+      setSetting(false);
+    }
+  };
+
+  return (
+    <div className="border-t border-border-subtle pt-3 mt-1 space-y-2">
+      <label className="text-[10px] font-bold text-text-dim uppercase">{t("providers.set_as_default")}</label>
+      {models.length > 0 ? (
+        <select
+          value={selectedModel}
+          onChange={e => setSelectedModel(e.target.value)}
+          className="w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand focus:ring-1 focus:ring-brand/20"
+        >
+          <option value="">{t("providers.auto_select_model")}</option>
+          {models.map(m => (
+            <option key={m.id} value={m.id}>{m.display_name || m.id}</option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          value={selectedModel}
+          onChange={e => setSelectedModel(e.target.value)}
+          placeholder={t("providers.model_name_placeholder")}
+          className="w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20"
+        />
+      )}
+      <Button
+        variant={isDefault ? "ghost" : "secondary"}
+        className="w-full"
+        onClick={handleSetDefault}
+        disabled={setting || isDefault}
+      >
+        {setting ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Star className="w-4 h-4 mr-1" />}
+        {isDefault ? t("providers.is_default") : t("providers.set_as_default")}
+      </Button>
+    </div>
+  );
+}
+
 // ── useProviderConfig hook ────────────────────────────────────────
 
 interface ProviderConfigState {
@@ -964,7 +1029,7 @@ export function ProvidersPage() {
   const providersQuery = useQuery({ queryKey: ["providers", "list"], queryFn: listProviders, refetchInterval: REFRESH_MS });
   const statusQuery = useQuery({ queryKey: ["status"], queryFn: getStatus, refetchInterval: REFRESH_MS });
   const testMutation = useMutation({ mutationFn: testProvider });
-  const defaultProviderMutation = useMutation({ mutationFn: setDefaultProvider });
+  const defaultProviderMutation = useMutation({ mutationFn: ({ id, model }: { id: string; model?: string }) => setDefaultProvider(id, model) });
 
   const config = useProviderConfig(
     () => void providersQuery.refetch(),
@@ -1052,9 +1117,9 @@ export function ProvidersPage() {
     }
   };
 
-  const handleSetDefault = async (id: string) => {
+  const handleSetDefault = async (id: string, model?: string) => {
     try {
-      await defaultProviderMutation.mutateAsync(id);
+      await defaultProviderMutation.mutateAsync({ id, model });
       await statusQuery.refetch();
       addToast(t("providers.default_set"), "success");
     } catch (e: any) {
@@ -1282,6 +1347,15 @@ export function ProvidersPage() {
                 </Button>
               )}
             </div>
+
+            {config.hasStoredKey && (
+              <SetDefaultModelSection
+                providerId={config.provider.id}
+                currentDefault={statusQuery.data?.default_provider}
+                onSetDefault={handleSetDefault}
+                t={t}
+              />
+            )}
           </div>
         )}
       </Modal>

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -92,7 +92,7 @@ function SetDefaultModelSection({ providerId, currentDefault, onSetDefault, t }:
   const isDefault = currentDefault === providerId;
 
   const modelsQuery = useQuery({
-    queryKey: ["models", "provider", providerId],
+    queryKey: ["models", "provider", providerId, { available: true }],
     queryFn: () => listModels({ provider: providerId, available: true }),
     staleTime: 60_000,
   });

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -111,7 +111,9 @@ function SetDefaultModelSection({ providerId, currentDefault, onSetDefault, t }:
   return (
     <div className="border-t border-border-subtle pt-3 mt-1 space-y-2">
       <label className="text-[10px] font-bold text-text-dim uppercase">{t("providers.set_as_default")}</label>
-      {models.length > 0 ? (
+      {modelsQuery.isLoading ? (
+        <div className="w-full h-10 rounded-xl bg-bg-subtle animate-pulse" />
+      ) : models.length > 0 ? (
         <select
           value={selectedModel}
           onChange={e => setSelectedModel(e.target.value)}

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1308,7 +1308,17 @@ pub async fn set_provider_url(
 pub async fn set_default_provider(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
+    body: Option<axum::Json<serde_json::Value>>,
 ) -> impl IntoResponse {
+    // Accept optional {"model": "model-id"} body to override the auto-selected model.
+    // This is needed for providers like ollama where models are dynamic and may
+    // not be in the static catalog.
+    let user_model = body
+        .as_ref()
+        .and_then(|b| b.get("model"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     // Verify the provider exists in the catalog
     let (default_model, env_var) = {
         let catalog = state
@@ -1323,7 +1333,7 @@ pub async fn set_default_provider(
                     .into_json_tuple();
             }
         };
-        let model_id = catalog.default_model_for_provider(&name);
+        let model_id = user_model.or_else(|| catalog.default_model_for_provider(&name));
         (model_id, provider.api_key_env.clone())
     };
 
@@ -1331,7 +1341,7 @@ pub async fn set_default_provider(
         Some(id) => id,
         None => {
             return ApiErrorResponse::bad_request(format!(
-                "No models found for provider '{}'",
+                "No models found for provider '{}'. Specify a model in the request body: {{\"model\": \"model-name\"}}",
                 name
             ))
             .into_json_tuple();

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1317,6 +1317,7 @@ pub async fn set_default_provider(
         .as_ref()
         .and_then(|b| b.get("model"))
         .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty() && s.len() <= 128)
         .map(String::from);
 
     // Verify the provider exists in the catalog


### PR DESCRIPTION
## Summary
When configuring a provider, the config modal now includes a "Set as Default" section with model selection. This fixes the issue where ollama's default model doesn't take effect because the static catalog has no ollama models registered.

## Changes
- **Backend** (`providers.rs`): `set_default_provider` accepts optional `{"model": "model-id"}` body to override auto-selection
- **Dashboard** (`ProvidersPage.tsx`): New `SetDefaultModelSection` component with model picker
  - For providers with catalog models: dropdown from `/api/models?provider=X&available=true`
  - For local providers (ollama/vllm): text input for model name
- **i18n**: Added `auto_select_model` and `model_name_placeholder` keys (en + zh)

## Test plan
- [x] `cargo build -p librefang-api --lib` passes
- [x] TypeScript type check — no new errors
- [ ] Live test: configure ollama → pick model → set as default → verify model works in conversation

Closes #2548