### PR TITLE
release: v2026.4.20-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.20] - 2026-04-20
+
+### Added
+
+- Canonical silent-response primitive, end the NO_REPLY literal leak (#2470) (@f-liva)
+- Gate /dashboard/* behind auth + tailwind v4 renames (#2785) (@houko)
+- Add stop button to interrupt in-flight agent streams (#2787) (@neo-wanderer)
+- Add native Cohere driver (#2791) (@houko)
+- Show tool execution progress in channel replies (#2792) (@houko)
+- Finish channel-progress — universal coverage, Telegram fix, show_progress, i18n, prettify, dashboard parity (#2793) (@houko)
+- Redesign `librefang status` for layered visibility (#2799) (@houko)
+- Unify create/edit modals + inline rename (#2800) (@houko)
+
+### Fixed
+
+- Make extract_categories config drive LLM prompt categories (#2761) (@neo-wanderer)
+- Sync terminal health and active window state (#2777) (@leszek3737)
+- Clear history consistently and refresh model state (#2780) (@leszek3737)
+- Align shared query flows for MCP, skills, and workflows (#2784) (@leszek3737)
+- Route comms_task through kernel wrapper; surface task system events (#2789) (@neo-wanderer)
+- Rewrite /install to /install.sh for CLI clients (#2794) (@houko)
+- Stop writing PATH into the wrong rc file (#2796) (@houko)
+- Auto-activate PATH after installation (#2797) (@houko)
+- Bypass auth for loopback connections (#2802) (@houko)
+- Drop stray </div> from #2800 modal refactor (#2803) (@houko)
+- Surface reload error to dashboard instead of opaque 'saved but reload failed' (#2805) (@houko)
+- Validate config BEFORE writing TOML so failed saves don't corrupt the file (#2806) (@houko)
+
+### Documentation
+
+- Clarify session_mode scope — cron/channels/forks ignore it (#2790) (@neo-wanderer)
+
+### Maintenance
+
+- Split PR/main pipelines; compute affected crates precisely (#2801) (@houko)
+- Merge release-* workflows into one (keep notify) (#2804) (@houko)
+
+
 ## [2026.4.19] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "chrono",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "axum",
  "clap",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10997,7 +10997,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32215",
+  "version": "26.4.32205",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.19-beta25",
+  "version": "2026.4.20-rc1",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.19-beta25",
+  "version": "2026.4.20-rc1",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.19b25",
+    version="2026.4.20rc1",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.19-beta25"
+version = "2026.4.20-rc1"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.20-rc1 -->
## Release v2026.4.20-rc1

### Added

- Canonical silent-response primitive, end the NO_REPLY literal leak (#2470) (@f-liva)
- Gate /dashboard/* behind auth + tailwind v4 renames (#2785) (@houko)
- Add stop button to interrupt in-flight agent streams (#2787) (@neo-wanderer)
- Add native Cohere driver (#2791) (@houko)
- Show tool execution progress in channel replies (#2792) (@houko)
- Finish channel-progress — universal coverage, Telegram fix, show_progress, i18n, prettify, dashboard parity (#2793) (@houko)
- Redesign `librefang status` for layered visibility (#2799) (@houko)
- Unify create/edit modals + inline rename (#2800) (@houko)

### Fixed

- Make extract_categories config drive LLM prompt categories (#2761) (@neo-wanderer)
- Sync terminal health and active window state (#2777) (@leszek3737)
- Clear history consistently and refresh model state (#2780) (@leszek3737)
- Align shared query flows for MCP, skills, and workflows (#2784) (@leszek3737)
- Route comms_task through kernel wrapper; surface task system events (#2789) (@neo-wanderer)
- Rewrite /install to /install.sh for CLI clients (#2794) (@houko)
- Stop writing PATH into the wrong rc file (#2796) (@houko)
- Auto-activate PATH after installation (#2797) (@houko)
- Bypass auth for loopback connections (#2802) (@houko)
- Drop stray </div> from #2800 modal refactor (#2803) (@houko)
- Surface reload error to dashboard instead of opaque 'saved but reload failed' (#2805) (@houko)
- Validate config BEFORE writing TOML so failed saves don't corrupt the file (#2806) (@houko)

### Documentation

- Clarify session_mode scope — cron/channels/forks ignore it (#2790) (@neo-wanderer)

### Maintenance

- Split PR/main pipelines; compute affected crates precisely (#2801) (@houko)
- Merge release-* workflows into one (keep notify) (#2804) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.19-beta25...v2026.4.20-rc1