### PR TITLE
feat(dashboard): cascading model switcher + search API key check

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -177,6 +177,7 @@ export interface DashboardSnapshot {
   agents: AgentItem[];
   skillCount: number;
   workflowCount: number;
+  webSearchAvailable: boolean;
 }
 
 export interface AgentIdentity {
@@ -748,6 +749,7 @@ export async function loadDashboardSnapshot(): Promise<DashboardSnapshot> {
     channels: ChannelItem[];
     skillCount: number;
     workflowCount: number;
+    webSearchAvailable: boolean;
   }>("/api/dashboard/snapshot");
 
   return {
@@ -758,6 +760,7 @@ export async function loadDashboardSnapshot(): Promise<DashboardSnapshot> {
     channels: snap.channels ?? [],
     skillCount: snap.skillCount ?? 0,
     workflowCount: snap.workflowCount ?? 0,
+    webSearchAvailable: snap.webSearchAvailable ?? false,
   };
 }
 

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1461,6 +1461,10 @@
     "group_standalone": "Standalone",
     "hand_coordinator": "coordinator",
     "web_search_tooltip": "Web Search: {{mode}}. Requires a search API key (Tavily, Brave, Jina, or Perplexity) in config.toml [web] section.",
+    "web_search_key_hint": "Needs search API key in config",
+    "web_search_no_key": "No search API key configured. Click to open settings.",
+    "web_search_setup": "Search",
+    "web_search_configure": "Configure API key",
     "select_agent": "Select Agent",
     "select_agent_desc": "Choose an agent from the list to establish a communication link.",
     "transmit_command": "Transmit neural pulse...",
@@ -1527,15 +1531,7 @@
     "info_model": "Model",
     "info_provider": "Provider",
     "info_state": "State",
-    "ws_not_connected": "WebSocket not connected. Please refresh the page.",
-    "session": "Session",
-    "sessions_title": "Sessions",
-    "new_session": "New session",
-    "delete_session": "Delete session",
-    "export": "Export",
-    "export_markdown": "Export as Markdown",
-    "approval_required": "Approval Required",
-    "approval_tool": "Tool"
+    "ws_not_connected": "WebSocket not connected. Please refresh the page."
   },
   "goals": {
     "title": "Goals",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1436,6 +1436,10 @@
     "group_standalone": "独立",
     "hand_coordinator": "协调者",
     "web_search_tooltip": "网络搜索: {{mode}}。需要在 config.toml [web] 中配置搜索 API key（Tavily、Brave、Jina 或 Perplexity）。",
+    "web_search_key_hint": "需要在配置中设置搜索 API key",
+    "web_search_no_key": "未配置搜索 API key，点击打开设置页面",
+    "web_search_setup": "搜索",
+    "web_search_configure": "配置 API key",
     "select_agent": "选择智能体",
     "select_agent_desc": "从列表中选择一个智能体以建立通信链路。",
     "transmit_command": "输入消息...",
@@ -1502,15 +1506,7 @@
     "info_model": "模型",
     "info_provider": "提供商",
     "info_state": "状态",
-    "ws_not_connected": "WebSocket 未连接，请刷新页面。",
-    "session": "会话",
-    "sessions_title": "会话列表",
-    "new_session": "新建会话",
-    "delete_session": "删除会话",
-    "export": "导出",
-    "export_markdown": "导出为 Markdown",
-    "approval_required": "需要审批",
-    "approval_tool": "工具"
+    "ws_not_connected": "WebSocket 未连接，请刷新页面。"
   },
   "goals": {
     "title": "目标",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -654,10 +654,8 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
               />
             </button>
             {thinkingExpanded && (
-              <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim prose prose-sm prose-invert max-w-none">
-                <MarkdownContent remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]}>
-                  {message.thinking}
-                </MarkdownContent>
+              <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim whitespace-pre-wrap break-words">
+                {message.thinking}
               </div>
             )}
           </div>
@@ -925,12 +923,13 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, s
 }
 
 // Connection status bar with session dropdown
-function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange }: {
+function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable }: {
   agentName: string; isLoading: boolean; messageCount: number; onClear: () => void; onExport: () => void; wsConnected?: boolean; modelName?: string; modelProvider?: string;
   sessions?: SessionListItem[]; activeSessionId?: string;
   onSwitchSession?: (sessionId: string) => void; onNewSession?: () => void; onDeleteSession?: (sessionId: string) => void;
   agentId: string; onModelChange: () => void;
   webSearchAugmentation?: "off" | "auto" | "always"; onWebSearchChange?: (mode: "off" | "auto" | "always") => void;
+  webSearchAvailable?: boolean;
 }) {
   const { t } = useTranslation();
   const [sessionOpen, setSessionOpen] = useState(false);
@@ -1190,26 +1189,52 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
             </div>
           )}
         </div>
-        {/* Web Search toggle (off → auto → always → off) */}
-        {onWebSearchChange && (
-          <button
-            onClick={() => {
-              const cycle: Record<string, "off" | "auto" | "always"> = { off: "auto", auto: "always", always: "off" };
-              onWebSearchChange(cycle[webSearchAugmentation || "auto"] || "auto");
-            }}
-            title={t("chat.web_search_tooltip", { defaultValue: "Web Search: {{mode}}. Requires a search API key (Tavily, Brave, Jina, or Perplexity) configured in config.toml [web] section.", mode: webSearchAugmentation || "auto" })}
-            className={`hidden sm:flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-mono transition-colors ${
-              webSearchAugmentation === "always"
-                ? "text-brand bg-brand/10 hover:bg-brand/20"
-                : webSearchAugmentation === "auto"
-                  ? "text-text-dim/50 hover:text-text hover:bg-surface-hover"
-                  : "text-text-dim/30 hover:text-text-dim/60 hover:bg-surface-hover"
-            }`}
-          >
-            <Globe className="h-3 w-3" />
-            <span className="hidden lg:inline">{webSearchAugmentation === "always" ? t("common.always", { defaultValue: "Always" }) : webSearchAugmentation === "auto" ? t("common.auto", { defaultValue: "Auto" }) : t("common.off", { defaultValue: "Off" })}</span>
-          </button>
-        )}
+        {/* Web Search toggle (off → auto → always → off) with config check */}
+        {onWebSearchChange && (() => {
+          const mode = webSearchAugmentation || "auto";
+          const isActive = mode !== "off";
+          const noKey = !webSearchAvailable;
+          return (
+            <div className="hidden sm:flex items-center gap-1.5">
+              <button
+                onClick={() => {
+                  if (noKey && mode === "off") {
+                    // No search key configured — navigate to Config page Web section
+                    window.location.href = "/dashboard/config";
+                    return;
+                  }
+                  const cycle: Record<string, "off" | "auto" | "always"> = { off: "auto", auto: "always", always: "off" };
+                  onWebSearchChange(cycle[mode] || "auto");
+                }}
+                title={noKey ? t("chat.web_search_no_key", { defaultValue: "No search API key configured. Click to open settings." }) : undefined}
+                className={`flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-mono transition-colors ${
+                  noKey && !isActive
+                    ? "text-warning/50 hover:text-warning hover:bg-warning/10"
+                    : mode === "always"
+                      ? "text-brand bg-brand/10 hover:bg-brand/20"
+                      : mode === "auto"
+                        ? "text-text-dim/50 hover:text-text hover:bg-surface-hover"
+                        : "text-text-dim/30 hover:text-text-dim/60 hover:bg-surface-hover"
+                }`}
+              >
+                <Globe className="h-3 w-3" />
+                <span>{noKey && !isActive
+                  ? t("chat.web_search_setup", { defaultValue: "Search" })
+                  : mode === "always" ? t("common.always", { defaultValue: "Always" }) : mode === "auto" ? t("common.auto", { defaultValue: "Auto" }) : t("common.off", { defaultValue: "Off" })
+                }</span>
+                {noKey && !isActive && <AlertCircle className="h-2.5 w-2.5 text-warning" />}
+              </button>
+              {isActive && noKey && (
+                <button
+                  onClick={() => { window.location.href = "/dashboard/config"; }}
+                  className="text-[9px] text-warning hover:text-warning/80 underline hidden xl:inline"
+                >
+                  {t("chat.web_search_configure", { defaultValue: "Configure API key" })}
+                </button>
+              )}
+            </div>
+          );
+        })()}
         {/* Session dropdown */}
         {sessions && sessions.length > 0 && (
           <div className="relative" ref={dropdownRef}>
@@ -1520,6 +1545,16 @@ export function ChatPage() {
     queryFn: () => listAgents({ includeHands: showHandAgents }),
     staleTime: 30000,
   });
+  // Check if web search is available (any search API key configured)
+  const configQuery = useQuery({
+    queryKey: ["config", "web-search-available"],
+    queryFn: async () => {
+      const cfg = await getFullConfig();
+      return (cfg as any)?.web?.search_available === true;
+    },
+    staleTime: 60000,
+  });
+  const webSearchAvailable = configQuery.data ?? false;
   const handsQuery = useQuery({
     queryKey: ["hands", "active", "chat"],
     queryFn: listActiveHands,
@@ -1849,6 +1884,7 @@ export function ChatPage() {
               agentId={selectedAgentId}
               onModelChange={() => queryClient.invalidateQueries({ queryKey: ["agents", "list"] })}
               webSearchAugmentation={selectedAgent?.web_search_augmentation}
+              webSearchAvailable={webSearchAvailable}
               onWebSearchChange={async (mode) => {
                 try {
                   await patchAgentConfig(selectedAgentId, { web_search_augmentation: mode });

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -812,9 +812,24 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     );
 
     // ── Web ──
+    // Check if at least one search provider has a configured API key
+    let search_available = [
+        &config.web.tavily.api_key_env,
+        &config.web.brave.api_key_env,
+        &config.web.jina.api_key_env,
+        &config.web.perplexity.api_key_env,
+    ]
+    .iter()
+    .any(|env_var| {
+        std::env::var(env_var)
+            .ok()
+            .filter(|v| !v.is_empty())
+            .is_some()
+    });
     set!("web", {
         "search_provider": format!("{:?}", config.web.search_provider),
         "cache_ttl_minutes": config.web.cache_ttl_minutes,
+        "search_available": search_available,
     });
     // Web subsections built separately to avoid recursion limit
     if let Some(web) = out.get_mut("web").and_then(|v| v.as_object_mut()) {
@@ -2089,6 +2104,21 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
     let providers = providers_result.unwrap_or_default();
     let channels = channels_result.unwrap_or_default();
 
+    // Check if at least one web search provider has a configured API key
+    let web_search_available = [
+        &cfg.web.tavily.api_key_env,
+        &cfg.web.brave.api_key_env,
+        &cfg.web.jina.api_key_env,
+        &cfg.web.perplexity.api_key_env,
+    ]
+    .iter()
+    .any(|env_var| {
+        std::env::var(env_var)
+            .ok()
+            .filter(|v| !v.is_empty())
+            .is_some()
+    });
+
     serde_json::json!({
         "health": health,
         "status": status,
@@ -2097,5 +2127,6 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         "channels": channels,
         "skillCount": skill_count,
         "workflowCount": workflow_count,
+        "webSearchAvailable": web_search_available,
     })
 }


### PR DESCRIPTION
## Summary

- **Cascading model switcher**: two-step provider → model picker in chat page
- **Provider matching**: use agent's known provider prop for accurate highlighting
- **Search key check**: backend reports `search_available` / `webSearchAvailable`, Globe button warns and links to Config page when no key is set
- **Agent list API**: returns `web_search_augmentation` field

## Test plan

- [ ] Chat → click model → provider list → select provider → model list → select model
- [ ] No search key → Globe shows warning icon, click goes to Config page
- [ ] Search key configured → Globe cycles off/auto/always normally

Follows up #2639