### PR TITLE
fix(mcp): derive 'connected' from health state + fix catalog card overflow (closes #2738)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -966,12 +966,12 @@ export function McpServersPage() {
                               : <Plug className={`w-5 h-5 ${alreadyAdded ? "text-success" : "text-brand"}`} />
                             }
                           </div>
-                          <div className="min-w-0">
+                          <div className="min-w-0 flex-1">
                             <h3 className={`text-sm font-black truncate transition-colors ${
                               alreadyAdded ? "" : "group-hover:text-brand"
                             }`}>{tpl.name}</h3>
                             {tpl.category && (
-                              <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">{tpl.category}</span>
+                              <span className="block truncate text-[10px] font-black uppercase tracking-widest text-text-dim/60">{tpl.category}</span>
                             )}
                           </div>
                         </div>

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2992,8 +2992,14 @@ pub async fn list_mcp_servers(State(state): State<Arc<AppState>>) -> impl IntoRe
         })
         .collect();
 
-    // Get connected servers and their tools from the live MCP connections
+    // Get connected servers and their tools from the live MCP connections.
+    //
+    // `connected` reflects liveness, not just vec residency: a subprocess that
+    // died silently (stdio transport crash, SSE drop) leaves its McpConnection
+    // in the vec until the health loop or a reconnect replaces it. Cross-check
+    // with `mcp_health` so the badge/count match reality (#2738).
     let connections = state.kernel.mcp_connections_ref().lock().await;
+    let health = state.kernel.mcp_health();
     let connected: Vec<serde_json::Value> = connections
         .iter()
         .map(|conn| {
@@ -3007,20 +3013,33 @@ pub async fn list_mcp_servers(State(state): State<Arc<AppState>>) -> impl IntoRe
                     })
                 })
                 .collect();
+            let is_alive = matches!(
+                health.get_health(conn.name()).map(|h| h.status),
+                Some(librefang_extensions::McpStatus::Ready),
+            );
             serde_json::json!({
                 "name": conn.name(),
                 "tools_count": tools.len(),
                 "tools": tools,
-                "connected": true,
+                "connected": is_alive,
             })
         })
         .collect();
+
+    let total_connected = connected
+        .iter()
+        .filter(|c| {
+            c.get("connected")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        })
+        .count();
 
     Json(serde_json::json!({
         "configured": config_servers,
         "connected": connected,
         "total_configured": config_servers.len(),
-        "total_connected": connected.len(),
+        "total_connected": total_connected,
     }))
 }
 


### PR DESCRIPTION
## Summary

Closes #2738. Two independent bugs on the MCP page both fixed here.

### Bug 1 — Wrong connected server count

`GET /api/mcp/servers` returned `connected: true` as a **hardcoded literal** for every entry in `mcp_connections` (skills.rs:3014). The vec is append-only except on explicit reload/reconnect — a subprocess that dies silently (stdio crash in Docker, SSE drop, HTTP endpoint down) stays in the vec and misreports as alive. The dashboard's Connected badge/count then shows the wrong number.

Fix: cross-check with `mcp_health` and emit `connected: true` only when the health monitor has last confirmed status = `Ready`. `total_connected` now counts filtered-true entries, not raw vec length.

Explains why @AIHunter83 (Linux/Docker) saw 2 connected with only 1 alive while @leszek3737 couldn't reproduce on Win/macOS — stdio subprocesses are much more likely to die silently in a container.

### Bug 2 — Text overlap on catalog cards

The catalog card's header text column was plain `min-w-0` — it shrank to its intrinsic content width instead of claiming available space, so long names/categories overflowed into the installed-badge slot. Most visible on Linux/Docker (DejaVu etc. render wider than Windows Segoe UI / macOS SF Pro, tipping layout into overflow that doesn't trigger on native Win/Mac).

Fix: add `flex-1` on the text column + `block truncate` on the category span.

## Test plan

- [x] `cargo build --workspace --lib` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Live: Docker + stdio MCP server → kill the subprocess → dashboard Connected count should drop (once health loop's next tick detects the dead connection, ~60s default)
- [ ] Live: MCP catalog with long category/description string → no overflow on Linux Chrome/Edge

## Files

- `crates/librefang-api/src/routes/skills.rs` — `list_mcp_servers` derives `connected` from `mcp_health.get_health(name).status == Ready` instead of hardcoded `true`; `total_connected` recomputed from filtered list
- `crates/librefang-api/dashboard/src/pages/McpServersPage.tsx` — catalog card header text column: `min-w-0 flex-1` + category span `block truncate`