### PR TITLE
fix(dashboard): remove nested scroll container from skills page

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -739,7 +739,7 @@ export function SkillsPage() {
         ) : filteredMarketplace.length === 0 ? (
           <EmptyState title={t("skills.no_results")} description={search ? t("skills.try_different_search", { defaultValue: "Try a different search term." }) : t("skills.browse_unavailable", { defaultValue: "Browse is temporarily unavailable. Try searching above." })} icon={<Search className="h-6 w-6" />} />
         ) : (
-          <div className="overflow-y-auto max-h-[600px] pr-1">
+          <div>
             <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
               {filteredMarketplace.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
@@ -762,7 +762,7 @@ export function SkillsPage() {
         ) : filteredSkillhub.length === 0 ? (
           <EmptyState title={t("skills.no_results")} icon={<Search className="h-6 w-6" />} />
         ) : (
-          <div className="overflow-y-auto max-h-[600px] pr-1">
+          <div>
             <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
               {filteredSkillhub.map(s => (
                 <MarketplaceSkillCard key={s.slug} skill={s} pendingId={installingId}
@@ -780,7 +780,7 @@ export function SkillsPage() {
         ) : filteredFanghub.length === 0 ? (
           <EmptyState title={t("skills.no_results")} icon={<Zap className="h-6 w-6" />} />
         ) : (
-          <div className="overflow-y-auto max-h-[600px] pr-1">
+          <div>
           <div className="grid gap-2 sm:gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
             {filteredFanghub.map((skill: FangHubSkill) => (
               <FangHubSkillCard


### PR DESCRIPTION
## Summary
Remove `max-h-[600px] overflow-y-auto` from the three marketplace/skillhub/fanghub card grids. The outer dashboard layout already provides page-level scrolling, so this inner container created a nested scrollbar that wasted bottom screen space.

Fixes #2663

## Test plan
- [x] `pnpm build` passes
- [ ] Skills page marketplace/skillhub/fanghub tabs use full page height without nested scrollbar