### PR TITLE
fix(dashboard): show Provider before Model in Config default_model section

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -33,6 +33,18 @@ const CATEGORY_SECTIONS: Record<string, string[]> = {
   infra: ["docker", "extensions", "session", "queue", "webhook_triggers", "vertex_ai"],
 };
 
+// Explicit field ordering for sections where the server-side JSON schema
+// ordering is wrong for the user. The API serialises `sec.fields` via
+// serde_json's default BTreeMap, which alphabetises keys — so for sections
+// like `default_model` the user sees `model` before `provider`, even though
+// model is a cascaded filter of the selected provider (ConfigPage:679). The
+// rendering code falls back to the alphabetised order for any section not
+// listed here, so forgetting an entry is a no-op rather than a regression.
+// Closes #2746.
+const SECTION_FIELD_ORDER: Record<string, string[]> = {
+  default_model: ["provider", "model", "api_key_env", "base_url"],
+};
+
 function sectionLabelFallback(key: string): string {
   return key.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
 }
@@ -613,7 +625,20 @@ export function ConfigPage({ category }: { category: string }) {
         )}
         {filteredSections.map(({ sKey, fields: visibleFields }) => {
           const sec = allSections[sKey];
-          const allFields = Object.entries(sec.fields);
+          const rawFields = Object.entries(sec.fields);
+          type FieldEntry = (typeof rawFields)[number];
+          // Apply the per-section override (see SECTION_FIELD_ORDER docstring).
+          // Listed keys come first in the declared order; any un-listed keys
+          // keep their original (alphabetical) position at the tail.
+          const order = SECTION_FIELD_ORDER[sKey];
+          const allFields: FieldEntry[] = order
+            ? [
+                ...order
+                  .map((k) => rawFields.find(([fk]) => fk === k))
+                  .filter((e): e is FieldEntry => e !== undefined),
+                ...rawFields.filter(([fk]) => !order.includes(fk)),
+              ]
+            : rawFields;
           const fieldsToShow = q
             ? allFields.filter(([fKey]) => visibleFields.includes(fKey))
             : allFields;


### PR DESCRIPTION
## Summary
Fixes #2746 — in the Config page's General tab, the `default_model` section renders `Model` before `Provider`, even though the Model dropdown is a cascaded filter of the selected Provider (`ConfigPage.tsx:679`). Users have to pick a model from a mixed-provider list first, then set the provider — the opposite of what the cascade was designed for.

## Root cause
The server builds the schema via `sec!("default_model", { "fields": { "provider": ..., "model": ..., "api_key_env": ..., "base_url": ... } })` in `crates/librefang-api/src/routes/config.rs:1627`. Declared order is correct. But `serde_json = "1"` in the root workspace manifest doesn't enable the `preserve_order` feature, so the resulting `Map<String, Value>` is a `BTreeMap` and the keys alphabetise to `api_key_env, base_url, model, provider` on the wire. The dashboard iterates that order via `Object.entries(sec.fields)` and the user sees Model first.

## Fix
Frontend-side `SECTION_FIELD_ORDER` override map in `ConfigPage.tsx`. Listed keys come first in declared order; un-listed keys keep their original (alphabetised) tail position; any section not in the map is a no-op. Registered for `default_model` only — matches the scope the user reported.

## Why not just flip `preserve_order` workspace-wide?
That's the systemic cure, and it would also fix the analogous issue in the `memory` section (`embedding_provider` alphabetises after `embedding_model`) and probably a few other latent cases. But it's a workspace-level Cargo.toml change affecting every serde_json codepath across 20+ crates and all their tests — worth its own issue and its own review. Keeping this PR narrow to the reported symptom.

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 244/244 pass
- [ ] Manually: open Config → General → `default_model`, verify Provider dropdown appears above Model dropdown; change Provider and verify Model list re-filters; confirm save still writes to the right backend paths