### PR TITLE
fix(drivers,api): thread caller agent context through the MCP HTTP bridge

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -939,9 +939,29 @@ pub async fn mcp_http(
         let workspace_root = caller_entry
             .as_ref()
             .and_then(|e| e.manifest.workspace.as_deref());
-        let allowed_tools_vec = caller_entry
-            .as_ref()
-            .map(|e| e.manifest.capabilities.tools.clone());
+        // Build the allowed-tool-name list the same way the direct agent-loop
+        // path does: `kernel.available_tools(id)` already resolves declared
+        // tools + ToolProfile expansion + skill-evolution defaults + MCP
+        // server scoping + `tool_allowlist`/`tool_blocklist` + global
+        // `tool_policy` + the `ToolAll` capability + the browser toggle.
+        // Then mirror the kernel's per-message mode filter (Observe/Assist/
+        // Full) that `send_message` applies before handing tools to
+        // `run_agent_loop` (kernel/mod.rs:3997, 5148, 6852).
+        //
+        // Using `manifest.capabilities.tools` raw would silently break every
+        // agent that declares `capabilities.tools = []` (the common
+        // "unrestricted" default) because `execute_tool` treats `Some([])`
+        // as "deny all" — the exact symptom would be every tool coming back
+        // as "Permission denied" through the bridge even though the agent
+        // was allowed everything on the direct path.
+        let allowed_tools_vec = caller_entry.as_ref().map(|e| {
+            let tools = state.kernel.available_tools(e.id);
+            e.mode
+                .filter_tools((*tools).clone())
+                .into_iter()
+                .map(|t| t.name)
+                .collect::<Vec<String>>()
+        });
         let allowed_skills_vec = caller_entry.as_ref().map(|e| e.manifest.skills.clone());
         let exec_policy = caller_entry
             .as_ref()

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -52,7 +52,7 @@ pub fn protocol_router() -> axum::Router<std::sync::Arc<AppState>> {
         )
 }
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Json;
 use librefang_runtime::kernel_handle::KernelHandle;
@@ -867,6 +867,7 @@ pub async fn a2a_external_task_status(
 )]
 pub async fn mcp_http(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(request): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     // Gather all available tools (builtin + skills + MCP)
@@ -915,6 +916,41 @@ pub async fn mcp_http(
             .unwrap_or_else(|e| e.into_inner())
             .snapshot();
 
+        // Resolve the caller agent from the `X-LibreFang-Agent-Id` header,
+        // if any. When a CLI driver (e.g. claude-code's `--mcp-config`)
+        // re-exposes LibreFang tools to a spawned CLI, the driver writes
+        // the owning agent's ID into this header so we can rehydrate the
+        // ToolExecContext fields that the direct agent-loop path would
+        // populate (workspace_root, allowed_tools, allowed_skills,
+        // exec_policy, hand_allowed_env). Without it, every file/media/
+        // cron/schedule tool fails with "workspace sandbox not configured"
+        // or "Agent ID required" — issue #2699.
+        //
+        // Unauthenticated external MCP clients do not set this header and
+        // continue to run with `None` context: the fallback behaviour is
+        // unchanged.
+        let caller_entry = headers
+            .get("x-librefang-agent-id")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<librefang_types::agent::AgentId>().ok())
+            .and_then(|id| state.kernel.agent_registry().get(id));
+
+        let caller_agent_id_string = caller_entry.as_ref().map(|e| e.id.to_string());
+        let workspace_root = caller_entry
+            .as_ref()
+            .and_then(|e| e.manifest.workspace.as_deref());
+        let allowed_tools_vec = caller_entry
+            .as_ref()
+            .map(|e| e.manifest.capabilities.tools.clone());
+        let allowed_skills_vec = caller_entry.as_ref().map(|e| e.manifest.skills.clone());
+        let exec_policy = caller_entry
+            .as_ref()
+            .and_then(|e| e.manifest.exec_policy.as_ref());
+        let hand_allowed_env: Option<Vec<String>> = caller_entry
+            .as_ref()
+            .and_then(|e| e.manifest.metadata.get("hand_allowed_env"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+
         // Execute the tool via the kernel's tool runner
         let kernel_handle: Arc<dyn librefang_runtime::kernel_handle::KernelHandle> =
             state.kernel.clone() as Arc<dyn librefang_runtime::kernel_handle::KernelHandle>;
@@ -935,18 +971,18 @@ pub async fn mcp_http(
             tool_name,
             &arguments,
             Some(&kernel_handle),
-            None, // allowed_tools
-            None, // caller_agent_id
+            allowed_tools_vec.as_deref(),
+            caller_agent_id_string.as_deref(),
             Some(&skill_snapshot),
-            None, // allowed_skills
+            allowed_skills_vec.as_deref(),
             Some(state.kernel.mcp_connections_ref()),
             Some(state.kernel.web_tools()),
             Some(state.kernel.browser()),
-            None,
-            None,
+            hand_allowed_env.as_deref(),
+            workspace_root,
             Some(state.kernel.media()),
-            None, // media_drivers
-            None, // exec_policy
+            Some(state.kernel.media_drivers()),
+            exec_policy,
             tts_opt,
             docker_opt,
             Some(state.kernel.processes()),

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -171,6 +171,7 @@ async fn start_test_server_with_provider(
         )
         .route("/api/tools", axum::routing::get(routes::list_tools))
         .route("/api/tools/{name}", axum::routing::get(routes::get_tool))
+        .route("/mcp", axum::routing::post(routes::mcp_http))
         .route("/api/shutdown", axum::routing::post(routes::shutdown))
         .layer(axum::middleware::from_fn(middleware::request_logging))
         .layer(TraceLayer::new_for_http())
@@ -1713,4 +1714,169 @@ metrics = []
     assert_eq!(agent_ids_obj.len(), 2, "agent_ids must contain both roles");
     assert_eq!(agent_ids_obj["main"], main_id.to_string());
     assert_eq!(agent_ids_obj["linter"], linter_id.to_string());
+}
+
+// ── issue #2699: `/mcp` must rehydrate caller context from the
+// `X-LibreFang-Agent-Id` header so CLI drivers (claude-code) can call
+// workspace/cron/media tools without every invocation failing.
+
+/// Manifest that grants `cron_list` — needed to exercise the caller-
+/// identity path on the `/mcp` endpoint. `TEST_MANIFEST` only grants
+/// `file_read`, which would be rejected by the allowed-tools filter
+/// that the fix correctly activates.
+const MCP_TEST_MANIFEST: &str = r#"
+name = "mcp-test-agent"
+version = "0.1.0"
+description = "Integration test agent for /mcp bridge"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent."
+
+[capabilities]
+tools = ["cron_list", "cron_create", "cron_cancel"]
+memory_read = ["*"]
+memory_write = ["self.*"]
+"#;
+
+async fn call_mcp_cron_list(
+    server: &TestServer,
+    agent_header: Option<&str>,
+) -> (reqwest::StatusCode, serde_json::Value) {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(format!("{}/mcp", server.base_url))
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "cron_list", "arguments": {}},
+        }));
+    if let Some(id) = agent_header {
+        req = req.header("X-LibreFang-Agent-Id", id);
+    }
+    let resp = req.send().await.expect("mcp request send");
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.expect("mcp body parse");
+    (status, body)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mcp_http_rehydrates_caller_context_from_agent_header() {
+    // Regression guard for issue #2699 — before the fix, the /mcp
+    // endpoint hardcoded `caller_agent_id = None`, so tools that
+    // require an agent identity (cron_*, file_*, media_*, schedule_*)
+    // failed with a generic error even when the call actually came
+    // from the CLI spawned by a registered agent.
+    let server = start_test_server().await;
+
+    // Spawn an agent with cron_* in its capabilities.tools.
+    let client = reqwest::Client::new();
+    let spawn_resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": MCP_TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn_resp.status(), 201);
+    let spawn_body: serde_json::Value = spawn_resp.json().await.unwrap();
+    let agent_id = spawn_body["agent_id"].as_str().unwrap().to_string();
+
+    // No header → cron_list must refuse with the "Agent ID required"
+    // error the tool surfaces when caller_agent_id is None.
+    let (status, body) = call_mcp_cron_list(&server, None).await;
+    assert_eq!(status, 200);
+    let content = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        is_error,
+        "cron_list without caller_agent_id must surface an error; got content={content}"
+    );
+    assert!(
+        content.contains("Agent ID required") || content.contains("agent_id"),
+        "unexpected error text without header: {content}"
+    );
+
+    // With the header → cron_list resolves the agent, passes the
+    // allowed-tools check, and returns an empty list. This is the
+    // path Claude Code CLI takes after the fix.
+    let (status, body) = call_mcp_cron_list(&server, Some(&agent_id)).await;
+    assert_eq!(status, 200);
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    let content = body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        !is_error,
+        "cron_list with X-LibreFang-Agent-Id must succeed; got error content={content}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mcp_http_invalid_agent_header_falls_back_to_unauthenticated() {
+    // An unparseable or unknown agent ID must degrade gracefully to
+    // the unauthenticated path (same behaviour as no header) rather
+    // than 500-ing. Keeps external MCP clients working even if a
+    // misconfigured bridge stuffs a garbage ID into the header.
+    let server = start_test_server().await;
+
+    let (status, body) = call_mcp_cron_list(&server, Some("not-a-uuid")).await;
+    assert_eq!(status, 200);
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        is_error,
+        "invalid header must still yield the unauthenticated error path"
+    );
+
+    // Well-formed UUID but not a registered agent — same deal.
+    let (status, body) =
+        call_mcp_cron_list(&server, Some("00000000-0000-0000-0000-000000000000")).await;
+    assert_eq!(status, 200);
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        is_error,
+        "unknown agent ID must still yield the unauthenticated error path"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mcp_http_enforces_agent_tool_allowlist() {
+    // The caller-context rehydration must ALSO propagate the agent's
+    // `capabilities.tools` allowlist so the bridge can't be used to
+    // privilege-escalate: if the agent didn't have a tool in its
+    // manifest, invoking it through `/mcp` with the agent's own ID
+    // must still be rejected. (TEST_MANIFEST only grants `file_read`,
+    // so `cron_list` must be denied.)
+    let server = start_test_server().await;
+
+    let client = reqwest::Client::new();
+    let spawn_resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn_resp.status(), 201);
+    let spawn_body: serde_json::Value = spawn_resp.json().await.unwrap();
+    let agent_id = spawn_body["agent_id"].as_str().unwrap().to_string();
+
+    let (status, body) = call_mcp_cron_list(&server, Some(&agent_id)).await;
+    assert_eq!(status, 200);
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    let content = body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        is_error,
+        "cron_list must be denied for an agent whose manifest omits it; got content={content}"
+    );
+    assert!(
+        content.contains("Permission denied") || content.contains("capability"),
+        "denial must mention permission/capability; got: {content}"
+    );
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1844,6 +1844,60 @@ async fn test_mcp_http_invalid_agent_header_falls_back_to_unauthenticated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_mcp_http_unrestricted_agent_can_call_any_tool() {
+    // Regression guard: a manifest with `capabilities.tools = []`
+    // (or no [capabilities] section at all — same result) means
+    // "unrestricted" on the direct agent-loop path. The bridge must
+    // match that semantics. A naive implementation that passes the
+    // raw `manifest.capabilities.tools` as `allowed_tools` would
+    // produce `Some([])`, which `execute_tool` reads as "deny all"
+    // and every tool invoked through the bridge would return
+    // "Permission denied: agent does not have capability to use tool
+    // 'cron_list'" even though the direct path allows everything.
+    //
+    // The bridge must resolve the allowed-tool set the same way
+    // `kernel::send_message` does: `kernel.available_tools(id)` +
+    // `entry.mode.filter_tools(...)`.
+    const UNRESTRICTED_MANIFEST: &str = r#"
+name = "unrestricted-test-agent"
+version = "0.1.0"
+description = "Agent with no tool restrictions"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent."
+"#;
+
+    let server = start_test_server().await;
+
+    let client = reqwest::Client::new();
+    let spawn_resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": UNRESTRICTED_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn_resp.status(), 201);
+    let spawn_body: serde_json::Value = spawn_resp.json().await.unwrap();
+    let agent_id = spawn_body["agent_id"].as_str().unwrap().to_string();
+
+    let (status, body) = call_mcp_cron_list(&server, Some(&agent_id)).await;
+    assert_eq!(status, 200);
+    let is_error = body["result"]["isError"].as_bool().unwrap_or(false);
+    let content = body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        !is_error,
+        "unrestricted agent must be able to call cron_list through the bridge; got content={content}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_mcp_http_enforces_agent_tool_allowlist() {
     // The caller-context rehydration must ALSO propagate the agent's
     // `capabilities.tools` allowlist so the bridge can't be used to

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9839,7 +9839,7 @@ system_prompt = "You are a helpful assistant."
     ///
     /// If `capabilities.tools` is empty (or contains `"*"`), all tools are
     /// available (backwards compatible).
-    fn available_tools(&self, agent_id: AgentId) -> Arc<Vec<ToolDefinition>> {
+    pub fn available_tools(&self, agent_id: AgentId) -> Arc<Vec<ToolDefinition>> {
         let cfg = self.config.load();
         // Check the tool list cache first — avoids recomputing builtins, skill tools,
         // and MCP tools on every message for the same agent.

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4715,6 +4715,7 @@ system_prompt = "You are a helpful assistant."
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let result = match tokio::time::timeout(
@@ -5374,6 +5375,7 @@ system_prompt = "You are a helpful assistant."
                 response_format: None,
                 timeout_secs: None,
                 extra_body: None,
+                agent_id: None,
             };
             let (complexity, routed_model) = router.select_model(&probe);
             // Check if the routed model's provider has a valid API key.
@@ -7752,6 +7754,7 @@ system_prompt = "You are a helpful assistant."
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let result = match tokio::time::timeout(
@@ -10397,6 +10400,7 @@ system_prompt = "You are a helpful assistant."
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let start = std::time::Instant::now();

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -101,6 +101,17 @@ pub struct CompletionRequest {
     /// When keys conflict with standard parameters (temperature, max_tokens, etc.),
     /// values from `extra_body` take precedence (last-wins in JSON serialization).
     pub extra_body: Option<HashMap<String, serde_json::Value>>,
+    /// Caller agent identity.
+    ///
+    /// When a CLI driver re-exposes LibreFang tools to the model through an
+    /// MCP bridge (e.g. `claude-code`'s `--mcp-config`), the bridge has no
+    /// implicit way to know which agent spawned the CLI. This field carries
+    /// the owning agent's ID so the driver can forward it (as an HTTP
+    /// header on the bridge connection) and the bridge can resolve the
+    /// agent's workspace, tool allowlist, and skill allowlist from the
+    /// registry. `None` for out-of-band callers (compaction, routing
+    /// probes, tests) that have no agent identity to propagate.
+    pub agent_id: Option<String>,
 }
 
 /// A response from an LLM completion.
@@ -422,6 +433,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let response = driver.stream(request, tx).await.unwrap();

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -1044,6 +1044,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.model, "gpt-4o");
@@ -1078,6 +1079,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.instructions.as_deref(), Some("System prompt."));
@@ -1104,6 +1106,7 @@ mod tests {
             response_format: Some(ResponseFormat::Json),
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");
@@ -1139,6 +1142,7 @@ mod tests {
             }),
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -288,22 +288,43 @@ impl ClaudeCodeDriver {
     /// `mcpServers` shape; the `type: "http"` transport points at the
     /// daemon's existing `/mcp` endpoint (see
     /// `librefang-api/src/routes/network.rs::mcp_http`).
-    fn write_mcp_config(bridge: &McpBridgeConfig) -> std::io::Result<PathBuf> {
+    fn write_mcp_config(
+        bridge: &McpBridgeConfig,
+        agent_id: Option<&str>,
+    ) -> std::io::Result<PathBuf> {
         let path =
             std::env::temp_dir().join(format!("librefang-mcp-{}.json", uuid::Uuid::new_v4()));
         let base = bridge.base_url.trim_end_matches('/');
         let url = format!("{base}/mcp");
 
+        // Collect per-connection headers. Claude CLI reuses the same config
+        // for every tool call in a CLI invocation, and one invocation serves
+        // exactly one agent, so agent identity can live on the connection
+        // instead of on each request.
+        let mut headers = serde_json::Map::new();
+        if let Some(key) = bridge.api_key.as_deref() {
+            if !key.trim().is_empty() {
+                headers.insert("X-API-Key".to_string(), serde_json::json!(key));
+            }
+        }
+        if let Some(id) = agent_id {
+            if !id.is_empty() {
+                // Used by `/mcp` to rehydrate `ToolExecContext` with the
+                // owning agent's workspace, tool allowlist, and skill
+                // allowlist. Without it, file/media/cron/schedule tools
+                // fail with "workspace sandbox not configured" or
+                // "Agent ID required" even though the agent is fully
+                // registered (issue #2699).
+                headers.insert("X-LibreFang-Agent-Id".to_string(), serde_json::json!(id));
+            }
+        }
+
         let mut server = serde_json::json!({
             "type": "http",
             "url": url,
         });
-        if let Some(key) = bridge.api_key.as_deref() {
-            if !key.trim().is_empty() {
-                server["headers"] = serde_json::json!({
-                    "X-API-Key": key,
-                });
-            }
+        if !headers.is_empty() {
+            server["headers"] = serde_json::Value::Object(headers);
         }
 
         let config = serde_json::json!({
@@ -533,7 +554,7 @@ impl LlmDriver for ClaudeCodeDriver {
 
         if !request.tools.is_empty() {
             if let Some(ref bridge) = self.mcp_bridge {
-                match Self::write_mcp_config(bridge) {
+                match Self::write_mcp_config(bridge, request.agent_id.as_deref()) {
                     Ok(path) => prepared.mcp_config_path = Some(path),
                     Err(e) => {
                         prepared.cleanup();
@@ -779,7 +800,7 @@ impl LlmDriver for ClaudeCodeDriver {
 
         if !request.tools.is_empty() {
             if let Some(ref bridge) = self.mcp_bridge {
-                match Self::write_mcp_config(bridge) {
+                match Self::write_mcp_config(bridge, request.agent_id.as_deref()) {
                     Ok(path) => prepared.mcp_config_path = Some(path),
                     Err(e) => {
                         prepared.cleanup();
@@ -1185,6 +1206,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1227,6 +1249,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1286,6 +1309,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1361,6 +1385,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1568,5 +1593,64 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .output();
         assert!(output.is_err(), "spawning a nonexistent binary should fail");
+    }
+
+    #[test]
+    fn test_mcp_config_carries_agent_id_header() {
+        // Regression: without the X-LibreFang-Agent-Id header, the /mcp
+        // endpoint has no way to rehydrate the caller's workspace / tool
+        // allowlist / skill allowlist / exec_policy, so every file_*,
+        // media_*, cron_create, schedule_create tool invoked from the
+        // spawned Claude CLI fails with "workspace sandbox not configured"
+        // or "Agent ID required" even though the agent is fully
+        // registered. See issue #2699.
+        let bridge = McpBridgeConfig {
+            base_url: "http://127.0.0.1:4545".to_string(),
+            api_key: Some("secret-key".to_string()),
+        };
+        let path = ClaudeCodeDriver::write_mcp_config(&bridge, Some("agent-1234")).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let headers = &cfg["mcpServers"]["librefang"]["headers"];
+        assert_eq!(headers["X-API-Key"], "secret-key");
+        assert_eq!(headers["X-LibreFang-Agent-Id"], "agent-1234");
+    }
+
+    #[test]
+    fn test_mcp_config_omits_agent_id_header_when_absent() {
+        // No agent_id → no X-LibreFang-Agent-Id header. The `/mcp`
+        // endpoint then falls back to its legacy unauthenticated
+        // behaviour (all context fields None), preserving backward
+        // compatibility for non-agent MCP clients that connect to /mcp
+        // directly.
+        let bridge = McpBridgeConfig {
+            base_url: "http://127.0.0.1:4545".to_string(),
+            api_key: Some("secret-key".to_string()),
+        };
+        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let headers = &cfg["mcpServers"]["librefang"]["headers"];
+        assert_eq!(headers["X-API-Key"], "secret-key");
+        assert!(headers.get("X-LibreFang-Agent-Id").is_none());
+    }
+
+    #[test]
+    fn test_mcp_config_no_headers_when_nothing_to_send() {
+        // Neither api_key nor agent_id set — the `headers` object must
+        // be omitted entirely (not an empty {}). Claude CLI tolerates
+        // either but the clean shape matches what the driver wrote
+        // before this change.
+        let bridge = McpBridgeConfig {
+            base_url: "http://127.0.0.1:4545".to_string(),
+            api_key: None,
+        };
+        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert!(cfg["mcpServers"]["librefang"].get("headers").is_none());
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback.rs
@@ -414,6 +414,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -1295,6 +1295,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let tools = convert_tools(&request);
@@ -1317,6 +1318,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let tools = convert_tools(&request);

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1755,6 +1755,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let oai = driver.build_request(&request).expect("build request");
         let extra = oai.extra_body.as_ref().expect("extra_body present");
@@ -1780,6 +1781,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let oai = driver.build_request(&request).expect("build request");
         let extra = oai.extra_body.as_ref().expect("extra_body present");
@@ -1805,6 +1807,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
         let oai = driver.build_request(&request).expect("build request");
         // Non-ollama: extra_body should mirror the (None) request.extra_body.

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -1057,6 +1057,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1104,6 +1105,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1178,6 +1180,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1277,6 +1280,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1319,6 +1323,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);

--- a/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
+++ b/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
@@ -368,6 +368,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         }
     }
 

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1924,6 +1924,7 @@ async fn generate_search_queries(
         response_format: None,
         timeout_secs: Some(15),
         extra_body: None,
+        agent_id: None,
     };
 
     let response =
@@ -2545,6 +2546,7 @@ pub async fn run_agent_loop(
             } else {
                 Some(manifest.model.extra_params.clone())
             },
+            agent_id: Some(agent_id_str.clone()),
         };
 
         // Notify phase: Thinking
@@ -3520,6 +3522,7 @@ pub async fn run_agent_loop_streaming(
             } else {
                 Some(manifest.model.extra_params.clone())
             },
+            agent_id: Some(agent_id_str.clone()),
         };
 
         // Notify phase: on first iteration emit Streaming; on subsequent

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -572,6 +572,7 @@ async fn summarize_messages(
         response_format: None,
         timeout_secs: None,
         extra_body: None,
+        agent_id: None,
     };
 
     // Retry logic for transient failures
@@ -695,6 +696,7 @@ async fn summarize_in_chunks(
         response_format: None,
         timeout_secs: None,
         extra_body: None,
+        agent_id: None,
     };
 
     match driver.complete(merge_request).await {

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -286,6 +286,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             response_format: Some(ResponseFormat::Json),
             timeout_secs: Some(30),
             extra_body: None,
+            agent_id: None,
         };
 
         let response = self.driver.complete(request).await.map_err(|e| {
@@ -339,6 +340,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             response_format: None,
             timeout_secs: Some(15),
             extra_body: None,
+            agent_id: None,
         };
 
         match self.driver.complete(request).await {

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -197,6 +197,7 @@ mod tests {
             response_format: None,
             timeout_secs: None,
             extra_body: None,
+            agent_id: None,
         }
     }
 

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -113,6 +113,7 @@ async fn test_mock_llm_driver_recording() {
         response_format: None,
         timeout_secs: None,
         extra_body: None,
+        agent_id: None,
     };
 
     // First call
@@ -284,6 +285,7 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
         response_format: None,
         timeout_secs: None,
         extra_body: None,
+        agent_id: None,
     };
 
     let resp = driver.complete(request).await.unwrap();
@@ -324,6 +326,7 @@ async fn test_failing_llm_driver() {
         response_format: None,
         timeout_secs: None,
         extra_body: None,
+        agent_id: None,
     };
 
     let result = driver.complete(request).await;


### PR DESCRIPTION
Fixes #2699.

## Symptom

Agents on the `claude-code` driver were seeing every LibreFang tool invocation come back with a sandbox / identity error even though the agent was registered, had a workspace on disk, and had a live `AgentId`:

- \`mcp__librefang__file_read\` / every \`file_*\` / \`media_*\` tool → \`Error: Workspace sandbox not configured: …\`
- \`mcp__librefang__cron_create\` / \`schedule_create\` / \`cron_list\` → \`Error: Agent ID required for cron_create\`

The issue (with the follow-up comment) walks the full chain and notes that for Telegram-channel agents this also blocks all inbound media (photos, voice notes) because \`media_describe\` trips the same hole and the escape hatches (\`shell_exec\`, \`web_fetch\`) are correctly blocked by the taint guard.

## Root cause

\`ClaudeCodeDriver\` writes an \`mcp_config.json\` and passes it to \`claude -p --mcp-config=…\`. Claude CLI then calls LibreFang tools through the daemon's own \`/mcp\` endpoint. That endpoint in \`routes/network.rs::mcp_http\` hardcoded every agent-scoped field of \`ToolExecContext\` to \`None\` — \`caller_agent_id\`, \`workspace_root\`, \`allowed_tools\`, \`allowed_skills\`, \`exec_policy\`, \`media_drivers\` — and the bridge had no channel to receive those from the driver in the first place. The direct \`agent_loop\` path populates all of them at \`agent_loop.rs:681-707\`.

## Fix

- \`CompletionRequest\` gains \`agent_id: Option<String>\`. The main agent loop sets it to the owning agent's UUID at both live LLM call sites; every other site (compaction, routing probes, tests, non-agent driver call sites) passes \`None\`.
- \`ClaudeCodeDriver::write_mcp_config\` accepts the agent ID and, when present, stamps \`X-LibreFang-Agent-Id: <id>\` into the per-connection headers alongside the existing \`X-API-Key\`. Claude CLI reuses the config for every tool call in a CLI invocation and one invocation serves exactly one agent, so agent identity belongs on the connection.
- \`mcp_http\` now reads that header, parses it as \`AgentId\`, looks up the entry in the registry, and rebuilds \`caller_agent_id\`, \`workspace_root\`, \`allowed_tools\`, \`allowed_skills\`, \`exec_policy\`, \`hand_allowed_env\`, and \`media_drivers\`. Invalid or unknown IDs degrade to the legacy all-\`None\` path so external MCP clients that don't set the header keep working unchanged.

## Security note

The header is now load-bearing for the allowlist check. An agent whose manifest declares \`capabilities.tools = [\"file_read\"]\` now gets \`cron_list\` rejected at the bridge — previously the bridge let any tool through because \`allowed_tools\` was \`None\`. \`test_mcp_http_enforces_agent_tool_allowlist\` is the explicit regression guard.

## Scope

Only \`claude-code\` ships an MCP bridge today; \`qwen_code\`, \`codex_cli\`, \`gemini_cli\` don't. They only pick up the new \`agent_id\` field in \`CompletionRequest\` (set to \`None\` at every test site). When any of them gains an MCP bridge in the future it plugs into the same \`X-LibreFang-Agent-Id\` contract on the server side.

## Tests

Driver side — \`claude_code.rs\` unit tests:
- \`test_mcp_config_carries_agent_id_header\` — header is written.
- \`test_mcp_config_omits_agent_id_header_when_absent\` — no header when \`None\`, and \`X-API-Key\` is still written.
- \`test_mcp_config_no_headers_when_nothing_to_send\` — no \`headers\` object at all when both are absent (keeps the shape stable for external MCP clients).

Bridge side — in-process integration tests in \`api_integration_test.rs\` against a real kernel:
- \`test_mcp_http_rehydrates_caller_context_from_agent_header\` — \`cron_list\` without header errors with \"Agent ID required\"; same call WITH \`X-LibreFang-Agent-Id\` succeeds.
- \`test_mcp_http_invalid_agent_header_falls_back_to_unauthenticated\` — garbage string and unknown UUID both fall back to the legacy path, not 500.
- \`test_mcp_http_enforces_agent_tool_allowlist\` — agent with \`capabilities.tools = [\"file_read\"]\` gets \`cron_list\` denied through the bridge.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (\`Co-authored-by\`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] \`cargo test -p librefang-llm-drivers claude_code::tests::test_mcp_config\` — 3 new tests green
- [x] \`cargo test -p librefang-api --test api_integration_test test_mcp_http\` — 3 new tests green
- [ ] Live smoke test on a NAS / Ambrogio deployment — owner sends a photo via Telegram to a \`claude-code\`-driven agent, expect \`media_describe\` / \`file_*\` / \`cron_create\` to succeed instead of the sandbox error

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries (invalid agent IDs don't 500 — they degrade to the legacy path)