### PR TITLE
fix(kernel): unblock main CI on Rust 1.95 clippy

### DIFF
--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -98,15 +98,15 @@ pub(super) fn apply_thinking_override(
     thinking_override: Option<bool>,
 ) {
     match thinking_override {
-        Some(true) => {
-            if manifest.thinking.is_none() {
-                manifest.thinking = Some(librefang_types::config::ThinkingConfig::default());
-            }
+        Some(true) if manifest.thinking.is_none() => {
+            manifest.thinking = Some(librefang_types::config::ThinkingConfig::default());
         }
         Some(false) => {
             manifest.thinking = None;
         }
-        None => {}
+        // Some(true) when thinking is already set — keep the existing budget
+        // — and None when no override is requested are both no-ops.
+        _ => {}
     }
 }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -6979,10 +6979,10 @@ system_prompt = "You are a helpful assistant."
         for req in &def.requires {
             match req.requirement_type {
                 librefang_hands::RequirementType::ApiKey
-                | librefang_hands::RequirementType::EnvVar => {
-                    if !req.check_value.is_empty() && !allowed_env.contains(&req.check_value) {
-                        allowed_env.push(req.check_value.clone());
-                    }
+                | librefang_hands::RequirementType::EnvVar
+                    if !req.check_value.is_empty() && !allowed_env.contains(&req.check_value) =>
+                {
+                    allowed_env.push(req.check_value.clone());
                 }
                 _ => {}
             }
@@ -7427,7 +7427,7 @@ system_prompt = "You are a helpful assistant."
         let mut bindings = self.bindings.lock().unwrap_or_else(|e| e.into_inner());
         bindings.push(binding);
         // Sort by specificity descending
-        bindings.sort_by(|a, b| b.match_rule.specificity().cmp(&a.match_rule.specificity()));
+        bindings.sort_by_key(|b| std::cmp::Reverse(b.match_rule.specificity()));
     }
 
     /// Remove a binding by index, returns the removed binding if valid.


### PR DESCRIPTION
## Summary

Main has been failing CI since the 1.95 stable bump — three new \`clippy\` lints promoted to errors under \`-D warnings\`:

\`\`\`
error: this \`if\` can be collapsed into the outer \`match\`
  --> crates/librefang-kernel/src/kernel/mod.rs:6981

error: consider using \`sort_by_key\`
  --> crates/librefang-kernel/src/kernel/mod.rs:7428

error: this \`if\` can be collapsed into the outer \`match\`
  --> crates/librefang-kernel/src/kernel/manifest_helpers.rs:102

error: could not compile \`librefang-kernel\` (lib) due to 3 previous errors
\`\`\`

## Fix

Three mechanical clippy rewrites, no semantics change:

1. **\`hand_activate()\`**: nested \`if\` inside \`ApiKey | EnvVar\` arm → match guard on the union pattern.
2. **\`add_binding()\`**: \`sort_by(|a, b| b.x.cmp(&a.x))\` → \`sort_by_key(|b| Reverse(b.x))\`.
3. **\`apply_thinking_override()\`**: \`Some(true) => { if is_none() { ... } }\` → \`Some(true) if is_none() => { ... }\`. Collapsing splits the original \`Some(true)\` arm in two, so the leftover \`Some(true)\` no-op path merges with \`None\` into a single \`_ => {}\` wildcard. The original \`Some(true)\` branch was already a no-op when \`thinking.is_some()\`, so this is behaviour-preserving.

## Test plan

- [x] \`cargo check -p librefang-kernel --lib\` — clean
- [ ] CI \`Quality\` job on this branch — relies on 1.95 clippy, will validate the lint fixes

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Security

- [x] No new unsafe code
- [x] No secrets in diff
- [x] User input validation unchanged