### PR TITLE
fix(config): surface reload error to dashboard instead of opaque 'saved but reload failed'

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1706,8 +1706,14 @@ export async function getConfigSchema(): Promise<{ sections: Record<string, Conf
   return get<{ sections: Record<string, ConfigSectionSchema> }>("/api/config/schema");
 }
 
-export async function setConfigValue(path: string, value: unknown): Promise<{ status: string; restart_required?: boolean }> {
-  return post<{ status: string; restart_required?: boolean }>("/api/config/set", { path, value });
+export async function setConfigValue(
+  path: string,
+  value: unknown,
+): Promise<{ status: string; restart_required?: boolean; reload_error?: string }> {
+  return post<{ status: string; restart_required?: boolean; reload_error?: string }>(
+    "/api/config/set",
+    { path, value },
+  );
 }
 
 export async function listBackups(): Promise<{ backups?: BackupItem[]; total?: number }> {

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -409,12 +409,22 @@ export function ConfigPage({ category }: { category: string }) {
         const data = await setConfigValue(path, value);
         const reloadFailed = data.status === "saved_reload_failed";
         const restartRequired = data.status === "applied_partial" || data.restart_required;
+        // When reload fails, prefer the kernel's specific error message
+        // (e.g. "Validation failed: network_enabled is true but
+        // shared_secret is empty") over the generic
+        // "Saved but reload failed" — without the cause the user can't
+        // tell apart "transient kernel hiccup" from "permanently
+        // invalid config that breaks the next restart too".
+        const reloadErr = reloadFailed && data.reload_error ? data.reload_error : null;
         const msg = reloadFailed
-          ? t("config.saved_reload_failed", "Saved but reload failed")
+          ? reloadErr
+            ? `${t("config.saved_reload_failed", "Saved but reload failed")}: ${reloadErr}`
+            : t("config.saved_reload_failed", "Saved but reload failed")
           : restartRequired
             ? t("config.saved_restart", "Saved (restart required)")
             : t("common.saved", "Saved");
         setSaveStatus((s) => ({ ...s, [path]: { ok: !reloadFailed, msg } }));
+        if (reloadFailed) errors++;
       } catch (err: any) {
         setSaveStatus((s) => ({ ...s, [path]: { ok: false, msg: err.message || t("config.save_failed") } }));
         errors++;

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1972,16 +1972,30 @@ pub async fn config_set(
     }
 
     // Trigger reload
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
+    let (reload_status, reload_error): (&'static str, Option<String>) =
+        match state.kernel.reload_config().await {
+            Ok(plan) => {
+                let s = if plan.restart_required {
+                    "applied_partial"
+                } else {
+                    "applied"
+                };
+                (s, None)
             }
-        }
-        Err(_) => "saved_reload_failed",
-    };
+            Err(e) => {
+                // Surface the actual reload failure reason so the dashboard
+                // can show users what's wrong (e.g. "validation failed:
+                // network_enabled is true but shared_secret is empty"
+                // instead of an opaque "saved but reload failed"). The TOML
+                // file has already been written at this point, so leaving
+                // the user without a reason is doubly bad — they can't
+                // distinguish "transient kernel hiccup, restart will pick
+                // it up" from "permanently invalid config that breaks
+                // restart too".
+                tracing::warn!(error = %e, %path, "config reload failed after write");
+                ("saved_reload_failed", Some(e))
+            }
+        };
 
     state.kernel.audit().record(
         "system",
@@ -1990,10 +2004,11 @@ pub async fn config_set(
         "completed",
     );
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": reload_status, "path": path})),
-    )
+    let mut body = serde_json::json!({"status": reload_status, "path": path});
+    if let Some(err) = reload_error {
+        body["reload_error"] = serde_json::Value::String(err);
+    }
+    (StatusCode::OK, Json(body))
 }
 
 /// Convert a serde_json::Value to a toml_edit::Value (format-preserving).


### PR DESCRIPTION
## Symptom
Saving any value in the dashboard's Config page shows the toast **\"Saved but reload failed\"** with no further detail.

## Root cause
\`POST /api/config/set\` (\`crates/librefang-api/src/routes/config.rs\`) writes the new TOML successfully and then triggers a hot reload via \`kernel.reload_config()\`. When the reload returns \`Err(e)\`, the route was throwing away \`e\` with \`Err(_) => \"saved_reload_failed\"\`, so the dashboard only saw the generic status string.

The TOML file is **already on disk** at this point. Without the cause, the user can't tell apart:
- a transient kernel hiccup (next restart will pick it up); from
- a validation error in the new value (next restart **will fail too** because the same config gets reloaded).

## Fix
1. **Backend**: log the error and include it in the JSON response as \`reload_error\`. Status string unchanged for backward compat.
2. **API type**: widen \`setConfigValue\`'s return type to \`{ status, restart_required?, reload_error? }\`.
3. **ConfigPage**: when \`reload_error\` is present, concatenate it onto the toast — e.g. \`\"Saved but reload failed: Validation failed: network_enabled is true but shared_secret is empty\"\`.
4. Count reload failures toward the \`errors\` total so the status row stays 5 s instead of disappearing in 3 s — long enough to read the cause.

## Common triggers I expect this to expose
- \`network_enabled = true\` without \`network.shared_secret\` set (caught by \`validate_config_for_reload\`)
- \`max_cron_jobs > 10000\`
- Any \`approval.validate()\` failure
- Anything else returned by \`reload_config()\` (config file deleted mid-flight, etc.)

## Test plan
- [x] \`pnpm run build\` green (dashboard)
- [x] cargo check on librefang-api running locally
- [ ] Manual: toggle \`network_enabled\` to true with empty \`shared_secret\`, save → toast shows the validation message instead of the bare \"Saved but reload failed\"