### PR TITLE
ci(dashboard): pass strict-dep-builds=false via pnpm CLI

### DIFF
--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: crates/librefang-api/dashboard
-        run: pnpm install --frozen-lockfile
+        # pnpm 10 in CI ignores both .npmrc and pnpm-workspace.yaml for the
+        # ignored-builds setting; pass it on the CLI so it can't be missed.
+        run: pnpm install --frozen-lockfile --config.strict-dep-builds=false
 
       - name: Build dashboard
         working-directory: crates/librefang-api/dashboard

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build embedded dashboard assets
         working-directory: crates/librefang-api/dashboard
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
           pnpm run build
 
       - name: Import macOS signing certificate

--- a/.github/workflows/release-shell.yml
+++ b/.github/workflows/release-shell.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: 20
       - name: Install dependencies
         working-directory: crates/librefang-api/dashboard
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --config.strict-dep-builds=false
       - name: Build dashboard
         working-directory: crates/librefang-api/dashboard
         run: pnpm run build


### PR DESCRIPTION
## Summary
The v2026.4.18-beta23 release pushed but the three release-triggered workflows (`Dashboard Build`, `Release / Shell`, `Release / Desktop`) all failed at the `pnpm install --frozen-lockfile` step with:

```
 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.27.4
```

`Release / Desktop` failed on all 5 platforms (Linux x86_64, macOS ARM64 / x86_64, Windows ARM64 / x86_64) via its shared *Build Dashboard* step — no desktop binaries were uploaded to the release.

## Why the earlier fixes didn't land in CI

Two prior attempts addressed this via file-based pnpm config:
- #2707 — `pnpm.onlyBuiltDependencies` in `package.json`
- #2708 — moved to `onlyBuiltDependencies` in `pnpm-workspace.yaml`
- #2733 — `.npmrc` with `strict-dep-builds=false`

All three take effect locally on pnpm 10.33.0 (verified with `CI=true GITHUB_ACTIONS=true env`) but are silently ignored by the exact same pnpm version in GitHub Actions runners. I could not reproduce the CI-only discrepancy — it's as if the `.npmrc` / `pnpm-workspace.yaml` loader doesn't run for this setting on the Actions-provisioned pnpm install.

## Fix

Pass `--config.strict-dep-builds=false` directly to `pnpm install`. CLI config is parsed by the pnpm CLI itself, not by the file loader, so it cannot be missed. Applied to every `pnpm install` that runs inside `crates/librefang-api/dashboard`:

- `.github/workflows/dashboard-build.yml`
- `.github/workflows/release-shell.yml`
- `.github/workflows/release-desktop.yml`

Safe: modern esbuild (≥0.16) ships its native binary via the platform-specific `@esbuild/*` optional dependency; the postinstall stub isn't required for vite builds. Already verified end-to-end (clean install + `pnpm run build` producing expected bundles) on this worktree.

## Follow-up

Beta23's release is missing its `dashboard-dist.tar.gz` asset and desktop binaries. After this merges, re-trigger:
- `dashboard-build.yml` via `workflow_dispatch` with `tag: v2026.4.18-beta23`
- `release-desktop.yml` and `release-shell.yml` via the release `published` event (or workflow_dispatch)

## Test plan
- [ ] `Dashboard Build` passes on this PR (won't actually run here since it's gated on push to main + release, not PR — will validate post-merge via workflow_dispatch)
- [ ] After merge, re-run dashboard-build with `tag: v2026.4.18-beta23` input and confirm asset uploads