### PR TITLE
fix(memory): make extract_categories config drive LLM prompt categories

### DIFF
--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -1667,8 +1667,18 @@ impl ProactiveMemory for ProactiveMemoryStore {
 
         let agent_id = Self::parse_agent_id(user_id)?;
 
+        let categories = self
+            .config
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .extract_categories
+            .clone();
+
         // Step 1: Extract structured memories
-        let extraction = self.extractor.extract_memories(messages).await?;
+        let extraction = self
+            .extractor
+            .extract_memories(messages, &categories)
+            .await?;
         if !extraction.has_content {
             // Fallback: store raw message content as session memory
             let content = messages
@@ -2137,7 +2147,11 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
         // for kernels running without an LLM extractor.
         let extraction_result = self
             .extractor
-            .extract_memories_with_agent_id(conversation, &agent_id.to_string())
+            .extract_memories_with_agent_id(
+                conversation,
+                &agent_id.to_string(),
+                &cfg.extract_categories,
+            )
             .await?;
 
         // Apply decision flow for each extracted memory
@@ -2360,12 +2374,9 @@ mod tests {
             .unwrap();
 
         assert!(result.has_content);
-        // DefaultMemoryExtractor should extract "I prefer" as user_preference
+        // DefaultMemoryExtractor should extract "I prefer" as preference
         assert!(!result.memories.is_empty());
-        assert_eq!(
-            result.memories[0].category,
-            Some("user_preference".to_string())
-        );
+        assert_eq!(result.memories[0].category, Some("preference".to_string()));
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -152,7 +152,14 @@ pub fn init_proactive_memory_with_defaults(
 
 const MAX_MEMORY_CONTENT_LENGTH: usize = 2000;
 
-const EXTRACTION_SYSTEM_PROMPT: &str = r#"You are a memory extraction system. Your goal: help a future assistant feel like it truly knows this person — their style, preferences, expertise, and what matters to them.
+fn build_extraction_prompt(categories: &[String]) -> String {
+    let categories_list = if categories.is_empty() {
+        "any relevant category".to_string()
+    } else {
+        categories.join(", ")
+    };
+    format!(
+        r#"You are a memory extraction system. Your goal: help a future assistant feel like it truly knows this person — their style, preferences, expertise, and what matters to them.
 
 Extract ONLY clearly stated or strongly demonstrated facts. Do NOT infer personality traits from single messages. Prioritize what would most change how you interact with someone.
 
@@ -188,7 +195,7 @@ Respond with a JSON object containing two arrays:
 
 1. "memories" - Facts and preferences to remember:
    - "content": the extracted memory (concise, one natural sentence with actionable nuance)
-   - "category": one of: communication_style, preference, expertise, work_style, project_context, personal_detail, frustration
+   - "category": one of: {categories_list}
    - "level": "user" for personal/preference info, "session" for current task context, "agent" for agent-specific learnings
 
 2. "relations" - Entity relationships (knowledge graph triples):
@@ -199,19 +206,28 @@ Respond with a JSON object containing two arrays:
    - "object_type": same types as subject_type
 
 Example:
-{
+{{
   "memories": [
-    {"content": "Experienced Rust developer who works on the LibreFang project — treat as expert, skip beginner explanations", "category": "expertise", "level": "user"},
-    {"content": "Prefers concise code reviews — skip obvious comments, focus on logic and correctness issues only", "category": "work_style", "level": "user"},
-    {"content": "Uses dark mode and minimal UI everywhere — avoid suggesting light themes or busy layouts", "category": "preference", "level": "user"}
+    {{"content": "Experienced Rust developer who works on the LibreFang project — treat as expert, skip beginner explanations", "category": "{first_cat}", "level": "user"}},
+    {{"content": "Prefers concise code reviews — skip obvious comments, focus on logic and correctness issues only", "category": "{second_cat}", "level": "user"}}
   ],
   "relations": [
-    {"subject": "User", "subject_type": "person", "relation": "experienced_with", "object": "Rust", "object_type": "tool"},
-    {"subject": "User", "subject_type": "person", "relation": "works_at", "object": "LibreFang", "object_type": "project"}
+    {{"subject": "User", "subject_type": "person", "relation": "experienced_with", "object": "Rust", "object_type": "tool"}}
   ]
-}
+}}
 
-If nothing worth extracting: {"memories": [], "relations": []}"#;
+If nothing worth extracting: {{"memories": [], "relations": []}}"#,
+        categories_list = categories_list,
+        first_cat = categories
+            .first()
+            .map(|s| s.as_str())
+            .unwrap_or("preference"),
+        second_cat = categories
+            .get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("preference"),
+    )
+}
 
 const DECISION_SYSTEM_PROMPT: &str = r#"You are a memory conflict resolution system. Given a NEW memory and a list of EXISTING memories, decide what action to take.
 
@@ -316,6 +332,7 @@ impl LlmMemoryExtractor {
         &self,
         conversation_text: &str,
         agent_id: &str,
+        categories: &[String],
     ) -> Result<Option<String>, LibreFangError> {
         let weak = {
             let guard = self
@@ -332,8 +349,9 @@ impl LlmMemoryExtractor {
             return Ok(Some(String::new()));
         };
         let prompt = format!(
-            "{EXTRACTION_SYSTEM_PROMPT}\n\nExtract memories from this conversation. \
-             Return JSON only, no commentary.\n\n{conversation_text}"
+            "{}\n\nExtract memories from this conversation. \
+             Return JSON only, no commentary.\n\n{conversation_text}",
+            build_extraction_prompt(categories)
         );
         match kernel
             .run_forked_agent_oneshot(agent_id, &prompt, Some(Vec::new()))
@@ -353,6 +371,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
     async fn extract_memories(
         &self,
         messages: &[serde_json::Value],
+        categories: &[String],
     ) -> librefang_types::error::LibreFangResult<ExtractionResult> {
         // Build a condensed version of the conversation for the LLM.
         // Skip system messages — only include user and assistant roles.
@@ -445,7 +464,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             tools: Vec::new(),
             max_tokens: 1024,
             temperature: 0.1,
-            system: Some(EXTRACTION_SYSTEM_PROMPT.to_string()),
+            system: Some(build_extraction_prompt(categories)),
             thinking: None,
             prompt_caching: self.prompt_caching,
             response_format: Some(ResponseFormat::Json),
@@ -472,6 +491,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
         &self,
         messages: &[serde_json::Value],
         agent_id: &str,
+        categories: &[String],
     ) -> librefang_types::error::LibreFangResult<ExtractionResult> {
         // Re-run the conversation-text builder from `extract_memories`
         // so the fork prompt gets the same truncation / role filtering.
@@ -538,7 +558,10 @@ impl MemoryExtractor for LlmMemoryExtractor {
         // handle is configured or the fork call fails (transient provider
         // error, rate limit, etc). Standalone path has `prompt_caching =
         // true` so the system prompt still caches across calls.
-        match self.try_forked_extract(&conversation_text, agent_id).await {
+        match self
+            .try_forked_extract(&conversation_text, agent_id, categories)
+            .await
+        {
             Ok(Some(text)) if text.is_empty() => Ok(ExtractionResult {
                 has_content: false,
                 memories: Vec::new(),
@@ -554,7 +577,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
             // No kernel handle configured (init didn't wire it) or fork
             // call failed — fall back to the standalone path so we still
             // get extraction, just without cache alignment.
-            Ok(None) | Err(_) => self.extract_memories(messages).await,
+            Ok(None) | Err(_) => self.extract_memories(messages, categories).await,
         }
     }
 

--- a/crates/librefang-types/src/memory.rs
+++ b/crates/librefang-types/src/memory.rs
@@ -221,10 +221,13 @@ impl Default for ProactiveMemoryConfig {
             extraction_threshold: 0.7,
             extraction_model: None,
             extract_categories: vec![
-                "user_preference".to_string(),
-                "important_fact".to_string(),
-                "task_context".to_string(),
-                "relationship".to_string(),
+                "communication_style".to_string(),
+                "preference".to_string(),
+                "expertise".to_string(),
+                "work_style".to_string(),
+                "project_context".to_string(),
+                "personal_detail".to_string(),
+                "frustration".to_string(),
             ],
             session_ttl_hours: 24,
             duplicate_threshold: 0.5,
@@ -324,15 +327,13 @@ pub enum MemoryAction {
 pub trait MemoryExtractor: Send + Sync {
     /// Extract important memories from conversation messages using LLM.
     ///
-    /// Takes conversation messages and returns extracted memory items.
-    /// The implementation should use an LLM to identify:
-    /// - User preferences
-    /// - Important facts
-    /// - Task context
-    /// - Relationship information
+    /// `categories` is the caller-supplied list from `ProactiveMemoryConfig::extract_categories`.
+    /// Implementations must restrict extracted memories to these categories so that the
+    /// config is the single source of truth — not a hardcoded list inside the prompt.
     async fn extract_memories(
         &self,
         messages: &[serde_json::Value],
+        categories: &[String],
     ) -> crate::error::LibreFangResult<ExtractionResult>;
 
     /// Same as `extract_memories` but also passes the invoking agent's
@@ -347,8 +348,9 @@ pub trait MemoryExtractor: Send + Sync {
         &self,
         messages: &[serde_json::Value],
         _agent_id: &str,
+        categories: &[String],
     ) -> crate::error::LibreFangResult<ExtractionResult> {
-        self.extract_memories(messages).await
+        self.extract_memories(messages, categories).await
     }
 
     /// Decide what to do with a new memory given existing similar memories.
@@ -569,6 +571,7 @@ impl MemoryExtractor for DefaultMemoryExtractor {
     async fn extract_memories(
         &self,
         messages: &[serde_json::Value],
+        _categories: &[String],
     ) -> crate::error::LibreFangResult<ExtractionResult> {
         let mut memories = Vec::new();
         let mut relations = Vec::new();
@@ -610,7 +613,7 @@ impl MemoryExtractor for DefaultMemoryExtractor {
                         &mut memories,
                         &extracted,
                         MemoryLevel::User,
-                        "user_preference",
+                        "preference",
                         role,
                     );
                     relations.push(RelationTriple {
@@ -650,7 +653,7 @@ impl MemoryExtractor for DefaultMemoryExtractor {
                         &mut memories,
                         &extracted,
                         MemoryLevel::User,
-                        "important_fact",
+                        "personal_detail",
                         role,
                     );
                     relations.push(RelationTriple {
@@ -684,7 +687,7 @@ impl MemoryExtractor for DefaultMemoryExtractor {
                         &mut memories,
                         &extracted,
                         MemoryLevel::User,
-                        "user_preference",
+                        "preference",
                         role,
                     );
                     relations.push(RelationTriple {
@@ -721,7 +724,7 @@ impl MemoryExtractor for DefaultMemoryExtractor {
                             &mut memories,
                             &extracted,
                             MemoryLevel::Session,
-                            "task_context",
+                            "project_context",
                             role,
                         );
                     }


### PR DESCRIPTION
## Summary

Fixes #2756.

`[proactive_memory].extract_categories` in `config.toml` was silently ignored — the LLM extractor used a hardcoded category list in the system prompt, and `extract_categories` only acted as a post-extraction filter. Since the two lists didn't overlap, every LLM-extracted memory was dropped with no error logged.

## Changes

- **`MemoryExtractor::extract_memories`** gains a `categories: &[String]` parameter — callers supply the configured list
- **`LlmMemoryExtractor`** replaces the static `EXTRACTION_SYSTEM_PROMPT` constant with `build_extraction_prompt(categories)`, injecting the caller-supplied categories into the prompt so the model outputs exactly those labels
- **`DefaultMemoryExtractor`** accepts and ignores the parameter (rule-based, not LLM-driven)
- **`ProactiveMemoryConfig::default()`** updated to use the LLM-prompt categories (`preference`, `personal_detail`, `project_context`, …) as the single source of truth — previously shipped mismatched defaults
- **`DefaultMemoryExtractor`** category strings aligned with the new defaults
- Both `ProactiveMemoryStore::add` and `auto_memorize` call sites pass `cfg.extract_categories`

## Before / After

**Before:** default config had `extract_categories = ["user_preference", "important_fact", …]`; LLM prompt output `preference`, `expertise`, etc. Filter dropped everything → zero structured memories stored, `category: null` on all entries.

**After:** `extract_categories` is injected into the prompt. Model outputs the configured labels. Filter works as intended. Both rule-based and LLM extractors are consistent with the default config out of the box.

## Testing

All 114 tests in the affected crates pass. The one pre-existing failure (`test_load_config_defaults` in `librefang-kernel`) is unrelated to this change and also fails on `main`.