### PR TITLE
ci(desktop): drop bogus npm cache config on setup-node

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -79,8 +79,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: crates/librefang-api/dashboard/package-lock.json
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
`release-desktop.yml` told `actions/setup-node@v6` to cache npm with a path that does not exist:

```yaml
- uses: actions/setup-node@v6
  with:
    node-version: 20
    cache: npm
    cache-dependency-path: crates/librefang-api/dashboard/package-lock.json
```

The dashboard is a pnpm project — `package-lock.json` is `.gitignore`d and never gets generated. `actions/setup-node@v6` (bumped from v4 in #2701) treats the missing path as fatal with:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

All five Desktop platforms (Linux x86_64, macOS x86_64 / ARM64, Windows x86_64 / ARM64) failed at the setup-node step on the `v2026.4.18-beta23` re-tag push — before the build or the now-fixed pnpm install step could run. See https://github.com/librefang/librefang/actions/runs/24595430860.

## Fix

Remove the `cache:` / `cache-dependency-path:` entries. Nothing was actually being cached — npm isn't used anywhere in this workflow — so the deletion is effectively a no-op for caching. `pnpm/action-setup@v6` a few lines below handles dashboard caching.

## Follow-up for beta23 recovery

`release-desktop.yml` and `release-shell.yml` only trigger on `push: tags: v*`. After this merges, re-push the tag once more to pick up the fix:

```bash
git push origin --delete v2026.4.18-beta23
git tag -f v2026.4.18-beta23 origin/main
git push origin v2026.4.18-beta23
```

Desktop will build cleanly. SDK will noisily fail again (npm/pypi version is already published); Docker and Create are idempotent.

## Test plan
- [ ] Tag re-push after merge produces desktop binaries (`librefang-desktop-*.dmg/.exe/.deb`) on the v2026.4.18-beta23 release
- [ ] Future release tags trigger Desktop without the cache path error