### PR TITLE
ci(dashboard): move pnpm onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -52,10 +52,5 @@
     "typescript": "^5.9.2",
     "vite": "^7.1.3",
     "vitest": "^4.1.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/crates/librefang-api/dashboard/pnpm-workspace.yaml
+++ b/crates/librefang-api/dashboard/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Summary
- Follow-up to #2707 — that fix placed the allowlist in \`package.json#pnpm.onlyBuiltDependencies\`, which worked locally but [run 24551044588](https://github.com/librefang/librefang/actions/runs/24551044588/job/71776694066) on \`main\` still failed with \`ERR_PNPM_IGNORED_BUILDS: esbuild@0.27.4\`.
- Root cause: in current pnpm 10 releases the [build-script allowlist is read from \`pnpm-workspace.yaml\`](https://pnpm.io/10.x/settings#onlybuiltdependencies). The \`package.json\` location is effectively deprecated — older pnpm 10.x (e.g. 10.13) still honoured it, but CI uses the latest 10.x (10.33 at time of this PR) which does not.
- Moves the setting into \`crates/librefang-api/dashboard/pnpm-workspace.yaml\` and drops the dead \`pnpm\` block from \`package.json\`.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` exits 0 with pnpm 10.33.0 locally
- [x] \`pnpm run build\` produces the dashboard bundle
- [ ] Dashboard Build workflow green on this PR