### PR TITLE
fix(extensions): use minimum bound for DevTools count in registry test

### DIFF
--- a/crates/librefang-extensions/src/registry.rs
+++ b/crates/librefang-extensions/src/registry.rs
@@ -376,7 +376,12 @@ mod tests {
         let mut reg = IntegrationRegistry::new(dir.path());
         reg.load_templates(&librefang_runtime::registry_sync::resolve_home_dir_for_tests());
         let devtools = reg.list_by_category(&IntegrationCategory::DevTools);
-        assert_eq!(devtools.len(), 6);
+        // Registry grows over time; assert a minimum rather than exact count.
+        assert!(
+            devtools.len() >= 6,
+            "expected at least 6 DevTools integrations, got {}",
+            devtools.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix `registry_list_by_category` test that hard-codes `== 6` for DevTools integration count
- Remote registry has grown to 10 DevTools integrations, breaking CI while local caches still have 6
- Changed to `>= 6` so the test doesn't break every time a new DevTools integration is added upstream

## Test plan
- [x] `cargo test -p librefang-extensions registry_list_by_category` passes