### PR TITLE
fix(auto_dream): unblock main CI — clippy 1.95 doc_lazy_continuation

### DIFF
--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -84,12 +84,15 @@ const MEMORY_WRITE_TOOLS: &[&str] = &["memory_store"];
 pub const DREAM_ALLOWED_TOOLS: &[&str] = &["memory_store", "memory_recall", "memory_list"];
 
 /// Minimum spacing between event-driven gate scans for the same agent.
-/// Mirrors libre-code's `SESSION_SCAN_INTERVAL_MS`. Without this, an
-/// agent taking 100 turns/hour past the time gate would run 100 lock-stat
-/// + session-count SQL probes before one of them actually fires a dream —
-/// the scan is cheap per call but pointless at that cadence. This does
-/// NOT apply to the scheduler (already sparse at `check_interval_secs`)
-/// or to manual triggers (operators explicitly asked for a check).
+/// Mirrors libre-code's `SESSION_SCAN_INTERVAL_MS`.
+///
+/// Without this throttle, an agent taking 100 turns/hour past the time
+/// gate would run 100 lock-stat plus session-count SQL probes before one
+/// actually fires a dream. Each scan is cheap but running 100 of them
+/// per hour is pointless at that cadence. Applies only to the
+/// event-driven path: the scheduler is already sparse at
+/// `check_interval_secs`, and manual triggers deliberately bypass
+/// because the operator explicitly asked for a check.
 const EVENT_SCAN_INTERVAL_MS: u64 = 10 * 60 * 1000;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unblocks main CI. A 9-line comment-text fix — no code semantics change.

## What broke

`rust-clippy` 1.95.0 tightened `doc_lazy_continuation` to reject an em-dash (\`—\`) at the start of a doc-comment line that follows a non-blank doc line — it interprets the block as a malformed list. The \`EVENT_SCAN_INTERVAL_MS\` doc comment introduced in #2755 hit this:

\`\`\`
error: doc list item without indentation
   --> crates/librefang-kernel/src/auto_dream/mod.rs:90:5
   = note: \`-D clippy::doc-lazy-continuation\` implied by \`-D warnings\`
\`\`\`

1.94 didn't flag this, so local \`cargo clippy\` passed. Every main CI run since #2755 merged has been red, and every PR branching from main is blocked.

## Fix

Rephrase the comment: add a paragraph break, drop the em-dash-led continuation, spell out the scope note as a standalone sentence. Pure prose cleanup.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — passes locally on rustc 1.94 (reproduction on 1.95 requires CI)
- [ ] Main CI Quality job goes green on merge

## Note

The same formatting fix is already applied independently on \`feat/forked-agent\` (PR #2767) so that PR's own Quality job passes. When #2767 merges it carries the same change; this small PR exists to unblock main faster without waiting for the larger PR's review cycle.