### PR TITLE
fix(dashboard): render thinking trace as markdown

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -671,8 +671,8 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
               />
             </button>
             {thinkingExpanded && (
-              <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim whitespace-pre-wrap break-words">
-                {message.thinking}
+              <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim break-words prose-sm">
+                <MarkdownContent content={message.thinking ?? ""} />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Thinking/reasoning trace was rendered as plain text with `whitespace-pre-wrap`, showing raw markdown source (`**bold**`, `- lists`, `` `code` ``) instead of formatted output
- Now uses `MarkdownContent` component for proper rendering, consistent with how message content is displayed

## Test plan
- [ ] Enable deep thinking, send a message, verify thinking trace renders markdown properly (bold, lists, code blocks, etc.)
- [ ] Verify thinking collapse/expand still works
- [ ] Verify streaming thinking deltas render correctly as they arrive