### PR TITLE
fix(dashboard): improve /help and system message formatting

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -615,7 +615,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
     if (isMultiLine) {
       return (
         <div className="flex justify-start py-2">
-          <div className="max-w-[min(90%,56ch)] text-xs text-text-dim/70 [&_code]:text-brand [&_code]:font-mono [&_ul]:space-y-1 [&_li]:list-none [&_li]:flex [&_li]:gap-2">
+          <div className="max-w-[min(90%,56ch)] text-xs text-text-dim/70 [&_code]:text-brand [&_code]:font-mono [&_ul]:space-y-1 [&_ul>li]:list-none [&_ul>li]:flex [&_ul>li]:gap-2">
             <MarkdownContent>{message.content}</MarkdownContent>
           </div>
         </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -302,10 +302,9 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
         ]);
       };
       if (trimmed === "/help") {
-        const rows = SLASH_COMMANDS.map(c =>
-          `| \`${c.cmd}${c.argsHint ? " " + c.argsHint : ""}\` | ${t(`chat.${c.descKey}`)} |`
-        ).join("\n");
-        sysMsg(`| ${t("chat.cmd_col_command", "命令")} | ${t("chat.cmd_col_desc", "说明")} |\n|---|---|\n${rows}`);
+        sysMsg(SLASH_COMMANDS.map(c =>
+          `- \`${c.cmd}${c.argsHint ? " " + c.argsHint : ""}\` — ${t(`chat.${c.descKey}`)}`
+        ).join("\n"));
         return;
       }
       if (trimmed === "/clear") { setMessages([]); return; }
@@ -615,12 +614,10 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
     const isMultiLine = message.content.includes("\n");
     if (isMultiLine) {
       return (
-        <div className="flex flex-col items-center gap-2 py-4 px-6">
-          <div className="h-px w-24 bg-gradient-to-r from-transparent via-border-subtle to-transparent" />
-          <div className="w-full max-w-lg text-[11px] text-text-dim/60 [&_table]:w-full [&_table]:border-collapse [&_td]:py-0.5 [&_td]:px-2 [&_td:first-child]:text-brand [&_td:first-child]:font-mono [&_td:first-child]:font-bold [&_th]:text-[9px] [&_th]:uppercase [&_th]:tracking-widest [&_th]:text-text-dim/40 [&_th]:pb-1 [&_th]:px-2 [&_code]:text-brand [&_code]:font-mono">
+        <div className="flex justify-start py-2">
+          <div className="max-w-[min(90%,56ch)] text-xs text-text-dim/70 [&_code]:text-brand [&_code]:font-mono [&_ul]:space-y-1 [&_li]:list-none [&_li]:flex [&_li]:gap-2">
             <MarkdownContent>{message.content}</MarkdownContent>
           </div>
-          <div className="h-px w-24 bg-gradient-to-r from-transparent via-border-subtle to-transparent" />
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- Multi-line system messages (e.g. `/help`, `/agents`) now render left-aligned with `MarkdownContent` instead of being squeezed into a centered divider
- Single-line status messages (e.g. "Session reset") keep the original elegant centered divider style
- `/help` output uses a bullet list (`- \`/cmd\` — desc`) instead of a markdown table

## Why
The centered divider only looks good for short one-liners. Multi-line content was either unreadable (all on one line) or awkward when forced into a centered layout. Left-aligned rendering fits naturally in the chat flow.

## Test plan
- [ ] Type `/help` → should show a bullet list of commands, left-aligned
- [ ] Type `/agents` → should show agent list left-aligned
- [ ] Backend commands like `/reset` returning a single-line status → centered divider unchanged