### PR TITLE
fix(dashboard): render struct-variant trigger patterns instead of crashing

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/triggerPattern.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/triggerPattern.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatTriggerPattern } from "./triggerPattern";
+
+describe("formatTriggerPattern", () => {
+  it("returns unit-variant strings unchanged", () => {
+    expect(formatTriggerPattern("lifecycle")).toBe("lifecycle");
+    expect(formatTriggerPattern("all")).toBe("all");
+    expect(formatTriggerPattern("memory_update")).toBe("memory_update");
+  });
+
+  it("formats struct variants as 'variant: value' — the bug in #2703", () => {
+    // Before the fix this object was rendered directly in JSX and React
+    // threw "Objects are not valid as a React child", blanking the page.
+    expect(
+      formatTriggerPattern({ agent_spawned: { name_pattern: "worker" } })
+    ).toBe("agent_spawned: worker");
+    expect(
+      formatTriggerPattern({ system_keyword: { keyword: "error" } })
+    ).toBe("system_keyword: error");
+    expect(
+      formatTriggerPattern({ content_match: { substring: "hello world" } })
+    ).toBe("content_match: hello world");
+  });
+
+  it("falls back to undefined for missing or unrecognized shapes", () => {
+    expect(formatTriggerPattern(undefined)).toBeUndefined();
+    expect(formatTriggerPattern(null)).toBeUndefined();
+    expect(formatTriggerPattern({})).toBeUndefined();
+    expect(formatTriggerPattern(42)).toBeUndefined();
+  });
+
+  it("returns just the variant name when payload has no string fields", () => {
+    expect(formatTriggerPattern({ weird_variant: {} })).toBe("weird_variant");
+    expect(formatTriggerPattern({ weird_variant: { n: 1 } })).toBe("weird_variant");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/triggerPattern.ts
+++ b/crates/librefang-api/dashboard/src/lib/triggerPattern.ts
@@ -1,0 +1,31 @@
+/**
+ * Format a serialized `TriggerPattern` (from `/api/triggers`) into a short
+ * human-readable label for list rendering.
+ *
+ * Serde default-serializes Rust enums without a tag, so unit variants like
+ * `Lifecycle` come over the wire as the string `"lifecycle"`, but struct
+ * variants like `AgentSpawned { name_pattern }` come as an object shaped
+ * `{ "agent_spawned": { "name_pattern": "..." } }`. Rendering that object
+ * directly in JSX throws "Objects are not valid as a React child" and
+ * blanks the page — see issue #2703.
+ *
+ * Returns `undefined` when the input is missing or shaped in a way we
+ * don't recognize, so callers can fall back to a different label (e.g. the
+ * trigger ID) instead of rendering junk.
+ */
+export function formatTriggerPattern(pattern: unknown): string | undefined {
+  if (pattern == null) return undefined;
+  if (typeof pattern === "string") return pattern;
+  if (typeof pattern !== "object") return undefined;
+
+  const entries = Object.entries(pattern as Record<string, unknown>);
+  if (entries.length === 0) return undefined;
+  const [variant, payload] = entries[0];
+
+  if (payload == null || typeof payload !== "object") {
+    return variant;
+  }
+  const values = Object.values(payload as Record<string, unknown>)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  return values.length > 0 ? `${variant}: ${values.join(" ")}` : variant;
+}

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -13,6 +13,7 @@ import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { Modal } from "../components/ui/Modal";
 import { truncateId } from "../lib/string";
+import { formatTriggerPattern } from "../lib/triggerPattern";
 import { useSchedules, useTriggers } from "../lib/queries/schedules";
 import {
   useCreateSchedule,
@@ -210,7 +211,7 @@ export function SchedulerPage() {
                       <Zap className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${isEnabled ? "text-warning" : "text-text-dim/30"}`} />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <h3 className="text-xs sm:text-sm font-bold truncate">{tr.pattern || tr.name || truncateId(tr.id, 12)}</h3>
+                      <h3 className="text-xs sm:text-sm font-bold truncate">{formatTriggerPattern(tr.pattern) || truncateId(tr.id, 12)}</h3>
                     </div>
                     <button
                       onClick={() => toggleTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}


### PR DESCRIPTION
## Summary

Closes #2703. The scheduler page blanks out the moment any trigger with a payloaded pattern exists — the user's report described it as "scheduler page error after hand running", but the hand is incidental; the same crash fires for any trigger registered via `POST /api/triggers` or the channel bridge's `/trigger add` with a non-unit pattern.

## Root cause

`TriggerPattern` (`crates/librefang-kernel/src/triggers.rs:49-76`) uses serde's default enum encoding with `rename_all = "snake_case"` — no tag. So:

- Unit variants (`Lifecycle`, `System`, `All`, `MemoryUpdate`, `AgentTerminated`, `TaskPosted`/`Claimed`/`Completed`) → serialize as plain strings, e.g. `"lifecycle"`.
- Struct variants (`AgentSpawned`, `SystemKeyword`, `MemoryKeyPattern`, `ContentMatch`) → serialize as objects, e.g. `{"agent_spawned": {"name_pattern": "worker"}}`.

`SchedulerPage.tsx:213` was:

\`\`\`tsx
<h3>{tr.pattern || tr.name || truncateId(tr.id, 12)}</h3>
\`\`\`

When `tr.pattern` is an object, React throws **"Objects are not valid as a React child"** and the event-triggers section (usually the whole page under the error boundary) blanks out. The `|| tr.name` fallback is dead code — the `/api/triggers` response (`workflows.rs:1019-1028`) never includes a `name` field, and `TriggerItem` in `api.ts` doesn't declare one.

Pre-existing bug — the offending line is unchanged since before #2706; it only became visible when users registered triggers with struct-variant patterns (e.g. via the coordinator-agent flow in #2703 or `/trigger add <agent> spawned:<name> …` from a channel).

## Fix

- New helper `lib/triggerPattern.ts::formatTriggerPattern(pattern)` that accepts both shapes:
  - string → returned unchanged (`"lifecycle"`)
  - `{ variant: { field: value } }` → formatted as `"agent_spawned: worker"`
  - null/unknown shapes → `undefined` so the caller can fall back to the trigger ID.
- `SchedulerPage` uses the helper and drops the dead `|| tr.name` branch.
- Unit tests cover the unit-variant, struct-variant (including the exact shape that caused #2703), and defensive branches.

Backend stays as-is — the serialization is correct, only the renderer was wrong.

## Test plan

- [x] \`pnpm test --run\` — new \`triggerPattern.test.ts\` passes, existing suite unaffected
- [x] \`pnpm typecheck\` / \`pnpm build\`
- [ ] Manual: register a trigger with \`/trigger add agent spawned:foo 'wake'\` via channel bridge, open Scheduler page — row renders as \`agent_spawned: foo\` instead of blanking the page