### PR TITLE
chore(dashboard): remove unused config_hint locale strings

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -504,7 +504,6 @@
     "filter_unreachable": "Unreachable",
     "results": "results",
     "config": "Configure",
-    "config_hint": "Configuration coming soon",
     "configure_provider": "Configure Provider",
     "key_saved": "API Key saved",
     "key_removed": "API Key removed",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -504,7 +504,6 @@
     "filter_unreachable": "无法连接",
     "results": "结果",
     "config": "配置",
-    "config_hint": "配置功能即将推出",
     "configure_provider": "配置供应商",
     "key_saved": "API Key 已保存",
     "key_removed": "API Key 已移除",


### PR DESCRIPTION
Summary
Remove unused config_hint locale strings from English and Chinese locale files. These strings were not referenced anywhere in the codebase, making them dead code.
Type
- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [ ] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [x] Other (chore/cleanup)
Changes
- Remove config_hint from locales/en.json
- Remove config_hint from locales/zh.json
Attribution
- [x] This PR preserves author attribution for any adapted prior work
Testing
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace passes
- [x] Live integration tested (if applicable)
Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries