### PR TITLE
fix(registry-sync): remove local files deleted from upstream registry

### DIFF
--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -390,8 +390,29 @@ fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
         }
     }
 
-    if synced > 0 || updated > 0 || skipped > 0 {
-        tracing::info!("{label} synced ({synced} new, {updated} updated, {skipped} unchanged)");
+    // Remove local files that no longer exist in the registry source.
+    // This cleans up defunct providers/integrations after upstream pruning.
+    let mut removed = 0usize;
+    if let Ok(dest_entries) = std::fs::read_dir(dest_dir) {
+        for entry in dest_entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) if n.ends_with(".toml") => n.to_string(),
+                _ => continue,
+            };
+            if !src_dir.join(&name).exists() {
+                if std::fs::remove_file(&path).is_ok() {
+                    removed += 1;
+                }
+            }
+        }
+    }
+
+    if synced > 0 || updated > 0 || removed > 0 || skipped > 0 {
+        tracing::info!("{label} synced ({synced} new, {updated} updated, {removed} removed, {skipped} unchanged)");
     }
 }
 


### PR DESCRIPTION
## Summary

Registry sync now removes local `.toml` files that no longer exist in the upstream registry, cleaning up defunct providers and integrations automatically.

## The bug

`sync_flat_files()` only added new files and updated changed ones, but never deleted files removed from the registry. After the registry cleanup in librefang-registry#58 (which removed 26 defunct providers like morph, writer, reka, liquid, etc.), those provider files persisted locally and their models kept showing up in the dashboard model switcher.

## The fix

After the existing sync loop, scan the destination directory and remove any `.toml` files that don't exist in the source (registry cache). Adds a `removed` counter to the log line.

## Files

- `crates/librefang-runtime/src/registry_sync.rs`