### PR TITLE
fix(agent-loop): apply thinking language instruction unconditionally

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1762,13 +1762,14 @@ fn build_prompt_setup(ctx: PromptSetupContext<'_>) -> PromptSetup {
         None
     };
 
-    // When extended thinking is enabled, instruct the model to think in the
-    // same language as the user's message so the reasoning trace is readable.
-    if ctx.manifest.thinking.is_some() {
-        system_prompt.push_str(
-            "\n\nIMPORTANT: Always use the same language as the user's message for both your thinking process and your response.",
-        );
-    }
+    // Instruct the model to match the user's language for both thinking and
+    // response. Applied unconditionally so it covers models that generate
+    // reasoning traces without an explicit thinking config (e.g. Gemma4,
+    // Qwen3 via Ollama). Models that cannot follow this instruction are
+    // unaffected.
+    system_prompt.push_str(
+        "\n\nIMPORTANT: Always use the same language as the user's message for both your thinking process and your response.",
+    );
 
     PromptSetup {
         system_prompt,


### PR DESCRIPTION
## Summary

- #2680 added a language instruction to the system prompt, but only when `manifest.thinking.is_some()`
- Models like Gemma4 and Qwen3 via Ollama generate reasoning traces inherently (returned in the `reasoning` field) without needing an explicit `[thinking]` config — so `manifest.thinking` is always `None` for these users, and the instruction was never injected
- Remove the condition so the instruction is unconditional: models that can follow it will match the user's language; models whose reasoning is model-internal (e.g. Gemma4) are unaffected

## Root cause

Ollama-hosted models expose thinking via a separate `reasoning` response field that the OpenAI driver captures regardless of `request.thinking`. The `manifest.thinking.is_some()` guard in `build_prompt_setup` therefore never fired for these models.

## Test plan

- [ ] Send a Chinese message with Gemma4 via Ollama — verify the instruction is now present in the system prompt (can confirm via debug logs)
- [ ] Send a Chinese message with Claude + thinking enabled — verify thinking trace is more likely to be in Chinese
- [ ] Send an English message — verify response remains in English
- [ ] Verify no regression for agents without any thinking config