### PR TITLE
 fix(api): allow dashboard static assets through auth gate

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -388,7 +388,13 @@ pub async fn auth(
     // deployments keep a public shell so the SPA can load its own API-key
     // entry UI; the individual `/api/*` endpoints still require a Bearer
     // token, which is the real security boundary.
-    let dashboard_shell_public = !auth_state.dashboard_auth_enabled && is_dashboard_path;
+    //
+    // Dashboard assets (JS/CSS/font chunks) are always public — they contain
+    // no sensitive data and the SPA shell needs them to render even the
+    // inline login page returned for unauthenticated browsers.
+    let is_dashboard_asset = path.starts_with("/dashboard/assets/");
+    let dashboard_shell_public =
+        (!auth_state.dashboard_auth_enabled && is_dashboard_path) || is_dashboard_asset;
 
     let always_public_get_only = is_get
         && (matches!(


### PR DESCRIPTION
Type: 

- [x] Bug fix

Summary:  

When dashboard_user/dashboard_pass are configured, the auth middleware gated all /dashboard/* paths — including JS/CSS chunks. The inline login page returned for unauthenticated browsers could not load its own assets, resulting in a blank white screen and 401 console errors.  
This fix makes /dashboard/assets/* always publicly reachable so the SPA shell (including the login form) can render. The /api/* endpoints remain fully protected.
Fixes #2822

Changes:

- crates/librefang-api/src/middleware.rs: added is_dashboard_asset check to the public-path logic so that static chunks under /dashboard/assets/ bypass auth regardless of dashboard_auth_enabled

Testing:

- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace passes
- [x] Live integration tested: reproduced the blank-screen-with-401s on http://<lan-ip>:4545/dashboard, applied fix, confirmed the login page renders and authenticates correctly

Security:

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries (path traversal already blocked by existing path.contains("..") check in react_asset)
