### PR TITLE
fix(kernel-metering): use librefang_types path for ModelTier in test

### DIFF
--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -635,7 +635,7 @@ mod tests {
         let local_id = catalog
             .list_models()
             .into_iter()
-            .find(|m| m.tier == librefang_runtime::model_catalog::ModelTier::Local)
+            .find(|m| m.tier == librefang_types::model_catalog::ModelTier::Local)
             .expect("registry must contain at least one local-tier model")
             .id
             .clone();


### PR DESCRIPTION
## Summary
- Fix `E0603: enum ModelTier is private` compilation error in `librefang-kernel-metering` test
- `ModelTier` is defined in `librefang_types` but was referenced via `librefang_runtime::model_catalog` which doesn't re-export it publicly
- This is the CI failure blocking #2653 and #2654

## Test plan
- [x] `cargo test -p librefang-kernel-metering --no-run` compiles successfully
- [x] No other occurrences of `librefang_runtime::model_catalog::ModelTier` in the codebase