### PR TITLE
fix(agent-loop): instruct model to think in user's language

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1762,6 +1762,14 @@ fn build_prompt_setup(ctx: PromptSetupContext<'_>) -> PromptSetup {
         None
     };
 
+    // When extended thinking is enabled, instruct the model to think in the
+    // same language as the user's message so the reasoning trace is readable.
+    if ctx.manifest.thinking.is_some() {
+        system_prompt.push_str(
+            "\n\nIMPORTANT: Always use the same language as the user's message for both your thinking process and your response.",
+        );
+    }
+
     PromptSetup {
         system_prompt,
         memory_context_msg,

--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -133,10 +133,9 @@ pub async fn sync_catalog_to(
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "toml")
                     && !repo_providers.join(entry.file_name()).exists()
+                    && std::fs::remove_file(&path).is_ok()
                 {
-                    if std::fs::remove_file(&path).is_ok() {
-                        tracing::debug!(file = %path.display(), "removed stale catalog provider");
-                    }
+                    tracing::debug!(file = %path.display(), "removed stale catalog provider");
                 }
             }
         }
@@ -245,10 +244,11 @@ async fn sync_catalog_http(
             for entry in cached_entries.flatten() {
                 let path = entry.path();
                 if let Some(name) = entry.file_name().to_str() {
-                    if name.ends_with(".toml") && !upstream_provider_files.contains(name) {
-                        if std::fs::remove_file(&path).is_ok() {
-                            tracing::debug!(file = %path.display(), "removed stale catalog provider");
-                        }
+                    if name.ends_with(".toml")
+                        && !upstream_provider_files.contains(name)
+                        && std::fs::remove_file(&path).is_ok()
+                    {
+                        tracing::debug!(file = %path.display(), "removed stale catalog provider");
                     }
                 }
             }

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -403,10 +403,8 @@ fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
                 Some(n) if n.ends_with(".toml") => n.to_string(),
                 _ => continue,
             };
-            if !src_dir.join(&name).exists() {
-                if std::fs::remove_file(&path).is_ok() {
-                    removed += 1;
-                }
+            if !src_dir.join(&name).exists() && std::fs::remove_file(&path).is_ok() {
+                removed += 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- When extended thinking is enabled, the model's reasoning trace defaults to English regardless of the user's language
- Appends a system prompt instruction telling the model to match the user's language for both thinking and response
- Only injected when thinking is enabled, no impact on normal conversations

## Test plan
- [ ] Send Chinese message with thinking enabled, verify thinking trace is in Chinese
- [ ] Send English message, verify thinking trace is in English
- [ ] Verify no impact when thinking is disabled