### PR TITLE
feat(channels): show tool execution progress in channel replies

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -316,13 +316,33 @@ use tracing::{debug, error, info, warn};
 use librefang_runtime::str_utils::safe_truncate_str;
 
 fn start_stream_text_bridge(
-    mut event_rx: mpsc::Receiver<StreamEvent>,
+    event_rx: mpsc::Receiver<StreamEvent>,
     kernel_handle: tokio::task::JoinHandle<
         KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
     >,
     is_group: bool,
 ) -> mpsc::Receiver<String> {
+    let (rx, _status) = start_stream_text_bridge_with_status(event_rx, kernel_handle, is_group);
+    rx
+}
+
+/// Same as `start_stream_text_bridge` but also returns a oneshot that
+/// resolves to the kernel's actual `Result` after the stream has fully
+/// drained. Callers use this to drive proper lifecycle reactions, accurate
+/// `record_delivery` metrics, and `suppress_error_responses` honor for
+/// public-feed adapters.
+fn start_stream_text_bridge_with_status(
+    mut event_rx: mpsc::Receiver<StreamEvent>,
+    kernel_handle: tokio::task::JoinHandle<
+        KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
+    >,
+    is_group: bool,
+) -> (
+    mpsc::Receiver<String>,
+    tokio::sync::oneshot::Receiver<Result<(), String>>,
+) {
     let (tx, rx) = mpsc::channel::<String>(64);
+    let (status_tx, status_rx) = tokio::sync::oneshot::channel();
     let error_tx = tx.clone();
 
     let bridge_handle = tokio::spawn(async move {
@@ -332,6 +352,10 @@ fn start_stream_text_bridge(
         // tool call or content-block array.
         let mut iter_buf = String::new();
         let mut saw_tool_use = false;
+        // Most recent tool name surfaced as a progress line. Used to avoid
+        // emitting back-to-back duplicate "🔧 same_tool" lines when a driver
+        // double-fires ToolUseStart for the same call.
+        let mut last_progress_tool: Option<String> = None;
 
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -357,14 +381,40 @@ fn start_stream_text_bridge(
                     iter_buf.clear();
                     saw_tool_use = false;
                 }
-                StreamEvent::ToolUseStart { .. } => {
+                StreamEvent::ToolUseStart { name, .. } => {
                     saw_tool_use = true;
+                    // Surface tool invocations to the user as a short progress
+                    // line. Streaming adapters (Telegram) edit this into the
+                    // live message; non-streaming adapters fall back to plain
+                    // text and the line just becomes part of the reply.
+                    if !name.is_empty() && last_progress_tool.as_deref() != Some(name.as_str()) {
+                        let line = format!("\n\n🔧 `{name}`\n");
+                        if tx.send(line).await.is_err() {
+                            break;
+                        }
+                        last_progress_tool = Some(name);
+                    }
+                }
+                StreamEvent::ToolExecutionResult { name, is_error, .. } => {
+                    // Only surface failures — successes are followed by the
+                    // model's next prose iteration which is signal enough.
+                    if is_error && !name.is_empty() {
+                        let line = format!("\n⚠️ `{name}` failed\n");
+                        if tx.send(line).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Allow the same tool name to fire a fresh progress line
+                    // on the next ToolUseStart (e.g. retried tool calls).
+                    if last_progress_tool.as_deref() == Some(name.as_str()) {
+                        last_progress_tool = None;
+                    }
                 }
                 StreamEvent::PhaseChange { .. } => {
-                    // PhaseChange events (e.g. "long_running") are NOT injected
-                    // into the text stream — they would persist in the response.
-                    // They flow through the SSE endpoint as `event: phase` and
-                    // each adapter handles them independently.
+                    // PhaseChange events (e.g. "long_running") fire on every
+                    // iteration and are too noisy for inline display. They
+                    // still flow through the SSE endpoint as `event: phase`
+                    // for the dashboard.
                 }
                 _ => {}
             }
@@ -380,18 +430,23 @@ fn start_stream_text_bridge(
     });
 
     tokio::spawn(async move {
-        let error_msg = match kernel_handle.await {
+        let (error_msg, status): (Option<String>, Result<(), String>) = match kernel_handle.await {
             Err(e) => {
                 error!("Streaming kernel task panicked: {e}");
-                Some(
-                    "Sorry, something went wrong on my end. Please try again in a moment."
-                        .to_string(),
+                (
+                    Some(
+                        "Sorry, something went wrong on my end. Please try again in a moment."
+                            .to_string(),
+                    ),
+                    Err(format!("kernel task panicked: {e}")),
                 )
             }
             Ok(Err(e)) => {
                 let err_str = e.to_string();
                 error!("Streaming kernel task returned error: {err_str}");
-                if err_str.contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER) {
+                let user_msg = if err_str
+                    .contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER)
+                {
                     Some(
                         "\n\n---\n[Task timed out. The output above may be incomplete.]"
                             .to_string(),
@@ -419,7 +474,8 @@ fn start_stream_text_bridge(
                     } else {
                         Some(sanitize_channel_error(&err_str))
                     }
-                }
+                };
+                (user_msg, Err(err_str))
             }
             Ok(Ok(result)) => {
                 debug!(
@@ -428,7 +484,7 @@ fn start_stream_text_bridge(
                     iterations = result.iterations,
                     "Streaming kernel task completed"
                 );
-                None
+                (None, Ok(()))
             }
         };
         // Send error notification to the user through the channel before
@@ -443,9 +499,12 @@ fn start_stream_text_bridge(
         if let Err(e) = bridge_handle.await {
             error!("Streaming bridge task panicked: {e}");
         }
+        // Report kernel terminal status to any caller that opted in. Sent
+        // last so awaiters can be sure the text channel has fully drained.
+        let _ = status_tx.send(status);
     });
 
-    rx
+    (rx, status_rx)
 }
 
 /// Wraps `LibreFangKernel` to implement `ChannelBridgeHandle`.
@@ -534,6 +593,30 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .await
             .map_err(|e| format!("{e}"))?;
         Ok(start_stream_text_bridge(
+            event_rx,
+            kernel_handle,
+            sender.is_group,
+        ))
+    }
+
+    async fn send_message_streaming_with_sender_status(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<
+        (
+            mpsc::Receiver<String>,
+            tokio::sync::oneshot::Receiver<Result<(), String>>,
+        ),
+        String,
+    > {
+        let (event_rx, kernel_handle) = self
+            .kernel
+            .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(start_stream_text_bridge_with_status(
             event_rx,
             kernel_handle,
             sender.is_group,
@@ -3307,6 +3390,296 @@ mod tests {
             msg.is_none(),
             "Expected tool call JSON to be filtered, but got: {:?}",
             msg
+        );
+    }
+
+    /// ToolUseStart should surface a short progress line so users see what
+    /// the agent is currently doing inside their channel reply (mirrors the
+    /// behavior of hermes-agent's commentary stream).
+    #[tokio::test]
+    async fn test_stream_bridge_surfaces_tool_use_progress() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "web_search".to_string(),
+            })
+            .await
+            .unwrap();
+        // Tool call syntax echoed as text — should be filtered at ContentComplete.
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "tool_use: web_search".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::ToolUse,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        // Next iteration: actual model prose after the tool result.
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "Found 3 results.".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            combined.contains("🔧") && combined.contains("web_search"),
+            "Expected tool progress line in stream, got: {combined:?}"
+        );
+        assert!(
+            combined.contains("Found 3 results."),
+            "Expected post-tool prose in stream, got: {combined:?}"
+        );
+    }
+
+    /// A failed tool execution should surface a visible warning line so the
+    /// user knows the agent's plan hit a snag.
+    #[tokio::test]
+    async fn test_stream_bridge_surfaces_tool_failure() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "shell_exec".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ToolExecutionResult {
+                name: "shell_exec".to_string(),
+                result_preview: "permission denied".to_string(),
+                is_error: true,
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            combined.contains("⚠️")
+                && combined.contains("shell_exec")
+                && combined.contains("failed"),
+            "Expected failure marker in stream, got: {combined:?}"
+        );
+    }
+
+    /// Successful tool executions should NOT emit a "done" line — the model's
+    /// next prose iteration is signal enough, and adding a line per call gets
+    /// noisy fast for agents that chain many tools.
+    #[tokio::test]
+    async fn test_stream_bridge_quiet_on_tool_success() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolExecutionResult {
+                name: "web_search".to_string(),
+                result_preview: "ok".to_string(),
+                is_error: false,
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            !combined.contains("✓") && !combined.contains("done"),
+            "Expected silence on tool success, got: {combined:?}"
+        );
+    }
+
+    /// Back-to-back duplicate ToolUseStart events for the same tool name
+    /// should produce only one progress line — some drivers double-fire.
+    #[tokio::test]
+    async fn test_stream_bridge_dedupes_consecutive_tool_progress() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        for _ in 0..3 {
+            event_tx
+                .send(StreamEvent::ToolUseStart {
+                    id: "tool_1".to_string(),
+                    name: "web_search".to_string(),
+                })
+                .await
+                .unwrap();
+        }
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        let progress_count = combined.matches("🔧").count();
+        assert_eq!(
+            progress_count, 1,
+            "Expected 1 progress line for repeated same-tool starts, got {progress_count}: {combined:?}"
+        );
+    }
+
+    /// The status oneshot must resolve to Ok(()) when the kernel handle
+    /// completes successfully — this is what bridge.rs uses to decide
+    /// `AgentPhase::Done` vs `AgentPhase::Error` and to populate
+    /// `record_delivery(success=true)`.
+    #[tokio::test]
+    async fn test_stream_bridge_status_success() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "hello".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        // Drain text channel
+        while rx.recv().await.is_some() {}
+
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_ok(),
+            "Expected kernel success status, got {status:?}"
+        );
+    }
+
+    /// The status oneshot must resolve to Err(...) when the agent loop
+    /// returns a KernelError. bridge.rs uses this to honor
+    /// `suppress_error_responses` (so Mastodon won't post sanitized errors
+    /// to a public timeline) and to record `success=false`.
+    #[tokio::test]
+    async fn test_stream_bridge_status_error() {
+        use librefang_kernel::error::KernelError;
+        use librefang_types::error::LibreFangError;
+
+        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async {
+            Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
+                LibreFangError::Internal("rate limit hit".to_string()).into(),
+            )
+        });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+
+        // Drain text channel — will include sanitized error message
+        let mut received = String::new();
+        while let Some(chunk) = rx.recv().await {
+            received.push_str(&chunk);
+        }
+
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_err(),
+            "Expected kernel error status, got {status:?}"
+        );
+        // The original error string should be preserved in the status,
+        // letting record_delivery / journal report what actually happened.
+        assert!(
+            status.as_ref().unwrap_err().contains("rate limit"),
+            "Expected original error in status, got {status:?}"
+        );
+        // The user-facing text should still get a sanitized DM reply.
+        assert!(
+            !received.is_empty(),
+            "Expected user-facing error text, got empty stream"
+        );
+    }
+
+    /// Group conversations should suppress error TEXT (no sanitized prose
+    /// posted to the channel) but the status oneshot must still report Err
+    /// so bridge.rs can record_delivery(success=false) and emit Error
+    /// reaction. Without this distinction, group errors would silently look
+    /// like successful empty replies.
+    #[tokio::test]
+    async fn test_stream_bridge_group_error_suppresses_text_but_reports_err() {
+        use librefang_kernel::error::KernelError;
+        use librefang_types::error::LibreFangError;
+
+        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async {
+            Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
+                LibreFangError::Internal("some internal failure".to_string()).into(),
+            )
+        });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, /* is_group */ true);
+
+        let mut received = String::new();
+        while let Some(chunk) = rx.recv().await {
+            received.push_str(&chunk);
+        }
+
+        assert!(
+            received.is_empty(),
+            "Group conversations must not surface sanitized errors as text, got: {received:?}"
+        );
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_err(),
+            "Group error must still be reported via status oneshot"
         );
     }
 

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -353,6 +353,42 @@ pub trait ChannelBridgeHandle: Send + Sync {
         self.send_message_streaming(agent_id, message).await
     }
 
+    /// Streaming send that *also* reports the kernel's terminal success/error
+    /// once the stream completes. Callers that need accurate delivery metrics,
+    /// lifecycle reactions, and error suppression should use this variant —
+    /// the plain `send_message_streaming_with_sender` collapses everything
+    /// into the text channel, which makes it impossible to distinguish a
+    /// successful reply from a sanitized error message after the fact.
+    ///
+    /// The oneshot resolves to `Ok(())` on success and `Err(error_string)` on
+    /// failure (panic, kernel error, or LLM error). It is sent only once the
+    /// kernel join handle has resolved, so awaiting it after draining the
+    /// text receiver is safe.
+    ///
+    /// Default implementation preserves existing behavior by reporting
+    /// fake-success — implementers that can detect kernel failure (e.g. the
+    /// real `LibreFangKernel` impl) should override this to surface real
+    /// status.
+    async fn send_message_streaming_with_sender_status(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<
+        (
+            mpsc::Receiver<String>,
+            tokio::sync::oneshot::Receiver<Result<(), String>>,
+        ),
+        String,
+    > {
+        let rx = self
+            .send_message_streaming_with_sender(agent_id, message, sender)
+            .await?;
+        let (status_tx, status_rx) = tokio::sync::oneshot::channel();
+        let _ = status_tx.send(Ok(()));
+        Ok((rx, status_rx))
+    }
+
     /// Push a proactive outbound message to a channel recipient.
     ///
     /// Used by the REST API push endpoint (`POST /api/agents/:id/push`) to let
@@ -2893,7 +2929,76 @@ async fn dispatch_message(
         }
     }
 
-    // Non-streaming path: send to agent and relay response (with sender identity).
+    // Non-streaming-adapter path. We route through the kernel's streaming
+    // API (via `_status` variant) so progress events (tool invocations,
+    // errors) get surfaced into the accumulated text — the channel bridge
+    // injects "🔧 tool_name" and "⚠️ tool failed" lines for streaming
+    // consumers, and we want non-streaming adapters (Discord/Slack/Matrix/...)
+    // to show those too. We accumulate deltas and send once via send_response
+    // so output_format and thread_id are still honored.
+    //
+    // The `_status` variant returns a oneshot that resolves to the kernel's
+    // terminal Result. We use it to drive the correct lifecycle reaction
+    // (Done vs Error), accurate `record_delivery` success metric, journal
+    // status, and to honor `suppress_error_responses` on public-feed adapters
+    // (Mastodon) — accumulated text contains a sanitized error string when
+    // the agent loop fails, which we must not leak to a public timeline.
+    //
+    // If the streaming kernel call is unavailable up-front we fall through
+    // to the non-streaming kernel call — preserves the pre-existing
+    // `handle_send_error` retry / re-resolution path.
+    if let Ok((mut delta_rx, status_rx)) = handle
+        .send_message_streaming_with_sender_status(agent_id, &text, &sender_ctx)
+        .await
+    {
+        let mut accumulated = String::new();
+        while let Some(delta) = delta_rx.recv().await {
+            accumulated.push_str(&delta);
+        }
+        // Status is sent after the text channel fully drains, so awaiting
+        // here will not block longer than the stream itself.
+        let kernel_status = status_rx.await.unwrap_or(Ok(()));
+        let success = kernel_status.is_ok();
+        let phase = if success {
+            AgentPhase::Done
+        } else {
+            AgentPhase::Error
+        };
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, phase).await;
+        if !accumulated.is_empty() && (success || !adapter.suppress_error_responses()) {
+            send_response(
+                adapter,
+                &message.sender,
+                accumulated,
+                thread_id,
+                output_format,
+            )
+            .await;
+        }
+        let err_str = kernel_status.as_ref().err().cloned();
+        handle
+            .record_delivery(
+                agent_id,
+                ct_str,
+                &message.sender.platform_id,
+                success,
+                err_str.as_deref(),
+                thread_id,
+            )
+            .await;
+        if let Some(j) = journal {
+            let jstatus = if success {
+                crate::message_journal::JournalStatus::Completed
+            } else {
+                crate::message_journal::JournalStatus::Failed
+            };
+            j.update_status(&message.platform_message_id, jstatus, err_str)
+                .await;
+        }
+        return;
+    }
+
+    // Fallback: streaming kernel call unavailable for this request.
     match handle
         .send_message_with_sender(agent_id, &text, &sender_ctx)
         .await


### PR DESCRIPTION
## Summary
- Surface tool calls (`🔧 web_search`) and failures (`⚠️ tool failed`) in the user's channel reply so they see what the agent is doing instead of waiting silently for the final answer
- Works on **all ~50 channel adapters** with zero per-adapter code changes — the injection happens at the shared bridge layer
- Telegram (the only `supports_streaming=true` adapter) shows progress via in-place message edits as it happens; Discord/Slack/Matrix/QQ/Feishu/etc. show the same content as one consolidated message after the agent completes
- New trait method `send_message_streaming_with_sender_status` exposes the kernel's terminal `Result` to the bridge, fixing four collateral regressions an earlier draft had: wrong `record_delivery` success metric, missing `Error` lifecycle reaction, lost `try_reresolution`, and accidental error leakage on `suppress_error_responses` adapters (Mastodon)

## Behavior
**Before** (Telegram, agent calls 2 tools):
```
(silent 8s)
Based on the search and weather data, Paris is 12°C.
```

**After** (Telegram, edits in place):
```
🔧 web_search
```
→
```
🔧 web_search

🔧 get_weather
```
→
```
🔧 web_search

🔧 get_weather

Based on the search and weather data, Paris is 12°C.
```

Discord/Slack/Matrix/etc.: same content, but delivered as one consolidated message after the agent finishes (still single message, not multiple).

Tool failures surface as `⚠️ \`tool_name\` failed`. Successful tools stay silent — the model's next prose iteration is signal enough, and emitting one line per tool gets noisy fast for agents that chain many calls.

## Design notes
- `start_stream_text_bridge` (api/channel_bridge.rs) is the shared event→text translator for all channels. It now injects formatted progress lines for `ToolUseStart` and failed `ToolExecutionResult`. `PhaseChange` is intentionally not surfaced — fires every iteration, too noisy.
- `last_progress_tool` guard dedupes back-to-back duplicate `ToolUseStart` events some drivers emit.
- A new helper `start_stream_text_bridge_with_status` returns the same text receiver plus a `oneshot::Receiver<Result<(), String>>` carrying the kernel's terminal status.
- `dispatch_message`'s non-streaming-adapter branch now routes through the streaming kernel call (via `_status` variant) so progress events reach those adapters too. Accumulates deltas, sends once via `send_response` so `output_format` and `thread_id` are still honored.
- The status oneshot lets the bridge:
  - Emit `AgentPhase::Done` vs `Error` reaction correctly
  - `record_delivery(success=...)` with the real outcome
  - Journal status `Completed` vs `Failed` with the error string
  - Honor `adapter.suppress_error_responses()` so Mastodon (public-feed) does not leak sanitized agent errors to its timeline

## Trade-offs
- Telegram's `buffered_text` fallback path (used when `send_streaming` HTTP fails mid-stream) was not migrated to the new `_status` variant — same regression class as the non-streaming path had, but Telegram is not in the `suppress_error_responses` opt-in list, so impact is bounded. Future PR.
- No `agent.toml show_progress` config — progress is on for all agents by default. Add later if anyone wants opt-out.

## Test plan
- [x] `cargo build --lib -p librefang-api -p librefang-channels` green
- [x] `cargo clippy --lib -p librefang-api -p librefang-channels -- -D warnings` zero warnings
- [x] `cargo clippy --tests --lib -p librefang-api -- -D warnings` zero warnings
- [x] 18 channel_bridge tests pass (including 4 new progress tests + 3 new status tests)
- [x] 84 channels bridge tests pass (no regression)
- [ ] Live integration test on Telegram (per CLAUDE.md): start daemon, send a real message that triggers tool use, verify progress lines appear in the live-edited Telegram message — **not done in this PR**, requires the user's daemon environment
- [ ] Live integration test on a non-streaming adapter (e.g. Discord) — same caveat