### PR TITLE
fix(catalog-sync): remove stale provider files from cache after sync

### DIFF
--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -126,6 +126,22 @@ pub async fn sync_catalog_to(
         }
     }
 
+    // Remove cached provider files that no longer exist in the upstream repo
+    if repo_providers.is_dir() {
+        if let Ok(cached_entries) = std::fs::read_dir(&providers_dir) {
+            for entry in cached_entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "toml")
+                    && !repo_providers.join(entry.file_name()).exists()
+                {
+                    if std::fs::remove_file(&path).is_ok() {
+                        tracing::debug!(file = %path.display(), "removed stale catalog provider");
+                    }
+                }
+            }
+        }
+    }
+
     // Copy aliases.toml if present
     let aliases_src = repo_dir.join("aliases.toml");
     if aliases_src.is_file() {
@@ -176,6 +192,7 @@ async fn sync_catalog_http(
 
     let mut downloaded = 0usize;
     let mut models_count = 0usize;
+    let mut upstream_provider_files = std::collections::HashSet::new();
 
     if let Some(items) = tree["tree"].as_array() {
         for item in items {
@@ -184,6 +201,11 @@ async fn sync_catalog_http(
                 && ((path.starts_with("providers/") && path.ends_with(".toml"))
                     || path == "aliases.toml")
             {
+                if path.starts_with("providers/") {
+                    if let Some(fname) = path.strip_prefix("providers/") {
+                        upstream_provider_files.insert(fname.to_string());
+                    }
+                }
                 let raw_url = if mirror.is_empty() {
                     format!("https://raw.githubusercontent.com/{CATALOG_REPO}/main/{path}")
                 } else {
@@ -210,6 +232,23 @@ async fn sync_catalog_http(
                     }
                     _ => {
                         tracing::warn!("Failed to download catalog file: {path}");
+                    }
+                }
+            }
+        }
+    }
+
+    // Remove cached provider files that no longer exist upstream
+    let providers_dir = cache_dir.join("providers");
+    if !upstream_provider_files.is_empty() {
+        if let Ok(cached_entries) = std::fs::read_dir(&providers_dir) {
+            for entry in cached_entries.flatten() {
+                let path = entry.path();
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.ends_with(".toml") && !upstream_provider_files.contains(name) {
+                        if std::fs::remove_file(&path).is_ok() {
+                            tracing::debug!(file = %path.display(), "removed stale catalog provider");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Catalog sync (`catalog_sync.rs`) copies provider TOML files from the upstream registry to `~/.librefang/cache/catalog/providers/` but never removed files deleted upstream
- This caused defunct providers (e.g. morph, lemonade, reka) to persist in the model switcher indefinitely — even after PR #2671 fixed the same issue in `registry_sync.rs`
- Adds a removal pass after both the **git** and **HTTP fallback** sync paths that deletes cached `.toml` files not present in the upstream source

## Test plan
- [ ] Start daemon, verify model switcher no longer shows defunct providers (morph, lemonade, etc.)
- [ ] Trigger catalog sync (`/api/catalog/sync`) and confirm stale files are removed from `~/.librefang/cache/catalog/providers/`
- [ ] Verify HTTP fallback path also cleans up stale files (disable git to test)