### PR TITLE
fix(cli): resolve Rust 1.95 collapsible_match clippy regressions in TUI

### DIFF
--- a/crates/librefang-cli/src/tui/screens/agents.rs
+++ b/crates/librefang-cli/src/tui/screens/agents.rs
@@ -584,13 +584,11 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::CreateMethod;
             }
-            KeyCode::Enter => {
-                if !self.custom_name.is_empty() {
-                    if self.custom_desc.is_empty() {
-                        self.custom_desc = format!("A custom {} agent", self.custom_name);
-                    }
-                    self.sub = AgentSubScreen::CustomDesc;
+            KeyCode::Enter if !self.custom_name.is_empty() => {
+                if self.custom_desc.is_empty() {
+                    self.custom_desc = format!("A custom {} agent", self.custom_name);
                 }
+                self.sub = AgentSubScreen::CustomDesc;
             }
             KeyCode::Char(c) => {
                 self.custom_name.push(c);
@@ -649,15 +647,11 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::CustomPrompt;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.tool_cursor > 0 {
-                    self.tool_cursor -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.tool_cursor > 0 => {
+                self.tool_cursor -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if self.tool_cursor < TOOL_OPTIONS.len() - 1 {
-                    self.tool_cursor += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j') if self.tool_cursor < TOOL_OPTIONS.len() - 1 => {
+                self.tool_cursor += 1;
             }
             KeyCode::Char(' ') => {
                 self.tool_checks[self.tool_cursor] = !self.tool_checks[self.tool_cursor];
@@ -682,21 +676,15 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::CustomTools;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.skill_cursor > 0 {
-                    self.skill_cursor -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.skill_cursor > 0 => {
+                self.skill_cursor -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if len > 0 && self.skill_cursor < len - 1 {
-                    self.skill_cursor += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j') if len > 0 && self.skill_cursor < len - 1 => {
+                self.skill_cursor += 1;
             }
-            KeyCode::Char(' ') => {
-                if len > 0 {
-                    let checked = &mut self.available_skills[self.skill_cursor].1;
-                    *checked = !*checked;
-                }
+            KeyCode::Char(' ') if len > 0 => {
+                let checked = &mut self.available_skills[self.skill_cursor].1;
+                *checked = !*checked;
             }
             KeyCode::Enter => {
                 // Advance to MCP server selection
@@ -714,21 +702,15 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::CustomSkills;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.mcp_cursor > 0 {
-                    self.mcp_cursor -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.mcp_cursor > 0 => {
+                self.mcp_cursor -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if len > 0 && self.mcp_cursor < len - 1 {
-                    self.mcp_cursor += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j') if len > 0 && self.mcp_cursor < len - 1 => {
+                self.mcp_cursor += 1;
             }
-            KeyCode::Char(' ') => {
-                if len > 0 {
-                    let checked = &mut self.available_mcp[self.mcp_cursor].1;
-                    *checked = !*checked;
-                }
+            KeyCode::Char(' ') if len > 0 => {
+                let checked = &mut self.available_mcp[self.mcp_cursor].1;
+                *checked = !*checked;
             }
             KeyCode::Enter => {
                 let toml = self.build_custom_toml();
@@ -745,21 +727,15 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::AgentDetail;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.skill_cursor > 0 {
-                    self.skill_cursor -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.skill_cursor > 0 => {
+                self.skill_cursor -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if len > 0 && self.skill_cursor < len - 1 {
-                    self.skill_cursor += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j') if len > 0 && self.skill_cursor < len - 1 => {
+                self.skill_cursor += 1;
             }
-            KeyCode::Char(' ') => {
-                if len > 0 {
-                    let checked = &mut self.available_skills[self.skill_cursor].1;
-                    *checked = !*checked;
-                }
+            KeyCode::Char(' ') if len > 0 => {
+                let checked = &mut self.available_skills[self.skill_cursor].1;
+                *checked = !*checked;
             }
             KeyCode::Enter => {
                 // Save — collect checked skill names (none checked = "all")
@@ -788,21 +764,15 @@ impl AgentSelectState {
             KeyCode::Esc => {
                 self.sub = AgentSubScreen::AgentDetail;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.mcp_cursor > 0 {
-                    self.mcp_cursor -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.mcp_cursor > 0 => {
+                self.mcp_cursor -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if len > 0 && self.mcp_cursor < len - 1 {
-                    self.mcp_cursor += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j') if len > 0 && self.mcp_cursor < len - 1 => {
+                self.mcp_cursor += 1;
             }
-            KeyCode::Char(' ') => {
-                if len > 0 {
-                    let checked = &mut self.available_mcp[self.mcp_cursor].1;
-                    *checked = !*checked;
-                }
+            KeyCode::Char(' ') if len > 0 => {
+                let checked = &mut self.available_mcp[self.mcp_cursor].1;
+                *checked = !*checked;
             }
             KeyCode::Enter => {
                 // Save — collect checked server names (none checked = "all")

--- a/crates/librefang-cli/src/tui/screens/audit.rs
+++ b/crates/librefang-cli/src/tui/screens/audit.rs
@@ -165,19 +165,15 @@ impl AuditState {
 
         let total = self.filtered.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.list_state.select(Some(next));
             }
             KeyCode::Char('f') => {
                 self.action_filter = self.action_filter.next();

--- a/crates/librefang-cli/src/tui/screens/comms.rs
+++ b/crates/librefang-cli/src/tui/screens/comms.rs
@@ -156,19 +156,19 @@ impl CommsState {
                 self.task_field = 0;
             }
             KeyCode::Char('r') => return CommsAction::Refresh,
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.focus == CommsFocus::EventList && !self.events.is_empty() {
-                    let i = self.event_list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { self.events.len() - 1 } else { i - 1 };
-                    self.event_list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k')
+                if self.focus == CommsFocus::EventList && !self.events.is_empty() =>
+            {
+                let i = self.event_list_state.selected().unwrap_or(0);
+                let next = if i == 0 { self.events.len() - 1 } else { i - 1 };
+                self.event_list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if self.focus == CommsFocus::EventList && !self.events.is_empty() {
-                    let i = self.event_list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % self.events.len();
-                    self.event_list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j')
+                if self.focus == CommsFocus::EventList && !self.events.is_empty() =>
+            {
+                let i = self.event_list_state.selected().unwrap_or(0);
+                let next = (i + 1) % self.events.len();
+                self.event_list_state.select(Some(next));
             }
             _ => {}
         }
@@ -190,18 +190,17 @@ impl CommsState {
                     self.send_field - 1
                 };
             }
-            KeyCode::Enter => {
+            KeyCode::Enter
                 if !self.send_from.is_empty()
                     && !self.send_to.is_empty()
-                    && !self.send_msg.is_empty()
-                {
-                    self.show_send_modal = false;
-                    return CommsAction::SendMessage {
-                        from: self.send_from.clone(),
-                        to: self.send_to.clone(),
-                        msg: self.send_msg.clone(),
-                    };
-                }
+                    && !self.send_msg.is_empty() =>
+            {
+                self.show_send_modal = false;
+                return CommsAction::SendMessage {
+                    from: self.send_from.clone(),
+                    to: self.send_to.clone(),
+                    msg: self.send_msg.clone(),
+                };
             }
             KeyCode::Char(c) => match self.send_field {
                 0 => self.send_from.push(c),
@@ -239,15 +238,13 @@ impl CommsState {
                     self.task_field - 1
                 };
             }
-            KeyCode::Enter => {
-                if !self.task_title.is_empty() {
-                    self.show_task_modal = false;
-                    return CommsAction::PostTask {
-                        title: self.task_title.clone(),
-                        desc: self.task_desc.clone(),
-                        assign: self.task_assign.clone(),
-                    };
-                }
+            KeyCode::Enter if !self.task_title.is_empty() => {
+                self.show_task_modal = false;
+                return CommsAction::PostTask {
+                    title: self.task_title.clone(),
+                    desc: self.task_desc.clone(),
+                    assign: self.task_assign.clone(),
+                };
             }
             KeyCode::Char(c) => match self.task_field {
                 0 => self.task_title.push(c),

--- a/crates/librefang-cli/src/tui/screens/extensions.rs
+++ b/crates/librefang-cli/src/tui/screens/extensions.rs
@@ -153,12 +153,10 @@ impl ExtensionsState {
                 self.sub = ExtSub::Health;
                 return ExtensionsAction::RefreshHealth;
             }
-            KeyCode::Char('/') => {
-                if self.sub == ExtSub::Browse {
-                    self.searching = true;
-                    self.search_query.clear();
-                    return ExtensionsAction::Continue;
-                }
+            KeyCode::Char('/') if self.sub == ExtSub::Browse => {
+                self.searching = true;
+                self.search_query.clear();
+                return ExtensionsAction::Continue;
             }
             _ => {}
         }
@@ -173,19 +171,15 @@ impl ExtensionsState {
     fn handle_browse(&mut self, key: KeyEvent) -> ExtensionsAction {
         let total = self.filtered().len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.browse_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.browse_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.browse_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.browse_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.browse_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.browse_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.browse_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.browse_list.select(Some(next));
             }
             KeyCode::Enter => {
                 let filtered = self.filtered();
@@ -223,24 +217,18 @@ impl ExtensionsState {
 
         let total = self.installed_list_data().len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.installed_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.installed_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.installed_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.installed_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.installed_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.installed_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.installed_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.installed_list.select(Some(next));
             }
-            KeyCode::Char('d') | KeyCode::Delete => {
-                if self.installed_list.selected().is_some() {
-                    self.confirm_remove = true;
-                }
+            KeyCode::Char('d') | KeyCode::Delete if self.installed_list.selected().is_some() => {
+                self.confirm_remove = true;
             }
             KeyCode::Char('r') => return ExtensionsAction::RefreshAll,
             _ => {}
@@ -251,19 +239,15 @@ impl ExtensionsState {
     fn handle_health(&mut self, key: KeyEvent) -> ExtensionsAction {
         let total = self.health_entries.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.health_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.health_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.health_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.health_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.health_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.health_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.health_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.health_list.select(Some(next));
             }
             KeyCode::Char('r') | KeyCode::Enter => {
                 if let Some(sel) = self.health_list.selected() {

--- a/crates/librefang-cli/src/tui/screens/hands.rs
+++ b/crates/librefang-cli/src/tui/screens/hands.rs
@@ -108,19 +108,15 @@ impl HandsState {
     fn handle_marketplace(&mut self, key: KeyEvent) -> HandsAction {
         let total = self.definitions.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.marketplace_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.marketplace_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.marketplace_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.marketplace_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.marketplace_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.marketplace_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.marketplace_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.marketplace_list.select(Some(next));
             }
             KeyCode::Enter | KeyCode::Char('a') => {
                 if let Some(sel) = self.marketplace_list.selected() {
@@ -155,24 +151,18 @@ impl HandsState {
 
         let total = self.instances.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.active_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.active_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.active_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.active_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.active_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.active_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.active_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.active_list.select(Some(next));
             }
-            KeyCode::Char('d') | KeyCode::Delete => {
-                if self.active_list.selected().is_some() {
-                    self.confirm_deactivate = true;
-                }
+            KeyCode::Char('d') | KeyCode::Delete if self.active_list.selected().is_some() => {
+                self.confirm_deactivate = true;
             }
             KeyCode::Char('p') => {
                 if let Some(sel) = self.active_list.selected() {

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -812,36 +812,30 @@ pub fn run() -> InitResult {
                                 state.key_test = KeyTestState::Idle;
                                 state.step = Step::Provider;
                             }
-                            KeyCode::Enter => {
+                            KeyCode::Enter
                                 if !state.api_key_input.is_empty()
-                                    && state.key_test == KeyTestState::Idle
-                                {
-                                    if let Some(p) = state.provider() {
-                                        let _ =
-                                            dotenv::save_env_key(p.env_var, &state.api_key_input);
-                                    }
-                                    state.key_test = KeyTestState::Testing;
-                                    let provider_name = state
-                                        .provider()
-                                        .map(|p| p.name.to_string())
-                                        .unwrap_or_default();
-                                    let key_value = state.api_key_input.clone();
-                                    let tx = test_tx.clone();
-                                    std::thread::spawn(move || {
-                                        let ok = crate::test_api_key(&provider_name, &key_value);
-                                        let _ = tx.send(ok);
-                                    });
+                                    && state.key_test == KeyTestState::Idle =>
+                            {
+                                if let Some(p) = state.provider() {
+                                    let _ = dotenv::save_env_key(p.env_var, &state.api_key_input);
                                 }
+                                state.key_test = KeyTestState::Testing;
+                                let provider_name = state
+                                    .provider()
+                                    .map(|p| p.name.to_string())
+                                    .unwrap_or_default();
+                                let key_value = state.api_key_input.clone();
+                                let tx = test_tx.clone();
+                                std::thread::spawn(move || {
+                                    let ok = crate::test_api_key(&provider_name, &key_value);
+                                    let _ = tx.send(ok);
+                                });
                             }
-                            KeyCode::Char(c) => {
-                                if state.key_test == KeyTestState::Idle {
-                                    state.api_key_input.push(c);
-                                }
+                            KeyCode::Char(c) if state.key_test == KeyTestState::Idle => {
+                                state.api_key_input.push(c);
                             }
-                            KeyCode::Backspace => {
-                                if state.key_test == KeyTestState::Idle {
-                                    state.api_key_input.pop();
-                                }
+                            KeyCode::Backspace if state.key_test == KeyTestState::Idle => {
+                                state.api_key_input.pop();
                             }
                             _ => {}
                         }

--- a/crates/librefang-cli/src/tui/screens/logs.rs
+++ b/crates/librefang-cli/src/tui/screens/logs.rs
@@ -212,19 +212,15 @@ impl LogsState {
 
         let total = self.filtered.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.list_state.select(Some(next));
             }
             KeyCode::Char('f') => {
                 self.level_filter = self.level_filter.next();
@@ -238,15 +234,11 @@ impl LogsState {
                 self.auto_refresh = !self.auto_refresh;
             }
             KeyCode::Char('r') => return LogsAction::Refresh,
-            KeyCode::End => {
-                if total > 0 {
-                    self.list_state.select(Some(total - 1));
-                }
+            KeyCode::End if total > 0 => {
+                self.list_state.select(Some(total - 1));
             }
-            KeyCode::Home => {
-                if total > 0 {
-                    self.list_state.select(Some(0));
-                }
+            KeyCode::Home if total > 0 => {
+                self.list_state.select(Some(0));
             }
             _ => {}
         }

--- a/crates/librefang-cli/src/tui/screens/memory.rs
+++ b/crates/librefang-cli/src/tui/screens/memory.rs
@@ -107,19 +107,15 @@ impl MemoryState {
     fn handle_agent_select(&mut self, key: KeyEvent) -> MemoryAction {
         let total = self.agents.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.agent_list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.agent_list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.agent_list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.agent_list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.agent_list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.agent_list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.agent_list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.agent_list_state.select(Some(next));
             }
             KeyCode::Enter => {
                 if let Some(sel) = self.agent_list_state.selected() {
@@ -167,19 +163,15 @@ impl MemoryState {
                 self.kv_pairs.clear();
                 self.selected_agent = None;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.kv_list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.kv_list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.kv_list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.kv_list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.kv_list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.kv_list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.kv_list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.kv_list_state.select(Some(next));
             }
             KeyCode::Char('a') => {
                 self.sub = MemorySub::AddKey;
@@ -197,12 +189,10 @@ impl MemoryState {
                     }
                 }
             }
-            KeyCode::Char('d') => {
-                if self.kv_list_state.selected().is_some() {
-                    self.confirm_delete = true;
-                }
+            KeyCode::Char('d') if self.kv_list_state.selected().is_some() => {
+                self.confirm_delete = true;
             }
-            KeyCode::Char('r') => {
+            KeyCode::Char('r') if self.selected_agent.is_some() => {
                 if let Some(agent) = &self.selected_agent {
                     self.loading = true;
                     return MemoryAction::LoadKv(agent.id.clone());

--- a/crates/librefang-cli/src/tui/screens/peers.rs
+++ b/crates/librefang-cli/src/tui/screens/peers.rs
@@ -63,19 +63,15 @@ impl PeersState {
         }
         let total = self.peers.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.list_state.select(Some(next));
             }
             KeyCode::Char('r') => return PeersAction::Refresh,
             _ => {}

--- a/crates/librefang-cli/src/tui/screens/sessions.rs
+++ b/crates/librefang-cli/src/tui/screens/sessions.rs
@@ -130,19 +130,15 @@ impl SessionsState {
 
         let total = self.filtered.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.list_state.select(Some(next));
             }
             KeyCode::Enter => {
                 if let Some(sel) = self.list_state.selected() {
@@ -155,10 +151,8 @@ impl SessionsState {
                     }
                 }
             }
-            KeyCode::Char('d') => {
-                if self.list_state.selected().is_some() {
-                    self.confirm_delete = true;
-                }
+            KeyCode::Char('d') if self.list_state.selected().is_some() => {
+                self.confirm_delete = true;
             }
             KeyCode::Char('/') => {
                 self.search_mode = true;

--- a/crates/librefang-cli/src/tui/screens/settings.rs
+++ b/crates/librefang-cli/src/tui/screens/settings.rs
@@ -175,21 +175,17 @@ impl SettingsState {
     fn handle_providers(&mut self, key: KeyEvent) -> SettingsAction {
         let total = self.providers.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.provider_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.provider_list.select(Some(next));
-                    self.test_result = None;
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.provider_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.provider_list.select(Some(next));
+                self.test_result = None;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.provider_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.provider_list.select(Some(next));
-                    self.test_result = None;
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.provider_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.provider_list.select(Some(next));
+                self.test_result = None;
             }
             KeyCode::Char('e') => {
                 if let Some(sel) = self.provider_list.selected() {
@@ -224,19 +220,15 @@ impl SettingsState {
     fn handle_models(&mut self, key: KeyEvent) -> SettingsAction {
         let total = self.models.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.model_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.model_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.model_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.model_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.model_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.model_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.model_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.model_list.select(Some(next));
             }
             KeyCode::Char('r') => return SettingsAction::RefreshModels,
             _ => {}
@@ -247,19 +239,15 @@ impl SettingsState {
     fn handle_tools(&mut self, key: KeyEvent) -> SettingsAction {
         let total = self.tools.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.tool_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.tool_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.tool_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.tool_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.tool_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.tool_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.tool_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.tool_list.select(Some(next));
             }
             KeyCode::Char('r') => return SettingsAction::RefreshTools,
             _ => {}

--- a/crates/librefang-cli/src/tui/screens/skills.rs
+++ b/crates/librefang-cli/src/tui/screens/skills.rs
@@ -168,24 +168,18 @@ impl SkillsState {
 
         let total = self.installed.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.installed_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.installed_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.installed_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.installed_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.installed_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.installed_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.installed_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.installed_list.select(Some(next));
             }
-            KeyCode::Char('u') => {
-                if self.installed_list.selected().is_some() {
-                    self.confirm_uninstall = true;
-                }
+            KeyCode::Char('u') if self.installed_list.selected().is_some() => {
+                self.confirm_uninstall = true;
             }
             KeyCode::Char('r') => return SkillsAction::RefreshInstalled,
             _ => {}
@@ -218,19 +212,15 @@ impl SkillsState {
 
         let total = self.clawhub_results.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.clawhub_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.clawhub_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.clawhub_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.clawhub_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.clawhub_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.clawhub_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.clawhub_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.clawhub_list.select(Some(next));
             }
             KeyCode::Char('i') => {
                 if let Some(sel) = self.clawhub_list.selected() {
@@ -258,19 +248,15 @@ impl SkillsState {
     fn handle_mcp(&mut self, key: KeyEvent) -> SkillsAction {
         let total = self.mcp_servers.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.mcp_list.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.mcp_list.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.mcp_list.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.mcp_list.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.mcp_list.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.mcp_list.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.mcp_list.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.mcp_list.select(Some(next));
             }
             KeyCode::Char('r') => return SkillsAction::RefreshMcp,
             _ => {}

--- a/crates/librefang-cli/src/tui/screens/templates.rs
+++ b/crates/librefang-cli/src/tui/screens/templates.rs
@@ -194,19 +194,15 @@ impl TemplatesState {
 
         let total = self.filtered.len();
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = if i == 0 { total - 1 } else { i - 1 };
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = if i == 0 { total - 1 } else { i - 1 };
+                self.list_state.select(Some(next));
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if total > 0 {
-                    let i = self.list_state.selected().unwrap_or(0);
-                    let next = (i + 1) % total;
-                    self.list_state.select(Some(next));
-                }
+            KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                let i = self.list_state.selected().unwrap_or(0);
+                let next = (i + 1) % total;
+                self.list_state.select(Some(next));
             }
             KeyCode::Enter => {
                 if let Some(sel) = self.list_state.selected() {

--- a/crates/librefang-cli/src/tui/screens/triggers.rs
+++ b/crates/librefang-cli/src/tui/screens/triggers.rs
@@ -157,19 +157,15 @@ impl TriggerState {
                     self.create_step -= 1;
                 }
             }
-            KeyCode::Enter => {
-                if self.create_step < 5 {
-                    self.create_step += 1;
-                }
+            KeyCode::Enter if self.create_step < 5 => {
+                self.create_step += 1;
             }
             KeyCode::Char(c) => match self.create_step {
                 0 => self.create_agent_id.push(c),
                 2 => self.create_pattern_param.push(c),
                 3 => self.create_prompt.push(c),
-                4 => {
-                    if c.is_ascii_digit() {
-                        self.create_max_fires.push(c);
-                    }
+                4 if c.is_ascii_digit() => {
+                    self.create_max_fires.push(c);
                 }
                 _ => {}
             },

--- a/crates/librefang-cli/src/tui/screens/usage.rs
+++ b/crates/librefang-cli/src/tui/screens/usage.rs
@@ -112,19 +112,15 @@ impl UsageState {
             UsageSub::ByModel => {
                 let total = self.by_model.len();
                 match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if total > 0 {
-                            let i = self.model_list.selected().unwrap_or(0);
-                            let next = if i == 0 { total - 1 } else { i - 1 };
-                            self.model_list.select(Some(next));
-                        }
+                    KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                        let i = self.model_list.selected().unwrap_or(0);
+                        let next = if i == 0 { total - 1 } else { i - 1 };
+                        self.model_list.select(Some(next));
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if total > 0 {
-                            let i = self.model_list.selected().unwrap_or(0);
-                            let next = (i + 1) % total;
-                            self.model_list.select(Some(next));
-                        }
+                    KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                        let i = self.model_list.selected().unwrap_or(0);
+                        let next = (i + 1) % total;
+                        self.model_list.select(Some(next));
                     }
                     KeyCode::Char('r') => return UsageAction::Refresh,
                     _ => {}
@@ -133,19 +129,15 @@ impl UsageState {
             UsageSub::ByAgent => {
                 let total = self.by_agent.len();
                 match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if total > 0 {
-                            let i = self.agent_list.selected().unwrap_or(0);
-                            let next = if i == 0 { total - 1 } else { i - 1 };
-                            self.agent_list.select(Some(next));
-                        }
+                    KeyCode::Up | KeyCode::Char('k') if total > 0 => {
+                        let i = self.agent_list.selected().unwrap_or(0);
+                        let next = if i == 0 { total - 1 } else { i - 1 };
+                        self.agent_list.select(Some(next));
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if total > 0 {
-                            let i = self.agent_list.selected().unwrap_or(0);
-                            let next = (i + 1) % total;
-                            self.agent_list.select(Some(next));
-                        }
+                    KeyCode::Down | KeyCode::Char('j') if total > 0 => {
+                        let i = self.agent_list.selected().unwrap_or(0);
+                        let next = (i + 1) % total;
+                        self.agent_list.select(Some(next));
                     }
                     KeyCode::Char('r') => return UsageAction::Refresh,
                     _ => {}

--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -339,13 +339,11 @@ impl WizardState {
             KeyCode::Esc => {
                 self.step = WizardStep::Provider;
             }
-            KeyCode::Enter => {
-                if !self.api_key_input.is_empty() {
-                    if let Some(p) = self.selected_provider_info() {
-                        self.model_input = catalog_default_model(p.name, p.default_model);
-                    }
-                    self.step = WizardStep::Model;
+            KeyCode::Enter if !self.api_key_input.is_empty() => {
+                if let Some(p) = self.selected_provider_info() {
+                    self.model_input = catalog_default_model(p.name, p.default_model);
                 }
+                self.step = WizardStep::Model;
             }
             KeyCode::Char(c) => {
                 self.api_key_input.push(c);


### PR DESCRIPTION
Follow-up to #2723 and #2724, applying the same pattern to the last remaining crate hit by the Rust 1.95 `collapsible_match` lint.

## Problem

`librefang-cli`'s TUI screens have 73 instances of:

```rust
KeyCode::Up | KeyCode::Char('k') => {
    if total > 0 {
        // body
    }
}
```

which Rust 1.95 now rejects under `-D warnings`. This was breaking CI on every open PR touching the workspace.

## Fix

Pure mechanical refactor to match-arm guard form:

```rust
KeyCode::Up | KeyCode::Char('k') if total > 0 => {
    // body
}
```

No behavior change. Same pattern as #2723 / #2724.

## Files

16 files under `crates/librefang-cli/src/tui/screens/`: agents, audit, comms, extensions, hands, init_wizard, logs, memory, peers, sessions, settings, skills, templates, triggers, usage, wizard. Net −141 LOC from the flatter structure.

## Testing

- `cargo clippy -p librefang-cli --all-targets -- -D warnings` green.
- `cargo build -p librefang-cli` green.
- `cargo fmt` applied.