### PR TITLE
fix(channels): match ImageFile in vision dispatch gates

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1021,7 +1021,7 @@ impl BridgeManager {
                                         ref url, ref caption, ref mime_type
                                     } = message.content {
                                         match download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await {
-                                            blocks if blocks.iter().any(|b| matches!(b, ContentBlock::Image { .. })) => Some(blocks),
+                                            blocks if blocks.iter().any(|b| matches!(b, ContentBlock::Image { .. } | ContentBlock::ImageFile { .. })) => Some(blocks),
                                             _ => None,
                                         }
                                     } else {
@@ -2187,10 +2187,12 @@ async fn dispatch_message(
     } = message.content
     {
         let blocks = download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await;
-        if blocks
-            .iter()
-            .any(|b| matches!(b, ContentBlock::Image { .. }))
-        {
+        if blocks.iter().any(|b| {
+            matches!(
+                b,
+                ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
+            )
+        }) {
             // We have actual image data — send as structured blocks for vision
             dispatch_with_blocks(
                 blocks,


### PR DESCRIPTION
## Summary

- `download_image_to_blocks()` returns `ContentBlock::ImageFile` (disk path) on success, but both dispatch gates in `bridge.rs` only matched `ContentBlock::Image` (inline base64)
- Images sent via Telegram (and other channels) were silently dropped — the LLM received text only
- Added `ContentBlock::ImageFile { .. }` to both `matches!()` patterns (lines 1027 and 2219)

Fixes #2318. Supersedes #2721 (which has conflicts).

## Test plan

- [x] `cargo build --workspace --lib` — passes
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Live: Telegram photo upload → agent describes image correctly