### PR TITLE
fix(catalog): don't auto-detect GITHUB_TOKEN providers as Configured

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -201,8 +201,19 @@ impl ModelCatalog {
                 continue;
             }
 
-            // Primary: check the provider's declared env var (non-empty after trim)
-            let has_key = std::env::var(&provider.api_key_env).is_ok_and(|v| !v.trim().is_empty());
+            // Primary: check the provider's declared env var (non-empty after trim).
+            //
+            // GITHUB_TOKEN is a generic PAT shared by multiple services (Copilot,
+            // GitHub Models, git operations, CI/CD). Its mere presence does NOT
+            // prove the user has access to a specific provider, so we do not
+            // auto-detect it as "Configured".  Users who actually want these
+            // providers will authenticate via the dashboard OAuth flow, which
+            // validates access before marking the provider as configured.
+            let has_key = if provider.api_key_env == "GITHUB_TOKEN" {
+                false
+            } else {
+                std::env::var(&provider.api_key_env).is_ok_and(|v| !v.trim().is_empty())
+            };
 
             // If the user explicitly removed this provider's key, skip
             // fallback/CLI detection — only honour the primary env var.


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` is a generic GitHub PAT used for many purposes (git operations, GitHub API, CI/CD). Multiple providers (github-copilot, microsoft) use it as their `api_key_env`
- Having a `GITHUB_TOKEN` does NOT mean the user has a Copilot subscription or GitHub Models access
- Skip auto-detection in `detect_auth()` for providers whose `api_key_env` is `GITHUB_TOKEN` — they won't appear as "Configured" in the model switcher just because the user has a GitHub token
- Users who actually want these providers authenticate via the dashboard OAuth flow, which validates real access

## Test plan
- [ ] Set `GITHUB_TOKEN` env var, verify github-copilot and microsoft providers show as "Missing" (not "Configured")
- [ ] Complete Copilot OAuth flow via dashboard, verify provider becomes "Configured" after successful token exchange
- [ ] Unset `GITHUB_TOKEN`, verify no regression for other providers