### PR TITLE
fix(whatsapp-gateway): stop mark-on-sight dedup from blocking decrypt-fail retransmits

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -9,6 +9,7 @@ const { randomUUID } = require('node:crypto');
 const toml = require('toml');
 const { EchoTracker } = require('./lib/echo-tracker');
 const lidCache = require('./lib/lid-cache');
+const { createDedupTracker } = require('./lib/dedup-tracker');
 const {
   isLidJid,
   isGroupJid,
@@ -652,23 +653,13 @@ setInterval(() => {
 // ---------------------------------------------------------------------------
 // Message deduplication — Baileys can deliver the same message multiple times
 // ---------------------------------------------------------------------------
-const recentMessageIds = new Map(); // Map<msgId, timestamp>
-const DEDUP_WINDOW_MS = 60_000; // 1 minute
-
-function isDuplicate(msgId) {
-  if (!msgId) return false;
-  if (recentMessageIds.has(msgId)) return true;
-  recentMessageIds.set(msgId, Date.now());
-  return false;
-}
-
-// Cleanup dedup cache every 2 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [id, ts] of recentMessageIds) {
-    if (now - ts > DEDUP_WINDOW_MS) recentMessageIds.delete(id);
-  }
-}, 2 * 60 * 1000);
+// Two-phase (wasProcessed / markProcessed): Baileys re-emits `messages.upsert`
+// for a msgId whose previous handling ended in decrypt failure (null payload /
+// SessionError / PreKeyError). That retransmit is the ONLY window for
+// `assertSessions` to recover the Signal session. A mark-on-sight dedup
+// blocks the retransmit and strands the sender — 2026-04-16 outage, see
+// lib/dedup-tracker.js docstring.
+const dedupTracker = createDedupTracker({ windowMs: 60_000 });
 
 // ---------------------------------------------------------------------------
 // Step F: Escalation deduplication — debounce NOTIFY_OWNER per stranger
@@ -1136,8 +1127,10 @@ async function startConnection() {
       // Skip status broadcasts
       if (msg.key.remoteJid === 'status@broadcast') continue;
 
-      // Deduplication: skip if we've already processed this message ID
-      if (isDuplicate(msg.key.id)) {
+      // Read-only dedup check: do NOT mark here. Marking happens after the
+      // decrypt-failure branch below so WA's retransmit of a failed-decrypt
+      // msgId can reach the session-recovery path instead of being stranded.
+      if (dedupTracker.wasProcessed(msg.key.id)) {
         console.log(`[gateway] Skipping duplicate message: ${msg.key.id}`);
         continue;
       }
@@ -1150,6 +1143,20 @@ async function startConnection() {
 
       const sender = msg.key.remoteJid || '';
       const innerMsg = msg.message || {};
+
+      // Libsignal decrypt failure surfaces as `msg.message == null`. We
+      // intentionally do NOT mark the id as processed so that WA's
+      // retransmit of the same msgId can reach this branch again after
+      // the session recovers. Marking on first sight would strand the
+      // sender permanently behind a "duplicate message" skip.
+      if (!msg.message && !msg.key.fromMe && sender) {
+        console.warn(`[gateway] Decrypt failed for ${msg.key.id} from ${sender} — leaving unmarked so WA can retransmit`);
+        continue;
+      }
+
+      // Decrypt succeeded. Mark so subsequent retransmits of this msgId
+      // are deduped.
+      dedupTracker.markProcessed(msg.key.id);
 
       // --- FASE 4: Handle reactions ---
       if (innerMsg.reactionMessage) {

--- a/packages/whatsapp-gateway/lib/dedup-tracker.js
+++ b/packages/whatsapp-gateway/lib/dedup-tracker.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Message-ID deduplication tracker.
+ *
+ * Two-phase API — `wasProcessed` and `markProcessed` are distinct:
+ * - Baileys re-emits `messages.upsert` for a given id whenever the previous
+ *   handling ended with a decrypt failure (null payload, SessionError,
+ *   PreKeyError). The retransmit is the ONLY opportunity for the gateway
+ *   to call `assertSessions` and recover the Signal session.
+ * - A tracker that marks on first sight blocks the retransmit and strands
+ *   the sender permanently until manual key re-scan. That was the 2026-04-16
+ *   outage with the Signore's own chat.
+ *
+ * The fix is structural: callers must decide when a message has been
+ * "really" processed and call `markProcessed` only then. Typical policy:
+ *   - decrypt succeeded (`msg.message != null`) → mark
+ *   - decrypt failed → leave unmarked so the retransmit reaches recovery
+ *
+ * The tracker prunes entries older than `windowMs` on each check (lazy);
+ * WhatsApp's own retransmit window is a few seconds, so 60 s is generous.
+ */
+function createDedupTracker({ windowMs = 60_000, now = () => Date.now() } = {}) {
+  const seen = new Map(); // id → timestamp
+
+  function prune(nowMs = now()) {
+    for (const [id, ts] of seen) {
+      if (nowMs - ts > windowMs) seen.delete(id);
+    }
+  }
+
+  return {
+    wasProcessed(id) {
+      if (!id) return false;
+      prune();
+      return seen.has(id);
+    },
+    markProcessed(id) {
+      if (!id) return;
+      seen.set(id, now());
+    },
+    unmarkProcessed(id) {
+      if (!id) return;
+      seen.delete(id);
+    },
+    size() {
+      return seen.size;
+    },
+    // Exposed for tests.
+    _prune: prune,
+  };
+}
+
+module.exports = { createDedupTracker };

--- a/packages/whatsapp-gateway/test/dedup-tracker.test.js
+++ b/packages/whatsapp-gateway/test/dedup-tracker.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createDedupTracker } = require('../lib/dedup-tracker');
+
+test('wasProcessed is false on first sight and does NOT mark', () => {
+  const t = createDedupTracker();
+  assert.equal(t.wasProcessed('abc'), false);
+  assert.equal(t.wasProcessed('abc'), false, 're-check still false without mark');
+});
+
+test('markProcessed then wasProcessed returns true', () => {
+  const t = createDedupTracker();
+  t.markProcessed('abc');
+  assert.equal(t.wasProcessed('abc'), true);
+});
+
+test('unmarkProcessed clears an entry so retry is admitted', () => {
+  const t = createDedupTracker();
+  t.markProcessed('abc');
+  t.unmarkProcessed('abc');
+  assert.equal(t.wasProcessed('abc'), false);
+});
+
+test('empty / missing id is never processed', () => {
+  const t = createDedupTracker();
+  assert.equal(t.wasProcessed(''), false);
+  assert.equal(t.wasProcessed(undefined), false);
+  assert.equal(t.wasProcessed(null), false);
+});
+
+test('mark/unmark with empty id is a no-op', () => {
+  const t = createDedupTracker();
+  t.markProcessed('');
+  t.markProcessed(undefined);
+  assert.equal(t.size(), 0);
+  t.unmarkProcessed(null);
+  assert.equal(t.size(), 0);
+});
+
+test('entries older than windowMs are pruned on check', () => {
+  let clock = 1_000_000;
+  const t = createDedupTracker({ windowMs: 100, now: () => clock });
+  t.markProcessed('abc');
+  assert.equal(t.wasProcessed('abc'), true);
+  clock += 50;
+  assert.equal(t.wasProcessed('abc'), true, 'still inside window');
+  clock += 60; // now 110 ms past mark
+  assert.equal(t.wasProcessed('abc'), false, 'pruned after window');
+});
+
+test('prune only evicts stale entries', () => {
+  let clock = 1_000_000;
+  const t = createDedupTracker({ windowMs: 100, now: () => clock });
+  t.markProcessed('old');
+  clock += 80;
+  t.markProcessed('fresh');
+  clock += 50; // old=130, fresh=50
+  assert.equal(t.wasProcessed('old'), false);
+  assert.equal(t.wasProcessed('fresh'), true);
+});
+
+// Regression test for the outage described in the module docstring:
+// retransmitted msgId after a decrypt failure must reach the recovery branch.
+test('retransmit of an unmarked (decrypt-failed) id is not blocked', () => {
+  const t = createDedupTracker();
+  // First arrival: we check wasProcessed but decrypt fails, so we never
+  // call markProcessed.
+  assert.equal(t.wasProcessed('signal-fail-1'), false);
+  // WA retransmits — we must still see it as not-processed so the handler
+  // can invoke session recovery.
+  assert.equal(t.wasProcessed('signal-fail-1'), false);
+  // Eventually decrypt succeeds on a later retry → mark.
+  t.markProcessed('signal-fail-1');
+  // Any further retransmits of the same id are now deduped.
+  assert.equal(t.wasProcessed('signal-fail-1'), true);
+});


### PR DESCRIPTION
## The bug

On one operator's deployment (2026-04-16 13:16 local) the WhatsApp gateway silently dropped every subsequent message from a specific sender for over an hour. The gateway log showed a classic pattern:

```
13:16  {"err":{"type":"SessionError","message":"No matching sessions found for message"},"key":{"remoteJid":"...@lid","id":"AC679879879D7AF31549B615842842D7",...}}
13:16+ [gateway] Skipping duplicate message: AC679879879D7AF31549B615842842D7
13:16+ [gateway] Skipping duplicate message: AC679879879D7AF31549B615842842D7
13:28  {"err":{"type":"PreKeyError","message":"Invalid PreKey ID"},"key":{"id":"3EB0727DAACEC803D8D17B",...}}
13:28+ [gateway] Skipping duplicate message: 3EB0727DAACEC803D8D17B
```

A libsignal decrypt failure was emitted on first arrival, and every WhatsApp retransmit of the same message id was then deduped and discarded — precisely the event that the gateway needs to see if the session is ever going to recover.

## Root cause

\`isDuplicate()\` did the lookup **and** the insert in the same function:

```js
function isDuplicate(msgId) {
  if (!msgId) return false;
  if (recentMessageIds.has(msgId)) return true;
  recentMessageIds.set(msgId, Date.now());  // ← marked on first sight
  return false;
}
```

So on the first arrival the id was marked, the decrypt failed, the handler bailed. WhatsApp retransmitted with the same id a second later. The retransmit hit \`isDuplicate\` → \`true\` → \`continue\`. Any logic that wanted to notice \"this id has been arriving repeatedly because decrypt keeps failing\" never got a chance to run.

Every later message from that sender is a **different** msgId and carries no information about the stuck one, so the session stays broken until somebody manually re-scans the safety number.

## Fix

- Extract dedup into \`lib/dedup-tracker.js\` with a two-phase API:
  - \`wasProcessed(id)\` — pure read
  - \`markProcessed(id)\` — explicit write
  - \`unmarkProcessed(id)\` — explicit clear (not used by the current caller but kept as a symmetric companion)
- In the \`messages.upsert\` loop:
  1. Check \`wasProcessed(msg.key.id)\` — skip if we have already handled it.
  2. If \`msg.message == null && !msg.key.fromMe\`, libsignal rejected the ciphertext. Log and \`continue\` **without** marking, so WA's retransmit can reach the decrypt path again.
  3. Otherwise the message was decrypted — call \`markProcessed\` so later retransmits of the same id dedupe as before.
- The tracker keeps the existing 60 s window and lazy prune, plus an injected-clock factory (\`createDedupTracker({ windowMs, now })\`) so tests can drive time deterministically.

No behavior change for the happy path: a message that decrypts successfully on first arrival is marked immediately after and all retransmits are still suppressed.

## Tests

\`packages/whatsapp-gateway/test/dedup-tracker.test.js\` — 8 cases:

- \`wasProcessed\` is read-only (two back-to-back checks stay false)
- \`markProcessed\` then \`wasProcessed\` returns true
- \`unmarkProcessed\` clears an entry
- empty / undefined / null id is never \"processed\" and never marked
- \`windowMs\` evicts on check
- \`prune\` only evicts stale entries
- direct regression test for the incident: an unmarked id remains admittable on retransmit until it is explicitly marked.

All pre-existing gateway test modules continue to pass.

## Test plan

- [x] \`node --test packages/whatsapp-gateway/test/dedup-tracker.test.js\` — 8/8 pass
- [x] \`node --test\` across all other gateway test files — all pass
- [x] \`node --check packages/whatsapp-gateway/index.js\` — clean
- [x] Deployed to the reporting operator's instance. Subsequent voice notes and text messages from the previously-stranded chat are now being handled.