### PR TITLE
fix(test): resolve clippy errors and stale lemonade integration test

### DIFF
--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -433,7 +433,7 @@ async fn test_build_router_serves_dashboard_locales() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_build_router_providers_marks_lemonade_as_local() {
+async fn test_build_router_providers_marks_local_provider_as_local() {
     let harness = start_full_router("").await;
 
     let response = harness
@@ -455,12 +455,12 @@ async fn test_build_router_providers_marks_lemonade_as_local() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let providers = json["providers"].as_array().unwrap();
-    let lemonade = providers
+    let ollama = providers
         .iter()
-        .find(|provider| provider["id"] == "lemonade")
-        .expect("lemonade provider should be present");
+        .find(|provider| provider["id"] == "ollama")
+        .expect("ollama provider should be present");
 
-    assert_eq!(lemonade["is_local"], serde_json::json!(true));
+    assert_eq!(ollama["is_local"], serde_json::json!(true));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -8422,23 +8422,28 @@ mod tests {
 
     #[test]
     fn test_should_augment_web_search_off() {
-        let mut manifest = AgentManifest::default();
-        manifest.web_search_augmentation = librefang_types::agent::WebSearchAugmentationMode::Off;
+        let manifest = AgentManifest {
+            web_search_augmentation: librefang_types::agent::WebSearchAugmentationMode::Off,
+            ..Default::default()
+        };
         assert!(!should_augment_web_search(&manifest));
     }
 
     #[test]
     fn test_should_augment_web_search_always() {
-        let mut manifest = AgentManifest::default();
-        manifest.web_search_augmentation =
-            librefang_types::agent::WebSearchAugmentationMode::Always;
+        let manifest = AgentManifest {
+            web_search_augmentation: librefang_types::agent::WebSearchAugmentationMode::Always,
+            ..Default::default()
+        };
         assert!(should_augment_web_search(&manifest));
     }
 
     #[test]
     fn test_should_augment_web_search_auto_with_tools() {
-        let mut manifest = AgentManifest::default();
-        manifest.web_search_augmentation = librefang_types::agent::WebSearchAugmentationMode::Auto;
+        let mut manifest = AgentManifest {
+            web_search_augmentation: librefang_types::agent::WebSearchAugmentationMode::Auto,
+            ..Default::default()
+        };
         // model_supports_tools = true → don't augment
         manifest.metadata.insert(
             "model_supports_tools".to_string(),
@@ -8449,8 +8454,10 @@ mod tests {
 
     #[test]
     fn test_should_augment_web_search_auto_without_tools() {
-        let mut manifest = AgentManifest::default();
-        manifest.web_search_augmentation = librefang_types::agent::WebSearchAugmentationMode::Auto;
+        let mut manifest = AgentManifest {
+            web_search_augmentation: librefang_types::agent::WebSearchAugmentationMode::Auto,
+            ..Default::default()
+        };
         // model_supports_tools = false → augment
         manifest.metadata.insert(
             "model_supports_tools".to_string(),
@@ -8461,8 +8468,10 @@ mod tests {
 
     #[test]
     fn test_should_augment_web_search_auto_no_metadata() {
-        let mut manifest = AgentManifest::default();
-        manifest.web_search_augmentation = librefang_types::agent::WebSearchAugmentationMode::Auto;
+        let manifest = AgentManifest {
+            web_search_augmentation: librefang_types::agent::WebSearchAugmentationMode::Auto,
+            ..Default::default()
+        };
         // No metadata → assume tools supported → don't augment (conservative)
         assert!(!should_augment_web_search(&manifest));
     }


### PR DESCRIPTION
## Summary
- Fix 5 `clippy::field_reassign_with_default` errors in web search augmentation tests (`agent_loop.rs`) by using struct initializer syntax
- Fix stale integration test that referenced `lemonade` provider whose TOML catalog file was removed in #1336 — replaced with `ollama`

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo build --workspace --lib` compiles cleanly
- [x] `test_build_router_providers_marks_local_provider_as_local` passes