### PR TITLE
feat(auto_dream): trigger on AgentLoopEnd hook, scheduler becomes backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Added
 
-- Auto-dream: per-agent background memory consolidation with four-layer gating (global / per-agent opt-in / time / session count / file lock). Includes web dashboard toggle card, TUI Dashboard strip, `[auto_dream]` config section, `DreamConsolidation` audit events with token and cost capture, runtime tool allowlist enforcement, and `GET/POST/PUT /api/auto-dream/status|trigger|abort|enabled` endpoints. (#2750) (@houko)
+- Auto-dream: per-agent background memory consolidation with four-layer gating (global / per-agent opt-in / time / session count / file lock). Triggered event-driven from the `AgentLoopEnd` hook (fires the moment an agent finishes a turn) with a sparse daily backstop scheduler for opted-in agents that never turn. Includes web dashboard toggle card, TUI Dashboard strip, `[auto_dream]` config section, `DreamConsolidation` audit events with token and cost capture, runtime tool allowlist enforcement, and `GET/POST/PUT /api/auto-dream/status|trigger|abort|enabled` endpoints. (#2750) (@houko)
 
 ### Maintenance
 

--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -83,6 +83,15 @@ const MEMORY_WRITE_TOOLS: &[&str] = &["memory_store"];
 /// Matches libre-code's `createAutoMemCanUseTool(memoryRoot)` restriction.
 pub const DREAM_ALLOWED_TOOLS: &[&str] = &["memory_store", "memory_recall", "memory_list"];
 
+/// Minimum spacing between event-driven gate scans for the same agent.
+/// Mirrors libre-code's `SESSION_SCAN_INTERVAL_MS`. Without this, an
+/// agent taking 100 turns/hour past the time gate would run 100 lock-stat
+/// + session-count SQL probes before one of them actually fires a dream —
+/// the scan is cheap per call but pointless at that cadence. This does
+/// NOT apply to the scheduler (already sparse at `check_interval_secs`)
+/// or to manual triggers (operators explicitly asked for a check).
+const EVENT_SCAN_INTERVAL_MS: u64 = 10 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Progress types
 // ---------------------------------------------------------------------------
@@ -169,6 +178,37 @@ type AbortSlot = Mutex<Option<oneshot::Sender<()>>>;
 /// a reliable "a manual dream is still running" signal for `can_abort` in
 /// the status endpoint.
 static ABORT_HANDLES: LazyLock<DashMap<AgentId, Arc<AbortSlot>>> = LazyLock::new(DashMap::new);
+
+/// Per-agent last-scan timestamp (Unix-ms). Entries are written under
+/// DashMap's per-shard lock, so concurrent racers for the same agent
+/// serialise naturally and only one wins the "first scan" slot.
+/// See `should_throttle_event_scan` for the read-and-update logic.
+static LAST_EVENT_SCAN_AT: LazyLock<DashMap<AgentId, u64>> = LazyLock::new(DashMap::new);
+
+/// Returns `true` if the event-driven path should skip this turn because
+/// we already evaluated this agent's gates within `EVENT_SCAN_INTERVAL_MS`.
+/// On a miss (or on first call for this agent), records `now` and returns
+/// `false` so the caller proceeds with the full gate check.
+///
+/// Uses DashMap's per-shard lock via `entry()` so two concurrent turns on
+/// the same agent cannot both see a fresh slot — one wins, the other is
+/// throttled. Scheduler and manual-trigger paths bypass this — they're
+/// sparse enough or explicitly user-intended, respectively.
+fn should_throttle_event_scan(agent_id: AgentId) -> bool {
+    let now = now_ms();
+    let mut throttled = false;
+    LAST_EVENT_SCAN_AT
+        .entry(agent_id)
+        .and_modify(|last| {
+            if now.saturating_sub(*last) < EVENT_SCAN_INTERVAL_MS {
+                throttled = true;
+            } else {
+                *last = now;
+            }
+        })
+        .or_insert(now);
+    throttled
+}
 
 fn insert_progress(agent_id: AgentId, progress: DreamProgress) {
     DREAM_PROGRESS.insert(agent_id, progress);
@@ -775,6 +815,17 @@ pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
             tracing::debug!(agent = %agent_id, "auto_dream: agent toggled off between hook and spawn, skipping");
             return;
         }
+        // Scan throttle: a chatty agent can push dozens of turns per minute
+        // past the three pre-filters. Each of those would otherwise run a
+        // full `check_agent_gates` (lock stat + sessions-touched SQL).
+        // Cheap individually but pointless at that rate — by design, at
+        // most one dream fires per `min_hours`, so scanning more often
+        // than every ~10 minutes is pure noise. Matches libre-code's
+        // `SESSION_SCAN_INTERVAL_MS = 10 min`.
+        if should_throttle_event_scan(agent_id) {
+            tracing::trace!(agent = %agent_id, "auto_dream: turn-end scan throttled (within 10 min of last scan)");
+            return;
+        }
         match check_agent_gates(&kernel, agent_id, false).await {
             AgentGateResult::Fire { prior_mtime } => {
                 tracing::debug!(agent = %agent_id, "auto_dream: turn-end triggered dream");
@@ -1241,6 +1292,39 @@ mod hook_tests {
             data: serde_json::json!({}),
         };
         assert!(hook.on_event(&ctx).is_ok());
+    }
+
+    /// First call for an agent must not throttle (nothing to compare
+    /// against); second call within the window must throttle; third call
+    /// after manually aging the stamp past the window must pass again.
+    #[test]
+    fn scan_throttle_rate_limits_same_agent() {
+        let agent = AgentId::new();
+        // First scan always proceeds.
+        assert!(!should_throttle_event_scan(agent));
+        // Immediate second scan should be throttled.
+        assert!(should_throttle_event_scan(agent));
+        // Age the stored timestamp past the interval to simulate elapsed
+        // time without sleeping.
+        LAST_EVENT_SCAN_AT.insert(agent, now_ms().saturating_sub(EVENT_SCAN_INTERVAL_MS + 1));
+        assert!(!should_throttle_event_scan(agent));
+        // And now throttled again until it ages out.
+        assert!(should_throttle_event_scan(agent));
+        LAST_EVENT_SCAN_AT.remove(&agent);
+    }
+
+    /// Throttle is per-agent — two agents racing with back-to-back turns
+    /// must each get their own first pass without starving each other.
+    #[test]
+    fn scan_throttle_is_per_agent() {
+        let agent_a = AgentId::new();
+        let agent_b = AgentId::new();
+        assert!(!should_throttle_event_scan(agent_a));
+        assert!(!should_throttle_event_scan(agent_b));
+        assert!(should_throttle_event_scan(agent_a));
+        assert!(should_throttle_event_scan(agent_b));
+        LAST_EVENT_SCAN_AT.remove(&agent_a);
+        LAST_EVENT_SCAN_AT.remove(&agent_b);
     }
 
     /// Other hook events (BeforeToolCall, etc.) must be silent no-ops —

--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -725,6 +725,98 @@ pub fn set_agent_enabled(
     Ok(())
 }
 
+/// Event-driven trigger: called from the `AgentLoopEnd` hook whenever any
+/// agent finishes a turn. Cheap early-exits for the globally-disabled and
+/// not-opted-in cases so the hot path (every turn for every agent) stays
+/// near-free. The actual gate check + dream invocation run on a detached
+/// tokio task so we never block the agent loop's return path on a lock
+/// stat or SQL query.
+///
+/// This is the primary trigger path. `spawn_scheduler` below is a sparse
+/// backstop for agents that may sit opted-in without ever turning.
+pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
+    {
+        let cfg = kernel.config_snapshot();
+        if !cfg.auto_dream.enabled {
+            return;
+        }
+    }
+    let enrolled = kernel
+        .agent_registry()
+        .get(agent_id)
+        .map(|e| e.manifest.auto_dream_enabled)
+        .unwrap_or(false);
+    if !enrolled {
+        return;
+    }
+
+    tokio::spawn(async move {
+        match check_agent_gates(&kernel, agent_id, false).await {
+            AgentGateResult::Fire { prior_mtime } => {
+                tracing::debug!(agent = %agent_id, "auto_dream: turn-end triggered dream");
+                // Same invocation mode as the scheduler: `None` for the
+                // abort channel so this dream runs to completion or its
+                // own timeout. Manual triggers remain the only
+                // abort-capable entry point.
+                run_dream(kernel, agent_id, prior_mtime, None).await;
+            }
+            AgentGateResult::TooSoon { hours_remaining } => {
+                tracing::trace!(agent = %agent_id, hours_remaining, "auto_dream: turn-end, time gate not open");
+            }
+            AgentGateResult::NoActivity {
+                sessions_since,
+                required,
+            } => {
+                tracing::trace!(agent = %agent_id, sessions_since, required, "auto_dream: turn-end, session gate not met");
+            }
+            AgentGateResult::LockHeld => {
+                tracing::debug!(agent = %agent_id, "auto_dream: turn-end, lock held (dream in progress)");
+            }
+            AgentGateResult::Skipped(reason) => {
+                tracing::warn!(agent = %agent_id, reason, "auto_dream: turn-end skipped");
+            }
+        }
+    });
+}
+
+/// `HookHandler` wiring the runtime's `AgentLoopEnd` event to auto-dream's
+/// event-driven trigger. Registered once during `LibreFangKernel::set_self_handle`
+/// so it can hold a `Weak<LibreFangKernel>` and upgrade on fire.
+pub struct AutoDreamTurnEndHook {
+    kernel: std::sync::Weak<LibreFangKernel>,
+}
+
+impl AutoDreamTurnEndHook {
+    pub fn new(kernel: std::sync::Weak<LibreFangKernel>) -> Self {
+        Self { kernel }
+    }
+}
+
+impl librefang_runtime::hooks::HookHandler for AutoDreamTurnEndHook {
+    fn on_event(&self, ctx: &librefang_runtime::hooks::HookContext) -> Result<(), String> {
+        use librefang_types::agent::HookEvent;
+        // Not our event — observe-only, silent no-op. AgentLoopEnd is the
+        // only one we care about; the registry filters by event type
+        // already, so this branch is defensive.
+        if ctx.event != HookEvent::AgentLoopEnd {
+            return Ok(());
+        }
+        // Kernel has been dropped (process shutting down) — nothing to do.
+        let Some(kernel) = self.kernel.upgrade() else {
+            return Ok(());
+        };
+        let Ok(uuid) = uuid::Uuid::parse_str(ctx.agent_id) else {
+            tracing::debug!(
+                agent_id = %ctx.agent_id,
+                "auto_dream: AgentLoopEnd hook saw non-UUID agent_id, skipping",
+            );
+            return Ok(());
+        };
+        maybe_fire_on_turn_end(kernel, AgentId(uuid));
+        Ok(())
+    }
+}
+
 pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
     tokio::spawn(async move {
         {
@@ -734,7 +826,7 @@ pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
                     min_hours = cfg.auto_dream.min_hours,
                     min_sessions = cfg.auto_dream.min_sessions,
                     check_interval_s = cfg.auto_dream.check_interval_secs,
-                    "auto_dream: enabled (per-agent opt-in via manifest)"
+                    "auto_dream: enabled (event-driven via AgentLoopEnd hook; scheduler is sparse backstop)"
                 );
             } else {
                 tracing::debug!("auto_dream: disabled");
@@ -764,11 +856,14 @@ pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
             for (agent_id, name) in enrolled_agents(&kernel) {
                 match check_agent_gates(&kernel, agent_id, false).await {
                     AgentGateResult::Fire { prior_mtime } => {
-                        // Scheduled dreams run inline — serial token spend.
-                        // `None` for abort_rx: scheduled dreams can't be
-                        // cancelled individually without stalling the
-                        // queue; users who want to interrupt wait for the
-                        // dream's own timeout or disable auto-dream.
+                        // Scheduled (backstop) dreams run inline — serial
+                        // token spend. This path mostly fires for opted-in
+                        // agents that never take a turn (channel bots
+                        // awaiting inbound traffic); active agents are
+                        // already covered by `maybe_fire_on_turn_end`
+                        // invoked from the AgentLoopEnd hook. `None` for
+                        // abort_rx: backstop dreams aren't individually
+                        // cancellable without stalling the queue.
                         run_dream(Arc::clone(&kernel), agent_id, prior_mtime, None).await;
                     }
                     AgentGateResult::TooSoon { hours_remaining } => {
@@ -1085,4 +1180,65 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod hook_tests {
+    use super::*;
+    use librefang_runtime::hooks::{HookContext, HookHandler};
+    use librefang_types::agent::HookEvent;
+
+    /// Hook must handle a dangling `Weak<LibreFangKernel>` (the kernel was
+    /// dropped, e.g. shutdown between turn end and hook dispatch) without
+    /// panicking. A panicking hook would crash the agent loop thread.
+    #[test]
+    fn hook_with_dropped_kernel_is_silent_noop() {
+        let hook = AutoDreamTurnEndHook::new(std::sync::Weak::new());
+        let ctx = HookContext {
+            agent_name: "probe",
+            agent_id: &uuid::Uuid::new_v4().to_string(),
+            event: HookEvent::AgentLoopEnd,
+            data: serde_json::json!({"reason": "normal_completion"}),
+        };
+        assert!(hook.on_event(&ctx).is_ok());
+    }
+
+    /// Hook must tolerate a non-UUID `agent_id` in the context rather than
+    /// erroring or panicking. Some internal agents (synthetic probe ids,
+    /// historical data) could surface a non-uuid; silent skip is safer than
+    /// crashing the hook registry.
+    #[test]
+    fn hook_with_non_uuid_agent_id_is_silent_noop() {
+        let hook = AutoDreamTurnEndHook::new(std::sync::Weak::new());
+        let ctx = HookContext {
+            agent_name: "probe",
+            agent_id: "not-a-uuid",
+            event: HookEvent::AgentLoopEnd,
+            data: serde_json::json!({}),
+        };
+        assert!(hook.on_event(&ctx).is_ok());
+    }
+
+    /// Other hook events (BeforeToolCall, etc.) must be silent no-ops —
+    /// auto-dream only reacts to AgentLoopEnd.
+    #[test]
+    fn hook_ignores_unrelated_events() {
+        let hook = AutoDreamTurnEndHook::new(std::sync::Weak::new());
+        for event in [
+            HookEvent::BeforeToolCall,
+            HookEvent::AfterToolCall,
+            HookEvent::BeforePromptBuild,
+        ] {
+            let ctx = HookContext {
+                agent_name: "probe",
+                agent_id: &uuid::Uuid::new_v4().to_string(),
+                event,
+                data: serde_json::json!({}),
+            };
+            assert!(
+                hook.on_event(&ctx).is_ok(),
+                "event {event:?} should be ignored"
+            );
+        }
+    }
 }

--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -726,31 +726,55 @@ pub fn set_agent_enabled(
 }
 
 /// Event-driven trigger: called from the `AgentLoopEnd` hook whenever any
-/// agent finishes a turn. Cheap early-exits for the globally-disabled and
-/// not-opted-in cases so the hot path (every turn for every agent) stays
-/// near-free. The actual gate check + dream invocation run on a detached
-/// tokio task so we never block the agent loop's return path on a lock
-/// stat or SQL query.
+/// agent finishes a turn. Cheap early-exits for the globally-disabled,
+/// not-opted-in, and shutting-down cases so the hot path (every turn for
+/// every agent) stays near-free. The actual gate check + dream invocation
+/// run on a detached tokio task so we never block the agent loop's return
+/// path on a lock stat or SQL query.
 ///
 /// This is the primary trigger path. `spawn_scheduler` below is a sparse
 /// backstop for agents that may sit opted-in without ever turning.
 pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
+    // Gate 1 (cheapest): kernel shutdown. The daemon is unwinding; no point
+    // spawning a new dream that the runtime will immediately have to cancel.
+    // Matches the same check at the head of the scheduler loop body.
+    if kernel.supervisor.is_shutting_down() {
+        return;
+    }
+    // Gate 2: global auto-dream toggle. `config_snapshot` is an ArcSwap
+    // load_full — lock-free, nanoseconds uncontested.
     {
         let cfg = kernel.config_snapshot();
         if !cfg.auto_dream.enabled {
             return;
         }
     }
-    let enrolled = kernel
-        .agent_registry()
-        .get(agent_id)
-        .map(|e| e.manifest.auto_dream_enabled)
-        .unwrap_or(false);
-    if !enrolled {
+    // Gate 3: per-agent opt-in. Use the lightweight bool-only accessor to
+    // avoid cloning the full AgentEntry (manifest Strings/Vecs) on the hot
+    // path. A missing agent returns false so freshly-deleted agents don't
+    // attempt a dream.
+    if !kernel.agent_registry().is_auto_dream_enabled(agent_id) {
         return;
     }
 
     tokio::spawn(async move {
+        // Re-check all three gates inside the task. The operator could have
+        // flipped the global switch, toggled this agent off, or started a
+        // shutdown in the microseconds between the synchronous pre-filter
+        // above and this task actually being scheduled. Re-checking all
+        // three (rather than just two) keeps the guarantees symmetrical —
+        // no gate is "best effort" relative to the others.
+        if kernel.supervisor.is_shutting_down() {
+            return;
+        }
+        if !kernel.config_snapshot().auto_dream.enabled {
+            tracing::debug!(agent = %agent_id, "auto_dream: global toggled off between hook and spawn, skipping");
+            return;
+        }
+        if !kernel.agent_registry().is_auto_dream_enabled(agent_id) {
+            tracing::debug!(agent = %agent_id, "auto_dream: agent toggled off between hook and spawn, skipping");
+            return;
+        }
         match check_agent_gates(&kernel, agent_id, false).await {
             AgentGateResult::Fire { prior_mtime } => {
                 tracing::debug!(agent = %agent_id, "auto_dream: turn-end triggered dream");

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -7469,17 +7469,23 @@ system_prompt = "You are a helpful assistant."
     ///
     /// Must be called once after the kernel is wrapped in `Arc`.
     pub fn set_self_handle(self: &Arc<Self>) {
-        let _ = self.self_handle.set(Arc::downgrade(self));
-        // Register auto-dream's AgentLoopEnd hook now that the Arc exists so
-        // the hook can hold a Weak<Self> and fire when a turn actually ends.
-        // Event-driven is the primary trigger; the scheduler loop is a
-        // sparse (1-day) backstop for agents that never finish a turn.
-        self.hooks.register(
-            librefang_types::agent::HookEvent::AgentLoopEnd,
-            std::sync::Arc::new(crate::auto_dream::AutoDreamTurnEndHook::new(
-                Arc::downgrade(self),
-            )),
-        );
+        // The `self_handle` slot is a `OnceLock` — calling `set()` twice is
+        // a silent no-op. Gate hook registration on the same first-call
+        // signal so a defensive double-invocation doesn't register the
+        // auto-dream hook twice (which would make every `AgentLoopEnd`
+        // fire two spawned gate-check tasks that race on the file lock).
+        if self.self_handle.set(Arc::downgrade(self)).is_ok() {
+            // First call — wire up the AgentLoopEnd hook now that the Arc
+            // exists so the handler can hold a Weak<Self>. Event-driven is
+            // the primary trigger; the scheduler loop is a sparse (1-day)
+            // backstop for agents that never finish a turn.
+            self.hooks.register(
+                librefang_types::agent::HookEvent::AgentLoopEnd,
+                std::sync::Arc::new(crate::auto_dream::AutoDreamTurnEndHook::new(
+                    Arc::downgrade(self),
+                )),
+            );
+        }
     }
 
     // ─── Agent Binding management ──────────────────────────────────────

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -7470,6 +7470,16 @@ system_prompt = "You are a helpful assistant."
     /// Must be called once after the kernel is wrapped in `Arc`.
     pub fn set_self_handle(self: &Arc<Self>) {
         let _ = self.self_handle.set(Arc::downgrade(self));
+        // Register auto-dream's AgentLoopEnd hook now that the Arc exists so
+        // the hook can hold a Weak<Self> and fire when a turn actually ends.
+        // Event-driven is the primary trigger; the scheduler loop is a
+        // sparse (1-day) backstop for agents that never finish a turn.
+        self.hooks.register(
+            librefang_types::agent::HookEvent::AgentLoopEnd,
+            std::sync::Arc::new(crate::auto_dream::AutoDreamTurnEndHook::new(
+                Arc::downgrade(self),
+            )),
+        );
     }
 
     // ─── Agent Binding management ──────────────────────────────────────

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -404,6 +404,19 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Cheap read-only check for the auto-dream opt-in flag, without cloning
+    /// the agent entry. Used on the hot path of the `AgentLoopEnd` hook,
+    /// which fires for every turn of every agent and would otherwise pay
+    /// the `AgentEntry` + manifest clone cost (several KB of Strings/Vecs
+    /// per turn) just to read one bool. Missing agent → `false`, matching
+    /// the "not enrolled" behaviour expected by callers.
+    pub fn is_auto_dream_enabled(&self, id: AgentId) -> bool {
+        self.agents
+            .get(&id)
+            .map(|e| e.manifest.auto_dream_enabled)
+            .unwrap_or(false)
+    }
+
     /// Update an agent's resource quota (budget limits).
     pub fn update_resources(
         &self,
@@ -611,6 +624,33 @@ mod tests {
 
         registry.update_auto_dream_enabled(id, false).unwrap();
         assert!(!registry.get(id).unwrap().manifest.auto_dream_enabled);
+    }
+
+    #[test]
+    fn test_is_auto_dream_enabled_tracks_flag() {
+        // Lightweight bool-only accessor must agree with the clone-based
+        // `get().manifest.auto_dream_enabled` path in all three states.
+        let registry = AgentRegistry::new();
+        let entry = test_entry("dreamer-fast");
+        let id = entry.id;
+        registry.register(entry).unwrap();
+        assert!(!registry.is_auto_dream_enabled(id));
+
+        registry.update_auto_dream_enabled(id, true).unwrap();
+        assert!(registry.is_auto_dream_enabled(id));
+
+        registry.update_auto_dream_enabled(id, false).unwrap();
+        assert!(!registry.is_auto_dream_enabled(id));
+    }
+
+    #[test]
+    fn test_is_auto_dream_enabled_missing_agent_is_false() {
+        // Missing agent must return false rather than panic — the auto-dream
+        // hook fires for every turn and cannot distinguish a killed agent
+        // from an opted-out one at that layer.
+        let registry = AgentRegistry::new();
+        let bogus = AgentId::new();
+        assert!(!registry.is_auto_dream_enabled(bogus));
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3223,7 +3223,7 @@ impl Default for HeartbeatTomlConfig {
 /// enabled = false
 /// min_hours = 24
 /// min_sessions = 5
-/// check_interval_secs = 600
+/// check_interval_secs = 86400
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -3240,8 +3240,14 @@ pub struct AutoDreamConfig {
     /// disable the session-count gate entirely.
     #[serde(default = "default_auto_dream_min_sessions")]
     pub min_sessions: u32,
-    /// How often the scheduler loop wakes up to check gates, in seconds.
-    /// Default: 600 (10 min). Cheap — one stat per enabled agent per tick.
+    /// How often the *backstop* scheduler loop wakes up to check gates, in
+    /// seconds. Default: 86400 (1 day). The primary trigger is the
+    /// `AgentLoopEnd` hook that fires the moment a turn completes — the
+    /// scheduler only catches opted-in agents that may go a long time
+    /// without any turn (e.g., a channel bot waiting for inbound traffic).
+    /// Lowering this just increases the rate of stat/SQL probes that mostly
+    /// find nothing to do; raising it delays dreams only for the idle
+    /// never-turned case.
     #[serde(default = "default_auto_dream_check_interval_secs")]
     pub check_interval_secs: u64,
     /// Optional override for the lock directory. When empty, defaults to
@@ -3263,7 +3269,12 @@ fn default_auto_dream_min_sessions() -> u32 {
 }
 
 fn default_auto_dream_check_interval_secs() -> u64 {
-    600
+    // 1 day. Dreams are primarily triggered by the AgentLoopEnd hook the
+    // moment a turn ends, not by this scheduler. The scheduler exists to
+    // catch the "agent is opted-in but has no activity" edge case (e.g.
+    // channel bots) where no turn ever fires. 1 day is frequent enough for
+    // that fallback without wasting 144× more stat calls per day.
+    86_400
 }
 
 fn default_auto_dream_timeout_secs() -> u64 {

--- a/docs/src/app/agent/memory/page.mdx
+++ b/docs/src/app/agent/memory/page.mdx
@@ -284,7 +284,7 @@ auto_dream_min_sessions = 1     # after every session, for a chatty one
 
 ### How a dream runs
 
-1. The scheduler wakes every `check_interval_secs` (default 10 min) and evaluates each opted-in agent against four cheap gates, in order: global enabled → time since last dream → session activity count → per-agent file lock. Any miss and the agent is skipped this tick.
+1. The primary trigger is the `AgentLoopEnd` hook — the moment an agent finishes a turn, the kernel evaluates its four gates in order: global enabled → time since last dream → session activity count → per-agent file lock. Any miss and the dream is skipped. A sparse backstop scheduler (default `check_interval_secs = 86400` / 1 day) covers opted-in agents that never turn (e.g. channel bots waiting on inbound traffic).
 2. On a pass, the agent is invoked through the synthetic `auto_dream` channel with a tool allowlist restricted to `memory_store` / `memory_recall` / `memory_list` — even a prompt-injected dream cannot escape into shell or network tools.
 3. Streamed progress (phase, tool calls, memories touched, last turn preview, token/cost) is kept in a per-agent registry and surfaced via the status endpoint.
 4. On success the lock's mtime advances to "now" (driving the time gate); on failure or abort the mtime is rolled back so the next tick will retry.

--- a/docs/src/app/configuration/core/page.mdx
+++ b/docs/src/app/configuration/core/page.mdx
@@ -95,14 +95,14 @@ decay_rate = 0.1
 
 ### `[auto_dream]`
 
-Background memory consolidation ("dreams") — a time-gated scheduler that periodically asks opt-in agents to reflect on and consolidate their own memory via a 4-phase prompt (Orient / Gather / Consolidate / Prune). Disabled by default; individual agents still opt in via `auto_dream_enabled = true` on their manifest.
+Background memory consolidation ("dreams") — asks opt-in agents to reflect on and consolidate their own memory via a 4-phase prompt (Orient / Gather / Consolidate / Prune). Dreams are triggered **event-driven** (the moment an agent finishes a turn the kernel checks whether its gates are open); a sparse backstop scheduler catches opted-in agents that go long periods without taking a turn. Disabled by default; individual agents still opt in via `auto_dream_enabled = true` on their manifest.
 
 ```toml
 [auto_dream]
 enabled = false
 min_hours = 24
 min_sessions = 5
-check_interval_secs = 600
+check_interval_secs = 86400
 timeout_secs = 600
 # lock_dir = ""   # defaults to <data_dir>/auto_dream/
 ```
@@ -112,7 +112,7 @@ timeout_secs = 600
 | `enabled` | bool | `false` | Master toggle. When `false`, no dream fires regardless of per-agent opt-in. |
 | `min_hours` | f64 | `24.0` | Minimum hours since that agent's last consolidation before the next one fires. |
 | `min_sessions` | u32 | `5` | Minimum sessions touched since that agent's last consolidation before the next one fires. Set to `0` to disable the session-count gate. |
-| `check_interval_secs` | u64 | `600` | How often the scheduler wakes up to check gates, in seconds. |
+| `check_interval_secs` | u64 | `86400` | How often the *backstop* scheduler wakes up, in seconds. The primary trigger is the `AgentLoopEnd` hook that fires on every turn end; this value only controls the fallback cadence for agents that never turn. |
 | `timeout_secs` | u64 | `600` | Timeout for a single dream invocation in seconds. |
 | `lock_dir` | string | `""` | Optional override for the lock directory. Empty = `<data_dir>/auto_dream/`. Per-agent locks are stored as `<dir>/<agent_id>.lock`. |
 
@@ -121,7 +121,7 @@ A dream fires for an agent when all gates hold: `enabled = true`, the agent's ma
 **Per-agent opt-in** can be toggled at runtime without restarting the agent:
 
 - **Web dashboard**: Settings → Auto-Dream card → checkbox next to each agent.
-- **API**: `PUT /api/auto-dream/agents/{id}/enabled` with body `{"enabled": true | false}`. The scheduler picks up the new state on its next tick.
+- **API**: `PUT /api/auto-dream/agents/{id}/enabled` with body `{"enabled": true | false}`. The new state takes effect at the next turn end (event-driven) or the next backstop tick, whichever comes first.
 - **Manifest**: set `auto_dream_enabled = true` in the agent's `.toml` for a persistent opt-in that survives restarts.
 
 **Per-agent threshold overrides** (optional) let you tune the schedule heterogeneously. Set either field on the agent's manifest to override the global `[auto_dream]` default — `None` (the default) inherits the global:

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -568,14 +568,14 @@ decay_rate = 0.1
 
 ### `[auto_dream]`
 
-Background memory consolidation ("dreams") — a time-gated scheduler that periodically asks opt-in agents to reflect on and consolidate their own memory via a 4-phase prompt (Orient / Gather / Consolidate / Prune). Disabled by default; individual agents still opt in via `auto_dream_enabled = true` on their manifest.
+Background memory consolidation ("dreams") — asks opt-in agents to reflect on and consolidate their own memory via a 4-phase prompt (Orient / Gather / Consolidate / Prune). Dreams trigger **event-driven** the moment an agent finishes a turn; a sparse backstop scheduler (default 1 day) catches opted-in agents that never turn. Disabled by default; individual agents still opt in via `auto_dream_enabled = true` on their manifest.
 
 ```toml
 [auto_dream]
 enabled = false
 min_hours = 24
 min_sessions = 5
-check_interval_secs = 600
+check_interval_secs = 86400
 timeout_secs = 600
 # lock_dir = ""   # defaults to <data_dir>/auto_dream/
 ```
@@ -585,13 +585,13 @@ timeout_secs = 600
 | `enabled` | bool | `false` | Master toggle. When `false`, no dream fires regardless of per-agent opt-in. |
 | `min_hours` | f64 | `24.0` | Minimum hours since that agent's last consolidation before the next one fires. |
 | `min_sessions` | u32 | `5` | Minimum sessions touched since that agent's last consolidation before the next one fires. Set to `0` to disable the session-count gate. |
-| `check_interval_secs` | u64 | `600` | How often the scheduler wakes up to check gates, in seconds. |
+| `check_interval_secs` | u64 | `86400` | Backstop scheduler cadence, in seconds. Primary trigger is the `AgentLoopEnd` hook; this only controls the fallback for agents that never turn. |
 | `timeout_secs` | u64 | `600` | Timeout for a single dream invocation in seconds. |
 | `lock_dir` | string | `""` | Optional override for the lock directory. Empty = `<data_dir>/auto_dream/`. Per-agent locks are stored as `<dir>/<agent_id>.lock`. |
 
 A dream fires for an agent when all gates hold: `enabled = true`, the agent's manifest has `auto_dream_enabled = true`, `min_hours` have elapsed since its last dream, `min_sessions` have been touched since then, and the per-agent lock can be acquired.
 
-Per-agent opt-in can be toggled at runtime via `PUT /api/auto-dream/agents/{id}/enabled` (body `{"enabled": bool}`) or via the Settings → Auto-Dream card on the web dashboard — the scheduler picks up the change on its next tick. See `/configuration/core#auto_dream` for the full reference including runtime tool restriction, manual controls, and audit events.
+Per-agent opt-in can be toggled at runtime via `PUT /api/auto-dream/agents/{id}/enabled` (body `{"enabled": bool}`) or via the Settings → Auto-Dream card on the web dashboard — the new state takes effect at the next turn end (event-driven) or the next backstop tick, whichever comes first. See `/configuration/core#auto_dream` for the full reference including runtime tool restriction, manual controls, and audit events.
 
 ---
 

--- a/docs/src/app/zh/agent/memory/page.mdx
+++ b/docs/src/app/zh/agent/memory/page.mdx
@@ -284,7 +284,7 @@ auto_dream_min_sessions = 1     # 每个会话之后都触发，适合高频 age
 
 ### 一次梦境的流程
 
-1. 调度器按 `check_interval_secs`（默认 10 分钟）唤醒一次，依次检查每个已加入 agent 的四道闸门：全局启用 → 时间间隔 → 会话活跃数 → 文件锁。任一不通过即跳过本次。
+1. 主触发路径是 `AgentLoopEnd` 钩子 —— agent 每完成一次 turn，kernel 立刻依次检查四道闸门：全局启用 → 时间间隔 → 会话活跃数 → 文件锁。任一不通过即跳过。另有稀疏的兜底调度器（默认 `check_interval_secs = 86400`，即每天一次）覆盖从不 turn 的 agent（例如等待外部触发的 channel bot）。
 2. 闸门通过后，agent 会以合成的 `auto_dream` 通道被调用，工具白名单收缩到 `memory_store` / `memory_recall` / `memory_list` —— 即使提示被注入，梦境也无法越权调用 shell 或网络工具。
 3. 流式进度（phase、工具调用次数、涉及的记忆条目、最近一 turn 预览、token / 费用）存入每 agent 的进度注册表，通过状态端点对外暴露。
 4. 成功后锁的 mtime 前进到 "现在"（作为时间闸门的基准）；失败或中止后会回滚 mtime，下次 tick 会重试。

--- a/docs/src/app/zh/configuration/core/page.mdx
+++ b/docs/src/app/zh/configuration/core/page.mdx
@@ -95,14 +95,14 @@ decay_rate = 0.1
 
 ### `[auto_dream]`
 
-后台记忆整固（"梦境"）—— 一个时间门控的调度器，周期性地让选择开启的 agent 通过 4 阶段提示词（定位 / 收集 / 整固 / 修剪）反思并整理自己的记忆。默认关闭；每个 agent 还需在 manifest 中通过 `auto_dream_enabled = true` 单独开启。
+后台记忆整固（"梦境"）—— 让选择开启的 agent 通过 4 阶段提示词（定位 / 收集 / 整固 / 修剪）反思并整理自己的记忆。梦境触发是 **事件驱动** 的：agent 每完成一次 turn，kernel 立刻检查闸门是否放行；同时保留一个稀疏的兜底调度器（默认每天一次），用于那些开启了 auto-dream 却长期不活动的 agent。默认关闭；每个 agent 还需在 manifest 中通过 `auto_dream_enabled = true` 单独开启。
 
 ```toml
 [auto_dream]
 enabled = false
 min_hours = 24
 min_sessions = 5
-check_interval_secs = 600
+check_interval_secs = 86400
 timeout_secs = 600
 # lock_dir = ""   # 默认为 <data_dir>/auto_dream/
 ```
@@ -112,7 +112,7 @@ timeout_secs = 600
 | `enabled` | bool | `false` | 全局开关。为 `false` 时即使单个 agent 已开启也不会触发。 |
 | `min_hours` | f64 | `24.0` | 距离该 agent 上次整固的最小小时数，满足后才会再次触发。 |
 | `min_sessions` | u32 | `5` | 距离该 agent 上次整固之后，被触及的最少会话数，满足后才会再次触发。设为 `0` 则禁用该闸门。 |
-| `check_interval_secs` | u64 | `600` | 调度器检查闸门的唤醒间隔（秒）。 |
+| `check_interval_secs` | u64 | `86400` | *兜底* 调度器的唤醒间隔（秒）。主触发路径是 `AgentLoopEnd` 钩子，该字段仅控制"从不 turn 的 agent"的兜底节奏。 |
 | `timeout_secs` | u64 | `600` | 单次梦境调用的超时时间（秒）。 |
 | `lock_dir` | string | `""` | 锁目录的可选覆盖路径。为空则使用 `<data_dir>/auto_dream/`，每个 agent 的锁存储为 `<dir>/<agent_id>.lock`。 |
 
@@ -121,7 +121,7 @@ timeout_secs = 600
 **每个 Agent 的加入状态** 可以无需重启在运行时切换：
 
 - **Web Dashboard**：设置页 → 梦境模式卡片 → 每个 agent 旁的勾选框。
-- **API**：`PUT /api/auto-dream/agents/{id}/enabled`，请求体 `{"enabled": true | false}`。调度器会在下一次 tick 读取新状态。
+- **API**：`PUT /api/auto-dream/agents/{id}/enabled`，请求体 `{"enabled": true | false}`。新状态在下一次 turn 结束（事件驱动）或下一次兜底 tick 时生效，以先到者为准。
 - **Manifest**：在 agent 的 `.toml` 里设置 `auto_dream_enabled = true`，获得重启后仍生效的持久加入状态。
 
 **每个 Agent 的阈值覆盖**（可选）允许异构调度。在 agent manifest 里任一字段不填（`None`）就继承全局默认：

--- a/docs/src/app/zh/configuration/page.mdx
+++ b/docs/src/app/zh/configuration/page.mdx
@@ -567,14 +567,14 @@ decay_rate = 0.1
 
 ### `[auto_dream]`
 
-后台记忆整固（"梦境"）—— 一个时间门控的调度器，周期性地让选择开启的 agent 通过 4 阶段提示词（定位 / 收集 / 整固 / 修剪）反思并整理自己的记忆。默认关闭；每个 agent 还需在 manifest 中通过 `auto_dream_enabled = true` 单独开启。
+后台记忆整固（"梦境"）—— 让选择开启的 agent 通过 4 阶段提示词（定位 / 收集 / 整固 / 修剪）反思并整理自己的记忆。触发是 **事件驱动** 的：agent 每完成一次 turn 即检查闸门；另保留一个稀疏的兜底调度器（默认每天一次）捕获长期不活动的 agent。默认关闭；每个 agent 还需在 manifest 中通过 `auto_dream_enabled = true` 单独开启。
 
 ```toml
 [auto_dream]
 enabled = false
 min_hours = 24
 min_sessions = 5
-check_interval_secs = 600
+check_interval_secs = 86400
 timeout_secs = 600
 # lock_dir = ""   # 默认为 <data_dir>/auto_dream/
 ```
@@ -584,13 +584,13 @@ timeout_secs = 600
 | `enabled` | bool | `false` | 全局开关。为 `false` 时即使单个 agent 已开启也不会触发。 |
 | `min_hours` | f64 | `24.0` | 距离该 agent 上次整固的最小小时数，满足后才会再次触发。 |
 | `min_sessions` | u32 | `5` | 距离该 agent 上次整固之后，被触及的最少会话数，满足后才会再次触发。设为 `0` 则禁用该闸门。 |
-| `check_interval_secs` | u64 | `600` | 调度器检查闸门的唤醒间隔（秒）。 |
+| `check_interval_secs` | u64 | `86400` | 兜底调度器的唤醒间隔（秒）。主触发路径是 `AgentLoopEnd` 钩子，此字段只控制从不 turn 的 agent 的兜底节奏。 |
 | `timeout_secs` | u64 | `600` | 单次梦境调用的超时时间（秒）。 |
 | `lock_dir` | string | `""` | 锁目录的可选覆盖路径。为空则使用 `<data_dir>/auto_dream/`，每个 agent 的锁存储为 `<dir>/<agent_id>.lock`。 |
 
 当所有闸门同时满足时才会触发：`enabled = true`、agent manifest 中 `auto_dream_enabled = true`、距离上次梦境至少 `min_hours` 小时、至少触及 `min_sessions` 个会话、以及能获取到该 agent 的文件锁。
 
-每个 agent 的 opt-in 状态可在运行时通过 `PUT /api/auto-dream/agents/{id}/enabled`（请求体 `{"enabled": bool}`）或 Web Dashboard 的设置页 → 梦境模式卡片切换 —— 调度器在下次 tick 读取新状态。完整参考（包含运行时工具限制、手动控制、审计事件）见 `/zh/configuration/core#auto_dream`。
+每个 agent 的 opt-in 状态可在运行时通过 `PUT /api/auto-dream/agents/{id}/enabled`（请求体 `{"enabled": bool}`）或 Web Dashboard 的设置页 → 梦境模式卡片切换 —— 新状态在下一次 turn 结束（事件驱动）或下一次兜底 tick 时生效，以先到者为准。完整参考（包含运行时工具限制、手动控制、审计事件）见 `/zh/configuration/core#auto_dream`。
 
 ---
 


### PR DESCRIPTION
## Summary

- Auto-dream now fires the moment an agent finishes a turn (via the existing `AgentLoopEnd` hook from `librefang-runtime`), instead of a 10-min scheduler sweep.
- The scheduler loop stays as a sparse backstop for opted-in agents that never take a turn (e.g. channel bots); default `check_interval_secs` bumped 600 → 86400 (1 day).

Follow-up to #2750.

## Why

The existing scheduler is O(time × agents): an install with 10 idle opted-in agents was doing ~1440 stat + 1440 SQL calls per day probing for no reason, while an agent that just passed the activity gate had to wait up to 10 minutes for the next tick.

librefang already has `HookRegistry` + `HookEvent::AgentLoopEnd` firing at every agent loop exit — we just didn't have a subscriber. This PR adds one.

## Shape

- `AutoDreamTurnEndHook` holds `Weak<LibreFangKernel>` and is registered once inside `set_self_handle` (right after the `Arc` is formed so the hook can hold a weak ref).
- Sync `on_event` does a cheap pre-filter (global toggle + manifest opt-in), then spawns a detached task for the gate check + `run_dream`. The file lock already serialises same-agent races; no new locks needed.
- Scheduler loop unchanged in logic — just re-commented as a backstop. The per-agent gate logic, status endpoint, runtime tool allowlist, audit trail, and UI are all untouched.

## Not in scope (deliberately)

- No new `TurnEndHook` trait / registry abstraction. The existing `HookRegistry` is reused. If a second subscriber appears (extract_memories, post-turn cost alert, etc.) we abstract then.
- No new API endpoints, no dashboard changes, no migration.

## Correctness review

- **Boot order**: `set_self_handle()` is called right after `Arc::new(kernel)` and before `start_background_agents().await` in `librefang-api/src/server.rs` — hook is registered before any turn can run.
- **Recursive trigger protection**: dreams are themselves agent loops and fire `AgentLoopEnd`. The hook spawns a gate check which finds the lock still held (or just-reset mtime failing the time gate) and no-ops. No cascade.
- **Concurrent-turn race**: two rapid turns for the same agent both spawn tasks; the file lock gives exactly one winner.
- **Dead `Weak`**: `upgrade()` returning `None` on kernel shutdown is a silent no-op (hook unit test).

## Test plan

- [x] `cargo build --workspace --lib`
- [x] `cargo test -p librefang-kernel auto_dream` — 21 passed (18 existing + 3 new hook tests: dangling-Weak kernel, non-UUID agent_id, unrelated event types)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Live integration: enable `[auto_dream]`, opt an agent in, send it a message, confirm a dream fires immediately on turn end
- [ ] Live integration: disable all agents, confirm scheduler no longer wakes every 10 min (tracing log should show backstop at 1 day cadence)

## Docs

Updated `configuration/{core,}/page.mdx` and `agent/memory/page.mdx` in en + zh, plus `CHANGELOG.md`, to describe event-driven as the primary trigger and the scheduler as a backstop.