### PR TITLE
fix(kernel): connect MCP servers immediately after dashboard add/update

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -3024,6 +3024,10 @@ pub async fn add_mcp_server(
         Err(_) => "saved_reload_failed",
     };
 
+    // Establish connection to the newly added server in the background.
+    let kernel = std::sync::Arc::clone(&state.kernel);
+    tokio::spawn(async move { kernel.connect_mcp_servers().await });
+
     state.kernel.audit().record(
         "system",
         librefang_runtime::audit::AuditAction::ConfigChange,
@@ -3123,6 +3127,11 @@ pub async fn update_mcp_server(
         }
         Err(_) => "saved_reload_failed",
     };
+
+    // Disconnect the old connection so connect_mcp_servers picks up the new config.
+    state.kernel.disconnect_mcp_server(&name).await;
+    let kernel = std::sync::Arc::clone(&state.kernel);
+    tokio::spawn(async move { kernel.connect_mcp_servers().await });
 
     state.kernel.audit().record(
         "system",

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8997,7 +8997,10 @@ system_prompt = "You are a helpful assistant."
     }
 
     /// Connect to all configured MCP servers and cache their tool definitions.
-    async fn connect_mcp_servers(self: &Arc<Self>) {
+    ///
+    /// Idempotent: servers that already have a live connection are skipped.
+    /// Called at boot and after hot-reload adds/updates MCP server config.
+    pub async fn connect_mcp_servers(self: &Arc<Self>) {
         use librefang_runtime::mcp::{McpConnection, McpServerConfig, McpTransport};
         use librefang_types::config::McpTransportEntry;
 
@@ -9008,6 +9011,14 @@ system_prompt = "You are a helpful assistant."
             .unwrap_or_default();
 
         for server_config in &servers {
+            // Skip servers that already have a live connection (idempotent).
+            {
+                let conns = self.mcp_connections.lock().await;
+                if conns.iter().any(|c| c.name() == server_config.name) {
+                    continue;
+                }
+            }
+
             let transport_entry = match &server_config.transport {
                 Some(t) => t,
                 None => {
@@ -9099,6 +9110,29 @@ system_prompt = "You are a helpful assistant."
                 self.mcp_connections.lock().await.len()
             );
         }
+    }
+
+    /// Disconnect an MCP server by name, removing it from the live connection list.
+    ///
+    /// The dropped `McpConnection` will shut down the underlying transport.
+    /// Returns `true` if a connection was found and removed.
+    pub async fn disconnect_mcp_server(&self, name: &str) -> bool {
+        let mut conns = self.mcp_connections.lock().await;
+        let before = conns.len();
+        conns.retain(|c| c.name() != name);
+        let removed = conns.len() < before;
+        if removed {
+            // Remove cached tools from this server and bump generation.
+            // MCP tools are prefixed: mcp_{normalized_server_name}_{tool_name}
+            let prefix = format!("mcp_{}_", librefang_runtime::mcp::normalize_name(name));
+            if let Ok(mut tools) = self.mcp_tools.lock() {
+                tools.retain(|t| !t.name.starts_with(&prefix));
+            }
+            self.mcp_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            info!(server = %name, "MCP server disconnected");
+        }
+        removed
     }
 
     /// Watch for OAuth completion by polling the vault for a stored access token.

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1092,6 +1092,12 @@ impl LlmDriver for ClaudeCodeDriver {
 
 /// Check if the Claude Code CLI is available.
 pub fn claude_code_available() -> bool {
+    if super::is_proxied_via_env(
+        &["ANTHROPIC_BASE_URL", "ANTHROPIC_API_URL"],
+        &["api.anthropic.com"],
+    ) {
+        return false;
+    }
     ClaudeCodeDriver::detect().is_some() || claude_credentials_exist()
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -228,6 +228,9 @@ impl LlmDriver for CodexCliDriver {
 
 /// Check if the Codex CLI is available.
 pub fn codex_cli_available() -> bool {
+    if super::is_proxied_via_env(&["OPENAI_BASE_URL", "OPENAI_API_BASE"], &["api.openai.com"]) {
+        return false;
+    }
     CodexCliDriver::detect().is_some() || codex_cli_credentials_exist()
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -211,6 +211,15 @@ impl LlmDriver for GeminiCliDriver {
 
 /// Check if the Gemini CLI is available.
 pub fn gemini_cli_available() -> bool {
+    if super::is_proxied_via_env(
+        &["GEMINI_API_BASE", "GOOGLE_AI_BASE_URL"],
+        &[
+            "generativelanguage.googleapis.com",
+            "aiplatform.googleapis.com",
+        ],
+    ) {
+        return false;
+    }
     GeminiCliDriver::detect().is_some() || gemini_cli_credentials_exist()
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -933,6 +933,30 @@ pub fn cli_provider_available(name: &str) -> bool {
     }
 }
 
+/// Check whether any of the given env vars redirect traffic away from official
+/// API hosts. Returns `true` when a proxy/non-official endpoint is detected.
+///
+/// CLI providers inherit environment variables (e.g. `ANTHROPIC_BASE_URL`)
+/// that can silently redirect all requests to a third-party proxy. When that
+/// happens the provider should not appear as "configured".
+///
+/// `env_vars` — env var names to check (first non-empty wins).
+/// `official_hosts` — substrings that identify the official API (e.g.
+/// `"api.anthropic.com"`). If the env var value contains none of them, the
+/// provider is considered proxied.
+pub fn is_proxied_via_env(env_vars: &[&str], official_hosts: &[&str]) -> bool {
+    for var in env_vars {
+        if let Ok(val) = std::env::var(var) {
+            let val = val.trim().trim_end_matches('/').to_lowercase();
+            if val.is_empty() {
+                continue;
+            }
+            return !official_hosts.iter().any(|host| val.contains(host));
+        }
+    }
+    false
+}
+
 /// Check if a provider name refers to a CLI-subprocess-based provider.
 pub fn is_cli_provider(name: &str) -> bool {
     matches!(


### PR DESCRIPTION
## Summary

Three related MCP fixes:

1. **MCP servers connect immediately after dashboard add/update** — no daemon restart needed
2. **CLI providers behind a proxy are no longer detected as "Configured"** — prevents 401 errors from LiteLLM/other proxies
3. **Env var expansion in MCP stdio args** — `$HOME`, `$USER` etc. expanded natively, no `sh -c` wrapper needed

## Bug 1: MCP servers not connecting after add

`connect_mcp_servers()` was only called at daemon boot. Adding a server via dashboard wrote config but never established the connection.

**Fix:** Make `connect_mcp_servers()` public + idempotent, add `disconnect_mcp_server()`, spawn reconnect from route handlers.

## Bug 2: CLI providers behind proxy detected as configured

CLI providers inherit `ANTHROPIC_BASE_URL` etc. which can redirect to a proxy. Provider still shows as "Configured" and fails with 401.

**Fix:** `is_proxied_via_env()` check — if base URL doesn't point to official API, treat as not installed.

## Bug 3: MCP templates can't use $HOME in args

Templates used `sh -c` to expand `$HOME`, but the shell-interpreter security check blocks `sh` as command.

**Fix:** `expand_env_vars()` in MCP connection code expands `$VAR` / `${VAR}` in stdio args. Registry template fix in librefang/librefang-registry#61.

## Files

- `crates/librefang-kernel/src/kernel/mod.rs` — connect/disconnect MCP
- `crates/librefang-api/src/routes/skills.rs` — spawn reconnect after add/update
- `crates/librefang-llm-drivers/src/drivers/mod.rs` — is_proxied_via_env()
- `crates/librefang-llm-drivers/src/drivers/{claude_code,codex_cli,gemini_cli}.rs` — proxy checks
- `crates/librefang-runtime-mcp/src/lib.rs` — expand_env_vars() in stdio args

## Test plan

- [x] `cargo build --workspace --lib` passes
- [ ] Add MCP server via dashboard → connects immediately
- [ ] `ANTHROPIC_BASE_URL=https://proxy.example.com` → claude-code not shown
- [ ] Template with `$HOME` in args → expanded correctly at connect time