### PR TITLE
fix(api): bypass auth for loopback connections

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -312,12 +312,13 @@ pub async fn auth(
     } else {
         after_version.strip_suffix('/').unwrap_or(&after_version)
     };
-    if path == "/api/shutdown" {
+    // Loopback requests (CLI on the same machine) bypass auth entirely.
+    {
         let is_loopback = request
             .extensions()
             .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
             .map(|ci| ci.0.ip().is_loopback())
-            .unwrap_or(false); // SECURITY: default-deny — unknown origin is NOT loopback
+            .unwrap_or(false);
         if is_loopback {
             return next.run(request).await;
         }


### PR DESCRIPTION
## Summary

- CLI running on the same machine as the daemon should never require a bearer token
- Loopback requests (127.0.0.1 / ::1) now skip all auth checks in the middleware
- Extends the existing loopback bypass that was already in place for `/api/shutdown` to cover all endpoints

## Test plan

- [ ] Start daemon with `api_key` or dashboard credentials configured
- [ ] Run `librefang hand list` — should return results without needing any token
- [ ] Remote requests (non-loopback) should still require auth as before