### PR TITLE
fix(dashboard): fix thinking trace not rendering (children prop)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -672,7 +672,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
             </button>
             {thinkingExpanded && (
               <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim break-words prose-sm">
-                <MarkdownContent content={message.thinking ?? ""} />
+                <MarkdownContent>{message.thinking ?? ""}</MarkdownContent>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- PR #2674 broke thinking trace display by passing content as a named `content` prop, but `MarkdownContent` expects `children`
- Fix: `<MarkdownContent>{text}</MarkdownContent>`

## Test plan
- [ ] Send message with thinking enabled, verify thinking trace displays and renders markdown