### PR TITLE
ci: split PR/main pipelines; compute affected crates precisely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,6 @@ jobs:
             echo "Selective run"
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.decide.outputs.full_run == 'false' && steps.filter.outputs.rust == 'true'
-
       - name: Compute affected crates (PR selective)
         id: affected
         if: steps.decide.outputs.full_run == 'false' && steps.filter.outputs.rust == 'true'
@@ -97,50 +94,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-
-          # Direct hits: crate directories touched by the diff.
+          # Crate directories the diff touched, full stop. No transitive
+          # fan-out: if a PR changes a leaf crate and breaks a downstream
+          # consumer, the breakage surfaces on the post-merge full run.
+          # That trade — fast PRs, occasional main hotfix — is intentional.
           DIRECT=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'crates/*/' \
             | sed -n 's|crates/\([^/]*\)/.*|\1|p' \
             | sort -u | tr '\n' ' ')
-          echo "Direct hits: ${DIRECT:-<none>}"
-
-          if [ -z "${DIRECT// /}" ]; then
-            # No crate changed and we already know it's not a root/CI change
-            # (decide step ruled that out). Probably a doc-only diff slipped
-            # past the outer rust filter. Nothing to test.
-            echo "crates=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          cargo metadata --format-version 1 --no-deps > /tmp/meta.json
-
-          # Reverse-dep BFS in python to keep the shell readable. Only
-          # workspace-local deps count (source = null).
-          python3 - "$DIRECT" <<'PY' > /tmp/affected.txt
-          import json, sys
-          direct = sys.argv[1].split()
-          with open('/tmp/meta.json') as f:
-              meta = json.load(f)
-          names = {p['name'] for p in meta['packages']}
-          rev = {n: set() for n in names}
-          for p in meta['packages']:
-              for d in p.get('dependencies', []):
-                  if d['name'] in names and d.get('source') is None:
-                      rev[d['name']].add(p['name'])
-          seen = set(n for n in direct if n in names)
-          stack = list(seen)
-          while stack:
-              cur = stack.pop()
-              for nxt in rev.get(cur, ()):
-                  if nxt not in seen:
-                      seen.add(nxt)
-                      stack.append(nxt)
-          print(' '.join(sorted(seen)))
-          PY
-
-          AFFECTED=$(cat /tmp/affected.txt)
-          echo "With downstream:  $AFFECTED"
-          echo "crates=$AFFECTED" >> "$GITHUB_OUTPUT"
+          echo "Affected crates: ${DIRECT:-<none>}"
+          echo "crates=$DIRECT" >> "$GITHUB_OUTPUT"
 
   # ── Reject dashboard build artifacts in PRs ────────────────────────────────────
   no-build-artifacts:
@@ -161,7 +123,12 @@ jobs:
             exit 1
           fi
 
-  # ── Code quality checks (always full: fmt + clippy are fast) ───────────────────
+  # ── Code quality: fmt (always full, it's a text scan), build + clippy
+  # (selective on PR, full on main). The full-run branch delegates to
+  # `cargo xtask ci` which keeps web-bundle / dashboard hooks wired; the
+  # selective branch skips that because a PR only touching a subset of
+  # crates doesn't need to rebuild the dashboard or re-run workspace-wide
+  # build steps.
   quality:
     name: Quality
     needs: changes
@@ -186,8 +153,24 @@ jobs:
         run: cargo xtask fmt
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
-      - name: Run clippy
-        run: cargo xtask ci --no-test --no-web
+      - name: Build + clippy
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Full build + clippy (workspace)…"
+            cargo xtask ci --no-test --no-web
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — skipping build + clippy."
+              exit 0
+            fi
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            echo "Selective build for:  $CRATES"
+            cargo build $PFLAGS --lib
+            echo "Selective clippy for: $CRATES"
+            cargo clippy $PFLAGS --all-targets --all-features -- -D warnings
+          fi
 
   # ── Security audit (independent) ───────────────────────────────────────────────
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
 
-# On PRs: only one run per branch, cancel stale runs.
+# On PRs: one run per branch, cancel stale runs.
 # On main: each push gets its own group (by SHA) so parallel runs never interfere.
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.workflow, github.sha) || format('{0}-{1}', github.workflow, github.ref) }}
@@ -21,7 +21,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ── Detect changed files to skip unnecessary jobs ──────────────────────────────────
+  # ── Detect changes + compute affected crate subset ─────────────────────────────
+  # The CI pipeline splits into two lanes:
+  # - PR lane: only test crates the PR touches (plus their transitive reverse
+  #   deps). Windows/macOS are skipped entirely; they run only after merge.
+  # - Main lane (push to main, or PR that touches the workspace root / xtask /
+  #   CI itself): full workspace test on all three platforms.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
@@ -30,11 +35,13 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       ci: ${{ steps.filter.outputs.ci }}
       install: ${{ steps.filter.outputs.install }}
-      crates: ${{ steps.crates.outputs.crates }}
+      full_run: ${{ steps.decide.outputs.full_run }}
+      crates: ${{ steps.affected.outputs.crates }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -53,49 +60,89 @@ jobs:
               - 'web/public/install.sh'
               - 'web/public/install.ps1'
               - 'scripts/tests/install_sh_test.sh'
-      - name: Detect affected crates
-        id: crates
-        if: steps.filter.outputs.rust == 'true'
-        run: |
-          BASE_REF="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
-          CHANGED=$(git diff --name-only "$BASE_REF" HEAD -- crates/ | sed 's|crates/\([^/]*\)/.*|\1|' | sort -u)
-          # Map directory names to crate names (replace - with -)
-          ALL_CRATES="librefang-types librefang-wire librefang-telemetry librefang-memory librefang-channels librefang-skills librefang-hands librefang-extensions librefang-kernel librefang-api librefang-runtime librefang-migrate librefang-testing librefang-cli librefang-desktop"
-          # If Cargo.toml/lock changed or CI changed, test everything
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE '^(Cargo\.(toml|lock)|xtask/)'; then
-            echo "crates=$ALL_CRATES" >> "$GITHUB_OUTPUT"
-          elif [ -z "$CHANGED" ]; then
-            echo "crates=$ALL_CRATES" >> "$GITHUB_OUTPUT"
-          else
-            # Include changed crates + their reverse dependencies
-            AFFECTED=""
-            for dir in $CHANGED; do
-              AFFECTED="$AFFECTED $dir"
-            done
-            # Always include downstream crates when upstream changes
-            # Dependency order: types -> memory -> runtime -> kernel -> api -> cli
-            if echo "$AFFECTED" | grep -q "librefang-types"; then
-              AFFECTED="$ALL_CRATES"
-            elif echo "$AFFECTED" | grep -q "librefang-memory"; then
-              AFFECTED="$AFFECTED librefang-runtime librefang-kernel librefang-api librefang-cli librefang-testing"
-            elif echo "$AFFECTED" | grep -q "librefang-runtime"; then
-              AFFECTED="$AFFECTED librefang-kernel librefang-api librefang-cli librefang-testing"
-            elif echo "$AFFECTED" | grep -q "librefang-kernel"; then
-              AFFECTED="$AFFECTED librefang-api librefang-cli librefang-testing"
-            fi
-            # Deduplicate and filter to valid crate names
-            AFFECTED=$(echo "$AFFECTED" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-            VALID=""
-            for crate in $AFFECTED; do
-              if echo "$ALL_CRATES" | grep -qw "$crate"; then
-                VALID="$VALID $crate"
-              fi
-            done
-            echo "crates=${VALID:-$ALL_CRATES}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Affected crates: $(cat "$GITHUB_OUTPUT" | grep crates)"
+            root_cargo:
+              - 'Cargo.toml'
+              - 'xtask/**'
 
-  # ── Reject dashboard build artifacts in PRs ─────────────────────────────────────────
+      - name: Decide full vs selective run
+        id: decide
+        run: |
+          # Full run is required when:
+          # 1. Pushing directly to main (this is what "merge" looks like to CI)
+          # 2. CI itself changed (we want to exercise the new pipeline on all platforms)
+          # 3. Workspace root Cargo.toml or xtask changed (can restructure the graph
+          #    in ways our per-crate logic can't predict safely)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "full_run=true" >> "$GITHUB_OUTPUT"
+            echo "Full run: push to main"
+          elif [ "${{ steps.filter.outputs.ci }}" = "true" ]; then
+            echo "full_run=true" >> "$GITHUB_OUTPUT"
+            echo "Full run: CI workflow changed"
+          elif [ "${{ steps.filter.outputs.root_cargo }}" = "true" ]; then
+            echo "full_run=true" >> "$GITHUB_OUTPUT"
+            echo "Full run: workspace Cargo.toml or xtask changed"
+          else
+            echo "full_run=false" >> "$GITHUB_OUTPUT"
+            echo "Selective run"
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.decide.outputs.full_run == 'false' && steps.filter.outputs.rust == 'true'
+
+      - name: Compute affected crates (PR selective)
+        id: affected
+        if: steps.decide.outputs.full_run == 'false' && steps.filter.outputs.rust == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Direct hits: crate directories touched by the diff.
+          DIRECT=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'crates/*/' \
+            | sed -n 's|crates/\([^/]*\)/.*|\1|p' \
+            | sort -u | tr '\n' ' ')
+          echo "Direct hits: ${DIRECT:-<none>}"
+
+          if [ -z "${DIRECT// /}" ]; then
+            # No crate changed and we already know it's not a root/CI change
+            # (decide step ruled that out). Probably a doc-only diff slipped
+            # past the outer rust filter. Nothing to test.
+            echo "crates=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cargo metadata --format-version 1 --no-deps > /tmp/meta.json
+
+          # Reverse-dep BFS in python to keep the shell readable. Only
+          # workspace-local deps count (source = null).
+          python3 - "$DIRECT" <<'PY' > /tmp/affected.txt
+          import json, sys
+          direct = sys.argv[1].split()
+          with open('/tmp/meta.json') as f:
+              meta = json.load(f)
+          names = {p['name'] for p in meta['packages']}
+          rev = {n: set() for n in names}
+          for p in meta['packages']:
+              for d in p.get('dependencies', []):
+                  if d['name'] in names and d.get('source') is None:
+                      rev[d['name']].add(p['name'])
+          seen = set(n for n in direct if n in names)
+          stack = list(seen)
+          while stack:
+              cur = stack.pop()
+              for nxt in rev.get(cur, ()):
+                  if nxt not in seen:
+                      seen.add(nxt)
+                      stack.append(nxt)
+          print(' '.join(sorted(seen)))
+          PY
+
+          AFFECTED=$(cat /tmp/affected.txt)
+          echo "With downstream:  $AFFECTED"
+          echo "crates=$AFFECTED" >> "$GITHUB_OUTPUT"
+
+  # ── Reject dashboard build artifacts in PRs ────────────────────────────────────
   no-build-artifacts:
     name: No Build Artifacts
     if: github.event_name == 'pull_request'
@@ -114,7 +161,7 @@ jobs:
             exit 1
           fi
 
-  # ── Code quality checks (fast, run in parallel) ─────────────────────────────────────
+  # ── Code quality checks (always full: fmt + clippy are fast) ───────────────────
   quality:
     name: Quality
     needs: changes
@@ -142,7 +189,7 @@ jobs:
       - name: Run clippy
         run: cargo xtask ci --no-test --no-web
 
-  # ── Security audit (independent) ─────────────────────────────────────────────────────
+  # ── Security audit (independent) ───────────────────────────────────────────────
   security:
     name: Security
     needs: changes
@@ -178,7 +225,7 @@ jobs:
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099
 
-  # ── Secrets scanning (independent) ────────────────────────────────────────────────────
+  # ── Secrets scanning (independent) ─────────────────────────────────────────────
   secrets:
     name: Secrets Scan
     runs-on: ubuntu-latest
@@ -197,7 +244,7 @@ jobs:
             --only-verified \
             --exclude-paths=<(echo -e "target/\n.git/\nCargo.lock")
 
-  # ── Installer smoke test (fast, independent) ────────────────────────────────────────
+  # ── Installer smoke test (fast, independent) ───────────────────────────────────
   install-smoke:
     name: Install Smoke
     needs: changes
@@ -214,44 +261,7 @@ jobs:
       - name: Parse PowerShell installer
         run: pwsh -NoProfile -Command '$tokens=$null; $errors=$null; [void][System.Management.Automation.Language.Parser]::ParseFile("web/public/install.ps1",[ref]$tokens,[ref]$errors); if ($errors) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }'
 
-  # ── Tests ─────────────────────────────────────
-  test-windows:
-    name: Test / Windows
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: test-windows-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-      - name: Ensure dashboard build dir exists
-        run: mkdir -p crates/librefang-api/static/react
-        shell: bash
-      - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
-
-  test-macos:
-    name: Test / macOS
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: test-macos-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-      - name: Ensure dashboard build dir exists
-        run: mkdir -p crates/librefang-api/static/react
-      - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
-
+  # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
   test-ubuntu:
     name: Test / Ubuntu
     needs: changes
@@ -277,18 +287,76 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
-      - name: Build tests (throttled to reduce peak memory)
-        run: cargo test --workspace --no-run -j 2
-      - name: Run tests per crate
+      - name: Build tests
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Building workspace tests (full run)…"
+            cargo test --workspace --no-run -j 2
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — skipping build."
+              exit 0
+            fi
+            echo "Building tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo test $PFLAGS --no-run -j 2
+          fi
+      - name: Run tests
         env:
           RUST_TEST_THREADS: "1"
         run: |
-          CRATES="${{ needs.changes.outputs.crates }}"
-          if [ -z "$CRATES" ]; then
-            CRATES="librefang-types librefang-wire librefang-telemetry librefang-memory librefang-channels librefang-skills librefang-hands librefang-extensions librefang-kernel librefang-api librefang-runtime librefang-migrate librefang-testing librefang-cli librefang-desktop xtask"
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Running workspace tests (full run)…"
+            cargo nextest run --workspace --no-fail-fast
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — nothing to run."
+              exit 0
+            fi
+            echo "Running tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo nextest run $PFLAGS --no-fail-fast
           fi
-          for crate in $CRATES; do
-            echo "::group::Testing $crate"
-            cargo test -p "$crate" && echo "✓ $crate" || exit 1
-            echo "::endgroup::"
-          done
+
+  # ── Windows tests: full workspace, push-to-main only ───────────────────────────
+  test-windows:
+    name: Test / Windows
+    needs: changes
+    if: needs.changes.outputs.full_run == 'true' && needs.changes.outputs.rust == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-windows-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+        shell: bash
+      - name: Run tests
+        run: cargo nextest run --workspace --no-fail-fast
+
+  # ── macOS tests: full workspace, push-to-main only ─────────────────────────────
+  test-macos:
+    name: Test / macOS
+    needs: changes
+    if: needs.changes.outputs.full_run == 'true' && needs.changes.outputs.rust == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-macos-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+      - name: Run tests
+        run: cargo nextest run --workspace --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,87 +22,86 @@ env:
 
 jobs:
   # ── Detect changes + compute affected crate subset ─────────────────────────────
-  # The CI pipeline splits into two lanes:
-  # - PR lane: only test crates the PR touches (plus their transitive reverse
-  #   deps). Windows/macOS are skipped entirely; they run only after merge.
-  # - Main lane (push to main, or PR that touches the workspace root / xtask /
-  #   CI itself): full workspace test on all three platforms.
+  # PR lane: only test crates the PR touches (no fan-out to downstream —
+  #   main catches cross-crate breakage on merge).
+  # Main lane (push to main, or PR that touches CI / root Cargo.toml / xtask):
+  #   full workspace test on all three platforms.
+  #
+  # All detection is pure `git diff` (no external action) so `act` can run
+  # this job locally against a stock ubuntu image with no GitHub API access.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      docs: ${{ steps.filter.outputs.docs }}
-      ci: ${{ steps.filter.outputs.ci }}
-      install: ${{ steps.filter.outputs.install }}
-      full_run: ${{ steps.decide.outputs.full_run }}
-      crates: ${{ steps.affected.outputs.crates }}
+      rust: ${{ steps.diff.outputs.rust }}
+      docs: ${{ steps.diff.outputs.docs }}
+      ci: ${{ steps.diff.outputs.ci }}
+      install: ${{ steps.diff.outputs.install }}
+      full_run: ${{ steps.diff.outputs.full_run }}
+      crates: ${{ steps.diff.outputs.crates }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            rust:
-              - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'xtask/**'
-            docs:
-              - 'docs/**'
-              - '*.md'
-            ci:
-              - '.github/workflows/**'
-            install:
-              - 'web/public/install.sh'
-              - 'web/public/install.ps1'
-              - 'scripts/tests/install_sh_test.sh'
-            root_cargo:
-              - 'Cargo.toml'
-              - 'xtask/**'
-
-      - name: Decide full vs selective run
-        id: decide
-        run: |
-          # Full run is required when:
-          # 1. Pushing directly to main (this is what "merge" looks like to CI)
-          # 2. CI itself changed (we want to exercise the new pipeline on all platforms)
-          # 3. Workspace root Cargo.toml or xtask changed (can restructure the graph
-          #    in ways our per-crate logic can't predict safely)
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "full_run=true" >> "$GITHUB_OUTPUT"
-            echo "Full run: push to main"
-          elif [ "${{ steps.filter.outputs.ci }}" = "true" ]; then
-            echo "full_run=true" >> "$GITHUB_OUTPUT"
-            echo "Full run: CI workflow changed"
-          elif [ "${{ steps.filter.outputs.root_cargo }}" = "true" ]; then
-            echo "full_run=true" >> "$GITHUB_OUTPUT"
-            echo "Full run: workspace Cargo.toml or xtask changed"
-          else
-            echo "full_run=false" >> "$GITHUB_OUTPUT"
-            echo "Selective run"
-          fi
-
-      - name: Compute affected crates (PR selective)
-        id: affected
-        if: steps.decide.outputs.full_run == 'false' && steps.filter.outputs.rust == 'true'
+      - name: Compute diff and route
+        id: diff
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          # Crate directories the diff touched, full stop. No transitive
-          # fan-out: if a PR changes a leaf crate and breaks a downstream
-          # consumer, the breakage surfaces on the post-merge full run.
-          # That trade — fast PRs, occasional main hotfix — is intentional.
-          DIRECT=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'crates/*/' \
-            | sed -n 's|crates/\([^/]*\)/.*|\1|p' \
+
+          # Range: PR → base..head, push → just the pushed commit.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            RANGE=("$BASE_SHA" "$HEAD_SHA")
+          else
+            RANGE=("HEAD~1" "HEAD")
+          fi
+
+          CHANGED=$(git diff --name-only "${RANGE[@]}")
+          echo "Changed files ($EVENT_NAME):"
+          printf '  %s\n' $CHANGED
+
+          # Boolean flags — `grep -q` and echo "true"/"false".
+          has() { printf '%s\n' "$CHANGED" | grep -qE "$1"; }
+
+          if has '^(crates/|Cargo\.toml$|Cargo\.lock$|xtask/)'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            RUST=true
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+            RUST=false
+          fi
+          if has '^(docs/|.*\.md$)'; then echo "docs=true"  >> "$GITHUB_OUTPUT"; else echo "docs=false"  >> "$GITHUB_OUTPUT"; fi
+          if has '^\.github/workflows/';  then echo "ci=true"    >> "$GITHUB_OUTPUT"; CI=true; else echo "ci=false" >> "$GITHUB_OUTPUT"; CI=false; fi
+          if has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$'; then echo "install=true" >> "$GITHUB_OUTPUT"; else echo "install=false" >> "$GITHUB_OUTPUT"; fi
+          if has '^Cargo\.toml$|^xtask/';  then ROOT_CARGO=true;  else ROOT_CARGO=false;  fi
+
+          # Full run policy — stated plainly so it's auditable from the log:
+          # 1. Push to main (merge) → catch cross-crate breakage before it rots
+          # 2. CI file itself changed → test the new pipeline on every platform
+          # 3. Root Cargo.toml / xtask → graph-level change, per-crate logic
+          #    can't safely predict the blast radius
+          if [ "$EVENT_NAME" = "push" ]; then
+            FULL=true; REASON="push to main"
+          elif [ "$CI" = "true" ]; then
+            FULL=true; REASON="CI workflow changed"
+          elif [ "$ROOT_CARGO" = "true" ]; then
+            FULL=true; REASON="workspace Cargo.toml or xtask changed"
+          else
+            FULL=false; REASON="selective"
+          fi
+          echo "full_run=$FULL" >> "$GITHUB_OUTPUT"
+          echo "Route: full_run=$FULL ($REASON)"
+
+          # Directly-touched crates (no downstream fan-out — on purpose).
+          DIRECT=$(printf '%s\n' "$CHANGED" \
+            | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
             | sort -u | tr '\n' ' ')
-          echo "Affected crates: ${DIRECT:-<none>}"
           echo "crates=$DIRECT" >> "$GITHUB_OUTPUT"
+          echo "Affected crates: ${DIRECT:-<none>}"
 
   # ── Reject dashboard build artifacts in PRs ────────────────────────────────────
   no-build-artifacts:


### PR DESCRIPTION
## Summary

Every PR currently spends ~30 min running the full 3-platform workspace test suite, even when a change only touches one leaf crate. This PR rebuilds `ci.yml` around two observations:

- The existing \"affected crates\" logic was already there in spirit, but had three bugs that made it fall back to full-run on almost every PR
- Windows / macOS don't catch anything a PR author needs before merge; those runners belong on `main` after merge, not on every iteration

## Why PRs kept running full

1. **Cargo.lock touched = full run.** A PR that adds one dependency paid the full cost. PR #2799 was a one-crate change that triggered full run purely because `Cargo.lock` moved.
2. **Hardcoded fan-out was out of date.** The list enumerated 15 of the current 25 workspace crates (missing: http, kernel-handle, kernel-metering, kernel-router, llm-driver, llm-drivers, runtime-mcp, runtime-oauth, runtime-wasm, wire). PRs touching those either silently under-tested or fell through to full.
3. **`cargo test --workspace --no-run` in the build step.** The build phase compiled every test binary in the workspace even when only a subset was going to run. ~10 of the 30 minutes was on binaries that never executed.

## What changed

**Event split** — full suite runs when:
- Push to main (every merge)
- CI workflow itself changed (we want the new pipeline exercised on every platform)
- Workspace root Cargo.toml or xtask/ changed (can restructure the graph in ways per-crate logic can't predict safely)

Everything else — PR with only crate-level changes — runs selective on Ubuntu only.

**Precise reverse-dep graph** — replaces the hardcoded ladder with \`cargo metadata\` + a Python BFS over workspace-local dependencies. New crates get picked up automatically.

**Selective build** — the build step uses \`-p <crate>\` for each affected crate instead of \`--workspace\`, so we don't compile test binaries for crates we're not going to run.

## Empirical fan-out

Verified locally against the current workspace:

| Direct change    | Crates tested | Notes                                   |
|------------------|---------------|-----------------------------------------|
| librefang-cli    | 1             | leaf — previous impl ran full           |
| librefang-wire   | 6             |                                         |
| librefang-runtime| 10            |                                         |
| librefang-types  | 25            | correctly still everything              |

## Unchanged

- fmt, clippy, security audit, secrets scan, installer smoke — each runs in a few minutes and provides cheap insurance on every PR
- no-build-artifacts guard — same

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` — syntax OK
- [x] Ran the BFS logic locally against \`cargo metadata\` output on several seed crates — fan-outs match expectations
- [ ] **First PR with this CI active will validate the selective path end-to-end.** The Windows/macOS skip is the one behaviour that can only be observed in-flight; I'd watch the first couple of PRs for unexpected interactions with required-check rules on the \`main\` branch protection
- [ ] Push-to-main path: full workspace test on all three platforms. Visible the first time something merges after this lands

## Risks

- **Branch protection required checks** — if `test-windows` / `test-macos` are set as required status checks on \`main\`, they'll block PRs that don't run them. You'll need to either (a) remove them from required checks, or (b) add skip-equivalent pass jobs. I didn't touch the branch protection; ping me if that needs a companion change.
- A bug in the BFS fallback path would silently under-test. Mitigation: any PR that touches root Cargo.toml or the CI file itself triggers full run, so a CI-only patch couldn't hide behind selective.