### PR TITLE
fix(dashboard): fix 12 UI bugs across scheduler, sessions, memory, models, plugins, providers, runtime, workflows

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -6,7 +6,7 @@ import {
   setProviderUrl,
   setDefaultProvider,
 } from "../../api";
-import { providerKeys } from "../queries/keys";
+import { providerKeys, runtimeKeys } from "../queries/keys";
 
 export function useTestProvider() {
   return useMutation({
@@ -60,6 +60,7 @@ export function useSetDefaultProvider() {
       setDefaultProvider(id, model),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.all });
+      queryClient.invalidateQueries({ queryKey: runtimeKeys.status() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime.ts
@@ -62,6 +62,7 @@ export function useDeleteTask() {
     mutationFn: deleteTaskFromQueue,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: runtimeKeys.tasks() });
+      queryClient.invalidateQueries({ queryKey: runtimeKeys.queueStatus() });
     },
   });
 }
@@ -72,6 +73,7 @@ export function useRetryTask() {
     mutationFn: retryTask,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: runtimeKeys.tasks() });
+      queryClient.invalidateQueries({ queryKey: runtimeKeys.queueStatus() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -22,7 +22,6 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
   const [content, setContent] = useState("");
   const [agentId, setAgentId] = useState("");
-  const [level, setLevel] = useState("episodic");
 
   const addMutation = useAddMemory();
 
@@ -48,29 +47,15 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
             />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.level")}</label>
-              <select
-                value={level}
-                onChange={(e) => setLevel(e.target.value)}
-                className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
-              >
-                <option value="episodic">{t("memory.episodic")}</option>
-                <option value="semantic">{t("memory.semantic")}</option>
-                <option value="working">{t("memory.working")}</option>
-              </select>
-            </div>
-            <div>
-              <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.agent_id")}</label>
-              <input
-                type="text"
-                value={agentId}
-                onChange={(e) => setAgentId(e.target.value)}
-                placeholder={t("memory.agent_optional")}
-                className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
-              />
-            </div>
+          <div>
+            <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.agent_id")}</label>
+            <input
+              type="text"
+              value={agentId}
+              onChange={(e) => setAgentId(e.target.value)}
+              placeholder={t("memory.agent_optional")}
+              className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
+            />
           </div>
         </div>
 

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -115,10 +115,11 @@ export function ModelsPage() {
     if (confirmDeleteId !== id) { setConfirmDeleteId(id); return; }
     setConfirmDeleteId(null);
     try {
+      const model = allModels.find(m => m.id === id);
+      const key = model ? modelKey(model) : null;
       await deleteMut.mutateAsync(id);
       addToast(t("models.model_deleted"), "success");
-      const orphan = hiddenModelKeys.find(k => k.endsWith(`:${id}`));
-      if (orphan) unhideModelAction(orphan);
+      if (key && hiddenModelKeys.includes(key)) unhideModelAction(key);
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
 
@@ -727,9 +728,9 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
     if (o.frequency_penalty != null) { setFreqPenalty(o.frequency_penalty); setFreqEnabled(true); }
     if (o.presence_penalty != null) { setPresPenalty(o.presence_penalty); setPresEnabled(true); }
     if (o.reasoning_effort) setReasoningEffort(o.reasoning_effort);
-    if (o.use_max_completion_tokens) setUseMaxCompletionTokens(true);
-    if (o.no_system_role) setNoSystemRole(true);
-    if (o.force_max_tokens) setForceMaxTokens(true);
+    if (o.use_max_completion_tokens != null) setUseMaxCompletionTokens(o.use_max_completion_tokens);
+    if (o.no_system_role != null) setNoSystemRole(o.no_system_role);
+    if (o.force_max_tokens != null) setForceMaxTokens(o.force_max_tokens);
     setOverridesLoaded(true);
   }, [overridesQuery.data, overridesLoaded]);
 

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -349,7 +349,7 @@ export function OverviewPage() {
               <div className="flex items-center gap-3 p-2.5 rounded-lg bg-main/40">
                 <div className="w-8 h-8 rounded-lg bg-brand/10 flex items-center justify-center shrink-0"><HardDrive className="w-4 h-4 text-brand" /></div>
                 <span className="text-xs text-text-dim flex-1">{t("overview.memory_usage")}</span>
-                <span className="text-sm font-mono font-black">{snapshot?.status?.memory_used_mb ? `${snapshot.status.memory_used_mb} MB` : "-"}</span>
+                <span className="text-sm font-mono font-black">{snapshot?.status?.memory_used_mb != null ? `${snapshot.status.memory_used_mb} MB` : "-"}</span>
               </div>
               <div className="flex items-center gap-3 p-2.5 rounded-lg bg-main/40">
                 <div className="w-8 h-8 rounded-lg bg-warning/10 flex items-center justify-center shrink-0"><Activity className="w-4 h-4 text-warning" /></div>

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -87,7 +87,7 @@ export function PluginsPage() {
   };
 
   const handleRegistryInstall = (name: string, repo: string) => {
-    setInstallingName(name);
+    setInstallingName(`${repo}:${name}`);
     installMutation.mutate(
       { source: "registry", name, github_repo: repo },
       {
@@ -300,9 +300,9 @@ export function PluginsPage() {
                                 variant="primary"
                                 size="sm"
                                 onClick={() => handleRegistryInstall(rp.name, reg.github_repo)}
-                                disabled={installingName === rp.name}
+                                disabled={installingName === `${reg.github_repo}:${rp.name}`}
                               >
-                                {installingName === rp.name
+                                {installingName === `${reg.github_repo}:${rp.name}`
                                   ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                                   : <Download className="w-3.5 h-3.5 mr-1" />}
                                 {t("plugins.install")}

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1144,7 +1144,6 @@ export function ProvidersPage() {
   const handleSetDefault = async (id: string, model?: string) => {
     try {
       await defaultProviderMutation.mutateAsync({ id, model });
-      await statusQuery.refetch();
       addToast(t("providers.default_set"), "success");
     } catch (e: any) {
       addToast(e?.message || t("common.error"), "error");

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -138,7 +138,8 @@ export function RuntimePage() {
   const refreshAll = () => {
     snapshotQuery.refetch(); versionQuery.refetch(); queueQuery.refetch();
     healthDetailQuery.refetch(); securityQuery.refetch();
-    auditQuery.refetch(); backupsQuery.refetch(); taskStatusQuery.refetch();
+    auditQuery.refetch(); auditVerifyQuery.refetch(); backupsQuery.refetch();
+    taskStatusQuery.refetch(); taskListQuery.refetch();
   };
 
   return (

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -57,11 +57,13 @@ export function SchedulerPage() {
   const schedules = useMemo(() => [...(schedulesQuery.data ?? [])].sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? "")), [schedulesQuery.data]);
   const triggers = triggersQuery.data ?? [];
 
+  const canSubmit = !name.trim() ? false
+    : targetType === "agent" ? !!agentId
+    : !!workflowId;
+
   const handleCreate = async (e: FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) return;
-    if (targetType === "agent" && !agentId) return;
-    if (targetType === "workflow" && !workflowId) return;
+    if (!canSubmit) return;
     try {
       await createMut.mutateAsync({
         name, cron, tz: cronTz, message, enabled: true,
@@ -315,7 +317,7 @@ export function SchedulerPage() {
                 <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(createMut.error as any)?.message}</div>
               )}
               <div className="flex gap-2 pt-2">
-                <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !name.trim() || (targetType === "agent" && !agentId) || (targetType === "workflow" && !workflowId)}>
+                <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !canSubmit}>
                   {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Plus className="w-4 h-4 mr-1" />}
                   {t("scheduler.create_job")}
                 </Button>

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -60,6 +60,8 @@ export function SchedulerPage() {
   const handleCreate = async (e: FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
+    if (targetType === "agent" && !agentId) return;
+    if (targetType === "workflow" && !workflowId) return;
     try {
       await createMut.mutateAsync({
         name, cron, tz: cronTz, message, enabled: true,
@@ -158,7 +160,7 @@ export function SchedulerPage() {
                     <button
                       onClick={() => toggleScheduleMut.mutate({ id: s.id, data: { enabled: !isEnabled } })}
                       className={`px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
-                      disabled={toggleScheduleMut.isPending}
+                      disabled={toggleScheduleMut.isPending && toggleScheduleMut.variables?.id === s.id}
                     >
                       {isEnabled ? t("common.active") : t("common.disabled", { defaultValue: "OFF" })}
                     </button>
@@ -216,7 +218,7 @@ export function SchedulerPage() {
                     <button
                       onClick={() => toggleTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}
                       className={`px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
-                      disabled={toggleTriggerMut.isPending}
+                      disabled={toggleTriggerMut.isPending && toggleTriggerMut.variables?.id === tr.id}
                     >
                       {isEnabled ? t("common.active") : t("common.disabled", { defaultValue: "OFF" })}
                     </button>
@@ -313,7 +315,7 @@ export function SchedulerPage() {
                 <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(createMut.error as any)?.message}</div>
               )}
               <div className="flex gap-2 pt-2">
-                <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !name.trim()}>
+                <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !name.trim() || (targetType === "agent" && !agentId) || (targetType === "workflow" && !workflowId)}>
                   {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Plus className="w-4 h-4 mr-1" />}
                   {t("scheduler.create_job")}
                 </Button>

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -52,6 +52,10 @@ export function SessionsPage() {
 
   const activeCount = sessions.filter(s => s.active).length;
 
+  function saveLabel(sessionId: string, label: string, agentId?: string) {
+    labelMutation.mutate({ sessionId, label, agentId }, { onSuccess: () => setEditingLabelId(null) });
+  }
+
   async function handleSwitch(agentId: string, sessionId: string) {
     setPendingId(sessionId);
     try {
@@ -157,11 +161,11 @@ export function SessionsPage() {
                           autoFocus
                           value={labelValue}
                           onChange={e => setLabelValue(e.target.value)}
-                          onKeyDown={e => { if (e.key === "Enter") labelMutation.mutate({ sessionId: s.session_id, label: labelValue, agentId: s.agent_id ?? undefined }, { onSuccess: () => setEditingLabelId(null) }); if (e.key === "Escape") setEditingLabelId(null); }}
+                          onKeyDown={e => { if (e.key === "Enter") saveLabel(s.session_id, labelValue, s.agent_id ?? undefined); if (e.key === "Escape") setEditingLabelId(null); }}
                           className="px-1.5 py-0.5 rounded border border-brand bg-main text-[10px] w-24 outline-none"
                           placeholder={t("sessions.label_placeholder", { defaultValue: "Label..." })}
                         />
-                        <button onClick={() => labelMutation.mutate({ sessionId: s.session_id, label: labelValue, agentId: s.agent_id ?? undefined }, { onSuccess: () => setEditingLabelId(null) })} className="text-success"><Check className="w-3 h-3" /></button>
+                        <button onClick={() => saveLabel(s.session_id, labelValue, s.agent_id ?? undefined)} className="text-success"><Check className="w-3 h-3" /></button>
                         <button onClick={() => setEditingLabelId(null)} className="text-text-dim"><X className="w-3 h-3" /></button>
                       </span>
                     ) : (

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -38,8 +38,6 @@ export function SessionsPage() {
     const list = sessionsQuery.data ?? [];
     return list
       .filter(s => {
-        // Hide sessions for agents that no longer exist
-        if (!agentMap.has(s.agent_id || "")) return false;
         if (!search) return true;
         const agent = agentMap.get(s.agent_id || "");
         return (agent?.name || "").toLowerCase().includes(search.toLowerCase()) || s.session_id.includes(search);
@@ -159,11 +157,11 @@ export function SessionsPage() {
                           autoFocus
                           value={labelValue}
                           onChange={e => setLabelValue(e.target.value)}
-                          onKeyDown={e => { if (e.key === "Enter") labelMutation.mutate({ sessionId: s.session_id, label: labelValue }, { onSuccess: () => setEditingLabelId(null) }); if (e.key === "Escape") setEditingLabelId(null); }}
+                          onKeyDown={e => { if (e.key === "Enter") labelMutation.mutate({ sessionId: s.session_id, label: labelValue, agentId: s.agent_id ?? undefined }, { onSuccess: () => setEditingLabelId(null) }); if (e.key === "Escape") setEditingLabelId(null); }}
                           className="px-1.5 py-0.5 rounded border border-brand bg-main text-[10px] w-24 outline-none"
                           placeholder={t("sessions.label_placeholder", { defaultValue: "Label..." })}
                         />
-                        <button onClick={() => labelMutation.mutate({ sessionId: s.session_id, label: labelValue }, { onSuccess: () => setEditingLabelId(null) })} className="text-success"><Check className="w-3 h-3" /></button>
+                        <button onClick={() => labelMutation.mutate({ sessionId: s.session_id, label: labelValue, agentId: s.agent_id ?? undefined }, { onSuccess: () => setEditingLabelId(null) })} className="text-success"><Check className="w-3 h-3" /></button>
                         <button onClick={() => setEditingLabelId(null)} className="text-text-dim"><X className="w-3 h-3" /></button>
                       </span>
                     ) : (

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1228,13 +1228,6 @@ export function SkillsPage() {
             <span className="hidden sm:inline">{t("skills.evo_create", { defaultValue: "Create Skill" })}</span>
           </button>
           <button
-            className="flex h-8 items-center gap-1.5 rounded-xl border border-brand/30 bg-brand/10 px-3 text-xs font-bold text-brand hover:bg-brand/20 transition-colors"
-            onClick={() => setShowCreateModal(true)}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{t("skills.evo_create", { defaultValue: "Create Skill" })}</span>
-          </button>
-          <button
             className="flex h-8 items-center gap-1.5 rounded-xl border border-border-subtle bg-surface px-3 text-xs font-bold text-text-dim hover:text-brand hover:border-brand/30 transition-colors"
             onClick={async () => {
               // Rescan the skills directory on disk before refetching the list.

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -70,12 +70,14 @@ export function WorkflowsPage() {
   );
 
   useEffect(() => {
-    if (!selectedWorkflowId || workflows.some(wf => wf.id === selectedWorkflowId)) return;
+    if (!selectedWorkflowId) return;
+    const all = workflowsQuery.data ?? [];
+    if (all.some(wf => wf.id === selectedWorkflowId)) return;
     setSelectedWorkflowId("");
     setSelectedRunId(null);
     setRunInput("");
     setDryRunResult(null);
-  }, [workflows, selectedWorkflowId]);
+  }, [workflowsQuery.data, selectedWorkflowId]);
 
   const handleRun = async () => {
     if (!selectedWorkflowId) return;

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "../lib/datetime";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -68,6 +68,14 @@ export function WorkflowsPage() {
       .filter(wf => !searchQuery || wf.name?.toLowerCase().includes(searchQuery.toLowerCase()) || wf.description?.toLowerCase().includes(searchQuery.toLowerCase())),
     [workflowsQuery.data, searchQuery]
   );
+
+  useEffect(() => {
+    if (!selectedWorkflowId || workflows.some(wf => wf.id === selectedWorkflowId)) return;
+    setSelectedWorkflowId("");
+    setSelectedRunId(null);
+    setRunInput("");
+    setDryRunResult(null);
+  }, [workflows, selectedWorkflowId]);
 
   const handleRun = async () => {
     if (!selectedWorkflowId) return;


### PR DESCRIPTION
  ## Type

  - [x] Bug fix
  - [x] Refactor / Performance

  ## Summary

  Fixes 12 UI-level bugs found across the dashboard SPA. No backend changes.

  ## Changes

  **SchedulerPage**
  - Submit button allowed create with empty agent/workflow id — added `canSubmit` derived bool used in both guard and `disabled` prop (eliminates logic duplication flagged
  in review)
  - Per-row toggle spinners blocked all rows instead of only the toggled one — scoped to `variables.id === row.id`

  **SessionsPage**
  - Sessions for deleted agents were hidden — removed incorrect filter; "unknown agent" fallback already existed in JSX
  - Label mutation missing `agentId` → cache invalidation for `agentKeys.sessions(id)` was silently skipped
  - Extracted `saveLabel` helper — onKeyDown and Check button now share one call site

  **MemoryPage**
  - Level selector had no effect (POST `/api/memory` does not accept `level`) — removed selector

  **ModelsPage**
  - Hidden-model cleanup on delete used `endsWith(':id')` suffix match — could unhide model from different provider with same id; replaced with exact `modelKey(model)`
  lookup
  - Boolean overrides (`use_max_completion_tokens`, `no_system_role`, `force_max_tokens`) used truthy check — explicit `false` from API not hydrated; fixed to `!= null`

  **OverviewPage**
  - `memory_used_mb: 0` displayed as `-` due to falsy check — fixed to `!= null`

  **PluginsPage**
  - Install spinner keyed by plugin `name` only — two registries with same plugin name caused spinner collision; keyed by `${repo}:${name}`

  **ProvidersPage / mutations/providers**
  - `useSetDefaultProvider` did not invalidate `runtimeKeys.status()` (different key tree from `providerKeys.all`) — added invalidation in mutation hook; removed manual
  `statusQuery.refetch()` from page

  **RuntimePage / mutations/runtime**
  - `refreshAll` omitted `auditVerifyQuery` and `taskListQuery` — added both
  - `useDeleteTask` / `useRetryTask` did not invalidate `runtimeKeys.queueStatus()` — queue counters stale after task ops

  **WorkflowsPage**
  - `selectedWorkflowId` not cleared after workflow deleted — panel stayed open for non-existent workflow; added `useEffect` watching `workflowsQuery.data` (unfiltered, so
  search does not clear selection)

  ## Security

  - [x] No new unsafe code
  - [x] No secrets or API keys in diff
  - [x] User input validated at boundaries