### PR TITLE
fix(web): rewrite /install to /install.sh for CLI clients

### DIFF
--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -36,6 +36,21 @@ function addHeaders(response, url) {
 
 const LOCALES = ['zh-TW', 'zh', 'ja', 'ko', 'de', 'es'];
 
+// Pretty installer URL → actual asset, chosen by client User-Agent so that
+// `curl -fsSL https://librefang.ai/install | sh` and the PowerShell one-liner
+// both work without the file extension. Browsers without a CLI-shaped UA fall
+// through to the SPA so a human pasting /install into the address bar still
+// sees a page instead of a shell script.
+const CLI_INSTALLER_UA = /(curl|wget|fetch|libfetch|httpie)/i;
+const POWERSHELL_INSTALLER_UA = /(powershell|pwsh)/i;
+
+function installerAssetFor(pathname, userAgent) {
+  if (pathname !== '/install') return null;
+  if (POWERSHELL_INSTALLER_UA.test(userAgent)) return '/install.ps1';
+  if (CLI_INSTALLER_UA.test(userAgent)) return '/install.sh';
+  return null;
+}
+
 // Canonicalize URLs: locale roots get a trailing slash ( /zh → /zh/ ), while
 // sub-paths stay un-slashed ( /zh/skills/ → /zh/skills ). Returns the
 // canonical pathname, or null if the request is already canonical.
@@ -67,6 +82,20 @@ export default {
     if (canonical !== null) {
       const target = canonical + url.search + url.hash;
       return Response.redirect(new URL(target, url).toString(), 301);
+    }
+
+    // Rewrite /install → /install.sh or /install.ps1 for CLI clients so the
+    // suffix-less install one-liners work. Must happen before the asset fetch
+    // (which would 404 on /install) and before the SPA fallback (which would
+    // hand the CLI an HTML page, causing `sh: newline unexpected`).
+    const installerAsset = installerAssetFor(
+      url.pathname,
+      request.headers.get('user-agent') || '',
+    );
+    if (installerAsset) {
+      const installerUrl = new URL(installerAsset, request.url);
+      const installerResponse = await env.ASSETS.fetch(new Request(installerUrl, request));
+      return addHeaders(installerResponse, url);
     }
 
     // Try serving static asset first

--- a/web/scripts/worker.test.ts
+++ b/web/scripts/worker.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+// @ts-expect-error — Cloudflare Pages worker, plain .js without types
+import worker from '../public/_worker.js';
+
+type AssetsBinding = { fetch: ReturnType<typeof vi.fn> };
+
+// Cloudflare's ASSETS.fetch accepts Request | URL | string. Mock handles all
+// three so we mirror the real binding contract.
+function assetKey(arg: Request | URL | string): string {
+  if (typeof arg === 'string') return new URL(arg).pathname;
+  if (arg instanceof URL) return arg.pathname;
+  return new URL(arg.url).pathname;
+}
+
+function makeEnv(responses: Record<string, Response>): { ASSETS: AssetsBinding } {
+  const fetchMock = vi.fn(async (arg: Request | URL | string) => {
+    const res = responses[assetKey(arg)];
+    if (res) return res;
+    return new Response('not found', { status: 404 });
+  });
+  return { ASSETS: { fetch: fetchMock } };
+}
+
+function calledPaths(mock: ReturnType<typeof vi.fn>): string[] {
+  return mock.mock.calls.map((c) => assetKey(c[0]));
+}
+
+function req(path: string, userAgent = ''): Request {
+  return new Request(`https://librefang.ai${path}`, {
+    headers: userAgent ? { 'user-agent': userAgent } : {},
+  });
+}
+
+describe('Cloudflare Pages _worker.js — /install UA routing', () => {
+  it('curl gets install.sh content, not HTML', async () => {
+    const env = makeEnv({
+      '/install.sh': new Response('#!/bin/sh\necho ok\n', {
+        status: 200,
+        headers: { 'content-type': 'application/x-sh' },
+      }),
+    });
+
+    const res = await worker.fetch(req('/install', 'curl/8.4.0'), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatch(/^#!\/bin\/sh/);
+    expect(env.ASSETS.fetch).toHaveBeenCalledTimes(1);
+    expect(calledPaths(env.ASSETS.fetch)[0]).toBe('/install.sh');
+  });
+
+  it('wget gets install.sh content', async () => {
+    const env = makeEnv({
+      '/install.sh': new Response('#!/bin/sh\n', { status: 200 }),
+    });
+    const res = await worker.fetch(req('/install', 'Wget/1.21.3'), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatch(/^#!/);
+  });
+
+  it('PowerShell 7 gets install.ps1 content', async () => {
+    const env = makeEnv({
+      '/install.ps1': new Response('# powershell install', { status: 200 }),
+    });
+    const ua =
+      'Mozilla/5.0 (Windows NT; Microsoft Windows 10.0.19045.3448; en-US) PowerShell/7.4.0';
+    const res = await worker.fetch(req('/install', ua), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('# powershell install');
+    expect(calledPaths(env.ASSETS.fetch)[0]).toBe('/install.ps1');
+  });
+
+  it('Windows PowerShell 5.1 gets install.ps1, not install.sh (Mozilla prefix must not fool CLI regex)', async () => {
+    const env = makeEnv({
+      '/install.ps1': new Response('# ps1', { status: 200 }),
+      '/install.sh': new Response('#!/bin/sh', { status: 200 }),
+    });
+    const ua =
+      'Mozilla/5.0 (Windows NT; Microsoft Windows 10.0.19045.3448; en-US) WindowsPowerShell/5.1.19041.3803';
+    await worker.fetch(req('/install', ua), env);
+    expect(calledPaths(env.ASSETS.fetch)[0]).toBe('/install.ps1');
+  });
+
+  it('browser UA falls through to SPA (does NOT get a shell script)', async () => {
+    const env = makeEnv({
+      '/': new Response('<!doctype html><html>spa</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      }),
+    });
+    const ua =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+    const res = await worker.fetch(req('/install', ua), env);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('<!doctype html>');
+    // Confirm we did NOT serve install.sh to a browser.
+    const paths = calledPaths(env.ASSETS.fetch);
+    expect(paths).not.toContain('/install.sh');
+    expect(paths).not.toContain('/install.ps1');
+  });
+
+  it('/install with no user-agent falls through to SPA (no false positive)', async () => {
+    const env = makeEnv({
+      '/': new Response('<!doctype html>', { status: 200 }),
+    });
+    const res = await worker.fetch(req('/install'), env);
+    expect(res.status).toBe(200);
+    expect(calledPaths(env.ASSETS.fetch)).not.toContain('/install.sh');
+  });
+
+  it('/install.sh direct request is unaffected by the rewrite path', async () => {
+    const env = makeEnv({
+      '/install.sh': new Response('#!/bin/sh\n', {
+        status: 200,
+        headers: { 'content-type': 'application/x-sh' },
+      }),
+    });
+    const res = await worker.fetch(req('/install.sh', 'curl/8.4.0'), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatch(/^#!\/bin\/sh/);
+    // Exactly one asset fetch, straight to /install.sh (no rewrite hop).
+    expect(env.ASSETS.fetch).toHaveBeenCalledTimes(1);
+    expect(calledPaths(env.ASSETS.fetch)[0]).toBe('/install.sh');
+  });
+
+  it('unrelated path with curl UA is not misrouted to install.sh', async () => {
+    const env = makeEnv({
+      '/about': new Response('<!doctype html>about', { status: 200 }),
+    });
+    await worker.fetch(req('/about', 'curl/8.4.0'), env);
+    const paths = calledPaths(env.ASSETS.fetch);
+    expect(paths).not.toContain('/install.sh');
+    expect(paths).toContain('/about');
+  });
+});


### PR DESCRIPTION
## Summary
- `curl -fsSL https://librefang.ai/install | sh` broke with `sh: Syntax error: newline unexpected` — the SPA fallback in `web/public/_worker.js` was returning `index.html` for any 404, including `/install` (suffix-less alias for `/install.sh`).
- Route `/install` by User-Agent before the asset fetch: CLI UAs (curl/wget/fetch/httpie) get `/install.sh`, PowerShell UAs get `/install.ps1`, browsers keep falling through to the SPA.
- Add vitest coverage for the routing contract (8 cases, including PowerShell's `Mozilla/5.0` prefix not fooling the CLI regex).

## Regression
Broken since #1824 (`fix(web): replace _redirects with _worker.js for SPA routing`, 2026-03-30). Unnoticed because `scripts/tests/install_sh_test.sh` only exercises the script body in source-only mode — the URL → script path has no coverage anywhere. This PR closes that gap.

## Test plan
- [x] `pnpm test worker.test` — 8/8 pass (curl, wget, PowerShell 7, Windows PowerShell 5.1, browser, no UA, direct `.sh`, unrelated path)
- [ ] After merge + Pages deploy: `curl -fsSL -A 'curl/8' https://librefang.ai/install | head -c 2` returns `#!`, and `curl -sI -A 'curl/8' https://librefang.ai/install` shows `content-type: application/x-sh`.

## Follow-up (not in this PR)
Consider promoting the two curl checks above to a post-deploy smoke step so the next `_worker.js` edit can't silently regress the install URL.