### PR TITLE
fix(api): clear Rust 1.95 clippy regressions in librefang-api

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2119,7 +2119,7 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         };
         let mut agent_entries_visible: Vec<_> = agent_entries.iter().collect();
         // Sort by last_active descending — matches AgentsPage default query order.
-        agent_entries_visible.sort_by(|a, b| b.last_active.cmp(&a.last_active));
+        agent_entries_visible.sort_by_key(|b| std::cmp::Reverse(b.last_active));
         agent_entries_visible
             .iter()
             .map(|e| super::agents::enrich_agent_json(e, &dm, &catalog))

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -1275,8 +1275,7 @@ pub async fn context_engine_metrics_prometheus(
             "librefang_hook_latency_ms_total{{plugin=\"{}\",hook=\"{}\"}} {}\n",
             plugin_label, hook, stats.total_ms
         ));
-        if stats.calls > 0 {
-            let avg = stats.total_ms / stats.calls;
+        if let Some(avg) = stats.total_ms.checked_div(stats.calls) {
             output.push_str(&format!(
                 "librefang_hook_latency_ms_avg{{plugin=\"{}\",hook=\"{}\"}} {}\n",
                 plugin_label, hook, avg
@@ -1974,8 +1973,8 @@ pub async fn context_engine_metrics_summary(
                 "successes": successes,
                 "failures": failures,
                 "total_ms": ms,
-                "avg_ms": if calls > 0 { ms / calls } else { 0 },
-                "error_rate_pct": if calls > 0 { (failures * 100) / calls } else { 0 },
+                "avg_ms": ms.checked_div(calls).unwrap_or(0),
+                "error_rate_pct": (failures * 100).checked_div(calls).unwrap_or(0),
             });
             (name.to_string(), v)
         })
@@ -1987,12 +1986,10 @@ pub async fn context_engine_metrics_summary(
             "calls": total_calls,
             "failures": total_failures,
             "total_ms": total_ms,
-            "avg_ms": if total_calls > 0 { total_ms / total_calls } else { 0 },
-            "error_rate_pct": if total_calls > 0 {
-                (total_failures * 100) / total_calls
-            } else {
-                0
-            },
+            "avg_ms": total_ms.checked_div(total_calls).unwrap_or(0),
+            "error_rate_pct": (total_failures * 100)
+                .checked_div(total_calls)
+                .unwrap_or(0),
         },
     }))
     .into_response()
@@ -2455,7 +2452,7 @@ pub async fn plugin_health(
                     } else {
                         0.0
                     };
-                    let avg_elapsed_ms = if calls > 0 { total_ms / calls } else { 0 };
+                    let avg_elapsed_ms = total_ms.checked_div(calls).unwrap_or(0);
                     serde_json::json!({
                         "calls": calls,
                         "errors": failures,

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -433,7 +433,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
     // Index probe results by provider list position for O(1) lookup
     let mut probe_map: HashMap<usize, librefang_runtime::provider_health::ProbeResult> =
         HashMap::with_capacity(local_providers.len());
-    for ((idx, _, _), result) in local_providers.iter().zip(probe_results.into_iter()) {
+    for ((idx, _, _), result) in local_providers.iter().zip(probe_results) {
         probe_map.insert(*idx, result);
     }
 
@@ -546,7 +546,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
 
     let mut probe_map: HashMap<usize, librefang_runtime::provider_health::ProbeResult> =
         HashMap::with_capacity(local_providers.len());
-    for ((idx, _, _), result) in local_providers.iter().zip(probe_results.into_iter()) {
+    for ((idx, _, _), result) in local_providers.iter().zip(probe_results) {
         probe_map.insert(*idx, result);
     }
 


### PR DESCRIPTION
## Summary

Companion to #2723. After the 1.95 stable bump, \`Quality\` CI reports 9 additional clippy errors in \`librefang-api\` that the kernel-only fix didn't cover:

\`\`\`
error: consider using \`sort_by_key\`            routes/config.rs:2122
error: manual checked division                  routes/plugins.rs:1278
error: manual checked division                  routes/plugins.rs:1977
error: manual checked division                  routes/plugins.rs:1978
error: manual checked division                  routes/plugins.rs:1990
error: manual checked division                  routes/plugins.rs:1991
error: manual checked division                  routes/plugins.rs:2458
error: explicit call to \`.into_iter()\`          routes/providers.rs:436
error: explicit call to \`.into_iter()\`          routes/providers.rs:549
\`\`\`

## Fix

- \`routes/config.rs\` — \`sort_by(|a,b| b.x.cmp(&a.x))\` → \`sort_by_key(|b| Reverse(b.x))\`.
- \`routes/plugins.rs\` — six \`if divisor > 0 { num / divisor } else { 0 }\` sites → \`num.checked_div(divisor).unwrap_or(0)\` (or \`if let Some(x) = ...\` when the whole branch is conditional). Behaviour-preserving: \`checked_div\` on unsigned integers returns \`None\` iff divisor is zero, exactly matching the original guarded division.
- \`routes/providers.rs\` — \`.zip(probe_results.into_iter())\` → \`.zip(probe_results)\`. \`Vec\` already impls \`IntoIterator\`.

Mechanical rewrites, no semantics change.

## Pre-existing flaky tests (not in this PR)

The macOS \`Test\` job has been failing 10 \`librefang-extensions\` tests (\`installer::tests::*\` / \`registry::tests::*\`) on recent main runs — \`panicked: NotFound("github")\`. Those tests rely on a live download of \`github.com/librefang/librefang-registry\` inside \`resolve_home_dir_for_tests()\`. Ubuntu consistently passes; macOS flakes. Unrelated to either 1.95 or #2719, and not in scope here.

## Attribution

- [x] This PR preserves author attribution

## Testing

- [x] \`cargo check -p librefang-api\` locally
- [ ] \`Quality\` job on this branch (awaits merge of #2723 or use both together) — the remaining 9 lints should clear

## Security

- [x] No new unsafe code
- [x] No secrets in diff