### PR TITLE
fix(dashboard): show 'service not running' for offline local providers

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1516,6 +1516,7 @@
     "ws_connected": "WS",
     "ws_streaming": "Streaming",
     "auth_missing": "API key for provider \"{{provider}}\" is not configured. Please set it in Settings > Providers before chatting.",
+    "provider_offline": "Local provider \"{{provider}}\" is not running. Please start the service first.",
     "switch_model": "Switch Model",
     "search_models": "Search models...",
     "loading_models": "Loading…",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1491,6 +1491,7 @@
     "ws_connected": "WS",
     "ws_streaming": "流式",
     "auth_missing": "供应商 \"{{provider}}\" 的 API Key 未配置，请在 设置 > 供应商 中设置后再对话。",
+    "provider_offline": "本地供应商 \"{{provider}}\" 未运行，请先启动服务。",
     "switch_model": "切换模型",
     "search_models": "搜索模型...",
     "loading_models": "加载中…",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -803,7 +803,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 });
 
 // Input box - with shortcut hints
-function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, supportsThinking, sttAvailable }: { onSend: (msg: string) => void; disabled: boolean; placeholder: string; authMissing?: boolean; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
+function ChatInput({ onSend, disabled, placeholder, authMissing, authStatus, providerName, supportsThinking, sttAvailable }: { onSend: (msg: string) => void; disabled: boolean; placeholder: string; authMissing?: boolean; authStatus?: string; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -912,7 +912,9 @@ function ChatInput({ onSend, disabled, placeholder, authMissing, providerName, s
       {authMissing && (
         <div className="flex items-center gap-2 rounded-xl border border-warning/30 bg-warning/5 px-4 py-2.5 text-sm text-warning">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
-          <span>{t("chat.auth_missing", { provider: providerName || "unknown" })}</span>
+          <span>{authStatus === "local_offline"
+            ? t("chat.provider_offline", { provider: providerName || "unknown" })
+            : t("chat.auth_missing", { provider: providerName || "unknown" })}</span>
         </div>
       )}
       {/* Slash command autocomplete */}
@@ -2055,6 +2057,7 @@ export function ChatPage() {
               disabled={isLoading}
               placeholder={isLoading ? t("chat.generating") : selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
               authMissing={isAuthUnavailable(selectedAgent?.auth_status)}
+              authStatus={selectedAgent?.auth_status}
               providerName={selectedAgent?.model_provider}
               supportsThinking={selectedAgent?.supports_thinking}
               sttAvailable={sttAvailable}


### PR DESCRIPTION
## Summary
- When a local provider (Ollama, vLLM, etc.) is not running, the chat input showed "API key not configured" — misleading for providers that don't need API keys
- Now distinguishes `local_offline` auth status and shows "provider is not running, please start the service first"
- Added i18n translations for both en and zh locales

## Test plan
- [ ] Stop Ollama, verify chat shows "本地供应商未运行" / "provider is not running" instead of "API Key 未配置"
- [ ] Start Ollama, verify warning disappears and chat works normally
- [ ] Verify other auth statuses (missing, configured, etc.) still show correct messages