### PR TITLE
fix(dashboard/workflows): align workflow mutation invalidation

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import * as http from "../http/client";
 import type { ApiActionResponse, ScheduleItem } from "../../api";
 import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule, useUpdateTrigger, useDeleteTrigger } from "./schedules";
-import { cronKeys, scheduleKeys, triggerKeys } from "../queries/keys";
+import { cronKeys, scheduleKeys, triggerKeys, workflowKeys } from "../queries/keys";
 import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
@@ -28,7 +28,7 @@ describe("useCreateSchedule", () => {
     vi.mocked(http.createSchedule).mockResolvedValue(scheduleResponse);
   });
 
-  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+  it("invalidates schedule, cron, and workflow list caches", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -37,13 +37,16 @@ describe("useCreateSchedule", () => {
     result.current.mutate({ name: "test schedule", agent_id: "agent-1", cron: "0 * * * *" });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(3);
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
       queryKey: scheduleKeys.all,
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
       queryKey: cronKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(3, {
+      queryKey: workflowKeys.lists(),
     });
   });
 });
@@ -53,7 +56,7 @@ describe("useUpdateSchedule", () => {
     vi.mocked(http.updateSchedule).mockResolvedValue(actionResponse);
   });
 
-  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+  it("invalidates schedule, cron, and workflow list caches", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -62,13 +65,16 @@ describe("useUpdateSchedule", () => {
     result.current.mutate({ id: "sched-1", data: { enabled: false } });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(3);
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
       queryKey: scheduleKeys.all,
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
       queryKey: cronKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(3, {
+      queryKey: workflowKeys.lists(),
     });
   });
 });
@@ -78,7 +84,7 @@ describe("useDeleteSchedule", () => {
     vi.mocked(http.deleteSchedule).mockResolvedValue(actionResponse);
   });
 
-  it("invalidates scheduleKeys.all and cronKeys.all", async () => {
+  it("invalidates schedule, cron, and workflow list caches", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -87,13 +93,16 @@ describe("useDeleteSchedule", () => {
     result.current.mutate("sched-1");
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(3);
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
       queryKey: scheduleKeys.all,
     });
     expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
       queryKey: cronKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(3, {
+      queryKey: workflowKeys.lists(),
     });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
@@ -7,15 +7,18 @@ import {
   updateTrigger,
   deleteTrigger,
 } from "../http/client";
-import { cronKeys, scheduleKeys, triggerKeys } from "../queries/keys";
+import { cronKeys, scheduleKeys, triggerKeys, workflowKeys } from "../queries/keys";
 
 // Schedules surface in two views: SchedulerPage (via useSchedules →
 // scheduleKeys) and HandsPage's cron widget (via useCronJobs → cronKeys).
 // Every write MUST invalidate both slices so acting from one page never
 // leaves the other showing stale data.
 function invalidateScheduleCaches(qc: ReturnType<typeof useQueryClient>) {
-  qc.invalidateQueries({ queryKey: scheduleKeys.all });
-  qc.invalidateQueries({ queryKey: cronKeys.all });
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: scheduleKeys.all }),
+    qc.invalidateQueries({ queryKey: cronKeys.all }),
+    qc.invalidateQueries({ queryKey: workflowKeys.lists() }),
+  ]);
 }
 
 export function useCreateSchedule() {

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  useRunWorkflow,
+  useDryRunWorkflow,
+  useDeleteWorkflow,
+  useCreateWorkflow,
+  useUpdateWorkflow,
+  useInstantiateTemplate,
+} from "./workflows";
+import { workflowKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+
+vi.mock("../http/client", () => ({
+  runWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
+  dryRunWorkflow: vi.fn().mockResolvedValue({ valid: true, steps: [] }),
+  deleteWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
+  createWorkflow: vi.fn().mockResolvedValue({ id: "wf-1" }),
+  updateWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
+  instantiateTemplate: vi.fn().mockResolvedValue({ workflow_id: "wf-1" }),
+  saveWorkflowAsTemplate: vi.fn().mockResolvedValue({ status: "ok" }),
+}));
+
+describe("useRunWorkflow", () => {
+  it("invalidates workflow runs, lists, and detail for the workflow", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRunWorkflow(), { wrapper });
+
+    await result.current.mutateAsync({ workflowId: "wf-1", input: "hello" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.runs("wf-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.lists(),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.detail("wf-1"),
+    });
+  });
+});
+
+describe("useDryRunWorkflow", () => {
+  it("does not invalidate cached workflow queries", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDryRunWorkflow(), { wrapper });
+
+    await result.current.mutateAsync({ workflowId: "wf-1", input: "hello" });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe.each([
+  { name: "useDeleteWorkflow", hook: useDeleteWorkflow, arg: "wf-1" },
+  {
+    name: "useCreateWorkflow",
+    hook: useCreateWorkflow,
+    arg: { name: "New workflow", steps: [] },
+  },
+  {
+    name: "useUpdateWorkflow",
+    hook: useUpdateWorkflow,
+    arg: { workflowId: "wf-1", payload: { name: "Updated workflow" } },
+  },
+  {
+    name: "useInstantiateTemplate",
+    hook: useInstantiateTemplate,
+    arg: { id: "tmpl-1", params: {} },
+  },
+])("$name", ({ hook, arg }) => {
+  it("invalidates workflowKeys.all", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    await result.current.mutateAsync(arg as never);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workflowKeys.all });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
@@ -15,11 +15,11 @@ export function useRunWorkflow() {
   return useMutation({
     mutationFn: ({ workflowId, input }: { workflowId: string; input: string }) =>
       runWorkflow(workflowId, input),
-    onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: workflowKeys.runs(variables.workflowId) });
-      qc.invalidateQueries({ queryKey: workflowKeys.lists() });
-      qc.invalidateQueries({ queryKey: workflowKeys.detail(variables.workflowId) });
-    },
+    onSuccess: (_data, variables) => Promise.all([
+      qc.invalidateQueries({ queryKey: workflowKeys.runs(variables.workflowId) }),
+      qc.invalidateQueries({ queryKey: workflowKeys.lists() }),
+      qc.invalidateQueries({ queryKey: workflowKeys.detail(variables.workflowId) }),
+    ]),
   });
 }
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
@@ -15,7 +15,11 @@ export function useRunWorkflow() {
   return useMutation({
     mutationFn: ({ workflowId, input }: { workflowId: string; input: string }) =>
       runWorkflow(workflowId, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: workflowKeys.all }),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: workflowKeys.runs(variables.workflowId) });
+      qc.invalidateQueries({ queryKey: workflowKeys.lists() });
+      qc.invalidateQueries({ queryKey: workflowKeys.detail(variables.workflowId) });
+    },
   });
 }
 

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -129,6 +129,15 @@ describe("query key factories", () => {
         "wf-1",
       ]);
     });
+
+    it("detail and runDetail are nested under their parent prefixes", () => {
+      expect(
+        workflowKeys.detail("wf-1").slice(0, workflowKeys.details().length),
+      ).toEqual(workflowKeys.details());
+      expect(
+        workflowKeys.runDetail("run-1").slice(0, workflowKeys.runDetails().length),
+      ).toEqual(workflowKeys.runDetails());
+    });
   });
 
   describe("auditKeys", () => {

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -1,10 +1,8 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "../lib/datetime";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import {
-  createSchedule,
   type DryRunResult,
   type WorkflowTemplate,
 } from "../api";
@@ -33,6 +31,7 @@ import {
   useDeleteWorkflow,
   useInstantiateTemplate,
 } from "../lib/mutations/workflows";
+import { useCreateSchedule } from "../lib/mutations/schedules";
 import { useUIStore } from "../lib/store";
 
 const categoryIconMap: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -43,7 +42,6 @@ export function WorkflowsPage() {
   const { t, i18n } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>("");
   const [runInput, setRunInput] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
@@ -61,6 +59,7 @@ export function WorkflowsPage() {
   const dryRunMutation = useDryRunWorkflow();
   const deleteMutation = useDeleteWorkflow();
   const instantiateMutation = useInstantiateTemplate();
+  const createScheduleMutation = useCreateSchedule();
 
   const workflows = useMemo(() =>
     [...(workflowsQuery.data ?? [])]
@@ -628,10 +627,23 @@ export function WorkflowsPage() {
           onSave={async (cron, tz) => {
             const wf = workflows.find(w => w.id === scheduleWorkflowId);
             try {
-              await createSchedule({ name: `${wf?.name || "workflow"} schedule`, cron, tz, workflow_id: scheduleWorkflowId, enabled: true });
+              await createScheduleMutation.mutateAsync({
+                name: `${wf?.name || "workflow"} schedule`,
+                cron,
+                tz,
+                workflow_id: scheduleWorkflowId,
+                enabled: true,
+              });
+              addToast(t("scheduler.save_success", { defaultValue: "Schedule saved" }), "success");
               setScheduleWorkflowId(null);
-              await queryClient.invalidateQueries({ queryKey: ["workflows"] });
-            } catch { /* ignore */ }
+            } catch (err) {
+              addToast(
+                err instanceof Error
+                  ? err.message
+                  : t("workflows.schedule_failed", { defaultValue: "Schedule creation failed" }),
+                "error",
+              );
+            }
           }}
           onClose={() => setScheduleWorkflowId(null)}
         />


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Fixes stale and inconsistent workflow scheduling/run state in the dashboard by routing `WorkflowsPage` writes through shared mutation hooks and tightening cache invalidation behavior.

## Changes

- move workflow schedule creation in `WorkflowsPage` from direct API call to `useCreateSchedule()`
- surface schedule creation errors to the user and add success feedback on save
- invalidate workflow list caches when schedule mutations succeed so schedule state updates immediately in workflow views
- narrow `useRunWorkflow()` invalidation to workflow runs, lists, and workflow detail instead of invalidating the full workflow domain
- make workflow run invalidation await `Promise.all(...)` so `mutateAsync()` waits for invalidation to complete
- add mutation tests for workflow hooks
- extend key factory tests for workflow detail/run detail anchoring
- update schedule mutation tests for workflow list invalidation

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `pnpm --dir crates/librefang-api/dashboard typecheck`
- [x] `pnpm --dir crates/librefang-api/dashboard test --run`
- [x] `pnpm --dir crates/librefang-api/dashboard build`

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries