### PR TITLE
fix(api,kernel): suppress NO_REPLY sentinel in streaming bridge, cron, and auto-reply

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -38,22 +38,6 @@ fn sanitize_channel_error(err: &str) -> String {
     }
 }
 
-/// Check if a response is a NO_REPLY sentinel. Matches:
-/// - Exact `"NO_REPLY"` (original behaviour)
-/// - Text ending with `NO_REPLY` (model sometimes adds context before it)
-/// - Exact `"[no reply needed]"` — the runtime writes this placeholder back
-/// - Text ending with `"[no reply needed]"`
-/// - Unbracketed `"no reply needed"` variant the model occasionally emits
-fn is_no_reply(text: &str) -> bool {
-    let t = text.trim();
-    t == "NO_REPLY"
-        || t.ends_with("NO_REPLY")
-        || t == "[no reply needed]"
-        || t.ends_with("[no reply needed]")
-        || t == "no reply needed"
-        || t.ends_with("no reply needed")
-}
-
 /// Check if text looks like a raw tool call leaked as content.
 ///
 /// Some providers emit tool calls as plain text (recovered by

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -38,6 +38,22 @@ fn sanitize_channel_error(err: &str) -> String {
     }
 }
 
+/// Check if a response is a NO_REPLY sentinel. Matches:
+/// - Exact `"NO_REPLY"` (original behaviour)
+/// - Text ending with `NO_REPLY` (model sometimes adds context before it)
+/// - Exact `"[no reply needed]"` — the runtime writes this placeholder back
+/// - Text ending with `"[no reply needed]"`
+/// - Unbracketed `"no reply needed"` variant the model occasionally emits
+fn is_no_reply(text: &str) -> bool {
+    let t = text.trim();
+    t == "NO_REPLY"
+        || t.ends_with("NO_REPLY")
+        || t == "[no reply needed]"
+        || t.ends_with("[no reply needed]")
+        || t == "no reply needed"
+        || t.ends_with("no reply needed")
+}
+
 /// Check if text looks like a raw tool call leaked as content.
 ///
 /// Some providers emit tool calls as plain text (recovered by
@@ -423,6 +439,7 @@ fn start_stream_text_bridge_with_status(
                     // 2. The text looks like a raw tool call emitted as text by
                     //    providers that don't use the tool_use API properly
                     //    (e.g. agent_send JSON leaked as visible text).
+                    // 3. The text is NO_REPLY or [no reply needed] (agent chose silence)
                     if !iter_buf.is_empty() {
                         if saw_tool_use {
                             debug!("Streaming bridge: filtered tool-use-adjacent text");
@@ -1877,7 +1894,14 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .should_reply(message, channel_type, agent_id)?;
         // Fire auto-reply synchronously (bridge already runs in background task)
         match self.kernel.send_message(agent_id, message).await {
-            Ok(result) => Some(result.response),
+            Ok(result) => {
+                // If the agent chose NO_REPLY (silent), don't send the literal text
+                if result.silent {
+                    None
+                } else {
+                    Some(result.response)
+                }
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "Auto-reply failed");
                 None

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9829,14 +9829,16 @@ system_prompt = "You are a helpful assistant."
                                     Ok(Ok(result)) => {
                                         tracing::info!(job = %job_name, "Cron job completed successfully");
                                         kernel.cron_scheduler.record_success(job_id);
-                                        // Deliver response to configured channel
-                                        cron_deliver_response(
-                                            &kernel,
-                                            agent_id,
-                                            &result.response,
-                                            &delivery,
-                                        )
-                                        .await;
+                                        // Deliver response to configured channel (skip NO_REPLY/silent)
+                                        if !result.silent {
+                                            cron_deliver_response(
+                                                &kernel,
+                                                agent_id,
+                                                &result.response,
+                                                &delivery,
+                                            )
+                                            .await;
+                                        }
                                     }
                                     Ok(Err(e)) => {
                                         let err_msg = format!("{e}");
@@ -12501,6 +12503,18 @@ async fn cron_deliver_response(
     use librefang_types::scheduler::CronDelivery;
 
     if response.is_empty() {
+        return;
+    }
+
+    // Skip NO_REPLY and [no reply needed] sentinels
+    let trimmed = response.trim();
+    if trimmed == "NO_REPLY"
+        || trimmed.ends_with("NO_REPLY")
+        || trimmed == "[no reply needed]"
+        || trimmed.ends_with("[no reply needed]")
+        || trimmed == "no reply needed"
+        || trimmed.ends_with("no reply needed")
+    {
         return;
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12506,18 +12506,6 @@ async fn cron_deliver_response(
         return;
     }
 
-    // Skip NO_REPLY and [no reply needed] sentinels
-    let trimmed = response.trim();
-    if trimmed == "NO_REPLY"
-        || trimmed.ends_with("NO_REPLY")
-        || trimmed == "[no reply needed]"
-        || trimmed.ends_with("[no reply needed]")
-        || trimmed == "no reply needed"
-        || trimmed.ends_with("no reply needed")
-    {
-        return;
-    }
-
     match delivery {
         CronDelivery::None => {}
         CronDelivery::Channel { channel, to } => {

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -5417,15 +5417,16 @@ mod tests {
         assert!(is_no_reply("[no reply needed]"));
         assert!(is_no_reply("Some context. [no reply needed]"));
 
-        // Unbracketed variant the model sometimes emits
+        // Unbracketed variant — exact match only (ends_with dropped to avoid prose false-positives)
         assert!(is_no_reply("no reply needed"));
-        assert!(is_no_reply("context here\nno reply needed"));
 
         // Negatives — real responses must never be silenced
         assert!(!is_no_reply(""));
         assert!(!is_no_reply("Just replying normally."));
         assert!(!is_no_reply("NO_REPLY is my favorite token")); // prefix, not suffix
         assert!(!is_no_reply("no reply needed? let me check")); // doesn't end with marker
+        assert!(!is_no_reply("I filed the bug; no reply needed")); // prose ending — not a sentinel
+        assert!(!is_no_reply("context here\nno reply needed")); // multi-line prose ending
     }
 
     #[test]

--- a/crates/librefang-types/src/lib.rs
+++ b/crates/librefang-types/src/lib.rs
@@ -31,6 +31,27 @@ pub mod tool_policy;
 pub mod webhook;
 pub mod workflow_template;
 
+/// Check if a response is a NO\_REPLY sentinel. Matches:
+/// - Exact `"NO_REPLY"` (original behaviour)
+/// - Text ending with `NO_REPLY` (model sometimes adds context before it,
+///   either on the same line or on a new line)
+/// - Exact `"[no reply needed]"` — the runtime writes this placeholder back
+///   into the session when the agent chooses silence, so the LLM sometimes
+///   mimics it on later turns.
+/// - Text ending with `"[no reply needed]"` (same reasoning as above)
+/// - Exact `"no reply needed"` — unbracketed variant the model occasionally
+///   emits. Only the exact-match form; `ends_with` is intentionally omitted
+///   because it false-positives on English prose ("I filed the bug; no reply
+///   needed.").
+pub fn is_no_reply_sentinel(text: &str) -> bool {
+    let t = text.trim();
+    t == "NO_REPLY"
+        || t.ends_with("NO_REPLY")
+        || t == "[no reply needed]"
+        || t.ends_with("[no reply needed]")
+        || t == "no reply needed"
+}
+
 /// Safely truncate a string to at most `max_bytes`, never splitting a UTF-8 char.
 pub fn truncate_str(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {


### PR DESCRIPTION
## Summary
- Filter NO_REPLY sentinel from streaming SSE and Telegram bridge output
- Skip NO_REPLY in cron execution paths to prevent phantom messages
- Suppress NO_REPLY in auto-reply and lifecycle flows

Closes #2232

Clean resubmit of #2646 (rebased on current main, no unrelated changes).

## Test plan
- [ ] Send message to agent with NO_REPLY tool → verify no "NO_REPLY" text in UI/Telegram
- [ ] Run cron-triggered agent → verify no phantom NO_REPLY messages
- [ ] `cargo test --workspace` passes