### PR TITLE
fix(ci): ignore RUSTSEC-2026-0098/0099 (rustls-webpki 0.102.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,8 @@ jobs:
             --ignore RUSTSEC-2024-0370 \
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0049 \
-            --ignore RUSTSEC-2026-0098
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099
 
   # ── Secrets scanning (independent) ────────────────────────────────────────────────────
   secrets:


### PR DESCRIPTION
## Summary
Two new advisories for `rustls-webpki 0.102.8` (pinned by `rumqttc 0.25.1`, no compatible upgrade):

- **RUSTSEC-2026-0098**: URI name constraints vulnerability
- **RUSTSEC-2026-0099**: Wildcard name constraints accepted

The `0.103` path is already upgraded to `0.103.12`. These only affect the `0.102.x` branch pulled in transitively via `rumqttc`.

## Context
Blocking CI on PR #2629 and any other PRs branched before this fix.