### PR TITLE
test(dashboard/queries): strengthen hook coverage and query test setup

### DIFF
--- a/crates/librefang-api/dashboard/.gitignore
+++ b/crates/librefang-api/dashboard/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 playwright-report
 test-results
+.gitnexus

--- a/crates/librefang-api/dashboard/.gitignore
+++ b/crates/librefang-api/dashboard/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 playwright-report
 test-results
-.gitnexus

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents-experiments.test.tsx
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
-import * as httpClient from "../http/client";
 import {
   useActivatePromptVersion,
   useStartExperiment,
@@ -12,6 +9,7 @@ import {
   useCreateExperiment,
 } from "./agents";
 import { agentKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", async () => {
   const actual = await vi.importActual<typeof import("../http/client")>(
@@ -28,29 +26,12 @@ vi.mock("../http/client", async () => {
   };
 });
 
-function createWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
-  };
-}
-
 describe("useActivatePromptVersion", () => {
   it("invalidates promptVersions and detail keys for the agent", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useActivatePromptVersion(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => useActivatePromptVersion(), { wrapper });
 
     result.current.mutate({ versionId: "v-1", agentId: "agent-1" });
 
@@ -68,16 +49,10 @@ describe("useActivatePromptVersion", () => {
 
 describe("useStartExperiment", () => {
   it("invalidates experiments and experimentMetrics keys", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useStartExperiment(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => useStartExperiment(), { wrapper });
 
     result.current.mutate({ experimentId: "exp-1", agentId: "agent-1" });
 
@@ -95,16 +70,10 @@ describe("useStartExperiment", () => {
 
 describe("usePauseExperiment", () => {
   it("invalidates experiments and experimentMetrics keys", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => usePauseExperiment(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => usePauseExperiment(), { wrapper });
 
     result.current.mutate({ experimentId: "exp-1", agentId: "agent-1" });
 
@@ -122,16 +91,10 @@ describe("usePauseExperiment", () => {
 
 describe("useDeletePromptVersion", () => {
   it("invalidates promptVersions for the agent", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useDeletePromptVersion(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => useDeletePromptVersion(), { wrapper });
 
     await result.current.mutateAsync({ versionId: "v-1", agentId: "agent-1" });
 
@@ -143,16 +106,10 @@ describe("useDeletePromptVersion", () => {
 
 describe("useCreatePromptVersion", () => {
   it("invalidates promptVersions for the agent", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useCreatePromptVersion(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => useCreatePromptVersion(), { wrapper });
 
     await result.current.mutateAsync({ agentId: "agent-1", version: { version: 1, content_hash: "abc", system_prompt: "sys", tools: [], variables: [], created_by: "user" } });
 
@@ -164,16 +121,10 @@ describe("useCreatePromptVersion", () => {
 
 describe("useCreateExperiment", () => {
   it("invalidates experiments for the agent", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => useCreateExperiment(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
-    });
+    const { result } = renderHook(() => useCreateExperiment(), { wrapper });
 
     await result.current.mutateAsync({ agentId: "agent-1", experiment: { name: "exp-1", status: "draft", traffic_split: [50, 50], success_criteria: { require_user_helpful: true, require_no_tool_errors: true, require_non_empty: true }, variants: [] } });
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents-experiments.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import * as httpClient from "../http/client";
+import {
+  useActivatePromptVersion,
+  useStartExperiment,
+  usePauseExperiment,
+  useDeletePromptVersion,
+  useCreatePromptVersion,
+  useCreateExperiment,
+} from "./agents";
+import { agentKeys } from "../queries/keys";
+
+vi.mock("../http/client", async () => {
+  const actual = await vi.importActual<typeof import("../http/client")>(
+    "../http/client",
+  );
+  return {
+    ...actual,
+    activatePromptVersion: vi.fn().mockResolvedValue({}),
+    startExperiment: vi.fn().mockResolvedValue({}),
+    pauseExperiment: vi.fn().mockResolvedValue({}),
+    deletePromptVersion: vi.fn().mockResolvedValue({}),
+    createPromptVersion: vi.fn().mockResolvedValue({}),
+    createExperiment: vi.fn().mockResolvedValue({}),
+  };
+});
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useActivatePromptVersion", () => {
+  it("invalidates promptVersions and detail keys for the agent", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useActivatePromptVersion(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutate({ versionId: "v-1", agentId: "agent-1" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.promptVersions("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.detail("agent-1"),
+    });
+  });
+});
+
+describe("useStartExperiment", () => {
+  it("invalidates experiments and experimentMetrics keys", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useStartExperiment(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutate({ experimentId: "exp-1", agentId: "agent-1" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experiments("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experimentMetrics("exp-1"),
+    });
+  });
+});
+
+describe("usePauseExperiment", () => {
+  it("invalidates experiments and experimentMetrics keys", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => usePauseExperiment(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutate({ experimentId: "exp-1", agentId: "agent-1" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experiments("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experimentMetrics("exp-1"),
+    });
+  });
+});
+
+describe("useDeletePromptVersion", () => {
+  it("invalidates promptVersions for the agent", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeletePromptVersion(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ versionId: "v-1", agentId: "agent-1" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.promptVersions("agent-1"),
+    });
+  });
+});
+
+describe("useCreatePromptVersion", () => {
+  it("invalidates promptVersions for the agent", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreatePromptVersion(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ agentId: "agent-1", version: { version: 1, content_hash: "abc", system_prompt: "sys", tools: [], variables: [], created_by: "user" } });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.promptVersions("agent-1"),
+    });
+  });
+});
+
+describe("useCreateExperiment", () => {
+  it("invalidates experiments for the agent", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateExperiment(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ agentId: "agent-1", experiment: { name: "exp-1", status: "draft", traffic_split: [50, 50], success_criteria: { require_user_helpful: true, require_no_tool_errors: true, require_non_empty: true }, variants: [] } });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experiments("agent-1"),
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import {
   useSwitchAgentSession,
   useDeleteAgentSession,
@@ -15,6 +13,7 @@ import {
   useResolveApproval,
 } from "./agents";
 import { agentKeys, sessionKeys, overviewKeys, approvalKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   switchAgentSession: vi.fn().mockResolvedValue({}),
@@ -31,16 +30,11 @@ vi.mock("../http/client", () => ({
 
 describe("useSwitchAgentSession", () => {
   it("invalidates agent detail, agent sessions, and session lists", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useSwitchAgentSession(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({
@@ -48,13 +42,13 @@ describe("useSwitchAgentSession", () => {
       sessionId: "session-1",
     });
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.detail("agent-1"),
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.sessions("agent-1"),
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.lists(),
     });
   });
@@ -62,16 +56,11 @@ describe("useSwitchAgentSession", () => {
 
 describe("useDeleteAgentSession", () => {
   it("with agentId invalidates agent sessions, agent detail, and session lists", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useDeleteAgentSession(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({
@@ -79,38 +68,33 @@ describe("useDeleteAgentSession", () => {
       agentId: "agent-1",
     });
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.sessions("agent-1"),
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.detail("agent-1"),
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.lists(),
     });
   });
 
   it("without agentId invalidates agentKeys.all and session lists", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useDeleteAgentSession(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({
       sessionId: "session-1",
     });
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.lists(),
     });
   });
@@ -118,16 +102,11 @@ describe("useDeleteAgentSession", () => {
 
 describe("usePatchAgentConfig", () => {
   it("invalidates agent lists and agent detail", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => usePatchAgentConfig(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({
@@ -135,10 +114,10 @@ describe("usePatchAgentConfig", () => {
       config: { max_tokens: 4096 },
     });
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.lists(),
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.detail("agent-1"),
     });
   });
@@ -152,59 +131,44 @@ describe.each([
   { name: "useResumeAgent", hook: useResumeAgent, arg: "agent-1" },
 ])("$name invalidates agentKeys.all and overviewKeys.snapshot", ({ hook, arg }) => {
   it("invalidates both keys", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => hook(), { wrapper: Wrapper });
+    const { result } = renderHook(() => hook(), { wrapper });
 
     await result.current.mutateAsync(arg);
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
-    expect(spy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
   });
 });
 
 describe("useCreateAgentSession", () => {
   it("invalidates agentKeys.all", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useCreateAgentSession(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({ agentId: "agent-1", label: "test" });
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
   });
 });
 
 describe("useResolveApproval", () => {
   it("invalidates approvalKeys.all", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const Wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useResolveApproval(), {
-      wrapper: Wrapper,
+      wrapper,
     });
 
     await result.current.mutateAsync({ id: "approval-1", approved: true });
 
-    expect(spy).toHaveBeenCalledWith({ queryKey: approvalKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: approvalKeys.all });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
@@ -1,8 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
-import * as http from "../http/client";
 import {
   useSwitchAgentSession,
   useDeleteAgentSession,

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import * as http from "../http/client";
+import {
+  useSwitchAgentSession,
+  useDeleteAgentSession,
+  usePatchAgentConfig,
+  useSpawnAgent,
+  useCloneAgent,
+  useSuspendAgent,
+  useDeleteAgent,
+  useResumeAgent,
+  useCreateAgentSession,
+  useResolveApproval,
+} from "./agents";
+import { agentKeys, sessionKeys, overviewKeys, approvalKeys } from "../queries/keys";
+
+vi.mock("../http/client", () => ({
+  switchAgentSession: vi.fn().mockResolvedValue({}),
+  deleteSession: vi.fn().mockResolvedValue({}),
+  patchAgentConfig: vi.fn().mockResolvedValue({}),
+  spawnAgent: vi.fn().mockResolvedValue({}),
+  cloneAgent: vi.fn().mockResolvedValue({}),
+  suspendAgent: vi.fn().mockResolvedValue({}),
+  resumeAgent: vi.fn().mockResolvedValue({}),
+  deleteAgent: vi.fn().mockResolvedValue({}),
+  createAgentSession: vi.fn().mockResolvedValue({}),
+  resolveApproval: vi.fn().mockResolvedValue({}),
+}));
+
+describe("useSwitchAgentSession", () => {
+  it("invalidates agent detail, agent sessions, and session lists", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSwitchAgentSession(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({
+      agentId: "agent-1",
+      sessionId: "session-1",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.detail("agent-1"),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.sessions("agent-1"),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.lists(),
+    });
+  });
+});
+
+describe("useDeleteAgentSession", () => {
+  it("with agentId invalidates agent sessions, agent detail, and session lists", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDeleteAgentSession(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({
+      sessionId: "session-1",
+      agentId: "agent-1",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.sessions("agent-1"),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.detail("agent-1"),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.lists(),
+    });
+  });
+
+  it("without agentId invalidates agentKeys.all and session lists", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDeleteAgentSession(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({
+      sessionId: "session-1",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.lists(),
+    });
+  });
+});
+
+describe("usePatchAgentConfig", () => {
+  it("invalidates agent lists and agent detail", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => usePatchAgentConfig(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({
+      agentId: "agent-1",
+      config: { max_tokens: 4096 },
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.lists(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.detail("agent-1"),
+    });
+  });
+});
+
+describe.each([
+  { name: "useSpawnAgent", hook: useSpawnAgent, arg: "agent-1" },
+  { name: "useCloneAgent", hook: useCloneAgent, arg: "agent-1" },
+  { name: "useSuspendAgent", hook: useSuspendAgent, arg: "agent-1" },
+  { name: "useDeleteAgent", hook: useDeleteAgent, arg: "agent-1" },
+  { name: "useResumeAgent", hook: useResumeAgent, arg: "agent-1" },
+])("$name invalidates agentKeys.all and overviewKeys.snapshot", ({ hook, arg }) => {
+  it("invalidates both keys", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => hook(), { wrapper: Wrapper });
+
+    await result.current.mutateAsync(arg);
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+    expect(spy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
+  });
+});
+
+describe("useCreateAgentSession", () => {
+  it("invalidates agentKeys.all", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useCreateAgentSession(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({ agentId: "agent-1", label: "test" });
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+  });
+});
+
+describe("useResolveApproval", () => {
+  it("invalidates approvalKeys.all", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useResolveApproval(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync({ id: "approval-1", approved: true });
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: approvalKeys.all });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import * as http from "../http/client";
 import { renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
+import type { HandMessageResponse } from "../../api";
 import {
   useActivateHand,
   useDeactivateHand,
@@ -14,6 +13,10 @@ import {
   useSendHandMessage,
 } from "./hands";
 import { agentKeys, handKeys, overviewKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+
+type SetHandSecretInput = Parameters<ReturnType<typeof useSetHandSecret>["mutateAsync"]>[0];
+type UpdateHandSettingsInput = Parameters<ReturnType<typeof useUpdateHandSettings>["mutateAsync"]>[0];
 
 vi.mock("../http/client", () => ({
   activateHand: vi.fn(() => Promise.resolve({})),
@@ -28,25 +31,20 @@ vi.mock("../http/client", () => ({
 
 describe("useActivateHand", () => {
   it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useActivateHand(), { wrapper });
 
     await result.current.mutateAsync("hand-1");
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: overviewKeys.snapshot(),
     });
   });
@@ -54,25 +52,20 @@ describe("useActivateHand", () => {
 
 describe("useDeactivateHand", () => {
   it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useDeactivateHand(), { wrapper });
 
     await result.current.mutateAsync("hand-1");
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: overviewKeys.snapshot(),
     });
   });
@@ -80,25 +73,20 @@ describe("useDeactivateHand", () => {
 
 describe("usePauseHand", () => {
   it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => usePauseHand(), { wrapper });
 
     await result.current.mutateAsync("hand-1");
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: overviewKeys.snapshot(),
     });
   });
@@ -106,25 +94,20 @@ describe("usePauseHand", () => {
 
 describe("useResumeHand", () => {
   it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useResumeHand(), { wrapper });
 
     await result.current.mutateAsync("hand-1");
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: overviewKeys.snapshot(),
     });
   });
@@ -132,49 +115,59 @@ describe("useResumeHand", () => {
 
 describe("useUninstallHand", () => {
   it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useUninstallHand(), { wrapper });
 
     await result.current.mutateAsync("hand-1");
 
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.all,
     });
-    expect(spy).toHaveBeenCalledWith({
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: overviewKeys.snapshot(),
     });
   });
 });
 
-describe.each([
-  { name: "useSetHandSecret", hook: useSetHandSecret, args: { handId: "h1", key: "k", value: "v" } },
-  { name: "useUpdateHandSettings", hook: useUpdateHandSettings, args: { handId: "h1", config: { foo: 1 } } },
-])("$name", ({ name, hook, args }) => {
+describe("useSetHandSecret", () => {
   it("invalidates handKeys.all", async () => {
-    vi.mocked(http[name === "useSetHandSecret" ? "setHandSecret" : "updateHandSettings"]).mockResolvedValue({} as any);
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+    const args: SetHandSecretInput = { handId: "h1", key: "k", value: "v" };
+    vi.mocked(http.setHandSecret).mockResolvedValue({ ok: true });
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useSetHandSecret(), { wrapper });
+
+    await result.current.mutateAsync(args);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
     });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+  });
+});
 
-    const { result } = renderHook(() => hook(), { wrapper });
+describe("useUpdateHandSettings", () => {
+  it("invalidates handKeys.all", async () => {
+    const args: UpdateHandSettingsInput = { handId: "h1", config: { foo: 1 } };
+    vi.mocked(http.updateHandSettings).mockResolvedValue({
+      status: "ok",
+      hand_id: "h1",
+      instance_id: "inst-1",
+      config: { foo: 1 },
+    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    await result.current.mutateAsync(args as any);
+    const { result } = renderHook(() => useUpdateHandSettings(), { wrapper });
 
-    expect(spy).toHaveBeenCalledWith({
+    await result.current.mutateAsync(args);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.all,
     });
   });
@@ -182,20 +175,16 @@ describe.each([
 
 describe("useSendHandMessage", () => {
   it("does not invalidate queries and calls mutationFn with correct args", async () => {
-    vi.mocked(http.sendHandMessage).mockResolvedValue({} as any);
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(qc, "invalidateQueries");
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const response: HandMessageResponse = { response: "ok" };
+    vi.mocked(http.sendHandMessage).mockResolvedValue(response);
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useSendHandMessage(), { wrapper });
 
     await result.current.mutateAsync({ instanceId: "inst-1", message: "hello" });
 
-    expect(spy).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
     expect(http.sendHandMessage).toHaveBeenCalledWith("inst-1", "hello");
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from "vitest";
+import * as http from "../http/client";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {
+  useActivateHand,
+  useDeactivateHand,
+  usePauseHand,
+  useResumeHand,
+  useUninstallHand,
+  useSetHandSecret,
+  useUpdateHandSettings,
+  useSendHandMessage,
+} from "./hands";
+import { agentKeys, handKeys, overviewKeys } from "../queries/keys";
+
+vi.mock("../http/client", () => ({
+  activateHand: vi.fn(() => Promise.resolve({})),
+  deactivateHand: vi.fn(() => Promise.resolve({})),
+  pauseHand: vi.fn(() => Promise.resolve({})),
+  resumeHand: vi.fn(() => Promise.resolve({})),
+  uninstallHand: vi.fn(() => Promise.resolve({})),
+  setHandSecret: vi.fn(() => Promise.resolve({})),
+  updateHandSettings: vi.fn(() => Promise.resolve({})),
+  sendHandMessage: vi.fn(() => Promise.resolve({})),
+}));
+
+describe("useActivateHand", () => {
+  it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useActivateHand(), { wrapper });
+
+    await result.current.mutateAsync("hand-1");
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe("useDeactivateHand", () => {
+  it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDeactivateHand(), { wrapper });
+
+    await result.current.mutateAsync("hand-1");
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe("usePauseHand", () => {
+  it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => usePauseHand(), { wrapper });
+
+    await result.current.mutateAsync("hand-1");
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe("useResumeHand", () => {
+  it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useResumeHand(), { wrapper });
+
+    await result.current.mutateAsync("hand-1");
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe("useUninstallHand", () => {
+  it("invalidates handKeys.all, agentKeys.all, and overviewKeys.snapshot()", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useUninstallHand(), { wrapper });
+
+    await result.current.mutateAsync("hand-1");
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: agentKeys.all,
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe.each([
+  { name: "useSetHandSecret", hook: useSetHandSecret, args: { handId: "h1", key: "k", value: "v" } },
+  { name: "useUpdateHandSettings", hook: useUpdateHandSettings, args: { handId: "h1", config: { foo: 1 } } },
+])("$name", ({ name, hook, args }) => {
+  it("invalidates handKeys.all", async () => {
+    vi.mocked(http[name === "useSetHandSecret" ? "setHandSecret" : "updateHandSettings"]).mockResolvedValue({} as any);
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    await result.current.mutateAsync(args as any);
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: handKeys.all,
+    });
+  });
+});
+
+describe("useSendHandMessage", () => {
+  it("does not invalidate queries and calls mutationFn with correct args", async () => {
+    vi.mocked(http.sendHandMessage).mockResolvedValue({} as any);
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSendHandMessage(), { wrapper });
+
+    await result.current.mutateAsync({ instanceId: "inst-1", message: "hello" });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(http.sendHandMessage).toHaveBeenCalledWith("inst-1", "hello");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
@@ -34,7 +34,7 @@ describe("useCompleteExperiment", () => {
     });
 
     const variables = { experimentId: "exp-1", agentId: "agent-1" };
-    result.current.mutateAsync(variables);
+    await result.current.mutateAsync(variables);
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);
@@ -61,7 +61,7 @@ describe("useSetSessionLabel", () => {
       ),
     });
 
-    result.current.mutateAsync({
+    await result.current.mutateAsync({
       sessionId: "sess-1",
       label: "test label",
       agentId: "agent-1",
@@ -90,7 +90,7 @@ describe("useSetSessionLabel", () => {
       ),
     });
 
-    result.current.mutateAsync({ sessionId: "sess-1", label: "test label" });
+    await result.current.mutateAsync({ sessionId: "sess-1", label: "test label" });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(1);
@@ -114,7 +114,7 @@ describe("useInstallSkill", () => {
       ),
     });
 
-    result.current.mutateAsync({ name: "test-skill" });
+    await result.current.mutateAsync({ name: "test-skill" });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);
@@ -139,7 +139,7 @@ describe("useInstallSkill", () => {
       ),
     });
 
-    result.current.mutateAsync({ name: "test-skill", hand: "test-hand" });
+    await result.current.mutateAsync({ name: "test-skill", hand: "test-hand" });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);

--- a/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
-import * as httpClient from "../http/client";
 import { useCompleteExperiment } from "./agents";
 import { useSetSessionLabel } from "./sessions";
 import { useInstallSkill } from "./skills";
 import { agentKeys, sessionKeys, skillKeys, fanghubKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", async () => {
   const actual = await vi.importActual<typeof import("../http/client")>(
@@ -22,15 +20,11 @@ vi.mock("../http/client", async () => {
 
 describe("useCompleteExperiment", () => {
   it("invalidates experiments and experimentMetrics keys", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useCompleteExperiment(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
+      wrapper,
     });
 
     const variables = { experimentId: "exp-1", agentId: "agent-1" };
@@ -50,15 +44,11 @@ describe("useCompleteExperiment", () => {
 
 describe("useSetSessionLabel", () => {
   it("with agentId invalidates session lists and agent sessions", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useSetSessionLabel(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
+      wrapper,
     });
 
     await result.current.mutateAsync({
@@ -79,15 +69,11 @@ describe("useSetSessionLabel", () => {
   });
 
   it("without agentId invalidates only session lists", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useSetSessionLabel(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
+      wrapper,
     });
 
     await result.current.mutateAsync({ sessionId: "sess-1", label: "test label" });
@@ -103,15 +89,11 @@ describe("useSetSessionLabel", () => {
 
 describe("useInstallSkill", () => {
   it("invalidates skillKeys.all and fanghubKeys.all", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useInstallSkill(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
+      wrapper,
     });
 
     await result.current.mutateAsync({ name: "test-skill" });
@@ -128,15 +110,11 @@ describe("useInstallSkill", () => {
   });
 
   it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useInstallSkill(), {
-      wrapper: ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      ),
+      wrapper,
     });
 
     await result.current.mutateAsync({ name: "test-skill", hand: "test-hand" });

--- a/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import * as httpClient from "../http/client";
+import { useCompleteExperiment } from "./agents";
+import { useSetSessionLabel } from "./sessions";
+import { useInstallSkill } from "./skills";
+import { agentKeys, sessionKeys, skillKeys, fanghubKeys } from "../queries/keys";
+
+vi.mock("../http/client", async () => {
+  const actual = await vi.importActual<typeof import("../http/client")>(
+    "../http/client",
+  );
+  return {
+    ...actual,
+    completeExperiment: vi.fn().mockResolvedValue({}),
+    setSessionLabel: vi.fn().mockResolvedValue({}),
+    installSkill: vi.fn().mockResolvedValue({}),
+  };
+});
+
+describe("useCompleteExperiment", () => {
+  it("invalidates experiments and experimentMetrics keys", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCompleteExperiment(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    const variables = { experimentId: "exp-1", agentId: "agent-1" };
+    result.current.mutateAsync(variables);
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experiments("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.experimentMetrics("exp-1"),
+    });
+  });
+});
+
+describe("useSetSessionLabel", () => {
+  it("with agentId invalidates session lists and agent sessions", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useSetSessionLabel(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutateAsync({
+      sessionId: "sess-1",
+      label: "test label",
+      agentId: "agent-1",
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.lists(),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.sessions("agent-1"),
+    });
+  });
+
+  it("without agentId invalidates only session lists", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useSetSessionLabel(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutateAsync({ sessionId: "sess-1", label: "test label" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.lists(),
+    });
+  });
+});
+
+describe("useInstallSkill", () => {
+  it("invalidates skillKeys.all and fanghubKeys.all", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useInstallSkill(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutateAsync({ name: "test-skill" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: fanghubKeys.all,
+    });
+  });
+
+  it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useInstallSkill(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      ),
+    });
+
+    result.current.mutateAsync({ name: "test-skill", hand: "test-hand" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: fanghubKeys.all,
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, type MockedFunction } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import {
   useRestoreBackup,
   useCreateBackup,
@@ -18,6 +16,7 @@ import {
   useSkillHubInstall,
 } from "./skills";
 import { runtimeKeys, overviewKeys, skillKeys, fanghubKeys, sessionKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../../api", () => ({
   restoreBackup: vi.fn().mockResolvedValue({ message: "ok" }),
@@ -38,14 +37,8 @@ vi.mock("../http/client", () => ({
 
 describe("useRestoreBackup", () => {
   it("invalidates runtimeKeys.backups() and overviewKeys.snapshot()", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => useRestoreBackup(), { wrapper });
 
@@ -65,14 +58,8 @@ describe("useRestoreBackup", () => {
 
 describe("useFangHubInstall", () => {
   it("invalidates skillKeys.all and fanghubKeys.all", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => useFangHubInstall(), { wrapper });
 
@@ -90,14 +77,8 @@ describe("useFangHubInstall", () => {
   });
 
   it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => useFangHubInstall(), { wrapper });
 
@@ -120,18 +101,13 @@ describe.each([
   { name: "useDeleteBackup", hook: useDeleteBackup, mutator: () => "backup-1", invalidateKeys: [runtimeKeys.backups()] },
 ] as const)("$name", ({ hook, mutator, invalidateKeys }) => {
   it("invalidates correct keys", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+    const typedHook = hook as MockedFunction<typeof hook>;
+    const { result } = renderHook(() => typedHook(), { wrapper });
 
-    const { result } = renderHook(() => hook(), { wrapper });
-
-    result.current.mutate(mutator() as any);
+    result.current.mutate(mutator() as never);
     await vi.waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
@@ -147,14 +123,8 @@ describe.each([
   { name: "useRetryTask", hook: useRetryTask, id: "task-2", invalidateKeys: [runtimeKeys.tasks()] },
 ] as const)("$name", ({ hook, id, invalidateKeys }) => {
   it("invalidates correct keys", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => hook(), { wrapper });
 
@@ -171,14 +141,8 @@ describe.each([
 
 describe("useCleanupSessions", () => {
   it("invalidates sessionKeys.all", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => useCleanupSessions(), { wrapper });
 
@@ -195,14 +159,8 @@ describe("useCleanupSessions", () => {
 
 describe("useShutdownServer", () => {
   it("calls shutdownServer without invalidating queries", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => useShutdownServer(), { wrapper });
 
@@ -221,14 +179,8 @@ describe.each([
   { name: "useSkillHubInstall", hook: useSkillHubInstall, input: { slug: "test-skill", hand: "test-hand" } },
 ] as const)("$name", ({ hook, input }) => {
   it("invalidates skillKeys.all", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(() => hook(), { wrapper });
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, type MockedFunction } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import {
   useRestoreBackup,
@@ -96,25 +96,35 @@ describe("useFangHubInstall", () => {
   });
 });
 
-describe.each([
-  { name: "useCreateBackup", hook: useCreateBackup, mutator: () => undefined, invalidateKeys: [runtimeKeys.backups()] },
-  { name: "useDeleteBackup", hook: useDeleteBackup, mutator: () => "backup-1", invalidateKeys: [runtimeKeys.backups()] },
-] as const)("$name", ({ hook, mutator, invalidateKeys }) => {
+describe("useCreateBackup", () => {
   it("invalidates correct keys", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const typedHook = hook as MockedFunction<typeof hook>;
-    const { result } = renderHook(() => typedHook(), { wrapper });
+    const { result } = renderHook(() => useCreateBackup(), { wrapper });
 
-    result.current.mutate(mutator() as never);
+    result.current.mutate();
     await vi.waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    for (const key of invalidateKeys) {
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
-    }
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: runtimeKeys.backups() });
+  });
+});
+
+describe("useDeleteBackup", () => {
+  it("invalidates correct keys", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteBackup(), { wrapper });
+
+    result.current.mutate("backup-1");
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: runtimeKeys.backups() });
   });
 });
 
@@ -173,18 +183,50 @@ describe("useShutdownServer", () => {
   });
 });
 
-describe.each([
-  { name: "useUninstallSkill", hook: useUninstallSkill, input: "skill-1" },
-  { name: "useClawHubInstall", hook: useClawHubInstall, input: { slug: "test-skill", version: "1.0.0", hand: "test-hand" } },
-  { name: "useSkillHubInstall", hook: useSkillHubInstall, input: { slug: "test-skill", hand: "test-hand" } },
-] as const)("$name", ({ hook, input }) => {
+describe("useUninstallSkill", () => {
   it("invalidates skillKeys.all", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    const { result } = renderHook(() => hook(), { wrapper });
+    const { result } = renderHook(() => useUninstallSkill(), { wrapper });
 
-    result.current.mutate(input as any);
+    result.current.mutate("skill-1");
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+  });
+});
+
+describe("useClawHubInstall", () => {
+  it("invalidates skillKeys.all", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClawHubInstall(), { wrapper });
+
+    result.current.mutate({ slug: "test-skill", version: "1.0.0", hand: "test-hand" });
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+  });
+});
+
+describe("useSkillHubInstall", () => {
+  it("invalidates skillKeys.all", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useSkillHubInstall(), { wrapper });
+
+    result.current.mutate({ slug: "test-skill", hand: "test-hand" });
     await vi.waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalled();
     });

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {
+  useRestoreBackup,
+  useCreateBackup,
+  useDeleteBackup,
+  useDeleteTask,
+  useRetryTask,
+  useCleanupSessions,
+  useShutdownServer,
+} from "./runtime";
+import {
+  useFangHubInstall,
+  useUninstallSkill,
+  useClawHubInstall,
+  useSkillHubInstall,
+} from "./skills";
+import { runtimeKeys, overviewKeys, skillKeys, fanghubKeys, sessionKeys } from "../queries/keys";
+
+vi.mock("../../api", () => ({
+  restoreBackup: vi.fn().mockResolvedValue({ message: "ok" }),
+  createBackup: vi.fn().mockResolvedValue({ message: "ok" }),
+  deleteBackup: vi.fn().mockResolvedValue({ message: "ok" }),
+  deleteTaskFromQueue: vi.fn().mockResolvedValue({ message: "ok" }),
+  retryTask: vi.fn().mockResolvedValue({ message: "ok" }),
+  cleanupSessions: vi.fn().mockResolvedValue({ message: "ok" }),
+  shutdownServer: vi.fn().mockResolvedValue({ status: "ok" }),
+}));
+
+vi.mock("../http/client", () => ({
+  installSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  clawhubInstall: vi.fn().mockResolvedValue({ status: "ok" }),
+  skillhubInstall: vi.fn().mockResolvedValue({ status: "ok" }),
+  uninstallSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+}));
+
+describe("useRestoreBackup", () => {
+  it("invalidates runtimeKeys.backups() and overviewKeys.snapshot()", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useRestoreBackup(), { wrapper });
+
+    result.current.mutate("backup-1");
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: runtimeKeys.backups(),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: overviewKeys.snapshot(),
+    });
+  });
+});
+
+describe("useFangHubInstall", () => {
+  it("invalidates skillKeys.all and fanghubKeys.all", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useFangHubInstall(), { wrapper });
+
+    result.current.mutate({ name: "test-skill" });
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: fanghubKeys.all,
+    });
+  });
+
+  it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useFangHubInstall(), { wrapper });
+
+    result.current.mutate({ name: "test-skill", hand: "test-hand" });
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: fanghubKeys.all,
+    });
+  });
+});
+
+describe.each([
+  { name: "useCreateBackup", hook: useCreateBackup, mutator: () => undefined, invalidateKeys: [runtimeKeys.backups()] },
+  { name: "useDeleteBackup", hook: useDeleteBackup, mutator: () => "backup-1", invalidateKeys: [runtimeKeys.backups()] },
+] as const)("$name", ({ hook, mutator, invalidateKeys }) => {
+  it("invalidates correct keys", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    result.current.mutate(mutator() as any);
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    for (const key of invalidateKeys) {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+    }
+  });
+});
+
+describe.each([
+  { name: "useDeleteTask", hook: useDeleteTask, id: "task-1", invalidateKeys: [runtimeKeys.tasks()] },
+  { name: "useRetryTask", hook: useRetryTask, id: "task-2", invalidateKeys: [runtimeKeys.tasks()] },
+] as const)("$name", ({ hook, id, invalidateKeys }) => {
+  it("invalidates correct keys", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    result.current.mutate(id);
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    for (const key of invalidateKeys) {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+    }
+  });
+});
+
+describe("useCleanupSessions", () => {
+  it("invalidates sessionKeys.all", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useCleanupSessions(), { wrapper });
+
+    result.current.mutate();
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.all,
+    });
+  });
+});
+
+describe("useShutdownServer", () => {
+  it("calls shutdownServer without invalidating queries", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useShutdownServer(), { wrapper });
+
+    result.current.mutate();
+    await vi.waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe.each([
+  { name: "useUninstallSkill", hook: useUninstallSkill, input: "skill-1" },
+  { name: "useClawHubInstall", hook: useClawHubInstall, input: { slug: "test-skill", version: "1.0.0", hand: "test-hand" } },
+  { name: "useSkillHubInstall", hook: useSkillHubInstall, input: { slug: "test-skill", hand: "test-hand" } },
+] as const)("$name", ({ hook, input }) => {
+  it("invalidates skillKeys.all", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    result.current.mutate(input as any);
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.all,
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import { useRunSchedule } from "./schedules";
 import { useSetConfigValue, useReloadConfig } from "./config";
 import { scheduleKeys, cronKeys, configKeys, overviewKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   runSchedule: vi.fn().mockResolvedValue({}),
@@ -14,57 +13,39 @@ vi.mock("../http/client", () => ({
 
 describe("useRunSchedule", () => {
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useRunSchedule(), { wrapper });
 
     await result.current.mutateAsync("schedule-1");
 
     await waitFor(() => {
-      expect(spy).toHaveBeenCalled();
+      expect(invalidateSpy).toHaveBeenCalled();
     });
-    expect(spy).toHaveBeenCalledWith({ queryKey: scheduleKeys.all });
-    expect(spy).toHaveBeenCalledWith({ queryKey: cronKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: scheduleKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: cronKeys.all });
   });
 });
 
 describe("useSetConfigValue", () => {
   it("invalidates configKeys.all", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useSetConfigValue(), { wrapper });
 
     await result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
 
     await waitFor(() => {
-      expect(spy).toHaveBeenCalled();
+      expect(invalidateSpy).toHaveBeenCalled();
     });
-    expect(spy).toHaveBeenCalledWith({ queryKey: configKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: configKeys.all });
   });
 
   it("calls options.onSuccess after invalidation", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { wrapper } = createQueryClientWrapper();
     const onSuccess = vi.fn();
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(
       () => useSetConfigValue({ onSuccess }),
@@ -81,35 +62,23 @@ describe("useSetConfigValue", () => {
 
 describe("useReloadConfig", () => {
   it("invalidates configKeys.all and overviewKeys.snapshot()", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const spy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useReloadConfig(), { wrapper });
 
     await result.current.mutateAsync();
 
     await waitFor(() => {
-      expect(spy).toHaveBeenCalled();
+      expect(invalidateSpy).toHaveBeenCalled();
     });
-    expect(spy).toHaveBeenCalledWith({ queryKey: configKeys.all });
-    expect(spy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: configKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
   });
 
   it("calls options.onSuccess after invalidation", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { wrapper } = createQueryClientWrapper();
     const onSuccess = vi.fn();
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
 
     const { result } = renderHook(
       () => useReloadConfig({ onSuccess }),

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
@@ -25,7 +25,7 @@ describe("useRunSchedule", () => {
 
     const { result } = renderHook(() => useRunSchedule(), { wrapper });
 
-    result.current.mutateAsync("schedule-1");
+    await result.current.mutateAsync("schedule-1");
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
@@ -48,7 +48,7 @@ describe("useSetConfigValue", () => {
 
     const { result } = renderHook(() => useSetConfigValue(), { wrapper });
 
-    result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
+    await result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
@@ -71,7 +71,7 @@ describe("useSetConfigValue", () => {
       { wrapper },
     );
 
-    result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
+    await result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalled();
@@ -92,7 +92,7 @@ describe("useReloadConfig", () => {
 
     const { result } = renderHook(() => useReloadConfig(), { wrapper });
 
-    result.current.mutateAsync();
+    await result.current.mutateAsync();
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe("useReloadConfig", () => {
       { wrapper },
     );
 
-    result.current.mutateAsync();
+    await result.current.mutateAsync();
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalled();

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules-config.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useRunSchedule } from "./schedules";
+import { useSetConfigValue, useReloadConfig } from "./config";
+import { scheduleKeys, cronKeys, configKeys, overviewKeys } from "../queries/keys";
+
+vi.mock("../http/client", () => ({
+  runSchedule: vi.fn().mockResolvedValue({}),
+  setConfigValue: vi.fn().mockResolvedValue({}),
+  reloadConfig: vi.fn().mockResolvedValue({}),
+}));
+
+describe("useRunSchedule", () => {
+  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useRunSchedule(), { wrapper });
+
+    result.current.mutateAsync("schedule-1");
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: scheduleKeys.all });
+    expect(spy).toHaveBeenCalledWith({ queryKey: cronKeys.all });
+  });
+});
+
+describe("useSetConfigValue", () => {
+  it("invalidates configKeys.all", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSetConfigValue(), { wrapper });
+
+    result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: configKeys.all });
+  });
+
+  it("calls options.onSuccess after invalidation", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const onSuccess = vi.fn();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useSetConfigValue({ onSuccess }),
+      { wrapper },
+    );
+
+    result.current.mutateAsync({ path: "kernel.max_agents", value: 10 });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useReloadConfig", () => {
+  it("invalidates configKeys.all and overviewKeys.snapshot()", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useReloadConfig(), { wrapper });
+
+    result.current.mutateAsync();
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: configKeys.all });
+    expect(spy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
+  });
+
+  it("calls options.onSuccess after invalidation", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const onSuccess = vi.fn();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useReloadConfig({ onSuccess }),
+      { wrapper },
+    );
+
+    result.current.mutateAsync();
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import * as http from "../http/client";
 import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule, useUpdateTrigger, useDeleteTrigger } from "./schedules";
 import { cronKeys, scheduleKeys, triggerKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   createSchedule: vi.fn(),
@@ -14,30 +13,18 @@ vi.mock("../http/client", () => ({
   deleteTrigger: vi.fn(),
 }));
 
-function createWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return {
-    qc,
-    wrapper: ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    ),
-  };
-}
-
 describe("useCreateSchedule", () => {
   beforeEach(() => {
     vi.mocked(http.createSchedule).mockResolvedValue({} as any);
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
-    const { qc, wrapper } = createWrapper();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useCreateSchedule(), { wrapper });
 
-    result.current.mutate({ agent_id: "agent-1", cron: "0 * * * *" });
+    result.current.mutate({ name: "test schedule", agent_id: "agent-1", cron: "0 * * * *" });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);
@@ -57,8 +44,8 @@ describe("useUpdateSchedule", () => {
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
-    const { qc, wrapper } = createWrapper();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useUpdateSchedule(), { wrapper });
 
@@ -78,12 +65,12 @@ describe("useUpdateSchedule", () => {
 
 describe("useDeleteSchedule", () => {
   beforeEach(() => {
-    vi.mocked(http.deleteSchedule).mockResolvedValue(undefined);
+    vi.mocked(http.deleteSchedule).mockResolvedValue({} as any);
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
-    const { qc, wrapper } = createWrapper();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useDeleteSchedule(), { wrapper });
 
@@ -107,8 +94,8 @@ describe("useUpdateTrigger", () => {
   });
 
   it("invalidates triggerKeys.all", async () => {
-    const { qc, wrapper } = createWrapper();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useUpdateTrigger(), { wrapper });
 
@@ -126,8 +113,8 @@ describe("useDeleteTrigger", () => {
   });
 
   it("invalidates triggerKeys.all", async () => {
-    const { qc, wrapper } = createWrapper();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useDeleteTrigger(), { wrapper });
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import * as http from "../http/client";
+import type { ApiActionResponse, ScheduleItem } from "../../api";
 import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule, useUpdateTrigger, useDeleteTrigger } from "./schedules";
 import { cronKeys, scheduleKeys, triggerKeys } from "../queries/keys";
 import { createQueryClientWrapper } from "../test/query-client";
@@ -13,9 +14,18 @@ vi.mock("../http/client", () => ({
   deleteTrigger: vi.fn(),
 }));
 
+const actionResponse: ApiActionResponse = { status: "ok" };
+const scheduleResponse: ScheduleItem = {
+  id: "sched-1",
+  name: "test schedule",
+  cron: "0 * * * *",
+  agent_id: "agent-1",
+  enabled: true,
+};
+
 describe("useCreateSchedule", () => {
   beforeEach(() => {
-    vi.mocked(http.createSchedule).mockResolvedValue({} as any);
+    vi.mocked(http.createSchedule).mockResolvedValue(scheduleResponse);
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
@@ -40,7 +50,7 @@ describe("useCreateSchedule", () => {
 
 describe("useUpdateSchedule", () => {
   beforeEach(() => {
-    vi.mocked(http.updateSchedule).mockResolvedValue({} as any);
+    vi.mocked(http.updateSchedule).mockResolvedValue(actionResponse);
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
@@ -65,7 +75,7 @@ describe("useUpdateSchedule", () => {
 
 describe("useDeleteSchedule", () => {
   beforeEach(() => {
-    vi.mocked(http.deleteSchedule).mockResolvedValue({} as any);
+    vi.mocked(http.deleteSchedule).mockResolvedValue(actionResponse);
   });
 
   it("invalidates scheduleKeys.all and cronKeys.all", async () => {
@@ -90,7 +100,7 @@ describe("useDeleteSchedule", () => {
 
 describe("useUpdateTrigger", () => {
   beforeEach(() => {
-    vi.mocked(http.updateTrigger).mockResolvedValue({} as any);
+    vi.mocked(http.updateTrigger).mockResolvedValue(actionResponse);
   });
 
   it("invalidates triggerKeys.all", async () => {
@@ -109,7 +119,7 @@ describe("useUpdateTrigger", () => {
 
 describe("useDeleteTrigger", () => {
   beforeEach(() => {
-    vi.mocked(http.deleteTrigger).mockResolvedValue({} as any);
+    vi.mocked(http.deleteTrigger).mockResolvedValue(actionResponse);
   });
 
   it("invalidates triggerKeys.all", async () => {

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import * as http from "../http/client";
+import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule, useUpdateTrigger, useDeleteTrigger } from "./schedules";
+import { cronKeys, scheduleKeys, triggerKeys } from "../queries/keys";
+
+vi.mock("../http/client", () => ({
+  createSchedule: vi.fn(),
+  updateSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+  updateTrigger: vi.fn(),
+  deleteTrigger: vi.fn(),
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    qc,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe("useCreateSchedule", () => {
+  beforeEach(() => {
+    vi.mocked(http.createSchedule).mockResolvedValue({} as any);
+  });
+
+  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+    const { qc, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateSchedule(), { wrapper });
+
+    result.current.mutate({ agent_id: "agent-1", cron: "0 * * * *" });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: scheduleKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
+      queryKey: cronKeys.all,
+    });
+  });
+});
+
+describe("useUpdateSchedule", () => {
+  beforeEach(() => {
+    vi.mocked(http.updateSchedule).mockResolvedValue({} as any);
+  });
+
+  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+    const { qc, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateSchedule(), { wrapper });
+
+    result.current.mutate({ id: "sched-1", data: { enabled: false } });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: scheduleKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
+      queryKey: cronKeys.all,
+    });
+  });
+});
+
+describe("useDeleteSchedule", () => {
+  beforeEach(() => {
+    vi.mocked(http.deleteSchedule).mockResolvedValue(undefined);
+  });
+
+  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+    const { qc, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteSchedule(), { wrapper });
+
+    result.current.mutate("sched-1");
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: scheduleKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
+      queryKey: cronKeys.all,
+    });
+  });
+});
+
+describe("useUpdateTrigger", () => {
+  beforeEach(() => {
+    vi.mocked(http.updateTrigger).mockResolvedValue({} as any);
+  });
+
+  it("invalidates triggerKeys.all", async () => {
+    const { qc, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateTrigger(), { wrapper });
+
+    await result.current.mutateAsync({ id: "trig-1", data: { enabled: true } });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: triggerKeys.all,
+    });
+  });
+});
+
+describe("useDeleteTrigger", () => {
+  beforeEach(() => {
+    vi.mocked(http.deleteTrigger).mockResolvedValue({} as any);
+  });
+
+  it("invalidates triggerKeys.all", async () => {
+    const { qc, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteTrigger(), { wrapper });
+
+    await result.current.mutateAsync("trig-1");
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: triggerKeys.all,
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
@@ -61,17 +61,28 @@ describe("usePromptVersions", () => {
   });
 
   it("should use the correct queryKey", async () => {
+    const mockData = [
+      {
+        id: "v1",
+        agent_id: "test-agent",
+        version: 1,
+        content_hash: "hash-1",
+        system_prompt: "system",
+        tools: [],
+        variables: [],
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "tester",
+        is_active: true,
+      },
+    ];
+    vi.mocked(http.listPromptVersions).mockResolvedValue(mockData);
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => usePromptVersions("test-agent"), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.promptVersions("test-agent") })).toBeDefined();
+      expect(queryClient.getQueryData(agentKeys.promptVersions("test-agent"))).toEqual(mockData);
     });
-
-    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.promptVersions("test-agent") });
-    expect(cache).toBeDefined();
-    expect(cache?.queryKey).toEqual(agentKeys.promptVersions("test-agent"));
   });
 });
 
@@ -126,17 +137,30 @@ describe("useExperiments", () => {
   });
 
   it("should use the correct queryKey", async () => {
+    const mockData = [
+      {
+        id: "exp-1",
+        agent_id: "test-agent",
+        name: "Test Experiment",
+        status: "running" as const,
+        traffic_split: [100],
+        success_criteria: {
+          require_user_helpful: true,
+          require_no_tool_errors: true,
+          require_non_empty: true,
+        },
+        created_at: "2024-01-01T00:00:00Z",
+        variants: [{ name: "A", prompt_version_id: "v1" }],
+      },
+    ];
+    vi.mocked(http.listExperiments).mockResolvedValue(mockData);
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useExperiments("test-agent"), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.experiments("test-agent") })).toBeDefined();
+      expect(queryClient.getQueryData(agentKeys.experiments("test-agent"))).toEqual(mockData);
     });
-
-    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.experiments("test-agent") });
-    expect(cache).toBeDefined();
-    expect(cache?.queryKey).toEqual(agentKeys.experiments("test-agent"));
   });
 });
 
@@ -196,11 +220,7 @@ describe("useExperimentMetrics", () => {
     renderHook(() => useExperimentMetrics("test-exp"), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.experimentMetrics("test-exp") })).toBeDefined();
+      expect(queryClient.getQueryData(agentKeys.experimentMetrics("test-exp"))).toEqual(mockData);
     });
-
-    expect(
-      queryClient.getQueryCache().find({ queryKey: agentKeys.experimentMetrics("test-exp") })?.queryKey,
-    ).toEqual(agentKeys.experimentMetrics("test-exp"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
@@ -59,7 +59,7 @@ describe("usePromptVersions", () => {
     expect(http.listPromptVersions).toHaveBeenCalledWith("agent-1");
   });
 
-  it("should use the correct queryKey", () => {
+  it("should use the correct queryKey", async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -68,6 +68,10 @@ describe("usePromptVersions", () => {
     );
 
     renderHook(() => usePromptVersions("test-agent"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(agentKeys.promptVersions("test-agent"))).toBeDefined();
+    });
 
     const cache = qc.getQueryCache().find(agentKeys.promptVersions("test-agent"));
     expect(cache).toBeDefined();
@@ -112,7 +116,7 @@ describe("useExperiments", () => {
     expect(http.listExperiments).toHaveBeenCalledWith("agent-1");
   });
 
-  it("should use the correct queryKey", () => {
+  it("should use the correct queryKey", async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -121,6 +125,10 @@ describe("useExperiments", () => {
     );
 
     renderHook(() => useExperiments("test-agent"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(agentKeys.experiments("test-agent"))).toBeDefined();
+    });
 
     const cache = qc.getQueryCache().find(agentKeys.experiments("test-agent"));
     expect(cache).toBeDefined();

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import * as http from "../http/client";
 import { usePromptVersions, useExperiments, useExperimentMetrics } from "./agents";
 import { agentKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   listPromptVersions: vi.fn(),
@@ -13,15 +12,6 @@ vi.mock("../http/client", () => ({
   ApiError: class ApiError extends Error {},
 }));
 
-function createWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
-
 describe("usePromptVersions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -29,7 +19,7 @@ describe("usePromptVersions", () => {
 
   it("should be disabled when agentId is empty string", () => {
     const { result } = renderHook(() => usePromptVersions(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -40,12 +30,23 @@ describe("usePromptVersions", () => {
 
   it("should be enabled and fetch when agentId is valid", async () => {
     const mockData = [
-      { id: "v1", agent_id: "agent-1", version: 1, is_active: true, created_at: "2024-01-01T00:00:00Z" },
+      {
+        id: "v1",
+        agent_id: "agent-1",
+        version: 1,
+        content_hash: "hash-1",
+        system_prompt: "system",
+        tools: [],
+        variables: [],
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "tester",
+        is_active: true,
+      },
     ];
     vi.mocked(http.listPromptVersions).mockResolvedValue(mockData);
 
     const { result } = renderHook(() => usePromptVersions("agent-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -60,20 +61,15 @@ describe("usePromptVersions", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => usePromptVersions("test-agent"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(agentKeys.promptVersions("test-agent"))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.promptVersions("test-agent") })).toBeDefined();
     });
 
-    const cache = qc.getQueryCache().find(agentKeys.promptVersions("test-agent"));
+    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.promptVersions("test-agent") });
     expect(cache).toBeDefined();
     expect(cache?.queryKey).toEqual(agentKeys.promptVersions("test-agent"));
   });
@@ -86,7 +82,7 @@ describe("useExperiments", () => {
 
   it("should be disabled when agentId is empty string", () => {
     const { result } = renderHook(() => useExperiments(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -97,12 +93,25 @@ describe("useExperiments", () => {
 
   it("should be enabled and fetch when agentId is valid", async () => {
     const mockData = [
-      { id: "exp-1", agent_id: "agent-1", name: "Test Experiment", status: "running", created_at: "2024-01-01T00:00:00Z" },
+      {
+        id: "exp-1",
+        agent_id: "agent-1",
+        name: "Test Experiment",
+        status: "running" as const,
+        traffic_split: [100],
+        success_criteria: {
+          require_user_helpful: true,
+          require_no_tool_errors: true,
+          require_non_empty: true,
+        },
+        created_at: "2024-01-01T00:00:00Z",
+        variants: [{ name: "A", prompt_version_id: "v1" }],
+      },
     ];
     vi.mocked(http.listExperiments).mockResolvedValue(mockData);
 
     const { result } = renderHook(() => useExperiments("agent-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -117,20 +126,15 @@ describe("useExperiments", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useExperiments("test-agent"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(agentKeys.experiments("test-agent"))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.experiments("test-agent") })).toBeDefined();
     });
 
-    const cache = qc.getQueryCache().find(agentKeys.experiments("test-agent"));
+    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.experiments("test-agent") });
     expect(cache).toBeDefined();
     expect(cache?.queryKey).toEqual(agentKeys.experiments("test-agent"));
   });
@@ -143,7 +147,7 @@ describe("useExperimentMetrics", () => {
 
   it("should be disabled when experimentId is empty string", () => {
     const { result } = renderHook(() => useExperimentMetrics(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -154,12 +158,22 @@ describe("useExperimentMetrics", () => {
 
   it("should be enabled and fetch when experimentId is valid", async () => {
     const mockData = [
-      { variant_id: "v1", success_rate: 0.95, avg_tokens: 100, total_cost_usd: 0.01 },
+      {
+        variant_id: "v1",
+        variant_name: "Variant A",
+        total_requests: 10,
+        successful_requests: 9,
+        failed_requests: 1,
+        success_rate: 0.95,
+        avg_latency_ms: 100,
+        avg_cost_usd: 0.001,
+        total_cost_usd: 0.01,
+      },
     ];
     vi.mocked(http.getExperimentMetrics).mockResolvedValue(mockData);
 
     const { result } = renderHook(() => useExperimentMetrics("exp-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -174,24 +188,19 @@ describe("useExperimentMetrics", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const mockData = [{ variant_id: "v1", success_rate: 0.5 }];
+    const mockData = [{ variant_id: "v1", variant_name: "Variant A", total_requests: 2, successful_requests: 1, failed_requests: 1, success_rate: 0.5, avg_latency_ms: 50, avg_cost_usd: 0.01, total_cost_usd: 0.02 }];
     vi.mocked(http.getExperimentMetrics).mockResolvedValue(mockData);
 
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useExperimentMetrics("test-exp"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(agentKeys.experimentMetrics("test-exp"))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.experimentMetrics("test-exp") })).toBeDefined();
     });
 
     expect(
-      qc.getQueryCache().find(agentKeys.experimentMetrics("test-exp"))?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: agentKeys.experimentMetrics("test-exp") })?.queryKey,
     ).toEqual(agentKeys.experimentMetrics("test-exp"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-experiments.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import * as http from "../http/client";
+import { usePromptVersions, useExperiments, useExperimentMetrics } from "./agents";
+import { agentKeys } from "./keys";
+
+vi.mock("../http/client", () => ({
+  listPromptVersions: vi.fn(),
+  listExperiments: vi.fn(),
+  getExperimentMetrics: vi.fn(),
+  ApiError: class ApiError extends Error {},
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("usePromptVersions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => usePromptVersions(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(http.listPromptVersions).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled and fetch when agentId is valid", async () => {
+    const mockData = [
+      { id: "v1", agent_id: "agent-1", version: 1, is_active: true, created_at: "2024-01-01T00:00:00Z" },
+    ];
+    vi.mocked(http.listPromptVersions).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => usePromptVersions("agent-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(http.listPromptVersions).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("should use the correct queryKey", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => usePromptVersions("test-agent"), { wrapper });
+
+    const cache = qc.getQueryCache().find(agentKeys.promptVersions("test-agent"));
+    expect(cache).toBeDefined();
+    expect(cache?.queryKey).toEqual(agentKeys.promptVersions("test-agent"));
+  });
+});
+
+describe("useExperiments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => useExperiments(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(http.listExperiments).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled and fetch when agentId is valid", async () => {
+    const mockData = [
+      { id: "exp-1", agent_id: "agent-1", name: "Test Experiment", status: "running", created_at: "2024-01-01T00:00:00Z" },
+    ];
+    vi.mocked(http.listExperiments).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useExperiments("agent-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(http.listExperiments).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("should use the correct queryKey", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useExperiments("test-agent"), { wrapper });
+
+    const cache = qc.getQueryCache().find(agentKeys.experiments("test-agent"));
+    expect(cache).toBeDefined();
+    expect(cache?.queryKey).toEqual(agentKeys.experiments("test-agent"));
+  });
+});
+
+describe("useExperimentMetrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be disabled when experimentId is empty string", () => {
+    const { result } = renderHook(() => useExperimentMetrics(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(http.getExperimentMetrics).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled and fetch when experimentId is valid", async () => {
+    const mockData = [
+      { variant_id: "v1", success_rate: 0.95, avg_tokens: 100, total_cost_usd: 0.01 },
+    ];
+    vi.mocked(http.getExperimentMetrics).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useExperimentMetrics("exp-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(http.getExperimentMetrics).toHaveBeenCalledWith("exp-1");
+  });
+
+  it("should use the correct queryKey", async () => {
+    const mockData = [{ variant_id: "v1", success_rate: 0.5 }];
+    vi.mocked(http.getExperimentMetrics).mockResolvedValue(mockData);
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useExperimentMetrics("test-exp"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(agentKeys.experimentMetrics("test-exp"))).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(agentKeys.experimentMetrics("test-exp"))?.queryKey,
+    ).toEqual(agentKeys.experimentMetrics("test-exp"));
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
@@ -53,13 +53,23 @@ describe("useAgentDetail", () => {
     expect(httpClient.getAgentDetail).toHaveBeenCalledWith("agent-1");
   });
 
-  it("should use the correct queryKey", () => {
-    const { result } = renderHook(() => useAgentDetail("test-id"), {
-      wrapper: createWrapper(),
+  it("should use the correct queryKey", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useAgentDetail("test-id"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(agentKeys.detail("test-id"))).toBeDefined();
     });
 
-    expect(result.current.data).toBeUndefined();
-    expect(httpClient.getAgentDetail).toHaveBeenCalledWith("test-id");
+    const cache = qc.getQueryCache().find(agentKeys.detail("test-id"));
+    expect(cache).toBeDefined();
+    expect(cache?.queryKey).toEqual(agentKeys.detail("test-id"));
   });
 });
 

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
@@ -41,18 +41,16 @@ describe("useAgentDetail", () => {
     expect(httpClient.getAgentDetail).toHaveBeenCalledWith("agent-1");
   });
 
-  it("should use the correct queryKey", async () => {
+  it("should cache under agentKeys.detail(id)", async () => {
+    const mockAgent = { id: "test-id", name: "Test Agent" };
+    vi.mocked(httpClient.getAgentDetail).mockResolvedValue(mockAgent);
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useAgentDetail("test-id"), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.detail("test-id") })).toBeDefined();
+      expect(queryClient.getQueryData(agentKeys.detail("test-id"))).toEqual(mockAgent);
     });
-
-    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.detail("test-id") });
-    expect(cache).toBeDefined();
-    expect(cache?.queryKey).toEqual(agentKeys.detail("test-id"));
   });
 });
 

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
@@ -1,27 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import { useAgentDetail, useAgentSessions, useAgentTemplates } from "./agents";
 import * as httpClient from "../http/client";
 import { agentKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   getAgentDetail: vi.fn(),
   listAgentSessions: vi.fn(),
   listAgentTemplates: vi.fn(),
 }));
-
-function createWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
-  };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -30,7 +18,7 @@ beforeEach(() => {
 describe("useAgentDetail", () => {
   it("should be disabled when agentId is empty string", () => {
     const { result } = renderHook(() => useAgentDetail(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -44,7 +32,7 @@ describe("useAgentDetail", () => {
     vi.mocked(httpClient.getAgentDetail).mockResolvedValue(mockAgent);
 
     const { result } = renderHook(() => useAgentDetail("agent-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -54,20 +42,15 @@ describe("useAgentDetail", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useAgentDetail("test-id"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(agentKeys.detail("test-id"))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: agentKeys.detail("test-id") })).toBeDefined();
     });
 
-    const cache = qc.getQueryCache().find(agentKeys.detail("test-id"));
+    const cache = queryClient.getQueryCache().find({ queryKey: agentKeys.detail("test-id") });
     expect(cache).toBeDefined();
     expect(cache?.queryKey).toEqual(agentKeys.detail("test-id"));
   });
@@ -76,7 +59,7 @@ describe("useAgentDetail", () => {
 describe("useAgentSessions", () => {
   it("should be disabled when agentId is empty string", () => {
     const { result } = renderHook(() => useAgentSessions(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -86,11 +69,11 @@ describe("useAgentSessions", () => {
   });
 
   it("should be enabled when agentId is a valid string", async () => {
-    const mockSessions = [{ id: "session-1", agentId: "agent-1" }];
+    const mockSessions = [{ session_id: "session-1", agent_id: "agent-1" }];
     vi.mocked(httpClient.listAgentSessions).mockResolvedValue(mockSessions);
 
     const { result } = renderHook(() => useAgentSessions("agent-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -102,11 +85,11 @@ describe("useAgentSessions", () => {
 
 describe("useAgentTemplates", () => {
   it("should fetch by default when enabled is not provided", async () => {
-    const mockTemplates = [{ id: "template-1", name: "Test Template" }];
+    const mockTemplates = [{ name: "Test Template", description: "Test description" }];
     vi.mocked(httpClient.listAgentTemplates).mockResolvedValue(mockTemplates);
 
     const { result } = renderHook(() => useAgentTemplates(), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -117,7 +100,7 @@ describe("useAgentTemplates", () => {
 
   it("should not fetch when enabled is false", () => {
     const { result } = renderHook(() => useAgentTemplates({ enabled: false }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -127,11 +110,11 @@ describe("useAgentTemplates", () => {
   });
 
   it("should fetch when enabled is true", async () => {
-    const mockTemplates = [{ id: "template-1", name: "Test Template" }];
+    const mockTemplates = [{ name: "Test Template", description: "Test description" }];
     vi.mocked(httpClient.listAgentTemplates).mockResolvedValue(mockTemplates);
 
     const { result } = renderHook(() => useAgentTemplates({ enabled: true }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useAgentDetail, useAgentSessions, useAgentTemplates } from "./agents";
+import * as httpClient from "../http/client";
+import { agentKeys } from "./keys";
+
+vi.mock("../http/client", () => ({
+  getAgentDetail: vi.fn(),
+  listAgentSessions: vi.fn(),
+  listAgentTemplates: vi.fn(),
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAgentDetail", () => {
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => useAgentDetail(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.getAgentDetail).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when agentId is a valid string", async () => {
+    const mockAgent = { id: "agent-1", name: "Test Agent" };
+    vi.mocked(httpClient.getAgentDetail).mockResolvedValue(mockAgent);
+
+    const { result } = renderHook(() => useAgentDetail("agent-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockAgent);
+    expect(httpClient.getAgentDetail).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("should use the correct queryKey", () => {
+    const { result } = renderHook(() => useAgentDetail("test-id"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(httpClient.getAgentDetail).toHaveBeenCalledWith("test-id");
+  });
+});
+
+describe("useAgentSessions", () => {
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => useAgentSessions(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.listAgentSessions).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when agentId is a valid string", async () => {
+    const mockSessions = [{ id: "session-1", agentId: "agent-1" }];
+    vi.mocked(httpClient.listAgentSessions).mockResolvedValue(mockSessions);
+
+    const { result } = renderHook(() => useAgentSessions("agent-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockSessions);
+    expect(httpClient.listAgentSessions).toHaveBeenCalledWith("agent-1");
+  });
+});
+
+describe("useAgentTemplates", () => {
+  it("should fetch by default when enabled is not provided", async () => {
+    const mockTemplates = [{ id: "template-1", name: "Test Template" }];
+    vi.mocked(httpClient.listAgentTemplates).mockResolvedValue(mockTemplates);
+
+    const { result } = renderHook(() => useAgentTemplates(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockTemplates);
+    expect(httpClient.listAgentTemplates).toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is false", () => {
+    const { result } = renderHook(() => useAgentTemplates({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.listAgentTemplates).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockTemplates = [{ id: "template-1", name: "Test Template" }];
+    vi.mocked(httpClient.listAgentTemplates).mockResolvedValue(mockTemplates);
+
+    const { result } = renderHook(() => useAgentTemplates({ enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockTemplates);
+    expect(httpClient.listAgentTemplates).toHaveBeenCalled();
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
@@ -1,24 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import { useCommsEvents } from "./channels";
 import { useModels, useModelOverrides } from "./models";
 import * as httpClient from "../http/client";
 import { commsKeys, modelKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   listCommsEvents: vi.fn(),
   listModels: vi.fn(),
   getModelOverrides: vi.fn(),
 }));
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -30,7 +22,7 @@ describe("useCommsEvents", () => {
     vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);
 
     const { result } = renderHook(() => useCommsEvents(), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -41,7 +33,7 @@ describe("useCommsEvents", () => {
 
   it("should not fetch when enabled is false", () => {
     const { result } = renderHook(() => useCommsEvents(50, { enabled: false }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -55,7 +47,7 @@ describe("useCommsEvents", () => {
     vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);
 
     const { result } = renderHook(() => useCommsEvents(50, { enabled: true }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -67,17 +59,14 @@ describe("useCommsEvents", () => {
   it("should use the correct queryKey", async () => {
     vi.mocked(httpClient.listCommsEvents).mockResolvedValue([]);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useCommsEvents(100, { enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(commsKeys.events(100))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: commsKeys.events(100) })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(commsKeys.events(100))?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: commsKeys.events(100) })?.queryKey,
     ).toEqual(commsKeys.events(100));
   });
 });
@@ -88,7 +77,7 @@ describe("useModels", () => {
     vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
 
     const { result } = renderHook(() => useModels(), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -99,7 +88,7 @@ describe("useModels", () => {
 
   it("should not fetch when enabled is false", () => {
     const { result } = renderHook(() => useModels({}, { enabled: false }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -113,7 +102,7 @@ describe("useModels", () => {
     vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
 
     const { result } = renderHook(() => useModels({}, { enabled: true }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -128,7 +117,7 @@ describe("useModels", () => {
 
     const filters = { provider: "anthropic", tier: "premium" };
     const { result } = renderHook(() => useModels(filters, { enabled: true }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -140,17 +129,14 @@ describe("useModels", () => {
     vi.mocked(httpClient.listModels).mockResolvedValue({ models: [], total: 0, available: 0 });
 
     const filters = { provider: "openai" };
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useModels(filters, { enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(modelKeys.list(filters))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: modelKeys.list(filters) })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(modelKeys.list(filters))?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: modelKeys.list(filters) })?.queryKey,
     ).toEqual(modelKeys.list(filters));
   });
 });
@@ -158,7 +144,7 @@ describe("useModels", () => {
 describe("useModelOverrides", () => {
   it("should be disabled when modelKey is empty string", () => {
     const { result } = renderHook(() => useModelOverrides(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -172,7 +158,7 @@ describe("useModelOverrides", () => {
     vi.mocked(httpClient.getModelOverrides).mockResolvedValue(mockOverrides);
 
     const { result } = renderHook(() => useModelOverrides("gpt-4"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -184,17 +170,14 @@ describe("useModelOverrides", () => {
   it("should use the correct queryKey", async () => {
     vi.mocked(httpClient.getModelOverrides).mockResolvedValue({});
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useModelOverrides("claude-3"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(modelKeys.overrides("claude-3"))).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: modelKeys.overrides("claude-3") })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(modelKeys.overrides("claude-3"))?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: modelKeys.overrides("claude-3") })?.queryKey,
     ).toEqual(modelKeys.overrides("claude-3"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
@@ -57,17 +57,15 @@ describe("useCommsEvents", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    vi.mocked(httpClient.listCommsEvents).mockResolvedValue([]);
+    const mockEvents: Array<{ id: string; kind: string }> = [];
+    vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);
 
     const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useCommsEvents(100, { enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: commsKeys.events(100) })).toBeDefined();
+      expect(queryClient.getQueryData(commsKeys.events(100))).toEqual(mockEvents);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: commsKeys.events(100) })?.queryKey,
-    ).toEqual(commsKeys.events(100));
   });
 });
 
@@ -126,18 +124,16 @@ describe("useModels", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    vi.mocked(httpClient.listModels).mockResolvedValue({ models: [], total: 0, available: 0 });
+    const mockResponse = { models: [], total: 0, available: 0 };
+    vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
 
     const filters = { provider: "openai" };
     const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useModels(filters, { enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: modelKeys.list(filters) })).toBeDefined();
+      expect(queryClient.getQueryData(modelKeys.list(filters))).toEqual(mockResponse);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: modelKeys.list(filters) })?.queryKey,
-    ).toEqual(modelKeys.list(filters));
   });
 });
 
@@ -168,16 +164,14 @@ describe("useModelOverrides", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    vi.mocked(httpClient.getModelOverrides).mockResolvedValue({});
+    const mockOverrides = {};
+    vi.mocked(httpClient.getModelOverrides).mockResolvedValue(mockOverrides);
 
     const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useModelOverrides("claude-3"), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: modelKeys.overrides("claude-3") })).toBeDefined();
+      expect(queryClient.getQueryData(modelKeys.overrides("claude-3"))).toEqual(mockOverrides);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: modelKeys.overrides("claude-3") })?.queryKey,
-    ).toEqual(modelKeys.overrides("claude-3"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useCommsEvents } from "./channels";
+import { useModels, useModelOverrides } from "./models";
+import * as httpClient from "../http/client";
+import { commsKeys, modelKeys } from "./keys";
+
+vi.mock("../http/client", () => ({
+  listCommsEvents: vi.fn(),
+  listModels: vi.fn(),
+  getModelOverrides: vi.fn(),
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useCommsEvents", () => {
+  it("should fetch when enabled is undefined (default)", async () => {
+    const mockEvents = [{ id: "evt-1", kind: "message" }];
+    vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);
+
+    const { result } = renderHook(() => useCommsEvents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockEvents);
+    expect(httpClient.listCommsEvents).toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is false", () => {
+    const { result } = renderHook(() => useCommsEvents(50, { enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.listCommsEvents).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockEvents = [{ id: "evt-1", kind: "message" }];
+    vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);
+
+    const { result } = renderHook(() => useCommsEvents(50, { enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockEvents);
+    expect(httpClient.listCommsEvents).toHaveBeenCalledWith(50);
+  });
+
+  it("should use the correct queryKey", async () => {
+    vi.mocked(httpClient.listCommsEvents).mockResolvedValue([]);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useCommsEvents(100, { enabled: true }), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(commsKeys.events(100))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(commsKeys.events(100))?.queryKey,
+    ).toEqual(commsKeys.events(100));
+  });
+});
+
+describe("useModels", () => {
+  it("should fetch when enabled is undefined (default)", async () => {
+    const mockResponse = { models: [{ id: "gpt-4", provider: "openai" }], total: 1, available: 1 };
+    vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useModels(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockResponse);
+    expect(httpClient.listModels).toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is false", () => {
+    const { result } = renderHook(() => useModels({}, { enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.listModels).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockResponse = { models: [{ id: "gpt-4", provider: "openai" }], total: 1, available: 1 };
+    vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useModels({}, { enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockResponse);
+    expect(httpClient.listModels).toHaveBeenCalledWith({});
+  });
+
+  it("should pass filters to the API call", async () => {
+    const mockResponse = { models: [{ id: "claude-3", provider: "anthropic" }], total: 1, available: 1 };
+    vi.mocked(httpClient.listModels).mockResolvedValue(mockResponse);
+
+    const filters = { provider: "anthropic", tier: "premium" };
+    const { result } = renderHook(() => useModels(filters, { enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(httpClient.listModels).toHaveBeenCalledWith(filters);
+  });
+
+  it("should use the correct queryKey", async () => {
+    vi.mocked(httpClient.listModels).mockResolvedValue({ models: [], total: 0, available: 0 });
+
+    const filters = { provider: "openai" };
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useModels(filters, { enabled: true }), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(modelKeys.list(filters))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(modelKeys.list(filters))?.queryKey,
+    ).toEqual(modelKeys.list(filters));
+  });
+});
+
+describe("useModelOverrides", () => {
+  it("should be disabled when modelKey is empty string", () => {
+    const { result } = renderHook(() => useModelOverrides(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.getModelOverrides).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when modelKey is valid", async () => {
+    const mockOverrides = { temperature: 0.7, max_tokens: 4096 };
+    vi.mocked(httpClient.getModelOverrides).mockResolvedValue(mockOverrides);
+
+    const { result } = renderHook(() => useModelOverrides("gpt-4"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockOverrides);
+    expect(httpClient.getModelOverrides).toHaveBeenCalledWith("gpt-4");
+  });
+
+  it("should use the correct queryKey", async () => {
+    vi.mocked(httpClient.getModelOverrides).mockResolvedValue({});
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useModelOverrides("claude-3"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(modelKeys.overrides("claude-3"))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(modelKeys.overrides("claude-3"))?.queryKey,
+    ).toEqual(modelKeys.overrides("claude-3"));
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import type { RegistrySchema } from "../../api";
 import { useRegistrySchema, useRawConfigToml } from "./config";
 import * as client from "../http/client";
 import { registryKeys, configKeys } from "./keys";
@@ -35,7 +36,7 @@ describe("useRegistrySchema", () => {
   });
 
   it("should be enabled when contentType is valid", async () => {
-    const mockSchema = { type: "object", properties: {} };
+    const mockSchema: RegistrySchema = { fields: {} };
     vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
 
     const { result } = renderHook(() => useRegistrySchema("application/json"), {
@@ -54,7 +55,7 @@ describe("useRegistrySchema", () => {
   });
 
   it("should use registryKeys.schema(contentType) as queryKey", async () => {
-    const mockSchema = { type: "object" };
+    const mockSchema: RegistrySchema = { sections: {} };
     vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
 
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -65,11 +66,11 @@ describe("useRegistrySchema", () => {
     renderHook(() => useRegistrySchema("text/plain"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(registryKeys.schema("text/plain"))).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: registryKeys.schema("text/plain") })).toBeDefined();
     });
 
     expect(
-      qc.getQueryCache().find(registryKeys.schema("text/plain"))?.queryKey,
+      qc.getQueryCache().find({ queryKey: registryKeys.schema("text/plain") })?.queryKey,
     ).toEqual(registryKeys.schema("text/plain"));
   });
 });
@@ -116,11 +117,11 @@ describe("useRawConfigToml", () => {
     renderHook(() => useRawConfigToml(true), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(configKeys.rawToml())).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: configKeys.rawToml() })).toBeDefined();
     });
 
     expect(
-      qc.getQueryCache().find(configKeys.rawToml())?.queryKey,
+      qc.getQueryCache().find({ queryKey: configKeys.rawToml() })?.queryKey,
     ).toEqual(configKeys.rawToml());
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
@@ -1,18 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import type { RegistrySchema } from "../../api";
 import { useRegistrySchema, useRawConfigToml } from "./config";
 import * as client from "../http/client";
 import { registryKeys, configKeys } from "./keys";
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   fetchRegistrySchema: vi.fn(),
@@ -26,7 +18,7 @@ beforeEach(() => {
 describe("useRegistrySchema", () => {
   it("should be disabled when contentType is empty string", () => {
     const { result } = renderHook(() => useRegistrySchema(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -40,7 +32,7 @@ describe("useRegistrySchema", () => {
     vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
 
     const { result } = renderHook(() => useRegistrySchema("application/json"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -58,27 +50,20 @@ describe("useRegistrySchema", () => {
     const mockSchema: RegistrySchema = { sections: {} };
     vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useRegistrySchema("text/plain"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: registryKeys.schema("text/plain") })).toBeDefined();
+      expect(queryClient.getQueryData(registryKeys.schema("text/plain"))).toEqual(mockSchema);
     });
-
-    expect(
-      qc.getQueryCache().find({ queryKey: registryKeys.schema("text/plain") })?.queryKey,
-    ).toEqual(registryKeys.schema("text/plain"));
   });
 });
 
 describe("useRawConfigToml", () => {
   it("should not fetch when enabled is false", () => {
     const { result } = renderHook(() => useRawConfigToml(false), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -92,7 +77,7 @@ describe("useRawConfigToml", () => {
     vi.mocked(client.getRawConfigToml).mockResolvedValue(mockToml);
 
     const { result } = renderHook(() => useRawConfigToml(true), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -107,21 +92,15 @@ describe("useRawConfigToml", () => {
   });
 
   it("should use configKeys.rawToml() as queryKey", async () => {
-    vi.mocked(client.getRawConfigToml).mockResolvedValue("toml content");
+    const mockToml = "toml content";
+    vi.mocked(client.getRawConfigToml).mockResolvedValue(mockToml);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useRawConfigToml(true), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: configKeys.rawToml() })).toBeDefined();
+      expect(queryClient.getQueryData(configKeys.rawToml())).toEqual(mockToml);
     });
-
-    expect(
-      qc.getQueryCache().find({ queryKey: configKeys.rawToml() })?.queryKey,
-    ).toEqual(configKeys.rawToml());
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useRegistrySchema, useRawConfigToml } from "./config";
+import * as client from "../http/client";
+import { registryKeys, configKeys } from "./keys";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+vi.mock("../http/client", () => ({
+  fetchRegistrySchema: vi.fn(),
+  getRawConfigToml: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useRegistrySchema", () => {
+  it("should be disabled when contentType is empty string", () => {
+    const { result } = renderHook(() => useRegistrySchema(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.fetchRegistrySchema).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when contentType is valid", async () => {
+    const mockSchema = { type: "object", properties: {} };
+    vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
+
+    const { result } = renderHook(() => useRegistrySchema("application/json"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockSchema);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.fetchRegistrySchema).toHaveBeenCalledWith("application/json");
+  });
+
+  it("should use registryKeys.schema(contentType) as queryKey", async () => {
+    const mockSchema = { type: "object" };
+    vi.mocked(client.fetchRegistrySchema).mockResolvedValue(mockSchema);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useRegistrySchema("text/plain"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(registryKeys.schema("text/plain"))).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(registryKeys.schema("text/plain"))?.queryKey,
+    ).toEqual(registryKeys.schema("text/plain"));
+  });
+});
+
+describe("useRawConfigToml", () => {
+  it("should not fetch when enabled is false", () => {
+    const { result } = renderHook(() => useRawConfigToml(false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getRawConfigToml).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockToml = "[kernel]\nlog_level = \"info\"";
+    vi.mocked(client.getRawConfigToml).mockResolvedValue(mockToml);
+
+    const { result } = renderHook(() => useRawConfigToml(true), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockToml);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getRawConfigToml).toHaveBeenCalled();
+  });
+
+  it("should use configKeys.rawToml() as queryKey", async () => {
+    vi.mocked(client.getRawConfigToml).mockResolvedValue("toml content");
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useRawConfigToml(true), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(configKeys.rawToml())).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(configKeys.rawToml())?.queryKey,
+    ).toEqual(configKeys.rawToml());
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import type { HandInstanceItem, HandInstanceStatus } from "../../api";
 import {
   useHandStats,
   useHandStatsBatch,
@@ -78,12 +79,8 @@ describe("useHandStats", () => {
     renderHook(() => useHandStats("hand-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(handKeys.stats("hand-2"))).toBeDefined();
+      expect(qc.getQueryData(handKeys.stats("hand-2"))).toEqual(mockStats);
     });
-
-    expect(
-      qc.getQueryCache().find(handKeys.stats("hand-2"))?.queryKey,
-    ).toEqual(handKeys.stats("hand-2"));
   });
 });
 
@@ -132,12 +129,10 @@ describe("useHandStatsBatch", () => {
     renderHook(() => useHandStatsBatch(ids), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(handKeys.statsBatch(ids))).toBeDefined();
+      expect(qc.getQueryData(handKeys.statsBatch(ids))).toBeDefined();
     });
 
-    expect(
-      qc.getQueryCache().find(handKeys.statsBatch(ids))?.queryKey,
-    ).toEqual(handKeys.statsBatch(ids));
+    expect(qc.getQueryData(handKeys.statsBatch(ids))).toEqual({ h1: {}, h2: {} });
   });
 
   it("should skip failed requests gracefully", async () => {
@@ -220,18 +215,14 @@ describe("useHandSession", () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={qc}>{children}</QueryClientProvider>
     );
-    const mockSession = { instance_id: "hand-3" };
+    const mockSession = { instance_id: "hand-3", messages: [] };
     vi.mocked(client.getHandSession).mockResolvedValue(mockSession);
 
     renderHook(() => useHandSession("hand-3"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(handKeys.session("hand-3"))).toBeDefined();
+      expect(qc.getQueryData(handKeys.session("hand-3"))).toEqual(mockSession);
     });
-
-    expect(
-      qc.getQueryCache().find(handKeys.session("hand-3"))?.queryKey,
-    ).toEqual(handKeys.session("hand-3"));
   });
 });
 
@@ -248,9 +239,12 @@ describe("useHandInstanceStatus", () => {
   });
 
   it("should be enabled when instanceId is valid", async () => {
-    const mockStatus = {
+    const mockStatus: HandInstanceStatus = {
       instance_id: "inst-1",
+      hand_id: "hand-1",
       status: "running",
+      activated_at: "2024-01-01T00:00:00Z",
+      config: {},
     };
     vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
 
@@ -274,7 +268,7 @@ describe("useHandInstanceStatus", () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={qc}>{children}</QueryClientProvider>
     );
-    const mockStatus = { instance_id: "inst-2" };
+    const mockStatus: HandInstanceStatus = { instance_id: "inst-2", hand_id: "hand-2", status: "running", activated_at: "2024-01-01T00:00:00Z", config: {} };
     vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
 
     const { result } = renderHook(() => useHandInstanceStatus("inst-2"), {
@@ -381,9 +375,9 @@ describe("useActiveHandsWhen", () => {
   });
 
   it("should be enabled when enabled is true", async () => {
-    const mockHands = [
-      { hand_id: "h1", status: "active" },
-      { hand_id: "h2", status: "active" },
+    const mockHands: HandInstanceItem[] = [
+      { instance_id: "inst-1", hand_id: "h1", status: "active" },
+      { instance_id: "inst-2", hand_id: "h2", status: "active" },
     ];
     vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
 
@@ -407,7 +401,7 @@ describe("useActiveHandsWhen", () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={qc}>{children}</QueryClientProvider>
     );
-    const mockHands = [{ hand_id: "h1" }];
+    const mockHands: HandInstanceItem[] = [{ instance_id: "inst-1", hand_id: "h1" }];
     vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
 
     const { result } = renderHook(() => useActiveHandsWhen(true), {

--- a/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import type { HandInstanceItem, HandInstanceStatus } from "../../api";
 import {
   useHandStats,
@@ -13,13 +11,7 @@ import {
 } from "./hands";
 import * as client from "../http/client";
 import { handKeys } from "./keys";
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   getHandStats: vi.fn(),
@@ -36,7 +28,7 @@ beforeEach(() => {
 describe("useHandStats", () => {
   it("should be disabled when instanceId is empty string", () => {
     const { result } = renderHook(() => useHandStats(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -54,7 +46,7 @@ describe("useHandStats", () => {
     vi.mocked(client.getHandStats).mockResolvedValue(mockStats);
 
     const { result } = renderHook(() => useHandStats("hand-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -69,17 +61,14 @@ describe("useHandStats", () => {
   });
 
   it("should use handKeys.stats(instanceId) as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const mockStats = { instance_id: "hand-2" };
     vi.mocked(client.getHandStats).mockResolvedValue(mockStats);
 
     renderHook(() => useHandStats("hand-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryData(handKeys.stats("hand-2"))).toEqual(mockStats);
+      expect(queryClient.getQueryData(handKeys.stats("hand-2"))).toEqual(mockStats);
     });
   });
 });
@@ -87,7 +76,7 @@ describe("useHandStats", () => {
 describe("useHandStatsBatch", () => {
   it("should be disabled when instanceIds is empty array", () => {
     const { result } = renderHook(() => useHandStatsBatch([]), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -106,7 +95,7 @@ describe("useHandStatsBatch", () => {
     });
 
     const { result } = renderHook(() => useHandStatsBatch(["h1", "h2"]), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -119,20 +108,17 @@ describe("useHandStatsBatch", () => {
   });
 
   it("should use handKeys.statsBatch(instanceIds) as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     vi.mocked(client.getHandStats).mockResolvedValue({});
 
     const ids = ["h1", "h2"] as const;
     renderHook(() => useHandStatsBatch(ids), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryData(handKeys.statsBatch(ids))).toBeDefined();
+      expect(queryClient.getQueryData(handKeys.statsBatch(ids))).toBeDefined();
     });
 
-    expect(qc.getQueryData(handKeys.statsBatch(ids))).toEqual({ h1: {}, h2: {} });
+    expect(queryClient.getQueryData(handKeys.statsBatch(ids))).toEqual({ h1: {}, h2: {} });
   });
 
   it("should skip failed requests gracefully", async () => {
@@ -143,7 +129,7 @@ describe("useHandStatsBatch", () => {
     });
 
     const { result } = renderHook(() => useHandStatsBatch(["h1", "h2"]), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => {
@@ -163,7 +149,7 @@ describe("useHandStatsBatch", () => {
     });
 
     const { result } = renderHook(() => useHandStatsBatch(["a", "b", "c"]), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => {
@@ -178,7 +164,7 @@ describe("useHandStatsBatch", () => {
 describe("useHandSession", () => {
   it("should be disabled when instanceId is empty string", () => {
     const { result } = renderHook(() => useHandSession(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -196,7 +182,7 @@ describe("useHandSession", () => {
     vi.mocked(client.getHandSession).mockResolvedValue(mockSession);
 
     const { result } = renderHook(() => useHandSession("hand-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -211,17 +197,14 @@ describe("useHandSession", () => {
   });
 
   it("should use handKeys.session(instanceId) as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const mockSession = { instance_id: "hand-3", messages: [] };
     vi.mocked(client.getHandSession).mockResolvedValue(mockSession);
 
     renderHook(() => useHandSession("hand-3"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryData(handKeys.session("hand-3"))).toEqual(mockSession);
+      expect(queryClient.getQueryData(handKeys.session("hand-3"))).toEqual(mockSession);
     });
   });
 });
@@ -229,7 +212,7 @@ describe("useHandSession", () => {
 describe("useHandInstanceStatus", () => {
   it("should be disabled when instanceId is empty string", () => {
     const { result } = renderHook(() => useHandInstanceStatus(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -249,7 +232,7 @@ describe("useHandInstanceStatus", () => {
     vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
 
     const { result } = renderHook(() => useHandInstanceStatus("inst-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -264,10 +247,7 @@ describe("useHandInstanceStatus", () => {
   });
 
   it("should use handKeys.instanceStatus(instanceId) as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const mockStatus: HandInstanceStatus = { instance_id: "inst-2", hand_id: "hand-2", status: "running", activated_at: "2024-01-01T00:00:00Z", config: {} };
     vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
 
@@ -279,7 +259,7 @@ describe("useHandInstanceStatus", () => {
       expect(result.current.data).toEqual(mockStatus);
     });
 
-    expect(qc.getQueryData(handKeys.instanceStatus("inst-2"))).toEqual(
+    expect(queryClient.getQueryData(handKeys.instanceStatus("inst-2"))).toEqual(
       mockStatus,
     );
   });
@@ -288,7 +268,7 @@ describe("useHandInstanceStatus", () => {
 describe("useHandManifestToml", () => {
   it("should be disabled when handId is empty and enabled is true", () => {
     const { result } = renderHook(() => useHandManifestToml("", true), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -300,7 +280,7 @@ describe("useHandManifestToml", () => {
   it("should be disabled when handId is valid and enabled is false", () => {
     const { result } = renderHook(
       () => useHandManifestToml("hand-x", false),
-      { wrapper: createWrapper() },
+      { wrapper: createQueryClientWrapper().wrapper },
     );
 
     expect(result.current.data).toBeUndefined();
@@ -312,7 +292,7 @@ describe("useHandManifestToml", () => {
   it("should be disabled when handId is empty and enabled is false", () => {
     const { result } = renderHook(
       () => useHandManifestToml("", false),
-      { wrapper: createWrapper() },
+      { wrapper: createQueryClientWrapper().wrapper },
     );
 
     expect(result.current.data).toBeUndefined();
@@ -327,7 +307,7 @@ describe("useHandManifestToml", () => {
 
     const { result } = renderHook(
       () => useHandManifestToml("hand-x", true),
-      { wrapper: createWrapper() },
+      { wrapper: createQueryClientWrapper().wrapper },
     );
 
     expect(result.current.isLoading).toBe(true);
@@ -342,10 +322,7 @@ describe("useHandManifestToml", () => {
   });
 
   it("should use handKeys.manifest(handId) as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const mockToml = "name = 'y'";
     vi.mocked(client.getHandManifestToml).mockResolvedValue(mockToml);
 
@@ -358,14 +335,14 @@ describe("useHandManifestToml", () => {
       expect(result.current.data).toEqual(mockToml);
     });
 
-    expect(qc.getQueryData(handKeys.manifest("hand-k"))).toEqual(mockToml);
+    expect(queryClient.getQueryData(handKeys.manifest("hand-k"))).toEqual(mockToml);
   });
 });
 
 describe("useActiveHandsWhen", () => {
   it("should be disabled when enabled is false", () => {
     const { result } = renderHook(() => useActiveHandsWhen(false), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -382,7 +359,7 @@ describe("useActiveHandsWhen", () => {
     vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
 
     const { result } = renderHook(() => useActiveHandsWhen(true), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -397,10 +374,7 @@ describe("useActiveHandsWhen", () => {
   });
 
   it("should use handKeys.active() as queryKey", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     const mockHands: HandInstanceItem[] = [{ instance_id: "inst-1", hand_id: "h1" }];
     vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
 
@@ -412,6 +386,6 @@ describe("useActiveHandsWhen", () => {
       expect(result.current.data).toEqual(mockHands);
     });
 
-    expect(qc.getQueryData(handKeys.active())).toEqual(mockHands);
+    expect(queryClient.getQueryData(handKeys.active())).toEqual(mockHands);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {
+  useHandStats,
+  useHandStatsBatch,
+  useHandSession,
+  useHandInstanceStatus,
+  useHandManifestToml,
+  useActiveHandsWhen,
+} from "./hands";
+import * as client from "../http/client";
+import { handKeys } from "./keys";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+vi.mock("../http/client", () => ({
+  getHandStats: vi.fn(),
+  getHandSession: vi.fn(),
+  getHandInstanceStatus: vi.fn(),
+  getHandManifestToml: vi.fn(),
+  listActiveHands: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useHandStats", () => {
+  it("should be disabled when instanceId is empty string", () => {
+    const { result } = renderHook(() => useHandStats(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandStats).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when instanceId is valid", async () => {
+    const mockStats = {
+      instance_id: "hand-1",
+      hand_id: "my-hand",
+      status: "active",
+    };
+    vi.mocked(client.getHandStats).mockResolvedValue(mockStats);
+
+    const { result } = renderHook(() => useHandStats("hand-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockStats);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandStats).toHaveBeenCalledWith("hand-1");
+  });
+
+  it("should use handKeys.stats(instanceId) as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    const mockStats = { instance_id: "hand-2" };
+    vi.mocked(client.getHandStats).mockResolvedValue(mockStats);
+
+    renderHook(() => useHandStats("hand-2"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(handKeys.stats("hand-2"))).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(handKeys.stats("hand-2"))?.queryKey,
+    ).toEqual(handKeys.stats("hand-2"));
+  });
+});
+
+describe("useHandStatsBatch", () => {
+  it("should be disabled when instanceIds is empty array", () => {
+    const { result } = renderHook(() => useHandStatsBatch([]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandStats).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when instanceIds has items", async () => {
+    const stats1 = { instance_id: "h1", status: "active" };
+    const stats2 = { instance_id: "h2", status: "paused" };
+    vi.mocked(client.getHandStats).mockImplementation(async (id: string) => {
+      if (id === "h1") return stats1;
+      if (id === "h2") return stats2;
+      throw new Error("unknown");
+    });
+
+    const { result } = renderHook(() => useHandStatsBatch(["h1", "h2"]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ h1: stats1, h2: stats2 });
+    });
+
+    expect(client.getHandStats).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use handKeys.statsBatch(instanceIds) as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    vi.mocked(client.getHandStats).mockResolvedValue({});
+
+    const ids = ["h1", "h2"] as const;
+    renderHook(() => useHandStatsBatch(ids), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(handKeys.statsBatch(ids))).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(handKeys.statsBatch(ids))?.queryKey,
+    ).toEqual(handKeys.statsBatch(ids));
+  });
+
+  it("should skip failed requests gracefully", async () => {
+    const stats1 = { instance_id: "h1" };
+    vi.mocked(client.getHandStats).mockImplementation(async (id: string) => {
+      if (id === "h1") return stats1;
+      throw new Error("network error");
+    });
+
+    const { result } = renderHook(() => useHandStatsBatch(["h1", "h2"]), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ h1: stats1 });
+    });
+
+    // h2 should not be in results because it failed
+    expect(result.current.data).not.toHaveProperty("h2");
+  });
+
+  it("should fetch all requests in parallel", async () => {
+    const resolveOrder: string[] = [];
+    vi.mocked(client.getHandStats).mockImplementation(async (id: string) => {
+      await new Promise((r) => setTimeout(r, Math.random() * 10));
+      resolveOrder.push(id);
+      return { instance_id: id };
+    });
+
+    const { result } = renderHook(() => useHandStatsBatch(["a", "b", "c"]), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    // All 3 calls should have been made (parallel, not sequential)
+    expect(client.getHandStats).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("useHandSession", () => {
+  it("should be disabled when instanceId is empty string", () => {
+    const { result } = renderHook(() => useHandSession(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandSession).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when instanceId is valid", async () => {
+    const mockSession = {
+      instance_id: "hand-1",
+      session_id: "sess-123",
+      messages: [],
+    };
+    vi.mocked(client.getHandSession).mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useHandSession("hand-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockSession);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandSession).toHaveBeenCalledWith("hand-1");
+  });
+
+  it("should use handKeys.session(instanceId) as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    const mockSession = { instance_id: "hand-3" };
+    vi.mocked(client.getHandSession).mockResolvedValue(mockSession);
+
+    renderHook(() => useHandSession("hand-3"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(handKeys.session("hand-3"))).toBeDefined();
+    });
+
+    expect(
+      qc.getQueryCache().find(handKeys.session("hand-3"))?.queryKey,
+    ).toEqual(handKeys.session("hand-3"));
+  });
+});
+
+describe("useHandInstanceStatus", () => {
+  it("should be disabled when instanceId is empty string", () => {
+    const { result } = renderHook(() => useHandInstanceStatus(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandInstanceStatus).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when instanceId is valid", async () => {
+    const mockStatus = {
+      instance_id: "inst-1",
+      status: "running",
+    };
+    vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
+
+    const { result } = renderHook(() => useHandInstanceStatus("inst-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockStatus);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandInstanceStatus).toHaveBeenCalledWith("inst-1");
+  });
+
+  it("should use handKeys.instanceStatus(instanceId) as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    const mockStatus = { instance_id: "inst-2" };
+    vi.mocked(client.getHandInstanceStatus).mockResolvedValue(mockStatus);
+
+    const { result } = renderHook(() => useHandInstanceStatus("inst-2"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockStatus);
+    });
+
+    expect(qc.getQueryData(handKeys.instanceStatus("inst-2"))).toEqual(
+      mockStatus,
+    );
+  });
+});
+
+describe("useHandManifestToml", () => {
+  it("should be disabled when handId is empty and enabled is true", () => {
+    const { result } = renderHook(() => useHandManifestToml("", true), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandManifestToml).not.toHaveBeenCalled();
+  });
+
+  it("should be disabled when handId is valid and enabled is false", () => {
+    const { result } = renderHook(
+      () => useHandManifestToml("hand-x", false),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandManifestToml).not.toHaveBeenCalled();
+  });
+
+  it("should be disabled when handId is empty and enabled is false", () => {
+    const { result } = renderHook(
+      () => useHandManifestToml("", false),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandManifestToml).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when handId is valid and enabled is true", async () => {
+    const mockToml = 'name = "my-hand"\nversion = "1.0"';
+    vi.mocked(client.getHandManifestToml).mockResolvedValue(mockToml);
+
+    const { result } = renderHook(
+      () => useHandManifestToml("hand-x", true),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockToml);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandManifestToml).toHaveBeenCalledWith("hand-x");
+  });
+
+  it("should use handKeys.manifest(handId) as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    const mockToml = "name = 'y'";
+    vi.mocked(client.getHandManifestToml).mockResolvedValue(mockToml);
+
+    const { result } = renderHook(
+      () => useHandManifestToml("hand-k", true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockToml);
+    });
+
+    expect(qc.getQueryData(handKeys.manifest("hand-k"))).toEqual(mockToml);
+  });
+});
+
+describe("useActiveHandsWhen", () => {
+  it("should be disabled when enabled is false", () => {
+    const { result } = renderHook(() => useActiveHandsWhen(false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.listActiveHands).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when enabled is true", async () => {
+    const mockHands = [
+      { hand_id: "h1", status: "active" },
+      { hand_id: "h2", status: "active" },
+    ];
+    vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
+
+    const { result } = renderHook(() => useActiveHandsWhen(true), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockHands);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.listActiveHands).toHaveBeenCalled();
+  });
+
+  it("should use handKeys.active() as queryKey", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    const mockHands = [{ hand_id: "h1" }];
+    vi.mocked(client.listActiveHands).mockResolvedValue(mockHands);
+
+    const { result } = renderHook(() => useActiveHandsWhen(true), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockHands);
+    });
+
+    expect(qc.getQueryData(handKeys.active())).toEqual(mockHands);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
@@ -1,71 +1,57 @@
 import { describe, it, expect } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useMemoryHealth } from "./memory";
 import { healthDetailQueryOptions } from "./runtime";
 import { runtimeKeys } from "./keys";
-
-function createWrapper(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
+import { createQueryClientWrapper } from "../test/query-client";
 
 describe("useMemoryHealth", () => {
   it("should return true when data.memory.embedding_available is true", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    qc.setQueryData(runtimeKeys.healthDetail(), {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(runtimeKeys.healthDetail(), {
       memory: { embedding_available: true },
     });
 
     const { result } = renderHook(() => useMemoryHealth(), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toBe(true));
   });
 
   it("should return false when data.memory.embedding_available is false", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    qc.setQueryData(runtimeKeys.healthDetail(), {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(runtimeKeys.healthDetail(), {
       memory: { embedding_available: false },
     });
 
     const { result } = renderHook(() => useMemoryHealth(), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toBe(false));
   });
 
   it("should return false when data.memory is undefined (default fallback)", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    qc.setQueryData(runtimeKeys.healthDetail(), {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(runtimeKeys.healthDetail(), {
       status: "ok",
     });
 
     const { result } = renderHook(() => useMemoryHealth(), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toBe(false));
   });
 
   it("should respect enabled option (not fetch when enabled: false)", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const { wrapper } = createQueryClientWrapper();
 
     const { result } = renderHook(
       () => useMemoryHealth({ enabled: false }),
-      { wrapper: createWrapper(qc) },
+      { wrapper },
     );
 
     expect(result.current.data).toBeUndefined();
@@ -73,30 +59,27 @@ describe("useMemoryHealth", () => {
   });
 
   it("should share the same queryKey as healthDetailQueryOptions (cache sharing)", async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    qc.setQueryData(runtimeKeys.healthDetail(), {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const sharedQueryState = {
       memory: { embedding_available: true },
-    });
+    };
+
+    queryClient.setQueryData(runtimeKeys.healthDetail(), sharedQueryState);
 
     const { result: healthResult } = renderHook(
       () => useQuery(healthDetailQueryOptions()),
-      { wrapper: createWrapper(qc) },
+      { wrapper },
     );
 
     const { result: memoryResult } = renderHook(
       () => useMemoryHealth(),
-      { wrapper: createWrapper(qc) },
+      { wrapper },
     );
 
     await waitFor(() => expect(healthResult.current.data).toBeDefined());
     await waitFor(() => expect(memoryResult.current.data).toBe(true));
 
-    expect(healthDetailQueryOptions().queryKey).toEqual(runtimeKeys.healthDetail());
-    expect(qc.getQueryData(runtimeKeys.healthDetail())).toEqual({
-      memory: { embedding_available: true },
-    });
+    expect(healthResult.current.data).toBe(sharedQueryState);
+    expect(queryClient.getQueryData(runtimeKeys.healthDetail())).toBe(sharedQueryState);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
@@ -92,10 +92,11 @@ describe("useMemoryHealth", () => {
     );
 
     await waitFor(() => expect(healthResult.current.data).toBeDefined());
+    await waitFor(() => expect(memoryResult.current.data).toBe(true));
 
-    const healthKey = healthResult.current.queryKey;
-    const memoryKey = memoryResult.current.queryKey;
-
-    expect(memoryKey).toEqual(healthKey);
+    expect(healthDetailQueryOptions().queryKey).toEqual(runtimeKeys.healthDetail());
+    expect(qc.getQueryData(runtimeKeys.healthDetail())).toEqual({
+      memory: { embedding_available: true },
+    });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useMemoryHealth } from "./memory";
+import { healthDetailQueryOptions } from "./runtime";
+import { runtimeKeys } from "./keys";
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useMemoryHealth", () => {
+  it("should return true when data.memory.embedding_available is true", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    qc.setQueryData(runtimeKeys.healthDetail(), {
+      memory: { embedding_available: true },
+    });
+
+    const { result } = renderHook(() => useMemoryHealth(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(true));
+  });
+
+  it("should return false when data.memory.embedding_available is false", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    qc.setQueryData(runtimeKeys.healthDetail(), {
+      memory: { embedding_available: false },
+    });
+
+    const { result } = renderHook(() => useMemoryHealth(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(false));
+  });
+
+  it("should return false when data.memory is undefined (default fallback)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    qc.setQueryData(runtimeKeys.healthDetail(), {
+      status: "ok",
+    });
+
+    const { result } = renderHook(() => useMemoryHealth(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(false));
+  });
+
+  it("should respect enabled option (not fetch when enabled: false)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(
+      () => useMemoryHealth({ enabled: false }),
+      { wrapper: createWrapper(qc) },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.status).toBe("pending");
+  });
+
+  it("should share the same queryKey as healthDetailQueryOptions (cache sharing)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    qc.setQueryData(runtimeKeys.healthDetail(), {
+      memory: { embedding_available: true },
+    });
+
+    const { result: healthResult } = renderHook(
+      () => useQuery(healthDetailQueryOptions()),
+      { wrapper: createWrapper(qc) },
+    );
+
+    const { result: memoryResult } = renderHook(
+      () => useMemoryHealth(),
+      { wrapper: createWrapper(qc) },
+    );
+
+    await waitFor(() => expect(healthResult.current.data).toBeDefined());
+
+    const healthKey = healthResult.current.queryKey;
+    const memoryKey = memoryResult.current.queryKey;
+
+    expect(memoryKey).toEqual(healthKey);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 
 // ── Mock API layer ──
 const { mockListApprovals, mockFetchApprovalCount } = vi.hoisted(() => ({
@@ -32,13 +30,7 @@ import { useApprovals, useApprovalCount } from "./approvals";
 import { useAvailableIntegrations } from "./mcp";
 import { usePluginRegistries } from "./plugins";
 import { approvalKeys, mcpKeys, pluginKeys } from "./keys";
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
+import { createQueryClientWrapper } from "../test/query-client";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -49,7 +41,7 @@ beforeEach(() => {
 describe("useApprovals", () => {
   it("should not fetch when enabled is false", async () => {
     const { result } = renderHook(() => useApprovals({ enabled: false }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -59,8 +51,8 @@ describe("useApprovals", () => {
   });
 
   it("should fetch by default when enabled is undefined", async () => {
-    const { result } = renderHook(() => useApprovals(), {
-      wrapper: createWrapper(),
+    renderHook(() => useApprovals(), {
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     // enabled defaults to undefined → query is enabled by default
@@ -76,7 +68,7 @@ describe("useApprovals", () => {
     mockListApprovals.mockResolvedValue(mockData);
 
     const { result } = renderHook(() => useApprovals({ enabled: true }), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toEqual(mockData));
@@ -88,18 +80,15 @@ describe("useApprovals", () => {
   it("should use approvalKeys.lists() as queryKey", async () => {
     mockListApprovals.mockResolvedValue([]);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useApprovals({ enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(approvalKeys.lists())).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: approvalKeys.lists() })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(approvalKeys.lists())?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: approvalKeys.lists() })?.queryKey,
     ).toEqual(approvalKeys.lists());
   });
 });
@@ -110,7 +99,7 @@ describe("useAvailableIntegrations", () => {
   it("should not fetch when enabled is false", async () => {
     const { result } = renderHook(
       () => useAvailableIntegrations({ enabled: false }),
-      { wrapper: createWrapper() },
+      { wrapper: createQueryClientWrapper().wrapper },
     );
 
     expect(result.current.data).toBeUndefined();
@@ -120,8 +109,8 @@ describe("useAvailableIntegrations", () => {
   });
 
   it("should fetch by default when enabled is undefined", async () => {
-    const { result } = renderHook(() => useAvailableIntegrations(), {
-      wrapper: createWrapper(),
+    renderHook(() => useAvailableIntegrations(), {
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     // mcpQueries.integrations() sets enabled: opts.enabled which is undefined
@@ -137,7 +126,7 @@ describe("useAvailableIntegrations", () => {
 
     const { result } = renderHook(
       () => useAvailableIntegrations({ enabled: true }),
-      { wrapper: createWrapper() },
+      { wrapper: createQueryClientWrapper().wrapper },
     );
 
     await waitFor(() => expect(result.current.data).toEqual(mockData));
@@ -149,18 +138,15 @@ describe("useAvailableIntegrations", () => {
   it("should use mcpKeys.integrations() as queryKey", async () => {
     mockListAvailableIntegrations.mockResolvedValue({ integrations: [] });
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useAvailableIntegrations({ enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(mcpKeys.integrations())).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: mcpKeys.integrations() })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(mcpKeys.integrations())?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: mcpKeys.integrations() })?.queryKey,
     ).toEqual(mcpKeys.integrations());
   });
 });
@@ -170,7 +156,7 @@ describe("useAvailableIntegrations", () => {
 describe("usePluginRegistries", () => {
   it("should not fetch when enabled is false", async () => {
     const { result } = renderHook(() => usePluginRegistries(false), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -180,8 +166,8 @@ describe("usePluginRegistries", () => {
   });
 
   it("should fetch by default when enabled is undefined", async () => {
-    const { result } = renderHook(() => usePluginRegistries(undefined), {
-      wrapper: createWrapper(),
+    renderHook(() => usePluginRegistries(undefined), {
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     // enabled is undefined → useQuery treats it as true → WILL fetch
@@ -195,7 +181,7 @@ describe("usePluginRegistries", () => {
     mockListPluginRegistries.mockResolvedValue(mockData);
 
     const { result } = renderHook(() => usePluginRegistries(true), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toEqual(mockData));
@@ -207,38 +193,27 @@ describe("usePluginRegistries", () => {
   it("should use pluginKeys.registries() as queryKey", async () => {
     mockListPluginRegistries.mockResolvedValue({ registries: [] });
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => usePluginRegistries(true), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(pluginKeys.registries())).toBeDefined();
+      expect(queryClient.getQueryCache().find({ queryKey: pluginKeys.registries() })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(pluginKeys.registries())?.queryKey,
+      queryClient.getQueryCache().find({ queryKey: pluginKeys.registries() })?.queryKey,
     ).toEqual(pluginKeys.registries());
   });
 });
 
 // ── useApprovalCount ──
 
-function createWrapperWithClient() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const wrapper = function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-  return { wrapper, qc };
-}
-
 describe("useApprovalCount", () => {
   it("should fetch by default (always enabled)", async () => {
     mockFetchApprovalCount.mockResolvedValue({ count: 5 });
 
     const { result } = renderHook(() => useApprovalCount(), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.data).toEqual({ count: 5 }));
@@ -248,45 +223,47 @@ describe("useApprovalCount", () => {
   it("should use default refetchInterval when not provided", async () => {
     mockFetchApprovalCount.mockResolvedValue({ count: 0 });
 
-    const { wrapper, qc } = createWrapperWithClient();
+    const { wrapper, queryClient } = createQueryClientWrapper();
     renderHook(() => useApprovalCount(), { wrapper });
 
     await vi.waitFor(() => {
-      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
       expect(query).toBeDefined();
     });
 
-    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
-    expect(query.options.refetchInterval).toBe(15_000);
+    const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
+    expect(query).toBeDefined();
+    expect((query?.options as { refetchInterval?: number }).refetchInterval).toBe(15_000);
   });
 
   it("should override refetchInterval when provided", async () => {
     mockFetchApprovalCount.mockResolvedValue({ count: 0 });
 
-    const { wrapper, qc } = createWrapperWithClient();
+    const { wrapper, queryClient } = createQueryClientWrapper();
     renderHook(() => useApprovalCount({ refetchInterval: 5_000 }), { wrapper });
 
     await vi.waitFor(() => {
-      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
       expect(query).toBeDefined();
     });
 
-    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
-    expect(query.options.refetchInterval).toBe(5_000);
+    const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
+    expect(query).toBeDefined();
+    expect((query?.options as { refetchInterval?: number }).refetchInterval).toBe(5_000);
   });
 
   it("should use approvalKeys.count() as queryKey", async () => {
     mockFetchApprovalCount.mockResolvedValue({ count: 0 });
 
-    const { wrapper, qc } = createWrapperWithClient();
+    const { wrapper, queryClient } = createQueryClientWrapper();
     renderHook(() => useApprovalCount(), { wrapper });
 
     await vi.waitFor(() => {
-      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
       expect(query).toBeDefined();
     });
 
-    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
+    const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() })!;
     expect(query.queryKey).toEqual(approvalKeys.count());
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -78,18 +78,16 @@ describe("useApprovals", () => {
   });
 
   it("should use approvalKeys.lists() as queryKey", async () => {
-    mockListApprovals.mockResolvedValue([]);
+    const mockData: Array<{ id: string; tool_name: string }> = [];
+    mockListApprovals.mockResolvedValue(mockData);
 
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useApprovals({ enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: approvalKeys.lists() })).toBeDefined();
+      expect(queryClient.getQueryData(approvalKeys.lists())).toEqual(mockData);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: approvalKeys.lists() })?.queryKey,
-    ).toEqual(approvalKeys.lists());
   });
 });
 
@@ -136,18 +134,16 @@ describe("useAvailableIntegrations", () => {
   });
 
   it("should use mcpKeys.integrations() as queryKey", async () => {
-    mockListAvailableIntegrations.mockResolvedValue({ integrations: [] });
+    const mockData = { integrations: [] };
+    mockListAvailableIntegrations.mockResolvedValue(mockData);
 
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => useAvailableIntegrations({ enabled: true }), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: mcpKeys.integrations() })).toBeDefined();
+      expect(queryClient.getQueryData(mcpKeys.integrations())).toEqual(mockData);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: mcpKeys.integrations() })?.queryKey,
-    ).toEqual(mcpKeys.integrations());
   });
 });
 
@@ -191,18 +187,16 @@ describe("usePluginRegistries", () => {
   });
 
   it("should use pluginKeys.registries() as queryKey", async () => {
-    mockListPluginRegistries.mockResolvedValue({ registries: [] });
+    const mockData = { registries: [] };
+    mockListPluginRegistries.mockResolvedValue(mockData);
 
     const { queryClient, wrapper } = createQueryClientWrapper();
 
     renderHook(() => usePluginRegistries(true), { wrapper });
 
     await waitFor(() => {
-      expect(queryClient.getQueryCache().find({ queryKey: pluginKeys.registries() })).toBeDefined();
+      expect(queryClient.getQueryData(pluginKeys.registries())).toEqual(mockData);
     });
-    expect(
-      queryClient.getQueryCache().find({ queryKey: pluginKeys.registries() })?.queryKey,
-    ).toEqual(pluginKeys.registries());
   });
 });
 
@@ -253,17 +247,14 @@ describe("useApprovalCount", () => {
   });
 
   it("should use approvalKeys.count() as queryKey", async () => {
-    mockFetchApprovalCount.mockResolvedValue({ count: 0 });
+    const mockData = { count: 0 };
+    mockFetchApprovalCount.mockResolvedValue(mockData);
 
     const { wrapper, queryClient } = createQueryClientWrapper();
     renderHook(() => useApprovalCount(), { wrapper });
 
     await vi.waitFor(() => {
-      const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() });
-      expect(query).toBeDefined();
+      expect(queryClient.getQueryData(approvalKeys.count())).toEqual(mockData);
     });
-
-    const query = queryClient.getQueryCache().find({ queryKey: approvalKeys.count() })!;
-    expect(query.queryKey).toEqual(approvalKeys.count());
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -58,7 +58,7 @@ describe("useApprovals", () => {
     expect(mockListApprovals).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when enabled is undefined", async () => {
+  it("should fetch by default when enabled is undefined", async () => {
     const { result } = renderHook(() => useApprovals(), {
       wrapper: createWrapper(),
     });
@@ -119,7 +119,7 @@ describe("useAvailableIntegrations", () => {
     expect(mockListAvailableIntegrations).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when enabled is undefined", async () => {
+  it("should fetch by default when enabled is undefined", async () => {
     const { result } = renderHook(() => useAvailableIntegrations(), {
       wrapper: createWrapper(),
     });
@@ -179,7 +179,7 @@ describe("usePluginRegistries", () => {
     expect(mockListPluginRegistries).not.toHaveBeenCalled();
   });
 
-  it("should not fetch when enabled is undefined", async () => {
+  it("should fetch by default when enabled is undefined", async () => {
     const { result } = renderHook(() => usePluginRegistries(undefined), {
       wrapper: createWrapper(),
     });

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+
+// ── Mock API layer ──
+const { mockListApprovals, mockFetchApprovalCount } = vi.hoisted(() => ({
+  mockListApprovals: vi.fn(),
+  mockFetchApprovalCount: vi.fn(),
+}));
+const { mockListAvailableIntegrations, mockListPluginRegistries } = vi.hoisted(() => ({
+  mockListAvailableIntegrations: vi.fn(),
+  mockListPluginRegistries: vi.fn(),
+}));
+
+vi.mock("../../api", async () => {
+  const actual = await vi.importActual("../../api");
+  return { ...actual, listApprovals: mockListApprovals, fetchApprovalCount: mockFetchApprovalCount };
+});
+
+vi.mock("../http/client", async () => {
+  const actual = await vi.importActual("../http/client");
+  return {
+    ...actual,
+    listAvailableIntegrations: mockListAvailableIntegrations,
+    listPluginRegistries: mockListPluginRegistries,
+  };
+});
+
+// ── Import hooks after mocks are set up ──
+import { useApprovals, useApprovalCount } from "./approvals";
+import { useAvailableIntegrations } from "./mcp";
+import { usePluginRegistries } from "./plugins";
+import { approvalKeys, mcpKeys, pluginKeys } from "./keys";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── useApprovals ──
+
+describe("useApprovals", () => {
+  it("should not fetch when enabled is false", async () => {
+    const { result } = renderHook(() => useApprovals({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListApprovals).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is undefined", async () => {
+    const { result } = renderHook(() => useApprovals(), {
+      wrapper: createWrapper(),
+    });
+
+    // enabled defaults to undefined → query is enabled by default
+    // but since we don't mock data, it will attempt to fetch
+    // Actually, when enabled is undefined, useQuery treats it as true
+    await vi.waitFor(() => {
+      expect(mockListApprovals).toHaveBeenCalled();
+    });
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockData = [{ id: "1", tool_name: "test" }];
+    mockListApprovals.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useApprovals({ enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockData));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListApprovals).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use approvalKeys.lists() as queryKey", async () => {
+    mockListApprovals.mockResolvedValue([]);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useApprovals({ enabled: true }), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(approvalKeys.lists())).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(approvalKeys.lists())?.queryKey,
+    ).toEqual(approvalKeys.lists());
+  });
+});
+
+// ── useAvailableIntegrations ──
+
+describe("useAvailableIntegrations", () => {
+  it("should not fetch when enabled is false", async () => {
+    const { result } = renderHook(
+      () => useAvailableIntegrations({ enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListAvailableIntegrations).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is undefined", async () => {
+    const { result } = renderHook(() => useAvailableIntegrations(), {
+      wrapper: createWrapper(),
+    });
+
+    // mcpQueries.integrations() sets enabled: opts.enabled which is undefined
+    // useQuery treats undefined enabled as true, so it WILL fetch
+    await vi.waitFor(() => {
+      expect(mockListAvailableIntegrations).toHaveBeenCalled();
+    });
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockData = { integrations: [{ id: "slack", name: "Slack" }] };
+    mockListAvailableIntegrations.mockResolvedValue(mockData);
+
+    const { result } = renderHook(
+      () => useAvailableIntegrations({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(mockData));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListAvailableIntegrations).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use mcpKeys.integrations() as queryKey", async () => {
+    mockListAvailableIntegrations.mockResolvedValue({ integrations: [] });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useAvailableIntegrations({ enabled: true }), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(mcpKeys.integrations())).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(mcpKeys.integrations())?.queryKey,
+    ).toEqual(mcpKeys.integrations());
+  });
+});
+
+// ── usePluginRegistries ──
+
+describe("usePluginRegistries", () => {
+  it("should not fetch when enabled is false", async () => {
+    const { result } = renderHook(() => usePluginRegistries(false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListPluginRegistries).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch when enabled is undefined", async () => {
+    const { result } = renderHook(() => usePluginRegistries(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    // enabled is undefined → useQuery treats it as true → WILL fetch
+    await vi.waitFor(() => {
+      expect(mockListPluginRegistries).toHaveBeenCalled();
+    });
+  });
+
+  it("should fetch when enabled is true", async () => {
+    const mockData = { registries: [{ id: "npm", url: "https://registry.npmjs.org" }] };
+    mockListPluginRegistries.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => usePluginRegistries(true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockData));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockListPluginRegistries).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use pluginKeys.registries() as queryKey", async () => {
+    mockListPluginRegistries.mockResolvedValue({ registries: [] });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => usePluginRegistries(true), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(pluginKeys.registries())).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(pluginKeys.registries())?.queryKey,
+    ).toEqual(pluginKeys.registries());
+  });
+});
+
+// ── useApprovalCount ──
+
+function createWrapperWithClient() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+  return { wrapper, qc };
+}
+
+describe("useApprovalCount", () => {
+  it("should fetch by default (always enabled)", async () => {
+    mockFetchApprovalCount.mockResolvedValue({ count: 5 });
+
+    const { result } = renderHook(() => useApprovalCount(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual({ count: 5 }));
+    expect(mockFetchApprovalCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use default refetchInterval when not provided", async () => {
+    mockFetchApprovalCount.mockResolvedValue({ count: 0 });
+
+    const { wrapper, qc } = createWrapperWithClient();
+    renderHook(() => useApprovalCount(), { wrapper });
+
+    await vi.waitFor(() => {
+      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      expect(query).toBeDefined();
+    });
+
+    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
+    expect(query.options.refetchInterval).toBe(15_000);
+  });
+
+  it("should override refetchInterval when provided", async () => {
+    mockFetchApprovalCount.mockResolvedValue({ count: 0 });
+
+    const { wrapper, qc } = createWrapperWithClient();
+    renderHook(() => useApprovalCount({ refetchInterval: 5_000 }), { wrapper });
+
+    await vi.waitFor(() => {
+      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      expect(query).toBeDefined();
+    });
+
+    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
+    expect(query.options.refetchInterval).toBe(5_000);
+  });
+
+  it("should use approvalKeys.count() as queryKey", async () => {
+    mockFetchApprovalCount.mockResolvedValue({ count: 0 });
+
+    const { wrapper, qc } = createWrapperWithClient();
+    renderHook(() => useApprovalCount(), { wrapper });
+
+    await vi.waitFor(() => {
+      const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() });
+      expect(query).toBeDefined();
+    });
+
+    const query = qc.getQueryCache().find({ queryKey: approvalKeys.count() })!;
+    expect(query.queryKey).toEqual(approvalKeys.count());
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
@@ -68,10 +68,10 @@ describe("useCronJobs", () => {
     );
     renderHook(() => useCronJobs("test-agent"), { wrapper });
     await waitFor(() => {
-      expect(qc.getQueryCache().find(cronKeys.jobs("test-agent"))).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: cronKeys.jobs("test-agent") })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(cronKeys.jobs("test-agent"))?.queryKey,
+      qc.getQueryCache().find({ queryKey: cronKeys.jobs("test-agent") })?.queryKey,
     ).toEqual(cronKeys.jobs("test-agent"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
@@ -1,21 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import { useCronJobs } from "./runtime";
 import * as api from "../../api";
 import { cronKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../../api", () => ({
   listCronJobs: vi.fn(),
 }));
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -24,7 +16,7 @@ beforeEach(() => {
 describe("useCronJobs", () => {
   it("should be disabled when agentId is undefined", () => {
     const { result } = renderHook(() => useCronJobs(), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -35,7 +27,7 @@ describe("useCronJobs", () => {
 
   it("should be disabled when agentId is empty string", () => {
     const { result } = renderHook(() => useCronJobs(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -51,7 +43,7 @@ describe("useCronJobs", () => {
     vi.mocked(api.listCronJobs).mockResolvedValue(mockJobs);
 
     const { result } = renderHook(() => useCronJobs("agent-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -61,17 +53,12 @@ describe("useCronJobs", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    vi.mocked(api.listCronJobs).mockResolvedValue([]);
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const mockJobs: Array<{ id: string; enabled: boolean; name: string; schedule: string }> = [];
+    vi.mocked(api.listCronJobs).mockResolvedValue(mockJobs);
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useCronJobs("test-agent"), { wrapper });
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: cronKeys.jobs("test-agent") })).toBeDefined();
+      expect(queryClient.getQueryData(cronKeys.jobs("test-agent"))).toEqual(mockJobs);
     });
-    expect(
-      qc.getQueryCache().find({ queryKey: cronKeys.jobs("test-agent") })?.queryKey,
-    ).toEqual(cronKeys.jobs("test-agent"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime-cron.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useCronJobs } from "./runtime";
+import * as api from "../../api";
+import { cronKeys } from "./keys";
+
+vi.mock("../../api", () => ({
+  listCronJobs: vi.fn(),
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useCronJobs", () => {
+  it("should be disabled when agentId is undefined", () => {
+    const { result } = renderHook(() => useCronJobs(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(api.listCronJobs).not.toHaveBeenCalled();
+  });
+
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => useCronJobs(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(api.listCronJobs).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when agentId is valid string, fetches data", async () => {
+    const mockJobs = [
+      { id: "job-1", enabled: true, name: "Test Job", schedule: "0 * * * *" },
+    ];
+    vi.mocked(api.listCronJobs).mockResolvedValue(mockJobs);
+
+    const { result } = renderHook(() => useCronJobs("agent-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockJobs);
+    expect(api.listCronJobs).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("should use the correct queryKey", async () => {
+    vi.mocked(api.listCronJobs).mockResolvedValue([]);
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useCronJobs("test-agent"), { wrapper });
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(cronKeys.jobs("test-agent"))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(cronKeys.jobs("test-agent"))?.queryKey,
+    ).toEqual(cronKeys.jobs("test-agent"));
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import type { HandSettingsResponse, SessionDetailResponse } from "../../api";
 import { useSessionDetails } from "./sessions";
 import { useHandDetail, useHandSettings } from "./hands";
 import { sessionKeys, handKeys } from "./keys";
 import * as client from "../http/client";
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   getSessionDetails: vi.fn(),
@@ -28,7 +20,7 @@ beforeEach(() => {
 describe("useSessionDetails", () => {
   it("should be disabled when sessionId is empty string", () => {
     const { result } = renderHook(() => useSessionDetails(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -42,7 +34,7 @@ describe("useSessionDetails", () => {
     vi.mocked(client.getSessionDetails).mockResolvedValue(mockSession);
 
     const { result } = renderHook(() => useSessionDetails("sess-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -57,27 +49,22 @@ describe("useSessionDetails", () => {
   });
 
   it("should use sessionKeys.detail(sessionId) as queryKey", async () => {
-    vi.mocked(client.getSessionDetails).mockResolvedValue({ session_id: "sess-2" });
+    const mockSession: SessionDetailResponse = { session_id: "sess-2" };
+    vi.mocked(client.getSessionDetails).mockResolvedValue(mockSession);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useSessionDetails("sess-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: sessionKeys.detail("sess-2") })).toBeDefined();
+      expect(queryClient.getQueryData(sessionKeys.detail("sess-2"))).toEqual(mockSession);
     });
-    expect(
-      qc.getQueryCache().find({ queryKey: sessionKeys.detail("sess-2") })?.queryKey,
-    ).toEqual(sessionKeys.detail("sess-2"));
   });
 });
 
 describe("useHandDetail", () => {
   it("should be disabled when handId is empty string", () => {
     const { result } = renderHook(() => useHandDetail(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -91,7 +78,7 @@ describe("useHandDetail", () => {
     vi.mocked(client.getHandDetail).mockResolvedValue(mockHand);
 
     const { result } = renderHook(() => useHandDetail("hand-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -106,27 +93,22 @@ describe("useHandDetail", () => {
   });
 
   it("should use handKeys.detail(handId) as queryKey", async () => {
-    vi.mocked(client.getHandDetail).mockResolvedValue({ id: "hand-2" });
+    const mockHand = { id: "hand-2" };
+    vi.mocked(client.getHandDetail).mockResolvedValue(mockHand);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useHandDetail("hand-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: handKeys.detail("hand-2") })).toBeDefined();
+      expect(queryClient.getQueryData(handKeys.detail("hand-2"))).toEqual(mockHand);
     });
-    expect(
-      qc.getQueryCache().find({ queryKey: handKeys.detail("hand-2") })?.queryKey,
-    ).toEqual(handKeys.detail("hand-2"));
   });
 });
 
 describe("useHandSettings", () => {
   it("should be disabled when handId is empty string", () => {
     const { result } = renderHook(() => useHandSettings(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -140,7 +122,7 @@ describe("useHandSettings", () => {
     vi.mocked(client.getHandSettings).mockResolvedValue(mockSettings);
 
     const { result } = renderHook(() => useHandSettings("hand-3"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -155,19 +137,14 @@ describe("useHandSettings", () => {
   });
 
   it("should use handKeys.settings(handId) as queryKey", async () => {
-    vi.mocked(client.getHandSettings).mockResolvedValue({ hand_id: "hand-4" });
+    const mockSettings: HandSettingsResponse = { hand_id: "hand-4" };
+    vi.mocked(client.getHandSettings).mockResolvedValue(mockSettings);
 
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-    );
+    const { queryClient, wrapper } = createQueryClientWrapper();
     renderHook(() => useHandSettings("hand-4"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find({ queryKey: handKeys.settings("hand-4") })).toBeDefined();
+      expect(queryClient.getQueryData(handKeys.settings("hand-4"))).toEqual(mockSettings);
     });
-    expect(
-      qc.getQueryCache().find({ queryKey: handKeys.settings("hand-4") })?.queryKey,
-    ).toEqual(handKeys.settings("hand-4"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import type { HandSettingsResponse, SessionDetailResponse } from "../../api";
 import { useSessionDetails } from "./sessions";
 import { useHandDetail, useHandSettings } from "./hands";
 import { sessionKeys, handKeys } from "./keys";
@@ -37,7 +38,7 @@ describe("useSessionDetails", () => {
   });
 
   it("should be enabled when sessionId is valid", async () => {
-    const mockSession = { id: "sess-1", status: "active" };
+    const mockSession: SessionDetailResponse = { session_id: "sess-1" };
     vi.mocked(client.getSessionDetails).mockResolvedValue(mockSession);
 
     const { result } = renderHook(() => useSessionDetails("sess-1"), {
@@ -56,7 +57,7 @@ describe("useSessionDetails", () => {
   });
 
   it("should use sessionKeys.detail(sessionId) as queryKey", async () => {
-    vi.mocked(client.getSessionDetails).mockResolvedValue({ id: "sess-2" });
+    vi.mocked(client.getSessionDetails).mockResolvedValue({ session_id: "sess-2" });
 
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -65,10 +66,10 @@ describe("useSessionDetails", () => {
     renderHook(() => useSessionDetails("sess-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(sessionKeys.detail("sess-2"))).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: sessionKeys.detail("sess-2") })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(sessionKeys.detail("sess-2"))?.queryKey,
+      qc.getQueryCache().find({ queryKey: sessionKeys.detail("sess-2") })?.queryKey,
     ).toEqual(sessionKeys.detail("sess-2"));
   });
 });
@@ -114,10 +115,10 @@ describe("useHandDetail", () => {
     renderHook(() => useHandDetail("hand-2"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(handKeys.detail("hand-2"))).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: handKeys.detail("hand-2") })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(handKeys.detail("hand-2"))?.queryKey,
+      qc.getQueryCache().find({ queryKey: handKeys.detail("hand-2") })?.queryKey,
     ).toEqual(handKeys.detail("hand-2"));
   });
 });
@@ -135,7 +136,7 @@ describe("useHandSettings", () => {
   });
 
   it("should be enabled when handId is valid", async () => {
-    const mockSettings = { handId: "hand-3", theme: "dark" };
+    const mockSettings: HandSettingsResponse = { hand_id: "hand-3", current_values: { theme: "dark" } };
     vi.mocked(client.getHandSettings).mockResolvedValue(mockSettings);
 
     const { result } = renderHook(() => useHandSettings("hand-3"), {
@@ -154,7 +155,7 @@ describe("useHandSettings", () => {
   });
 
   it("should use handKeys.settings(handId) as queryKey", async () => {
-    vi.mocked(client.getHandSettings).mockResolvedValue({ handId: "hand-4" });
+    vi.mocked(client.getHandSettings).mockResolvedValue({ hand_id: "hand-4" });
 
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -163,10 +164,10 @@ describe("useHandSettings", () => {
     renderHook(() => useHandSettings("hand-4"), { wrapper });
 
     await waitFor(() => {
-      expect(qc.getQueryCache().find(handKeys.settings("hand-4"))).toBeDefined();
+      expect(qc.getQueryCache().find({ queryKey: handKeys.settings("hand-4") })).toBeDefined();
     });
     expect(
-      qc.getQueryCache().find(handKeys.settings("hand-4"))?.queryKey,
+      qc.getQueryCache().find({ queryKey: handKeys.settings("hand-4") })?.queryKey,
     ).toEqual(handKeys.settings("hand-4"));
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-hands.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useSessionDetails } from "./sessions";
+import { useHandDetail, useHandSettings } from "./hands";
+import { sessionKeys, handKeys } from "./keys";
+import * as client from "../http/client";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+vi.mock("../http/client", () => ({
+  getSessionDetails: vi.fn(),
+  getHandDetail: vi.fn(),
+  getHandSettings: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSessionDetails", () => {
+  it("should be disabled when sessionId is empty string", () => {
+    const { result } = renderHook(() => useSessionDetails(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getSessionDetails).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when sessionId is valid", async () => {
+    const mockSession = { id: "sess-1", status: "active" };
+    vi.mocked(client.getSessionDetails).mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useSessionDetails("sess-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockSession);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getSessionDetails).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("should use sessionKeys.detail(sessionId) as queryKey", async () => {
+    vi.mocked(client.getSessionDetails).mockResolvedValue({ id: "sess-2" });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useSessionDetails("sess-2"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(sessionKeys.detail("sess-2"))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(sessionKeys.detail("sess-2"))?.queryKey,
+    ).toEqual(sessionKeys.detail("sess-2"));
+  });
+});
+
+describe("useHandDetail", () => {
+  it("should be disabled when handId is empty string", () => {
+    const { result } = renderHook(() => useHandDetail(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandDetail).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when handId is valid", async () => {
+    const mockHand = { id: "hand-1", name: "Test Hand" };
+    vi.mocked(client.getHandDetail).mockResolvedValue(mockHand);
+
+    const { result } = renderHook(() => useHandDetail("hand-1"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockHand);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandDetail).toHaveBeenCalledWith("hand-1");
+  });
+
+  it("should use handKeys.detail(handId) as queryKey", async () => {
+    vi.mocked(client.getHandDetail).mockResolvedValue({ id: "hand-2" });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useHandDetail("hand-2"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(handKeys.detail("hand-2"))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(handKeys.detail("hand-2"))?.queryKey,
+    ).toEqual(handKeys.detail("hand-2"));
+  });
+});
+
+describe("useHandSettings", () => {
+  it("should be disabled when handId is empty string", () => {
+    const { result } = renderHook(() => useHandSettings(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandSettings).not.toHaveBeenCalled();
+  });
+
+  it("should be enabled when handId is valid", async () => {
+    const mockSettings = { handId: "hand-3", theme: "dark" };
+    vi.mocked(client.getHandSettings).mockResolvedValue(mockSettings);
+
+    const { result } = renderHook(() => useHandSettings("hand-3"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fetchStatus).toBe("fetching");
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockSettings);
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(client.getHandSettings).toHaveBeenCalledWith("hand-3");
+  });
+
+  it("should use handKeys.settings(handId) as queryKey", async () => {
+    vi.mocked(client.getHandSettings).mockResolvedValue({ handId: "hand-4" });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useHandSettings("hand-4"), { wrapper });
+
+    await waitFor(() => {
+      expect(qc.getQueryCache().find(handKeys.settings("hand-4"))).toBeDefined();
+    });
+    expect(
+      qc.getQueryCache().find(handKeys.settings("hand-4"))?.queryKey,
+    ).toEqual(handKeys.settings("hand-4"));
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import type { ClawHubBrowseResponse, ClawHubSkillDetail } from "../../api";
 import {
   useClawHubSearch,
   useClawHubSkill,
@@ -45,7 +46,7 @@ describe("useClawHubSearch", () => {
   });
 
   it("should fetch when query is valid", async () => {
-    const mockResults = [{ slug: "skill-a", name: "Skill A" }];
+    const mockResults: ClawHubBrowseResponse = { items: [{ slug: "skill-a", name: "Skill A", description: "desc", version: "1.0.0" }] };
     vi.mocked(httpClient.clawhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useClawHubSearch("test"), {
@@ -60,7 +61,7 @@ describe("useClawHubSearch", () => {
 
   it("should use the correct queryKey", async () => {
     const qc = createQueryClient();
-    vi.mocked(httpClient.clawhubSearch).mockResolvedValue([]);
+    vi.mocked(httpClient.clawhubSearch).mockResolvedValue({ items: [] });
 
     const { result } = renderHook(() => useClawHubSearch("test"), {
       wrapper: createWrapper(qc),
@@ -86,7 +87,7 @@ describe("useClawHubSkill", () => {
   });
 
   it("should fetch when slug is valid", async () => {
-    const mockSkill = { slug: "my-skill", name: "My Skill" };
+    const mockSkill: ClawHubSkillDetail = { slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" };
     vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useClawHubSkill("my-skill"), {
@@ -101,7 +102,7 @@ describe("useClawHubSkill", () => {
 
   it("should use the correct queryKey", async () => {
     const qc = createQueryClient();
-    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue({});
+    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue({ slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" });
 
     const { result } = renderHook(() => useClawHubSkill("my-skill"), {
       wrapper: createWrapper(qc),
@@ -127,7 +128,7 @@ describe("useSkillHubSearch", () => {
   });
 
   it("should fetch when query is valid", async () => {
-    const mockResults = [{ slug: "skill-b", name: "Skill B" }];
+    const mockResults: ClawHubBrowseResponse = { items: [{ slug: "skill-b", name: "Skill B", description: "desc", version: "1.0.0" }] };
     vi.mocked(httpClient.skillhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useSkillHubSearch("test"), {
@@ -142,7 +143,7 @@ describe("useSkillHubSearch", () => {
 
   it("should use the correct queryKey", async () => {
     const qc = createQueryClient();
-    vi.mocked(httpClient.skillhubSearch).mockResolvedValue([]);
+    vi.mocked(httpClient.skillhubSearch).mockResolvedValue({ items: [] });
 
     const { result } = renderHook(() => useSkillHubSearch("test"), {
       wrapper: createWrapper(qc),
@@ -168,7 +169,7 @@ describe("useSkillHubSkill", () => {
   });
 
   it("should fetch when slug is valid", async () => {
-    const mockSkill = { slug: "my-skill", name: "My Skill" };
+    const mockSkill: ClawHubSkillDetail = { slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" };
     vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
@@ -183,7 +184,7 @@ describe("useSkillHubSkill", () => {
 
   it("should use the correct queryKey", async () => {
     const qc = createQueryClient();
-    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue({});
+    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue({ slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" });
 
     const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
       wrapper: createWrapper(qc),

--- a/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import type { ClawHubBrowseResponse, ClawHubSkillDetail } from "../../api";
 import {
   useClawHubSearch,
@@ -11,6 +9,7 @@ import {
 } from "./skills";
 import * as httpClient from "../http/client";
 import { clawhubKeys, skillhubKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   clawhubSearch: vi.fn(),
@@ -19,16 +18,6 @@ vi.mock("../http/client", () => ({
   skillhubGetSkill: vi.fn(),
 }));
 
-function createQueryClient() {
-  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
-}
-
-function createWrapper(qc: QueryClient) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -36,7 +25,7 @@ beforeEach(() => {
 describe("useClawHubSearch", () => {
   it("should be disabled when query is empty string", () => {
     const { result } = renderHook(() => useClawHubSearch(""), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -50,7 +39,7 @@ describe("useClawHubSearch", () => {
     vi.mocked(httpClient.clawhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useClawHubSearch("test"), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -60,24 +49,24 @@ describe("useClawHubSearch", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = createQueryClient();
-    vi.mocked(httpClient.clawhubSearch).mockResolvedValue({ items: [] });
+    const mockResults: ClawHubBrowseResponse = { items: [] };
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    vi.mocked(httpClient.clawhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useClawHubSearch("test"), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = qc.getQueryCache().find({ queryKey: clawhubKeys.search("test") });
-    expect(cached).toBeDefined();
+    expect(queryClient.getQueryData(clawhubKeys.search("test"))).toEqual(mockResults);
   });
 });
 
 describe("useClawHubSkill", () => {
   it("should be disabled when slug is empty string", () => {
     const { result } = renderHook(() => useClawHubSkill(""), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -91,7 +80,7 @@ describe("useClawHubSkill", () => {
     vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useClawHubSkill("my-skill"), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -101,24 +90,24 @@ describe("useClawHubSkill", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = createQueryClient();
-    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue({ slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" });
+    const mockSkill: ClawHubSkillDetail = { slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" };
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useClawHubSkill("my-skill"), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = qc.getQueryCache().find({ queryKey: clawhubKeys.detail("my-skill") });
-    expect(cached).toBeDefined();
+    expect(queryClient.getQueryData(clawhubKeys.detail("my-skill"))).toEqual(mockSkill);
   });
 });
 
 describe("useSkillHubSearch", () => {
   it("should be disabled when query is empty string", () => {
     const { result } = renderHook(() => useSkillHubSearch(""), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -132,7 +121,7 @@ describe("useSkillHubSearch", () => {
     vi.mocked(httpClient.skillhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useSkillHubSearch("test"), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -142,24 +131,24 @@ describe("useSkillHubSearch", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = createQueryClient();
-    vi.mocked(httpClient.skillhubSearch).mockResolvedValue({ items: [] });
+    const mockResults: ClawHubBrowseResponse = { items: [] };
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    vi.mocked(httpClient.skillhubSearch).mockResolvedValue(mockResults);
 
     const { result } = renderHook(() => useSkillHubSearch("test"), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = qc.getQueryCache().find({ queryKey: skillhubKeys.search("test") });
-    expect(cached).toBeDefined();
+    expect(queryClient.getQueryData(skillhubKeys.search("test"))).toEqual(mockResults);
   });
 });
 
 describe("useSkillHubSkill", () => {
   it("should be disabled when slug is empty string", () => {
     const { result } = renderHook(() => useSkillHubSkill(""), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -173,7 +162,7 @@ describe("useSkillHubSkill", () => {
     vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
-      wrapper: createWrapper(createQueryClient()),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -183,16 +172,16 @@ describe("useSkillHubSkill", () => {
   });
 
   it("should use the correct queryKey", async () => {
-    const qc = createQueryClient();
-    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue({ slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" });
+    const mockSkill: ClawHubSkillDetail = { slug: "my-skill", name: "My Skill", description: "desc", version: "1.0.0", author: "tester", stars: 0, downloads: 0, tags: [], readme: "# My Skill" };
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue(mockSkill);
 
     const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
-      wrapper: createWrapper(qc),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const cached = qc.getQueryCache().find({ queryKey: skillhubKeys.detail("my-skill") });
-    expect(cached).toBeDefined();
+    expect(queryClient.getQueryData(skillhubKeys.detail("my-skill"))).toEqual(mockSkill);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills-search.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {
+  useClawHubSearch,
+  useClawHubSkill,
+  useSkillHubSearch,
+  useSkillHubSkill,
+} from "./skills";
+import * as httpClient from "../http/client";
+import { clawhubKeys, skillhubKeys } from "./keys";
+
+vi.mock("../http/client", () => ({
+  clawhubSearch: vi.fn(),
+  clawhubGetSkill: vi.fn(),
+  skillhubSearch: vi.fn(),
+  skillhubGetSkill: vi.fn(),
+}));
+
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function createWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useClawHubSearch", () => {
+  it("should be disabled when query is empty string", () => {
+    const { result } = renderHook(() => useClawHubSearch(""), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.clawhubSearch).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when query is valid", async () => {
+    const mockResults = [{ slug: "skill-a", name: "Skill A" }];
+    vi.mocked(httpClient.clawhubSearch).mockResolvedValue(mockResults);
+
+    const { result } = renderHook(() => useClawHubSearch("test"), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockResults);
+    expect(httpClient.clawhubSearch).toHaveBeenCalledWith("test");
+  });
+
+  it("should use the correct queryKey", async () => {
+    const qc = createQueryClient();
+    vi.mocked(httpClient.clawhubSearch).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useClawHubSearch("test"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryCache().find({ queryKey: clawhubKeys.search("test") });
+    expect(cached).toBeDefined();
+  });
+});
+
+describe("useClawHubSkill", () => {
+  it("should be disabled when slug is empty string", () => {
+    const { result } = renderHook(() => useClawHubSkill(""), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.clawhubGetSkill).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when slug is valid", async () => {
+    const mockSkill = { slug: "my-skill", name: "My Skill" };
+    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue(mockSkill);
+
+    const { result } = renderHook(() => useClawHubSkill("my-skill"), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockSkill);
+    expect(httpClient.clawhubGetSkill).toHaveBeenCalledWith("my-skill");
+  });
+
+  it("should use the correct queryKey", async () => {
+    const qc = createQueryClient();
+    vi.mocked(httpClient.clawhubGetSkill).mockResolvedValue({});
+
+    const { result } = renderHook(() => useClawHubSkill("my-skill"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryCache().find({ queryKey: clawhubKeys.detail("my-skill") });
+    expect(cached).toBeDefined();
+  });
+});
+
+describe("useSkillHubSearch", () => {
+  it("should be disabled when query is empty string", () => {
+    const { result } = renderHook(() => useSkillHubSearch(""), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.skillhubSearch).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when query is valid", async () => {
+    const mockResults = [{ slug: "skill-b", name: "Skill B" }];
+    vi.mocked(httpClient.skillhubSearch).mockResolvedValue(mockResults);
+
+    const { result } = renderHook(() => useSkillHubSearch("test"), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockResults);
+    expect(httpClient.skillhubSearch).toHaveBeenCalledWith("test");
+  });
+
+  it("should use the correct queryKey", async () => {
+    const qc = createQueryClient();
+    vi.mocked(httpClient.skillhubSearch).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSkillHubSearch("test"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryCache().find({ queryKey: skillhubKeys.search("test") });
+    expect(cached).toBeDefined();
+  });
+});
+
+describe("useSkillHubSkill", () => {
+  it("should be disabled when slug is empty string", () => {
+    const { result } = renderHook(() => useSkillHubSkill(""), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.skillhubGetSkill).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when slug is valid", async () => {
+    const mockSkill = { slug: "my-skill", name: "My Skill" };
+    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue(mockSkill);
+
+    const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockSkill);
+    expect(httpClient.skillhubGetSkill).toHaveBeenCalledWith("my-skill");
+  });
+
+  it("should use the correct queryKey", async () => {
+    const qc = createQueryClient();
+    vi.mocked(httpClient.skillhubGetSkill).mockResolvedValue({});
+
+    const { result } = renderHook(() => useSkillHubSkill("my-skill"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = qc.getQueryCache().find({ queryKey: skillhubKeys.detail("my-skill") });
+    expect(cached).toBeDefined();
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
@@ -1,23 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 import type { WorkflowRunDetail } from "../../api";
-import { useWorkflowRuns, useWorkflowRunDetail, workflowQueries } from "./workflows";
+import { useWorkflowRuns, useWorkflowRunDetail } from "./workflows";
 import * as httpClient from "../http/client";
 import { workflowKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   listWorkflowRuns: vi.fn(),
   getWorkflowRun: vi.fn(),
 }));
-
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -26,7 +18,7 @@ beforeEach(() => {
 describe("useWorkflowRuns", () => {
   it("should be disabled when workflowId is empty string", () => {
     const { result } = renderHook(() => useWorkflowRuns(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -40,7 +32,7 @@ describe("useWorkflowRuns", () => {
     vi.mocked(httpClient.listWorkflowRuns).mockResolvedValue(mockRuns);
 
     const { result } = renderHook(() => useWorkflowRuns("wf-123"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -50,16 +42,22 @@ describe("useWorkflowRuns", () => {
   });
 
   it("should use the correct queryKey", () => {
-    expect(workflowQueries.runs("wf-456").queryKey).toEqual(
-      workflowKeys.runs("wf-456"),
-    );
+    const mockRuns = [{ id: "run-2", status: "queued" }];
+    vi.mocked(httpClient.listWorkflowRuns).mockResolvedValue(mockRuns);
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    renderHook(() => useWorkflowRuns("wf-456"), { wrapper });
+
+    return waitFor(() => {
+      expect(queryClient.getQueryData(workflowKeys.runs("wf-456"))).toEqual(mockRuns);
+    });
   });
 });
 
 describe("useWorkflowRunDetail", () => {
   it("should be disabled when runId is empty string", () => {
     const { result } = renderHook(() => useWorkflowRunDetail(""), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     expect(result.current.data).toBeUndefined();
@@ -73,7 +71,7 @@ describe("useWorkflowRunDetail", () => {
     vi.mocked(httpClient.getWorkflowRun).mockResolvedValue(mockRun);
 
     const { result } = renderHook(() => useWorkflowRunDetail("run-1"), {
-      wrapper: createWrapper(),
+      wrapper: createQueryClientWrapper().wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -83,8 +81,22 @@ describe("useWorkflowRunDetail", () => {
   });
 
   it("should use the correct queryKey", () => {
-    expect(workflowQueries.runDetail("run-2").queryKey).toEqual(
-      workflowKeys.runDetail("run-2"),
-    );
+    const mockRun: WorkflowRunDetail = {
+      id: "run-2",
+      workflow_id: "wf-2",
+      workflow_name: "Queued Workflow",
+      input: "{}",
+      state: "queued",
+      started_at: "2024-01-01T00:00:00Z",
+      step_results: [],
+    };
+    vi.mocked(httpClient.getWorkflowRun).mockResolvedValue(mockRun);
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    renderHook(() => useWorkflowRunDetail("run-2"), { wrapper });
+
+    return waitFor(() => {
+      expect(queryClient.getQueryData(workflowKeys.runDetail("run-2"))).toEqual(mockRun);
+    });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import type { WorkflowRunDetail } from "../../api";
 import { useWorkflowRuns, useWorkflowRunDetail, workflowQueries } from "./workflows";
 import * as httpClient from "../http/client";
 import { workflowKeys } from "./keys";
@@ -68,7 +69,7 @@ describe("useWorkflowRunDetail", () => {
   });
 
   it("should fetch when runId is valid", async () => {
-    const mockRun = { id: "run-1", status: "running", steps: [] };
+    const mockRun: WorkflowRunDetail = { id: "run-1", workflow_id: "wf-1", workflow_name: "Test Workflow", input: "{}", state: "running", started_at: "2024-01-01T00:00:00Z", step_results: [] };
     vi.mocked(httpClient.getWorkflowRun).mockResolvedValue(mockRun);
 
     const { result } = renderHook(() => useWorkflowRunDetail("run-1"), {

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useWorkflowRuns, useWorkflowRunDetail, workflowQueries } from "./workflows";
+import * as httpClient from "../http/client";
+import { workflowKeys } from "./keys";
+
+vi.mock("../http/client", () => ({
+  listWorkflowRuns: vi.fn(),
+  getWorkflowRun: vi.fn(),
+}));
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useWorkflowRuns", () => {
+  it("should be disabled when workflowId is empty string", () => {
+    const { result } = renderHook(() => useWorkflowRuns(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when workflowId is valid", async () => {
+    const mockRuns = [{ id: "run-1", status: "completed" }];
+    vi.mocked(httpClient.listWorkflowRuns).mockResolvedValue(mockRuns);
+
+    const { result } = renderHook(() => useWorkflowRuns("wf-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockRuns);
+    expect(httpClient.listWorkflowRuns).toHaveBeenCalledWith("wf-123");
+  });
+
+  it("should use the correct queryKey", () => {
+    expect(workflowQueries.runs("wf-456").queryKey).toEqual(
+      workflowKeys.runs("wf-456"),
+    );
+  });
+});
+
+describe("useWorkflowRunDetail", () => {
+  it("should be disabled when runId is empty string", () => {
+    const { result } = renderHook(() => useWorkflowRunDetail(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.getWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("should fetch when runId is valid", async () => {
+    const mockRun = { id: "run-1", status: "running", steps: [] };
+    vi.mocked(httpClient.getWorkflowRun).mockResolvedValue(mockRun);
+
+    const { result } = renderHook(() => useWorkflowRunDetail("run-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockRun);
+    expect(httpClient.getWorkflowRun).toHaveBeenCalledWith("run-1");
+  });
+
+  it("should use the correct queryKey", () => {
+    expect(workflowQueries.runDetail("run-2").queryKey).toEqual(
+      workflowKeys.runDetail("run-2"),
+    );
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/test/query-client.tsx
+++ b/crates/librefang-api/dashboard/src/lib/test/query-client.tsx
@@ -1,0 +1,16 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren, ReactElement } from "react";
+
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+export function createQueryClientWrapper(queryClient = createTestQueryClient()) {
+  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { queryClient, wrapper };
+}


### PR DESCRIPTION
## Type

- [x] Refactor / Performance
- [x] Other

## Summary

Expand and stabilize dashboard React Query hook tests across `src/lib/mutations` and `src/lib/queries`, then refactor the test setup to share a common QueryClient wrapper. This also fixes test typing drift against current API types and aligns query cache assertions with the current TanStack Query API.

## Changes

- added mutation invalidation coverage and enabled-guard coverage for dashboard hooks
- tightened async mutation assertions to avoid race-prone `mutateAsync` usage patterns
- fixed misleading enabled-guard test names so they match actual behavior
- fixed flaky query-key tests by waiting for cache population before assertions
- introduced a shared test utility at `src/lib/test/query-client.tsx` for QueryClient and wrapper setup
- replaced repeated local QueryClient boilerplate across dashboard query and mutation tests
- updated query cache assertions to use current `find({ queryKey })` semantics or `getQueryData(...)` where clearer
- corrected stale or incomplete mock payloads in tests to match current types from `src/api.ts`
- cleaned up test-only unused imports and invalid mock return values
- verified the dashboard package with:
  - `pnpm typecheck`
  - `pnpm test --run`
  - `pnpm build`

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
