### PR TITLE
fix(cli): change wizard default ollama model to gemma3:4b

### DIFF
--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -152,7 +152,7 @@ const PROVIDERS: &[ProviderInfo] = &[
     ProviderInfo {
         name: "ollama",
         env_var: "OLLAMA_API_KEY",
-        default_model: "llama3.2",
+        default_model: "gemma4",
         needs_key: false,
     },
     ProviderInfo {


### PR DESCRIPTION
## Summary

- Wizard's default Ollama model was hardcoded to `llama3.2`, changed to `gemma3:4b`

## Test plan

- [ ] Run `librefang wizard` and verify the default Ollama model shows `gemma3:4b`