### PR TITLE
fix(kernel): persist agent sessions across daemon restarts

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2655,9 +2655,27 @@ system_prompt = "You are a helpful assistant."
         source_toml_path: Option<PathBuf>,
         predetermined_id: Option<AgentId>,
     ) -> KernelResult<AgentId> {
-        let agent_id = predetermined_id.unwrap_or_default();
-        let session_id = SessionId::new();
         let name = manifest.name.clone();
+        // Use a deterministic agent ID derived from the agent name so the
+        // same agent gets the same UUID across daemon restarts. This preserves
+        // session history associations in SQLite. Child agents spawned at
+        // runtime still use random IDs (via predetermined_id = None + parent).
+        let agent_id = predetermined_id.unwrap_or_else(|| {
+            if parent.is_none() {
+                AgentId::from_name(&name)
+            } else {
+                AgentId::new()
+            }
+        });
+
+        // Restore the most recent session for this agent if one exists in the
+        // database, so conversation history survives daemon restarts.
+        let session_id = self
+            .memory
+            .get_agent_session_ids(agent_id)
+            .ok()
+            .and_then(|ids| ids.into_iter().next())
+            .unwrap_or_default();
 
         // SECURITY: If this spawn is linked to a running parent agent,
         // enforce that the child's capabilities are a subset of the

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -251,7 +251,7 @@ impl SessionStore {
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         let mut stmt = conn
-            .prepare("SELECT id FROM sessions WHERE agent_id = ?1")
+            .prepare("SELECT id FROM sessions WHERE agent_id = ?1 ORDER BY created_at DESC")
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         let rows = stmt
             .query_map(rusqlite::params![agent_id.0.to_string()], |row| {

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -127,9 +127,10 @@ pub enum HookEvent {
 pub struct AgentId(pub Uuid);
 
 impl AgentId {
-    /// A fixed namespace UUID for deriving deterministic hand-agent IDs.
-    /// Generated once via UUID v4; never changes.
-    const HAND_NAMESPACE: Uuid = Uuid::from_bytes([
+    /// Fixed namespace UUID for all deterministic agent ID derivation.
+    /// Uses a single namespace with typed prefixes to avoid collisions
+    /// between agents, hands, and hand-roles sharing the same name.
+    const NAMESPACE: Uuid = Uuid::from_bytes([
         0x9b, 0x6a, 0xe3, 0x2d, 0x7a, 0x4f, 0x4c, 0x1e, 0x8d, 0x0f, 0xa1, 0xb2, 0xc3, 0xd4, 0xe5,
         0xf6,
     ]);
@@ -139,26 +140,25 @@ impl AgentId {
         Self(Uuid::new_v4())
     }
 
-    /// Generate a deterministic AgentId for a hand agent.
-    ///
-    /// Uses UUID v5 (SHA-1) with a fixed namespace so the same `hand_id`
-    /// always maps to the same UUID across daemon restarts.
-    pub fn from_hand_id(hand_id: &str) -> Self {
-        Self(Uuid::new_v5(&Self::HAND_NAMESPACE, hand_id.as_bytes()))
-    }
-
-    /// A fixed namespace UUID for deriving deterministic agent IDs from names.
-    const AGENT_NAMESPACE: Uuid = Uuid::from_bytes([
-        0xa7, 0x3e, 0xf1, 0x4b, 0x5c, 0x2d, 0x48, 0x9a, 0xb6, 0x1e, 0xd8, 0x4a, 0x9c, 0x0f, 0x7b,
-        0xe2,
-    ]);
-
     /// Generate a deterministic AgentId from an agent name.
     ///
     /// Uses UUID v5 (SHA-1) so the same agent name always produces the same
     /// ID across daemon restarts, preserving session history associations.
     pub fn from_name(name: &str) -> Self {
-        Self(Uuid::new_v5(&Self::AGENT_NAMESPACE, name.as_bytes()))
+        Self(Uuid::new_v5(
+            &Self::NAMESPACE,
+            format!("agent:{name}").as_bytes(),
+        ))
+    }
+
+    /// Generate a deterministic AgentId for a hand.
+    ///
+    /// Uses UUID v5 with a `hand:` prefix so the same `hand_id`
+    /// always maps to the same UUID across daemon restarts.
+    pub fn from_hand_id(hand_id: &str) -> Self {
+        // Backward compat: existing hands used bare hand_id without prefix.
+        // Keep the same input to preserve existing IDs.
+        Self(Uuid::new_v5(&Self::NAMESPACE, hand_id.as_bytes()))
     }
 
     /// Generate a deterministic agent ID for a specific role within a multi-agent hand instance.
@@ -173,7 +173,7 @@ impl AgentId {
             Some(id) => format!("{hand_id}:{role}:{id}"),
             None => format!("{hand_id}:{role}"),
         };
-        Self(Uuid::new_v5(&Self::HAND_NAMESPACE, input.as_bytes()))
+        Self(Uuid::new_v5(&Self::NAMESPACE, input.as_bytes()))
     }
 }
 

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -147,6 +147,20 @@ impl AgentId {
         Self(Uuid::new_v5(&Self::HAND_NAMESPACE, hand_id.as_bytes()))
     }
 
+    /// A fixed namespace UUID for deriving deterministic agent IDs from names.
+    const AGENT_NAMESPACE: Uuid = Uuid::from_bytes([
+        0xa7, 0x3e, 0xf1, 0x4b, 0x5c, 0x2d, 0x48, 0x9a, 0xb6, 0x1e, 0xd8, 0x4a, 0x9c, 0x0f, 0x7b,
+        0xe2,
+    ]);
+
+    /// Generate a deterministic AgentId from an agent name.
+    ///
+    /// Uses UUID v5 (SHA-1) so the same agent name always produces the same
+    /// ID across daemon restarts, preserving session history associations.
+    pub fn from_name(name: &str) -> Self {
+        Self(Uuid::new_v5(&Self::AGENT_NAMESPACE, name.as_bytes()))
+    }
+
     /// Generate a deterministic agent ID for a specific role within a multi-agent hand instance.
     ///
     /// **Backward compatibility**: when `instance_id` is `None`, uses the legacy


### PR DESCRIPTION
## Summary
Agent chat history was lost on every daemon restart because agents got new random UUIDs on each spawn, breaking the link to their saved sessions in SQLite.

## Root cause
`spawn_agent_inner` called `AgentId::default()` (= `Uuid::new_v4()`) for every spawn, including boot-time agents loaded from TOML. The session data was correctly persisted in SQLite, but the new agent ID couldn't find it.

## Fix
1. **Deterministic agent IDs**: Add `AgentId::from_name(name)` using UUID v5 with a fixed namespace. Top-level agents (no parent) now get stable IDs derived from their name.
2. **Session restoration**: On spawn, query SQLite for existing sessions belonging to this agent ID and reuse the most recent one instead of creating a new empty session.

Child agents spawned at runtime (via tool calls, workflows) still use random IDs since they are ephemeral.

## Migration
First restart after this change will **not** recover pre-existing sessions (old data used random agent IDs). All subsequent restarts will preserve history correctly.

## Test plan
- [x] `cargo clippy -p librefang-types -p librefang-kernel --lib -- -D warnings`
- [ ] Live test: send messages → restart daemon → verify chat history is preserved