### PR TITLE
fix(mcp): send empty object for no-arg tools, exclude paths from taint (#2677)

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1041,11 +1041,10 @@ impl McpConnection {
                 };
 
                 let mut params = rmcp::model::CallToolRequestParams::new(raw_name.clone());
-                if let Some(obj) = arguments.as_object() {
-                    if !obj.is_empty() {
-                        params.arguments = Some(obj.clone());
-                    }
-                }
+                // Always send an object — MCP spec requires `arguments` to
+                // be an object, and some servers (e.g. filesystem) reject
+                // `undefined`/`null` even for zero-parameter tools.
+                params.arguments = Some(arguments.as_object().cloned().unwrap_or_default());
 
                 let timeout = std::time::Duration::from_secs(self.config.timeout_secs);
                 let result: rmcp::model::CallToolResult =

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -276,7 +276,22 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
         // API tokens never embed dates. This prevents false positives on
         // MCP session handles of the form `tab-2026-04-16-<uuid-parts>`.
         let has_date_component = date_component_regex().is_match(trimmed);
-        let looks_opaque = trimmed.len() >= 32 && charset_ok && mixed_enough && !has_date_component;
+        // File paths (absolute or relative with directory separators)
+        // are structured identifiers, not credentials. Exclude strings
+        // that look like paths: start with `/` or `C:\`, or contain
+        // multiple `/` segments with a file extension at the end.
+        let looks_like_path = trimmed.starts_with('/')
+            || trimmed.starts_with("C:\\")
+            || trimmed.starts_with("D:\\")
+            || (trimmed.contains('/')
+                && trimmed
+                    .rfind('.')
+                    .is_some_and(|dot| dot > trimmed.rfind('/').unwrap_or(0)));
+        let looks_opaque = trimmed.len() >= 32
+            && charset_ok
+            && mixed_enough
+            && !has_date_component
+            && !looks_like_path;
         let well_known = trimmed.starts_with("sk-")
             || trimmed.starts_with("ghp_")
             || trimmed.starts_with("github_pat_")

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -281,8 +281,10 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
         // that look like paths: start with `/` or `C:\`, or contain
         // multiple `/` segments with a file extension at the end.
         let looks_like_path = trimmed.starts_with('/')
-            || trimmed.starts_with("C:\\")
-            || trimmed.starts_with("D:\\")
+            || (trimmed.len() >= 3
+                && trimmed.as_bytes()[1] == b':'
+                && trimmed.as_bytes()[2] == b'\\')
+            || trimmed.starts_with("\\\\")
             || (trimmed.contains('/')
                 && trimmed
                     .rfind('.')


### PR DESCRIPTION
Fixes #2677

## Summary
Two fixes for MCP filesystem failures:

1. **Empty arguments → `{}`**: When the LLM calls a zero-parameter MCP tool (e.g. `list_allowed_directories`), the arguments were sent as `undefined`/`null`. MCP spec requires an object, so servers reject with "expected object, received undefined". Now always sends `{}`.

2. **File paths excluded from taint**: The opaque-token heuristic flagged long file paths (≥32 chars with mixed letters+digits) as credentials. Paths like `/mnt/obsidian/CS/logs/2026-04-13-asterisk-AE1.md` would trigger `taint violation: sensitive value in MCP argument '$.path'`. Now excludes strings that look like file paths (start with `/`, `C:\`, `D:\`, or contain `/` with a file extension).

## Test plan
- [ ] Call `list_allowed_directories` (no args) — should return directory list instead of "expected object" error
- [ ] Call `read_file` with a long path — should not trigger taint violation
- [ ] Existing taint tests pass (18/18)
- [ ] Real API keys still blocked by taint scanner