### PR TITLE
fix(deploy): force wildcard bind for api_listen in Docker

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -22,6 +22,13 @@ fi
 
 # Railway/Render/Fly inject PORT — reapply on every boot since a rescheduled
 # machine may land on a different port.
+# In Docker, 127.0.0.1 is the container's own loopback and is unreachable from
+# the host. Force wildcard bind unless the user has already customised it.
+if grep -q '^api_listen = "127.0.0.1:' "$CONFIG" 2>/dev/null; then
+  sed -i 's|^api_listen = "127.0.0.1:|api_listen = "0.0.0.0:|' "$CONFIG"
+  chown node:node "$CONFIG"
+fi
+
 if [ -n "$PORT" ]; then
   sed -i "s|^api_listen = .*|api_listen = \"0.0.0.0:${PORT}\"|" "$CONFIG"
   chown node:node "$CONFIG"


### PR DESCRIPTION
Type:

- [x] Bug fix

Summary:  

In Docker, binding to 127.0.0.1 makes the API unreachable from the host because 127.0.0.1 inside the container is the container's own loopback, not the host's. This updates the entrypoint script to automatically swap the default loopback bind address to 0.0.0.0 unless the user has manually configured a different address.
Fixes #2823

Changes:  

- deploy/docker-entrypoint.sh: Added automatic rewrite of api_listen = "127.0.0.1:..." to 0.0.0.0:... on container startup when the config still carries the default loopback address.

Testing:  

- [x] Live integration tested in Docker container — container starts, api_listen correctly rewritten to 0.0.0.0:4545, dashboard accessible from host at http://localhost:4545.

Security:  
- [x] No new unsafe code  
- [x] No secrets or API keys in diff  
- [x] Only touches the config file generated by librefang init; no direct user input processing
