### PR TITLE
fix(terminal): skip origin validation for authenticated requests

### DIFF
--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -349,35 +349,14 @@ pub(super) async fn authorize_terminal_request(
 
     let require_proxy_headers = cfg.terminal.require_proxy_headers;
     let listen_port = cfg.listen_port();
-    if let Err(reason) = validate_ws_origin(
-        headers,
-        listen_port,
-        &cfg.terminal.allowed_origins,
-        cfg.terminal.allow_remote,
-    ) {
-        if !cfg.terminal.allow_remote {
-            warn!(
-                ip = %locality.source_ip,
-                proxied = locality.is_proxied,
-                reason = "origin_mismatch",
-                origin = %reason,
-                "Terminal WebSocket rejected — origin validation failed"
-            );
-            return Err(axum::http::StatusCode::FORBIDDEN.into_response());
-        }
-        warn!(
-            ip = %locality.source_ip,
-            proxied = locality.is_proxied,
-            reason = "origin_mismatch",
-            origin = %reason,
-            "Terminal WebSocket origin mismatch — continuing to auth token check"
-        );
-    }
 
     let provided_token = ws_auth_token(headers, uri);
 
-    // Validate the token (if any) before consulting the policy matrix so the
-    // decision table can treat token-ok / token-bad / no-token uniformly.
+    // Validate the token (if any) before origin checks so that authenticated
+    // requests are never rejected on origin alone. Origin validation is a CSRF
+    // defense — it only matters when the browser silently attaches credentials
+    // (cookies). Explicit Bearer tokens cannot be forged cross-origin, so
+    // authenticated requests bypass origin checks entirely.
     let token_status = if let Some(token_str) = provided_token.as_deref() {
         let api_auth = {
             use subtle::ConstantTimeEq;
@@ -412,6 +391,37 @@ pub(super) async fn authorize_terminal_request(
     } else {
         TokenStatus::NoToken
     };
+
+    // Only enforce origin validation for unauthenticated requests.
+    // Authenticated requests (valid token) are already protected against CSRF
+    // because the token must be explicitly provided — browsers cannot inject it
+    // cross-origin.
+    if !matches!(token_status, TokenStatus::Valid(_)) {
+        if let Err(reason) = validate_ws_origin(
+            headers,
+            listen_port,
+            &cfg.terminal.allowed_origins,
+            cfg.terminal.allow_remote,
+        ) {
+            if !cfg.terminal.allow_remote {
+                warn!(
+                    ip = %locality.source_ip,
+                    proxied = locality.is_proxied,
+                    reason = "origin_mismatch",
+                    origin = %reason,
+                    "Terminal rejected — origin validation failed"
+                );
+                return Err(axum::http::StatusCode::FORBIDDEN.into_response());
+            }
+            warn!(
+                ip = %locality.source_ip,
+                proxied = locality.is_proxied,
+                reason = "origin_mismatch",
+                origin = %reason,
+                "Terminal origin mismatch — continuing to auth decision"
+            );
+        }
+    }
 
     let decision = decide_auth(
         token_status,


### PR DESCRIPTION
## Summary

Reorders terminal auth logic: token validation now runs **before** origin checks. Authenticated requests (valid API key, session, or user key) bypass origin validation entirely.

**Why:** Origin validation is a CSRF defense — it prevents malicious websites from making the browser silently connect to the terminal via cookies. Explicit Bearer tokens cannot be forged cross-origin, so origin checks are redundant for authenticated requests. Previously, valid token-bearing requests from non-whitelisted origins (e.g. Vite dev server on LAN IP) were rejected with 403 despite having correct credentials.

**What changes:**
- Token validation moved before `validate_ws_origin()`
- `validate_ws_origin()` only runs when `token_status` is not `Valid`
- No behavior change for unauthenticated requests — origin checks still apply

## Testing

- [x] `cargo build --workspace --lib` passes
- [x] Auth policy matrix tests unchanged (auth logic itself is not modified)