### PR TITLE
fix(dashboard/agents): drop stray </div> from #2800 modal refactor

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1126,7 +1126,6 @@ export function AgentsPage() {
                 </Button>
               </div>
             </div>
-          </div>
         </Modal>
         );
       })()}


### PR DESCRIPTION
Hot-fix for the broken main build (Dashboard Build run 24653833129).

## Root cause
The detail-modal refactor in #2800 replaced \`<div backdrop><div dialog>\` with \`<Modal>\` but left **one** extra closing \`</div>\` at the bottom of the modal body. Inside \`<Modal>\` the only opens are the header (line 729, closed 809) and the body wrapper (line 810). The third \`</div>\` at line 1129 had no matching open — vite/esbuild's strict JSX parser caught it on CI.

\`\`\`
Unexpected closing \"div\" tag does not match opening \"Modal\" tag
/…/AgentsPage.tsx:1129:12
\`\`\`

## Why local \`npm run build\` missed it
My local \`node_modules\` had an older esbuild that was lenient about the imbalance. CI uses \`pnpm install\` which pulled the strict current version. Verified the fix with \`pnpm run build\` locally — green.

## Fix
Remove the extra \`</div>\` at line 1129. Net change: -1 line.

## Test plan
- [x] \`pnpm run build\` green locally
- [ ] CI Dashboard Build passes