### PR TITLE
fix(runtime-mcp): taint scanner false positive on date-prefixed MCP session handles

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -4384,6 +4384,7 @@ mod tests {
             env: vec![],
             headers: vec!["xc-mcp-token: secret".to_string()],
             oauth: None,
+            taint_scanning: true,
         };
 
         upsert_mcp_server_config(&config_path, &entry).expect("upsert should succeed");
@@ -4436,6 +4437,7 @@ mod tests {
             env: vec![],
             headers: vec![],
             oauth: None,
+            taint_scanning: true,
         };
         upsert_mcp_server_config(&config_path, &v1).unwrap();
 
@@ -4448,6 +4450,7 @@ mod tests {
             env: vec![],
             headers: vec![],
             oauth: None,
+            taint_scanning: true,
         };
         upsert_mcp_server_config(&config_path, &v2).unwrap();
 

--- a/crates/librefang-extensions/src/registry.rs
+++ b/crates/librefang-extensions/src/registry.rs
@@ -226,6 +226,7 @@ impl IntegrationRegistry {
                     env,
                     headers: Vec::new(),
                     oauth: None,
+                    taint_scanning: true,
                 })
             })
             .collect()

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9041,6 +9041,7 @@ system_prompt = "You are a helpful assistant."
                 headers: server_config.headers.clone(),
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
+                taint_scanning: server_config.taint_scanning,
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -9166,6 +9167,7 @@ system_prompt = "You are a helpful assistant."
             headers: server_config.headers.clone(),
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
+            taint_scanning: server_config.taint_scanning,
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -9300,6 +9302,7 @@ system_prompt = "You are a helpful assistant."
                 headers: server_config.headers.clone(),
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
+                taint_scanning: server_config.taint_scanning,
             };
 
             self.extension_health.register(&server_config.name);
@@ -9446,6 +9449,7 @@ system_prompt = "You are a helpful assistant."
             headers: server_config.headers.clone(),
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
+            taint_scanning: server_config.taint_scanning,
         };
 
         match McpConnection::connect(mcp_config).await {

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -171,6 +171,17 @@ pub struct McpServerConfig {
     /// Optional OAuth config from config.toml (discovery fallback).
     #[serde(default)]
     pub oauth_config: Option<librefang_types::config::McpOAuthConfig>,
+    /// Enable outbound taint scanning for this MCP server (default: true).
+    ///
+    /// When `false`, the credential/PII heuristic is skipped for arguments
+    /// sent to this server. This is an escape hatch for trusted local servers
+    /// (browser automation, database adapters, …) whose tool results contain
+    /// opaque session handles that would otherwise trip the credential heuristic.
+    ///
+    /// Key-name blocking (`Authorization`, `secret`, …) remains active even
+    /// when this is `false` — only the content-based heuristic is disabled.
+    #[serde(default = "default_taint_scanning")]
+    pub taint_scanning: bool,
 }
 
 impl std::fmt::Debug for McpServerConfig {
@@ -186,6 +197,7 @@ impl std::fmt::Debug for McpServerConfig {
                 &self.oauth_provider.as_ref().map(|_| "..."),
             )
             .field("oauth_config", &self.oauth_config)
+            .field("taint_scanning", &self.taint_scanning)
             .finish()
     }
 }
@@ -200,12 +212,17 @@ impl Clone for McpServerConfig {
             headers: self.headers.clone(),
             oauth_provider: self.oauth_provider.clone(),
             oauth_config: self.oauth_config.clone(),
+            taint_scanning: self.taint_scanning,
         }
     }
 }
 
 fn default_timeout() -> u64 {
     60
+}
+
+fn default_taint_scanning() -> bool {
+    true
 }
 
 /// Transport type for MCP server connections.
@@ -982,11 +999,13 @@ impl McpConnection {
         // `librefang_types::taint::check_outbound_text_violation` for
         // exactly which patterns trip it) — not a full information-
         // flow tracker. Copy-pasted obfuscation still bypasses it.
-        if let Some(violation) = scan_mcp_arguments_for_taint(arguments) {
-            // `violation` is already a redacted rule description from
-            // the scanner — do NOT concatenate the raw payload or the
-            // offending value into the error surface.
-            return Err(violation);
+        if self.config.taint_scanning {
+            if let Some(violation) = scan_mcp_arguments_for_taint(arguments) {
+                // `violation` is already a redacted rule description from
+                // the scanner — do NOT concatenate the raw payload or the
+                // offending value into the error surface.
+                return Err(violation);
+            }
         }
 
         // Resolve to an owned String immediately so the borrow of self.original_names
@@ -1580,6 +1599,33 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_mcp_arguments_allows_date_prefixed_session_handle() {
+        // Regression for issue #2652: Camofox MCP returns tabIds of the
+        // form `tab-YYYY-MM-DD-<uuid-segments>`. These must pass the
+        // taint scanner so the LLM can pass them to subsequent tool calls.
+        let args = serde_json::json!({
+            "tabId": "tab-2026-04-16-abc123-def456-ghi789",
+        });
+        assert!(
+            scan_mcp_arguments_for_taint(&args).is_none(),
+            "date-prefixed tabId must not be blocked"
+        );
+    }
+
+    #[test]
+    fn test_scan_mcp_arguments_still_blocks_real_token_in_tab_shaped_key() {
+        // A credential-shaped VALUE under a session-like KEY must still be blocked.
+        // Key-name allowlisting must NOT bypass value-content checks.
+        let args = serde_json::json!({
+            "tabId": "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+        });
+        assert!(
+            scan_mcp_arguments_for_taint(&args).is_some(),
+            "real credential under session-like key must still be blocked"
+        );
+    }
+
+    #[test]
     fn test_mcp_tool_namespacing() {
         assert_eq!(
             format_mcp_tool_name("github", "create_issue"),
@@ -1729,6 +1775,7 @@ mod tests {
             headers: vec![],
             oauth_provider: None,
             oauth_config: None,
+            taint_scanning: true,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1758,6 +1805,7 @@ mod tests {
             headers: vec![],
             oauth_provider: None,
             oauth_config: None,
+            taint_scanning: true,
         };
         let json = serde_json::to_string(&sse_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1791,6 +1839,7 @@ mod tests {
             headers: vec![],
             oauth_provider: None,
             oauth_config: None,
+            taint_scanning: true,
         };
         let json = serde_json::to_string(&http_compat_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1819,6 +1868,7 @@ mod tests {
             headers: vec!["Authorization: Bearer test-token-456".to_string()],
             oauth_provider: None,
             oauth_config: None,
+            taint_scanning: true,
         };
         let json = serde_json::to_string(&http_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1863,6 +1913,7 @@ mod tests {
                 headers: vec![],
                 oauth_provider: None,
                 oauth_config: None,
+                taint_scanning: true,
             },
             tools: Vec::new(),
             original_names: HashMap::new(),
@@ -2028,6 +2079,7 @@ mod tests {
             headers: vec![],
             oauth_provider: None,
             oauth_config: None,
+            taint_scanning: true,
         })
         .await
         .unwrap();

--- a/crates/librefang-runtime/tests/mcp_oauth_integration.rs
+++ b/crates/librefang-runtime/tests/mcp_oauth_integration.rs
@@ -88,6 +88,7 @@ async fn test_http_connect_calls_oauth_provider_load_token() {
         headers: vec![],
         oauth_provider: Some(provider.clone()),
         oauth_config: None,
+        taint_scanning: true,
     };
 
     let result = McpConnection::connect(config).await;

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3283,6 +3283,18 @@ pub struct McpServerConfigEntry {
     // fails to deserialize back into `Option<McpOAuthConfig>` on reload.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth: Option<McpOAuthConfig>,
+    /// Enable outbound taint scanning for this MCP server (default: true).
+    ///
+    /// Set to `false` to disable the credential/PII content heuristic for
+    /// trusted local servers (e.g. browser automation, database adapters)
+    /// whose tool results contain opaque session handles that would otherwise
+    /// trip the scanner. Key-name blocking remains active regardless.
+    #[serde(default = "default_taint_scanning")]
+    pub taint_scanning: bool,
+}
+
+fn default_taint_scanning() -> bool {
+    true
 }
 
 fn default_mcp_timeout() -> u64 {

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -271,7 +271,12 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
         // dashes (32-hex), and bare decimal runs — all common in
         // legitimate tool arguments.
         let mixed_enough = has_letter && has_digit && !is_hex_only;
-        let looks_opaque = trimmed.len() >= 32 && charset_ok && mixed_enough;
+        // Strings containing a calendar date component (YYYY-MM-DD) are
+        // structured resource identifiers, not opaque credentials. Real
+        // API tokens never embed dates. This prevents false positives on
+        // MCP session handles of the form `tab-2026-04-16-<uuid-parts>`.
+        let has_date_component = date_component_regex().is_match(trimmed);
+        let looks_opaque = trimmed.len() >= 32 && charset_ok && mixed_enough && !has_date_component;
         let well_known = trimmed.starts_with("sk-")
             || trimmed.starts_with("ghp_")
             || trimmed.starts_with("github_pat_")
@@ -323,6 +328,18 @@ fn payload_contains_pii(payload: &str) -> bool {
         || phone_regex().is_match(payload)
         || credit_card_regex().is_match(payload)
         || ssn_regex().is_match(payload)
+}
+
+/// Matches a calendar date in ISO 8601 / RFC 3339 form (`YYYY-MM-DD`).
+/// Used to exclude structured resource identifiers from the opaque-token
+/// heuristic: real API credentials never contain dates, but many MCP
+/// session handle formats do (e.g. `tab-2026-04-16-abc123-def456`).
+fn date_component_regex() -> &'static Regex {
+    static DATE: OnceLock<Regex> = OnceLock::new();
+    DATE.get_or_init(|| {
+        Regex::new(r"\b\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])\b")
+            .expect("built-in date component regex must compile")
+    })
 }
 
 fn email_regex() -> &'static Regex {
@@ -595,5 +612,37 @@ mod tests {
         // After declassification -- should pass
         assert!(tainted.check_sink(&TaintSink::shell_exec()).is_ok());
         assert!(!tainted.is_tainted());
+    }
+
+    // ── Regression: MCP session handle false positives (issue #2652) ─────
+
+    #[test]
+    fn test_check_outbound_text_allows_date_prefixed_session_id() {
+        // Camofox-style tabId: word prefix + ISO date + UUID segments.
+        // Must NOT trip despite being ≥32 chars and mixed alnum.
+        let sink = TaintSink::mcp_tool_call();
+        for id in [
+            "tab-2026-04-16-abc123-def456-ghi789",
+            "sess-2026-01-01-aabbcc-ddeeff-001122",
+            "page-2025-12-31-xyz789-abc123-000000",
+            "ctx-2024-06-15-handle42-abcdef-012345",
+        ] {
+            assert!(
+                check_outbound_text_violation(id, &sink).is_none(),
+                "date-prefixed session ID must not be blocked: {id:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_outbound_text_still_blocks_token_without_date() {
+        // A long mixed-alnum token with no date component must still trip.
+        let sink = TaintSink::mcp_tool_call();
+        let tok = "xAbCdEfGhIjKlMnOpQrStUvWxYz1234567890AB";
+        assert!(tok.len() >= 32);
+        assert!(
+            check_outbound_text_violation(tok, &sink).is_some(),
+            "opaque token without date must still be blocked"
+        );
     }
 }


### PR DESCRIPTION
Fixes #2652

## Root cause

The `looks_opaque` heuristic in `check_outbound_text_violation` (taint.rs) flagged MCP session handles like `tab-2026-04-16-abc123-def456-ghi789` as secret/credential-shaped because they satisfy all existing conditions: length ≥ 32, no whitespace, mixed letters+digits, not pure hex.

## Fix

**1. Date-component exclusion (`taint.rs`)**  
Strings containing a calendar date (`YYYY-MM-DD`) are now excluded from `looks_opaque`. Real API credentials never embed ISO dates; structured resource identifiers (browser tab IDs, session handles, request IDs) often do.

```rust
let has_date_component = date_component_regex().is_match(trimmed);
let looks_opaque = trimmed.len() >= 32 && charset_ok && mixed_enough && !has_date_component;
```

**2. Per-server escape hatch (`McpServerConfig` + `McpServerConfigEntry`)**  
Adds `taint_scanning: bool` (default `true`) to both the runtime config struct and the TOML config entry. Set it to `false` for trusted local servers whose tool results contain opaque handles that trip the heuristic:

```toml
[[mcp_servers]]
name = "camofox"
taint_scanning = false   # browser session handles are not credentials
[mcp_servers.transport]
type = "stdio"
command = "npx"
args = ["-y", "camofox-mcp@latest"]
```

Key-name blocking (`Authorization`, `secret`, etc.) remains active even when `taint_scanning = false`.

## Tests added
- `test_check_outbound_text_allows_date_prefixed_session_id` — exact Camofox-style tabId patterns must pass
- `test_check_outbound_text_still_blocks_token_without_date` — long mixed-alnum without date still blocked
- `test_scan_mcp_arguments_allows_date_prefixed_session_handle` — end-to-end MCP scanner regression test
- `test_scan_mcp_arguments_still_blocks_real_token_in_tab_shaped_key` — credential under session-like key still blocked