### PR TITLE
fix(dashboard): sync terminal health and active window state

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2852,11 +2852,7 @@ export interface TerminalHealth {
 }
 
 export async function getTerminalHealth(): Promise<TerminalHealth> {
-  const response = await fetch("/api/terminal/health", {
-    headers: buildHeaders(),
-  });
-  if (!response.ok) throw await parseError(response);
-  return (await response.json()) as TerminalHealth;
+  return get<TerminalHealth>("/api/terminal/health");
 }
 
 export async function listTerminalWindows(): Promise<TerminalWindow[]> {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2844,6 +2844,21 @@ export interface TerminalWindow {
   active: boolean;
 }
 
+export interface TerminalHealth {
+  ok: boolean;
+  tmux: boolean;
+  max_windows: number;
+  os: string;
+}
+
+export async function getTerminalHealth(): Promise<TerminalHealth> {
+  const response = await fetch("/api/terminal/health", {
+    headers: buildHeaders(),
+  });
+  if (!response.ok) throw await parseError(response);
+  return (await response.json()) as TerminalHealth;
+}
+
 export async function listTerminalWindows(): Promise<TerminalWindow[]> {
   const response = await fetch("/api/terminal/windows", {
     headers: buildHeaders(),

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -23,6 +23,7 @@ interface TerminalTabsProps {
   tmuxAvailable: boolean;
   maxWindows: number;
   activeWindowId: string | null;
+  displayedActiveWindowId: string | null;
   onSwitchWindow: (windowId: string) => void;
   terminalRef: RefObject<Terminal | null>;
   fitAddonRef: RefObject<FitAddon | null>;
@@ -35,6 +36,7 @@ export function TerminalTabs({
   tmuxAvailable,
   maxWindows,
   activeWindowId,
+  displayedActiveWindowId,
   onSwitchWindow,
   terminalRef,
   fitAddonRef,
@@ -180,7 +182,7 @@ export function TerminalTabs({
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-gray-900/80 border-b border-gray-700/50 overflow-x-auto shrink-0">
       {windows.map((w) => {
-        const isActive = w.id === activeWindowId;
+          const isActive = w.id === displayedActiveWindowId;
         const isEditing = editingId === w.id;
         return (
           <div

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -22,7 +22,6 @@ interface TerminalTabsProps {
   ws: WebSocket | null;
   tmuxAvailable: boolean;
   maxWindows: number;
-  activeWindowId: string | null;
   displayedActiveWindowId: string | null;
   onSwitchWindow: (windowId: string) => void;
   terminalRef: RefObject<Terminal | null>;
@@ -35,7 +34,6 @@ export function TerminalTabs({
   ws,
   tmuxAvailable,
   maxWindows,
-  activeWindowId,
   displayedActiveWindowId,
   onSwitchWindow,
   terminalRef,
@@ -87,10 +85,10 @@ export function TerminalTabs({
   }, []);
 
   useEffect(() => {
-    if (activeWindowId !== null || windows.length === 0) return;
+    if (displayedActiveWindowId !== null || windows.length === 0) return;
     const active = windows.find((w) => w.active);
     onSwitchWindow(active ? active.id : windows[0].id);
-  }, [windows, activeWindowId, onSwitchWindow]);
+  }, [windows, displayedActiveWindowId, onSwitchWindow]);
 
   useEffect(() => {
     if (editingId) {
@@ -155,7 +153,7 @@ export function TerminalTabs({
       if (currentWindows.length <= 1) return;
       try {
         await deleteMutation.mutateAsync(windowId);
-        if (activeWindowId === windowId) {
+        if (displayedActiveWindowId === windowId) {
           const remaining = currentWindows.filter((w) => w.id !== windowId);
           if (remaining.length > 0) {
             const next = remaining[0];
@@ -172,7 +170,7 @@ export function TerminalTabs({
         addToast(t("terminal.tabs.delete_failed"), "error");
       }
     },
-    [deleteMutation, activeWindowId, ws, onSwitchWindow, addToast, t]
+    [deleteMutation, displayedActiveWindowId, ws, onSwitchWindow, addToast, t]
   );
 
   if (!tmuxAvailable) return null;
@@ -182,7 +180,7 @@ export function TerminalTabs({
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-gray-900/80 border-b border-gray-700/50 overflow-x-auto shrink-0">
       {windows.map((w) => {
-          const isActive = w.id === displayedActiveWindowId;
+        const isActive = w.id === displayedActiveWindowId;
         const isEditing = editingId === w.id;
         return (
           <div

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -95,6 +95,7 @@ export {
   getWorkflowRun,
   listWorkflowTemplates,
   // terminal
+  getTerminalHealth,
   listTerminalWindows,
   // auto-dream
   getAutoDreamStatus,
@@ -222,5 +223,6 @@ export type {
   HandStatsResponse,
   MemoryItem,
   ModelOverrides,
+  TerminalHealth,
   TerminalWindow,
 } from "../../api";

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -295,4 +295,12 @@ describe("query key factories", () => {
       }
     });
   });
+
+  describe("terminalKeys anchoring", () => {
+    it("health and windows are prefixed with terminalKeys.all", () => {
+      const prefix = terminalKeys.all;
+      expect(terminalKeys.health().slice(0, prefix.length)).toEqual(prefix);
+      expect(terminalKeys.windows().slice(0, prefix.length)).toEqual(prefix);
+    });
+  });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -290,5 +290,6 @@ export const metricsKeys = {
 
 export const terminalKeys = {
   all: ["terminal"] as const,
+  health: () => [...terminalKeys.all, "health"] as const,
   windows: () => [...terminalKeys.all, "windows"] as const,
 };

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -9,6 +9,9 @@ const { mockListApprovals, mockFetchApprovalCount } = vi.hoisted(() => ({
 const { mockListPluginRegistries } = vi.hoisted(() => ({
   mockListPluginRegistries: vi.fn(),
 }));
+const { mockGetTerminalHealth } = vi.hoisted(() => ({
+  mockGetTerminalHealth: vi.fn(),
+}));
 
 vi.mock("../../api", async () => {
   const actual = await vi.importActual("../../api");
@@ -17,16 +20,19 @@ vi.mock("../../api", async () => {
 
 vi.mock("../http/client", async () => {
   const actual = await vi.importActual("../http/client");
-  return {
-    ...actual,
-    listPluginRegistries: mockListPluginRegistries,
-  };
+    return {
+      ...actual,
+      listPluginRegistries: mockListPluginRegistries,
+      getTerminalHealth: mockGetTerminalHealth,
+    };
 });
 
 // ── Import hooks after mocks are set up ──
 import { useApprovals, useApprovalCount } from "./approvals";
 import { usePluginRegistries } from "./plugins";
+import { useTerminalHealth } from "./terminal";
 import { approvalKeys, pluginKeys } from "./keys";
+import { terminalKeys } from "./keys";
 import { createQueryClientWrapper } from "../test/query-client";
 
 beforeEach(() => {
@@ -196,6 +202,43 @@ describe("useApprovalCount", () => {
 
     await vi.waitFor(() => {
       expect(queryClient.getQueryData(approvalKeys.count())).toEqual(mockData);
+    });
+  });
+});
+
+describe("useTerminalHealth", () => {
+  it("should not fetch when enabled is false", async () => {
+    const { result } = renderHook(() => useTerminalHealth({ enabled: false }), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockGetTerminalHealth).not.toHaveBeenCalled();
+  });
+
+  it("should fetch terminal health when enabled is true", async () => {
+    const mockData = { tmux: true, max_windows: 16, os: "linux" };
+    mockGetTerminalHealth.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useTerminalHealth({ enabled: true }), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockData));
+    expect(mockGetTerminalHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use terminalKeys.health() as queryKey", async () => {
+    const mockData = { tmux: true, max_windows: 16, os: "macos" };
+    mockGetTerminalHealth.mockResolvedValue(mockData);
+
+    const { wrapper, queryClient } = createQueryClientWrapper();
+    renderHook(() => useTerminalHealth({ enabled: true }), { wrapper });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(terminalKeys.health())).toEqual(mockData);
     });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
@@ -30,8 +30,8 @@ export function useTerminalHealth(options: UseTerminalQueryOptions = {}) {
   return useQuery({
     ...terminalQueries.health(),
     enabled,
-    staleTime,
-    refetchInterval,
+    ...(staleTime !== undefined ? { staleTime } : {}),
+    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
   });
 }
 
@@ -40,7 +40,7 @@ export function useTerminalWindows(options: UseTerminalQueryOptions = {}) {
   return useQuery({
     ...terminalQueries.windows(),
     enabled,
-    staleTime,
-    refetchInterval,
+    ...(staleTime !== undefined ? { staleTime } : {}),
+    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
@@ -1,10 +1,22 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { listTerminalWindows } from "../http/client";
+import { getTerminalHealth, listTerminalWindows } from "../http/client";
 import { terminalKeys } from "./keys";
 
 const REFRESH_MS = 10_000;
 
+type UseTerminalQueryOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
 export const terminalQueries = {
+  health: () =>
+    queryOptions({
+      queryKey: terminalKeys.health(),
+      queryFn: getTerminalHealth,
+      staleTime: 60_000,
+    }),
   windows: () =>
     queryOptions({
       queryKey: terminalKeys.windows(),
@@ -13,6 +25,22 @@ export const terminalQueries = {
     }),
 };
 
-export function useTerminalWindows(options: { enabled?: boolean } = {}) {
-  return useQuery({ ...terminalQueries.windows(), enabled: options.enabled });
+export function useTerminalHealth(options: UseTerminalQueryOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...terminalQueries.health(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
+}
+
+export function useTerminalWindows(options: UseTerminalQueryOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...terminalQueries.windows(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
@@ -1,0 +1,228 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalPage } from "./TerminalPage";
+
+const invalidateQueries = vi.fn();
+const navigateMock = vi.fn();
+const useTerminalHealthMock = vi.fn();
+const terminalTabsPropsMock = vi.fn();
+const useUIStoreMock = vi.fn();
+
+type MockSocketHandler = ((event?: unknown) => void) | null;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.OPEN;
+  sentMessages: string[] = [];
+  onopen: MockSocketHandler = null;
+  onmessage: MockSocketHandler = null;
+  onerror: MockSocketHandler = null;
+  onclose: MockSocketHandler = null;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  emitOpen() {
+    this.onopen?.();
+  }
+
+  emitMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) => {
+        if (key === "terminal.subtitle_error" && opts?.error) {
+          return `error: ${String(opts.error)}`;
+        }
+        return key;
+      },
+    }),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries }),
+  };
+});
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon() {}
+    open() {}
+    write() {}
+    onData() {}
+    onResize() {}
+    dispose() {}
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    buildAuthenticatedWebSocketUrl: () => "ws://localhost/api/terminal/ws",
+  };
+});
+
+vi.mock("../lib/queries/terminal", () => ({
+  useTerminalHealth: (...args: unknown[]) => useTerminalHealthMock(...args),
+}));
+
+vi.mock("../lib/store", () => ({
+  useUIStore: (selector: (state: {
+    terminalEnabled: boolean | null;
+    addToast: (message: string, type?: "success" | "error" | "info") => void;
+  }) => unknown) =>
+    useUIStoreMock(selector),
+}));
+
+vi.mock("../components/TerminalTabs", () => ({
+  TerminalTabs: (props: {
+    displayedActiveWindowId: string | null;
+    onSwitchWindow: (id: string) => void;
+  }) => {
+    terminalTabsPropsMock(props);
+    return (
+      <div>
+        <div data-testid="displayed-window">{props.displayedActiveWindowId ?? "none"}</div>
+        <button onClick={() => props.onSwitchWindow("window-2")}>switch-window</button>
+      </div>
+    );
+  },
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TerminalPage />
+    </QueryClientProvider>
+  );
+}
+
+describe("TerminalPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    useUIStoreMock.mockImplementation(
+      (selector: (state: {
+        terminalEnabled: boolean | null;
+        addToast: (message: string, type?: "success" | "error" | "info") => void;
+      }) => unknown) =>
+        selector({
+          terminalEnabled: true,
+          addToast: vi.fn(),
+        })
+    );
+    useTerminalHealthMock.mockReturnValue({
+      data: { tmux: true, max_windows: 16, os: "linux" },
+      isError: false,
+    });
+  });
+
+  it("clears optimistic window after websocket error message", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.emitOpen();
+      ws.emitMessage({ type: "active_window", window_id: "window-1" });
+    });
+
+    await screen.findByText("window-1");
+    await user.click(screen.getByRole("button", { name: "switch-window" }));
+
+    expect(screen.getByTestId("displayed-window")).toHaveTextContent("window-2");
+
+    act(() => {
+      ws.emitMessage({ type: "error", content: "switch failed" });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("displayed-window")).toHaveTextContent("window-1");
+    });
+  });
+
+  it("invalidates only terminal windows after active_window message", async () => {
+    renderPage();
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.emitOpen();
+      ws.emitMessage({ type: "active_window", window_id: "window-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["terminal", "windows"] });
+    });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["terminal"] });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["terminal", "health"] });
+  });
+
+  it("does not resend null desired window on reconnect after disconnect before active window", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const firstSocket = MockWebSocket.instances[0];
+    act(() => {
+      firstSocket.emitOpen();
+    });
+
+    await screen.findByRole("button", { name: "terminal.disconnect" });
+
+    await user.click(screen.getByRole("button", { name: "terminal.disconnect" }));
+
+    await user.click(screen.getByRole("button", { name: "terminal.connect" }));
+
+    const secondSocket = MockWebSocket.instances[1];
+    act(() => {
+      secondSocket.emitOpen();
+    });
+
+    const switchMessages = secondSocket.sentMessages
+      .map((msg) => JSON.parse(msg) as { type: string; window?: string })
+      .filter((msg) => msg.type === "switch_window");
+
+    expect(switchMessages).toEqual([]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -237,9 +237,17 @@ export function TerminalPage() {
       wsRef.current.close();
       wsRef.current = null;
     }
+    desiredWindowIdRef.current = activeWindowId;
+    setPendingWindowId(null);
     setIsConnected(false);
     setIsConnecting(false);
-  }, [sendCloseMessage]);
+  }, [sendCloseMessage, activeWindowId]);
+
+  useEffect(() => {
+    if (terminalEnabled === true) return;
+    desiredWindowIdRef.current = null;
+    setPendingWindowId(null);
+  }, [terminalEnabled]);
 
   const handleInstallTmux = useCallback(() => {
     const cmd = getTmuxInstallCommand(serverOs);
@@ -443,7 +451,6 @@ export function TerminalPage() {
         ws={wsRef.current}
         tmuxAvailable={tmuxAvailable}
         maxWindows={maxWindows}
-        activeWindowId={activeWindowId}
         displayedActiveWindowId={displayedActiveWindowId}
         onSwitchWindow={handleSwitchWindow}
         terminalRef={terminalRef}

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -172,13 +172,14 @@ export function TerminalPage() {
           setError(typeof msg.content === "string" && msg.content
             ? msg.content
             : t("terminal.error_unknown"));
+          setPendingWindowId(null);
           break;
         case "active_window":
           if (msg.window_id) {
             desiredWindowIdRef.current = msg.window_id;
             setActiveWindowId(msg.window_id);
             setPendingWindowId(null);
-            queryClient.invalidateQueries({ queryKey: terminalKeys.all });
+            queryClient.invalidateQueries({ queryKey: terminalKeys.windows() });
           }
           break;
       }
@@ -237,7 +238,9 @@ export function TerminalPage() {
       wsRef.current.close();
       wsRef.current = null;
     }
-    desiredWindowIdRef.current = activeWindowId;
+    if (activeWindowId) {
+      desiredWindowIdRef.current = activeWindowId;
+    }
     setPendingWindowId(null);
     setIsConnected(false);
     setIsConnecting(false);

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -1,6 +1,6 @@
 import "@xterm/xterm/css/xterm.css";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { useTranslation } from "react-i18next";
@@ -13,12 +13,13 @@ import {
   Minimize2,
 } from "lucide-react";
 import { useUIStore } from "../lib/store";
-import { buildAuthenticatedWebSocketUrl, authHeader } from "../api";
+import { buildAuthenticatedWebSocketUrl } from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { EmptyState } from "../components/ui/EmptyState";
 import { TerminalTabs } from "../components/TerminalTabs";
+import { useTerminalHealth } from "../lib/queries/terminal";
 
 interface ServerMessage {
   type: "started" | "output" | "exit" | "error" | "active_window";
@@ -31,13 +32,6 @@ interface ServerMessage {
   content?: string;
   isRoot?: boolean;
   window_id?: string;
-}
-
-interface TerminalHealth {
-  ok: boolean;
-  tmux: boolean;
-  max_windows: number;
-  os: string;
 }
 
 const RECONNECT_DELAY_MS = 2000;
@@ -64,17 +58,29 @@ export function TerminalPage() {
   const intentionalDisconnectRef = useRef(false);
   const connectRef = useRef<() => void>(() => {});
   const attemptRef = useRef(0);
+  const desiredWindowIdRef = useRef<string | null>(null);
 
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isRoot, setIsRoot] = useState(false);
-  const [tmuxAvailable, setTmuxAvailable] = useState(false);
-  const [maxWindows, setMaxWindows] = useState(16);
   const [activeWindowId, setActiveWindowId] = useState<string | null>(null);
+  const [pendingWindowId, setPendingWindowId] = useState<string | null>(null);
   const [serverOs, setServerOs] = useState<string>("linux");
   const [isFullscreen, setIsFullscreen] = useState(false);
   const terminalEnabled = useUIStore((s) => s.terminalEnabled);
+  const {
+    data: terminalHealth,
+    isError: terminalHealthError,
+  } = useTerminalHealth({ enabled: terminalEnabled === true });
+
+  const tmuxAvailable = !terminalHealthError && (terminalHealth?.tmux ?? false);
+  const maxWindows = terminalHealth?.max_windows ?? 16;
+
+  const displayedActiveWindowId = useMemo(
+    () => pendingWindowId ?? activeWindowId,
+    [pendingWindowId, activeWindowId]
+  );
 
   useEffect(() => {
     if (terminalEnabled === false) {
@@ -82,20 +88,11 @@ export function TerminalPage() {
     }
   }, [terminalEnabled, navigate]);
 
-  // Fetch terminal health for tmux feature flag.
   useEffect(() => {
-    if (terminalEnabled !== true) return;
-    fetch("/api/terminal/health", { headers: authHeader() })
-      .then((r) => r.json())
-      .then((data: TerminalHealth) => {
-        setTmuxAvailable(data.tmux ?? false);
-        setMaxWindows(data.max_windows ?? 16);
-        if (data.os) setServerOs(data.os);
-      })
-      .catch(() => {
-        setTmuxAvailable(false);
-      });
-  }, [terminalEnabled]);
+    if (terminalHealth?.os) {
+      setServerOs(terminalHealth.os);
+    }
+  }, [terminalHealth]);
 
   const sendCloseMessage = useCallback((ws: WebSocket | null) => {
     if (ws?.readyState === WebSocket.OPEN) {
@@ -131,6 +128,9 @@ export function TerminalPage() {
       if (terminalRef.current && fitAddonRef.current) {
         const { cols, rows } = terminalRef.current;
         ws.send(JSON.stringify({ type: "resize", cols, rows }));
+      }
+      if (desiredWindowIdRef.current) {
+        ws.send(JSON.stringify({ type: "switch_window", window: desiredWindowIdRef.current }));
       }
     };
 
@@ -175,7 +175,9 @@ export function TerminalPage() {
           break;
         case "active_window":
           if (msg.window_id) {
+            desiredWindowIdRef.current = msg.window_id;
             setActiveWindowId(msg.window_id);
+            setPendingWindowId(null);
             queryClient.invalidateQueries({ queryKey: terminalKeys.all });
           }
           break;
@@ -247,7 +249,8 @@ export function TerminalPage() {
   }, [serverOs]);
 
   const handleSwitchWindow = useCallback((id: string) => {
-    setActiveWindowId(id);
+    desiredWindowIdRef.current = id;
+    setPendingWindowId(id);
   }, []);
 
   const toggleFullscreen = useCallback(() => {
@@ -441,6 +444,7 @@ export function TerminalPage() {
         tmuxAvailable={tmuxAvailable}
         maxWindows={maxWindows}
         activeWindowId={activeWindowId}
+        displayedActiveWindowId={displayedActiveWindowId}
         onSwitchWindow={handleSwitchWindow}
         terminalRef={terminalRef}
         fitAddonRef={fitAddonRef}


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Fixes terminal dashboard state drift by moving terminal health into the shared query layer and keeping tmux tab selection aligned with backend-confirmed active windows across reconnects.

## Changes

- add `getTerminalHealth()` to the dashboard API client and expose it through `src/lib/http/client.ts`
- add `terminalKeys.health()` and `useTerminalHealth()` with shared query defaults and key coverage tests
- remove direct `fetch("/api/terminal/health")` from `TerminalPage` in favor of the shared query hook
- track pending vs backend-confirmed terminal window state so optimistic tab switches are reconciled correctly
- resend intended `switch_window` after websocket reconnect and clear stale desired-window state during teardown
- simplify `TerminalTabs` to use the displayed active tab state consistently

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] pnpm typecheck && pnpm test --run && pnpm build passes in crates/librefang-api/dashboard
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries