### PR TITLE
fix(registry-sync): use fetch+reset instead of pull to handle detached HEAD

### DIFF
--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -269,13 +269,23 @@ fn git_clone_fallback(
     tracing::info!("Attempting git clone fallback");
 
     if registry_cache.join(".git").exists() {
-        // Already a git repo — try pull
+        // Already a git repo — fetch and reset to origin/main so that a
+        // detached HEAD or local branch can never stall the sync.
+        let fetch_ok = Command::new("git")
+            .args(["fetch", "--depth", "1", "-q", "origin", "main"])
+            .current_dir(registry_cache)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !fetch_ok {
+            return Err("git fetch origin main failed".into());
+        }
         let status = Command::new("git")
-            .args(["pull", "--ff-only", "-q"])
+            .args(["reset", "--hard", "origin/main", "-q"])
             .current_dir(registry_cache)
             .status()?;
         if !status.success() {
-            return Err(format!("git pull exited with {status}").into());
+            return Err(format!("git reset exited with {status}").into());
         }
     } else {
         // Clean slate


### PR DESCRIPTION
## Problem

`git pull --ff-only` in `git_clone_fallback` fails when the local registry cache HEAD is on a local branch (e.g. `fix/ollama-add-gemma4`) rather than tracking `origin/main`. The pull either errors out or does nothing, leaving the cache stale even though upstream has new commits.

## Fix

Replace with `git fetch --depth 1 origin main` + `git reset --hard origin/main`.

This is immune to local branch state — no matter whether HEAD is detached, on a feature branch, or behind/ahead of main, the working tree is always aligned to the latest `origin/main` after the two commands complete.