### PR TITLE
fix(ci): add issues:write to pr-status-labels workflow

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
The Review State job in `pr-status-labels.yml` fails with 403 when triggered by `pull_request_review` events:

```
POST /repos/.../issues/2627/labels → 403 "Resource not accessible by integration"
```

The workflow declares `pull-requests: write` but `pull_request_review` trigger requires explicit `issues: write` for the labels API endpoint.

## Fix
Add `issues: write` to the workflow permissions block.

## Context
Observed on PR #2627 — the CI failure is unrelated to that PR's code changes.