### PR TITLE
fix(kernel): add peer_id to cron jobs for peer-scoped memory access

### DIFF
--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1329,6 +1329,7 @@ pub async fn create_schedule(
         schedule: librefang_types::scheduler::CronSchedule::Cron { expr: cron, tz },
         action,
         delivery: librefang_types::scheduler::CronDelivery::None,
+        peer_id: None,
         created_at: chrono::Utc::now(),
         last_run: None,
         next_run: None,

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -558,6 +558,7 @@ mod tests {
                 text: "ping".into(),
             },
             delivery: CronDelivery::None,
+            peer_id: None,
             created_at: Utc::now(),
             last_run: None,
             next_run: None,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8670,7 +8670,7 @@ system_prompt = "You are a helpful assistant."
                                 // get their own isolated session (channel="cron").
                                 let cron_sender = SenderContext {
                                     channel: "cron".to_string(),
-                                    user_id: String::new(),
+                                    user_id: job.peer_id.clone().unwrap_or_default(),
                                     display_name: "cron".to_string(),
                                     is_group: false,
                                     was_mentioned: false,
@@ -12017,6 +12017,7 @@ impl KernelHandle for LibreFangKernel {
             schedule,
             action,
             delivery,
+            peer_id: None,
             enabled: true,
             created_at: chrono::Utc::now(),
             next_run: None,

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -185,6 +185,12 @@ pub struct CronJob {
     pub action: CronAction,
     /// Where to deliver the result.
     pub delivery: CronDelivery,
+    /// Optional peer/user ID to use as the `SenderContext.user_id` when the
+    /// job fires. When set, memory lookups keyed by peer (e.g.
+    /// `peer:{user_id}:KEY`) will resolve correctly. Defaults to `None`
+    /// (empty user_id — backward-compatible behaviour).
+    #[serde(default)]
+    pub peer_id: Option<String>,
     /// When the job was created.
     pub created_at: DateTime<Utc>,
     /// When the job last fired (if ever).
@@ -424,6 +430,7 @@ mod tests {
                 text: "ping".into(),
             },
             delivery: CronDelivery::None,
+            peer_id: None,
             created_at: Utc::now(),
             last_run: None,
             next_run: None,


### PR DESCRIPTION
## Summary

When a cron job fires, the synthetic `SenderContext` has an empty `user_id`. This means `peer_scoped_key("KEY", None)` returns bare `"KEY"` but stored entries use `"peer:{user_id}:KEY"`. The lookup silently misses. Additionally, `memory_list(None)` actively filters out all `peer:*` keys.

**Net effect:** any memory written by a user in a Telegram conversation is completely invisible to the same agent when it runs on a schedule.

### Changes

- Add optional `peer_id: Option<String>` field to `CronJob` struct (`#[serde(default)]` for backward compatibility)
- Use `job.peer_id` in the cron `SenderContext.user_id` when the job fires
- Update all `CronJob` construction sites to include `peer_id: None`

### Reproduction

1. Configure agent with Telegram channel and peer-scoped memory
2. In Telegram DM, store a memory: `"remember: TO-DO buy milk"`
3. Entry stored as `peer:{telegram_user_id}:TO-DO`
4. Add cron: `"What is on my TO-DO list?"`
5. Cron fires → agent says "no TO-DO items" (lookup returns `None` for existing key)

### Config example

```toml
[[cron]]
schedule = "0 9 * * *"
message  = "What is on my TO-DO list?"
peer_id  = "123456789"   # Telegram user ID to run as
```

## Test plan

- [x] `cargo build --workspace --lib`
- [x] `cargo test -p librefang-kernel -p librefang-types` — all passed
- [x] `cargo clippy` — clean
- [ ] Live cron job with `peer_id` set retrieves peer-scoped memories

Closes #2752