### PR TITLE
fix(config): validate config BEFORE writing TOML so failed saves don't corrupt the file

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1706,8 +1706,14 @@ export async function getConfigSchema(): Promise<{ sections: Record<string, Conf
   return get<{ sections: Record<string, ConfigSectionSchema> }>("/api/config/schema");
 }
 
-export async function setConfigValue(path: string, value: unknown): Promise<{ status: string; restart_required?: boolean }> {
-  return post<{ status: string; restart_required?: boolean }>("/api/config/set", { path, value });
+export async function setConfigValue(
+  path: string,
+  value: unknown,
+): Promise<{ status: string; restart_required?: boolean; reload_error?: string }> {
+  return post<{ status: string; restart_required?: boolean; reload_error?: string }>(
+    "/api/config/set",
+    { path, value },
+  );
 }
 
 export async function listBackups(): Promise<{ backups?: BackupItem[]; total?: number }> {

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -409,12 +409,22 @@ export function ConfigPage({ category }: { category: string }) {
         const data = await setConfigValue(path, value);
         const reloadFailed = data.status === "saved_reload_failed";
         const restartRequired = data.status === "applied_partial" || data.restart_required;
+        // When reload fails, prefer the kernel's specific error message
+        // (e.g. "Validation failed: network_enabled is true but
+        // shared_secret is empty") over the generic
+        // "Saved but reload failed" — without the cause the user can't
+        // tell apart "transient kernel hiccup" from "permanently
+        // invalid config that breaks the next restart too".
+        const reloadErr = reloadFailed && data.reload_error ? data.reload_error : null;
         const msg = reloadFailed
-          ? t("config.saved_reload_failed", "Saved but reload failed")
+          ? reloadErr
+            ? `${t("config.saved_reload_failed", "Saved but reload failed")}: ${reloadErr}`
+            : t("config.saved_reload_failed", "Saved but reload failed")
           : restartRequired
             ? t("config.saved_restart", "Saved (restart required)")
             : t("common.saved", "Saved");
         setSaveStatus((s) => ({ ...s, [path]: { ok: !reloadFailed, msg } }));
+        if (reloadFailed) errors++;
       } catch (err: any) {
         setSaveStatus((s) => ({ ...s, [path]: { ok: false, msg: err.message || t("config.save_failed") } }));
         errors++;

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1945,14 +1945,41 @@ pub async fn config_set(
         }
     }
 
-    // Validate by parsing the result as KernelConfig before writing
+    // Validate by parsing the result as KernelConfig before writing.
+    // This is the *schema* check (types deserialize cleanly), not the
+    // *business* check (e.g. cross-field invariants).
     let new_toml_str = doc.to_string();
-    if let Err(e) = toml::from_str::<librefang_types::config::KernelConfig>(&new_toml_str) {
+    let mut parsed_config =
+        match toml::from_str::<librefang_types::config::KernelConfig>(&new_toml_str) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "status": "error",
+                        "error": format!("invalid config after edit: {e}")
+                    })),
+                );
+            }
+        };
+
+    // Business-level validation BEFORE writing to disk. Without this
+    // check, edits like `network_enabled = true` (without setting
+    // `shared_secret`) would persist a definitely-broken config to disk
+    // and only fail at the post-write reload step, leaving the user
+    // with a `saved_reload_failed` status and a TOML file that will
+    // also fail the next daemon startup. Apply clamp_bounds first to
+    // mirror the reload-side preprocessing — otherwise a user-set
+    // out-of-range value would be flagged here even though reload
+    // would silently fix it.
+    parsed_config.clamp_bounds();
+    if let Err(errors) = librefang_kernel::config_reload::validate_config_for_reload(&parsed_config)
+    {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
                 "status": "error",
-                "error": format!("invalid config after edit: {e}")
+                "error": format!("invalid config: {}", errors.join("; "))
             })),
         );
     }

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1972,16 +1972,30 @@ pub async fn config_set(
     }
 
     // Trigger reload
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
+    let (reload_status, reload_error): (&'static str, Option<String>) =
+        match state.kernel.reload_config().await {
+            Ok(plan) => {
+                let s = if plan.restart_required {
+                    "applied_partial"
+                } else {
+                    "applied"
+                };
+                (s, None)
             }
-        }
-        Err(_) => "saved_reload_failed",
-    };
+            Err(e) => {
+                // Surface the actual reload failure reason so the dashboard
+                // can show users what's wrong (e.g. "validation failed:
+                // network_enabled is true but shared_secret is empty"
+                // instead of an opaque "saved but reload failed"). The TOML
+                // file has already been written at this point, so leaving
+                // the user without a reason is doubly bad — they can't
+                // distinguish "transient kernel hiccup, restart will pick
+                // it up" from "permanently invalid config that breaks
+                // restart too".
+                tracing::warn!(error = %e, %path, "config reload failed after write");
+                ("saved_reload_failed", Some(e))
+            }
+        };
 
     state.kernel.audit().record(
         "system",
@@ -1990,10 +2004,11 @@ pub async fn config_set(
         "completed",
     );
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": reload_status, "path": path})),
-    )
+    let mut body = serde_json::json!({"status": reload_status, "path": path});
+    if let Some(err) = reload_error {
+        body["reload_error"] = serde_json::Value::String(err);
+    }
+    (StatusCode::OK, Json(body))
 }
 
 /// Convert a serde_json::Value to a toml_edit::Value (format-preserving).


### PR DESCRIPTION
Follow-up to #2805. That PR surfaced the kernel's reload error to the dashboard, which fixed the symptom (\"opaque \\\"saved but reload failed\\\" toast\") — but the underlying state was still broken: when business validation fails after the write, the TOML on disk is already the new (invalid) version, and the next daemon restart will fail validation too.

## Change
Move \`validate_config_for_reload\` to **before** the file write. The schema check at line 1948 (\`toml::from_str::<KernelConfig>\`) only proves the new TOML deserializes; it does not catch cross-field invariants like \"\`network_enabled\` requires \`network.shared_secret\`\" or \"\`max_cron_jobs <= 10000\`\".

Now \`config_set\` runs in this order:

1. Schema validation (\`toml::from_str\`) — unchanged
2. \`clamp_bounds()\` — mirrors what \`reload_config\` does, so users aren't blocked by an out-of-range value the reload path would silently fix
3. \`validate_config_for_reload()\` — same checks as the post-write reload
4. **Only after all three pass do we write the file**

On failure: HTTP 400 with \`{\"status\":\"error\",\"error\":\"invalid config: <reason>\"}\`. The dashboard's \`setConfigValue\` catch block surfaces \`err.message\`, so the user sees something like:

> invalid config: network_enabled is true but network.shared_secret is empty

…without the TOML on disk ever being corrupted.

## Why this is the right fix
Keeping the post-write \`reload_error\` plumbing from #2805 is fine as defense-in-depth — it'll still fire if a hot-reload action misbehaves on a config that passed both pre-write checks (rare). But the common case (\`network_enabled\` alone, etc.) now fails fast and clean.

## Test plan
- [x] cargo check on librefang-api
- [x] dashboard \`pnpm run build\`
- [ ] Manual: try to enable \`network_enabled\` without \`shared_secret\`. Expected:
  - 400 returned, toast says \"invalid config: network_enabled is true but network.shared_secret is empty\"
  - \`~/.librefang/config.toml\` unchanged on disk (verify with \`grep network_enabled\` before and after)