### PR TITLE
refactor(dashboard): redesign MCP servers page UI

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1976,6 +1976,16 @@
     "registry_empty_desc": "Integration templates will appear after a registry sync.",
     "registry_installed": "Installed",
     "registry_add": "Add",
-    "registry_add_success": "Integration added as MCP server"
+    "registry_add_success": "Integration added as MCP server",
+    "search_placeholder": "Search servers...",
+    "filter_all": "All",
+    "filter_connected": "Connected",
+    "filter_disconnected": "Disconnected",
+    "no_results": "No matching servers",
+    "no_results_desc": "Try a different search term or filter.",
+    "show_more_tools": "Show {{count}} more...",
+    "stdio_config": "Stdio Configuration",
+    "connection": "Connection",
+    "url_hint": "URL must start with http:// or https://"
   }
 }

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1983,6 +1983,16 @@
     "registry_empty_desc": "集成模板将在 Registry 同步后显示。",
     "registry_installed": "已安装",
     "registry_add": "添加",
-    "registry_add_success": "集成已添加为 MCP 服务器"
+    "registry_add_success": "集成已添加为 MCP 服务器",
+    "search_placeholder": "搜索服务器...",
+    "filter_all": "全部",
+    "filter_connected": "已连接",
+    "filter_disconnected": "未连接",
+    "no_results": "没有匹配的服务器",
+    "no_results_desc": "请尝试其他搜索词或筛选条件。",
+    "show_more_tools": "显示另外 {{count}} 个...",
+    "stdio_config": "Stdio 配置",
+    "connection": "连接",
+    "url_hint": "URL 必须以 http:// 或 https:// 开头"
   }
 }

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -267,6 +267,11 @@ function ServerCard({
   const toolsCount = conn?.tools_count ?? 0;
   const [showAllTools, setShowAllTools] = useState(false);
 
+  // Reset "show all" when tools section is collapsed
+  useEffect(() => {
+    if (!isExpanded) setShowAllTools(false);
+  }, [isExpanded]);
+
   const visibleTools = useMemo(() => {
     if (!conn?.tools) return [];
     if (showAllTools || conn.tools.length <= 5) return conn.tools;
@@ -551,7 +556,10 @@ export function McpServersPage() {
   const registryTemplates = registryQuery.data?.integrations ?? [];
   const configuredNames = new Set(configured.map(s => s.name));
 
-  const connectedCount = configured.filter(s => connectedMap.get(s.name)?.connected).length;
+  const connectedCount = useMemo(
+    () => configured.filter(s => connectedMap.get(s.name)?.connected).length,
+    [configured, connectedMap],
+  );
   const disconnectedCount = configured.length - connectedCount;
 
   return (

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   listMcpServers, addMcpServer, updateMcpServer, deleteMcpServer,
@@ -22,11 +22,13 @@ import { useCreateShortcut } from "../lib/useCreateShortcut";
 import {
   Plug, Plus, Trash2, Settings, ChevronDown, ChevronUp, Wrench, Terminal, Globe, Radio,
   Shield, ShieldCheck, ShieldAlert, ShieldX, Package, Check, ExternalLink,
+  Search, Clock, Filter,
 } from "lucide-react";
 
 const REFRESH_MS = 30000;
 
 type TransportType = "stdio" | "sse" | "http";
+type StatusFilter = "all" | "connected" | "disconnected";
 
 interface ServerFormState {
   name: string;
@@ -96,11 +98,11 @@ function getTransportType(server: McpServerConfigured): TransportType {
 }
 
 function getTransportDetail(server: McpServerConfigured): string {
-  if (!server.transport) return "—";
+  if (!server.transport) return "\u2014";
   if (server.transport.type === "stdio") {
     return `${server.transport.command ?? ""} ${(server.transport.args ?? []).join(" ")}`.trim();
   }
-  return server.transport.url ?? "—";
+  return server.transport.url ?? "\u2014";
 }
 
 function TransportIcon({ type }: { type: TransportType }) {
@@ -111,7 +113,8 @@ function TransportIcon({ type }: { type: TransportType }) {
   }
 }
 
-/** Auth badge for an MCP server — shows auth state and action buttons. */
+// ── Auth Badge ──────────────────────────────────────────────────────
+
 function AuthBadge({
   server,
   onAuthSuccess,
@@ -125,7 +128,6 @@ function AuthBadge({
   const [polling, setPolling] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Poll only when auth flow is in progress (not for needs_auth)
   useEffect(() => {
     if ((authState === "pending_auth" && polling) || polling) {
       pollRef.current = setInterval(async () => {
@@ -149,17 +151,12 @@ function AuthBadge({
   }, [authState, polling, server.name, onAuthSuccess, addToast]);
 
   const handleStartAuth = useCallback(async () => {
-    // Open the window immediately on user click to avoid popup blocker.
-    // The async API call can take several seconds (discovery + registration),
-    // and browsers block window.open() if it's not in the click handler's
-    // synchronous call stack.
     const authWindow = window.open("about:blank", "_blank");
     try {
       const result = await startMcpAuth(server.name);
       if (authWindow && !authWindow.closed) {
         authWindow.location.href = result.auth_url;
       } else {
-        // Popup was blocked — fall back to same-tab redirect
         window.location.href = result.auth_url;
       }
       setPolling(true);
@@ -175,16 +172,14 @@ function AuthBadge({
   const handleRevoke = useCallback(async () => {
     try {
       await revokeMcpAuth(server.name);
-      onAuthSuccess(); // refresh
+      onAuthSuccess();
       addToast(t("mcp.auth_revoked"), "success");
     } catch (e: any) {
       addToast(e?.message || t("mcp.auth_revoke_failed"), "error");
     }
   }, [server.name, onAuthSuccess, addToast, t]);
 
-  if (authState === "not_required") {
-    return null;
-  }
+  if (authState === "not_required") return null;
 
   if (authState === "authorized") {
     return (
@@ -236,7 +231,6 @@ function AuthBadge({
     );
   }
 
-  // Unknown state — offer authorize button
   return (
     <button
       onClick={handleStartAuth}
@@ -247,6 +241,172 @@ function AuthBadge({
     </button>
   );
 }
+
+// ── Server Card ─────────────────────────────────────────────────────
+
+function ServerCard({
+  server,
+  conn,
+  isExpanded,
+  onToggleTools,
+  onEdit,
+  onDelete,
+  onAuthSuccess,
+  t,
+}: {
+  server: McpServerConfigured;
+  conn?: McpServerConnected;
+  isExpanded: boolean;
+  onToggleTools: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onAuthSuccess: () => void;
+  t: (key: string, opts?: any) => string;
+}) {
+  const isConnected = conn?.connected ?? false;
+  const toolsCount = conn?.tools_count ?? 0;
+  const [showAllTools, setShowAllTools] = useState(false);
+
+  const visibleTools = useMemo(() => {
+    if (!conn?.tools) return [];
+    if (showAllTools || conn.tools.length <= 5) return conn.tools;
+    return conn.tools.slice(0, 5);
+  }, [conn?.tools, showAllTools]);
+
+  const hiddenCount = (conn?.tools?.length ?? 0) - visibleTools.length;
+
+  return (
+    <Card hover padding="none" className="flex flex-col overflow-hidden group">
+      {/* Gradient top bar */}
+      <div className={`h-1.5 bg-gradient-to-r ${
+        isConnected
+          ? "from-success via-success/60 to-success/30"
+          : "from-error via-error/60 to-error/30"
+      }`} />
+
+      <div className="p-5 flex-1 flex flex-col">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className={`w-10 h-10 rounded-lg flex items-center justify-center shadow-sm ${
+              isConnected
+                ? "bg-gradient-to-br from-success/10 to-success/5 border border-success/20"
+                : "bg-gradient-to-br from-brand/10 to-brand/5 border border-brand/20"
+            }`}>
+              <Plug className={`w-5 h-5 ${isConnected ? "text-success" : "text-brand"}`} />
+            </div>
+            <div className="min-w-0">
+              <h2 className={`text-base font-black truncate transition-colors ${
+                isConnected ? "group-hover:text-success" : "group-hover:text-brand"
+              }`}>{server.name}</h2>
+              <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">
+                {getTransportType(server)}
+              </p>
+            </div>
+          </div>
+          <Badge variant={isConnected ? "success" : "error"} dot>
+            {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
+          </Badge>
+        </div>
+
+        {/* OAuth auth badge */}
+        <AuthBadge server={server} onAuthSuccess={onAuthSuccess} />
+
+        {/* Stats */}
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <div className="p-3 rounded-xl bg-gradient-to-br from-main/60 to-main/30 border border-border-subtle/50">
+            <div className="flex items-center gap-1.5 mb-1">
+              <Wrench className={`w-3 h-3 ${isConnected ? "text-success" : "text-brand"}`} />
+              <p className="text-[9px] font-black uppercase tracking-wider text-text-dim/70">{t("mcp.tools")}</p>
+            </div>
+            <p className="text-xl font-black text-text-main">{toolsCount}</p>
+          </div>
+          <div className="p-3 rounded-xl bg-gradient-to-br from-main/60 to-main/30 border border-border-subtle/50">
+            <div className="flex items-center gap-1.5 mb-1">
+              <Clock className="w-3 h-3 text-warning" />
+              <p className="text-[9px] font-black uppercase tracking-wider text-text-dim/70">{t("mcp.timeout")}</p>
+            </div>
+            <p className="text-xl font-black text-text-main">{server.timeout_secs ?? 30}s</p>
+          </div>
+        </div>
+
+        {/* Transport badge + detail */}
+        <div className="flex items-center gap-2 mb-3">
+          <Badge variant="default">
+            <TransportIcon type={getTransportType(server)} />
+            <span className="ml-1">{getTransportType(server).toUpperCase()}</span>
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2 text-xs mb-2">
+          {getTransportType(server) === "stdio" ? (
+            <Terminal className="w-3 h-3 text-text-dim/50 shrink-0" />
+          ) : (
+            <Globe className="w-3 h-3 text-text-dim/50 shrink-0" />
+          )}
+          <span className="text-text-dim font-mono text-[10px] truncate">{getTransportDetail(server)}</span>
+        </div>
+      </div>
+
+      {/* Tools expand */}
+      {toolsCount > 0 && (
+        <>
+          <button
+            onClick={onToggleTools}
+            className="flex items-center justify-center gap-1.5 py-2.5 border-t border-border-subtle text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? t("mcp.hide_tools") : t("mcp.show_tools")}
+          >
+            {isExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+            {t("mcp.tools")} ({toolsCount})
+          </button>
+          {isExpanded && conn?.tools && (
+            <div className="border-t border-border-subtle px-4 py-3 space-y-2 max-h-64 overflow-y-auto scrollbar-thin">
+              {visibleTools.map((tool) => (
+                <div key={tool.name} className="p-2.5 rounded-lg bg-main/40 border border-border-subtle/50">
+                  <span className="text-xs font-mono font-bold text-text-main">{tool.name}</span>
+                  {tool.description && (
+                    <p className="text-[10px] text-text-dim leading-snug mt-0.5">{tool.description}</p>
+                  )}
+                </div>
+              ))}
+              {hiddenCount > 0 && (
+                <button
+                  onClick={() => setShowAllTools(true)}
+                  className="w-full text-center text-[10px] font-bold text-brand hover:text-brand/80 py-1.5 transition-colors"
+                >
+                  {t("mcp.show_more_tools", { count: hiddenCount })}
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Actions */}
+      <div className="flex border-t border-border-subtle">
+        <button
+          onClick={onEdit}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors rounded-bl-xl sm:rounded-bl-2xl"
+          aria-label={t("mcp.edit_server")}
+        >
+          <Settings className="h-3.5 w-3.5" />
+          {t("common.edit")}
+        </button>
+        <div className="w-px bg-border-subtle" />
+        <button
+          onClick={onDelete}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-error hover:bg-error/5 transition-colors rounded-br-xl sm:rounded-br-2xl"
+          aria-label={t("mcp.delete_server")}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          {t("common.delete")}
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+// ── Main Page ───────────────────────────────────────────────────────
 
 export function McpServersPage() {
   const { t } = useTranslation();
@@ -259,6 +419,8 @@ export function McpServersPage() {
   const [deletingServer, setDeletingServer] = useState<string | null>(null);
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [form, setForm] = useState<ServerFormState>(defaultForm);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 
   useCreateShortcut(() => setShowAddModal(true));
 
@@ -312,10 +474,30 @@ export function McpServersPage() {
   const configured = data?.configured ?? [];
   const connected = data?.connected ?? [];
 
-  const connectedMap = new Map<string, McpServerConnected>();
-  for (const c of connected) {
-    connectedMap.set(c.name, c);
-  }
+  const connectedMap = useMemo(() => {
+    const map = new Map<string, McpServerConnected>();
+    for (const c of connected) map.set(c.name, c);
+    return map;
+  }, [connected]);
+
+  // Search + filter
+  const filteredServers = useMemo(() => {
+    let result = configured;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(s =>
+        s.name.toLowerCase().includes(q) ||
+        getTransportDetail(s).toLowerCase().includes(q)
+      );
+    }
+    if (statusFilter !== "all") {
+      result = result.filter(s => {
+        const isConn = connectedMap.get(s.name)?.connected ?? false;
+        return statusFilter === "connected" ? isConn : !isConn;
+      });
+    }
+    return result;
+  }, [configured, searchQuery, statusFilter, connectedMap]);
 
   function toggleTools(name: string) {
     setExpandedTools(prev => {
@@ -369,6 +551,9 @@ export function McpServersPage() {
   const registryTemplates = registryQuery.data?.integrations ?? [];
   const configuredNames = new Set(configured.map(s => s.name));
 
+  const connectedCount = configured.filter(s => connectedMap.get(s.name)?.connected).length;
+  const disconnectedCount = configured.length - connectedCount;
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -415,138 +600,103 @@ export function McpServersPage() {
 
       {tab === "servers" && (
         <>
-      {/* Summary badges */}
-      {data && (
-        <div className="flex items-center gap-3 flex-wrap">
-          <Badge variant="default">{t("mcp.total_configured", { count: data.total_configured })}</Badge>
-          <Badge variant={data.total_connected > 0 ? "success" : "default"} dot>
-            {t("mcp.total_connected", { count: data.total_connected })}
-          </Badge>
-        </div>
-      )}
-
-      {/* Loading state */}
-      {serversQuery.isLoading && <ListSkeleton rows={3} />}
-
-      {/* Empty state */}
-      {!serversQuery.isLoading && configured.length === 0 && (
-        <EmptyState
-          icon={<Plug className="h-10 w-10" />}
-          title={t("mcp.empty")}
-          description={t("mcp.empty_desc")}
-          action={
-            <Button size="sm" leftIcon={<Package className="h-3.5 w-3.5" />} onClick={() => setTab("registry")}>
-              {t("mcp.tab_registry")}
-            </Button>
-          }
-        />
-      )}
-
-      {/* Server cards */}
-      {configured.length > 0 && (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6">
-          {configured.map((server) => {
-            const conn = connectedMap.get(server.name);
-            const isConnected = conn?.connected ?? false;
-            const toolsCount = conn?.tools_count ?? 0;
-            const isExpanded = expandedTools.has(server.name);
-
-            return (
-              <Card key={server.name} padding="none" className="flex flex-col">
-                <div className="p-4 flex flex-col gap-3">
-                  {/* Header row */}
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex items-center gap-2.5 min-w-0">
-                      <div className="p-2 rounded-xl bg-brand/10 text-brand shrink-0">
-                        <Plug className="h-4 w-4" />
-                      </div>
-                      <div className="min-w-0">
-                        <h3 className="text-sm font-bold tracking-tight truncate">{server.name}</h3>
-                        <div className="flex items-center gap-1.5 mt-0.5">
-                          <TransportIcon type={getTransportType(server)} />
-                          <span className="text-[10px] font-bold uppercase tracking-wider text-text-dim">
-                            {getTransportType(server)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <Badge variant={isConnected ? "success" : "error"} dot>
-                      {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
-                    </Badge>
-                  </div>
-
-                  {/* OAuth auth badge */}
-                  <AuthBadge
-                    server={server}
-                    onAuthSuccess={() => serversQuery.refetch()}
-                  />
-
-                  {/* Transport detail */}
-                  <div className="text-xs text-text-dim font-mono truncate">
-                    {getTransportDetail(server)}
-                  </div>
-
-                  {/* Tools count */}
-                  <div className="flex items-center gap-2">
-                    <Wrench className="h-3.5 w-3.5 text-text-dim" />
-                    <span className="text-xs text-text-dim">
-                      {toolsCount > 0 ? t("mcp.tools_count", { count: toolsCount }) : t("mcp.no_tools")}
+          {/* Search + filter toolbar */}
+          {configured.length > 0 && (
+            <div className="flex flex-col sm:flex-row gap-3">
+              {/* Search */}
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-dim/50" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder={t("mcp.search_placeholder")}
+                  className="w-full rounded-xl border border-border-subtle bg-surface pl-10 pr-4 py-2.5 text-sm font-medium text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm"
+                />
+              </div>
+              {/* Status filter */}
+              <div className="flex gap-1 rounded-xl border border-border-subtle bg-surface p-1 shrink-0">
+                {([
+                  { value: "all" as const, label: t("mcp.filter_all"), count: configured.length },
+                  { value: "connected" as const, label: t("mcp.filter_connected"), count: connectedCount },
+                  { value: "disconnected" as const, label: t("mcp.filter_disconnected"), count: disconnectedCount },
+                ] as const).map(({ value, label, count }) => (
+                  <button
+                    key={value}
+                    onClick={() => setStatusFilter(value)}
+                    className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[10px] font-bold transition-colors ${
+                      statusFilter === value
+                        ? "bg-brand/10 text-brand shadow-sm"
+                        : "text-text-dim hover:text-text"
+                    }`}
+                  >
+                    <Filter className="h-3 w-3" />
+                    {label}
+                    <span className={`px-1 py-0.5 rounded-full text-[8px] font-bold ${
+                      statusFilter === value ? "bg-brand/20 text-brand" : "bg-border-subtle text-text-dim"
+                    }`}>
+                      {count}
                     </span>
-                  </div>
-                </div>
-
-                {/* Expand tools section */}
-                {toolsCount > 0 && (
-                  <>
-                    <button
-                      onClick={() => toggleTools(server.name)}
-                      className="flex items-center justify-center gap-1.5 py-2 border-t border-border-subtle text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
-                      aria-expanded={isExpanded}
-                      aria-label={isExpanded ? t("mcp.hide_tools") : t("mcp.show_tools")}
-                    >
-                      {isExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-                      {t("mcp.tools")}
-                    </button>
-                    {isExpanded && conn?.tools && (
-                      <div className="border-t border-border-subtle px-4 py-3 space-y-1.5 max-h-48 overflow-y-auto scrollbar-thin">
-                        {conn.tools.map((tool) => (
-                          <div key={tool.name} className="flex flex-col">
-                            <span className="text-xs font-bold text-text-main">{tool.name}</span>
-                            {tool.description && (
-                              <span className="text-[10px] text-text-dim leading-snug">{tool.description}</span>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </>
-                )}
-
-                {/* Actions */}
-                <div className="flex border-t border-border-subtle">
-                  <button
-                    onClick={() => openEdit(server)}
-                    className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors rounded-bl-xl sm:rounded-bl-2xl"
-                    aria-label={t("mcp.edit_server")}
-                  >
-                    <Settings className="h-3.5 w-3.5" />
-                    {t("common.edit")}
                   </button>
-                  <div className="w-px bg-border-subtle" />
-                  <button
-                    onClick={() => setDeletingServer(server.name)}
-                    className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-error hover:bg-error/5 transition-colors rounded-br-xl sm:rounded-br-2xl"
-                    aria-label={t("mcp.delete_server")}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    {t("common.delete")}
-                  </button>
-                </div>
-              </Card>
-            );
-          })}
-        </div>
-      )}
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Summary badges */}
+          {data && (
+            <div className="flex items-center gap-3 flex-wrap">
+              <Badge variant="default">{t("mcp.total_configured", { count: data.total_configured })}</Badge>
+              <Badge variant={data.total_connected > 0 ? "success" : "default"} dot>
+                {t("mcp.total_connected", { count: data.total_connected })}
+              </Badge>
+            </div>
+          )}
+
+          {/* Loading */}
+          {serversQuery.isLoading && <ListSkeleton rows={3} />}
+
+          {/* Empty */}
+          {!serversQuery.isLoading && configured.length === 0 && (
+            <EmptyState
+              icon={<Plug className="h-10 w-10" />}
+              title={t("mcp.empty")}
+              description={t("mcp.empty_desc")}
+              action={
+                <Button size="sm" leftIcon={<Package className="h-3.5 w-3.5" />} onClick={() => setTab("registry")}>
+                  {t("mcp.tab_registry")}
+                </Button>
+              }
+            />
+          )}
+
+          {/* No search results */}
+          {!serversQuery.isLoading && configured.length > 0 && filteredServers.length === 0 && (
+            <EmptyState
+              icon={<Search className="h-10 w-10" />}
+              title={t("mcp.no_results")}
+              description={t("mcp.no_results_desc")}
+            />
+          )}
+
+          {/* Server cards */}
+          {filteredServers.length > 0 && (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+              {filteredServers.map((server) => (
+                <ServerCard
+                  key={server.name}
+                  server={server}
+                  conn={connectedMap.get(server.name)}
+                  isExpanded={expandedTools.has(server.name)}
+                  onToggleTools={() => toggleTools(server.name)}
+                  onEdit={() => openEdit(server)}
+                  onDelete={() => setDeletingServer(server.name)}
+                  onAuthSuccess={() => serversQuery.refetch()}
+                  t={t}
+                />
+              ))}
+            </div>
+          )}
         </>
       )}
 
@@ -566,18 +716,18 @@ export function McpServersPage() {
               {registryTemplates.map((tpl) => {
                 const alreadyAdded = configuredNames.has(tpl.id);
                 return (
-                  <Card key={tpl.id} padding="none" className="flex flex-col">
-                    <div className="h-1 bg-gradient-to-r from-brand via-brand/60 to-brand/30" />
-                    <div className="p-4 flex flex-col gap-3 flex-1">
+                  <Card key={tpl.id} padding="none" className="flex flex-col overflow-hidden">
+                    <div className="h-1.5 bg-gradient-to-r from-brand via-brand/60 to-brand/30" />
+                    <div className="p-5 flex flex-col gap-3 flex-1">
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex items-center gap-2.5 min-w-0">
                           <div className="w-10 h-10 rounded-lg flex items-center justify-center text-xl bg-gradient-to-br from-brand/10 to-brand/5 border border-brand/20">
-                            {tpl.icon || "🔌"}
+                            {tpl.icon || <Plug className="w-5 h-5 text-brand" />}
                           </div>
                           <div className="min-w-0">
-                            <h3 className="text-sm font-bold truncate">{tpl.name}</h3>
+                            <h3 className="text-sm font-black truncate">{tpl.name}</h3>
                             {tpl.category && (
-                              <span className="text-[10px] font-bold uppercase tracking-wider text-text-dim">{tpl.category}</span>
+                              <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">{tpl.category}</span>
                             )}
                           </div>
                         </div>
@@ -669,9 +819,13 @@ export function McpServersPage() {
             </div>
           </div>
 
-          {/* stdio fields */}
+          {/* stdio fields — grouped */}
           {form.transportType === "stdio" && (
-            <>
+            <div className="rounded-xl border border-border-subtle p-4 space-y-4 bg-main/30">
+              <div className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-text-dim">
+                <Terminal className="h-3 w-3" />
+                {t("mcp.stdio_config")}
+              </div>
               <Input
                 label={t("mcp.command")}
                 value={form.command}
@@ -687,20 +841,41 @@ export function McpServersPage() {
                   onChange={(e) => updateField("args", e.target.value)}
                   placeholder={t("mcp.args_placeholder")}
                   rows={3}
-                  className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-medium text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
+                  className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-mono text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
                 />
               </div>
-            </>
+            </div>
           )}
 
-          {/* sse/http fields */}
+          {/* sse/http fields — grouped */}
           {(form.transportType === "sse" || form.transportType === "http") && (
-            <Input
-              label={t("mcp.url")}
-              value={form.url}
-              onChange={(e) => updateField("url", e.target.value)}
-              placeholder={t("mcp.url_placeholder")}
-            />
+            <div className="rounded-xl border border-border-subtle p-4 space-y-4 bg-main/30">
+              <div className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-text-dim">
+                {form.transportType === "sse" ? <Radio className="h-3 w-3" /> : <Globe className="h-3 w-3" />}
+                {form.transportType.toUpperCase()} {t("mcp.connection")}
+              </div>
+              <Input
+                label={t("mcp.url")}
+                value={form.url}
+                onChange={(e) => updateField("url", e.target.value)}
+                placeholder={t("mcp.url_placeholder")}
+              />
+              {form.url && !form.url.startsWith("http://") && !form.url.startsWith("https://") && (
+                <p className="text-[10px] text-warning font-bold">{t("mcp.url_hint")}</p>
+              )}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+                  {t("mcp.headers")}
+                </label>
+                <textarea
+                  value={form.headers}
+                  onChange={(e) => updateField("headers", e.target.value)}
+                  placeholder={t("mcp.headers_placeholder")}
+                  rows={2}
+                  className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-mono text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
+                />
+              </div>
+            </div>
           )}
 
           {/* Timeout */}
@@ -723,25 +898,9 @@ export function McpServersPage() {
               onChange={(e) => updateField("env", e.target.value)}
               placeholder={t("mcp.env_placeholder")}
               rows={2}
-              className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-medium font-mono text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
+              className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-mono text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
             />
           </div>
-
-          {/* Headers (only for sse/http) */}
-          {(form.transportType === "sse" || form.transportType === "http") && (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
-                {t("mcp.headers")}
-              </label>
-              <textarea
-                value={form.headers}
-                onChange={(e) => updateField("headers", e.target.value)}
-                placeholder={t("mcp.headers_placeholder")}
-                rows={2}
-                className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-medium font-mono text-text-main placeholder:text-text-dim/40 focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/10 hover:border-brand/20 transition-colors duration-200 shadow-sm resize-none"
-              />
-            </div>
-          )}
 
           {/* Actions */}
           <div className="flex gap-3 pt-2">


### PR DESCRIPTION
## Summary
- Redesign MCP servers page to match ProvidersPage/SkillsPage design language
- Add search and status filtering (All / Connected / Disconnected)
- Upgrade server cards with gradient top bars, stats grid, and better visual hierarchy
- Improve Add/Edit modal with grouped transport fields and URL validation hints
- Improve tools list with card-style items and fold-at-5 behavior
- Extract ServerCard component for cleaner code structure
- Add i18n keys for en and zh locales

## Test plan
- [x] `pnpm build` passes with no TypeScript errors
- [ ] Visual review: server cards show green/red gradient based on connection status
- [ ] Search filters by server name and transport detail
- [ ] Status filter buttons work correctly with counts
- [ ] Add/Edit modal groups stdio fields in bordered section
- [ ] Tools list folds at 5 items with "Show N more" button
- [ ] Registry tab unchanged and functional