### PR TITLE
fix(dashboard): include hands in scheduler page agent list

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -38,7 +38,7 @@ export function SchedulerPage() {
   const [message, setMessage] = useState("");
   const [confirmDelete, setConfirmDelete] = useState<{ type: "schedule" | "trigger"; id: string } | null>(null);
 
-  const agentsQuery = useAgents();
+  const agentsQuery = useAgents({ includeHands: true });
   const schedulesQuery = useSchedules();
   const triggersQuery = useTriggers();
   const workflowsQuery = useWorkflows();


### PR DESCRIPTION
Summary
Fix scheduler page error when schedules target hand agents. The agent lookup was only fetching regular agents, causing undefined errors when displaying hand agent schedules.
Closes #2703
Changes
- crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx: Add { includeHands: true } to useAgents() call so hands are included in the agent map used for schedule display
Type
- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other
Attribution
- [x] This PR preserves author attribution for any adapted prior work
Testing
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace passes
- [x] Live integration tested (if applicable)
Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries