### PR TITLE
fix(types): change WebSearchAugmentationMode default from off to auto

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -8422,8 +8422,8 @@ mod tests {
 
     #[test]
     fn test_should_augment_web_search_off() {
-        let manifest = AgentManifest::default();
-        // Default is Off
+        let mut manifest = AgentManifest::default();
+        manifest.web_search_augmentation = librefang_types::agent::WebSearchAugmentationMode::Off;
         assert!(!should_augment_web_search(&manifest));
     }
 
@@ -8503,11 +8503,11 @@ mod tests {
     }
 
     #[test]
-    fn test_manifest_default_web_search_augmentation_is_off() {
+    fn test_manifest_default_web_search_augmentation_is_auto() {
         let manifest = AgentManifest::default();
         assert_eq!(
             manifest.web_search_augmentation,
-            librefang_types::agent::WebSearchAugmentationMode::Off,
+            librefang_types::agent::WebSearchAugmentationMode::Auto,
         );
     }
 
@@ -8532,7 +8532,7 @@ mod tests {
         let manifest: AgentManifest = toml::from_str(toml_str).unwrap();
         assert_eq!(
             manifest.web_search_augmentation,
-            librefang_types::agent::WebSearchAugmentationMode::Off,
+            librefang_types::agent::WebSearchAugmentationMode::Auto,
         );
     }
 }

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -249,10 +249,10 @@ pub enum SessionMode {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WebSearchAugmentationMode {
-    /// Disabled (default).
-    #[default]
+    /// Disabled.
     Off,
-    /// Augment only when the model catalog reports `supports_tools == false`.
+    /// Augment only when the model catalog reports `supports_tools == false` (default).
+    #[default]
     Auto,
     /// Always search the web before every LLM call.
     Always,


### PR DESCRIPTION
## Summary
- Change default `WebSearchAugmentationMode` from `off` to `auto`
- `auto` only activates when the model catalog says `supports_tools == false`, so it's safe as default
- Models that support tool calling are unaffected

Follows up #2635