### PR TITLE
chore(dashboard): follow-up cleanup from #2783 review

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.test.tsx
@@ -19,6 +19,7 @@ import { createQueryClientWrapper } from "../test/query-client";
 vi.mock("../http/client", () => ({
   switchAgentSession: vi.fn().mockResolvedValue({}),
   deleteSession: vi.fn().mockResolvedValue({}),
+  patchAgent: vi.fn().mockResolvedValue({}),
   patchAgentConfig: vi.fn().mockResolvedValue({}),
   spawnAgent: vi.fn().mockResolvedValue({}),
   cloneAgent: vi.fn().mockResolvedValue({}),

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -297,6 +297,24 @@ describe("query key factories", () => {
       expect(mediaKeys.videoTask("task-1", "fal").slice(0, taskPrefix.length)).toEqual(taskPrefix);
       expect(mediaKeys.videoTasks().slice(0, mediaKeys.all.length)).toEqual(mediaKeys.all);
     });
+
+    it("videoTaskDisabled is stable and only collides with a literal sentinel id", () => {
+      expect(mediaKeys.videoTaskDisabled()).toEqual([
+        "media",
+        "videoTasks",
+        "__disabled__",
+        "__disabled__",
+      ]);
+      // Stable across calls (so useQuery's cache identity is preserved).
+      expect(mediaKeys.videoTaskDisabled()).toEqual(mediaKeys.videoTaskDisabled());
+      // 4-segment shape matches videoTask(taskId, provider) so useQuery's
+      // generics unify cleanly across the enabled/disabled branches.
+      expect(mediaKeys.videoTaskDisabled().length).toBe(4);
+      // Shares the videoTasks prefix — consumers can invalidate all video
+      // task queries (live + disabled placeholder) in one call.
+      const prefix = mediaKeys.videoTasks();
+      expect(mediaKeys.videoTaskDisabled().slice(0, prefix.length)).toEqual(prefix);
+    });
   });
 
   describe("telemetryKeys", () => {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -260,6 +260,12 @@ export const mediaKeys = {
   videoTasks: () => [...mediaKeys.all, "videoTasks"] as const,
   videoTask: (taskId: string, provider: string) =>
     [...mediaKeys.videoTasks(), taskId, provider] as const,
+  // Stable key for the disabled state of useVideoTask — paired with skipToken
+  // so every not-yet-submitted render shares the same (unused) cache slot.
+  // Shape mirrors `videoTask(taskId, provider)` (4 segments) so both branches
+  // of the query are type-compatible under useQuery's generic inference.
+  videoTaskDisabled: () =>
+    [...mediaKeys.videoTasks(), "__disabled__", "__disabled__"] as const,
 };
 
 export const mcpKeys = {

--- a/crates/librefang-api/dashboard/src/lib/queries/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/media.ts
@@ -5,34 +5,12 @@ import {
   type MediaVideoStatus,
 } from "../http/client";
 import { mediaKeys } from "./keys";
-
-function mergeQueryOptions<T extends { enabled?: unknown; staleTime?: unknown; refetchInterval?: unknown }>(
-  base: T,
-  overrides: { enabled?: unknown; staleTime?: unknown; refetchInterval?: unknown },
-): T {
-  const result = { ...base };
-  if (overrides.enabled !== undefined) result.enabled = overrides.enabled;
-  if (overrides.staleTime !== undefined) result.staleTime = overrides.staleTime;
-  if (overrides.refetchInterval !== undefined) result.refetchInterval = overrides.refetchInterval;
-  return result;
-}
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 60_000;
 const REFRESH_MS = 60_000;
 const VIDEO_TASK_STALE_MS = 1_000;
 const VIDEO_TASK_REFETCH_MS = 5_000;
-
-type UseMediaProvidersOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
-type UseVideoTaskOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 type VideoTaskParams = {
   taskId: string;
@@ -56,11 +34,8 @@ export const mediaQueries = {
     }),
 };
 
-export function useMediaProviders(options: UseMediaProvidersOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  const query = mediaQueries.providers();
-
-  return useQuery(mergeQueryOptions(query, { enabled, staleTime, refetchInterval }));
+export function useMediaProviders(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mediaQueries.providers(), options));
 }
 
 function shouldPollVideoTask(status?: MediaVideoStatus) {
@@ -70,19 +45,26 @@ function shouldPollVideoTask(status?: MediaVideoStatus) {
 
 export function useVideoTask(
   params: VideoTaskParams | null,
-  options: UseVideoTaskOptions = {},
+  options: QueryOverrides = {},
 ) {
-  const { enabled, staleTime, refetchInterval } = options;
-  const isEnabled = Boolean(enabled ?? true) && Boolean(params?.taskId) && Boolean(params?.provider);
+  const base = params
+    ? mediaQueries.videoTask(params)
+    : {
+        queryKey: mediaKeys.videoTaskDisabled(),
+        queryFn: skipToken,
+        staleTime: VIDEO_TASK_STALE_MS,
+        gcTime: 0,
+      } as const;
+
+  const isEnabled =
+    (options.enabled ?? true) && !!params?.taskId && !!params?.provider;
 
   return useQuery({
-    queryKey: params ? mediaKeys.videoTask(params.taskId, params.provider) : mediaKeys.videoTask("__placeholder__", "__placeholder__"),
-    queryFn: params ? () => pollVideo(params.taskId, params.provider) : skipToken,
-    gcTime: 0,
+    ...base,
     enabled: isEnabled,
-    staleTime: staleTime ?? VIDEO_TASK_STALE_MS,
+    staleTime: options.staleTime ?? VIDEO_TASK_STALE_MS,
     refetchInterval: (query) => {
-      const resolvedInterval = refetchInterval ?? VIDEO_TASK_REFETCH_MS;
+      const resolvedInterval = options.refetchInterval ?? VIDEO_TASK_REFETCH_MS;
       if (resolvedInterval === false) return false;
       return shouldPollVideoTask(query.state.data as MediaVideoStatus | undefined)
         ? resolvedInterval

--- a/crates/librefang-api/dashboard/src/lib/queries/options.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/options.ts
@@ -1,0 +1,13 @@
+export type QueryOverrides = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function withOverrides<T>(base: T, overrides: QueryOverrides): T {
+  const out = { ...base } as Record<string, unknown>;
+  if (overrides.enabled !== undefined) out.enabled = overrides.enabled;
+  if (overrides.staleTime !== undefined) out.staleTime = overrides.staleTime;
+  if (overrides.refetchInterval !== undefined) out.refetchInterval = overrides.refetchInterval;
+  return out as T;
+}

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
@@ -12,30 +12,9 @@ import {
   listCronJobs,
 } from "../../api";
 import { runtimeKeys, auditKeys, cronKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 export { useDashboardSnapshot, useVersionInfo } from "./overview";
-
-type UseAuditRecentOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
-export const runtimePageRefreshers = [
-  "refetchSnapshot",
-  "refetchVersion",
-  "refetchQueue",
-  "refetchHealthDetail",
-  "refetchSecurity",
-  "refetchAuditRecent",
-  "refetchAuditVerify",
-  "refetchBackups",
-  "refetchTaskStatus",
-  "refetchTaskList",
-] as const;
-
-export type RuntimePageRefresherName =
-  (typeof runtimePageRefreshers)[number];
 
 export const systemStatusQueryOptions = () =>
   queryOptions({
@@ -93,19 +72,8 @@ export const auditRecentQueryOptions = (limit: number) =>
     refetchInterval: 30_000,
   });
 
-export function useAuditRecent(
-  limit: number,
-  options: UseAuditRecentOptions = {},
-) {
-  const { enabled, staleTime, refetchInterval } = options;
-  const query = auditRecentQueryOptions(limit);
-
-  return useQuery({
-    ...query,
-    ...(enabled !== undefined ? { enabled } : {}),
-    ...(staleTime !== undefined ? { staleTime } : {}),
-    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
-  });
+export function useAuditRecent(limit: number, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(auditRecentQueryOptions(limit), options));
 }
 
 export const auditVerifyQueryOptions = () =>

--- a/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
@@ -1,15 +1,10 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { getMetricsText } from "../http/client";
 import { telemetryKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 5_000;
 const REFRESH_MS = 5_000;
-
-type UseTelemetryMetricsOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 export const telemetryQueryOptions = () =>
   queryOptions({
@@ -19,16 +14,6 @@ export const telemetryQueryOptions = () =>
     refetchInterval: REFRESH_MS,
   });
 
-export function useTelemetryMetrics(
-  options: UseTelemetryMetricsOptions = {},
-) {
-  const { enabled, staleTime, refetchInterval } = options;
-  const query = telemetryQueryOptions();
-
-  return useQuery({
-    ...query,
-    ...(enabled !== undefined ? { enabled } : {}),
-    ...(staleTime !== undefined ? { staleTime } : {}),
-    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
-  });
+export function useTelemetryMetrics(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(telemetryQueryOptions(), options));
 }

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
@@ -454,7 +454,11 @@ function VideoPanel({
   const [prompt, setPrompt] = useState("");
   const [provider, setProvider] = useState("");
   const [model, setModel] = useState("");
-  const [status, setStatus] = useState<MediaVideoStatus | null>(null);
+  // Local draft shown immediately after submission, before the first poll
+  // returns. Once the query has data we derive status from the query instead —
+  // keeping a mirrored copy of query data in state is a React anti-pattern
+  // and can race the first fetch for a new taskId.
+  const [submittedDraft, setSubmittedDraft] = useState<MediaVideoStatus | null>(null);
   const [taskId, setTaskId] = useState<string | null>(null);
   const [taskProvider, setTaskProvider] = useState<string | null>(null);
   const completionToastShown = useRef<string | null>(null);
@@ -469,10 +473,7 @@ function VideoPanel({
     },
   );
 
-  useEffect(() => {
-    if (!videoTaskQuery.data) return;
-    setStatus(videoTaskQuery.data);
-  }, [videoTaskQuery.data]);
+  const status: MediaVideoStatus | null = videoTaskQuery.data ?? submittedDraft;
 
   useEffect(() => {
     if (!videoTaskQuery.isError) return;
@@ -516,7 +517,7 @@ function VideoPanel({
           },
           {
             onSuccess: (data) => {
-              setStatus({ status: "submitted", task_id: data.task_id });
+              setSubmittedDraft({ status: "submitted", task_id: data.task_id });
               setTaskId(data.task_id);
               setTaskProvider(data.provider);
               completionToastShown.current = null;

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -26,8 +26,6 @@ import {
   useBackups,
   useTaskQueueStatus,
   useTaskQueue,
-  runtimePageRefreshers,
-  type RuntimePageRefresherName,
 } from "../lib/queries/runtime";
 import {
   useShutdownServer,
@@ -102,19 +100,6 @@ export function RuntimePage() {
   const taskStatusQuery = useTaskQueueStatus();
   const taskListQuery = useTaskQueue();
 
-  const refreshers: Record<RuntimePageRefresherName, () => unknown> = {
-    refetchSnapshot: () => snapshotQuery.refetch(),
-    refetchVersion: () => versionQuery.refetch(),
-    refetchQueue: () => queueQuery.refetch(),
-    refetchHealthDetail: () => healthDetailQuery.refetch(),
-    refetchSecurity: () => securityQuery.refetch(),
-    refetchAuditRecent: () => auditQuery.refetch(),
-    refetchAuditVerify: () => auditVerifyQuery.refetch(),
-    refetchBackups: () => backupsQuery.refetch(),
-    refetchTaskStatus: () => taskStatusQuery.refetch(),
-    refetchTaskList: () => taskListQuery.refetch(),
-  };
-
   const shutdownMutation = useShutdownServer({
     onSuccess: () => setShowShutdownConfirm(false),
   });
@@ -151,9 +136,20 @@ export function RuntimePage() {
   const tasks = taskListQuery.data?.tasks ?? [];
 
   const refreshAll = () => {
-    runtimePageRefreshers.forEach((name) => {
-      refreshers[name]();
-    });
+    for (const q of [
+      snapshotQuery,
+      versionQuery,
+      queueQuery,
+      healthDetailQuery,
+      securityQuery,
+      auditQuery,
+      auditVerifyQuery,
+      backupsQuery,
+      taskStatusQuery,
+      taskListQuery,
+    ]) {
+      q.refetch();
+    }
   };
 
   return (


### PR DESCRIPTION
Follow-up to #2783 addressing the 5 code-smell items raised in review. No behaviour change for end users, no new public API surface.

## Summary
1. **Shared override-merge helper**. Extracted the three copies (in `queries/media.ts`, `queries/runtime.ts`, `queries/telemetry.ts`) into a single `withOverrides` helper in the new `lib/queries/options.ts`.
2. **`useVideoTask` now reuses `mediaQueries.videoTask`** instead of re-inlining `queryKey`/`queryFn`. The factory is no longer dead code.
3. **Replaced the `"__placeholder__"` sentinel queryKey** with `mediaKeys.videoTaskDisabled()`. 4-segment shape preserved so TanStack's generics unify across the enabled/disabled branches; intent is explicit and `invalidateQueries({ queryKey: mediaKeys.videoTasks() })` still hits both live + disabled entries.
4. **VideoPanel: dropped the dual-state mirror**. `videoTaskQuery.data` is no longer copied into a local `status` via `useEffect`. Derive `status = videoTaskQuery.data ?? submittedDraft` instead, where `submittedDraft` only covers the window between `submit.onSuccess` and the first poll resolving. Removes one `useEffect` and a subtle stale-data race on taskId change.
5. **Moved Runtime page's refresher fan-out back in-file**. The `runtimePageRefreshers` string array + `RuntimePageRefresherName` type were only consumed by `RuntimePage.tsx` but required cross-file upkeep. `refreshAll` is now a local `for` loop over the query objects themselves.

## Drive-by
- Fixed a pre-existing broken test on main: `agents.test.tsx`'s `vi.mock("../http/client")` was missing `patchAgent` after that export was added, causing `usePatchAgent.invalidates…` to fail. One-line mock entry.

## Stats
`9 files changed, 82 insertions(+), 113 deletions(-)` — net code reduction from the dedupe.

## Test plan
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test --run` — 275/275 passing (was 274/275 before the `patchAgent` mock fix).
- [ ] CI