### PR TITLE
fix(auto_dream): gate Duration import with cfg(unix) for Windows CI

### DIFF
--- a/crates/librefang-kernel/src/auto_dream/lock.rs
+++ b/crates/librefang-kernel/src/auto_dream/lock.rs
@@ -317,6 +317,7 @@ fn is_process_running(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::time::Duration;
 
     fn tmpfile(name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

Follow-up to #2769: the only user of `std::time::Duration` in `auto_dream::lock` tests (`acquire_reclaims_stale_pid`) was marked `#[cfg(unix)]` in #2769, but its import wasn't. On Windows this leaves the import orphaned, and with `RUSTFLAGS: -D warnings` the unused-import warning becomes a hard error:

```
error: unused import: `std::time::Duration`
error: could not compile `librefang-kernel` (lib test) due to 1 previous error
```

Main CI's Test / Windows job has been red since the #2769 merge. This one-line change gates the import with `#[cfg(unix)]` to match its single caller.

## Test plan

- [x] `cargo build --workspace --lib` (macOS — unaffected, import is still used)
- [ ] Windows CI turns green after merge