### PR TITLE
fix(config): tmux_enabled default, config_ref guard, dashboard model cascading

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -22,7 +22,7 @@ const CATEGORY_SECTIONS: Record<string, string[]> = {
   memory: ["memory", "proactive_memory"],
   tools: ["web", "browser", "links", "media", "tts", "canvas"],
   channels: ["channels", "broadcast", "auto_reply"],
-  security: ["approval", "exec_policy", "vault", "oauth", "external_auth"],
+  security: ["approval", "exec_policy", "vault", "oauth", "external_auth", "terminal"],
   network: ["network", "a2a", "pairing"],
   infra: ["docker", "extensions", "session", "queue", "webhook_triggers", "vertex_ai"],
 };
@@ -338,9 +338,29 @@ export function ConfigPage({ category }: { category: string }) {
   const handleFieldChange = useCallback(
     (sectionKey: string, fieldKey: string, value: unknown, rootLevel?: boolean) => {
       const path = rootLevel ? fieldKey : `${sectionKey}.${fieldKey}`;
-      setPendingChanges((p) => ({ ...p, [path]: value }));
+      setPendingChanges((p) => {
+        const next = { ...p, [path]: value };
+        // Cascading: when provider changes in default_model, clear model if
+        // the current selection doesn't belong to the new provider.
+        if (sectionKey === "default_model" && fieldKey === "provider" && value) {
+          const modelPath = "default_model.model";
+          const currentModel = modelPath in p ? p[modelPath] : getNestedValue(configQuery.data ?? {}, "default_model", "model");
+          const modelOptions = (schemaQuery.data?.sections?.default_model?.fields?.model as ConfigFieldSchema)?.options;
+          if (modelOptions && currentModel) {
+            const modelBelongsToProvider = modelOptions.some((o: unknown) =>
+              typeof o === "object" && o !== null && "id" in o && "provider" in o
+              && (o as { id: string }).id === String(currentModel)
+              && (o as { provider: string }).provider === String(value)
+            );
+            if (!modelBelongsToProvider) {
+              next[modelPath] = null;
+            }
+          }
+        }
+        return next;
+      });
     },
-    []
+    [configQuery.data, schemaQuery.data]
   );
 
   const saveMutation = useMutation({
@@ -643,7 +663,7 @@ export function ConfigPage({ category }: { category: string }) {
               )}
               <div className="divide-y divide-border-subtle/30">
                 {fieldsToShow.map(([fieldKey, fieldSchema]) => {
-                  const { type: fieldType, options, min, max, step } = resolveFieldType(fieldSchema);
+                  const { type: fieldType, options: rawOptions, min, max, step } = resolveFieldType(fieldSchema);
                   const path = sec.root_level ? fieldKey : `${sKey}.${fieldKey}`;
                   const currentValue = path in pendingChanges
                     ? pendingChanges[path]
@@ -653,6 +673,24 @@ export function ConfigPage({ category }: { category: string }) {
                   const statusForField = saveStatus[path] ?? null;
                   const fieldDesc = t(`config.desc_${fieldKey}`, "");
                   const fieldLabel = t(`config.fld_${fieldKey}`, fieldLabelFallback(fieldKey));
+
+                  // Cascading filter: when editing model in default_model,
+                  // only show models matching the selected provider.
+                  let options = rawOptions;
+                  if (sKey === "default_model" && fieldKey === "model" && rawOptions) {
+                    const providerPath = "default_model.provider";
+                    const selectedProvider = providerPath in pendingChanges
+                      ? String(pendingChanges[providerPath] ?? "")
+                      : String(getNestedValue(config, "default_model", "provider") ?? "");
+                    if (selectedProvider) {
+                      options = rawOptions.filter((o) => {
+                        if (typeof o === "object" && o !== null && "provider" in o) {
+                          return (o as { provider: string }).provider === selectedProvider;
+                        }
+                        return true;
+                      });
+                    }
+                  }
 
                   return (
                     <div key={fieldKey} className="flex items-start gap-4 px-5 py-3 group">

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1791,6 +1791,16 @@ pub async fn config_schema(State(state): State<Arc<AppState>>) -> impl IntoRespo
         "audience": "string",
         "session_ttl_secs": { "type": "number", "min": 60, "max": 2592000, "step": 60 }
     }});
+    sec!("terminal", { "fields": {
+        "enabled": "boolean",
+        "allow_remote": "boolean",
+        "require_proxy_headers": "boolean",
+        "allow_unauthenticated_remote": "boolean",
+        "allowed_origins": "string[]",
+        "tmux_enabled": "boolean",
+        "max_windows": { "type": "number", "min": 1, "max": 64, "step": 1 },
+        "tmux_binary_path": "string"
+    }});
 
     Json(serde_json::json!({ "sections": serde_json::Value::Object(sections) }))
 }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1223,21 +1223,23 @@ pub async fn run_daemon(
     }
 
     // Clean up tmux session so child shell processes don't linger after shutdown.
-    {
+    // Read config fields and drop the Guard before any `.await`.
+    let (tmux_cleanup_enabled, tmux_cleanup_path) = {
         let cfg = kernel.config_ref();
-        if cfg.terminal.tmux_enabled {
-            let tmux_path = std::path::PathBuf::from(
-                cfg.terminal.tmux_binary_path.as_deref().unwrap_or("tmux"),
-            );
-            let ctrl = crate::terminal_tmux::TmuxController::new(
-                tmux_path,
-                crate::terminal_tmux::DEFAULT_TMUX_SESSION_NAME.to_string(),
-            );
-            if let Err(e) = ctrl.kill_session().await {
-                tracing::debug!("tmux session cleanup: {e}");
-            } else {
-                info!("tmux session cleaned up");
-            }
+        (
+            cfg.terminal.tmux_enabled,
+            std::path::PathBuf::from(cfg.terminal.tmux_binary_path.as_deref().unwrap_or("tmux")),
+        )
+    };
+    if tmux_cleanup_enabled {
+        let ctrl = crate::terminal_tmux::TmuxController::new(
+            tmux_cleanup_path,
+            crate::terminal_tmux::DEFAULT_TMUX_SESSION_NAME.to_string(),
+        );
+        if let Err(e) = ctrl.kill_session().await {
+            tracing::debug!("tmux session cleanup: {e}");
+        } else {
+            info!("tmux session cleaned up");
         }
     }
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5893,7 +5893,7 @@ fn default_terminal_enabled() -> bool {
 }
 
 fn default_tmux_enabled() -> bool {
-    false
+    true
 }
 
 fn default_max_windows() -> u32 {
@@ -5908,7 +5908,7 @@ impl Default for TerminalConfig {
             allow_remote: false,
             require_proxy_headers: false,
             allow_unauthenticated_remote: false,
-            tmux_enabled: false,
+            tmux_enabled: true,
             max_windows: 16,
             tmux_binary_path: None,
         }
@@ -6169,7 +6169,7 @@ max_tokens_per_hour = 500000
     #[test]
     fn test_terminal_config_tmux_defaults() {
         let tc = TerminalConfig::default();
-        assert!(!tc.tmux_enabled, "tmux_enabled should default to false");
+        assert!(tc.tmux_enabled, "tmux_enabled should default to true");
         assert_eq!(tc.max_windows, 16, "max_windows should default to 16");
         assert!(
             tc.tmux_binary_path.is_none(),
@@ -6180,7 +6180,7 @@ max_tokens_per_hour = 500000
     #[test]
     fn test_terminal_config_empty_toml_uses_defaults() {
         let tc: TerminalConfig = toml::from_str("").unwrap();
-        assert!(!tc.tmux_enabled);
+        assert!(tc.tmux_enabled);
         assert_eq!(tc.max_windows, 16);
         assert!(tc.tmux_binary_path.is_none());
     }


### PR DESCRIPTION
## Summary

Follow-up fixes for #2651 (tmux multi-window terminal):

- **`tmux_enabled` default → `true`**: Code defaulted to `false` but docs said `true`. Changed code to match docs — tmux tabs enabled by default when binary is available, users can disable via `config.toml`
- **`config_ref()` guard across `.await`**: Shutdown cleanup held the `arc_swap::Guard` across an async call. Restructured to read config fields and drop the guard before `.await`, matching the established pattern in route handlers
- **Dashboard terminal config**: Added `[terminal]` section to the config schema and ConfigPage (under Security category) so users can toggle `tmux_enabled`, `max_windows`, etc. from the UI
- **Model/provider cascading**: `default_model` section now filters the model dropdown by selected provider. Changing provider auto-clears model if it doesn't belong to the new provider

## Testing

- [x] `cargo build --workspace --lib` passes
- [x] `cargo test -p librefang-types -- terminal` passes (4/4)
- [x] `cargo test -p librefang-api` passes
- [x] `cargo clippy -p librefang-api -p librefang-types --all-targets -- -D warnings` zero warnings