### PR TITLE
ci: replace cloudflare/wrangler-action with direct npx wrangler calls

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,8 +22,6 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 
@@ -48,8 +46,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy docs/out --project-name=librefang-docs --branch=${{ github.head_ref || github.ref_name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler@4 pages deploy docs/out --project-name=librefang-docs --branch="${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,8 +22,6 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 
@@ -49,8 +47,7 @@ jobs:
       - run: cd web && pnpm build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy web/dist --project-name=librefang --branch=${{ github.head_ref || github.ref_name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler@4 pages deploy web/dist --project-name=librefang --branch="${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -15,29 +15,33 @@ jobs:
   deploy-worker:
     name: Deploy Main Worker
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+      - uses: actions/setup-node@v6
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: deploy/worker
+          node-version: "24"
+
+      - name: Deploy Worker
+        working-directory: deploy/worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler@4 deploy
 
   deploy-github-stats:
     name: Deploy GitHub Stats Worker
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 
-      - name: Deploy GitHub Stats Worker
-        uses: cloudflare/wrangler-action@v3
+      - uses: actions/setup-node@v6
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: web/workers/github-stats-worker
+          node-version: "24"
+
+      - name: Deploy GitHub Stats Worker
+        working-directory: web/workers/github-stats-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler@4 deploy


### PR DESCRIPTION
## Summary

- `wrangler-action@v3` declares `runs.using: node20`, so every deploy run logs a Node.js 20 deprecation warning and gets force-shimmed to Node.js 24 by the runner.
- Upstream's Node.js 24 migration PR ([cloudflare/wrangler-action#415](https://github.com/cloudflare/wrangler-action/pull/415)) is still open with conflicts — no release to bump to.
- Drop the action wrapper and call wrangler directly via `npx -y wrangler@4`. Runs natively on the runner's Node.js 24, no shim, no warning.
- Replaces the action's `apiToken` / `accountId` inputs with the standard `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` env vars that wrangler reads by default.
- Drops the now-redundant `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env on these three workflows. The same var is kept on `ci.yml`, `test-web.yml`, `lighthouse.yml` where other JS actions may still need it.

Affects:
- `.github/workflows/deploy-worker.yml` (adds explicit `setup-node@v6` step since this file didn't have one)
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/deploy-web.yml`

Closes #2739

## Test plan

- [ ] After merge, `workflow_dispatch` on **Deploy Workers** → both jobs green, no deprecation warning
- [ ] Verify a docs push triggers **Deploy Docs** and succeeds
- [ ] Verify a web push triggers **Deploy Website** and succeeds