### PR TITLE
fix(install): stop writing PATH into the wrong rc file

### DIFF
--- a/scripts/tests/install_sh_test.sh
+++ b/scripts/tests/install_sh_test.sh
@@ -22,17 +22,52 @@ HOME="$TMP_HOME" LIBREFANG_INSTALLER_SOURCE_ONLY=1 . "$INSTALLER_PATH"
 [ "$(shell_rc_from_shell fish)" = "$TMP_HOME/.config/fish/config.fish" ] || fail "fish rc mapping"
 pass "shell_rc_from_shell mappings"
 
-# choose_shell_rc fallback order: bashrc -> zshrc -> fish
+# choose_shell_rc: $SHELL fallback when detect_user_shell came back empty.
+# Real-world hit: curl|sh pipelines where `ps -p $PPID -o comm=` returns
+# something unexpected and USER_SHELL ends up blank.
 mkdir -p "$TMP_HOME/.config/fish"
 : > "$TMP_HOME/.config/fish/config.fish"
 : > "$TMP_HOME/.zshrc"
 : > "$TMP_HOME/.bashrc"
-[ "$(choose_shell_rc "")" = "$TMP_HOME/.bashrc" ] || fail "fallback should prefer .bashrc"
-rm -f "$TMP_HOME/.bashrc"
-[ "$(choose_shell_rc "")" = "$TMP_HOME/.zshrc" ] || fail "fallback should pick .zshrc when .bashrc missing"
+[ "$(SHELL=/usr/bin/zsh choose_shell_rc "")" = "$TMP_HOME/.zshrc" ] \
+    || fail "empty arg + SHELL=zsh should pick .zshrc"
+[ "$(SHELL=/bin/bash choose_shell_rc "")" = "$TMP_HOME/.bashrc" ] \
+    || fail "empty arg + SHELL=bash should pick .bashrc"
+[ "$(SHELL=/usr/bin/fish choose_shell_rc "")" = "$TMP_HOME/.config/fish/config.fish" ] \
+    || fail "empty arg + SHELL=fish should pick fish config"
+pass "choose_shell_rc uses \$SHELL when detect returned empty"
+
+# File-existence fallback: when both the arg and $SHELL are unusable, prefer
+# .zshrc > .bashrc > fish. Old order (bashrc first) silently wrote PATH into
+# .bashrc for zsh users whose shell detection had failed upstream — zsh then
+# can't see librefang in new shells.
+[ "$(SHELL= choose_shell_rc "")" = "$TMP_HOME/.zshrc" ] \
+    || fail "file fallback should prefer .zshrc over .bashrc"
 rm -f "$TMP_HOME/.zshrc"
-[ "$(choose_shell_rc "")" = "$TMP_HOME/.config/fish/config.fish" ] || fail "fallback should pick fish config last"
-pass "choose_shell_rc fallback order"
+[ "$(SHELL= choose_shell_rc "")" = "$TMP_HOME/.bashrc" ] \
+    || fail "file fallback should pick .bashrc when .zshrc missing"
+rm -f "$TMP_HOME/.bashrc"
+[ "$(SHELL= choose_shell_rc "")" = "$TMP_HOME/.config/fish/config.fish" ] \
+    || fail "file fallback should pick fish config last"
+pass "choose_shell_rc file-existence fallback order"
+
+# The "already installed" check must match the install path, not any line
+# mentioning the word "librefang". Prior `grep -q "librefang"` was too loose:
+# a user named `librefang` (HOME=/home/librefang) caused any .zshrc line
+# containing that path fragment — oh-my-zsh cache vars, plugin paths, a
+# comment — to silently suppress the PATH append, leaving the shell with no
+# way to find the binary.
+: > "$TMP_HOME/.zshrc"
+: > "$TMP_HOME/.bashrc"
+echo 'ZSH_CACHE_DIR="/home/librefang/.cache/oh-my-zsh"' >> "$TMP_HOME/.zshrc"
+echo '# user note: librefang install coming soon' >> "$TMP_HOME/.zshrc"
+grep -qE "\.librefang/bin" "$TMP_HOME/.zshrc" \
+    && fail "rc with only librefang-in-path words should not match \.librefang/bin"
+
+echo 'export PATH="/home/alice/.librefang/bin:$PATH"' >> "$TMP_HOME/.zshrc"
+grep -qE "\.librefang/bin" "$TMP_HOME/.zshrc" \
+    || fail "rc with real librefang/bin PATH export should match"
+pass "already-installed check uses precise \.librefang/bin pattern"
 
 # auto-start flag parser
 for truthy in 1 true TRUE yes YES on ON; do

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -116,11 +116,23 @@ choose_shell_rc() {
         return 0
     fi
 
-    # Check bash/zsh first (more common defaults), fish last.
-    if [ -f "$HOME/.bashrc" ]; then
-        printf "%s\n" "$HOME/.bashrc"
-    elif [ -f "$HOME/.zshrc" ]; then
+    # When detect_user_shell returns empty (rare — curl|sh with unusual ps
+    # output), fall back to $SHELL before guessing by file existence. $SHELL
+    # is set by login and is usually accurate even inside the sh subshell.
+    SHELL_RC=$(shell_rc_from_shell "${SHELL:-}")
+    if [ -n "$SHELL_RC" ]; then
+        printf "%s\n" "$SHELL_RC"
+        return 0
+    fi
+
+    # Last resort: pick by file existence. Prefer .zshrc: bashrc exists on
+    # many distros by default even for zsh users, so bashrc-first would
+    # quietly write PATH into the wrong rc for anyone whose shell detection
+    # failed upstream (then zsh can't see librefang).
+    if [ -f "$HOME/.zshrc" ]; then
         printf "%s\n" "$HOME/.zshrc"
+    elif [ -f "$HOME/.bashrc" ]; then
+        printf "%s\n" "$HOME/.bashrc"
     elif [ -f "$HOME/.config/fish/config.fish" ]; then
         printf "%s\n" "$HOME/.config/fish/config.fish"
     else
@@ -266,13 +278,16 @@ install() {
                     rm -f "$TMP_FISH_RC"
                 fi
 
-                if ! grep -q "librefang" "$SHELL_RC" 2>/dev/null; then
+                # Match the actual install path, not any line mentioning
+                # "librefang" — otherwise usernames, oh-my-zsh plugin paths,
+                # or comments containing the word silently skip the append.
+                if ! grep -qE "\.librefang/bin" "$SHELL_RC" 2>/dev/null; then
                     echo "fish_add_path \"$INSTALL_DIR\"" >> "$SHELL_RC"
                     echo "  Added $INSTALL_DIR to PATH in $SHELL_RC"
                 fi
                 ;;
             *)
-                if ! grep -q "librefang" "$SHELL_RC" 2>/dev/null; then
+                if ! grep -qE "\.librefang/bin" "$SHELL_RC" 2>/dev/null; then
                     echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$SHELL_RC"
                     echo "  Added $INSTALL_DIR to PATH in $SHELL_RC"
                 fi


### PR DESCRIPTION
## Summary
After `curl -fsSL https://librefang.ai/install | sh` a zsh user could end up with `librefang: command not found` in new shells, with the rc looking untouched. Two separate bugs both routed the PATH export away from `.zshrc`.

### Bug 1 — fallback prefers `.bashrc` over `.zshrc`
`choose_shell_rc` goes through `detect_user_shell` → `$SHELL` wasn't consulted → file-existence fallback with **bashrc first**. Most distros create `~/.bashrc` by default even for zsh users, so anyone whose shell detection failed upstream (non-obvious `ps -p $PPID -o comm=` output in `curl|sh` pipelines) got PATH written into `.bashrc`. zsh never reads it.

Fix: consult `$SHELL` via `shell_rc_from_shell` before the file check, and flip the file-existence order to `.zshrc > .bashrc > fish`. `$SHELL` is login-set and survives the `sh` subshell.

### Bug 2 — `grep -q "librefang"` too permissive
The "already installed" guard skipped the PATH append whenever **any** line in the rc contained the word `librefang`. A user literally named `librefang` (`HOME=/home/librefang`) has oh-my-zsh cache vars, plugin paths, or comments that trip this, leaving no PATH entry anywhere.

Fix: match the actual install path fragment `\.librefang/bin`.

## Test plan
- [x] `sh scripts/tests/install_sh_test.sh` — all pass, including:
  - `$SHELL` fallback for zsh / bash / fish
  - file-existence fallback prefers `.zshrc`
  - precise pattern does **not** match `/home/librefang/.cache/...` or `# librefang` comments, **does** match `export PATH=".../.librefang/bin:..."`
- [ ] Post-merge: `curl -fsSL https://librefang.ai/install | sh` on a fresh zsh user and confirm `.zshrc` gets the `export PATH=...` line (stdout shows `Added /home/.../.librefang/bin to PATH in /home/.../.zshrc`).

## Not fixing here
The deeper question — *should an installer mutate rc files at all vs. asking the user* — is out of scope. This PR only makes the existing "write to rc" behavior correct for zsh users.