### PR TITLE
fix(dashboard): don't reset spawn mutation while a create is in flight

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -342,7 +342,15 @@ export function AgentsPage() {
     setTomlParseError(null);
     setTemplateName("");
     setTemplateCustomName("");
-    spawnMutation.reset();
+    // Don't reset while a spawn is in flight — reset() flips isPending
+    // back to false, and since the fetch isn't actually aborted the user
+    // could reopen the modal and submit again before the first response
+    // lands, producing a duplicate-spawn "already exists" error (the
+    // exact bug #2741 was meant to fix). Once the original request
+    // settles, isPending goes false on its own.
+    if (!spawnMutation.isPending) {
+      spawnMutation.reset();
+    }
   };
 
   // Bidirectional Form ⇄ TOML sync. Going Form→TOML pushes the form's


### PR DESCRIPTION
## Summary
Follow-up to #2742. Codex review flagged a P2: `closeCreateModal()` was unconditionally calling `spawnMutation.reset()`, which flips `isPending` back to `false` even when the POST is still in flight. Since `spawnAgent` doesn't abort the fetch, a user who Cancels mid-flight and reopens the modal can re-enable the Create button and submit a second request before the first response lands — producing a duplicate-spawn "already exists" error, i.e. the exact bug #2741 was meant to eliminate.

Fix: gate the reset on `!spawnMutation.isPending`. The in-flight request keeps `isPending` true across reopens, so the Create button stays disabled until the original settles; the subsequent `onSuccess`/`onError` closes + toasts as usual. The stale-error-banner use case `reset()` was protecting is unaffected — by the time there's a banner to clear, the mutation has already settled.

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 244/244 pass
- [ ] Manually: Create → Cancel mid-flight → Reopen → Create button stays disabled until original settles; no duplicate request