### PR TITLE
fix(dashboard/chat): clear history consistently and refresh model state

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -110,6 +110,7 @@ export {
   suspendAgent,
   resumeAgent,
   deleteAgent,
+  clearAgentHistory,
   patchAgentConfig,
   createAgentSession,
   switchAgentSession,

--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -6,7 +6,7 @@ import {
   setProviderUrl,
   setDefaultProvider,
 } from "../../api";
-import { providerKeys, runtimeKeys } from "../queries/keys";
+import { modelKeys, providerKeys, runtimeKeys } from "../queries/keys";
 
 export function useTestProvider() {
   return useMutation({
@@ -21,6 +21,7 @@ export function useSetProviderKey() {
       setProviderKey(id, key),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.all });
+      queryClient.invalidateQueries({ queryKey: modelKeys.lists() });
     },
   });
 }
@@ -31,6 +32,7 @@ export function useDeleteProviderKey() {
     mutationFn: (id: string) => deleteProviderKey(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.all });
+      queryClient.invalidateQueries({ queryKey: modelKeys.lists() });
     },
   });
 }
@@ -49,6 +51,7 @@ export function useSetProviderUrl() {
     }) => setProviderUrl(id, baseUrl, proxyUrl),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.all });
+      queryClient.invalidateQueries({ queryKey: modelKeys.lists() });
     },
   });
 }
@@ -60,6 +63,7 @@ export function useSetDefaultProvider() {
       setDefaultProvider(id, model),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.all });
+      queryClient.invalidateQueries({ queryKey: modelKeys.lists() });
       queryClient.invalidateQueries({ queryKey: runtimeKeys.status() });
     },
   });

--- a/crates/librefang-api/dashboard/src/lib/queries/models.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/models.ts
@@ -27,9 +27,15 @@ export const modelQueries = {
 
 export function useModels(
   filters: { provider?: string; tier?: string; available?: boolean } = {},
-  options: { enabled?: boolean } = {},
+  options: { enabled?: boolean; staleTime?: number; refetchInterval?: number | false } = {},
 ) {
-  return useQuery({ ...modelQueries.list(filters), enabled: options.enabled });
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...modelQueries.list(filters),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
 export function useModelOverrides(modelKey: string) {

--- a/crates/librefang-api/dashboard/src/lib/queries/models.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/models.ts
@@ -29,13 +29,7 @@ export function useModels(
   filters: { provider?: string; tier?: string; available?: boolean } = {},
   options: { enabled?: boolean; staleTime?: number; refetchInterval?: number | false } = {},
 ) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...modelQueries.list(filters),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+  return useQuery({ ...modelQueries.list(filters), ...options });
 }
 
 export function useModelOverrides(modelKey: string) {

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -6,9 +6,10 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { buildAuthenticatedWebSocketUrl, sendAgentMessage, loadAgentSession } from "../api";
 import type { ApprovalItem, SessionListItem, ModelItem, AgentTool, AgentItem } from "../api";
+import { clearAgentHistory } from "../lib/http/client";
 import { useFullConfig } from "../lib/queries/config";
 import { useMediaProviders } from "../lib/queries/media";
-import { useModels, modelQueries } from "../lib/queries/models";
+import { useModels } from "../lib/queries/models";
 import { usePendingApprovals } from "../lib/queries/approvals";
 import { useAgents, useAgentSessions } from "../lib/queries/agents";
 import { useActiveHandsWhen } from "../lib/queries/hands";
@@ -317,6 +318,19 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
       .finally(() => setAgentLoading(loadId, false));
   }, [agentId, sessionVersion]);
 
+  const clearHistory = useCallback(async () => {
+    if (!agentId) {
+      setMessages([]);
+      return;
+    }
+    await clearAgentHistory(agentId);
+    sessionCache.delete(agentId);
+    if (prevAgentRef.current === agentId) {
+      messagesRef.current = [];
+    }
+    setMessages([]);
+  }, [agentId]);
+
   // Send message - WS first, HTTP fallback
   const sendMessage = useCallback(async (content: string) => {
     if (!content.trim()) return;
@@ -336,7 +350,10 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
         ).join("\n"));
         return;
       }
-      if (trimmed === "/clear") { setMessages([]); return; }
+      if (trimmed === "/clear") {
+        void clearHistory();
+        return;
+      }
       if (trimmed === "/agents") {
         const names = agents.map(a => `- **${a.name}** (${a.state || "unknown"})`).join("\n");
         sysMsg(names || t("chat.no_agents_available"));
@@ -625,9 +642,7 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
 
     // HTTP fallback — direct, no fake streaming
     await sendViaHttp();
-  }, [agentId, agents, wsConnected, ws, deepThinking, showThinkingProcess, finishTurnIfCurrent]);
-
-  const clearHistory = useCallback(() => setMessages([]), []);
+  }, [agentId, agents, wsConnected, ws, deepThinking, showThinkingProcess, finishTurnIfCurrent, clearHistory]);
 
   return { messages, isLoading, sendMessage, clearHistory, wsConnected };
 }
@@ -1073,26 +1088,23 @@ function ChatInput({ onSend, disabled, inputDisabled, placeholder, authMissing, 
 }
 
 // Connection status bar with session dropdown
-function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable }: {
+function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable, onOpenConfig }: {
   agentName: string; isLoading: boolean; messageCount: number; onClear: () => void; onExport: () => void; wsConnected?: boolean; modelName?: string; modelProvider?: string;
   sessions?: SessionListItem[]; activeSessionId?: string;
   onSwitchSession?: (sessionId: string) => void; onNewSession?: () => void; onDeleteSession?: (sessionId: string) => void;
   agentId: string; onModelChange: () => void;
   webSearchAugmentation?: "off" | "auto" | "always"; onWebSearchChange?: (mode: "off" | "auto" | "always") => void;
   webSearchAvailable?: boolean;
+  onOpenConfig: () => void;
 }) {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [sessionOpen, setSessionOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Model popover state
   const [modelOpen, setModelOpen] = useState(false);
   const modelRef = useRef<HTMLDivElement>(null);
-  const [models, setModels] = useState<ModelItem[]>([]);
   const [modelSearch, setModelSearch] = useState("");
-  const [modelLoading, setModelLoading] = useState(false);
-  const [modelFetchError, setModelFetchError] = useState<string | null>(null);
   const [patchError, setPatchError] = useState<string | null>(null);
   const [patchPending, setPatchPending] = useState(false);
   const [optimisticModel, setOptimisticModel] = useState<string | null>(null);
@@ -1101,6 +1113,14 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
   const hiddenModelKeys = useUIStore((s) => s.hiddenModelKeys);
   const hiddenSet = useMemo(() => new Set(hiddenModelKeys), [hiddenModelKeys]);
   const patchAgentConfigMutation = usePatchAgentConfig();
+  const modelsQuery = useModels(
+    { available: true },
+    {
+      enabled: modelOpen,
+      // Model picker opens on demand. Keep query idle until popover visible.
+      staleTime: 0,
+    },
+  );
 
   // Clear optimistic model once the real modelName catches up
   useEffect(() => {
@@ -1135,17 +1155,9 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
     return () => document.removeEventListener("mousedown", handler);
   }, [modelOpen]);
 
-  // Fetch available models lazily when popover first opens
-  useEffect(() => {
-    if (!modelOpen || models.length > 0 || modelLoading) return;
-    setModelLoading(true);
-    setModelFetchError(null);
-    queryClient.fetchQuery(modelQueries.list({ available: true }))
-      .then((res: { models: ModelItem[] }) => setModels(res.models))
-      .catch(() => setModelFetchError(t("chat.unable_to_load_models")))
-      .finally(() => setModelLoading(false));
-  }, [modelOpen, models.length, modelLoading, queryClient, t]);
-
+  const models = modelsQuery.data?.models ?? [];
+  const modelLoading = modelsQuery.isLoading || modelsQuery.isFetching;
+  const modelFetchError = modelsQuery.error ? t("chat.unable_to_load_models") : null;
   const visibleModels = useMemo(() => filterVisible(models, hiddenSet), [models, hiddenSet]);
 
   // Unique providers derived from loaded models, sorted alphabetically
@@ -1275,7 +1287,7 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
                   <div className="px-2.5 py-2 space-y-1.5">
                     <p className="text-xs text-error">{modelFetchError}</p>
                     <button
-                      onClick={() => { setModels([]); setModelFetchError(null); }}
+                      onClick={() => { void modelsQuery.refetch(); }}
                       className="text-[10px] text-brand hover:underline"
                     >
                       {t("chat.retry")}
@@ -1353,11 +1365,11 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
             <div className="hidden sm:flex items-center gap-1.5">
               <button
                 onClick={() => {
-                  if (noKey && mode === "off") {
-                    // No search key configured — navigate to Config page Web section
-                    window.location.href = "/dashboard/config";
-                    return;
-                  }
+                    if (noKey && mode === "off") {
+                      // No search key configured — navigate to Config page Web section
+                      onOpenConfig();
+                      return;
+                    }
                   const cycle: Record<string, "off" | "auto" | "always"> = { off: "auto", auto: "always", always: "off" };
                   onWebSearchChange(cycle[mode] || "auto");
                 }}
@@ -1381,7 +1393,7 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
               </button>
               {isActive && noKey && (
                 <button
-                  onClick={() => { window.location.href = "/dashboard/config"; }}
+                  onClick={onOpenConfig}
                   className="text-[9px] text-warning hover:text-warning/80 underline hidden xl:inline"
                 >
                   {t("chat.web_search_configure", { defaultValue: "Configure API key" })}
@@ -2018,7 +2030,8 @@ export function ChatPage() {
               onNewSession={handleNewSession}
               onDeleteSession={handleDeleteSession}
               agentId={selectedAgentId}
-                onModelChange={() => void agentsQuery.refetch()}
+              onModelChange={() => void agentsQuery.refetch()}
+              onOpenConfig={() => navigate({ to: "/config" })}
               webSearchAugmentation={selectedAgent?.web_search_augmentation}
               webSearchAvailable={webSearchAvailable}
               onWebSearchChange={async (mode) => {

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -164,7 +164,7 @@ const sessionCache = new Map<string, ChatMessage[]>();
 
 // Chat message management - includes history loading and sending (with WS streaming)
 // sessionVersion: bump to force reload after session switch
-function useChatMessages(agentId: string | null, agents: any[] = [], sessionVersion = 0, onModelSwitch?: () => void) {
+function useChatMessages(agentId: string | null, agents: any[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void) {
   const { t } = useTranslation();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   // Per-agent loading state. A single shared `isLoading` would freeze the
@@ -323,13 +323,17 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
       setMessages([]);
       return;
     }
-    await clearAgentHistory(agentId);
-    sessionCache.delete(agentId);
-    if (prevAgentRef.current === agentId) {
-      messagesRef.current = [];
+    try {
+      await clearAgentHistory(agentId);
+      sessionCache.delete(agentId);
+      if (prevAgentRef.current === agentId) {
+        messagesRef.current = [];
+      }
+      setMessages([]);
+    } catch (error) {
+      onClearError?.(error instanceof Error ? error.message : t("common.error"));
     }
-    setMessages([]);
-  }, [agentId]);
+  }, [agentId, onClearError, t]);
 
   // Send message - WS first, HTTP fallback
   const sendMessage = useCallback(async (content: string) => {
@@ -1747,7 +1751,8 @@ export function ChatPage() {
     selectedAgentId || null,
     agents,
     sessionVersion,
-      () => void agentsQuery.refetch(),
+    () => void agentsQuery.refetch(),
+    (message) => addToast(message, "error"),
   );
   // Track LLM text streaming (cleared on `typing:stop`) independently of
   // `isLoading`, which stays true through post-processing until the final
@@ -2019,7 +2024,7 @@ export function ChatPage() {
               agentName={selectedAgent?.name || ""}
               isLoading={isLoading}
               messageCount={messages.length}
-              onClear={clearHistory}
+              onClear={() => { void clearHistory(); }}
               onExport={handleExport}
               wsConnected={wsConnected}
               modelName={selectedAgent?.model_name}


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Fixes stale and misleading state on `/chat` by making clear-history semantics match backend state, keeping config navigation inside SPA routing, and refreshing model-picker data when provider state changes.

## Changes

- route `/clear` and chat clear action through `clearAgentHistory(...)` instead of only wiping local React state
- clear per-agent `sessionCache` together with visible messages so cleared history does not return from cached session data
- surface clear-history failures to users via error toast instead of silently diverging UI state
- replace `window.location.href = "/dashboard/config"` with SPA navigation to `/config`
- switch model picker from one-shot local fetch state to shared `useModels({ available: true })` query state
- invalidate model list queries after provider mutations so chat model picker sees updated availability/config changes
- simplify `useModels(...)` options forwarding and keep `ConnectionBar` clear handler API sync at call site

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries