### PR TITLE
fix(ci): resolve channel_bridge test deadlock that blocked CI for 6h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -349,6 +350,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3819,7 +3819,7 @@ mod tests {
         use librefang_kernel::error::KernelError;
         use librefang_types::error::LibreFangError;
 
-        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async {
             Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
                 LibreFangError::Internal("rate limit hit".to_string()).into(),
@@ -3863,7 +3863,7 @@ mod tests {
         use librefang_kernel::error::KernelError;
         use librefang_types::error::LibreFangError;
 
-        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async {
             Err::<librefang_runtime::agent_loop::AgentLoopResult, KernelError>(
                 LibreFangError::Internal("some internal failure".to_string()).into(),
@@ -3908,7 +3908,7 @@ mod tests {
         use librefang_kernel::error::KernelError;
         use librefang_types::error::LibreFangError;
 
-        let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
+        let (_, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async {
             // Mirror the kernel-side error format: a string that contains
             // the timeout marker constant.


### PR DESCRIPTION
## Root cause

Three `test_stream_bridge_*` tests in `channel_bridge.rs` were deadlocked:

```rust
let (_event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
```

`_event_tx` with a named binding stays alive until end of the test function. The bridge task blocks on `event_rx.recv()` waiting for the sender to drop; the test blocks on `rx.recv()` waiting for the bridge — neither can proceed.

Ubuntu hit `timeout-minutes: 45` and got killed. Windows/macOS had no timeout, so they ran into GitHub's 6-hour hard limit.

## Fix

- `_event_tx` → `_` in all three affected tests (sender drops immediately)
- Add `timeout-minutes: 60` to Windows/macOS CI jobs