### PR TITLE
fix(tests): decouple catalog tests from hardcoded model counts

### DIFF
--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -433,7 +433,7 @@ async fn test_build_router_serves_dashboard_locales() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_build_router_providers_marks_lemonade_as_local() {
+async fn test_build_router_providers_marks_local_providers() {
     let harness = start_full_router("").await;
 
     let response = harness
@@ -455,12 +455,13 @@ async fn test_build_router_providers_marks_lemonade_as_local() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let providers = json["providers"].as_array().unwrap();
-    let lemonade = providers
+    // Ollama is always in the registry and must be marked as a local provider.
+    let ollama = providers
         .iter()
-        .find(|provider| provider["id"] == "lemonade")
-        .expect("lemonade provider should be present");
+        .find(|provider| provider["id"] == "ollama")
+        .expect("ollama provider should be present");
 
-    assert_eq!(lemonade["is_local"], serde_json::json!(true));
+    assert_eq!(ollama["is_local"], serde_json::json!(true));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -630,8 +630,17 @@ mod tests {
     #[test]
     fn test_estimate_cost_with_catalog_local_zero_price_stays_zero() {
         let catalog = test_catalog();
+        // Use a local model that always has zero cost; pick dynamically so this
+        // stays green regardless of which specific models the registry ships.
+        let local_id = catalog
+            .list_models()
+            .into_iter()
+            .find(|m| m.tier == librefang_runtime::model_catalog::ModelTier::Local)
+            .expect("registry must contain at least one local-tier model")
+            .id
+            .clone();
         let cost = MeteringEngine::estimate_cost_with_catalog(
-            &catalog, "llama3.2", 1_000_000, 1_000_000, 0, 0,
+            &catalog, &local_id, 1_000_000, 1_000_000, 0, 0,
         );
         assert!(cost.abs() < f64::EPSILON);
     }

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1161,7 +1161,7 @@ id = "acme"
     fn test_models_by_provider() {
         let catalog = test_catalog();
         let anthropic = catalog.models_by_provider("anthropic");
-        assert_eq!(anthropic.len(), 7);
+        assert!(!anthropic.is_empty());
         assert!(anthropic.iter().all(|m| m.provider == "anthropic"));
     }
 
@@ -1219,9 +1219,9 @@ id = "acme"
     fn test_provider_model_counts() {
         let catalog = test_catalog();
         let anthropic = catalog.get_provider("anthropic").unwrap();
-        assert_eq!(anthropic.model_count, 7);
+        assert!(anthropic.model_count > 0);
         let groq = catalog.get_provider("groq").unwrap();
-        assert_eq!(groq.model_count, 10);
+        assert!(groq.model_count > 0);
     }
 
     #[test]
@@ -1287,7 +1287,7 @@ id = "acme"
     fn test_xai_models() {
         let catalog = test_catalog();
         let xai = catalog.models_by_provider("xai");
-        assert_eq!(xai.len(), 9);
+        assert!(!xai.is_empty());
         assert!(xai.iter().any(|m| m.id == "grok-4-0709"));
         assert!(xai.iter().any(|m| m.id == "grok-4-fast-reasoning"));
         assert!(xai.iter().any(|m| m.id == "grok-4-fast-non-reasoning"));
@@ -1295,22 +1295,20 @@ id = "acme"
         assert!(xai.iter().any(|m| m.id == "grok-4-1-fast-non-reasoning"));
         assert!(xai.iter().any(|m| m.id == "grok-3"));
         assert!(xai.iter().any(|m| m.id == "grok-3-mini"));
-        assert!(xai.iter().any(|m| m.id == "grok-2"));
-        assert!(xai.iter().any(|m| m.id == "grok-2-mini"));
     }
 
     #[test]
     fn test_perplexity_models() {
         let catalog = test_catalog();
         let pp = catalog.models_by_provider("perplexity");
-        assert_eq!(pp.len(), 4);
+        assert!(!pp.is_empty());
     }
 
     #[test]
     fn test_cohere_models() {
         let catalog = test_catalog();
         let co = catalog.models_by_provider("cohere");
-        assert_eq!(co.len(), 4);
+        assert!(!co.is_empty());
     }
 
     #[test]
@@ -1339,9 +1337,17 @@ id = "acme"
     #[test]
     fn test_merge_skips_existing() {
         let mut catalog = test_catalog();
-        // "llama3.2" is already a builtin Ollama model
+        // Pick an existing builtin Ollama model ID dynamically so this test
+        // stays green regardless of which models the registry ships.
+        let existing_id = catalog
+            .models_by_provider("ollama")
+            .into_iter()
+            .next()
+            .expect("ollama must have at least one builtin model")
+            .id
+            .clone();
         let before = catalog.list_models().len();
-        catalog.merge_discovered_models("ollama", &["llama3.2".to_string()]);
+        catalog.merge_discovered_models("ollama", &[existing_id]);
         let after = catalog.list_models().len();
         assert_eq!(after, before); // no new model added
     }
@@ -1440,14 +1446,14 @@ id = "acme"
         // return the custom entry so the correct provider is used for routing.
         let mut catalog = test_catalog();
 
-        // Pick a known builtin model and verify it exists
-        let builtin = catalog.find_model("grok-2").unwrap();
+        // Pick a known builtin xai model and verify it exists
+        let builtin = catalog.find_model("grok-3").unwrap();
         assert_eq!(builtin.provider, "xai");
 
         // Add a custom model with the same ID but a different provider
         assert!(catalog.add_custom_model(ModelCatalogEntry {
-            id: "grok-2".to_string(),
-            display_name: "Grok 2 via OpenRouter".to_string(),
+            id: "grok-3".to_string(),
+            display_name: "Grok 3 via OpenRouter".to_string(),
             provider: "openrouter".to_string(),
             tier: ModelTier::Custom,
             context_window: 131_072,
@@ -1462,7 +1468,7 @@ id = "acme"
         }));
 
         // find_model should now return the custom entry, not the builtin
-        let found = catalog.find_model("grok-2").unwrap();
+        let found = catalog.find_model("grok-3").unwrap();
         assert_eq!(found.provider, "openrouter");
         assert_eq!(found.tier, ModelTier::Custom);
     }
@@ -1565,7 +1571,7 @@ id = "acme"
     fn test_bedrock_models() {
         let catalog = test_catalog();
         let bedrock = catalog.models_by_provider("bedrock");
-        assert_eq!(bedrock.len(), 11);
+        assert!(!bedrock.is_empty());
     }
 
     #[test]

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -7122,7 +7122,12 @@ description = "test"
         let dir = tempfile::TempDir::new().unwrap();
         let registry = create_skill_registry_with_file(dir.path(), "abs", "dummy.txt", "ok");
 
-        let input = serde_json::json!({ "skill": "abs", "path": "/etc/passwd" });
+        // Use a platform-appropriate absolute path so the test passes on Windows too.
+        let abs_path = std::env::temp_dir()
+            .join("passwd")
+            .to_string_lossy()
+            .into_owned();
+        let input = serde_json::json!({ "skill": "abs", "path": abs_path });
         let result = tool_skill_read_file(&input, Some(&registry), None).await;
         assert!(result.unwrap_err().contains("absolute paths"));
     }


### PR DESCRIPTION
## Problem

Tests were asserting exact model counts (`assert_eq!(anthropic.len(), 7)`) and hardcoding specific model IDs (`grok-2`, `llama3.2`, `lemonade`) that change whenever the registry is updated. Every catalog change broke CI.

## Fix

- Replace `assert_eq!(x.len(), N)` with `assert!(!x.is_empty())` or `assert!(x > 0)` for registry-sourced counts
- `test_merge_skips_existing`: pick the first existing ollama model dynamically instead of hardcoding `llama3.2`
- `test_find_model_prefers_custom_over_builtin`: use `grok-3` (current) instead of removed `grok-2`
- `test_xai_models`: remove assertions for `grok-2`/`grok-2-mini` which were intentionally removed
- `test_estimate_cost_with_catalog_local_zero_price_stays_zero`: find the first local-tier model dynamically
- `test_build_router_providers_marks_lemonade_as_local` → renamed, now asserts `ollama` (always present) is local
- `skill_read_file_rejects_absolute_path`: use `std::env::temp_dir()` for cross-platform absolute path (fixes Windows)

Fixes the 7 CI failures introduced by registry PR #58.