### PR TITLE
ci(dashboard): allowlist esbuild postinstall for pnpm 10

### DIFF
--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -47,5 +47,10 @@
     "typescript": "^5.9.2",
     "vite": "^7.1.3",
     "vitest": "^4.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Dashboard Build failure on `main` ([run 24550909700](https://github.com/librefang/librefang/actions/runs/24550909700/job/71776283628))
- #2700 bumped `pnpm/action-setup` v4→v6, which defaults to pnpm 10. pnpm 10 turned `ERR_PNPM_IGNORED_BUILDS` into a hard install failure, and `esbuild@0.27.4`'s postinstall (native binary placement) was being blocked.
- Allowlists `esbuild` via `pnpm.onlyBuiltDependencies` in `crates/librefang-api/dashboard/package.json`.

## Test plan
- [x] `pnpm install --frozen-lockfile` exits 0 under pnpm 10.13 (previously exit 1 with `ERR_PNPM_IGNORED_BUILDS`)
- [x] `pnpm run build` produces the dashboard bundle successfully
- [ ] Dashboard Build workflow green on this PR