### PR TITLE
fix(ci): resolve channel_bridge test deadlock that blocked CI for 6h

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,5 @@
 [profile.default]
 # Show immediately which tests fail
 failure-output = "immediate"
+# Kill any test that runs longer than 60s (prevents hangs from blocking the whole suite)
+slow-timeout = { period = "60s", terminate-after = 1 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,3 @@
 [profile.default]
 # Show immediately which tests fail
 failure-output = "immediate"
-# Kill any test that runs longer than 60s (prevents hangs from blocking the whole suite)
-slow-timeout = { period = "60s", terminate-after = 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -239,6 +240,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
 
-# On PRs: only one run per branch, cancel stale runs.
+# On PRs: one run per branch, cancel stale runs.
 # On main: each push gets its own group (by SHA) so parallel runs never interfere.
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.workflow, github.sha) || format('{0}-{1}', github.workflow, github.ref) }}
@@ -21,81 +21,93 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ── Detect changed files to skip unnecessary jobs ──────────────────────────────────
+  # ── Detect changes + compute affected crate subset ─────────────────────────────
+  # PR lane: only test crates the PR touches (no fan-out to downstream —
+  #   main catches cross-crate breakage on merge).
+  # Main lane (push to main, or PR that touches CI / root Cargo.toml / xtask):
+  #   full workspace test on all three platforms.
+  #
+  # All detection is pure `git diff` (no external action) so `act` can run
+  # this job locally against a stock ubuntu image with no GitHub API access.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      docs: ${{ steps.filter.outputs.docs }}
-      ci: ${{ steps.filter.outputs.ci }}
-      install: ${{ steps.filter.outputs.install }}
-      crates: ${{ steps.crates.outputs.crates }}
+      rust: ${{ steps.diff.outputs.rust }}
+      docs: ${{ steps.diff.outputs.docs }}
+      ci: ${{ steps.diff.outputs.ci }}
+      install: ${{ steps.diff.outputs.install }}
+      full_run: ${{ steps.diff.outputs.full_run }}
+      crates: ${{ steps.diff.outputs.crates }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            rust:
-              - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'xtask/**'
-            docs:
-              - 'docs/**'
-              - '*.md'
-            ci:
-              - '.github/workflows/**'
-            install:
-              - 'web/public/install.sh'
-              - 'web/public/install.ps1'
-              - 'scripts/tests/install_sh_test.sh'
-      - name: Detect affected crates
-        id: crates
-        if: steps.filter.outputs.rust == 'true'
-        run: |
-          BASE_REF="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
-          CHANGED=$(git diff --name-only "$BASE_REF" HEAD -- crates/ | sed 's|crates/\([^/]*\)/.*|\1|' | sort -u)
-          # Map directory names to crate names (replace - with -)
-          ALL_CRATES="librefang-types librefang-wire librefang-telemetry librefang-memory librefang-channels librefang-skills librefang-hands librefang-extensions librefang-kernel librefang-api librefang-runtime librefang-migrate librefang-testing librefang-cli librefang-desktop"
-          # If Cargo.toml/lock changed or CI changed, test everything
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE '^(Cargo\.(toml|lock)|xtask/)'; then
-            echo "crates=$ALL_CRATES" >> "$GITHUB_OUTPUT"
-          elif [ -z "$CHANGED" ]; then
-            echo "crates=$ALL_CRATES" >> "$GITHUB_OUTPUT"
-          else
-            # Include changed crates + their reverse dependencies
-            AFFECTED=""
-            for dir in $CHANGED; do
-              AFFECTED="$AFFECTED $dir"
-            done
-            # Always include downstream crates when upstream changes
-            # Dependency order: types -> memory -> runtime -> kernel -> api -> cli
-            if echo "$AFFECTED" | grep -q "librefang-types"; then
-              AFFECTED="$ALL_CRATES"
-            elif echo "$AFFECTED" | grep -q "librefang-memory"; then
-              AFFECTED="$AFFECTED librefang-runtime librefang-kernel librefang-api librefang-cli librefang-testing"
-            elif echo "$AFFECTED" | grep -q "librefang-runtime"; then
-              AFFECTED="$AFFECTED librefang-kernel librefang-api librefang-cli librefang-testing"
-            elif echo "$AFFECTED" | grep -q "librefang-kernel"; then
-              AFFECTED="$AFFECTED librefang-api librefang-cli librefang-testing"
-            fi
-            # Deduplicate and filter to valid crate names
-            AFFECTED=$(echo "$AFFECTED" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-            VALID=""
-            for crate in $AFFECTED; do
-              if echo "$ALL_CRATES" | grep -qw "$crate"; then
-                VALID="$VALID $crate"
-              fi
-            done
-            echo "crates=${VALID:-$ALL_CRATES}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Affected crates: $(cat "$GITHUB_OUTPUT" | grep crates)"
 
-  # ── Reject dashboard build artifacts in PRs ─────────────────────────────────────────
+      - name: Compute diff and route
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          # Range: PR → base..head, push → just the pushed commit.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            RANGE=("$BASE_SHA" "$HEAD_SHA")
+          else
+            RANGE=("HEAD~1" "HEAD")
+          fi
+
+          CHANGED=$(git diff --name-only "${RANGE[@]}")
+          echo "Changed files ($EVENT_NAME):"
+          printf '  %s\n' $CHANGED
+
+          # Boolean flags — `grep -q` against the diff filenames.
+          has() { printf '%s\n' "$CHANGED" | grep -qE "$1"; }
+
+          RUST=false;    has '^(crates/|Cargo\.toml$|Cargo\.lock$|xtask/)'            && RUST=true
+          DOCS=false;    has '^(docs/|.*\.md$)'                                       && DOCS=true
+          CI=false;      has '^\.github/workflows/'                                   && CI=true
+          INSTALL=false; has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$' && INSTALL=true
+          ROOT_CARGO=false; has '^Cargo\.toml$|^xtask/'                               && ROOT_CARGO=true
+
+          # Full run policy — stated plainly so it's auditable from the log:
+          # 1. Push to main (merge) → catch cross-crate breakage before it rots
+          # 2. CI file itself changed → test the new pipeline on every platform
+          # 3. Root Cargo.toml / xtask → graph-level change, per-crate logic
+          #    can't safely predict the blast radius
+          #
+          # Platform regressions don't need a special full_run bucket — PR lane
+          # test jobs on Windows/macOS cover their affected crates directly.
+          if [ "$EVENT_NAME" = "push" ]; then
+            FULL=true; REASON="push to main"
+          elif [ "$CI" = "true" ]; then
+            FULL=true; REASON="CI workflow changed"
+          elif [ "$ROOT_CARGO" = "true" ]; then
+            FULL=true; REASON="workspace Cargo.toml or xtask changed"
+          else
+            FULL=false; REASON="selective"
+          fi
+
+          {
+            echo "rust=$RUST"
+            echo "docs=$DOCS"
+            echo "ci=$CI"
+            echo "install=$INSTALL"
+            echo "full_run=$FULL"
+          } >> "$GITHUB_OUTPUT"
+          echo "Route: full_run=$FULL ($REASON)"
+
+          # Directly-touched crates (no downstream fan-out — on purpose).
+          DIRECT=$(printf '%s\n' "$CHANGED" \
+            | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
+            | sort -u | tr '\n' ' ')
+          echo "crates=$DIRECT" >> "$GITHUB_OUTPUT"
+          echo "Affected crates: ${DIRECT:-<none>}"
+
+  # ── Reject dashboard build artifacts in PRs ────────────────────────────────────
   no-build-artifacts:
     name: No Build Artifacts
     if: github.event_name == 'pull_request'
@@ -114,7 +126,12 @@ jobs:
             exit 1
           fi
 
-  # ── Code quality checks (fast, run in parallel) ─────────────────────────────────────
+  # ── Code quality: fmt (always full, it's a text scan), build + clippy
+  # (selective on PR, full on main). The full-run branch delegates to
+  # `cargo xtask ci` which keeps web-bundle / dashboard hooks wired; the
+  # selective branch skips that because a PR only touching a subset of
+  # crates doesn't need to rebuild the dashboard or re-run workspace-wide
+  # build steps.
   quality:
     name: Quality
     needs: changes
@@ -139,10 +156,26 @@ jobs:
         run: cargo xtask fmt
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
-      - name: Run clippy
-        run: cargo xtask ci --no-test --no-web
+      - name: Build + clippy
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Full build + clippy (workspace)…"
+            cargo xtask ci --no-test --no-web
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — skipping build + clippy."
+              exit 0
+            fi
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            echo "Selective build for:  $CRATES"
+            cargo build $PFLAGS --lib
+            echo "Selective clippy for: $CRATES"
+            cargo clippy $PFLAGS --all-targets --all-features -- -D warnings
+          fi
 
-  # ── Security audit (independent) ─────────────────────────────────────────────────────
+  # ── Security audit (independent) ───────────────────────────────────────────────
   security:
     name: Security
     needs: changes
@@ -178,7 +211,7 @@ jobs:
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099
 
-  # ── Secrets scanning (independent) ────────────────────────────────────────────────────
+  # ── Secrets scanning (independent) ─────────────────────────────────────────────
   secrets:
     name: Secrets Scan
     runs-on: ubuntu-latest
@@ -197,7 +230,7 @@ jobs:
             --only-verified \
             --exclude-paths=<(echo -e "target/\n.git/\nCargo.lock")
 
-  # ── Installer smoke test (fast, independent) ────────────────────────────────────────
+  # ── Installer smoke test (fast, independent) ───────────────────────────────────
   install-smoke:
     name: Install Smoke
     needs: changes
@@ -214,46 +247,7 @@ jobs:
       - name: Parse PowerShell installer
         run: pwsh -NoProfile -Command '$tokens=$null; $errors=$null; [void][System.Management.Automation.Language.Parser]::ParseFile("web/public/install.ps1",[ref]$tokens,[ref]$errors); if ($errors) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }'
 
-  # ── Tests ─────────────────────────────────────
-  test-windows:
-    name: Test / Windows
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: test-windows-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-      - name: Ensure dashboard build dir exists
-        run: mkdir -p crates/librefang-api/static/react
-        shell: bash
-      - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
-
-  test-macos:
-    name: Test / macOS
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
-    runs-on: macos-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: test-macos-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-      - name: Ensure dashboard build dir exists
-        run: mkdir -p crates/librefang-api/static/react
-      - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
-
+  # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
   test-ubuntu:
     name: Test / Ubuntu
     needs: changes
@@ -279,18 +273,107 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
-      - name: Build tests (throttled to reduce peak memory)
-        run: cargo test --workspace --no-run -j 2
-      - name: Run tests per crate
+      - name: Build tests
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Building workspace tests (full run)…"
+            cargo test --workspace --no-run -j 2
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — skipping build."
+              exit 0
+            fi
+            echo "Building tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo test $PFLAGS --no-run -j 2
+          fi
+      - name: Run tests
         env:
           RUST_TEST_THREADS: "1"
         run: |
-          CRATES="${{ needs.changes.outputs.crates }}"
-          if [ -z "$CRATES" ]; then
-            CRATES="librefang-types librefang-wire librefang-telemetry librefang-memory librefang-channels librefang-skills librefang-hands librefang-extensions librefang-kernel librefang-api librefang-runtime librefang-migrate librefang-testing librefang-cli librefang-desktop xtask"
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Running workspace tests (full run)…"
+            cargo nextest run --workspace --no-fail-fast
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — nothing to run."
+              exit 0
+            fi
+            echo "Running tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo nextest run $PFLAGS --no-fail-fast
           fi
-          for crate in $CRATES; do
-            echo "::group::Testing $crate"
-            cargo test -p "$crate" && echo "✓ $crate" || exit 1
-            echo "::endgroup::"
-          done
+
+  # ── Windows tests: selective on PR, full on main ───────────────────────────────
+  test-windows:
+    name: Test / Windows
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-windows-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+        shell: bash
+      - name: Run tests
+        shell: bash
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Running workspace tests (full run)…"
+            cargo nextest run --workspace --no-fail-fast
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — nothing to run."
+              exit 0
+            fi
+            echo "Running tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo nextest run $PFLAGS --no-fail-fast
+          fi
+
+  # ── macOS tests: selective on PR, full on main ─────────────────────────────────
+  test-macos:
+    name: Test / macOS
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-macos-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+      - name: Run tests
+        run: |
+          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+            echo "Running workspace tests (full run)…"
+            cargo nextest run --workspace --no-fail-fast
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — nothing to run."
+              exit 0
+            fi
+            echo "Running tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo nextest run $PFLAGS --no-fail-fast
+          fi

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -111,6 +111,7 @@ export {
   // agents
   spawnAgent,
   cloneAgent,
+  stopAgent,
   suspendAgent,
   resumeAgent,
   deleteAgent,

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   spawnAgent,
   cloneAgent,
+  stopAgent,
   suspendAgent,
   resumeAgent,
   deleteAgent,
@@ -39,6 +40,16 @@ export function useCloneAgent() {
       qc.invalidateQueries({ queryKey: agentKeys.all });
       qc.invalidateQueries({ queryKey: overviewKeys.snapshot() });
     },
+  });
+}
+
+// Abort an in-flight agent run. The backend aborts the kernel task; the UI
+// side separately reconciles streaming state (see ChatPage.stopMessage), so
+// this hook intentionally doesn't invalidate queries — agent list state is
+// unchanged by a stop.
+export function useStopAgent() {
+  return useMutation({
+    mutationFn: (agentId: string) => stopAgent(agentId),
   });
 }
 

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1750,6 +1750,7 @@
     "session": "Session",
     "sessions_title": "Sessions",
     "send_hint": "Enter to send, Cmd+Enter for newline",
+    "stop_hint": "Stop generating",
     "voice_input": "Voice input",
     "voice_stop": "Stop recording",
     "voice_recording": "Listening...",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1725,6 +1725,7 @@
     "session": "会话",
     "sessions_title": "会话列表",
     "send_hint": "Enter 发送 · ⌘+↵ 换行",
+    "stop_hint": "停止生成",
     "voice_input": "语音输入",
     "voice_stop": "停止录音",
     "voice_recording": "正在聆听...",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -17,7 +17,7 @@ import { approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
 import { normalizeToolOutput } from "../lib/chat";
 import { useTtsManager } from "../lib/tts";
-import { MessageCircle, Send, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe } from "lucide-react";
+import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe } from "lucide-react";
 import { Badge } from "../components/ui/Badge";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { useUIStore } from "../lib/store";
@@ -31,6 +31,7 @@ import {
   useDeleteAgentSession,
   usePatchAgentConfig,
   useResolveApproval,
+  useStopAgent,
   useSwitchAgentSession,
 } from "../lib/mutations/agents";
 import "katex/dist/katex.min.css";
@@ -166,6 +167,7 @@ const sessionCache = new Map<string, ChatMessage[]>();
 // sessionVersion: bump to force reload after session switch
 function useChatMessages(agentId: string | null, agents: any[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void) {
   const { t } = useTranslation();
+  const stopAgentMutation = useStopAgent();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   // Per-agent loading state. A single shared `isLoading` would freeze the
   // ChatInput on every agent while one of them is streaming (#2322). Keyed
@@ -186,6 +188,16 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
   // is already in flight (user can now type + send while the previous turn's
   // `response` event is still pending — see `ChatInput` inputDisabled split).
   const latestTurnRef = useRef<Record<string, string>>({});
+  // Per-agent in-flight turn lifecycle state, hoisted out of sendMessage's
+  // closure so stopMessage can reach `cleanup`, `fallbackTimer`, and
+  // `responded`. Without this, stopMessage POSTs /stop but the WS fallback
+  // watchdog stays armed and 180s later re-sends the stopped message over
+  // HTTP (#2787 review).
+  const activeTurnsRef = useRef<Record<string, {
+    cleanup?: () => void;
+    fallbackTimer?: ReturnType<typeof setTimeout> | null;
+    responded: boolean;
+  }>>({});
   const finishTurnIfCurrent = useCallback((agent: string, botId: string) => {
     if (latestTurnRef.current[agent] === botId) {
       setAgentLoading(agent, false);
@@ -476,13 +488,27 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
     // Try WebSocket streaming first
     if (wsConnected && ws.current && ws.current.readyState === WebSocket.OPEN) {
       try {
-        let responded = false;
-        let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+        // Hoist per-turn lifecycle state onto the ref so stopMessage can tear
+        // down the WS listener + watchdog. Any prior entry for this agent
+        // should already have been cleaned up by its own terminal path, but
+        // be defensive and clear it.
+        const prevTurn = activeTurnsRef.current[sendAgentId];
+        if (prevTurn) {
+          prevTurn.responded = true;
+          if (prevTurn.fallbackTimer) clearTimeout(prevTurn.fallbackTimer);
+          prevTurn.cleanup?.();
+        }
+        const turn: {
+          cleanup?: () => void;
+          fallbackTimer?: ReturnType<typeof setTimeout> | null;
+          responded: boolean;
+        } = { responded: false, fallbackTimer: null };
+        activeTurnsRef.current[sendAgentId] = turn;
 
         const resetFallbackTimer = () => {
-          if (fallbackTimer) clearTimeout(fallbackTimer);
-          fallbackTimer = setTimeout(() => {
-            if (!responded) {
+          if (turn.fallbackTimer) clearTimeout(turn.fallbackTimer);
+          turn.fallbackTimer = setTimeout(() => {
+            if (!turn.responded) {
               cleanup();
               sendViaHttp();
             }
@@ -490,11 +516,15 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
         };
 
         const cleanup = () => {
-          responded = true;
-          if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+          turn.responded = true;
+          if (turn.fallbackTimer) { clearTimeout(turn.fallbackTimer); turn.fallbackTimer = null; }
           onDropRef.current = null;
           ws.current?.removeEventListener("message", handleMessage);
+          if (activeTurnsRef.current[sendAgentId] === turn) {
+            delete activeTurnsRef.current[sendAgentId];
+          }
         };
+        turn.cleanup = cleanup;
 
         // Set up message handler for this response
         const handleMessage = (event: MessageEvent) => {
@@ -590,9 +620,9 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
               // and send a final response. Shorten the inactivity window to
               // 30s so the WS doesn't stay half-open forever if the failure
               // is terminal.
-              if (fallbackTimer) clearTimeout(fallbackTimer);
-              fallbackTimer = setTimeout(() => {
-                if (!responded) { cleanup(); sendViaHttp(); }
+              if (turn.fallbackTimer) clearTimeout(turn.fallbackTimer);
+              turn.fallbackTimer = setTimeout(() => {
+                if (!turn.responded) { cleanup(); sendViaHttp(); }
               }, 30_000);
             } else if (data.type === "response") {
               updateAgentMessages(sendAgentId, prev => prev.map(m =>
@@ -621,8 +651,11 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
 
         // Register fallback: if WS drops mid-stream, retry via HTTP
         onDropRef.current = () => {
-          if (!responded) {
+          if (!turn.responded) {
             ws.current?.removeEventListener("message", handleMessage);
+            if (activeTurnsRef.current[sendAgentId] === turn) {
+              delete activeTurnsRef.current[sendAgentId];
+            }
             sendViaHttp();
           }
         };
@@ -648,7 +681,43 @@ function useChatMessages(agentId: string | null, agents: any[] = [], sessionVers
     await sendViaHttp();
   }, [agentId, agents, wsConnected, ws, deepThinking, showThinkingProcess, finishTurnIfCurrent, clearHistory]);
 
-  return { messages, isLoading, sendMessage, clearHistory, wsConnected };
+  // Abort an in-flight agent run. Hits the backend stop endpoint (which aborts
+  // the tokio task on the kernel side) and optimistically finalizes any
+  // streaming messages for this agent so the input re-enables immediately —
+  // we don't wait for the WS to emit a terminal event.
+  const stopMessage = useCallback(async () => {
+    if (!agentId) return;
+    const targetId = agentId;
+    updateAgentMessages(targetId, prev => prev.map(m =>
+      m.isStreaming ? { ...m, isStreaming: false } : m,
+    ));
+    const pendingBotId = latestTurnRef.current[targetId];
+    if (pendingBotId) finishTurnIfCurrent(targetId, pendingBotId);
+    // Tear down the in-flight WS turn: mark responded, clear the 180s/30s
+    // watchdog, and detach the message listener. Without this the watchdog
+    // would fire after the backend aborts (WS goes silent) and re-send the
+    // stopped message over HTTP (#2787 review).
+    const turn = activeTurnsRef.current[targetId];
+    if (turn) {
+      turn.responded = true;
+      if (turn.fallbackTimer) {
+        clearTimeout(turn.fallbackTimer);
+        turn.fallbackTimer = null;
+      }
+      turn.cleanup?.();
+      // cleanup() deletes the entry itself, but guard against custom
+      // cleanup implementations.
+      delete activeTurnsRef.current[targetId];
+    }
+    try {
+      await stopAgentMutation.mutateAsync(targetId);
+    } catch {
+      // Backend stop failure is non-fatal for the UI — the run may have
+      // completed between user click and request. UI is already unblocked.
+    }
+  }, [agentId, updateAgentMessages, finishTurnIfCurrent, stopAgentMutation]);
+
+  return { messages, isLoading, sendMessage, stopMessage, clearHistory, wsConnected };
 }
 
 // Message bubble component — memoized to skip re-render during streaming of other messages
@@ -861,7 +930,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
 });
 
 // Input box - with shortcut hints
-function ChatInput({ onSend, disabled, inputDisabled, placeholder, authMissing, authStatus, providerName, supportsThinking, sttAvailable }: { onSend: (msg: string) => void; disabled: boolean; inputDisabled?: boolean; placeholder: string; authMissing?: boolean; authStatus?: string; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
+function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, placeholder, authMissing, authStatus, providerName, supportsThinking, sttAvailable }: { onSend: (msg: string) => void; onStop?: () => void; isStreaming?: boolean; disabled: boolean; inputDisabled?: boolean; placeholder: string; authMissing?: boolean; authStatus?: string; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -1076,16 +1145,30 @@ function ChatInput({ onSend, disabled, inputDisabled, placeholder, authMissing, 
             {voiceInput.isRecording ? <MicOff className="h-4 w-4" /> : voiceInput.isTranscribing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Mic className="h-4 w-4" />}
           </button>
         )}
-        <button
-          type="submit"
-          disabled={!message.trim() || effectiveDisabled}
-          className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-brand to-brand/90 text-white font-bold text-sm shadow-lg shadow-brand/20 hover:shadow-brand/40 hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0"
-        >
-          <Send className="h-4 w-4" />
-          <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">
-            {t("chat.send_hint")}
-          </span>
-        </button>
+        {isStreaming && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            title={t("chat.stop_hint")}
+            className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-error to-error/90 text-white font-bold text-sm shadow-lg shadow-error/20 hover:shadow-error/40 hover:-translate-y-0.5 transition-all duration-300"
+          >
+            <Square className="h-4 w-4 fill-current" />
+            <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">
+              {t("chat.stop_hint")}
+            </span>
+          </button>
+        ) : (
+          <button
+            type="submit"
+            disabled={!message.trim() || effectiveDisabled}
+            className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-brand to-brand/90 text-white font-bold text-sm shadow-lg shadow-brand/20 hover:shadow-brand/40 hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          >
+            <Send className="h-4 w-4" />
+            <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">
+              {t("chat.send_hint")}
+            </span>
+          </button>
+        )}
       </div>
     </form>
   );
@@ -1747,7 +1830,7 @@ export function ChatPage() {
   );
   // Session state — bump version to force message reload after switch
   const [sessionVersion, setSessionVersion] = useState(0);
-  const { messages, isLoading, sendMessage, clearHistory, wsConnected } = useChatMessages(
+  const { messages, isLoading, sendMessage, stopMessage, clearHistory, wsConnected } = useChatMessages(
     selectedAgentId || null,
     agents,
     sessionVersion,
@@ -2103,6 +2186,8 @@ export function ChatPage() {
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
               onSend={sendMessage}
+              onStop={stopMessage}
+              isStreaming={isStreaming}
               disabled={isLoading}
               inputDisabled={isStreaming}
               placeholder={isStreaming ? t("chat.generating") : selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3613,7 +3613,7 @@ mod tests {
         use librefang_kernel::error::KernelError;
         use librefang_types::error::LibreFangError;
 
-        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async {
             Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
                 LibreFangError::Internal("rate limit hit".to_string()).into(),
@@ -3657,7 +3657,7 @@ mod tests {
         use librefang_kernel::error::KernelError;
         use librefang_types::error::LibreFangError;
 
-        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async {
             Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
                 LibreFangError::Internal("some internal failure".to_string()).into(),

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -316,13 +316,33 @@ use tracing::{debug, error, info, warn};
 use librefang_runtime::str_utils::safe_truncate_str;
 
 fn start_stream_text_bridge(
-    mut event_rx: mpsc::Receiver<StreamEvent>,
+    event_rx: mpsc::Receiver<StreamEvent>,
     kernel_handle: tokio::task::JoinHandle<
         KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
     >,
     is_group: bool,
 ) -> mpsc::Receiver<String> {
+    let (rx, _status) = start_stream_text_bridge_with_status(event_rx, kernel_handle, is_group);
+    rx
+}
+
+/// Same as `start_stream_text_bridge` but also returns a oneshot that
+/// resolves to the kernel's actual `Result` after the stream has fully
+/// drained. Callers use this to drive proper lifecycle reactions, accurate
+/// `record_delivery` metrics, and `suppress_error_responses` honor for
+/// public-feed adapters.
+fn start_stream_text_bridge_with_status(
+    mut event_rx: mpsc::Receiver<StreamEvent>,
+    kernel_handle: tokio::task::JoinHandle<
+        KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
+    >,
+    is_group: bool,
+) -> (
+    mpsc::Receiver<String>,
+    tokio::sync::oneshot::Receiver<Result<(), String>>,
+) {
     let (tx, rx) = mpsc::channel::<String>(64);
+    let (status_tx, status_rx) = tokio::sync::oneshot::channel();
     let error_tx = tx.clone();
 
     let bridge_handle = tokio::spawn(async move {
@@ -332,6 +352,10 @@ fn start_stream_text_bridge(
         // tool call or content-block array.
         let mut iter_buf = String::new();
         let mut saw_tool_use = false;
+        // Most recent tool name surfaced as a progress line. Used to avoid
+        // emitting back-to-back duplicate "🔧 same_tool" lines when a driver
+        // double-fires ToolUseStart for the same call.
+        let mut last_progress_tool: Option<String> = None;
 
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -357,14 +381,40 @@ fn start_stream_text_bridge(
                     iter_buf.clear();
                     saw_tool_use = false;
                 }
-                StreamEvent::ToolUseStart { .. } => {
+                StreamEvent::ToolUseStart { name, .. } => {
                     saw_tool_use = true;
+                    // Surface tool invocations to the user as a short progress
+                    // line. Streaming adapters (Telegram) edit this into the
+                    // live message; non-streaming adapters fall back to plain
+                    // text and the line just becomes part of the reply.
+                    if !name.is_empty() && last_progress_tool.as_deref() != Some(name.as_str()) {
+                        let line = format!("\n\n🔧 `{name}`\n");
+                        if tx.send(line).await.is_err() {
+                            break;
+                        }
+                        last_progress_tool = Some(name);
+                    }
+                }
+                StreamEvent::ToolExecutionResult { name, is_error, .. } => {
+                    // Only surface failures — successes are followed by the
+                    // model's next prose iteration which is signal enough.
+                    if is_error && !name.is_empty() {
+                        let line = format!("\n⚠️ `{name}` failed\n");
+                        if tx.send(line).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Allow the same tool name to fire a fresh progress line
+                    // on the next ToolUseStart (e.g. retried tool calls).
+                    if last_progress_tool.as_deref() == Some(name.as_str()) {
+                        last_progress_tool = None;
+                    }
                 }
                 StreamEvent::PhaseChange { .. } => {
-                    // PhaseChange events (e.g. "long_running") are NOT injected
-                    // into the text stream — they would persist in the response.
-                    // They flow through the SSE endpoint as `event: phase` and
-                    // each adapter handles them independently.
+                    // PhaseChange events (e.g. "long_running") fire on every
+                    // iteration and are too noisy for inline display. They
+                    // still flow through the SSE endpoint as `event: phase`
+                    // for the dashboard.
                 }
                 _ => {}
             }
@@ -380,18 +430,23 @@ fn start_stream_text_bridge(
     });
 
     tokio::spawn(async move {
-        let error_msg = match kernel_handle.await {
+        let (error_msg, status): (Option<String>, Result<(), String>) = match kernel_handle.await {
             Err(e) => {
                 error!("Streaming kernel task panicked: {e}");
-                Some(
-                    "Sorry, something went wrong on my end. Please try again in a moment."
-                        .to_string(),
+                (
+                    Some(
+                        "Sorry, something went wrong on my end. Please try again in a moment."
+                            .to_string(),
+                    ),
+                    Err(format!("kernel task panicked: {e}")),
                 )
             }
             Ok(Err(e)) => {
                 let err_str = e.to_string();
                 error!("Streaming kernel task returned error: {err_str}");
-                if err_str.contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER) {
+                let user_msg = if err_str
+                    .contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER)
+                {
                     Some(
                         "\n\n---\n[Task timed out. The output above may be incomplete.]"
                             .to_string(),
@@ -419,7 +474,8 @@ fn start_stream_text_bridge(
                     } else {
                         Some(sanitize_channel_error(&err_str))
                     }
-                }
+                };
+                (user_msg, Err(err_str))
             }
             Ok(Ok(result)) => {
                 debug!(
@@ -428,7 +484,7 @@ fn start_stream_text_bridge(
                     iterations = result.iterations,
                     "Streaming kernel task completed"
                 );
-                None
+                (None, Ok(()))
             }
         };
         // Send error notification to the user through the channel before
@@ -443,9 +499,12 @@ fn start_stream_text_bridge(
         if let Err(e) = bridge_handle.await {
             error!("Streaming bridge task panicked: {e}");
         }
+        // Report kernel terminal status to any caller that opted in. Sent
+        // last so awaiters can be sure the text channel has fully drained.
+        let _ = status_tx.send(status);
     });
 
-    rx
+    (rx, status_rx)
 }
 
 /// Wraps `LibreFangKernel` to implement `ChannelBridgeHandle`.
@@ -534,6 +593,30 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .await
             .map_err(|e| format!("{e}"))?;
         Ok(start_stream_text_bridge(
+            event_rx,
+            kernel_handle,
+            sender.is_group,
+        ))
+    }
+
+    async fn send_message_streaming_with_sender_status(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<
+        (
+            mpsc::Receiver<String>,
+            tokio::sync::oneshot::Receiver<Result<(), String>>,
+        ),
+        String,
+    > {
+        let (event_rx, kernel_handle) = self
+            .kernel
+            .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(start_stream_text_bridge_with_status(
             event_rx,
             kernel_handle,
             sender.is_group,
@@ -3307,6 +3390,296 @@ mod tests {
             msg.is_none(),
             "Expected tool call JSON to be filtered, but got: {:?}",
             msg
+        );
+    }
+
+    /// ToolUseStart should surface a short progress line so users see what
+    /// the agent is currently doing inside their channel reply (mirrors the
+    /// behavior of hermes-agent's commentary stream).
+    #[tokio::test]
+    async fn test_stream_bridge_surfaces_tool_use_progress() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "web_search".to_string(),
+            })
+            .await
+            .unwrap();
+        // Tool call syntax echoed as text — should be filtered at ContentComplete.
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "tool_use: web_search".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::ToolUse,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        // Next iteration: actual model prose after the tool result.
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "Found 3 results.".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            combined.contains("🔧") && combined.contains("web_search"),
+            "Expected tool progress line in stream, got: {combined:?}"
+        );
+        assert!(
+            combined.contains("Found 3 results."),
+            "Expected post-tool prose in stream, got: {combined:?}"
+        );
+    }
+
+    /// A failed tool execution should surface a visible warning line so the
+    /// user knows the agent's plan hit a snag.
+    #[tokio::test]
+    async fn test_stream_bridge_surfaces_tool_failure() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "shell_exec".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ToolExecutionResult {
+                name: "shell_exec".to_string(),
+                result_preview: "permission denied".to_string(),
+                is_error: true,
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            combined.contains("⚠️")
+                && combined.contains("shell_exec")
+                && combined.contains("failed"),
+            "Expected failure marker in stream, got: {combined:?}"
+        );
+    }
+
+    /// Successful tool executions should NOT emit a "done" line — the model's
+    /// next prose iteration is signal enough, and adding a line per call gets
+    /// noisy fast for agents that chain many tools.
+    #[tokio::test]
+    async fn test_stream_bridge_quiet_on_tool_success() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::ToolExecutionResult {
+                name: "web_search".to_string(),
+                result_preview: "ok".to_string(),
+                is_error: false,
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        assert!(
+            !combined.contains("✓") && !combined.contains("done"),
+            "Expected silence on tool success, got: {combined:?}"
+        );
+    }
+
+    /// Back-to-back duplicate ToolUseStart events for the same tool name
+    /// should produce only one progress line — some drivers double-fire.
+    #[tokio::test]
+    async fn test_stream_bridge_dedupes_consecutive_tool_progress() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+
+        for _ in 0..3 {
+            event_tx
+                .send(StreamEvent::ToolUseStart {
+                    id: "tool_1".to_string(),
+                    name: "web_search".to_string(),
+                })
+                .await
+                .unwrap();
+        }
+        drop(event_tx);
+
+        let mut received: Vec<String> = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        let combined = received.join("");
+        let progress_count = combined.matches("🔧").count();
+        assert_eq!(
+            progress_count, 1,
+            "Expected 1 progress line for repeated same-tool starts, got {progress_count}: {combined:?}"
+        );
+    }
+
+    /// The status oneshot must resolve to Ok(()) when the kernel handle
+    /// completes successfully — this is what bridge.rs uses to decide
+    /// `AgentPhase::Done` vs `AgentPhase::Error` and to populate
+    /// `record_delivery(success=true)`.
+    #[tokio::test]
+    async fn test_stream_bridge_status_success() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "hello".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        // Drain text channel
+        while rx.recv().await.is_some() {}
+
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_ok(),
+            "Expected kernel success status, got {status:?}"
+        );
+    }
+
+    /// The status oneshot must resolve to Err(...) when the agent loop
+    /// returns a KernelError. bridge.rs uses this to honor
+    /// `suppress_error_responses` (so Mastodon won't post sanitized errors
+    /// to a public timeline) and to record `success=false`.
+    #[tokio::test]
+    async fn test_stream_bridge_status_error() {
+        use librefang_kernel::error::KernelError;
+        use librefang_types::error::LibreFangError;
+
+        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async {
+            Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
+                LibreFangError::Internal("rate limit hit".to_string()).into(),
+            )
+        });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+
+        // Drain text channel — will include sanitized error message
+        let mut received = String::new();
+        while let Some(chunk) = rx.recv().await {
+            received.push_str(&chunk);
+        }
+
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_err(),
+            "Expected kernel error status, got {status:?}"
+        );
+        // The original error string should be preserved in the status,
+        // letting record_delivery / journal report what actually happened.
+        assert!(
+            status.as_ref().unwrap_err().contains("rate limit"),
+            "Expected original error in status, got {status:?}"
+        );
+        // The user-facing text should still get a sanitized DM reply.
+        assert!(
+            !received.is_empty(),
+            "Expected user-facing error text, got empty stream"
+        );
+    }
+
+    /// Group conversations should suppress error TEXT (no sanitized prose
+    /// posted to the channel) but the status oneshot must still report Err
+    /// so bridge.rs can record_delivery(success=false) and emit Error
+    /// reaction. Without this distinction, group errors would silently look
+    /// like successful empty replies.
+    #[tokio::test]
+    async fn test_stream_bridge_group_error_suppresses_text_but_reports_err() {
+        use librefang_kernel::error::KernelError;
+        use librefang_types::error::LibreFangError;
+
+        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async {
+            Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
+                LibreFangError::Internal("some internal failure".to_string()).into(),
+            )
+        });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, /* is_group */ true);
+
+        let mut received = String::new();
+        while let Some(chunk) = rx.recv().await {
+            received.push_str(&chunk);
+        }
+
+        assert!(
+            received.is_empty(),
+            "Group conversations must not surface sanitized errors as text, got: {received:?}"
+        );
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_err(),
+            "Group error must still be reported via status oneshot"
         );
     }
 

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -315,14 +315,55 @@ use tracing::{debug, error, info, warn};
 
 use librefang_runtime::str_utils::safe_truncate_str;
 
+/// Convert a snake_case / kebab-case / dotted tool ID into a human-readable
+/// display name. Used in progress lines so users see "Web Search" instead of
+/// "web_search". Words already containing uppercase letters keep their case
+/// after the first char (so MCP_call → MCP Call, not Mcp Call).
+fn prettify_tool_name(name: &str) -> String {
+    name.split(['_', '-', '.'])
+        .filter(|s| !s.is_empty())
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Localized "failed" suffix for tool-failure progress lines.
+///
+/// Falls back to English for any unsupported / unknown language.
+fn tr_progress_failed(language: &str) -> &'static str {
+    let resolved = librefang_types::i18n::resolve_language(language);
+    match resolved {
+        "zh-CN" => "失败",
+        "es" => "falló",
+        "ja" => "失敗",
+        "de" => "fehlgeschlagen",
+        "fr" => "échoué",
+        _ => "failed",
+    }
+}
+
 fn start_stream_text_bridge(
     event_rx: mpsc::Receiver<StreamEvent>,
     kernel_handle: tokio::task::JoinHandle<
         KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
     >,
     is_group: bool,
+    show_progress: bool,
+    language: &str,
 ) -> mpsc::Receiver<String> {
-    let (rx, _status) = start_stream_text_bridge_with_status(event_rx, kernel_handle, is_group);
+    let (rx, _status) = start_stream_text_bridge_with_status(
+        event_rx,
+        kernel_handle,
+        is_group,
+        show_progress,
+        language,
+    );
     rx
 }
 
@@ -331,12 +372,20 @@ fn start_stream_text_bridge(
 /// drained. Callers use this to drive proper lifecycle reactions, accurate
 /// `record_delivery` metrics, and `suppress_error_responses` honor for
 /// public-feed adapters.
+///
+/// `show_progress` controls whether tool-invocation lines (`🔧 tool_name`)
+/// and tool-failure lines (`⚠️ tool_name failed`) are injected into the
+/// text stream. When `false`, the stream is pure model output — useful for
+/// agents whose responses are consumed by parsers or whose channel context
+/// must not have inline status markers.
 fn start_stream_text_bridge_with_status(
     mut event_rx: mpsc::Receiver<StreamEvent>,
     kernel_handle: tokio::task::JoinHandle<
         KernelResult<librefang_runtime::agent_loop::AgentLoopResult>,
     >,
     is_group: bool,
+    show_progress: bool,
+    language: &str,
 ) -> (
     mpsc::Receiver<String>,
     tokio::sync::oneshot::Receiver<Result<(), String>>,
@@ -344,6 +393,7 @@ fn start_stream_text_bridge_with_status(
     let (tx, rx) = mpsc::channel::<String>(64);
     let (status_tx, status_rx) = tokio::sync::oneshot::channel();
     let error_tx = tx.clone();
+    let failed_word: &str = tr_progress_failed(language);
 
     let bridge_handle = tokio::spawn(async move {
         // Buffer text per iteration. Some providers emit tool call syntax
@@ -352,10 +402,14 @@ fn start_stream_text_bridge_with_status(
         // tool call or content-block array.
         let mut iter_buf = String::new();
         let mut saw_tool_use = false;
-        // Most recent tool name surfaced as a progress line. Used to avoid
-        // emitting back-to-back duplicate "🔧 same_tool" lines when a driver
-        // double-fires ToolUseStart for the same call.
-        let mut last_progress_tool: Option<String> = None;
+        // Tool names already surfaced in the current iteration. Cleared at
+        // every ContentComplete so a tool retried in a *later* iteration
+        // still gets a visible progress line. Within one iteration, repeat
+        // calls to the same tool collapse into a single "🔧 tool" line —
+        // important for batch agents that fan out to the same tool many
+        // times in one turn (e.g. parallel web searches).
+        let mut iter_tools_seen: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -380,6 +434,9 @@ fn start_stream_text_bridge_with_status(
                     }
                     iter_buf.clear();
                     saw_tool_use = false;
+                    // Iteration boundary: a tool retried in the *next*
+                    // iteration deserves its own visible "🔧 tool" line.
+                    iter_tools_seen.clear();
                 }
                 StreamEvent::ToolUseStart { name, .. } => {
                     saw_tool_use = true;
@@ -387,34 +444,50 @@ fn start_stream_text_bridge_with_status(
                     // line. Streaming adapters (Telegram) edit this into the
                     // live message; non-streaming adapters fall back to plain
                     // text and the line just becomes part of the reply.
-                    if !name.is_empty() && last_progress_tool.as_deref() != Some(name.as_str()) {
-                        let line = format!("\n\n🔧 `{name}`\n");
+                    // Skip entirely when the agent has show_progress=false.
+                    //
+                    // All progress lines use `\n\n…\n\n` so adjacent markers
+                    // (e.g. `🔧 X` followed by `⚠️ X failed`) render with a
+                    // blank line between them on every renderer that respects
+                    // markdown blank-line semantics, instead of being
+                    // collapsed into one paragraph.
+                    if show_progress && !name.is_empty() && iter_tools_seen.insert(name.clone()) {
+                        let pretty = prettify_tool_name(&name);
+                        let line = format!("\n\n🔧 {pretty}\n\n");
                         if tx.send(line).await.is_err() {
                             break;
                         }
-                        last_progress_tool = Some(name);
                     }
                 }
-                StreamEvent::ToolExecutionResult { name, is_error, .. } => {
-                    // Only surface failures — successes are followed by the
-                    // model's next prose iteration which is signal enough.
-                    if is_error && !name.is_empty() {
-                        let line = format!("\n⚠️ `{name}` failed\n");
-                        if tx.send(line).await.is_err() {
-                            break;
-                        }
-                    }
-                    // Allow the same tool name to fire a fresh progress line
-                    // on the next ToolUseStart (e.g. retried tool calls).
-                    if last_progress_tool.as_deref() == Some(name.as_str()) {
-                        last_progress_tool = None;
+                // Only surface failures — successes are followed by the
+                // model's next prose iteration which is signal enough.
+                StreamEvent::ToolExecutionResult { name, is_error, .. }
+                    if show_progress && is_error && !name.is_empty() =>
+                {
+                    let pretty = prettify_tool_name(&name);
+                    let line = format!("\n\n⚠️ {pretty} {failed_word}\n\n");
+                    if tx.send(line).await.is_err() {
+                        break;
                     }
                 }
-                StreamEvent::PhaseChange { .. } => {
-                    // PhaseChange events (e.g. "long_running") fire on every
-                    // iteration and are too noisy for inline display. They
-                    // still flow through the SSE endpoint as `event: phase`
-                    // for the dashboard.
+                // Most PhaseChange events (`thinking`, `tool_use`,
+                // `streaming`, `done`) fire every iteration and are too
+                // noisy for inline display — they still flow through the
+                // SSE endpoint for the dashboard.
+                //
+                // We only surface phases that carry actionable user-facing
+                // information:
+                //   - `context_warning`: agent's context window was
+                //     trimmed or overflowed; user needs to know quality
+                //     may degrade and that /reset or /compact may help
+                StreamEvent::PhaseChange { phase, detail }
+                    if show_progress && phase == "context_warning" =>
+                {
+                    let body = detail.as_deref().unwrap_or("Context window trimmed");
+                    let line = format!("\n\n⚠️ {body}\n\n");
+                    if tx.send(line).await.is_err() {
+                        break;
+                    }
                 }
                 _ => {}
             }
@@ -444,9 +517,9 @@ fn start_stream_text_bridge_with_status(
             Ok(Err(e)) => {
                 let err_str = e.to_string();
                 error!("Streaming kernel task returned error: {err_str}");
-                let user_msg = if err_str
-                    .contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER)
-                {
+                let is_timeout =
+                    err_str.contains(librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER);
+                let user_msg = if is_timeout {
                     Some(
                         "\n\n---\n[Task timed out. The output above may be incomplete.]"
                             .to_string(),
@@ -475,7 +548,15 @@ fn start_stream_text_bridge_with_status(
                         Some(sanitize_channel_error(&err_str))
                     }
                 };
-                (user_msg, Err(err_str))
+                // Timeout-with-partial-output is a soft success: the model
+                // emitted a useful chunk before the inactivity timer fired,
+                // and the user already saw it streamed in. Reporting status
+                // = Err here would flip the lifecycle reaction to ❌ and
+                // record_delivery to success=false, which is a UX regression
+                // — pre-V2 the bridge had no status channel and treated
+                // these turns as Done. Keep that semantics by reporting Ok.
+                let status = if is_timeout { Ok(()) } else { Err(err_str) };
+                (user_msg, status)
             }
             Ok(Ok(result)) => {
                 debug!(
@@ -573,12 +654,25 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         agent_id: AgentId,
         message: &str,
     ) -> Result<mpsc::Receiver<String>, String> {
+        let show_progress = self
+            .kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|e| e.manifest.show_progress)
+            .unwrap_or(true);
+        let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
             .send_message_streaming_with_routing(agent_id, message, None)
             .await
             .map_err(|e| format!("{e}"))?;
-        Ok(start_stream_text_bridge(event_rx, kernel_handle, false))
+        Ok(start_stream_text_bridge(
+            event_rx,
+            kernel_handle,
+            false,
+            show_progress,
+            &language,
+        ))
     }
 
     async fn send_message_streaming_with_sender(
@@ -587,6 +681,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         message: &str,
         sender: &SenderContext,
     ) -> Result<mpsc::Receiver<String>, String> {
+        let show_progress = self
+            .kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|e| e.manifest.show_progress)
+            .unwrap_or(true);
+        let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
             .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
@@ -596,6 +697,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             event_rx,
             kernel_handle,
             sender.is_group,
+            show_progress,
+            &language,
         ))
     }
 
@@ -611,6 +714,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         ),
         String,
     > {
+        let show_progress = self
+            .kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|e| e.manifest.show_progress)
+            .unwrap_or(true);
+        let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
             .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
@@ -620,6 +730,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             event_rx,
             kernel_handle,
             sender.is_group,
+            show_progress,
+            &language,
         ))
     }
 
@@ -3364,7 +3476,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
-        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false, true, "en");
 
         // Simulate a provider emitting an agent_send tool call as plain text
         // (no ToolUseStart event) followed by ContentComplete.
@@ -3403,7 +3515,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
-        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false, true, "en");
 
         event_tx
             .send(StreamEvent::ToolUseStart {
@@ -3448,8 +3560,8 @@ mod tests {
         }
         let combined = received.join("");
         assert!(
-            combined.contains("🔧") && combined.contains("web_search"),
-            "Expected tool progress line in stream, got: {combined:?}"
+            combined.contains("🔧") && combined.contains("Web Search"),
+            "Expected tool progress line in stream (with prettified name), got: {combined:?}"
         );
         assert!(
             combined.contains("Found 3 results."),
@@ -3466,7 +3578,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
-        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false, true, "en");
 
         event_tx
             .send(StreamEvent::ToolUseStart {
@@ -3492,9 +3604,9 @@ mod tests {
         let combined = received.join("");
         assert!(
             combined.contains("⚠️")
-                && combined.contains("shell_exec")
+                && combined.contains("Shell Exec")
                 && combined.contains("failed"),
-            "Expected failure marker in stream, got: {combined:?}"
+            "Expected failure marker in stream (with prettified name), got: {combined:?}"
         );
     }
 
@@ -3508,7 +3620,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
-        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false, true, "en");
 
         event_tx
             .send(StreamEvent::ToolExecutionResult {
@@ -3531,6 +3643,100 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_prettify_tool_name_snake_to_title() {
+        assert_eq!(prettify_tool_name("web_search"), "Web Search");
+        assert_eq!(prettify_tool_name("get_user_data"), "Get User Data");
+    }
+
+    #[test]
+    fn test_prettify_tool_name_kebab_and_dotted() {
+        assert_eq!(prettify_tool_name("web-search"), "Web Search");
+        assert_eq!(prettify_tool_name("http.get"), "Http Get");
+    }
+
+    #[test]
+    fn test_prettify_tool_name_preserves_internal_caps() {
+        // MCP and HTTP shouldn't be downcased to "Mcp" / "Http" by the
+        // prettifier — only the FIRST character of each word is uppercased.
+        assert_eq!(prettify_tool_name("MCP_call"), "MCP Call");
+        assert_eq!(prettify_tool_name("HTTPRequest"), "HTTPRequest");
+    }
+
+    #[test]
+    fn test_tr_progress_failed_languages() {
+        assert_eq!(tr_progress_failed("en"), "failed");
+        assert_eq!(tr_progress_failed("zh-CN"), "失败");
+        assert_eq!(tr_progress_failed("zh"), "失败");
+        assert_eq!(tr_progress_failed("ja"), "失敗");
+        // Unknown language falls back to English.
+        assert_eq!(tr_progress_failed("xx"), "failed");
+    }
+
+    /// When `show_progress=false`, neither tool-invocation nor failure
+    /// markers should be injected into the user-facing text — the stream
+    /// must be pure model output. This is what `agent.toml show_progress
+    /// = false` opts agents into for parser-consumed or pristine-output
+    /// scenarios.
+    #[tokio::test]
+    async fn test_stream_bridge_show_progress_false_suppresses_all_markers() {
+        use librefang_runtime::agent_loop::AgentLoopResult;
+
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
+
+        let mut rx = start_stream_text_bridge(
+            event_rx,
+            kernel_handle,
+            false,
+            /* show_progress */ false,
+            "en",
+        );
+
+        event_tx
+            .send(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "web_search".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ToolExecutionResult {
+                name: "web_search".to_string(),
+                result_preview: "irrelevant".to_string(),
+                is_error: true,
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::TextDelta {
+                text: "Final answer.".to_string(),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        drop(event_tx);
+
+        let mut received = String::new();
+        while let Some(msg) = rx.recv().await {
+            received.push_str(&msg);
+        }
+        assert!(
+            !received.contains("🔧") && !received.contains("⚠️"),
+            "Expected no progress/failure markers when show_progress=false, got: {received:?}"
+        );
+        assert!(
+            received.contains("Final answer."),
+            "Expected actual model prose to still flow through, got: {received:?}"
+        );
+    }
+
     /// Back-to-back duplicate ToolUseStart events for the same tool name
     /// should produce only one progress line — some drivers double-fire.
     #[tokio::test]
@@ -3540,7 +3746,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
-        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false);
+        let mut rx = start_stream_text_bridge(event_rx, kernel_handle, false, true, "en");
 
         for _ in 0..3 {
             event_tx
@@ -3577,7 +3783,7 @@ mod tests {
         let kernel_handle = tokio::spawn(async { Ok(AgentLoopResult::default()) });
 
         let (mut rx, status_rx) =
-            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false, true, "en");
 
         event_tx
             .send(StreamEvent::TextDelta {
@@ -3621,7 +3827,7 @@ mod tests {
         });
 
         let (mut rx, status_rx) =
-            start_stream_text_bridge_with_status(event_rx, kernel_handle, false);
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false, true, "en");
 
         // Drain text channel — will include sanitized error message
         let mut received = String::new();
@@ -3664,8 +3870,13 @@ mod tests {
             )
         });
 
-        let (mut rx, status_rx) =
-            start_stream_text_bridge_with_status(event_rx, kernel_handle, /* is_group */ true);
+        let (mut rx, status_rx) = start_stream_text_bridge_with_status(
+            event_rx,
+            kernel_handle,
+            /* is_group */ true,
+            true,
+            "en",
+        );
 
         let mut received = String::new();
         while let Some(chunk) = rx.recv().await {
@@ -3680,6 +3891,52 @@ mod tests {
         assert!(
             status.is_err(),
             "Group error must still be reported via status oneshot"
+        );
+    }
+
+    /// Inactivity-timeout errors (carrying TIMEOUT_PARTIAL_OUTPUT_MARKER)
+    /// must be reported via the status oneshot as Ok(()) — not Err. The
+    /// model emitted useful prose before the inactivity timer fired and
+    /// pre-V2 the bridge had no status channel and treated these turns as
+    /// Done. Reporting Err here would flip lifecycle reaction to Error and
+    /// record_delivery to success=false, which is a UX regression.
+    ///
+    /// We still inject the "[Task timed out…]" tail into the user-facing
+    /// text so they understand the reply may be incomplete.
+    #[tokio::test]
+    async fn test_stream_bridge_timeout_partial_output_reports_ok_status() {
+        use librefang_kernel::error::KernelError;
+        use librefang_types::error::LibreFangError;
+
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let kernel_handle = tokio::spawn(async {
+            // Mirror the kernel-side error format: a string that contains
+            // the timeout marker constant.
+            let err = format!(
+                "agent loop timed out: {}",
+                librefang_runtime::agent_loop::TIMEOUT_PARTIAL_OUTPUT_MARKER
+            );
+            Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
+                LibreFangError::Internal(err).into(),
+            )
+        });
+
+        let (mut rx, status_rx) =
+            start_stream_text_bridge_with_status(event_rx, kernel_handle, false, true, "en");
+
+        let mut received = String::new();
+        while let Some(chunk) = rx.recv().await {
+            received.push_str(&chunk);
+        }
+        assert!(
+            received.contains("[Task timed out"),
+            "Expected timeout tail in user-facing text, got: {received:?}"
+        );
+
+        let status = status_rx.await.expect("status oneshot dropped");
+        assert!(
+            status.is_ok(),
+            "Timeout-with-partial-output is a soft success — status must be Ok, got: {status:?}"
         );
     }
 

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1155,6 +1155,62 @@ fn filter_to_comms_event(
             }),
             _ => None,
         },
+        EventPayload::System(sys) => {
+            use librefang_types::event::SystemEvent;
+            match sys {
+                SystemEvent::TaskPosted {
+                    task_id,
+                    title,
+                    assigned_to,
+                    created_by,
+                } => {
+                    let target_id = assigned_to.clone().unwrap_or_default();
+                    let source_id = created_by.clone().unwrap_or_default();
+                    Some(CommsEvent {
+                        id: event.id.to_string(),
+                        timestamp: event.timestamp.to_rfc3339(),
+                        kind: CommsEventKind::TaskPosted,
+                        source_id: source_id.clone(),
+                        source_name: resolve_name(&source_id),
+                        target_id: target_id.clone(),
+                        target_name: resolve_name(&target_id),
+                        detail: format!("Task posted: {} ({})", title, task_id),
+                    })
+                }
+                SystemEvent::TaskClaimed {
+                    task_id,
+                    claimed_by,
+                } => Some(CommsEvent {
+                    id: event.id.to_string(),
+                    timestamp: event.timestamp.to_rfc3339(),
+                    kind: CommsEventKind::TaskClaimed,
+                    source_id: claimed_by.clone(),
+                    source_name: resolve_name(claimed_by),
+                    target_id: String::new(),
+                    target_name: String::new(),
+                    detail: format!("Task claimed: {}", task_id),
+                }),
+                SystemEvent::TaskCompleted {
+                    task_id,
+                    completed_by,
+                    result,
+                } => Some(CommsEvent {
+                    id: event.id.to_string(),
+                    timestamp: event.timestamp.to_rfc3339(),
+                    kind: CommsEventKind::TaskCompleted,
+                    source_id: completed_by.clone(),
+                    source_name: resolve_name(completed_by),
+                    target_id: String::new(),
+                    target_name: String::new(),
+                    detail: format!(
+                        "Task completed: {} — {}",
+                        task_id,
+                        librefang_types::truncate_str(result, 200)
+                    ),
+                }),
+                _ => None,
+            }
+        }
         _ => None,
     }
 }
@@ -1467,7 +1523,6 @@ pub async fn comms_task(
 
     match state
         .kernel
-        .memory_substrate()
         .task_post(
             &req.title,
             &req.description,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -353,6 +353,42 @@ pub trait ChannelBridgeHandle: Send + Sync {
         self.send_message_streaming(agent_id, message).await
     }
 
+    /// Streaming send that *also* reports the kernel's terminal success/error
+    /// once the stream completes. Callers that need accurate delivery metrics,
+    /// lifecycle reactions, and error suppression should use this variant —
+    /// the plain `send_message_streaming_with_sender` collapses everything
+    /// into the text channel, which makes it impossible to distinguish a
+    /// successful reply from a sanitized error message after the fact.
+    ///
+    /// The oneshot resolves to `Ok(())` on success and `Err(error_string)` on
+    /// failure (panic, kernel error, or LLM error). It is sent only once the
+    /// kernel join handle has resolved, so awaiting it after draining the
+    /// text receiver is safe.
+    ///
+    /// Default implementation preserves existing behavior by reporting
+    /// fake-success — implementers that can detect kernel failure (e.g. the
+    /// real `LibreFangKernel` impl) should override this to surface real
+    /// status.
+    async fn send_message_streaming_with_sender_status(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: &SenderContext,
+    ) -> Result<
+        (
+            mpsc::Receiver<String>,
+            tokio::sync::oneshot::Receiver<Result<(), String>>,
+        ),
+        String,
+    > {
+        let rx = self
+            .send_message_streaming_with_sender(agent_id, message, sender)
+            .await?;
+        let (status_tx, status_rx) = tokio::sync::oneshot::channel();
+        let _ = status_tx.send(Ok(()));
+        Ok((rx, status_rx))
+    }
+
     /// Push a proactive outbound message to a channel recipient.
     ///
     /// Used by the REST API push endpoint (`POST /api/agents/:id/push`) to let
@@ -2893,7 +2929,76 @@ async fn dispatch_message(
         }
     }
 
-    // Non-streaming path: send to agent and relay response (with sender identity).
+    // Non-streaming-adapter path. We route through the kernel's streaming
+    // API (via `_status` variant) so progress events (tool invocations,
+    // errors) get surfaced into the accumulated text — the channel bridge
+    // injects "🔧 tool_name" and "⚠️ tool failed" lines for streaming
+    // consumers, and we want non-streaming adapters (Discord/Slack/Matrix/...)
+    // to show those too. We accumulate deltas and send once via send_response
+    // so output_format and thread_id are still honored.
+    //
+    // The `_status` variant returns a oneshot that resolves to the kernel's
+    // terminal Result. We use it to drive the correct lifecycle reaction
+    // (Done vs Error), accurate `record_delivery` success metric, journal
+    // status, and to honor `suppress_error_responses` on public-feed adapters
+    // (Mastodon) — accumulated text contains a sanitized error string when
+    // the agent loop fails, which we must not leak to a public timeline.
+    //
+    // If the streaming kernel call is unavailable up-front we fall through
+    // to the non-streaming kernel call — preserves the pre-existing
+    // `handle_send_error` retry / re-resolution path.
+    if let Ok((mut delta_rx, status_rx)) = handle
+        .send_message_streaming_with_sender_status(agent_id, &text, &sender_ctx)
+        .await
+    {
+        let mut accumulated = String::new();
+        while let Some(delta) = delta_rx.recv().await {
+            accumulated.push_str(&delta);
+        }
+        // Status is sent after the text channel fully drains, so awaiting
+        // here will not block longer than the stream itself.
+        let kernel_status = status_rx.await.unwrap_or(Ok(()));
+        let success = kernel_status.is_ok();
+        let phase = if success {
+            AgentPhase::Done
+        } else {
+            AgentPhase::Error
+        };
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, phase).await;
+        if !accumulated.is_empty() && (success || !adapter.suppress_error_responses()) {
+            send_response(
+                adapter,
+                &message.sender,
+                accumulated,
+                thread_id,
+                output_format,
+            )
+            .await;
+        }
+        let err_str = kernel_status.as_ref().err().cloned();
+        handle
+            .record_delivery(
+                agent_id,
+                ct_str,
+                &message.sender.platform_id,
+                success,
+                err_str.as_deref(),
+                thread_id,
+            )
+            .await;
+        if let Some(j) = journal {
+            let jstatus = if success {
+                crate::message_journal::JournalStatus::Completed
+            } else {
+                crate::message_journal::JournalStatus::Failed
+            };
+            j.update_status(&message.platform_message_id, jstatus, err_str)
+                .await;
+        }
+        return;
+    }
+
+    // Fallback: streaming kernel call unavailable for this request.
     match handle
         .send_message_with_sender(agent_id, &text, &sender_ctx)
         .await

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -79,8 +79,13 @@ pub trait KernelHandle: Send + Sync {
     /// Claim the next available task (optionally filtered by assignee). Returns task JSON or None.
     async fn task_claim(&self, agent_id: &str) -> Result<Option<serde_json::Value>, String>;
 
-    /// Mark a task as completed with a result string.
-    async fn task_complete(&self, task_id: &str, result: &str) -> Result<(), String>;
+    /// Mark a task as completed with a result string. `agent_id` identifies the completer.
+    async fn task_complete(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+        result: &str,
+    ) -> Result<(), String>;
 
     /// List tasks, optionally filtered by status.
     async fn task_list(&self, status: Option<&str>) -> Result<Vec<serde_json::Value>, String>;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1970,10 +1970,22 @@ impl LibreFangKernel {
                     configured_model.as_str()
                 };
                 let api_key_env = config.memory.embedding_api_key_env.as_deref().unwrap_or("");
-                let custom_url = config
-                    .provider_urls
-                    .get(provider.as_str())
-                    .map(|s| s.as_str());
+                // Prefer the catalog's provider base_url (which already has
+                // `config.provider_urls` overrides applied at this point, see
+                // `apply_url_overrides` above). Falls back to `provider_urls`
+                // directly if the catalog has no entry for this provider —
+                // and ultimately to the hardcoded default baked into
+                // `create_embedding_driver` if neither source knows.
+                let custom_url = model_catalog
+                    .get_provider(provider)
+                    .map(|p| p.base_url.as_str())
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| {
+                        config
+                            .provider_urls
+                            .get(provider.as_str())
+                            .map(|s| s.as_str())
+                    });
                 match create_embedding_driver(
                     provider,
                     model,
@@ -2001,7 +2013,17 @@ impl LibreFangKernel {
                     } else {
                         configured_model.as_str()
                     };
-                    let provider_url = config.provider_urls.get(detected).map(|s| s.as_str());
+                    // Prefer catalog-derived base_url (with user overrides
+                    // already applied) over raw `config.provider_urls`, so a
+                    // provider entry from the registry with a non-default
+                    // base URL (e.g. Cohere's `api.cohere.com/v2`) is actually
+                    // honored rather than silently falling back to the
+                    // hardcoded default inside `create_embedding_driver`.
+                    let provider_url = model_catalog
+                        .get_provider(detected)
+                        .map(|p| p.base_url.as_str())
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| config.provider_urls.get(detected).map(|s| s.as_str()));
                     // Determine the API key env var for the detected provider.
                     let key_env = match detected {
                         "openai" => "OPENAI_API_KEY",

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12163,7 +12163,23 @@ impl KernelHandle for LibreFangKernel {
         Ok(result)
     }
 
-    async fn task_complete(&self, task_id: &str, result: &str) -> Result<(), String> {
+    async fn task_complete(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+        result: &str,
+    ) -> Result<(), String> {
+        let resolved = match librefang_types::agent::AgentId::from_str(agent_id) {
+            Ok(_) => agent_id.to_string(),
+            Err(_) => match self.registry.find_by_name(agent_id) {
+                Some(entry) => entry.id.to_string(),
+                None => {
+                    return Err(format!(
+                        "Task complete failed: agent {agent_id:?} not found by UUID or name"
+                    ));
+                }
+            },
+        };
         self.memory
             .task_complete(task_id, result)
             .await
@@ -12175,6 +12191,7 @@ impl KernelHandle for LibreFangKernel {
             librefang_types::event::EventPayload::System(
                 librefang_types::event::SystemEvent::TaskCompleted {
                     task_id: task_id.to_string(),
+                    completed_by: resolved,
                     result: result.to_string(),
                 },
             ),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2025,10 +2025,11 @@ impl LibreFangKernel {
                         .filter(|s| !s.is_empty())
                         .or_else(|| config.provider_urls.get(detected).map(|s| s.as_str()));
                     // Determine the API key env var for the detected provider.
+                    // `detect_embedding_provider` never returns `"groq"` (Groq
+                    // has no embeddings endpoint), so it doesn't appear here.
                     let key_env = match detected {
                         "openai" => "OPENAI_API_KEY",
                         "openrouter" => "OPENROUTER_API_KEY",
-                        "groq" => "GROQ_API_KEY",
                         "mistral" => "MISTRAL_API_KEY",
                         "together" => "TOGETHER_API_KEY",
                         "fireworks" => "FIREWORKS_API_KEY",
@@ -2054,9 +2055,9 @@ impl LibreFangKernel {
                 } else {
                     warn!(
                         "No embedding provider available. Set one of: OPENAI_API_KEY, \
-                         OPENROUTER_API_KEY, GROQ_API_KEY, MISTRAL_API_KEY, \
-                         TOGETHER_API_KEY, FIREWORKS_API_KEY, COHERE_API_KEY, \
-                         or configure Ollama."
+                         OPENROUTER_API_KEY, MISTRAL_API_KEY, TOGETHER_API_KEY, \
+                         FIREWORKS_API_KEY, COHERE_API_KEY, or configure Ollama. \
+                         (GROQ_API_KEY is not accepted — Groq has no embeddings endpoint.)"
                     );
                     None
                 }

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -638,8 +638,12 @@ fn describe_event(event: &Event) -> String {
             } => {
                 format!("Task claimed: {task_id} by {claimed_by}")
             }
-            SystemEvent::TaskCompleted { task_id, result } => {
-                format!("Task completed: {task_id} result={result}")
+            SystemEvent::TaskCompleted {
+                task_id,
+                completed_by,
+                result,
+            } => {
+                format!("Task completed: {task_id} by {completed_by} result={result}")
             }
         },
         EventPayload::ApprovalRequested(ar) => {

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -1420,6 +1420,83 @@ mod tests {
         }
     }
 
+    /// Clear every env var that `detect_embedding_provider` inspects. Each
+    /// detect-priority test must call this first and restore the vars after
+    /// so host env state doesn't pollute the priority it exercises.
+    fn clear_detect_env() -> Vec<(&'static str, Option<String>)> {
+        let keys = [
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "GROQ_API_KEY",
+            "MISTRAL_API_KEY",
+            "TOGETHER_API_KEY",
+            "FIREWORKS_API_KEY",
+            "COHERE_API_KEY",
+            "OLLAMA_HOST",
+        ];
+        let saved = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        saved
+    }
+
+    fn restore_detect_env(saved: Vec<(&'static str, Option<String>)>) {
+        for (k, v) in saved {
+            match v {
+                Some(value) => std::env::set_var(k, value),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_ignores_groq() {
+        // Regression guard: Groq has no /v1/embeddings endpoint (confirmed
+        // empirically — `GET api.groq.com/openai/v1/models` returns only
+        // chat + Whisper). Auto-detect MUST NOT pick Groq, otherwise users
+        // who only set GROQ_API_KEY get silent 404s at the first embed call.
+        let saved = clear_detect_env();
+        std::env::set_var("GROQ_API_KEY", "test-groq-key");
+
+        assert_eq!(
+            detect_embedding_provider(),
+            None,
+            "GROQ_API_KEY alone must not auto-select any embedding provider"
+        );
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_picks_cohere_when_only_cohere_set() {
+        let saved = clear_detect_env();
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        assert_eq!(detect_embedding_provider(), Some("cohere"));
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_priority_openai_beats_cohere() {
+        // OpenAI is still #1 in the priority list; setting both keys picks OpenAI.
+        let saved = clear_detect_env();
+        std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        assert_eq!(detect_embedding_provider(), Some("openai"));
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_none_when_nothing_set() {
+        let saved = clear_detect_env();
+        assert_eq!(detect_embedding_provider(), None);
+        restore_detect_env(saved);
+    }
+
     #[test]
     fn test_resolve_cohere_input_type_default() {
         let had = std::env::var("LIBREFANG_COHERE_INPUT_TYPE").ok();

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -1272,10 +1272,14 @@ mod tests {
             base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: None,
         };
-        let err = CohereEmbeddingDriver::new(cfg).unwrap_err();
+        // `.unwrap_err()` would require `CohereEmbeddingDriver: Debug`, which
+        // it deliberately doesn't derive (would leak the api_key). Match on
+        // the Result directly instead so we only need `EmbeddingError: Debug`.
+        let result = CohereEmbeddingDriver::new(cfg);
         assert!(
-            matches!(err, EmbeddingError::MissingApiKey(_)),
-            "expected MissingApiKey, got {err:?}"
+            matches!(&result, Err(EmbeddingError::MissingApiKey(_))),
+            "expected MissingApiKey, got {:?}",
+            result.as_ref().err()
         );
     }
 
@@ -1407,11 +1411,14 @@ mod tests {
         let had = std::env::var("COHERE_API_KEY").ok();
         std::env::set_var("COHERE_API_KEY", "test-cohere-key");
 
-        let err =
-            create_embedding_driver("cohere", "embed-english-v3.0", "", None, None).unwrap_err();
+        // `.unwrap_err()` would require `Box<dyn EmbeddingDriver + Send + Sync>: Debug`,
+        // which the trait object doesn't provide (the trait has no Debug
+        // supertrait). Match on the Result directly.
+        let result = create_embedding_driver("cohere", "embed-english-v3.0", "", None, None);
         assert!(
-            matches!(err, EmbeddingError::InvalidInput(_)),
-            "expected InvalidInput when no base_url is available, got {err:?}"
+            matches!(&result, Err(EmbeddingError::InvalidInput(_))),
+            "expected InvalidInput when no base_url is available, got {:?}",
+            result.as_ref().err()
         );
 
         match had {

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -233,12 +233,25 @@ pub struct CohereEmbeddingDriver {
     api_key: Zeroizing<String>,
     base_url: String,
     model: String,
-    /// `input_type` sent to Cohere v3 models. Defaults to `search_document`
-    /// (correct for indexing memory/documents, the primary path today) and
-    /// can be overridden via the `LIBREFANG_COHERE_INPUT_TYPE` env var for
-    /// deployments whose primary path is query-time embedding or
-    /// clustering.  Invalid values are ignored with a warning because
-    /// Cohere returns a cryptic 400 otherwise.
+    /// `input_type` sent to Cohere's v2 API for every request from this
+    /// driver instance. Cohere's `embed-*` v3 model family uses this to
+    /// produce asymmetric embeddings: callers are supposed to send
+    /// `search_document` when embedding the corpus and `search_query` when
+    /// embedding a live user query, which measurably improves retrieval
+    /// quality.
+    ///
+    /// **Known limitation:** `EmbeddingDriver` in librefang today doesn't
+    /// distinguish "indexing" from "querying" — both go through the same
+    /// `embed()` method — so we pin a single `input_type` per driver.  The
+    /// default (`search_document`) is optimized for the indexing path,
+    /// which is the dominant call pattern for memory ingest.  Deployments
+    /// whose primary path is query-time embedding or clustering can
+    /// override the per-process default via the
+    /// `LIBREFANG_COHERE_INPUT_TYPE` env var (`search_document` |
+    /// `search_query` | `classification` | `clustering`); invalid values
+    /// are ignored with a warning because Cohere returns a cryptic 400
+    /// otherwise.  Per-call overrides would require a trait change and
+    /// are tracked as follow-up work.
     input_type: String,
     client: reqwest::Client,
     dims: usize,
@@ -1403,23 +1416,36 @@ mod tests {
     }
 
     #[test]
-    fn test_create_embedding_driver_cloud_provider_requires_base_url() {
+    fn test_create_embedding_driver_cloud_providers_require_base_url() {
         // Cloud providers no longer have hardcoded URL fallbacks — the catalog
         // (or an explicit override) must supply the base_url. Pin the
-        // behavior so a regression can't silently re-introduce the
-        // version-drift bug.
+        // behavior across every cloud provider so a regression can't
+        // silently re-introduce the version-drift bug for any of them.
+        //
+        // Cohere has an earlier api_key check that would preempt the URL
+        // check, so we set COHERE_API_KEY here to force the URL branch to
+        // fire. Other cloud providers don't reject empty api_key at
+        // construction, so they reach the URL check regardless.
         let had = std::env::var("COHERE_API_KEY").ok();
         std::env::set_var("COHERE_API_KEY", "test-cohere-key");
 
         // `.unwrap_err()` would require `Box<dyn EmbeddingDriver + Send + Sync>: Debug`,
-        // which the trait object doesn't provide (the trait has no Debug
-        // supertrait). Match on the Result directly.
-        let result = create_embedding_driver("cohere", "embed-english-v3.0", "", None, None);
-        assert!(
-            matches!(&result, Err(EmbeddingError::InvalidInput(_))),
-            "expected InvalidInput when no base_url is available, got {:?}",
-            result.as_ref().err()
-        );
+        // which the trait object doesn't provide. Match on Result directly.
+        for (provider, model) in [
+            ("openai", "text-embedding-3-small"),
+            ("openrouter", "openai/text-embedding-3-small"),
+            ("mistral", "mistral-embed"),
+            ("together", "BAAI/bge-large-en-v1.5"),
+            ("fireworks", "nomic-ai/nomic-embed-text-v1.5"),
+            ("cohere", "embed-english-v3.0"),
+        ] {
+            let result = create_embedding_driver(provider, model, "", None, None);
+            assert!(
+                matches!(&result, Err(EmbeddingError::InvalidInput(_))),
+                "expected InvalidInput for {provider} when no base_url is available, got {:?}",
+                result.as_ref().err()
+            );
+        }
 
         match had {
             Some(v) => std::env::set_var("COHERE_API_KEY", v),

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -206,16 +206,21 @@ impl EmbeddingDriver for OpenAIEmbeddingDriver {
 }
 
 // ---------------------------------------------------------------------------
-// Cohere embedding driver (native `/v1/embed` endpoint)
+// Cohere embedding driver (native `/v2/embed` endpoint)
 // ---------------------------------------------------------------------------
 
 /// Cohere native embedding driver.
 ///
 /// Cohere's embed API is **not** OpenAI-compatible — it uses a different
-/// endpoint (`/v1/embed` vs. `/v1/embeddings`), a different request shape
-/// (`texts` instead of `input`), and v3 models require an `input_type`
-/// parameter.  A dedicated driver is therefore necessary; sending Cohere
+/// endpoint (`/v2/embed` vs. `/v1/embeddings`), a different request shape
+/// (`texts` + required `input_type`), and v2 returns embeddings grouped by
+/// embedding type (`{ "embeddings": { "float": [[...]] } }`) rather than a
+/// flat array.  A dedicated driver is therefore necessary; sending Cohere
 /// requests through `OpenAIEmbeddingDriver` produces 404s.
+///
+/// The driver targets Cohere's **v2** API for consistency with
+/// `librefang-llm-drivers` (the chat driver also uses `api.cohere.com/v2`)
+/// and because v2 is the path Cohere recommends for new integrations.
 pub struct CohereEmbeddingDriver {
     api_key: Zeroizing<String>,
     base_url: String,
@@ -261,11 +266,23 @@ struct CohereEmbedRequest<'a> {
     texts: &'a [&'a str],
     model: &'a str,
     input_type: &'a str,
+    /// Required by the v2 API — tells Cohere which numeric representation to
+    /// return. We only ever want `float`; the other options (`int8`, `uint8`,
+    /// `binary`, `ubinary`, `base64`) are for bandwidth-sensitive deployments
+    /// that we don't support yet.
+    embedding_types: &'a [&'a str],
+}
+
+/// v2 response wraps embeddings in an object keyed by embedding type —
+/// we always request `float`, so we extract `embeddings.float`.
+#[derive(Deserialize)]
+struct CohereEmbedResponse {
+    embeddings: CohereEmbeddingsByType,
 }
 
 #[derive(Deserialize)]
-struct CohereEmbedResponse {
-    embeddings: Vec<Vec<f32>>,
+struct CohereEmbeddingsByType {
+    float: Vec<Vec<f32>>,
 }
 
 impl CohereEmbeddingDriver {
@@ -338,6 +355,7 @@ impl EmbeddingDriver for CohereEmbeddingDriver {
             texts,
             model: &self.model,
             input_type: &self.input_type,
+            embedding_types: &["float"],
         };
 
         let resp = self
@@ -362,14 +380,15 @@ impl EmbeddingDriver for CohereEmbeddingDriver {
             .json()
             .await
             .map_err(|e| EmbeddingError::Parse(e.to_string()))?;
+        let embeddings = data.embeddings.float;
 
         debug!(
             "Cohere embedded {} texts (dims={})",
-            data.embeddings.len(),
-            data.embeddings.first().map(|e| e.len()).unwrap_or(0)
+            embeddings.len(),
+            embeddings.first().map(|e| e.len()).unwrap_or(0)
         );
 
-        Ok(data.embeddings)
+        Ok(embeddings)
     }
 
     fn dimensions(&self) -> usize {
@@ -707,7 +726,7 @@ pub fn create_embedding_driver(
         return Ok(Box::new(driver));
     }
 
-    // Cohere uses its native `/v1/embed` endpoint with a different request
+    // Cohere uses its native `/v2/embed` endpoint with a different request
     // shape than OpenAI's `/v1/embeddings`. Handle it before the OpenAI-
     // compatible fall-through so a generic OpenAI driver doesn't 404.
     if provider == "cohere" {
@@ -744,7 +763,7 @@ pub fn create_embedding_driver(
         let base_url = custom_base_url
             .filter(|u| !u.is_empty())
             .map(|u| u.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| "https://api.cohere.com/v1".to_string());
+            .unwrap_or_else(|| "https://api.cohere.com/v2".to_string());
 
         warn!(
             provider = "cohere",
@@ -1225,7 +1244,7 @@ mod tests {
             provider: "cohere".to_string(),
             model: "embed-english-v3.0".to_string(),
             api_key: String::new(),
-            base_url: "https://api.cohere.com/v1".to_string(),
+            base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: None,
         };
         let err = CohereEmbeddingDriver::new(cfg).unwrap_err();
@@ -1241,7 +1260,7 @@ mod tests {
             provider: "cohere".to_string(),
             model: "embed-english-light-v3.0".to_string(),
             api_key: "bogus".to_string(),
-            base_url: "https://api.cohere.com/v1".to_string(),
+            base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: None,
         };
         let driver = CohereEmbeddingDriver::new(cfg).unwrap();
@@ -1254,7 +1273,7 @@ mod tests {
             provider: "cohere".to_string(),
             model: "embed-english-v3.0".to_string(),
             api_key: "bogus".to_string(),
-            base_url: "https://api.cohere.com/v1".to_string(),
+            base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: Some(512),
         };
         let driver = CohereEmbeddingDriver::new(cfg).unwrap();
@@ -1267,7 +1286,7 @@ mod tests {
             provider: "cohere".to_string(),
             model: "embed-english-v3.0".to_string(),
             api_key: "bogus".to_string(),
-            base_url: "https://api.cohere.com/v1".to_string(),
+            base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: None,
         };
         let driver = CohereEmbeddingDriver::new(cfg).unwrap();
@@ -1282,7 +1301,7 @@ mod tests {
             provider: "cohere".to_string(),
             model: "embed-english-v3.0".to_string(),
             api_key: "bogus".to_string(),
-            base_url: "https://api.cohere.com/v1".to_string(),
+            base_url: "https://api.cohere.com/v2".to_string(),
             dimensions_override: None,
         };
         let driver = CohereEmbeddingDriver::new(cfg).unwrap();
@@ -1393,7 +1412,7 @@ mod tests {
             "cohere",
             "embed-english-v3.0",
             "",
-            Some("https://cohere-proxy.internal/v1/"),
+            Some("https://cohere-proxy.internal/v2/"),
             None,
         )
         .unwrap();

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -1401,8 +1401,12 @@ mod tests {
     #[test]
     fn test_create_embedding_driver_cohere_remaps_openai_model_name() {
         // When auto-detect sends us an OpenAI-flavored model name, the Cohere
-        // branch should fall back to `embed-english-v3.0` rather than passing
-        // the unknown name through (which would 404 at request time).
+        // branch should fall back to `embed-multilingual-v3.0` rather than
+        // passing the unknown name through (which would 404 at request
+        // time). The assertion below checks dims == 1024, which holds for
+        // both `embed-multilingual-v3.0` and `embed-english-v3.0`; the
+        // actual fallback choice is pinned in code and documented in the
+        // warn!() call inside `create_embedding_driver`.
         let had = std::env::var("COHERE_API_KEY").ok();
         std::env::set_var("COHERE_API_KEY", "test-cohere-key");
 

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -26,6 +26,8 @@ pub enum EmbeddingError {
     Parse(String),
     #[error("Missing API key: {0}")]
     MissingApiKey(String),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
     #[error("Unsupported: {0}")]
     Unsupported(String),
 }
@@ -218,14 +220,40 @@ pub struct CohereEmbeddingDriver {
     api_key: Zeroizing<String>,
     base_url: String,
     model: String,
-    /// `input_type` sent to Cohere v3 models. Defaults to `search_document`,
-    /// which is the right choice for indexing memory/documents. Callers that
-    /// use the driver only for query-time embeddings should eventually gain
-    /// a way to override this, but for now indexing is the primary path and
-    /// `search_document` is a safe, widely-compatible default.
+    /// `input_type` sent to Cohere v3 models. Defaults to `search_document`
+    /// (correct for indexing memory/documents, the primary path today) and
+    /// can be overridden via the `LIBREFANG_COHERE_INPUT_TYPE` env var for
+    /// deployments whose primary path is query-time embedding or
+    /// clustering.  Invalid values are ignored with a warning because
+    /// Cohere returns a cryptic 400 otherwise.
     input_type: String,
     client: reqwest::Client,
     dims: usize,
+}
+
+/// Valid values for Cohere v3 `input_type`, per the official API reference.
+const COHERE_VALID_INPUT_TYPES: &[&str] = &[
+    "search_document",
+    "search_query",
+    "classification",
+    "clustering",
+];
+
+/// Resolve `input_type` for Cohere v3 models, applying the
+/// `LIBREFANG_COHERE_INPUT_TYPE` env var override if present and valid.
+fn resolve_cohere_input_type() -> String {
+    match std::env::var("LIBREFANG_COHERE_INPUT_TYPE") {
+        Ok(v) if COHERE_VALID_INPUT_TYPES.contains(&v.as_str()) => v,
+        Ok(v) if !v.trim().is_empty() => {
+            warn!(
+                invalid = %v,
+                valid = ?COHERE_VALID_INPUT_TYPES,
+                "LIBREFANG_COHERE_INPUT_TYPE is not one of the valid Cohere input_type values; ignoring"
+            );
+            "search_document".to_string()
+        }
+        _ => "search_document".to_string(),
+    }
 }
 
 #[derive(Serialize)]
@@ -262,7 +290,7 @@ impl CohereEmbeddingDriver {
             api_key: Zeroizing::new(config.api_key),
             base_url: config.base_url,
             model: config.model,
-            input_type: "search_document".to_string(),
+            input_type: resolve_cohere_input_type(),
             client: crate::http_client::proxied_client(),
             dims,
         })
@@ -298,7 +326,7 @@ impl EmbeddingDriver for CohereEmbeddingDriver {
             return Ok(vec![]);
         }
         if texts.len() > COHERE_EMBED_MAX_BATCH {
-            return Err(EmbeddingError::Unsupported(format!(
+            return Err(EmbeddingError::InvalidInput(format!(
                 "Cohere embed API accepts at most {} texts per request (got {})",
                 COHERE_EMBED_MAX_BATCH,
                 texts.len()
@@ -1261,8 +1289,8 @@ mod tests {
         let texts: Vec<&str> = vec!["x"; COHERE_EMBED_MAX_BATCH + 1];
         let err = driver.embed(&texts).await.unwrap_err();
         assert!(
-            matches!(err, EmbeddingError::Unsupported(_)),
-            "expected Unsupported, got {err:?}"
+            matches!(err, EmbeddingError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
         );
     }
 
@@ -1311,6 +1339,46 @@ mod tests {
         match had {
             Some(v) => std::env::set_var("COHERE_API_KEY", v),
             None => std::env::remove_var("COHERE_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_cohere_input_type_default() {
+        let had = std::env::var("LIBREFANG_COHERE_INPUT_TYPE").ok();
+        std::env::remove_var("LIBREFANG_COHERE_INPUT_TYPE");
+
+        assert_eq!(resolve_cohere_input_type(), "search_document");
+
+        if let Some(v) = had {
+            std::env::set_var("LIBREFANG_COHERE_INPUT_TYPE", v);
+        }
+    }
+
+    #[test]
+    fn test_resolve_cohere_input_type_valid_override() {
+        let had = std::env::var("LIBREFANG_COHERE_INPUT_TYPE").ok();
+        std::env::set_var("LIBREFANG_COHERE_INPUT_TYPE", "search_query");
+
+        assert_eq!(resolve_cohere_input_type(), "search_query");
+
+        match had {
+            Some(v) => std::env::set_var("LIBREFANG_COHERE_INPUT_TYPE", v),
+            None => std::env::remove_var("LIBREFANG_COHERE_INPUT_TYPE"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_cohere_input_type_invalid_falls_back() {
+        let had = std::env::var("LIBREFANG_COHERE_INPUT_TYPE").ok();
+        std::env::set_var("LIBREFANG_COHERE_INPUT_TYPE", "not-a-real-type");
+
+        // Invalid values must not leak through to the Cohere API (it would
+        // 400 with a cryptic message). Fall back to search_document.
+        assert_eq!(resolve_cohere_input_type(), "search_document");
+
+        match had {
+            Some(v) => std::env::set_var("LIBREFANG_COHERE_INPUT_TYPE", v),
+            None => std::env::remove_var("LIBREFANG_COHERE_INPUT_TYPE"),
         }
     }
 

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -776,14 +776,23 @@ pub fn create_embedding_driver(
         let cohere_model = if model.starts_with("embed-") {
             model.to_string()
         } else {
+            // Default to the **multilingual** v3 model rather than English-only:
+            // librefang is used in non-English deployments, and
+            // `embed-multilingual-v3.0` has the same 1024 dims, the same per-
+            // token price, and supports 100+ languages (English quality is
+            // only marginally lower than `embed-english-v3.0`). A silent
+            // fallback that treats Chinese/Japanese/Korean corpora as English
+            // would degrade retrieval quality in ways the user can't see.
             warn!(
                 provider = "cohere",
                 requested_model = %model,
-                fallback_model = "embed-english-v3.0",
-                "Requested model is not a Cohere embed-* model; falling back to embed-english-v3.0. \
-                 Set `[memory].embedding_model` in config.toml to pick a specific Cohere model."
+                fallback_model = "embed-multilingual-v3.0",
+                "Requested model is not a Cohere embed-* model; falling back to embed-multilingual-v3.0. \
+                 Set `[memory].embedding_model` in config.toml to pick a specific Cohere model \
+                 (e.g. `embed-english-v3.0` for English-only corpora, or `embed-*-light-v3.0` \
+                 for the 384-dim light variants)."
             );
-            "embed-english-v3.0".to_string()
+            "embed-multilingual-v3.0".to_string()
         };
 
         // Cohere is a cloud provider — require the catalog (or caller) to

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -760,10 +760,20 @@ pub fn create_embedding_driver(
             "embed-english-v3.0".to_string()
         };
 
+        // Cohere is a cloud provider — require the catalog (or caller) to
+        // supply the base URL. No hardcoded fallback: that's exactly the
+        // trap that split v1 vs v2 and caused this PR in the first place.
         let base_url = custom_base_url
             .filter(|u| !u.is_empty())
             .map(|u| u.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| "https://api.cohere.com/v2".to_string());
+            .ok_or_else(|| {
+                EmbeddingError::InvalidInput(
+                    "Cohere embedding driver requires a base URL. Expected it from the model \
+                     catalog (`providers/cohere.toml`) or `config.toml` `provider_urls.cohere`, \
+                     but got none."
+                        .to_string(),
+                )
+            })?;
 
         warn!(
             provider = "cohere",
@@ -813,21 +823,23 @@ pub fn create_embedding_driver(
                 trimmed.to_string()
             }
         })
+        .map(Ok)
         .unwrap_or_else(|| match provider {
-            "openai" => "https://api.openai.com/v1".to_string(),
-            "openrouter" => "https://openrouter.ai/api/v1".to_string(),
-            "groq" => "https://api.groq.com/openai/v1".to_string(),
-            "together" => "https://api.together.xyz/v1".to_string(),
-            "fireworks" => "https://api.fireworks.ai/inference/v1".to_string(),
-            "mistral" => "https://api.mistral.ai/v1".to_string(),
-            "ollama" => "http://localhost:11434/v1".to_string(),
-            "vllm" => "http://localhost:8000/v1".to_string(),
-            "lmstudio" => "http://localhost:1234/v1".to_string(),
-            other => {
-                warn!("Unknown embedding provider '{other}', using OpenAI-compatible format");
-                format!("https://{other}/v1")
-            }
-        });
+            // Local providers keep hardcoded defaults: their localhost URLs
+            // aren't registry-tracked and the ports are stable by convention.
+            "ollama" => Ok("http://localhost:11434/v1".to_string()),
+            "vllm" => Ok("http://localhost:8000/v1".to_string()),
+            "lmstudio" => Ok("http://localhost:1234/v1".to_string()),
+            // Cloud providers MUST come from the model catalog or an explicit
+            // override. A hardcoded fallback is exactly the bug class this
+            // plumbing is trying to eliminate (stale baked-in URL silently
+            // overriding a registry entry pinned to a newer version).
+            cloud => Err(EmbeddingError::InvalidInput(format!(
+                "Embedding provider '{cloud}' requires a base URL. Expected it from the \
+                 model catalog (`providers/{cloud}.toml`) or `config.toml` \
+                 `provider_urls.{cloud}`, but got none."
+            ))),
+        })?;
 
     // SECURITY: Warn when embedding requests will be sent to an external API
     let is_local = base_url.contains("localhost")
@@ -1331,8 +1343,14 @@ mod tests {
         let had = std::env::var("COHERE_API_KEY").ok();
         std::env::set_var("COHERE_API_KEY", "test-cohere-key");
 
-        let driver = create_embedding_driver("cohere", "embed-english-v3.0", "", None, None)
-            .expect("cohere driver should build with key present");
+        let driver = create_embedding_driver(
+            "cohere",
+            "embed-english-v3.0",
+            "",
+            Some("https://api.cohere.com/v2"),
+            None,
+        )
+        .expect("cohere driver should build with key present");
         assert_eq!(driver.dimensions(), 1024);
 
         match had {
@@ -1349,11 +1367,39 @@ mod tests {
         let had = std::env::var("COHERE_API_KEY").ok();
         std::env::set_var("COHERE_API_KEY", "test-cohere-key");
 
-        let driver =
-            create_embedding_driver("cohere", "text-embedding-3-small", "", None, None).unwrap();
+        let driver = create_embedding_driver(
+            "cohere",
+            "text-embedding-3-small",
+            "",
+            Some("https://api.cohere.com/v2"),
+            None,
+        )
+        .unwrap();
         // After remap, dims should match embed-english-v3.0 (1024), NOT the
         // 1536 that text-embedding-3-small would have inferred.
         assert_eq!(driver.dimensions(), 1024);
+
+        match had {
+            Some(v) => std::env::set_var("COHERE_API_KEY", v),
+            None => std::env::remove_var("COHERE_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn test_create_embedding_driver_cloud_provider_requires_base_url() {
+        // Cloud providers no longer have hardcoded URL fallbacks — the catalog
+        // (or an explicit override) must supply the base_url. Pin the
+        // behavior so a regression can't silently re-introduce the
+        // version-drift bug.
+        let had = std::env::var("COHERE_API_KEY").ok();
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        let err =
+            create_embedding_driver("cohere", "embed-english-v3.0", "", None, None).unwrap_err();
+        assert!(
+            matches!(err, EmbeddingError::InvalidInput(_)),
+            "expected InvalidInput when no base_url is available, got {err:?}"
+        );
 
         match had {
             Some(v) => std::env::set_var("COHERE_API_KEY", v),

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -2,7 +2,13 @@
 //!
 //! Provides an `EmbeddingDriver` trait and implementations:
 //! - `OpenAIEmbeddingDriver` — works with any provider offering a `/v1/embeddings`
-//!   endpoint (OpenAI, Groq, Together, Fireworks, Ollama, etc.).
+//!   endpoint (OpenAI, OpenRouter, Together, Fireworks, Mistral, Ollama, vLLM,
+//!   LM Studio, etc.). **Groq is intentionally excluded**: it does not expose an
+//!   embeddings endpoint (`/v1/models` lists only chat + Whisper), so autowiring
+//!   Groq here would produce silent 404s.
+//! - `CohereEmbeddingDriver` — Cohere's native `/v2/embed` endpoint, which
+//!   differs from OpenAI's shape (`texts` + required `input_type`, embeddings
+//!   returned in `{ "embeddings": { "float": [[...]] } }`).
 //! - `BedrockEmbeddingDriver` — Amazon Bedrock embedding models via SigV4-signed
 //!   REST calls (no heavy `aws-sdk-*` dependency).
 
@@ -35,7 +41,7 @@ pub enum EmbeddingError {
 /// Configuration for creating an embedding driver.
 #[derive(Debug, Clone)]
 pub struct EmbeddingConfig {
-    /// Provider name (openai, groq, together, ollama, etc.).
+    /// Provider name (openai, together, mistral, cohere, ollama, etc.).
     pub provider: String,
     /// Model name (e.g., "text-embedding-3-small", "all-MiniLM-L6-v2").
     pub model: String,
@@ -85,7 +91,9 @@ pub trait EmbeddingDriver: Send + Sync {
 /// OpenAI-compatible embedding driver.
 ///
 /// Works with any provider that implements the `/v1/embeddings` endpoint:
-/// OpenAI, Groq, Together, Fireworks, Ollama, vLLM, LM Studio, etc.
+/// OpenAI, OpenRouter, Together, Fireworks, Mistral, Ollama, vLLM, LM Studio,
+/// etc.  Cohere uses `CohereEmbeddingDriver` (different endpoint + shape) and
+/// Groq is intentionally excluded because its API has no embeddings route.
 pub struct OpenAIEmbeddingDriver {
     api_key: Zeroizing<String>,
     base_url: String,
@@ -637,20 +645,24 @@ impl EmbeddingDriver for BedrockEmbeddingDriver {
 /// embedding provider.
 ///
 /// Checks in priority order:
-/// 1. `OPENAI_API_KEY`    → `"openai"`
-/// 2. `GROQ_API_KEY`      → `"groq"`
-/// 3. `MISTRAL_API_KEY`   → `"mistral"`
-/// 4. `TOGETHER_API_KEY`  → `"together"`
-/// 5. `FIREWORKS_API_KEY` → `"fireworks"`
-/// 6. `COHERE_API_KEY`    → `"cohere"`
+/// 1. `OPENAI_API_KEY`     → `"openai"`
+/// 2. `OPENROUTER_API_KEY` → `"openrouter"`
+/// 3. `MISTRAL_API_KEY`    → `"mistral"`
+/// 4. `TOGETHER_API_KEY`   → `"together"`
+/// 5. `FIREWORKS_API_KEY`  → `"fireworks"`
+/// 6. `COHERE_API_KEY`     → `"cohere"`
 /// 7. `OLLAMA_HOST` set, or Ollama running on localhost → `"ollama"`
 /// 8. `None` if nothing is available
+///
+/// `GROQ_API_KEY` is deliberately **not** in this list. Groq has no
+/// `/v1/embeddings` endpoint (verify with `GET api.groq.com/openai/v1/models`
+/// — only chat + Whisper models are returned), so picking it for embeddings
+/// would produce silent 404s at the first real call.
 pub fn detect_embedding_provider() -> Option<&'static str> {
     // Cloud providers — check API key env vars in priority order.
     let cloud_providers: &[(&str, &str)] = &[
         ("OPENAI_API_KEY", "openai"),
         ("OPENROUTER_API_KEY", "openrouter"),
-        ("GROQ_API_KEY", "groq"),
         ("MISTRAL_API_KEY", "mistral"),
         ("TOGETHER_API_KEY", "together"),
         ("FIREWORKS_API_KEY", "fireworks"),
@@ -691,9 +703,10 @@ pub fn create_embedding_driver(
     if provider == "auto" {
         let detected = detect_embedding_provider().ok_or_else(|| {
             EmbeddingError::MissingApiKey(
-                "No embedding provider available. Set one of: OPENAI_API_KEY, GROQ_API_KEY, \
-                 MISTRAL_API_KEY, TOGETHER_API_KEY, FIREWORKS_API_KEY, COHERE_API_KEY, \
-                 or configure Ollama."
+                "No embedding provider available. Set one of: OPENAI_API_KEY, \
+                 OPENROUTER_API_KEY, MISTRAL_API_KEY, TOGETHER_API_KEY, FIREWORKS_API_KEY, \
+                 COHERE_API_KEY, or configure Ollama. (GROQ_API_KEY is not accepted here — \
+                 Groq does not expose an embeddings endpoint.)"
                     .to_string(),
             )
         })?;

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -204,6 +204,152 @@ impl EmbeddingDriver for OpenAIEmbeddingDriver {
 }
 
 // ---------------------------------------------------------------------------
+// Cohere embedding driver (native `/v1/embed` endpoint)
+// ---------------------------------------------------------------------------
+
+/// Cohere native embedding driver.
+///
+/// Cohere's embed API is **not** OpenAI-compatible — it uses a different
+/// endpoint (`/v1/embed` vs. `/v1/embeddings`), a different request shape
+/// (`texts` instead of `input`), and v3 models require an `input_type`
+/// parameter.  A dedicated driver is therefore necessary; sending Cohere
+/// requests through `OpenAIEmbeddingDriver` produces 404s.
+pub struct CohereEmbeddingDriver {
+    api_key: Zeroizing<String>,
+    base_url: String,
+    model: String,
+    /// `input_type` sent to Cohere v3 models. Defaults to `search_document`,
+    /// which is the right choice for indexing memory/documents. Callers that
+    /// use the driver only for query-time embeddings should eventually gain
+    /// a way to override this, but for now indexing is the primary path and
+    /// `search_document` is a safe, widely-compatible default.
+    input_type: String,
+    client: reqwest::Client,
+    dims: usize,
+}
+
+#[derive(Serialize)]
+struct CohereEmbedRequest<'a> {
+    texts: &'a [&'a str],
+    model: &'a str,
+    input_type: &'a str,
+}
+
+#[derive(Deserialize)]
+struct CohereEmbedResponse {
+    embeddings: Vec<Vec<f32>>,
+}
+
+impl CohereEmbeddingDriver {
+    /// Create a new Cohere embedding driver.
+    ///
+    /// Returns [`EmbeddingError::MissingApiKey`] when `config.api_key` is
+    /// empty, because Cohere's API rejects unauthenticated calls outright
+    /// and a misleading 401 at the first real `embed` call would be harder
+    /// to diagnose than failing at boot.
+    pub fn new(config: EmbeddingConfig) -> Result<Self, EmbeddingError> {
+        if config.api_key.is_empty() {
+            return Err(EmbeddingError::MissingApiKey(
+                "Cohere embedding driver requires a non-empty API key (COHERE_API_KEY)".to_string(),
+            ));
+        }
+
+        let dims = config
+            .dimensions_override
+            .unwrap_or_else(|| infer_cohere_dimensions(&config.model));
+
+        Ok(Self {
+            api_key: Zeroizing::new(config.api_key),
+            base_url: config.base_url,
+            model: config.model,
+            input_type: "search_document".to_string(),
+            client: crate::http_client::proxied_client(),
+            dims,
+        })
+    }
+}
+
+/// Cohere embed v3 model limit. Requests over this size get rejected by the
+/// API; we fail fast with a clearer error instead of letting the server return
+/// a cryptic 400.
+const COHERE_EMBED_MAX_BATCH: usize = 96;
+
+/// Infer embedding dimensions from a Cohere model name.
+///
+/// Cohere publishes these dimensions in their official model list.  The
+/// default for unknown names is 1024, which matches the most common v3
+/// models; callers who need a different size should pass
+/// `dimensions_override` explicitly.
+fn infer_cohere_dimensions(model: &str) -> usize {
+    match model {
+        "embed-english-v3.0" | "embed-multilingual-v3.0" => 1024,
+        "embed-english-light-v3.0" | "embed-multilingual-light-v3.0" => 384,
+        "embed-english-v2.0" => 4096,
+        "embed-english-light-v2.0" => 1024,
+        "embed-multilingual-v2.0" => 768,
+        _ => 1024,
+    }
+}
+
+#[async_trait]
+impl EmbeddingDriver for CohereEmbeddingDriver {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+        if texts.len() > COHERE_EMBED_MAX_BATCH {
+            return Err(EmbeddingError::Unsupported(format!(
+                "Cohere embed API accepts at most {} texts per request (got {})",
+                COHERE_EMBED_MAX_BATCH,
+                texts.len()
+            )));
+        }
+
+        let url = format!("{}/embed", self.base_url);
+        let body = CohereEmbedRequest {
+            texts,
+            model: &self.model,
+            input_type: &self.input_type,
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key.as_str()))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(EmbeddingError::Api {
+                status,
+                message: body_text,
+            });
+        }
+
+        let data: CohereEmbedResponse = resp
+            .json()
+            .await
+            .map_err(|e| EmbeddingError::Parse(e.to_string()))?;
+
+        debug!(
+            "Cohere embedded {} texts (dims={})",
+            data.embeddings.len(),
+            data.embeddings.first().map(|e| e.len()).unwrap_or(0)
+        );
+
+        Ok(data.embeddings)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Amazon Bedrock embedding driver (SigV4-signed REST calls)
 // ---------------------------------------------------------------------------
 
@@ -530,6 +676,62 @@ pub fn create_embedding_driver(
             .filter(|u| !u.is_empty())
             .map(|s| s.to_string());
         let driver = BedrockEmbeddingDriver::new(model.to_string(), region, dimensions_override)?;
+        return Ok(Box::new(driver));
+    }
+
+    // Cohere uses its native `/v1/embed` endpoint with a different request
+    // shape than OpenAI's `/v1/embeddings`. Handle it before the OpenAI-
+    // compatible fall-through so a generic OpenAI driver doesn't 404.
+    if provider == "cohere" {
+        let resolved_key_env = if api_key_env.is_empty() {
+            "COHERE_API_KEY"
+        } else {
+            api_key_env
+        };
+        let api_key = std::env::var(resolved_key_env).unwrap_or_default();
+        if api_key.is_empty() {
+            return Err(EmbeddingError::MissingApiKey(format!(
+                "Cohere embedding driver requires {resolved_key_env} (currently unset or empty)"
+            )));
+        }
+
+        // Model name fallback: auto-detect hands us the model from config,
+        // which is often OpenAI-shaped ("text-embedding-3-small"). Cohere
+        // rejects those with a 404 at request time, so transparently
+        // substitute a sensible default and log a warn so the user notices
+        // and can pin a real Cohere model in config.
+        let cohere_model = if model.starts_with("embed-") {
+            model.to_string()
+        } else {
+            warn!(
+                provider = "cohere",
+                requested_model = %model,
+                fallback_model = "embed-english-v3.0",
+                "Requested model is not a Cohere embed-* model; falling back to embed-english-v3.0. \
+                 Set `[memory].embedding_model` in config.toml to pick a specific Cohere model."
+            );
+            "embed-english-v3.0".to_string()
+        };
+
+        let base_url = custom_base_url
+            .filter(|u| !u.is_empty())
+            .map(|u| u.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| "https://api.cohere.com/v1".to_string());
+
+        warn!(
+            provider = "cohere",
+            base_url = %base_url,
+            "Embedding driver configured to send data to external API — text content will leave this machine"
+        );
+
+        let config = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: cohere_model,
+            api_key,
+            base_url,
+            dimensions_override,
+        };
+        let driver = CohereEmbeddingDriver::new(config)?;
         return Ok(Box::new(driver));
     }
 
@@ -964,6 +1166,175 @@ mod tests {
         match had_secret {
             Some(v) => std::env::set_var("AWS_SECRET_ACCESS_KEY", v),
             None => std::env::remove_var("AWS_SECRET_ACCESS_KEY"),
+        }
+    }
+
+    // ── Cohere native driver tests ─────────────────────────────────────
+
+    #[test]
+    fn test_infer_cohere_dimensions_v3() {
+        assert_eq!(infer_cohere_dimensions("embed-english-v3.0"), 1024);
+        assert_eq!(infer_cohere_dimensions("embed-multilingual-v3.0"), 1024);
+        assert_eq!(infer_cohere_dimensions("embed-english-light-v3.0"), 384);
+        assert_eq!(
+            infer_cohere_dimensions("embed-multilingual-light-v3.0"),
+            384
+        );
+    }
+
+    #[test]
+    fn test_infer_cohere_dimensions_v2_and_default() {
+        assert_eq!(infer_cohere_dimensions("embed-english-v2.0"), 4096);
+        assert_eq!(infer_cohere_dimensions("embed-english-light-v2.0"), 1024);
+        assert_eq!(infer_cohere_dimensions("embed-multilingual-v2.0"), 768);
+        // Unknown Cohere model names fall back to 1024 (the v3 default).
+        assert_eq!(infer_cohere_dimensions("embed-some-future-model"), 1024);
+    }
+
+    #[test]
+    fn test_cohere_driver_requires_api_key() {
+        let cfg = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: "embed-english-v3.0".to_string(),
+            api_key: String::new(),
+            base_url: "https://api.cohere.com/v1".to_string(),
+            dimensions_override: None,
+        };
+        let err = CohereEmbeddingDriver::new(cfg).unwrap_err();
+        assert!(
+            matches!(err, EmbeddingError::MissingApiKey(_)),
+            "expected MissingApiKey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_cohere_driver_dims_from_model() {
+        let cfg = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: "embed-english-light-v3.0".to_string(),
+            api_key: "bogus".to_string(),
+            base_url: "https://api.cohere.com/v1".to_string(),
+            dimensions_override: None,
+        };
+        let driver = CohereEmbeddingDriver::new(cfg).unwrap();
+        assert_eq!(driver.dimensions(), 384);
+    }
+
+    #[test]
+    fn test_cohere_driver_dimensions_override() {
+        let cfg = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: "embed-english-v3.0".to_string(),
+            api_key: "bogus".to_string(),
+            base_url: "https://api.cohere.com/v1".to_string(),
+            dimensions_override: Some(512),
+        };
+        let driver = CohereEmbeddingDriver::new(cfg).unwrap();
+        assert_eq!(driver.dimensions(), 512);
+    }
+
+    #[tokio::test]
+    async fn test_cohere_driver_empty_input_returns_empty() {
+        let cfg = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: "embed-english-v3.0".to_string(),
+            api_key: "bogus".to_string(),
+            base_url: "https://api.cohere.com/v1".to_string(),
+            dimensions_override: None,
+        };
+        let driver = CohereEmbeddingDriver::new(cfg).unwrap();
+        // Empty batch must not hit the network.
+        let out = driver.embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cohere_driver_batch_over_limit_fails_fast() {
+        let cfg = EmbeddingConfig {
+            provider: "cohere".to_string(),
+            model: "embed-english-v3.0".to_string(),
+            api_key: "bogus".to_string(),
+            base_url: "https://api.cohere.com/v1".to_string(),
+            dimensions_override: None,
+        };
+        let driver = CohereEmbeddingDriver::new(cfg).unwrap();
+        let texts: Vec<&str> = vec!["x"; COHERE_EMBED_MAX_BATCH + 1];
+        let err = driver.embed(&texts).await.unwrap_err();
+        assert!(
+            matches!(err, EmbeddingError::Unsupported(_)),
+            "expected Unsupported, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_create_embedding_driver_cohere_missing_key() {
+        let had = std::env::var("COHERE_API_KEY").ok();
+        std::env::remove_var("COHERE_API_KEY");
+
+        let result = create_embedding_driver("cohere", "embed-english-v3.0", "", None, None);
+        assert!(matches!(result, Err(EmbeddingError::MissingApiKey(_))));
+
+        if let Some(v) = had {
+            std::env::set_var("COHERE_API_KEY", v);
+        }
+    }
+
+    #[test]
+    fn test_create_embedding_driver_cohere_with_key() {
+        let had = std::env::var("COHERE_API_KEY").ok();
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        let driver = create_embedding_driver("cohere", "embed-english-v3.0", "", None, None)
+            .expect("cohere driver should build with key present");
+        assert_eq!(driver.dimensions(), 1024);
+
+        match had {
+            Some(v) => std::env::set_var("COHERE_API_KEY", v),
+            None => std::env::remove_var("COHERE_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn test_create_embedding_driver_cohere_remaps_openai_model_name() {
+        // When auto-detect sends us an OpenAI-flavored model name, the Cohere
+        // branch should fall back to `embed-english-v3.0` rather than passing
+        // the unknown name through (which would 404 at request time).
+        let had = std::env::var("COHERE_API_KEY").ok();
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        let driver =
+            create_embedding_driver("cohere", "text-embedding-3-small", "", None, None).unwrap();
+        // After remap, dims should match embed-english-v3.0 (1024), NOT the
+        // 1536 that text-embedding-3-small would have inferred.
+        assert_eq!(driver.dimensions(), 1024);
+
+        match had {
+            Some(v) => std::env::set_var("COHERE_API_KEY", v),
+            None => std::env::remove_var("COHERE_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn test_create_embedding_driver_cohere_custom_base_url() {
+        // Users running behind a proxy / Cohere-compatible gateway should be
+        // able to override the base URL.
+        let had = std::env::var("COHERE_API_KEY").ok();
+        std::env::set_var("COHERE_API_KEY", "test-cohere-key");
+
+        let driver = create_embedding_driver(
+            "cohere",
+            "embed-english-v3.0",
+            "",
+            Some("https://cohere-proxy.internal/v1/"),
+            None,
+        )
+        .unwrap();
+        // Trailing slash must be stripped so `{base}/embed` is well-formed.
+        assert_eq!(driver.dimensions(), 1024);
+
+        match had {
+            Some(v) => std::env::set_var("COHERE_API_KEY", v),
+            None => std::env::remove_var("COHERE_API_KEY"),
         }
     }
 }

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -527,7 +527,7 @@ pub async fn execute_tool_raw(
         "agent_find" => tool_agent_find(input, *kernel),
         "task_post" => tool_task_post(input, *kernel, *caller_agent_id).await,
         "task_claim" => tool_task_claim(*kernel, *caller_agent_id).await,
-        "task_complete" => tool_task_complete(input, *kernel).await,
+        "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id).await,
         "task_list" => tool_task_list(input, *kernel).await,
         "event_publish" => tool_event_publish(input, *kernel).await,
 
@@ -2605,15 +2605,17 @@ async fn tool_task_claim(
 async fn tool_task_complete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
 ) -> Result<String, String> {
     let kh = require_kernel(kernel)?;
+    let agent_id = caller_agent_id.ok_or("task_complete requires a calling agent context")?;
     let task_id = input["task_id"]
         .as_str()
         .ok_or("Missing 'task_id' parameter")?;
     let result = input["result"]
         .as_str()
         .ok_or("Missing 'result' parameter")?;
-    kh.task_complete(task_id, result).await?;
+    kh.task_complete(agent_id, task_id, result).await?;
     Ok(format!("Task {task_id} marked as completed."))
 }
 
@@ -5550,7 +5552,12 @@ mod tests {
             Err("not used".to_string())
         }
 
-        async fn task_complete(&self, _task_id: &str, _result: &str) -> Result<(), String> {
+        async fn task_complete(
+            &self,
+            _agent_id: &str,
+            _task_id: &str,
+            _result: &str,
+        ) -> Result<(), String> {
             Err("not used".to_string())
         }
 
@@ -7349,7 +7356,12 @@ mod tests {
             Err("not used".to_string())
         }
 
-        async fn task_complete(&self, _task_id: &str, _result: &str) -> Result<(), String> {
+        async fn task_complete(
+            &self,
+            _agent_id: &str,
+            _task_id: &str,
+            _result: &str,
+        ) -> Result<(), String> {
             Err("not used".to_string())
         }
 

--- a/crates/librefang-types/src/event.rs
+++ b/crates/librefang-types/src/event.rs
@@ -329,6 +329,8 @@ pub enum SystemEvent {
     TaskCompleted {
         /// The task ID.
         task_id: String,
+        /// Agent that completed the task.
+        completed_by: String,
         /// The task result/verdict.
         result: String,
     },


### PR DESCRIPTION
## Root cause

Three `test_stream_bridge_*` tests in `channel_bridge.rs` were deadlocked:

```rust
let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
```

`_event_tx` with a named binding stays alive until the end of the test function. The bridge task blocks on `event_rx.recv()` waiting for the sender to drop; the test blocks on `rx.recv()` waiting for the bridge to send — neither can proceed.

Ubuntu hit `timeout-minutes: 45` and got killed. Windows/macOS had no timeout, so they ran into GitHub's 6-hour hard limit.

## Fix

- `_event_tx` → `_` in both affected tests (sender drops immediately)
- Add `timeout-minutes: 60` to Windows/macOS CI jobs
- Add `slow-timeout` to nextest config so future hangs surface immediately with the test name