### PR TITLE
refactor(dashboard): route ProvidersPage model queries through useModels

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1,11 +1,12 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
 import { useMemo, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { listModels, createRegistryContent } from "../api";
+import { createRegistryContent } from "../api";
 import type { ProviderItem } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { useProviders, useProviderStatus } from "../lib/queries/providers";
+import { useModels } from "../lib/queries/models";
 import { useTestProvider, useSetProviderKey, useDeleteProviderKey, useSetProviderUrl, useSetDefaultProvider } from "../lib/mutations/providers";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -91,11 +92,7 @@ function SetDefaultModelSection({ providerId, currentDefault, onSetDefault, t }:
   const [setting, setSetting] = useState(false);
   const isDefault = currentDefault === providerId;
 
-  const modelsQuery = useQuery({
-    queryKey: ["models", "provider", providerId, { available: true }],
-    queryFn: () => listModels({ provider: providerId, available: true }),
-    staleTime: 60_000,
-  });
+  const modelsQuery = useModels({ provider: providerId, available: true });
 
   const models = modelsQuery.data?.models || [];
 
@@ -569,10 +566,7 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
   const isConfigured = isProviderAvailable(provider.auth_status);
   const authBadge = getAuthBadge(provider.auth_status);
 
-  const modelsQuery = useQuery({
-    queryKey: ["models", "provider", provider.id],
-    queryFn: () => listModels({ provider: provider.id }),
-  });
+  const modelsQuery = useModels({ provider: provider.id });
   const models = modelsQuery.data?.models ?? [];
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to #2706. Two inline `useQuery` + `listModels` calls in `ProvidersPage.tsx` (`SetDefaultModelSection` and `DetailsModal`) were left with hand-built query keys when the rest of the dashboard was migrated to the shared hook layer:

- `["models","provider",id,{available:true}]` (L94-98 pre-PR)
- `["models","provider",id]` (L572-575 pre-PR)

Neither shares cache with `useModels` under `modelKeys.list(filters)` = `["models","list",filters]`. They also don't share with each other (`{provider}` vs `{provider, available: true}` sit at different sub-paths). This violates the AGENTS.md rule introduced in #2706:

> `crates/librefang-api/dashboard/AGENTS.md:110` — Never build a `queryKey` inline — always call the factory.

## Changes

Both sites now call `useModels(filters)`:

```diff
-  const modelsQuery = useQuery({
-    queryKey: ["models", "provider", providerId, { available: true }],
-    queryFn: () => listModels({ provider: providerId, available: true }),
-    staleTime: 60_000,
-  });
+  const modelsQuery = useModels({ provider: providerId, available: true });
```

Result: the provider modals reuse the same cache entries as ChatPage / AgentsPage, and pick up the factory's `staleTime` (30s) / `refetchInterval` (60s) instead of ad-hoc per-call settings. `listModels` and `useQuery` are dropped from ProvidersPage's imports.

Net: **+5 / -11**.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test --run` — 49/49 pass
- [x] `pnpm build` — succeeds
- [ ] Manual: open a provider config modal → "Set as default" model picker populates; open a provider details modal → model list populates