### PR TITLE
fix(cron): auto-delete At-schedule jobs after execution (#2808)

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -166,6 +166,10 @@ impl CronScheduler {
         // Compute initial next_run
         job.next_run = Some(compute_next_run(&job.schedule));
 
+        // Defense-in-depth: At-schedules must always be one_shot regardless of
+        // what the caller passed (#2808).
+        let one_shot = one_shot || matches!(job.schedule, CronSchedule::At { .. });
+
         let id = job.id;
         self.jobs.insert(id, JobMeta::new(job, one_shot));
         Ok(id)
@@ -699,6 +703,47 @@ mod tests {
         assert_eq!(meta.last_status.as_deref(), Some("ok"));
         assert_eq!(meta.consecutive_errors, 0);
         assert!(meta.job.last_run.is_some());
+    }
+
+    // -- test_at_schedule_defaults_to_one_shot (#2808) ----------------------
+
+    #[test]
+    fn test_at_schedule_is_forced_one_shot() {
+        // add_job with one_shot=false but At schedule → must be treated as one_shot
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let mut job = make_job(agent);
+        job.schedule = CronSchedule::At {
+            at: Utc::now() + chrono::Duration::seconds(60),
+        };
+
+        // Caller explicitly passes one_shot=false — defense-in-depth must override
+        let id = sched.add_job(job, false).unwrap();
+        assert_eq!(sched.total_jobs(), 1);
+        let meta = sched.get_meta(id).unwrap();
+        assert!(meta.one_shot, "At schedule must be forced to one_shot=true");
+
+        sched.record_success(id);
+        assert_eq!(
+            sched.total_jobs(),
+            0,
+            "At-schedule job must be removed after success"
+        );
+    }
+
+    #[test]
+    fn test_at_schedule_one_shot_true_stays_one_shot() {
+        // Explicit one_shot=true on At schedule must also be removed after firing
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let mut job = make_job(agent);
+        job.schedule = CronSchedule::At {
+            at: Utc::now() + chrono::Duration::seconds(60),
+        };
+
+        let id = sched.add_job(job, true).unwrap();
+        sched.record_success(id);
+        assert_eq!(sched.total_jobs(), 0);
     }
 
     // -- test_record_failure_auto_disable -----------------------------------

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -424,14 +424,19 @@ impl CronScheduler {
     /// Increments the consecutive error counter. If it reaches
     /// [`MAX_CONSECUTIVE_ERRORS`], the job is automatically disabled.
     pub fn record_failure(&self, id: CronJobId, error_msg: &str) {
-        if let Some(mut meta) = self.jobs.get_mut(&id) {
+        let should_remove = if let Some(mut meta) = self.jobs.get_mut(&id) {
             meta.job.last_run = Some(Utc::now());
             meta.last_status = Some(format!(
                 "error: {}",
                 librefang_types::truncate_str(error_msg, 256)
             ));
             meta.consecutive_errors += 1;
-            if meta.consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+            if meta.one_shot {
+                // one_shot jobs (e.g. At-schedule) are removed after the first
+                // failure too — there is no meaningful retry for a one-time job
+                // whose scheduled moment has already passed (#2808).
+                true
+            } else if meta.consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
                 warn!(
                     job_id = %id,
                     errors = meta.consecutive_errors,
@@ -439,9 +444,16 @@ impl CronScheduler {
                 );
                 meta.job.enabled = false;
                 meta.auto_disabled = true;
+                false
             } else {
                 meta.job.next_run = Some(compute_next_run_after(&meta.job.schedule, Utc::now()));
+                false
             }
+        } else {
+            false
+        };
+        if should_remove {
+            self.jobs.remove(&id);
         }
     }
 }
@@ -744,6 +756,27 @@ mod tests {
         let id = sched.add_job(job, true).unwrap();
         sched.record_success(id);
         assert_eq!(sched.total_jobs(), 0);
+    }
+
+    #[test]
+    fn test_at_schedule_removed_on_failure() {
+        // one_shot At-schedule job must be removed on first failure too
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let mut job = make_job(agent);
+        job.schedule = CronSchedule::At {
+            at: Utc::now() + chrono::Duration::seconds(60),
+        };
+
+        let id = sched.add_job(job, false).unwrap();
+        assert_eq!(sched.total_jobs(), 1);
+
+        sched.record_failure(id, "something went wrong");
+        assert_eq!(
+            sched.total_jobs(),
+            0,
+            "At-schedule job must be removed after failure"
+        );
     }
 
     // -- test_record_failure_auto_disable -----------------------------------

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12302,7 +12302,10 @@ impl KernelHandle for LibreFangKernel {
             // Issue #2338.
             CronDelivery::LastChannel
         };
-        let one_shot = job_json["one_shot"].as_bool().unwrap_or(false);
+        // At-schedules are inherently single-execution; default one_shot=true for them
+        // so the job auto-deletes after firing instead of lingering as a zombie (#2808).
+        let is_at_schedule = matches!(schedule, CronSchedule::At { .. });
+        let one_shot = job_json["one_shot"].as_bool().unwrap_or(is_at_schedule);
 
         let aid = librefang_types::agent::AgentId(
             uuid::Uuid::parse_str(agent_id).map_err(|e| format!("Invalid agent ID: {e}"))?,


### PR DESCRIPTION
## Problem

`At` cron jobs fired correctly (thanks to #2339) but were never removed. After execution:
1. `record_success()` checked `meta.one_shot` — it was `false` → job not removed
2. `compute_next_run_after(At, now)` pushed `next_run` to ~year 2126
3. Jobs accumulated permanently as zombies in `/api/cron/jobs`

## Fix

Two-layer fix:

**`cron_create` (kernel/mod.rs)** — default `one_shot=true` for `At` schedules:
```rust
let is_at_schedule = matches!(schedule, CronSchedule::At { .. });
let one_shot = job_json["one_shot"].as_bool().unwrap_or(is_at_schedule);
```

**`CronScheduler::add_job` (cron.rs)** — defense-in-depth, force `one_shot=true` for any `At` job regardless of caller:
```rust
let one_shot = one_shot || matches!(job.schedule, CronSchedule::At { .. });
```

## Tests

Added two new tests in `cron::tests`:
- `test_at_schedule_is_forced_one_shot` — verifies `add_job(..., false)` with `At` schedule stores `one_shot=true` and removes the job after `record_success`
- `test_at_schedule_one_shot_true_stays_one_shot` — explicit `one_shot=true` also cleans up correctly

Closes #2808