### PR TITLE
fix(kernel-metering): replace into_iter() with iter() on slice

### DIFF
--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -634,7 +634,7 @@ mod tests {
         // stays green regardless of which specific models the registry ships.
         let local_id = catalog
             .list_models()
-            .into_iter()
+            .iter()
             .find(|m| m.tier == librefang_types::model_catalog::ModelTier::Local)
             .expect("registry must contain at least one local-tier model")
             .id


### PR DESCRIPTION
## Summary
- Fix `clippy::into_iter_on_ref` error in `librefang-kernel-metering` test — `.into_iter()` on a slice is equivalent to `.iter()` and triggers a clippy deny
- This is the remaining CI blocker after #2657

## Test plan
- [x] `cargo clippy -p librefang-kernel-metering --all-targets -- -D warnings` passes