### PR TITLE
fix(drivers): classify Gemini CLI quota exhaustion as rate-limit, not auth error

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -174,10 +174,23 @@ impl LlmDriver for GeminiCliDriver {
             let detail = if !stderr.is_empty() { &stderr } else { &stdout };
             let code = output.status.code().unwrap_or(1);
 
-            let message = if detail.contains("not authenticated")
-                || detail.contains("auth")
-                || detail.contains("login")
-                || detail.contains("credentials")
+            // Check quota/rate-limit BEFORE auth — Gemini CLI's error output
+            // for quota exhaustion contains "credentials" (from "Loaded cached
+            // credentials") which would false-positive the auth check.
+            let lower = detail.to_lowercase();
+            if lower.contains("exhausted your capacity")
+                || lower.contains("quota")
+                || lower.contains("rate limit")
+                || lower.contains("too many requests")
+                || lower.contains("429")
+            {
+                return Err(LlmError::RateLimited {
+                    retry_after_ms: 60_000,
+                    message: Some(format!("Gemini quota exhausted: {detail}")),
+                });
+            }
+
+            let message = if lower.contains("not authenticated") || lower.contains("login required")
             {
                 format!("Gemini CLI is not authenticated. Run: gemini auth\nDetail: {detail}")
             } else {


### PR DESCRIPTION
## Summary

Gemini CLI quota exhaustion (429) was misclassified as an auth error, showing "Gemini CLI is not authenticated. Run: gemini auth" when the actual problem was "You have exhausted your capacity on this model."

## Root cause

The error classification checked `detail.contains("credentials")` for auth, but Gemini CLI's quota error output includes `"Loaded cached credentials"` in its log, triggering a false positive.

## Fix

Check quota/rate-limit patterns (`exhausted your capacity`, `quota`, `429`, etc.) **before** auth patterns. Narrowed auth check to `"not authenticated"` and `"login required"` only.

Returns `LlmError::RateLimited` with a 60s retry instead of a misleading auth error.

## Files

- `crates/librefang-llm-drivers/src/drivers/gemini_cli.rs`