### PR TITLE
release: v2026.4.19-beta25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.19] - 2026-04-19
+
+### Added
+
+- Add auto-dream per-agent background memory consolidation (#2750) (@houko)
+- Trigger on AgentLoopEnd hook, scheduler becomes backstop (#2755) (@houko)
+- Derivative LLM calls reuse parent's prompt cache (#2767) (@houko)
+
+### Fixed
+
+- Show Provider before Model in Config default_model section (#2749) (@houko)
+- Add peer_id to cron jobs for peer-scoped memory access (#2759) (@DaBlitzStein)
+- Match ImageFile in vision dispatch gates (#2762) (@DaBlitzStein)
+- Default api_listen to 127.0.0.1:4545 for local-only startup (closes #2766) (#2769) (@houko)
+- Clear stale TOTP banners, refetch status on reset, localize error messages (#2771) (@leszek3737)
+- Fix 12 UI bugs across scheduler, sessions, memory, models, plugins, providers, runtime, workflows (#2772) (@leszek3737)
+- Gate Duration import with cfg(unix) for Windows CI (#2773) (@houko)
+- Harden canvas workflow recovery and related UI state (#2774) (@leszek3737)
+- Derive 'connected' from health state + fix catalog card overflow (closes #2738) (#2775) (@houko)
+- Align workflow mutation invalidation (#2778) (@leszek3737)
+
+### Documentation
+
+- Fix stale documentation references (#2720) (@leszek3737)
+
+### Maintenance
+
+- Replace cloudflare/wrangler-action with direct npx wrangler calls (#2740) (@houko)
+
+
 ## [Unreleased]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "clap",
  "clap_complete",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "axum",
  "clap",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "axum",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10994,7 +10994,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32204",
+  "version": "26.4.32215",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.18-beta24",
+  "version": "2026.4.19-beta25",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.18-beta24",
+  "version": "2026.4.19-beta25",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.18b24",
+    version="2026.4.19b25",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.18-beta24"
+version = "2026.4.19-beta25"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.19-beta25 -->
## Release v2026.4.19-beta25

### Added

- Add auto-dream per-agent background memory consolidation (#2750) (@houko)
- Trigger on AgentLoopEnd hook, scheduler becomes backstop (#2755) (@houko)
- Derivative LLM calls reuse parent's prompt cache (#2767) (@houko)

### Fixed

- Show Provider before Model in Config default_model section (#2749) (@houko)
- Add peer_id to cron jobs for peer-scoped memory access (#2759) (@DaBlitzStein)
- Match ImageFile in vision dispatch gates (#2762) (@DaBlitzStein)
- Default api_listen to 127.0.0.1:4545 for local-only startup (closes #2766) (#2769) (@houko)
- Clear stale TOTP banners, refetch status on reset, localize error messages (#2771) (@leszek3737)
- Fix 12 UI bugs across scheduler, sessions, memory, models, plugins, providers, runtime, workflows (#2772) (@leszek3737)
- Gate Duration import with cfg(unix) for Windows CI (#2773) (@houko)
- Harden canvas workflow recovery and related UI state (#2774) (@leszek3737)
- Derive 'connected' from health state + fix catalog card overflow (closes #2738) (#2775) (@houko)
- Align workflow mutation invalidation (#2778) (@leszek3737)

### Documentation

- Fix stale documentation references (#2720) (@leszek3737)

### Maintenance

- Replace cloudflare/wrangler-action with direct npx wrangler calls (#2740) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.18-beta24...v2026.4.19-beta25