### PR TITLE
fix(dashboard): release chat loading flag on WS error so user can retry

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -557,9 +557,18 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
               updateAgentMessages(sendAgentId, prev => prev.map(m =>
                 m.id === botMsg.id ? { ...m, isStreaming: false, error } : m
               ));
-              // Don't cleanup immediately — the agent may recover and send a final
-              // response. Shorten the inactivity window to 30s so the user isn't
-              // blocked forever if the agent truly failed.
+              // Release the loading flag so the send button re-enables and the
+              // "streaming" badge drops — the user just saw an error and
+              // should be able to retry immediately (#2745). Keep the WS
+              // listener + recovery fallback timer alive in case the agent
+              // does send a late `response` event; those handlers operate on
+              // the same botMsg.id and will overwrite the error state if
+              // recovery actually happens.
+              finishTurnIfCurrent(sendAgentId, botMsg.id);
+              // Don't cleanup the listener immediately — the agent may recover
+              // and send a final response. Shorten the inactivity window to
+              // 30s so the WS doesn't stay half-open forever if the failure
+              // is terminal.
               if (fallbackTimer) clearTimeout(fallbackTimer);
               fallbackTimer = setTimeout(() => {
                 if (!responded) { cleanup(); sendViaHttp(); }


### PR DESCRIPTION
## Summary
Fixes #2745 — after a chat turn fails with a terminal error (model not found, quota exceeded, etc.), the send button stayed disabled and the "streaming" badge stayed visible for up to 30 seconds, even though the error was already rendered in the thread.

## Root cause
`ChatPage.tsx` gates two separate inputs on two separate flags:

- `ChatInput inputDisabled={isStreaming}` — the textarea; `isStreaming` is derived from any assistant message having `isStreaming: true`
- `ChatInput disabled={isLoading}` — the send button; `isLoading` is per-agent and cleared only via `finishTurnIfCurrent`
- The header "generating" badge at line 1211 also reads `isLoading`

The WS `error` handler (line 555) cleared the per-message `isStreaming` flag but never called `finishTurnIfCurrent`, so `isLoading` stayed true. The 30-second fallback timer at line 564 would eventually time out and call `sendViaHttp` whose `finally` releases the flag — that's why the UI unblocked "once streaming disappears" per the issue reporter.

## Fix
Call `finishTurnIfCurrent(sendAgentId, botMsg.id)` inside the `error` branch. The WS listener and fallback timer are intentionally kept alive so a late `response` / `typing:stop` / `tool_*` event can still overwrite the errored state on the same `botMsg.id` — the original recovery path is preserved. Only the user-facing lock is released.

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 244/244 pass
- [ ] Manually: send message to an agent configured with a non-existent model → error appears in the thread → send button re-enables immediately, "generating" badge disappears, user can retry
- [ ] Manually: with a working agent, verify a normal `response` turn still flows as before (no regression in happy path)