### PR TITLE
feat(providers): per-provider proxy URL support (#2549)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -45,6 +45,7 @@ export interface ProviderItem {
   latency_ms?: number;
   api_key_env?: string;
   base_url?: string;
+  proxy_url?: string;
   key_required?: boolean;
   health?: string;
   media_capabilities?: string[];
@@ -952,8 +953,10 @@ export async function deleteProviderKey(providerId: string): Promise<ApiActionRe
   return del<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/key`);
 }
 
-export async function setProviderUrl(providerId: string, baseUrl: string): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/url`, { base_url: baseUrl });
+export async function setProviderUrl(providerId: string, baseUrl: string, proxyUrl?: string): Promise<ApiActionResponse> {
+  const body: Record<string, string> = { base_url: baseUrl };
+  if (proxyUrl !== undefined) body.proxy_url = proxyUrl;
+  return put<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/url`, body);
 }
 
 export async function setDefaultProvider(providerId: string, model?: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -375,6 +375,8 @@
     "optional": "optional",
     "remove_key": "Remove Key",
     "base_url": "Base URL",
+    "proxy_url": "Proxy URL",
+    "proxy_url_placeholder": "http://proxy:8080 or socks5://proxy:1080",
     "api_key": "API Key",
     "set_as_default": "Set as Default",
     "default_set": "Default provider updated",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -375,6 +375,8 @@
     "optional": "可选",
     "remove_key": "移除 Key",
     "base_url": "Base URL",
+    "proxy_url": "代理 URL",
+    "proxy_url_placeholder": "http://proxy:8080 或 socks5://proxy:1080",
     "api_key": "API Key",
     "set_as_default": "设为默认",
     "default_set": "默认供应商已更新",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -152,6 +152,7 @@ interface ProviderConfigState {
   provider: ProviderItem | null;
   keyInput: string;
   urlInput: string;
+  proxyInput: string;
   hasStoredKey: boolean;
   saving: boolean;
   error: string | null;
@@ -168,13 +169,13 @@ function useProviderConfig(
   setActiveTab: (tab: "configured" | "unconfigured") => void,
 ) {
   const [state, setState] = useState<ProviderConfigState>({
-    provider: null, keyInput: "", urlInput: "", hasStoredKey: false,
+    provider: null, keyInput: "", urlInput: "", proxyInput: "", hasStoredKey: false,
     saving: false, error: null, testing: false, testResult: null,
   });
 
   const open = useCallback((p: ProviderItem) => {
     setState({
-      provider: p, keyInput: "", urlInput: p.base_url || "",
+      provider: p, keyInput: "", urlInput: p.base_url || "", proxyInput: p.proxy_url || "",
       hasStoredKey: p.auth_status === "configured" || p.auth_status === "validated_key" || p.auth_status === "invalid_key" || p.auth_status === "auto_detected",
       saving: false, error: null, testing: false, testResult: null,
     });
@@ -184,13 +185,16 @@ function useProviderConfig(
 
   const setKeyInput = useCallback((v: string) => setState(s => ({ ...s, keyInput: v })), []);
   const setUrlInput = useCallback((v: string) => setState(s => ({ ...s, urlInput: v })), []);
+  const setProxyInput = useCallback((v: string) => setState(s => ({ ...s, proxyInput: v })), []);
 
   const saveKey = useCallback(async () => {
     if (!state.provider) return;
     setState(s => ({ ...s, saving: true, error: null }));
     try {
-      if (state.urlInput.trim() && state.urlInput !== state.provider.base_url) {
-        await setProviderUrl(state.provider.id, state.urlInput.trim());
+      const urlChanged = state.urlInput.trim() && state.urlInput !== state.provider.base_url;
+      const proxyChanged = state.proxyInput !== (state.provider.proxy_url || "");
+      if (urlChanged || proxyChanged) {
+        await setProviderUrl(state.provider.id, state.urlInput.trim() || state.provider.base_url || "", proxyChanged ? state.proxyInput.trim() : undefined);
       }
       if (state.keyInput.trim()) {
         await setProviderKey(state.provider.id, state.keyInput.trim());
@@ -204,7 +208,7 @@ function useProviderConfig(
     } finally {
       setState(s => ({ ...s, saving: false }));
     }
-  }, [state.provider, state.keyInput, state.urlInput, refetchProviders, addToast, t, activeTab, setActiveTab]);
+  }, [state.provider, state.keyInput, state.urlInput, state.proxyInput, refetchProviders, addToast, t, activeTab, setActiveTab]);
 
   const removeKey = useCallback(async () => {
     if (!state.provider) return;
@@ -229,8 +233,10 @@ function useProviderConfig(
         await setProviderKey(state.provider.id, state.keyInput.trim());
         setState(s => ({ ...s, hasStoredKey: true, keyInput: "" }));
       }
-      if (state.urlInput.trim() && state.urlInput !== state.provider.base_url) {
-        await setProviderUrl(state.provider.id, state.urlInput.trim());
+      const urlChanged = state.urlInput.trim() && state.urlInput !== state.provider.base_url;
+      const proxyChanged = state.proxyInput !== (state.provider.proxy_url || "");
+      if (urlChanged || proxyChanged) {
+        await setProviderUrl(state.provider.id, state.urlInput.trim() || state.provider.base_url || "", proxyChanged ? state.proxyInput.trim() : undefined);
       }
       const result = await testMutation.mutateAsync(state.provider.id);
       if (result.status === "error") {
@@ -244,9 +250,9 @@ function useProviderConfig(
     } finally {
       setState(s => ({ ...s, testing: false }));
     }
-  }, [state.provider, state.keyInput, state.urlInput, testMutation, refetchProviders, t]);
+  }, [state.provider, state.keyInput, state.urlInput, state.proxyInput, testMutation, refetchProviders, t]);
 
-  return { ...state, open, close, setKeyInput, setUrlInput, saveKey, removeKey, testKey };
+  return { ...state, open, close, setKeyInput, setUrlInput, setProxyInput, saveKey, removeKey, testKey };
 }
 
 // ── ProviderCard ─────────────────────────────────────────────────
@@ -1318,6 +1324,13 @@ export function ProvidersPage() {
                 className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
             </div>
 
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("providers.proxy_url")} <span className="normal-case font-normal text-text-dim/50">({t("providers.optional")})</span></label>
+              <input type="text" value={config.proxyInput} onChange={e => config.setProxyInput(e.target.value)}
+                placeholder={t("providers.proxy_url_placeholder")}
+                className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
+            </div>
+
             {config.error && (
               <div className="flex items-center gap-2 text-error text-xs">
                 <AlertCircle className="w-4 h-4 shrink-0" />
@@ -1334,7 +1347,7 @@ export function ProvidersPage() {
 
             <div className="flex gap-2 pt-2">
               <Button variant="primary" className="flex-1" onClick={config.saveKey}
-                disabled={config.saving || config.testing || (!config.keyInput.trim() && config.urlInput === (config.provider.base_url || ""))}>
+                disabled={config.saving || config.testing || (!config.keyInput.trim() && config.urlInput === (config.provider.base_url || "") && config.proxyInput === (config.provider.proxy_url || ""))}>
                 {config.saving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Key className="w-4 h-4 mr-1" />}
                 {t("common.save")}
               </Button>

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1071,6 +1071,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     }
 
     set!("provider_urls", config.provider_urls);
+    set!("provider_proxy_urls", config.provider_proxy_urls);
     set!("provider_api_keys", provider_api_keys);
     set!("provider_regions", config.provider_regions);
 

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -935,9 +935,10 @@ pub async fn mcp_http(
             tool_name,
             &arguments,
             Some(&kernel_handle),
-            None,
-            None,
+            None, // allowed_tools
+            None, // caller_agent_id
             Some(&skill_snapshot),
+            None, // allowed_skills
             Some(state.kernel.mcp_connections_ref()),
             Some(state.kernel.web_tools()),
             Some(state.kernel.browser()),

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -448,6 +448,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             "key_required": p.key_required,
             "api_key_env": p.api_key_env,
             "base_url": p.base_url,
+            "proxy_url": p.proxy_url,
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
         });
@@ -559,6 +560,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "key_required": p.key_required,
             "api_key_env": p.api_key_env,
             "base_url": p.base_url,
+            "proxy_url": p.proxy_url,
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
         });
@@ -634,6 +636,7 @@ pub async fn get_provider(
         "key_required": provider.key_required,
         "api_key_env": provider.api_key_env,
         "base_url": provider.base_url,
+        "proxy_url": provider.proxy_url,
         "models": models,
     });
 
@@ -1321,6 +1324,9 @@ pub async fn set_provider_url(
             .into_json_tuple();
     }
 
+    // Optional proxy_url in same request
+    let proxy_url = body["proxy_url"].as_str().map(|s| s.trim().to_string());
+
     // Update catalog in memory
     {
         let mut catalog = state
@@ -1329,12 +1335,20 @@ pub async fn set_provider_url(
             .write()
             .unwrap_or_else(|e| e.into_inner());
         catalog.set_provider_url(&name, &base_url);
+        if let Some(ref pu) = proxy_url {
+            catalog.set_provider_proxy_url(&name, pu);
+        }
     }
 
     // Persist to config.toml [provider_urls] section
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = upsert_provider_url(&config_path, &name, &base_url) {
         return ApiErrorResponse::internal(format!("Failed to save config: {e}")).into_json_tuple();
+    }
+    if let Some(ref pu) = proxy_url {
+        if let Err(e) = upsert_provider_proxy_url(&config_path, &name, pu) {
+            tracing::warn!("Failed to persist proxy_url: {e}");
+        }
     }
 
     // Probe reachability at the new URL
@@ -1565,6 +1579,50 @@ fn upsert_provider_url(
 
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)?;
+    }
+
+    std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
+    Ok(())
+}
+
+/// Persist a per-provider proxy URL to `[provider_proxy_urls]` in config.toml.
+fn upsert_provider_proxy_url(
+    config_path: &std::path::Path,
+    provider: &str,
+    proxy_url: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let content = if config_path.exists() {
+        std::fs::read_to_string(config_path)?
+    } else {
+        String::new()
+    };
+
+    let mut doc: toml::Value = if content.trim().is_empty() {
+        toml::Value::Table(toml::map::Map::new())
+    } else {
+        toml::from_str(&content)?
+    };
+
+    let root = doc.as_table_mut().ok_or("Config is not a TOML table")?;
+
+    if !root.contains_key("provider_proxy_urls") {
+        root.insert(
+            "provider_proxy_urls".to_string(),
+            toml::Value::Table(toml::map::Map::new()),
+        );
+    }
+    let table = root
+        .get_mut("provider_proxy_urls")
+        .and_then(|v| v.as_table_mut())
+        .ok_or("provider_proxy_urls is not a table")?;
+
+    if proxy_url.is_empty() {
+        table.remove(provider);
+    } else {
+        table.insert(
+            provider.to_string(),
+            toml::Value::String(proxy_url.to_string()),
+        );
     }
 
     std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1326,6 +1326,19 @@ pub async fn set_provider_url(
 
     // Optional proxy_url in same request
     let proxy_url = body["proxy_url"].as_str().map(|s| s.trim().to_string());
+    if let Some(ref pu) = proxy_url {
+        if !pu.is_empty()
+            && !pu.starts_with("http://")
+            && !pu.starts_with("https://")
+            && !pu.starts_with("socks5://")
+            && !pu.starts_with("socks5h://")
+        {
+            return ApiErrorResponse::bad_request(
+                "proxy_url must start with http://, https://, socks5://, or socks5h://",
+            )
+            .into_json_tuple();
+        }
+    }
 
     // Update catalog in memory
     {

--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -162,6 +162,24 @@ pub fn proxied_client() -> reqwest::Client {
         .expect("HTTP client with proxy/TLS config should always build")
 }
 
+/// Build a [`reqwest::Client`] that routes all traffic through the given proxy URL,
+/// ignoring the global proxy config. Used for per-provider proxy overrides.
+pub fn proxied_client_with_override(proxy_url: &str) -> reqwest::Client {
+    let mut builder = reqwest::Client::builder()
+        .use_preconfigured_tls(tls_config())
+        .user_agent(USER_AGENT);
+    if let Ok(proxy) = Proxy::all(proxy_url) {
+        builder = builder.proxy(proxy);
+    } else {
+        tracing::warn!(
+            url = proxy_url,
+            "Invalid per-provider proxy URL, falling back to global proxy"
+        );
+        return proxied_client();
+    }
+    builder.build().unwrap_or_else(|_| proxied_client())
+}
+
 /// Backward-compatible alias for [`proxied_client_builder`].
 pub fn client_builder() -> reqwest::ClientBuilder {
     proxied_client_builder()

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1456,6 +1456,10 @@ impl LibreFangKernel {
                 .cloned()
         });
         let mcp_bridge_cfg = build_mcp_bridge_cfg(&config);
+        let default_proxy_url = config
+            .provider_proxy_urls
+            .get(&config.default_model.provider)
+            .cloned();
         let driver_config = DriverConfig {
             provider: config.default_model.provider.clone(),
             api_key: default_api_key.clone(),
@@ -1465,6 +1469,7 @@ impl LibreFangKernel {
             skip_permissions: true,
             message_timeout_secs: config.default_model.message_timeout_secs,
             mcp_bridge: Some(mcp_bridge_cfg.clone()),
+            proxy_url: default_proxy_url.clone(),
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -1500,6 +1505,7 @@ impl LibreFangKernel {
                     skip_permissions: true,
                     message_timeout_secs: config.default_model.message_timeout_secs,
                     mcp_bridge: Some(mcp_bridge_cfg.clone()),
+                    proxy_url: default_proxy_url.clone(),
                 };
                 match drivers::create_driver(&profile_config) {
                     Ok(profile_driver) => {
@@ -1604,6 +1610,7 @@ impl LibreFangKernel {
                             skip_permissions: true,
                             message_timeout_secs: config.default_model.message_timeout_secs,
                             mcp_bridge: Some(mcp_bridge_cfg.clone()),
+                            proxy_url: config.provider_proxy_urls.get(provider).cloned(),
                         };
                         match drivers::create_driver(&auto_config) {
                             Ok(d) => {
@@ -1654,6 +1661,7 @@ impl LibreFangKernel {
                 skip_permissions: true,
                 message_timeout_secs: config.default_model.message_timeout_secs,
                 mcp_bridge: Some(mcp_bridge_cfg.clone()),
+                proxy_url: config.provider_proxy_urls.get(&fb.provider).cloned(),
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -1755,6 +1763,13 @@ impl LibreFangKernel {
             info!(
                 "applied {} provider URL override(s)",
                 config.provider_urls.len()
+            );
+        }
+        if !config.provider_proxy_urls.is_empty() {
+            model_catalog.apply_proxy_url_overrides(&config.provider_proxy_urls);
+            info!(
+                "applied {} provider proxy URL override(s)",
+                config.provider_proxy_urls.len()
             );
         }
         // Load user's custom models from ~/.librefang/custom_models.json (highest priority)
@@ -7198,6 +7213,9 @@ system_prompt = "You are a helpful assistant."
                     if !new_config.provider_urls.is_empty() {
                         catalog.apply_url_overrides(&new_config.provider_urls);
                     }
+                    if !new_config.provider_proxy_urls.is_empty() {
+                        catalog.apply_proxy_url_overrides(&new_config.provider_proxy_urls);
+                    }
                     // Also update media driver cache with new provider URLs
                     self.media_drivers
                         .update_provider_urls(new_config.provider_urls.clone());
@@ -8820,6 +8838,7 @@ system_prompt = "You are a helpful assistant."
                 skip_permissions: true,
                 message_timeout_secs: cfg.default_model.message_timeout_secs,
                 mcp_bridge: Some(build_mcp_bridge_cfg(&cfg)),
+                proxy_url: cfg.provider_proxy_urls.get(agent_provider).cloned(),
             };
 
             match self.driver_cache.get_or_create(&driver_config) {
@@ -8904,6 +8923,7 @@ system_prompt = "You are a helpful assistant."
                     mcp_bridge: Some(build_mcp_bridge_cfg(&cfg)),
                     skip_permissions: true,
                     message_timeout_secs: cfg.default_model.message_timeout_secs,
+                    proxy_url: cfg.provider_proxy_urls.get(&fb_provider).cloned(),
                 };
                 match self.driver_cache.get_or_create(&config) {
                     Ok(d) => chain.push((d, strip_provider_prefix(&fb.model, &fb_provider))),

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -238,6 +238,10 @@ pub struct DriverConfig {
     /// Not serialized: set only by the kernel when constructing drivers.
     #[serde(skip)]
     pub mcp_bridge: Option<McpBridgeConfig>,
+    /// Per-provider proxy URL override.
+    /// When set, the driver uses this proxy instead of the global proxy config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_url: Option<String>,
 }
 
 /// Configuration for bridging LibreFang tools into a CLI-based driver via MCP.
@@ -266,6 +270,7 @@ impl Default for DriverConfig {
             skip_permissions: default_skip_permissions(),
             message_timeout_secs: default_message_timeout_secs(),
             mcp_bridge: None,
+            proxy_url: None,
         }
     }
 }
@@ -301,6 +306,7 @@ impl std::fmt::Debug for DriverConfig {
             .field("skip_permissions", &self.skip_permissions)
             .field("message_timeout_secs", &self.message_timeout_secs)
             .field("mcp_bridge", &self.mcp_bridge.as_ref().map(|b| &b.base_url))
+            .field("proxy_url", &self.proxy_url.as_ref().map(|_| "<redacted>"))
             .finish()
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -25,10 +25,19 @@ pub struct AnthropicDriver {
 impl AnthropicDriver {
     /// Create a new Anthropic driver.
     pub fn new(api_key: String, base_url: String) -> Self {
+        Self::with_proxy(api_key, base_url, None)
+    }
+
+    /// Create a new Anthropic driver with an optional per-provider proxy.
+    pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        let client = match proxy_url {
+            Some(url) => librefang_http::proxied_client_with_override(url),
+            None => librefang_http::proxied_client(),
+        };
         Self {
             api_key: Zeroizing::new(api_key),
             base_url,
-            client: librefang_http::proxied_client(),
+            client,
         }
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -175,6 +175,14 @@ pub struct ChatGptDriver {
 
 impl ChatGptDriver {
     pub fn new(session_token: String, base_url: String) -> Self {
+        Self::with_proxy(session_token, base_url, None)
+    }
+
+    pub fn with_proxy(session_token: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        let client = match proxy_url {
+            Some(url) => librefang_http::proxied_client_with_override(url),
+            None => librefang_http::proxied_client(),
+        };
         Self {
             session_token: Zeroizing::new(session_token),
             base_url: if base_url.is_empty() {
@@ -183,7 +191,7 @@ impl ChatGptDriver {
                 base_url
             },
             token_cache: ChatGptTokenCache::new(),
-            client: librefang_http::proxied_client(),
+            client,
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -34,10 +34,19 @@ pub struct GeminiDriver {
 impl GeminiDriver {
     /// Create a new Gemini driver.
     pub fn new(api_key: String, base_url: String) -> Self {
+        Self::with_proxy(api_key, base_url, None)
+    }
+
+    /// Create a new Gemini driver with an optional per-provider proxy.
+    pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        let client = match proxy_url {
+            Some(url) => librefang_http::proxied_client_with_override(url),
+            None => librefang_http::proxied_client(),
+        };
         Self {
             api_key: Zeroizing::new(api_key),
             base_url,
-            client: librefang_http::proxied_client(),
+            client,
         }
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -682,10 +682,18 @@ fn create_driver_from_entry(
         )));
     }
 
+    let proxy_url = config.proxy_url.as_deref();
+
     match entry.api_format {
-        ApiFormat::OpenAI => Ok(Arc::new(openai::OpenAIDriver::new(api_key, base_url))),
-        ApiFormat::Anthropic => Ok(Arc::new(anthropic::AnthropicDriver::new(api_key, base_url))),
-        ApiFormat::Gemini => Ok(Arc::new(gemini::GeminiDriver::new(api_key, base_url))),
+        ApiFormat::OpenAI => Ok(Arc::new(openai::OpenAIDriver::with_proxy(
+            api_key, base_url, proxy_url,
+        ))),
+        ApiFormat::Anthropic => Ok(Arc::new(anthropic::AnthropicDriver::with_proxy(
+            api_key, base_url, proxy_url,
+        ))),
+        ApiFormat::Gemini => Ok(Arc::new(gemini::GeminiDriver::with_proxy(
+            api_key, base_url, proxy_url,
+        ))),
         ApiFormat::ClaudeCode => {
             let mut d = claude_code::ClaudeCodeDriver::with_timeout(
                 config.base_url.clone(),
@@ -794,9 +802,10 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             let env_var = format!("{}_API_KEY", provider.to_uppercase().replace('-', "_"));
             std::env::var(&env_var).unwrap_or_default()
         });
-        return Ok(Arc::new(openai::OpenAIDriver::new(
+        return Ok(Arc::new(openai::OpenAIDriver::with_proxy(
             api_key,
             base_url.clone(),
+            config.proxy_url.as_deref(),
         )));
     }
 
@@ -1041,6 +1050,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -1057,6 +1067,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1179,6 +1190,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1202,6 +1214,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1225,6 +1238,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let result = create_driver(&config);
         assert!(result.is_err());
@@ -1257,6 +1271,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -1283,6 +1298,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
 
         let driver = create_driver(&config);
@@ -1321,6 +1337,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1340,6 +1357,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         // Clear any env var that might interfere
         std::env::remove_var("AZURE_OPENAI_ENDPOINT");
@@ -1368,6 +1386,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let d1 = cache.get_or_create(&config).unwrap();
         let d2 = cache.get_or_create(&config).unwrap();
@@ -1387,6 +1406,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let config_b = DriverConfig {
             provider: "ollama".to_string(),
@@ -1397,6 +1417,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let d_a = cache.get_or_create(&config_a).unwrap();
         let d_b = cache.get_or_create(&config_b).unwrap();
@@ -1419,6 +1440,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         cache.get_or_create(&config).unwrap();
         assert_eq!(cache.len(), 1);

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -722,7 +722,9 @@ fn create_driver_from_entry(
             config.base_url.clone(),
             config.skip_permissions,
         ))),
-        ApiFormat::ChatGpt => Ok(Arc::new(chatgpt::ChatGptDriver::new(api_key, base_url))),
+        ApiFormat::ChatGpt => Ok(Arc::new(chatgpt::ChatGptDriver::with_proxy(
+            api_key, base_url, proxy_url,
+        ))),
         ApiFormat::Copilot => Ok(Arc::new(copilot::CopilotDriver::new(api_key, base_url))),
         ApiFormat::VertexAI => Ok(Arc::new(vertex_ai::VertexAiDriver::new(config)?)),
         ApiFormat::AzureOpenAI => {
@@ -748,11 +750,12 @@ fn create_driver_from_entry(
                 .clone()
                 .or_else(|| std::env::var("AZURE_OPENAI_API_VERSION").ok())
                 .unwrap_or_else(|| "2024-02-01".to_string());
-            Ok(Arc::new(openai::OpenAIDriver::new_azure(
+            Ok(Arc::new(openai::OpenAIDriver::new_azure_with_proxy(
                 api_key,
                 endpoint,
                 deployment,
                 api_version,
+                proxy_url,
             )))
         }
     }

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -93,10 +93,11 @@ impl DriverCache {
         let key_hash = hasher.finish();
 
         format!(
-            "{}|{}|{}",
+            "{}|{}|{}|{}",
             config.provider,
             key_hash,
-            config.base_url.as_deref().unwrap_or("")
+            config.base_url.as_deref().unwrap_or(""),
+            config.proxy_url.as_deref().unwrap_or("")
         )
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -31,10 +31,19 @@ pub struct OpenAIDriver {
 impl OpenAIDriver {
     /// Create a new OpenAI-compatible driver.
     pub fn new(api_key: String, base_url: String) -> Self {
+        Self::with_proxy(api_key, base_url, None)
+    }
+
+    /// Create a new OpenAI-compatible driver with an optional per-provider proxy.
+    pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        let client = match proxy_url {
+            Some(url) => librefang_http::proxied_client_with_override(url),
+            None => librefang_http::proxied_client(),
+        };
         Self {
             api_key: Zeroizing::new(api_key),
             base_url,
-            client: librefang_http::proxied_client(),
+            client,
             extra_headers: Vec::new(),
             use_api_key_header: false,
             url_query: None,

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -60,15 +60,29 @@ impl OpenAIDriver {
         deployment: String,
         api_version: String,
     ) -> Self {
+        Self::new_azure_with_proxy(api_key, endpoint, deployment, api_version, None)
+    }
+
+    pub fn new_azure_with_proxy(
+        api_key: String,
+        endpoint: String,
+        deployment: String,
+        api_version: String,
+        proxy_url: Option<&str>,
+    ) -> Self {
         let base_url = format!(
             "{}/openai/deployments/{}",
             endpoint.trim_end_matches('/'),
             deployment
         );
+        let client = match proxy_url {
+            Some(url) => librefang_http::proxied_client_with_override(url),
+            None => librefang_http::proxied_client(),
+        };
         Self {
             api_key: Zeroizing::new(api_key),
             base_url,
-            client: librefang_http::proxied_client(),
+            client,
             extra_headers: Vec::new(),
             use_api_key_header: true,
             url_query: Some(format!("api-version={}", api_version)),

--- a/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
@@ -958,6 +958,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "us-central1");
@@ -977,6 +978,7 @@ mod tests {
             skip_permissions: true,
             message_timeout_secs: 300,
             mcp_bridge: None,
+            proxy_url: None,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "europe-west4");

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -523,6 +523,7 @@ impl ModelCatalog {
                 available_models: Vec::new(),
                 // Added at runtime via set_provider_url → always custom.
                 is_custom: true,
+                proxy_url: None,
             });
             // Re-detect auth for the newly added provider
             self.detect_auth();
@@ -546,6 +547,24 @@ impl ModelCatalog {
                     }
                 }
             }
+        }
+    }
+
+    /// Set a per-provider proxy URL override.
+    pub fn set_provider_proxy_url(&mut self, provider: &str, proxy_url: &str) {
+        if let Some(p) = self.providers.iter_mut().find(|p| p.id == provider) {
+            p.proxy_url = if proxy_url.is_empty() {
+                None
+            } else {
+                Some(proxy_url.to_string())
+            };
+        }
+    }
+
+    /// Apply a batch of per-provider proxy URL overrides from config.
+    pub fn apply_proxy_url_overrides(&mut self, overrides: &HashMap<String, String>) {
+        for (provider, proxy_url) in overrides {
+            self.set_provider_proxy_url(provider, proxy_url);
         }
     }
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1985,6 +1985,11 @@ pub struct KernelConfig {
     /// e.g. `ollama = "http://192.168.1.100:11434/v1"`
     #[serde(default)]
     pub provider_urls: HashMap<String, String>,
+    /// Per-provider proxy URL overrides (provider ID → proxy URL).
+    /// Allows routing specific providers through a proxy while others connect directly.
+    /// e.g. `openai = "http://proxy.corp:8080"`, `ollama = ""` (direct)
+    #[serde(default)]
+    pub provider_proxy_urls: HashMap<String, String>,
     /// Provider region selection (provider ID → region name).
     /// Selects a regional endpoint from the provider's `[provider.regions]` map.
     /// e.g. `qwen = "us"` to use the US endpoint instead of China mainland.
@@ -3533,6 +3538,7 @@ impl Default for KernelConfig {
             thinking: None,
             budget: BudgetConfig::default(),
             provider_urls: HashMap::new(),
+            provider_proxy_urls: HashMap::new(),
             provider_regions: HashMap::new(),
             provider_api_keys: HashMap::new(),
             vertex_ai: VertexAiConfig::default(),

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -52,6 +52,7 @@ impl KernelConfig {
             "thinking",
             "budget",
             "provider_urls",
+            "provider_proxy_urls",
             "provider_regions",
             "provider_api_keys",
             "vertex_ai",

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -282,6 +282,10 @@ pub struct ProviderInfo {
     /// re-create their TOML on the next boot anyway.
     #[serde(default)]
     pub is_custom: bool,
+    /// Per-provider proxy URL override. When set, API calls to this provider
+    /// are routed through this proxy instead of the global proxy config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_url: Option<String>,
 }
 
 impl Default for ProviderInfo {
@@ -299,6 +303,7 @@ impl Default for ProviderInfo {
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
             is_custom: false,
+            proxy_url: None,
         }
     }
 }
@@ -354,6 +359,7 @@ impl From<ProviderCatalogToml> for ProviderInfo {
             // Populated by the runtime catalog loader (classifies based on
             // whether the file is also present in registry/providers/).
             is_custom: false,
+            proxy_url: None,
         }
     }
 }
@@ -519,6 +525,7 @@ mod tests {
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
             is_custom: false,
+            proxy_url: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         let parsed: ProviderInfo = serde_json::from_str(&json).unwrap();
@@ -733,6 +740,7 @@ aliases = []
             media_capabilities: Vec::new(),
             available_models: Vec::new(),
             is_custom: false,
+            proxy_url: None,
         };
 
         // Simulate region selection: if user picks "us", use that region's base_url

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "2026.4.13-beta19"
+    "version": "2026.4.15-beta22"
   },
   "paths": {
     "/.well-known/agent.json": {
@@ -7364,6 +7364,16 @@
             "type": "boolean",
             "description": "If true, this is an ephemeral \"side question\" (`/btw`).\nThe message is answered using the agent's system prompt but WITHOUT\nloading or saving session history — the real conversation is untouched."
           },
+          "group_participants": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ParticipantRefSchema"
+            },
+            "description": "Optional group participant roster (Phase 2 §C addressee guard).\n\nForwarded by the WhatsApp gateway for group messages so the kernel's\naddressee guard (`is_addressed_to_other_participant`) can detect when\na turn is addressed to a named participant other than the agent.\n\n`#[serde(default)]` ensures backward compatibility for callers (Telegram,\ndirect API) that don't populate this field."
+          },
           "is_group": {
             "type": "boolean",
             "description": "Whether this message originated from a group chat (vs DM)."
@@ -7505,6 +7515,24 @@
         "properties": {
           "path": {
             "type": "string"
+          }
+        }
+      },
+      "ParticipantRefSchema": {
+        "type": "object",
+        "description": "OpenAPI schema stand-in for `librefang_channels::types::ParticipantRef`.\n\nThe real type lives in `librefang-channels`, which does not depend on\nutoipa. This mirror struct exists only so `#[schema(value_type = ...)]`\non `MessageRequest.group_participants` can expose the shape to the\ngenerated OpenAPI document.",
+        "required": [
+          "jid",
+          "display_name"
+        ],
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable name (push-name, contact name, or first part of JID)."
+          },
+          "jid": {
+            "type": "string",
+            "description": "Platform JID (e.g. `1234567890@s.whatsapp.net`)."
           }
         }
       },


### PR DESCRIPTION
## Summary
- Add per-provider HTTP proxy URL configuration to the dashboard and backend
- Users can set different proxy URLs for each provider (e.g., OpenAI via proxy, ollama direct)
- New `[provider_proxy_urls]` section in config.toml for persistence
- Dashboard config modal now has a "Proxy URL" input below "Base URL"

## Changes
- **Config types**: `provider_proxy_urls: HashMap<String, String>` in `KernelConfig`
- **Model catalog**: `proxy_url` field on `ProviderInfo`, with `set_provider_proxy_url()` and `apply_proxy_url_overrides()`
- **DriverConfig**: `proxy_url: Option<String>` field
- **librefang-http**: `proxied_client_with_override(proxy_url)` builds a reqwest client using a specific proxy
- **LLM drivers**: OpenAI, Anthropic, Gemini drivers accept optional proxy_url via `with_proxy()` constructor
- **Kernel**: All `DriverConfig` construction sites populate `proxy_url` from config
- **API**: `set_provider_url` accepts optional `proxy_url` in body, persists to `[provider_proxy_urls]`
- **Dashboard**: Proxy URL input in config modal, i18n (en + zh)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo test --workspace` — 975 passed, 1 pre-existing failure (unrelated ffmpeg test)
- [ ] Live test: set proxy URL for a provider via dashboard → verify config.toml persistence → verify LLM calls route through proxy

Closes #2549