### PR TITLE
release: v2026.4.18-beta23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,112 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.18] - 2026-04-18
+
+### Added
+
+- Improve models page UX (#2547) (@houko)
+- Improve models and providers page UX (#2607) (@houko)
+- Trigger agent on routing aliases in group messages (#2292) (#2619) (@houko)
+- Model selection when setting default provider (#2548) (#2622) (@houko)
+- Add skill_read_file tool for progressive disclosure (#2374) (#2623) (@houko)
+- LLM-based reply-intent precheck for group conversations (#2291) (#2625) (@houko)
+- Persisted LID→PN cache with SQLite mirror (Phase 4 §B) (#2627) (@f-liva)
+- Per-model inference parameter settings (#2629) (@houko)
+- Per-provider proxy URL support (#2549) (#2634) (@houko)
+- Add web search augmentation for non-tool-calling models (#2635) (@houko)
+- Add web search toggle to chat page (#2639) (@houko)
+- Cascading model switcher + search API key check (#2641) (@houko)
+- Tmux-backed multi-window tabs with auth and security hardening (#2651) (@leszek3737)
+- One-click marketplace install with env setup modal (#2666) (@houko)
+- Support OpenRouter as embedding provider (#2685) (@houko)
+- Add per-agent tools allowlist/blocklist editor (#2693) (@leszek3737)
+- Add skill self-evolution system (#2694) (@houko)
+- First-run wizard, security docs, nav surfacing (#2704) (@houko)
+- Add visual editor for agent creation (#2709) (#2716) (@houko)
+- TOML viewer modals for hands & config + widen agent create modal (#2722) (@houko)
+
+### Fixed
+
+- Add missing entries to default .gitignore on workspace init (#2546) (@houko)
+- Prevent auto-detection from overriding provider key removal (#2550) (@houko)
+- Only auto-promote Ideas discussions to issues (#2614) (@houko)
+- Upgrade react to 19.2.5 to fix CVE-2025-55182 (#2615) (@houko)
+- Token limit override, cron timezone, skill prompt cap (#2556, #2352, #2374) (#2616) (@houko)
+- Ignore RUSTSEC-2026-0098 (rustls-webpki) (#2621) (@houko)
+- Wire StreamDedup into SSE streaming handler (#2626) (@f-liva)
+- Add issues:write to pr-status-labels workflow (#2630) (@houko)
+- Ignore RUSTSEC-2026-0098/0099 (rustls-webpki 0.102.x) (#2632) (@houko)
+- Auto-reload on stale chunk import failure (#2633) (@houko)
+- Replace npm with pnpm in dashboard CI workflows (#2636) (@houko)
+- Add missing i18n keys for ChatPage session and export (#2637) (@houko)
+- Change WebSearchAugmentationMode default from off to auto (#2638) (@houko)
+- Render thinking content as markdown (#2640) (@houko)
+- Fix duplicate configQuery declaration (#2642) (@houko)
+- Persist agent sessions across daemon restarts (#2643) (@houko)
+- Improve config schema UX — ranges, selects, i18n (#2644) (@houko)
+- Improve /help and system message formatting (#2653) (@houko)
+- Taint scanner false positive on date-prefixed MCP session handles (#2654) (@houko)
+- Decouple catalog tests from hardcoded model counts (#2655) (@houko)
+- Resolve clippy errors and stale lemonade integration test (#2656) (@houko)
+- Use librefang_types path for ModelTier in test (#2657) (@houko)
+- Replace into_iter() with iter() on slice (#2658) (@houko)
+- Use minimum bound for DevTools count in registry test (#2659) (@houko)
+- Populate wizard model from catalog instead of hardcoded string (#2660) (@houko)
+- Use fetch+reset instead of pull to handle detached HEAD (#2662) (@houko)
+- Remove nested scroll container from skills page (#2665) (@houko)
+- Connect MCP servers immediately after dashboard add/update (#2668) (@houko)
+- Expand env vars in stdio args (#2669) (@houko)
+- Classify Gemini CLI quota exhaustion as rate-limit, not auth error (#2670) (@houko)
+- Remove local files deleted from upstream registry (#2671) (@houko)
+- Remove stale provider files from cache after sync (#2672) (@houko)
+- Don't auto-detect GITHUB_TOKEN providers as Configured (#2673) (@houko)
+- Render thinking trace as markdown (#2674) (@houko)
+- Show 'service not running' for offline local providers (#2675) (@houko)
+- Fix thinking trace not rendering (children prop) (#2676) (@houko)
+- Instruct model to think in user's language (#2680) (@houko)
+- Apply thinking language instruction unconditionally (#2681) (@houko)
+- Tmux default, config_ref guard, dashboard config improvements (#2682) (@houko)
+- Tmux_enabled default, config_ref guard, dashboard model cascading (#2683) (@houko)
+- Send empty object for no-arg tools, exclude paths from taint (#2677) (#2684) (@houko)
+- Skip origin validation for authenticated requests (#2686) (@houko)
+- Add i18n for approval card and translate risk levels (#2687) (@houko)
+- Grant MCP server tools regardless of capabilities.tools restrictions (#2688) (@houko)
+- Remove capabilities.tools filter for MCP tools entirely (#2689) (@houko)
+- Stop mark-on-sight dedup from blocking decrypt-fail retransmits (#2692) (@f-liva)
+- Propagate Telegram Bot API errors instead of swallowing them (#2695) (@f-liva)
+- Fix agent cards layout overflow on narrow screens (#2697) (@leszek3737)
+- Unblock chat input after stream completes #2698 (#2702) (@leszek3737)
+- Expose ImageFile parent dirs via --add-dir for claude-code (#2711) (@f-liva)
+- Render struct-variant trigger patterns instead of crashing (#2717) (@houko)
+- Thread caller agent context through the MCP HTTP bridge (#2719) (@houko)
+- Unblock main CI on Rust 1.95 clippy (#2723) (@houko)
+- Clear Rust 1.95 clippy regressions in librefang-api (#2724) (@houko)
+- Resolve Rust 1.95 collapsible_match clippy regressions in TUI (#2729) (@DaBlitzStein)
+
+### Changed
+
+- Redesign MCP servers page UI (#2661) (@houko)
+- Rename Registry to Marketplace, redesign MCP marketplace cards (#2664) (@houko)
+- Extract data layer into shared query/mutation hooks (#2706) (@leszek3737)
+- Route ProvidersPage model queries through useModels (#2710) (@houko)
+
+### Maintenance
+
+- Bump pnpm/action-setup from 4 to 6 (#2700) (@app/dependabot)
+- Bump actions/checkout from 4 to 6 (#2701) (@app/dependabot)
+- Allowlist esbuild postinstall for pnpm 10 (#2707) (@houko)
+- Move pnpm onlyBuiltDependencies to pnpm-workspace.yaml (#2708) (@houko)
+- Ignore .omc/ and .claude/ AI tool artifacts (#2714) (@DaBlitzStein)
+- Remove unused config_hint locale strings (#2726) (@Chukwuebuka-2003)
+- Strengthen hook coverage and query test setup (#2731) (@leszek3737)
+- Fix pnpm strict-dep-builds failure on main (#2733) (@houko)
+
+### Other
+
+- Refactor/fix(runtime): harden proactive memory LLM output parsing and add test coverage (#2705) (@leszek3737)
+
+
 ## [2026.4.15] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "clap",
  "clap_complete",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "axum",
  "clap",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "axum",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10994,7 +10994,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32172",
+  "version": "26.4.32203",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.15-beta22",
+  "version": "2026.4.18-beta23",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.15-beta22",
+  "version": "2026.4.18-beta23",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.15b22",
+    version="2026.4.18b23",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.15-beta22"
+version = "2026.4.18-beta23"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.18-beta23 -->
## Release v2026.4.18-beta23

## [2026.4.18] - 2026-04-18

### Highlights

- **Visual agent authoring.** A new first-run wizard (#2704) and a point-and-click visual editor for agent creation (#2709, #2716) let new users get to a running agent without hand-writing TOML; existing agents gain a per-agent tool allowlist/blocklist editor (#2693) and read-only TOML viewer modals (#2722).
- **Self-evolving skills.** Skills can now refine their own prompts and tool defaults from prior runs (#2694); large skill bodies load progressively through the new `skill_read_file` tool (#2623).
- **MCP marketplace & bridge.** The `/mcp-servers` page gets a marketplace tab with one-click install and env-setup modal (#2666, #2664); servers connect immediately on add/update (#2668), stdio args expand env vars (#2669), and CLI drivers can finally call LibreFang tools back through the MCP HTTP bridge with full caller context — workspace, exec_policy, allowed_tools/skills — resolved from `X-LibreFang-Agent-Id` (#2719).
- **Web-aware chat.** Web search augmentation turns on for non-tool-calling models (#2635), controllable per chat (#2639) and defaulting to `auto` (#2638). Thinking traces now render as markdown and follow the user's language (#2640, #2674, #2676, #2680, #2681).
- **Terminal & channels.** Tmux-backed multi-window terminal tabs (#2651) land in the dashboard with fullscreen mode (#2732). Agent sessions persist across daemon restarts (#2643). Group-chat routing gets LLM reply-intent precheck (#2625), addressee detection (#2480), and decrypt-fail retransmit handling (#2692).
- **Operator controls.** Per-provider proxy URL (#2634), per-model inference params (#2629), per-provider cost/token limits (#2482), and `require_auth_for_reads` (#2398) close the last dashboard enumeration surface when auth is configured. React bumped to 19.2.5 for CVE-2025-55182 (#2615).

### Added

- Improve models page UX (#2547) (@houko)
- Improve models and providers page UX (#2607) (@houko)
- Trigger agent on routing aliases in group messages (#2292) (#2619) (@houko)
- Model selection when setting default provider (#2548) (#2622) (@houko)
- Add skill_read_file tool for progressive disclosure (#2374) (#2623) (@houko)
- LLM-based reply-intent precheck for group conversations (#2291) (#2625) (@houko)
- Persisted LID→PN cache with SQLite mirror (Phase 4 §B) (#2627) (@f-liva)
- Per-model inference parameter settings (#2629) (@houko)
- Per-provider proxy URL support (#2549) (#2634) (@houko)
- Add web search augmentation for non-tool-calling models (#2635) (@houko)
- Add web search toggle to chat page (#2639) (@houko)
- Cascading model switcher + search API key check (#2641) (@houko)
- Tmux-backed multi-window tabs with auth and security hardening (#2651) (@leszek3737)
- One-click marketplace install with env setup modal (#2666) (@houko)
- Support OpenRouter as embedding provider (#2685) (@houko)
- Add per-agent tools allowlist/blocklist editor (#2693) (@leszek3737)
- Add skill self-evolution system (#2694) (@houko)
- First-run wizard, security docs, nav surfacing (#2704) (@houko)
- Add visual editor for agent creation (#2709) (#2716) (@houko)
- TOML viewer modals for hands & config + widen agent create modal (#2722) (@houko)

### Fixed

- Add missing entries to default .gitignore on workspace init (#2546) (@houko)
- Prevent auto-detection from overriding provider key removal (#2550) (@houko)
- Only auto-promote Ideas discussions to issues (#2614) (@houko)
- Upgrade react to 19.2.5 to fix CVE-2025-55182 (#2615) (@houko)
- Token limit override, cron timezone, skill prompt cap (#2556, #2352, #2374) (#2616) (@houko)
- Ignore RUSTSEC-2026-0098 (rustls-webpki) (#2621) (@houko)
- Wire StreamDedup into SSE streaming handler (#2626) (@f-liva)
- Add issues:write to pr-status-labels workflow (#2630) (@houko)
- Ignore RUSTSEC-2026-0098/0099 (rustls-webpki 0.102.x) (#2632) (@houko)
- Auto-reload on stale chunk import failure (#2633) (@houko)
- Replace npm with pnpm in dashboard CI workflows (#2636) (@houko)
- Add missing i18n keys for ChatPage session and export (#2637) (@houko)
- Change WebSearchAugmentationMode default from off to auto (#2638) (@houko)
- Render thinking content as markdown (#2640) (@houko)
- Fix duplicate configQuery declaration (#2642) (@houko)
- Persist agent sessions across daemon restarts (#2643) (@houko)
- Improve config schema UX — ranges, selects, i18n (#2644) (@houko)
- Improve /help and system message formatting (#2653) (@houko)
- Taint scanner false positive on date-prefixed MCP session handles (#2654) (@houko)
- Decouple catalog tests from hardcoded model counts (#2655) (@houko)
- Resolve clippy errors and stale lemonade integration test (#2656) (@houko)
- Use librefang_types path for ModelTier in test (#2657) (@houko)
- Replace into_iter() with iter() on slice (#2658) (@houko)
- Use minimum bound for DevTools count in registry test (#2659) (@houko)
- Populate wizard model from catalog instead of hardcoded string (#2660) (@houko)
- Use fetch+reset instead of pull to handle detached HEAD (#2662) (@houko)
- Remove nested scroll container from skills page (#2665) (@houko)
- Connect MCP servers immediately after dashboard add/update (#2668) (@houko)
- Expand env vars in stdio args (#2669) (@houko)
- Classify Gemini CLI quota exhaustion as rate-limit, not auth error (#2670) (@houko)
- Remove local files deleted from upstream registry (#2671) (@houko)
- Remove stale provider files from cache after sync (#2672) (@houko)
- Don't auto-detect GITHUB_TOKEN providers as Configured (#2673) (@houko)
- Render thinking trace as markdown (#2674) (@houko)
- Show 'service not running' for offline local providers (#2675) (@houko)
- Fix thinking trace not rendering (children prop) (#2676) (@houko)
- Instruct model to think in user's language (#2680) (@houko)
- Apply thinking language instruction unconditionally (#2681) (@houko)
- Tmux default, config_ref guard, dashboard config improvements (#2682) (@houko)
- Tmux_enabled default, config_ref guard, dashboard model cascading (#2683) (@houko)
- Send empty object for no-arg tools, exclude paths from taint (#2677) (#2684) (@houko)
- Skip origin validation for authenticated requests (#2686) (@houko)
- Add i18n for approval card and translate risk levels (#2687) (@houko)
- Grant MCP server tools regardless of capabilities.tools restrictions (#2688) (@houko)
- Remove capabilities.tools filter for MCP tools entirely (#2689) (@houko)
- Stop mark-on-sight dedup from blocking decrypt-fail retransmits (#2692) (@f-liva)
- Propagate Telegram Bot API errors instead of swallowing them (#2695) (@f-liva)
- Fix agent cards layout overflow on narrow screens (#2697) (@leszek3737)
- Unblock chat input after stream completes #2698 (#2702) (@leszek3737)
- Expose ImageFile parent dirs via --add-dir for claude-code (#2711) (@f-liva)
- Render struct-variant trigger patterns instead of crashing (#2717) (@houko)
- Thread caller agent context through the MCP HTTP bridge (#2719) (@houko)
- Unblock main CI on Rust 1.95 clippy (#2723) (@houko)
- Clear Rust 1.95 clippy regressions in librefang-api (#2724) (@houko)
- Resolve Rust 1.95 collapsible_match clippy regressions in TUI (#2729) (@DaBlitzStein)

### Changed

- Redesign MCP servers page UI (#2661) (@houko)
- Rename Registry to Marketplace, redesign MCP marketplace cards (#2664) (@houko)
- Extract data layer into shared query/mutation hooks (#2706) (@leszek3737)
- Route ProvidersPage model queries through useModels (#2710) (@houko)

### Maintenance

- Bump pnpm/action-setup from 4 to 6 (#2700) (@app/dependabot)
- Bump actions/checkout from 4 to 6 (#2701) (@app/dependabot)
- Allowlist esbuild postinstall for pnpm 10 (#2707) (@houko)
- Move pnpm onlyBuiltDependencies to pnpm-workspace.yaml (#2708) (@houko)
- Ignore .omc/ and .claude/ AI tool artifacts (#2714) (@DaBlitzStein)
- Remove unused config_hint locale strings (#2726) (@Chukwuebuka-2003)
- Strengthen hook coverage and query test setup (#2731) (@leszek3737)
- Fix pnpm strict-dep-builds failure on main (#2733) (@houko)

### Other

- Refactor/fix(runtime): harden proactive memory LLM output parsing and add test coverage (#2705) (@leszek3737)



---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.15-beta22...v2026.4.18-beta23
