### PR TITLE
feat(triggers): complete trigger feature — persistence, CRUD API, CLI subcommands, dashboard UI (#2827)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -393,6 +393,7 @@ export interface TriggerPatch {
   max_fires?: number;
   cooldown_secs?: number | null;
   session_mode?: string | null;
+  target_agent_id?: string | null;
 }
 
 export interface CreateTriggerPayload {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -381,6 +381,28 @@ export interface TriggerItem {
   fire_count?: number;
   max_fires?: number;
   created_at?: string;
+  target_agent_id?: string | null;
+  cooldown_secs?: number | null;
+  session_mode?: string | null;
+}
+
+export interface TriggerPatch {
+  pattern?: unknown;
+  prompt_template?: string;
+  enabled?: boolean;
+  max_fires?: number;
+  cooldown_secs?: number | null;
+  session_mode?: string | null;
+}
+
+export interface CreateTriggerPayload {
+  agent_id: string;
+  pattern: unknown;
+  prompt_template: string;
+  max_fires?: number;
+  target_agent_id?: string;
+  cooldown_secs?: number;
+  session_mode?: string;
 }
 
 export interface CronJobItem {
@@ -1544,11 +1566,21 @@ export async function listTriggers(): Promise<TriggerItem[]> {
   return data.triggers ?? data ?? [];
 }
 
+export async function getTrigger(triggerId: string): Promise<TriggerItem> {
+  return get<TriggerItem>(`/api/triggers/${encodeURIComponent(triggerId)}`);
+}
+
+export async function createTrigger(
+  payload: CreateTriggerPayload
+): Promise<ApiActionResponse & { trigger_id?: string }> {
+  return post<ApiActionResponse & { trigger_id?: string }>("/api/triggers", payload);
+}
+
 export async function updateTrigger(
   triggerId: string,
-  payload: { enabled: boolean }
+  updates: TriggerPatch
 ): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(`/api/triggers/${encodeURIComponent(triggerId)}`, payload);
+  return patch<ApiActionResponse>(`/api/triggers/${encodeURIComponent(triggerId)}`, updates);
 }
 
 export async function deleteTrigger(triggerId: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -79,6 +79,7 @@ export {
   // schedules & triggers
   listSchedules,
   listTriggers,
+  getTrigger,
   // sessions
   listSessions,
   getSessionDetails,
@@ -195,6 +196,7 @@ export {
   updateSchedule,
   deleteSchedule,
   runSchedule,
+  createTrigger,
   updateTrigger,
   deleteTrigger,
   // skills

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
@@ -4,9 +4,11 @@ import {
   updateSchedule,
   deleteSchedule,
   runSchedule,
+  createTrigger,
   updateTrigger,
   deleteTrigger,
 } from "../http/client";
+import type { TriggerPatch, CreateTriggerPayload } from "../../api";
 import { cronKeys, scheduleKeys, triggerKeys, workflowKeys } from "../queries/keys";
 
 // Schedules surface in two views: SchedulerPage (via useSchedules →
@@ -54,10 +56,21 @@ export function useRunSchedule() {
   });
 }
 
+export function useCreateTrigger() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateTriggerPayload) => createTrigger(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: triggerKeys.all });
+      qc.invalidateQueries({ queryKey: cronKeys.all });
+    },
+  });
+}
+
 export function useUpdateTrigger() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: { enabled: boolean } }) =>
+    mutationFn: ({ id, data }: { id: string; data: TriggerPatch }) =>
       updateTrigger(id, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: triggerKeys.all });

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
@@ -56,15 +56,23 @@ export function useRunSchedule() {
   });
 }
 
+// Trigger writes must invalidate triggerKeys.all (not just the per-agent
+// sub-key) so that SchedulerPage — which queries triggerKeys.lists() without
+// an agentId — also refreshes.  triggerKeys.list(agentId) is a strictly
+// longer key; react-query prefix matching never reaches the shorter lists()
+// key from it.
+function invalidateTriggerCaches(qc: ReturnType<typeof useQueryClient>) {
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: triggerKeys.all }),
+    qc.invalidateQueries({ queryKey: cronKeys.all }),
+  ]);
+}
+
 export function useCreateTrigger() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (payload: CreateTriggerPayload) => createTrigger(payload),
-    onSuccess: (_data, payload) => {
-      // Invalidate the specific agent's list; falls back to all lists.
-      qc.invalidateQueries({ queryKey: triggerKeys.list(payload.agent_id) });
-      qc.invalidateQueries({ queryKey: cronKeys.all });
-    },
+    onSuccess: () => invalidateTriggerCaches(qc),
   });
 }
 
@@ -73,12 +81,7 @@ export function useUpdateTrigger() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: TriggerPatch; agentId?: string }) =>
       updateTrigger(id, data),
-    onSuccess: (_data, { id, agentId }) => {
-      // Invalidate the specific detail entry and the owning agent's list.
-      qc.invalidateQueries({ queryKey: triggerKeys.detail(id) });
-      qc.invalidateQueries({ queryKey: triggerKeys.list(agentId) });
-      qc.invalidateQueries({ queryKey: cronKeys.all });
-    },
+    onSuccess: () => invalidateTriggerCaches(qc),
   });
 }
 
@@ -86,11 +89,9 @@ export function useDeleteTrigger() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id }: { id: string; agentId?: string }) => deleteTrigger(id),
-    onSuccess: (_data, { id, agentId }) => {
-      // Remove the stale detail entry and invalidate the owning agent's list.
+    onSuccess: (_data, { id }) => {
       qc.removeQueries({ queryKey: triggerKeys.detail(id) });
-      qc.invalidateQueries({ queryKey: triggerKeys.list(agentId) });
-      qc.invalidateQueries({ queryKey: cronKeys.all });
+      return invalidateTriggerCaches(qc);
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
@@ -60,8 +60,9 @@ export function useCreateTrigger() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (payload: CreateTriggerPayload) => createTrigger(payload),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: triggerKeys.all });
+    onSuccess: (_data, payload) => {
+      // Invalidate the specific agent's list; falls back to all lists.
+      qc.invalidateQueries({ queryKey: triggerKeys.list(payload.agent_id) });
       qc.invalidateQueries({ queryKey: cronKeys.all });
     },
   });
@@ -70,10 +71,12 @@ export function useCreateTrigger() {
 export function useUpdateTrigger() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: TriggerPatch }) =>
+    mutationFn: ({ id, data }: { id: string; data: TriggerPatch; agentId?: string }) =>
       updateTrigger(id, data),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: triggerKeys.all });
+    onSuccess: (_data, { id, agentId }) => {
+      // Invalidate the specific detail entry and the owning agent's list.
+      qc.invalidateQueries({ queryKey: triggerKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: triggerKeys.list(agentId) });
       qc.invalidateQueries({ queryKey: cronKeys.all });
     },
   });
@@ -82,9 +85,11 @@ export function useUpdateTrigger() {
 export function useDeleteTrigger() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: deleteTrigger,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: triggerKeys.all });
+    mutationFn: ({ id }: { id: string; agentId?: string }) => deleteTrigger(id),
+    onSuccess: (_data, { id, agentId }) => {
+      // Remove the stale detail entry and invalidate the owning agent's list.
+      qc.removeQueries({ queryKey: triggerKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: triggerKeys.list(agentId) });
       qc.invalidateQueries({ queryKey: cronKeys.all });
     },
   });

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -142,6 +142,8 @@ export const scheduleKeys = {
 export const triggerKeys = {
   all: ["triggers"] as const,
   lists: () => [...triggerKeys.all, "list"] as const,
+  details: () => [...triggerKeys.all, "detail"] as const,
+  detail: (id: string) => [...triggerKeys.details(), id] as const,
 };
 
 export const cronKeys = {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -142,6 +142,7 @@ export const scheduleKeys = {
 export const triggerKeys = {
   all: ["triggers"] as const,
   lists: () => [...triggerKeys.all, "list"] as const,
+  list: (agentId?: string) => [...triggerKeys.lists(), agentId] as const,
   details: () => [...triggerKeys.all, "detail"] as const,
   detail: (id: string) => [...triggerKeys.details(), id] as const,
 };

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -7,7 +7,8 @@ import { Badge } from "../components/ui/Badge";
 import { PageHeader } from "../components/ui/PageHeader";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
-import { Clock, Plus, Play, Trash2, Calendar, Zap, Loader2, AlertCircle, ChevronRight } from "lucide-react";
+import { Clock, Plus, Play, Trash2, Calendar, Zap, Loader2, AlertCircle, ChevronRight, Pencil } from "lucide-react";
+import type { TriggerItem } from "../api";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -57,6 +58,13 @@ export function SchedulerPage() {
   const [triggerMaxFires, setTriggerMaxFires] = useState<number>(0);
   const [triggerTargetAgent, setTriggerTargetAgent] = useState("");
 
+  // Trigger-edit state
+  const [editTrigger, setEditTrigger] = useState<TriggerItem | null>(null);
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editMaxFires, setEditMaxFires] = useState<number>(0);
+  const [editCooldown, setEditCooldown] = useState<string>("");
+  const [editSessionMode, setEditSessionMode] = useState<string>("");
+
   const agentsQuery = useAgents();
   const schedulesQuery = useSchedules();
   const triggersQuery = useTriggers();
@@ -67,7 +75,7 @@ export function SchedulerPage() {
   const runMut = useRunSchedule();
   const deleteScheduleMut = useDeleteSchedule();
   const toggleScheduleMut = useUpdateSchedule();
-  const toggleTriggerMut = useUpdateTrigger();
+  const updateTriggerMut = useUpdateTrigger();
   const deleteTriggerMut = useDeleteTrigger();
 
   const agents = agentsQuery.data ?? [];
@@ -113,6 +121,26 @@ export function SchedulerPage() {
       });
       setShowCreate(false);
       setTriggerAgentId(""); setTriggerPatternPreset('"lifecycle"'); setTriggerPatternCustom(""); setTriggerPrompt(""); setTriggerMaxFires(0); setTriggerTargetAgent("");
+    } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
+  };
+
+  const openEditTrigger = (tr: TriggerItem) => {
+    setEditTrigger(tr);
+    setEditPrompt(tr.prompt_template ?? "");
+    setEditMaxFires(tr.max_fires ?? 0);
+    setEditCooldown(tr.cooldown_secs != null ? String(tr.cooldown_secs) : "");
+    setEditSessionMode(tr.session_mode ?? "");
+  };
+
+  const handleEditTrigger = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!editTrigger) return;
+    const patch: Record<string, unknown> = { prompt_template: editPrompt, max_fires: editMaxFires };
+    patch.cooldown_secs = editCooldown === "" ? null : Number(editCooldown);
+    patch.session_mode = editSessionMode === "" ? null : editSessionMode;
+    try {
+      await updateTriggerMut.mutateAsync({ id: editTrigger.id, data: patch as any });
+      setEditTrigger(null);
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
 
@@ -249,8 +277,9 @@ export function SchedulerPage() {
           />
         ) : (
           <div className="space-y-2 stagger-children">
-            {triggers.map((tr: any) => {
+            {triggers.map((tr: TriggerItem) => {
               const isEnabled = tr.enabled !== false;
+              const targetAgent = agentMap.get(tr.target_agent_id ?? "");
               return (
                 <div key={tr.id} className={`p-3 sm:p-4 rounded-xl sm:rounded-2xl border transition-colors space-y-1.5 ${isEnabled ? "border-border-subtle hover:border-warning/30" : "border-border-subtle/50 opacity-50"}`}>
                   <div className="flex items-center gap-2 sm:gap-3">
@@ -261,13 +290,16 @@ export function SchedulerPage() {
                       <h3 className="text-xs sm:text-sm font-bold truncate">{formatTriggerPattern(tr.pattern) || truncateId(tr.id, 12)}</h3>
                     </div>
                     <button
-                      onClick={() => toggleTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}
+                      onClick={() => updateTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}
                       className={`px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
-                      disabled={toggleTriggerMut.isPending && toggleTriggerMut.variables?.id === tr.id}
+                      disabled={updateTriggerMut.isPending && updateTriggerMut.variables?.id === tr.id}
                     >
                       {isEnabled ? t("common.active") : t("common.disabled", { defaultValue: "OFF" })}
                     </button>
                     <div className="flex items-center gap-1 shrink-0">
+                      <button onClick={() => openEditTrigger(tr)} className="p-1.5 rounded-lg text-text-dim/30 hover:text-brand hover:bg-brand/10 transition-colors">
+                        <Pencil className="w-3.5 h-3.5" />
+                      </button>
                       {isConfirmingDelete("trigger", tr.id) ? (
                         <div className="flex items-center gap-1">
                           <button onClick={() => handleDeleteTrigger(tr.id)} className="px-2 py-1 rounded-lg bg-error text-white text-[10px] font-bold">{t("common.confirm")}</button>
@@ -285,11 +317,20 @@ export function SchedulerPage() {
                       <p className="text-[9px] sm:text-[10px] text-text-dim/60 truncate">{tr.prompt_template}</p>
                     </div>
                   )}
-                  {tr.fire_count != null && (
-                    <div className="flex items-center gap-2 pl-9 sm:pl-11 text-[9px] sm:text-[10px] text-text-dim/40">
-                      <span>{t("scheduler.fired", { defaultValue: "Fired" })}: {tr.fire_count}{tr.max_fires ? `/${tr.max_fires}` : ""}</span>
-                    </div>
-                  )}
+                  <div className="flex items-center gap-3 pl-9 sm:pl-11 text-[9px] sm:text-[10px] text-text-dim/40 flex-wrap">
+                    {tr.fire_count != null && (
+                      <span>Fired: {tr.fire_count}{tr.max_fires ? `/${tr.max_fires}` : ""}</span>
+                    )}
+                    {tr.cooldown_secs != null && (
+                      <span>Cooldown: {tr.cooldown_secs}s</span>
+                    )}
+                    {tr.session_mode && (
+                      <span className="font-mono">session: {tr.session_mode}</span>
+                    )}
+                    {targetAgent && (
+                      <span className="font-bold text-brand">→ {targetAgent.name}</span>
+                    )}
+                  </div>
                 </div>
               );
             })}
@@ -450,6 +491,65 @@ export function SchedulerPage() {
             </div>
           </form>
         )}
+      </Modal>
+
+      {/* Edit Trigger Modal */}
+      <Modal isOpen={!!editTrigger} onClose={() => setEditTrigger(null)} title="Edit trigger" size="md">
+        <form onSubmit={handleEditTrigger} className="p-5 space-y-4">
+          {editTrigger && (
+            <div className="rounded-xl bg-warning/5 border border-warning/20 px-3 py-2 text-[10px] text-text-dim/60">
+              <span className="font-bold text-warning/80">Pattern: </span>
+              {formatTriggerPattern(editTrigger.pattern) || String(editTrigger.pattern)}
+            </div>
+          )}
+          <div>
+            <label className="text-[10px] font-bold text-text-dim uppercase">Prompt template</label>
+            <textarea
+              value={editPrompt}
+              onChange={e => setEditPrompt(e.target.value)}
+              rows={3}
+              placeholder="Prompt sent to the agent when the event fires…"
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">Max fires (0 = unlimited)</label>
+              <input
+                type="number" min={0} value={editMaxFires}
+                onChange={e => setEditMaxFires(Number(e.target.value))}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">Cooldown (seconds, blank = none)</label>
+              <input
+                type="number" min={0} value={editCooldown}
+                onChange={e => setEditCooldown(e.target.value)}
+                placeholder="none"
+                className={inputClass}
+              />
+            </div>
+          </div>
+          <div>
+            <label className="text-[10px] font-bold text-text-dim uppercase">Session mode (blank = agent default)</label>
+            <select value={editSessionMode} onChange={e => setEditSessionMode(e.target.value)} className={inputClass}>
+              <option value="">agent default</option>
+              <option value="persistent">persistent</option>
+              <option value="new">new</option>
+            </select>
+          </div>
+          {updateTriggerMut.error && (
+            <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(updateTriggerMut.error as any)?.message}</div>
+          )}
+          <div className="flex gap-2 pt-2">
+            <Button type="submit" variant="primary" className="flex-1" disabled={updateTriggerMut.isPending}>
+              {updateTriggerMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Pencil className="w-4 h-4 mr-1" />}
+              Save changes
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => setEditTrigger(null)}>{t("common.cancel")}</Button>
+          </div>
+        </form>
       </Modal>
     </div>
   );

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -142,7 +142,7 @@ export function SchedulerPage() {
     patch.session_mode = editSessionMode === "" ? null : editSessionMode;
     patch.target_agent_id = editTargetAgent === "" ? null : editTargetAgent;
     try {
-      await updateTriggerMut.mutateAsync({ id: editTrigger.id, data: patch as any });
+      await updateTriggerMut.mutateAsync({ id: editTrigger.id, data: patch as any, agentId: editTrigger.agent_id });
       setEditTrigger(null);
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
@@ -165,7 +165,8 @@ export function SchedulerPage() {
     }
     setConfirmDelete(null);
     try {
-      await deleteTriggerMut.mutateAsync(id);
+      const agentId = triggersQuery.data?.find((tr: TriggerItem) => tr.id === id)?.agent_id;
+      await deleteTriggerMut.mutateAsync({ id, agentId });
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
 
@@ -293,7 +294,7 @@ export function SchedulerPage() {
                       <h3 className="text-xs sm:text-sm font-bold truncate">{formatTriggerPattern(tr.pattern) || truncateId(tr.id, 12)}</h3>
                     </div>
                     <button
-                      onClick={() => updateTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}
+                      onClick={() => updateTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled }, agentId: tr.agent_id })}
                       className={`px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
                       disabled={updateTriggerMut.isPending && updateTriggerMut.variables?.id === tr.id}
                     >

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -64,6 +64,7 @@ export function SchedulerPage() {
   const [editMaxFires, setEditMaxFires] = useState<number>(0);
   const [editCooldown, setEditCooldown] = useState<string>("");
   const [editSessionMode, setEditSessionMode] = useState<string>("");
+  const [editTargetAgent, setEditTargetAgent] = useState<string>("");
 
   const agentsQuery = useAgents();
   const schedulesQuery = useSchedules();
@@ -130,6 +131,7 @@ export function SchedulerPage() {
     setEditMaxFires(tr.max_fires ?? 0);
     setEditCooldown(tr.cooldown_secs != null ? String(tr.cooldown_secs) : "");
     setEditSessionMode(tr.session_mode ?? "");
+    setEditTargetAgent(tr.target_agent_id ?? "");
   };
 
   const handleEditTrigger = async (e: FormEvent) => {
@@ -138,6 +140,7 @@ export function SchedulerPage() {
     const patch: Record<string, unknown> = { prompt_template: editPrompt, max_fires: editMaxFires };
     patch.cooldown_secs = editCooldown === "" ? null : Number(editCooldown);
     patch.session_mode = editSessionMode === "" ? null : editSessionMode;
+    patch.target_agent_id = editTargetAgent === "" ? null : editTargetAgent;
     try {
       await updateTriggerMut.mutateAsync({ id: editTrigger.id, data: patch as any });
       setEditTrigger(null);
@@ -537,6 +540,15 @@ export function SchedulerPage() {
               <option value="">agent default</option>
               <option value="persistent">persistent</option>
               <option value="new">new</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-[10px] font-bold text-text-dim uppercase">Target agent (blank = owner)</label>
+            <select value={editTargetAgent} onChange={e => setEditTargetAgent(e.target.value)} className={inputClass}>
+              <option value="">owner (default)</option>
+              {agents.map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
             </select>
           </div>
           {updateTriggerMut.error && (

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -17,6 +17,7 @@ import { formatTriggerPattern } from "../lib/triggerPattern";
 import { useSchedules, useTriggers } from "../lib/queries/schedules";
 import {
   useCreateSchedule,
+  useCreateTrigger,
   useDeleteSchedule,
   useRunSchedule,
   useUpdateSchedule,
@@ -24,10 +25,19 @@ import {
   useDeleteTrigger,
 } from "../lib/mutations/schedules";
 
+const TRIGGER_PATTERN_PRESETS = [
+  { label: "lifecycle (spawned + terminated)", value: '"lifecycle"' },
+  { label: "agent_spawned", value: '"agent_spawned"' },
+  { label: "agent_terminated", value: '"agent_terminated"' },
+  { label: "all events", value: '"all"' },
+  { label: "custom JSON…", value: "custom" },
+] as const;
+
 export function SchedulerPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
   const [showCreate, setShowCreate] = useState(false);
+  const [createMode, setCreateMode] = useState<"schedule" | "trigger">("schedule");
   useCreateShortcut(() => setShowCreate(true));
   const [showCronPicker, setShowCronPicker] = useState(false);
   const [name, setName] = useState("");
@@ -39,12 +49,21 @@ export function SchedulerPage() {
   const [message, setMessage] = useState("");
   const [confirmDelete, setConfirmDelete] = useState<{ type: "schedule" | "trigger"; id: string } | null>(null);
 
+  // Trigger-creation state
+  const [triggerAgentId, setTriggerAgentId] = useState("");
+  const [triggerPatternPreset, setTriggerPatternPreset] = useState<string>('"lifecycle"');
+  const [triggerPatternCustom, setTriggerPatternCustom] = useState("");
+  const [triggerPrompt, setTriggerPrompt] = useState("");
+  const [triggerMaxFires, setTriggerMaxFires] = useState<number>(0);
+  const [triggerTargetAgent, setTriggerTargetAgent] = useState("");
+
   const agentsQuery = useAgents();
   const schedulesQuery = useSchedules();
   const triggersQuery = useTriggers();
   const workflowsQuery = useWorkflows();
 
   const createMut = useCreateSchedule();
+  const createTriggerMut = useCreateTrigger();
   const runMut = useRunSchedule();
   const deleteScheduleMut = useDeleteSchedule();
   const toggleScheduleMut = useUpdateSchedule();
@@ -70,6 +89,30 @@ export function SchedulerPage() {
         ...(targetType === "agent" ? { agent_id: agentId } : { workflow_id: workflowId }),
       });
       setShowCreate(false); setName(""); setMessage(""); setCron("0 9 * * *"); setCronTz(undefined); setAgentId(""); setWorkflowId(""); setTargetType("agent");
+    } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
+  };
+
+  const handleCreateTrigger = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!triggerAgentId) return;
+    const patternStr = triggerPatternPreset === "custom" ? triggerPatternCustom : triggerPatternPreset;
+    let pattern: unknown;
+    try {
+      pattern = JSON.parse(patternStr);
+    } catch {
+      addToast("Invalid pattern JSON", "error");
+      return;
+    }
+    try {
+      await createTriggerMut.mutateAsync({
+        agent_id: triggerAgentId,
+        pattern,
+        prompt_template: triggerPrompt,
+        ...(triggerMaxFires > 0 ? { max_fires: triggerMaxFires } : {}),
+        ...(triggerTargetAgent ? { target_agent_id: triggerTargetAgent } : {}),
+      });
+      setShowCreate(false);
+      setTriggerAgentId(""); setTriggerPatternPreset('"lifecycle"'); setTriggerPatternCustom(""); setTriggerPrompt(""); setTriggerMaxFires(0); setTriggerTargetAgent("");
     } catch (err: any) { addToast(err.message || t("common.error"), "error"); }
   };
 
@@ -256,74 +299,157 @@ export function SchedulerPage() {
 
       {/* Create Modal */}
       <Modal isOpen={showCreate} onClose={() => setShowCreate(false)} title={t("scheduler.create_job")} size="md">
-        <form onSubmit={handleCreate} className="p-5 space-y-4">
-              <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.job_name")}</label>
-                <input value={name} onChange={e => setName(e.target.value)} placeholder={t("scheduler.job_name_placeholder")} className={inputClass} />
-              </div>
-              <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.cron_exp")}</label>
-                <button
-                  type="button"
-                  onClick={() => setShowCronPicker(true)}
-                  className="w-full flex items-center justify-between px-3 py-2 rounded-xl border border-border-subtle bg-main hover:border-brand transition-colors text-left"
-                >
-                  <div>
-                    <p className="text-sm">{cronHint(cron)}{cronTz && cronTz !== "UTC" ? ` (${cronTz.split("/").pop()?.replace(/_/g, " ")})` : ""}</p>
-                    <p className="text-[10px] font-mono text-text-dim/50">{cron}{cronTz ? ` · ${cronTz}` : ""}</p>
-                  </div>
-                  <ChevronRight className="w-4 h-4 text-text-dim/40 shrink-0" />
+        {/* Mode tabs */}
+        <div className="flex gap-1 px-5 pt-4">
+          <button
+            type="button"
+            onClick={() => setCreateMode("schedule")}
+            className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors flex items-center justify-center gap-1 ${createMode === "schedule" ? "bg-brand text-white" : "bg-main text-text-dim"}`}
+          >
+            <Clock className="w-3.5 h-3.5" /> {t("scheduler.schedules")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreateMode("trigger")}
+            className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors flex items-center justify-center gap-1 ${createMode === "trigger" ? "bg-warning text-white" : "bg-main text-text-dim"}`}
+          >
+            <Zap className="w-3.5 h-3.5" /> {t("scheduler.event_triggers")}
+          </button>
+        </div>
+
+        {createMode === "schedule" ? (
+          <form onSubmit={handleCreate} className="p-5 space-y-4">
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.job_name")}</label>
+              <input value={name} onChange={e => setName(e.target.value)} placeholder={t("scheduler.job_name_placeholder")} className={inputClass} />
+            </div>
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.cron_exp")}</label>
+              <button
+                type="button"
+                onClick={() => setShowCronPicker(true)}
+                className="w-full flex items-center justify-between px-3 py-2 rounded-xl border border-border-subtle bg-main hover:border-brand transition-colors text-left"
+              >
+                <div>
+                  <p className="text-sm">{cronHint(cron)}{cronTz && cronTz !== "UTC" ? ` (${cronTz.split("/").pop()?.replace(/_/g, " ")})` : ""}</p>
+                  <p className="text-[10px] font-mono text-text-dim/50">{cron}{cronTz ? ` · ${cronTz}` : ""}</p>
+                </div>
+                <ChevronRight className="w-4 h-4 text-text-dim/40 shrink-0" />
+              </button>
+            </div>
+            {showCronPicker && (
+              <ScheduleModal
+                title={t("scheduler.cron_exp")}
+                initialCron={cron}
+                initialTz={cronTz}
+                onSave={(c, tz) => { setCron(c); setCronTz(tz); setShowCronPicker(false); }}
+                onClose={() => setShowCronPicker(false)}
+              />
+            )}
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.target", { defaultValue: "Target" })}</label>
+              <div className="flex gap-1 mb-2">
+                <button type="button" onClick={() => setTargetType("agent")}
+                  className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors ${targetType === "agent" ? "bg-brand text-white" : "bg-main text-text-dim"}`}>
+                  {t("scheduler.target_agent")}
+                </button>
+                <button type="button" onClick={() => setTargetType("workflow")}
+                  className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors ${targetType === "workflow" ? "bg-brand text-white" : "bg-main text-text-dim"}`}>
+                  {t("scheduler.target_workflow", { defaultValue: "Workflow" })}
                 </button>
               </div>
-              {showCronPicker && (
-                <ScheduleModal
-                  title={t("scheduler.cron_exp")}
-                  initialCron={cron}
-                  initialTz={cronTz}
-                  onSave={(c, tz) => { setCron(c); setCronTz(tz); setShowCronPicker(false); }}
-                  onClose={() => setShowCronPicker(false)}
+              {targetType === "agent" ? (
+                <select value={agentId} onChange={e => setAgentId(e.target.value)} className={inputClass}>
+                  <option value="">{t("scheduler.select_agent")}</option>
+                  {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+                </select>
+              ) : (
+                <select value={workflowId} onChange={e => setWorkflowId(e.target.value)} className={inputClass}>
+                  <option value="">{t("scheduler.select_workflow", { defaultValue: "Select workflow..." })}</option>
+                  {workflows.map(w => <option key={w.id} value={w.id}>{w.name}</option>)}
+                </select>
+              )}
+            </div>
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.message")}</label>
+              <textarea value={message} onChange={e => setMessage(e.target.value)} rows={3}
+                placeholder={t("scheduler.message_placeholder")} className={`${inputClass} resize-none`} />
+            </div>
+            {createMut.error && (
+              <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(createMut.error as any)?.message}</div>
+            )}
+            <div className="flex gap-2 pt-2">
+              <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !canSubmit}>
+                {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Plus className="w-4 h-4 mr-1" />}
+                {t("scheduler.create_job")}
+              </Button>
+              <Button type="button" variant="secondary" onClick={() => setShowCreate(false)}>{t("common.cancel")}</Button>
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={handleCreateTrigger} className="p-5 space-y-4">
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.target_agent")}</label>
+              <select value={triggerAgentId} onChange={e => setTriggerAgentId(e.target.value)} className={inputClass} required>
+                <option value="">{t("scheduler.select_agent")}</option>
+                {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">Event pattern</label>
+              <select value={triggerPatternPreset} onChange={e => setTriggerPatternPreset(e.target.value)} className={inputClass}>
+                {TRIGGER_PATTERN_PRESETS.map(p => (
+                  <option key={p.value} value={p.value}>{p.label}</option>
+                ))}
+              </select>
+              {triggerPatternPreset === "custom" && (
+                <input
+                  value={triggerPatternCustom}
+                  onChange={e => setTriggerPatternCustom(e.target.value)}
+                  placeholder='e.g. "agent_spawned" or {"agent_spawned":{"name_pattern":"*"}}'
+                  className={`${inputClass} mt-1 font-mono text-xs`}
                 />
               )}
+            </div>
+            <div>
+              <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.message")}</label>
+              <textarea
+                value={triggerPrompt}
+                onChange={e => setTriggerPrompt(e.target.value)}
+                rows={3}
+                placeholder="Prompt template sent to the agent when the event fires…"
+                className={`${inputClass} resize-none`}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.target", { defaultValue: "Target" })}</label>
-                <div className="flex gap-1 mb-2">
-                  <button type="button" onClick={() => setTargetType("agent")}
-                    className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors ${targetType === "agent" ? "bg-brand text-white" : "bg-main text-text-dim"}`}>
-                    {t("scheduler.target_agent")}
-                  </button>
-                  <button type="button" onClick={() => setTargetType("workflow")}
-                    className={`flex-1 py-1.5 rounded-lg text-[11px] font-bold transition-colors ${targetType === "workflow" ? "bg-brand text-white" : "bg-main text-text-dim"}`}>
-                    {t("scheduler.target_workflow", { defaultValue: "Workflow" })}
-                  </button>
-                </div>
-                {targetType === "agent" ? (
-                  <select value={agentId} onChange={e => setAgentId(e.target.value)} className={inputClass}>
-                    <option value="">{t("scheduler.select_agent")}</option>
-                    {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
-                  </select>
-                ) : (
-                  <select value={workflowId} onChange={e => setWorkflowId(e.target.value)} className={inputClass}>
-                    <option value="">{t("scheduler.select_workflow", { defaultValue: "Select workflow..." })}</option>
-                    {workflows.map(w => <option key={w.id} value={w.id}>{w.name}</option>)}
-                  </select>
-                )}
+                <label className="text-[10px] font-bold text-text-dim uppercase">Max fires (0 = unlimited)</label>
+                <input
+                  type="number" min={0} value={triggerMaxFires}
+                  onChange={e => setTriggerMaxFires(Number(e.target.value))}
+                  className={inputClass}
+                />
               </div>
               <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">{t("scheduler.message")}</label>
-                <textarea value={message} onChange={e => setMessage(e.target.value)} rows={3}
-                  placeholder={t("scheduler.message_placeholder")} className={`${inputClass} resize-none`} />
+                <label className="text-[10px] font-bold text-text-dim uppercase">Target agent (optional)</label>
+                <select value={triggerTargetAgent} onChange={e => setTriggerTargetAgent(e.target.value)} className={inputClass}>
+                  <option value="">Same agent</option>
+                  {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+                </select>
               </div>
-              {createMut.error && (
-                <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(createMut.error as any)?.message}</div>
-              )}
-              <div className="flex gap-2 pt-2">
-                <Button type="submit" variant="primary" className="flex-1" disabled={createMut.isPending || !canSubmit}>
-                  {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Plus className="w-4 h-4 mr-1" />}
-                  {t("scheduler.create_job")}
-                </Button>
-                <Button type="button" variant="secondary" onClick={() => setShowCreate(false)}>{t("common.cancel")}</Button>
-              </div>
-        </form>
+            </div>
+            {createTriggerMut.error && (
+              <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(createTriggerMut.error as any)?.message}</div>
+            )}
+            <div className="flex gap-2 pt-2">
+              <Button type="submit" variant="primary" className="flex-1" disabled={createTriggerMut.isPending || !triggerAgentId}>
+                {createTriggerMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
+                Create trigger
+              </Button>
+              <Button type="button" variant="secondary" onClick={() => setShowCreate(false)}>{t("common.cancel")}</Button>
+            </div>
+          </form>
+        )}
       </Modal>
     </div>
   );

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -182,6 +182,7 @@ use crate::types;
         routes::save_workflow_as_template,
         routes::list_triggers,
         routes::create_trigger,
+        routes::get_trigger,
         routes::delete_trigger,
         routes::update_trigger,
         routes::list_schedules,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -12,7 +12,9 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         )
         .route(
             "/triggers/{id}",
-            axum::routing::delete(delete_trigger).put(update_trigger),
+            axum::routing::get(get_trigger)
+                .delete(delete_trigger)
+                .patch(update_trigger),
         )
         // Schedules
         .route(
@@ -97,7 +99,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_kernel::triggers::{TriggerId, TriggerPattern};
+use librefang_kernel::triggers::{Trigger, TriggerId, TriggerPatch, TriggerPattern};
 use librefang_kernel::workflow::{
     ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowRunId, WorkflowStep,
 };
@@ -1004,6 +1006,26 @@ pub async fn create_trigger(
         (status = 200, description = "List triggers", body = serde_json::Value)
     )
 )]
+/// Serialize a `Trigger` to a JSON value (shared by list and get endpoints).
+fn trigger_to_json(t: &Trigger) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "id": t.id.to_string(),
+        "agent_id": t.agent_id.to_string(),
+        "pattern": serde_json::to_value(&t.pattern).unwrap_or_default(),
+        "prompt_template": t.prompt_template,
+        "enabled": t.enabled,
+        "fire_count": t.fire_count,
+        "max_fires": t.max_fires,
+        "created_at": t.created_at.to_rfc3339(),
+        "cooldown_secs": t.cooldown_secs,
+        "session_mode": serde_json::to_value(&t.session_mode).unwrap_or(serde_json::Value::Null),
+    });
+    if let Some(target) = &t.target_agent {
+        v["target_agent_id"] = serde_json::json!(target.to_string());
+    }
+    v
+}
+
 pub async fn list_triggers(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
@@ -1013,27 +1035,24 @@ pub async fn list_triggers(
         .and_then(|id| id.parse::<AgentId>().ok());
 
     let triggers = state.kernel.list_triggers(agent_filter);
-    let list: Vec<serde_json::Value> = triggers
-        .iter()
-        .map(|t| {
-            let mut v = serde_json::json!({
-                "id": t.id.to_string(),
-                "agent_id": t.agent_id.to_string(),
-                "pattern": serde_json::to_value(&t.pattern).unwrap_or_default(),
-                "prompt_template": t.prompt_template,
-                "enabled": t.enabled,
-                "fire_count": t.fire_count,
-                "max_fires": t.max_fires,
-                "created_at": t.created_at.to_rfc3339(),
-            });
-            if let Some(target) = &t.target_agent {
-                v["target_agent_id"] = serde_json::json!(target.to_string());
-            }
-            v
-        })
-        .collect();
+    let list: Vec<serde_json::Value> = triggers.iter().map(trigger_to_json).collect();
     let total = list.len();
     Json(serde_json::json!({"triggers": list, "total": total}))
+}
+
+/// GET /api/triggers/:id — Fetch a single trigger by ID.
+pub async fn get_trigger(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let trigger_id = TriggerId(match id.parse() {
+        Ok(u) => u,
+        Err(_) => return ApiErrorResponse::bad_request("Invalid trigger ID").into_json_tuple(),
+    });
+    match state.kernel.get_trigger(trigger_id) {
+        Some(t) => (StatusCode::OK, Json(trigger_to_json(&t))),
+        None => ApiErrorResponse::not_found("Trigger not found").into_json_tuple(),
+    }
 }
 
 /// DELETE /api/triggers/:id — Remove a trigger.
@@ -1063,8 +1082,11 @@ pub async fn delete_trigger(
 // Trigger update endpoint
 // ---------------------------------------------------------------------------
 
-/// PUT /api/triggers/:id — Update a trigger (enable/disable toggle).
-#[utoipa::path(put, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), request_body = serde_json::Value, responses((status = 200, description = "Trigger updated", body = serde_json::Value)))]
+/// PATCH /api/triggers/:id — Partially update a trigger.
+///
+/// All body fields are optional. Only provided fields are changed.
+/// Supported fields: `pattern`, `prompt_template`, `enabled`, `max_fires`,
+/// `cooldown_secs` (pass `null` to clear), `session_mode` (pass `null` to clear).
 pub async fn update_trigger(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1072,24 +1094,67 @@ pub async fn update_trigger(
 ) -> impl IntoResponse {
     let trigger_id = TriggerId(match id.parse() {
         Ok(u) => u,
-        Err(_) => {
-            return ApiErrorResponse::bad_request("Invalid trigger ID").into_json_tuple();
-        }
+        Err(_) => return ApiErrorResponse::bad_request("Invalid trigger ID").into_json_tuple(),
     });
 
-    if let Some(enabled) = req.get("enabled").and_then(|v| v.as_bool()) {
-        if state.kernel.set_trigger_enabled(trigger_id, enabled) {
-            (
-                StatusCode::OK,
-                Json(
-                    serde_json::json!({"status": "updated", "trigger_id": id, "enabled": enabled}),
-                ),
-            )
-        } else {
-            ApiErrorResponse::not_found("Trigger not found").into_json_tuple()
+    // Parse pattern if provided
+    let pattern = if req.get("pattern").is_some() && !req["pattern"].is_null() {
+        match serde_json::from_value::<TriggerPattern>(req["pattern"].clone()) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                return ApiErrorResponse::bad_request(format!("Invalid pattern: {e}"))
+                    .into_json_tuple()
+            }
         }
     } else {
-        ApiErrorResponse::bad_request("Missing 'enabled' field").into_json_tuple()
+        None
+    };
+
+    // Parse session_mode: absent = no change, null = clear, string = set
+    let session_mode: Option<Option<librefang_types::agent::SessionMode>> =
+        if req.get("session_mode").is_none() {
+            None
+        } else if req["session_mode"].is_null() {
+            Some(None)
+        } else {
+            match serde_json::from_value(req["session_mode"].clone()) {
+                Ok(m) => Some(Some(m)),
+                Err(e) => {
+                    return ApiErrorResponse::bad_request(format!("Invalid session_mode: {e}"))
+                        .into_json_tuple()
+                }
+            }
+        };
+
+    // Parse cooldown_secs: absent = no change, null = clear, number = set
+    let cooldown_secs: Option<Option<u64>> = if req.get("cooldown_secs").is_none() {
+        None
+    } else if req["cooldown_secs"].is_null() {
+        Some(None)
+    } else {
+        match req["cooldown_secs"].as_u64() {
+            Some(n) => Some(Some(n)),
+            None => {
+                return ApiErrorResponse::bad_request(
+                    "cooldown_secs must be a non-negative integer",
+                )
+                .into_json_tuple()
+            }
+        }
+    };
+
+    let patch = TriggerPatch {
+        pattern,
+        prompt_template: req["prompt_template"].as_str().map(|s| s.to_string()),
+        enabled: req["enabled"].as_bool(),
+        max_fires: req["max_fires"].as_u64(),
+        cooldown_secs,
+        session_mode,
+    };
+
+    match state.kernel.update_trigger(trigger_id, patch) {
+        Some(t) => (StatusCode::OK, Json(trigger_to_json(&t))),
+        None => ApiErrorResponse::not_found("Trigger not found").into_json_tuple(),
     }
 }
 

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1044,6 +1044,7 @@ fn trigger_to_json(t: &Trigger) -> serde_json::Value {
     v
 }
 
+#[utoipa::path(get, path = "/api/triggers", tag = "workflows", params(("agent_id" = Option<String>, Query, description = "Filter by agent ID")), responses((status = 200, description = "List triggers", body = serde_json::Value)))]
 pub async fn list_triggers(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1178,6 +1178,16 @@ pub async fn update_trigger(
         }
     };
 
+    // Validate target agent exists when being set (mirrors POST validation)
+    if let Some(Some(target_id)) = target_agent {
+        if state.kernel.agent_registry().get(target_id).is_none() {
+            return ApiErrorResponse::bad_request(format!(
+                "target_agent_id '{target_id}' does not exist"
+            ))
+            .into_json_tuple();
+        }
+    }
+
     let patch = TriggerPatch {
         pattern,
         prompt_template: req["prompt_template"].as_str().map(|s| s.to_string()),

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1106,7 +1106,8 @@ pub async fn delete_trigger(
 ///
 /// All body fields are optional. Only provided fields are changed.
 /// Supported fields: `pattern`, `prompt_template`, `enabled`, `max_fires`,
-/// `cooldown_secs` (pass `null` to clear), `session_mode` (pass `null` to clear).
+/// `cooldown_secs` (pass `null` to clear), `session_mode` (pass `null` to clear),
+/// `target_agent_id` (pass `null` to clear, omit to leave unchanged).
 pub async fn update_trigger(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1163,6 +1164,20 @@ pub async fn update_trigger(
         }
     };
 
+    // Parse target_agent_id: absent = no change, null = clear, string = set
+    let target_agent: Option<Option<AgentId>> = if req.get("target_agent_id").is_none() {
+        None
+    } else if req["target_agent_id"].is_null() {
+        Some(None)
+    } else {
+        match req["target_agent_id"].as_str().and_then(|s| s.parse().ok()) {
+            Some(id) => Some(Some(id)),
+            None => {
+                return ApiErrorResponse::bad_request("Invalid 'target_agent_id'").into_json_tuple()
+            }
+        }
+    };
+
     let patch = TriggerPatch {
         pattern,
         prompt_template: req["prompt_template"].as_str().map(|s| s.to_string()),
@@ -1170,6 +1185,7 @@ pub async fn update_trigger(
         max_fires: req["max_fires"].as_u64(),
         cooldown_secs,
         session_mode,
+        target_agent,
     };
 
     match state.kernel.update_trigger(trigger_id, patch) {

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1040,6 +1040,7 @@ pub async fn list_triggers(
     Json(serde_json::json!({"triggers": list, "total": total}))
 }
 
+#[utoipa::path(get, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Trigger detail", body = serde_json::Value), (status = 404, description = "Not found")))]
 /// GET /api/triggers/:id — Fetch a single trigger by ID.
 pub async fn get_trigger(
     State(state): State<Arc<AppState>>,
@@ -1082,6 +1083,7 @@ pub async fn delete_trigger(
 // Trigger update endpoint
 // ---------------------------------------------------------------------------
 
+#[utoipa::path(patch, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Updated trigger", body = serde_json::Value), (status = 404, description = "Not found")))]
 /// PATCH /api/triggers/:id — Partially update a trigger.
 ///
 /// All body fields are optional. Only provided fields are changed.

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -972,12 +972,30 @@ pub async fn create_trigger(
         },
     };
 
+    let cooldown_secs: Option<u64> = req["cooldown_secs"].as_u64();
+
+    let session_mode: Option<librefang_types::agent::SessionMode> =
+        match req.get("session_mode").and_then(|v| v.as_str()) {
+            None => None,
+            Some(s) => match serde_json::from_value(serde_json::json!(s)) {
+                Ok(m) => Some(m),
+                Err(_) => {
+                    return ApiErrorResponse::bad_request(format!(
+                        "Invalid 'session_mode': '{s}' (expected 'persistent' or 'new')"
+                    ))
+                    .into_json_tuple();
+                }
+            },
+        };
+
     match state.kernel.register_trigger_with_target(
         agent_id,
         pattern,
         prompt_template,
         max_fires,
         target_agent,
+        cooldown_secs,
+        session_mode,
     ) {
         Ok(trigger_id) => {
             let mut resp = serde_json::json!({

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1199,9 +1199,18 @@ enum TriggerCommands {
         /// New maximum fires limit (0 = unlimited).
         #[arg(long)]
         max_fires: Option<u64>,
-        /// New cooldown in seconds (0 = no cooldown).
+        /// New cooldown in seconds between fires.
         #[arg(long)]
         cooldown: Option<u64>,
+        /// Remove the cooldown limit entirely.
+        #[arg(long)]
+        clear_cooldown: bool,
+        /// Override session mode for this trigger (persistent|new).
+        #[arg(long)]
+        session_mode: Option<String>,
+        /// Remove the session mode override (revert to agent default).
+        #[arg(long)]
+        clear_session_mode: bool,
     },
     /// Enable a trigger.
     #[command(
@@ -1912,6 +1921,9 @@ fn main() {
                 enabled,
                 max_fires,
                 cooldown,
+                clear_cooldown,
+                session_mode,
+                clear_session_mode,
             } => cmd_trigger_update(
                 &trigger_id,
                 pattern.as_deref(),
@@ -1919,6 +1931,9 @@ fn main() {
                 enabled,
                 max_fires,
                 cooldown,
+                clear_cooldown,
+                session_mode.as_deref(),
+                clear_session_mode,
             ),
             TriggerCommands::Enable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, true),
             TriggerCommands::Disable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, false),
@@ -5973,6 +5988,9 @@ fn cmd_trigger_update(
     enabled: Option<bool>,
     max_fires: Option<u64>,
     cooldown: Option<u64>,
+    clear_cooldown: bool,
+    session_mode: Option<&str>,
+    clear_session_mode: bool,
 ) {
     let base = require_daemon("trigger update");
     let client = daemon_client();
@@ -5994,8 +6012,15 @@ fn cmd_trigger_update(
     if let Some(m) = max_fires {
         payload["max_fires"] = serde_json::json!(m);
     }
-    if let Some(c) = cooldown {
+    if clear_cooldown {
+        payload["cooldown_secs"] = serde_json::Value::Null;
+    } else if let Some(c) = cooldown {
         payload["cooldown_secs"] = serde_json::json!(c);
+    }
+    if clear_session_mode {
+        payload["session_mode"] = serde_json::Value::Null;
+    } else if let Some(m) = session_mode {
+        payload["session_mode"] = serde_json::json!(m);
     }
 
     let body = daemon_json(

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1147,9 +1147,17 @@ enum TriggerCommands {
         #[arg(long)]
         agent_id: Option<String>,
     },
+    /// Show details of a single trigger.
+    #[command(
+        long_about = "Show full details of a trigger by its UUID.\n\nExamples:\n  librefang trigger get <TRIGGER_ID>"
+    )]
+    Get {
+        /// Trigger ID (UUID).
+        trigger_id: String,
+    },
     /// Create a trigger for an agent.
     #[command(
-        long_about = "Create an event trigger that fires an agent when a matching event occurs.\n\nThe pattern is a JSON object describing what events to match. Use the\n{{event}} placeholder in the prompt template.\n\nExamples:\n  librefang trigger create <AGENT_ID> '\"lifecycle\"'\n  librefang trigger create <AGENT_ID> '{\"agent_spawned\":{\"name_pattern\":\"*\"}}' \\\n    --prompt \"New agent: {{event}}\" --max-fires 10"
+        long_about = "Create an event trigger that fires an agent when a matching event occurs.\n\nThe pattern is a JSON object describing what events to match. Use the\n{{event}} placeholder in the prompt template.\n\nExamples:\n  librefang trigger create <AGENT_ID> '\"lifecycle\"'\n  librefang trigger create <AGENT_ID> '{\"agent_spawned\":{\"name_pattern\":\"*\"}}' \\\n    --prompt \"New agent: {{event}}\" --max-fires 10\n  librefang trigger create <OWNER_ID> '\"task_posted\"' --target-agent <WORKER_ID>"
     )]
     Create {
         /// Agent ID (UUID) that owns the trigger.
@@ -1162,6 +1170,54 @@ enum TriggerCommands {
         /// Maximum number of times to fire (0 = unlimited).
         #[arg(long, default_value = "0")]
         max_fires: u64,
+        /// Route triggered messages to this agent instead of the owner (cross-session wake).
+        #[arg(long)]
+        target_agent: Option<String>,
+        /// Cooldown in seconds before this trigger can fire again (0 = no cooldown).
+        #[arg(long)]
+        cooldown: Option<u64>,
+        /// Session mode override: "persistent" or "new".
+        #[arg(long)]
+        session_mode: Option<String>,
+    },
+    /// Update fields of an existing trigger.
+    #[command(
+        long_about = "Update one or more fields of a trigger. Only supplied flags are changed.\n\nExamples:\n  librefang trigger update <ID> --prompt \"New prompt: {{event}}\"\n  librefang trigger update <ID> --max-fires 5 --cooldown 30\n  librefang trigger update <ID> --enabled false"
+    )]
+    Update {
+        /// Trigger ID (UUID).
+        trigger_id: String,
+        /// New pattern JSON.
+        #[arg(long)]
+        pattern: Option<String>,
+        /// New prompt template.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// Enable or disable the trigger.
+        #[arg(long)]
+        enabled: Option<bool>,
+        /// New maximum fires limit (0 = unlimited).
+        #[arg(long)]
+        max_fires: Option<u64>,
+        /// New cooldown in seconds (0 = no cooldown).
+        #[arg(long)]
+        cooldown: Option<u64>,
+    },
+    /// Enable a trigger.
+    #[command(
+        long_about = "Enable a previously disabled trigger.\n\nExamples:\n  librefang trigger enable <TRIGGER_ID>"
+    )]
+    Enable {
+        /// Trigger ID (UUID).
+        trigger_id: String,
+    },
+    /// Disable a trigger without deleting it.
+    #[command(
+        long_about = "Disable a trigger without removing it.\n\nExamples:\n  librefang trigger disable <TRIGGER_ID>"
+    )]
+    Disable {
+        /// Trigger ID (UUID).
+        trigger_id: String,
     },
     /// Delete a trigger by ID.
     #[command(
@@ -1831,12 +1887,41 @@ fn main() {
         },
         Some(Commands::Trigger(sub)) => match sub {
             TriggerCommands::List { agent_id } => cmd_trigger_list(agent_id.as_deref()),
+            TriggerCommands::Get { trigger_id } => cmd_trigger_get(&trigger_id),
             TriggerCommands::Create {
                 agent_id,
                 pattern_json,
                 prompt,
                 max_fires,
-            } => cmd_trigger_create(&agent_id, &pattern_json, &prompt, max_fires),
+                target_agent,
+                cooldown,
+                session_mode,
+            } => cmd_trigger_create(
+                &agent_id,
+                &pattern_json,
+                &prompt,
+                max_fires,
+                target_agent.as_deref(),
+                cooldown,
+                session_mode.as_deref(),
+            ),
+            TriggerCommands::Update {
+                trigger_id,
+                pattern,
+                prompt,
+                enabled,
+                max_fires,
+                cooldown,
+            } => cmd_trigger_update(
+                &trigger_id,
+                pattern.as_deref(),
+                prompt.as_deref(),
+                enabled,
+                max_fires,
+                cooldown,
+            ),
+            TriggerCommands::Enable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, true),
+            TriggerCommands::Disable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, false),
             TriggerCommands::Delete { trigger_id } => cmd_trigger_delete(&trigger_id),
         },
         Some(Commands::Migrate(args)) => cmd_migrate(args),
@@ -5747,7 +5832,15 @@ fn cmd_trigger_list(agent_id: Option<&str>) {
     }
 }
 
-fn cmd_trigger_create(agent_id: &str, pattern_json: &str, prompt: &str, max_fires: u64) {
+fn cmd_trigger_create(
+    agent_id: &str,
+    pattern_json: &str,
+    prompt: &str,
+    max_fires: u64,
+    target_agent: Option<&str>,
+    cooldown: Option<u64>,
+    session_mode: Option<&str>,
+) {
     let base = require_daemon("trigger create");
     let agent_id = resolve_agent_id(&base, agent_id);
     let pattern: serde_json::Value = serde_json::from_str(pattern_json).unwrap_or_else(|e| {
@@ -5760,16 +5853,27 @@ fn cmd_trigger_create(agent_id: &str, pattern_json: &str, prompt: &str, max_fire
         std::process::exit(1);
     });
 
+    let mut payload = serde_json::json!({
+        "agent_id": agent_id,
+        "pattern": pattern,
+        "prompt_template": prompt,
+        "max_fires": max_fires,
+    });
+    if let Some(t) = target_agent {
+        payload["target_agent_id"] = serde_json::json!(t);
+    }
+    if let Some(c) = cooldown {
+        payload["cooldown_secs"] = serde_json::json!(c);
+    }
+    if let Some(m) = session_mode {
+        payload["session_mode"] = serde_json::json!(m);
+    }
+
     let client = daemon_client();
     let body = daemon_json(
         client
             .post(format!("{base}/api/triggers"))
-            .json(&serde_json::json!({
-                "agent_id": agent_id,
-                "pattern": pattern,
-                "prompt_template": prompt,
-                "max_fires": max_fires,
-            }))
+            .json(&payload)
             .send(),
     );
 
@@ -5777,6 +5881,9 @@ fn cmd_trigger_create(agent_id: &str, pattern_json: &str, prompt: &str, max_fire
         println!("Trigger created successfully!");
         println!("  Trigger ID: {id}");
         println!("  Agent ID:   {agent_id}");
+        if let Some(t) = target_agent {
+            println!("  Target:     {t}");
+        }
     } else {
         eprintln!(
             "Failed to create trigger: {}",
@@ -5804,6 +5911,137 @@ fn cmd_trigger_delete(trigger_id: &str) {
         );
         std::process::exit(1);
     }
+}
+
+fn cmd_trigger_get(trigger_id: &str) {
+    let base = require_daemon("trigger get");
+    let client = daemon_client();
+    let body = daemon_json(
+        client
+            .get(format!("{base}/api/triggers/{trigger_id}"))
+            .send(),
+    );
+
+    if body.get("error").is_some() {
+        eprintln!(
+            "Failed to get trigger: {}",
+            body["error"].as_str().unwrap_or("Unknown error")
+        );
+        std::process::exit(1);
+    }
+
+    println!("Trigger ID:    {}", body["id"].as_str().unwrap_or("-"));
+    println!(
+        "Agent ID:      {}",
+        body["agent_id"].as_str().unwrap_or("-")
+    );
+    println!("Pattern:       {}", body["pattern"]);
+    println!(
+        "Prompt:        {}",
+        body["prompt_template"].as_str().unwrap_or("-")
+    );
+    println!(
+        "Enabled:       {}",
+        body["enabled"].as_bool().unwrap_or(false)
+    );
+    println!(
+        "Fire count:    {}",
+        body["fire_count"].as_u64().unwrap_or(0)
+    );
+    println!(
+        "Max fires:     {}",
+        body["max_fires"]
+            .as_u64()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "unlimited".to_string())
+    );
+    if let Some(t) = body["target_agent_id"].as_str() {
+        println!("Target agent:  {t}");
+    }
+    if let Some(c) = body["cooldown_secs"].as_u64() {
+        println!("Cooldown:      {c}s");
+    }
+    if let Some(m) = body["session_mode"].as_str() {
+        println!("Session mode:  {m}");
+    }
+}
+
+fn cmd_trigger_update(
+    trigger_id: &str,
+    pattern: Option<&str>,
+    prompt: Option<&str>,
+    enabled: Option<bool>,
+    max_fires: Option<u64>,
+    cooldown: Option<u64>,
+) {
+    let base = require_daemon("trigger update");
+    let client = daemon_client();
+
+    let mut payload = serde_json::json!({});
+    if let Some(p) = pattern {
+        let parsed: serde_json::Value = serde_json::from_str(p).unwrap_or_else(|e| {
+            eprintln!("Invalid pattern JSON: {e}");
+            std::process::exit(1);
+        });
+        payload["pattern"] = parsed;
+    }
+    if let Some(t) = prompt {
+        payload["prompt_template"] = serde_json::json!(t);
+    }
+    if let Some(e) = enabled {
+        payload["enabled"] = serde_json::json!(e);
+    }
+    if let Some(m) = max_fires {
+        payload["max_fires"] = serde_json::json!(m);
+    }
+    if let Some(c) = cooldown {
+        payload["cooldown_secs"] = serde_json::json!(c);
+    }
+
+    let body = daemon_json(
+        client
+            .patch(format!("{base}/api/triggers/{trigger_id}"))
+            .json(&payload)
+            .send(),
+    );
+
+    if body.get("error").is_some() {
+        eprintln!(
+            "Failed to update trigger: {}",
+            body["error"].as_str().unwrap_or("Unknown error")
+        );
+        std::process::exit(1);
+    }
+    println!("Trigger {trigger_id} updated.");
+}
+
+fn cmd_trigger_set_enabled(trigger_id: &str, enabled: bool) {
+    let base = require_daemon(if enabled {
+        "trigger enable"
+    } else {
+        "trigger disable"
+    });
+    let client = daemon_client();
+    let payload = serde_json::json!({ "enabled": enabled });
+    let body = daemon_json(
+        client
+            .patch(format!("{base}/api/triggers/{trigger_id}"))
+            .json(&payload)
+            .send(),
+    );
+
+    if body.get("error").is_some() {
+        eprintln!(
+            "Failed to {} trigger: {}",
+            if enabled { "enable" } else { "disable" },
+            body["error"].as_str().unwrap_or("Unknown error")
+        );
+        std::process::exit(1);
+    }
+    println!(
+        "Trigger {trigger_id} {}.",
+        if enabled { "enabled" } else { "disabled" }
+    );
 }
 
 /// Require a running daemon — exit with helpful message if not found.

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1211,6 +1211,12 @@ enum TriggerCommands {
         /// Remove the session mode override (revert to agent default).
         #[arg(long)]
         clear_session_mode: bool,
+        /// Set the cross-session wake target agent ID (UUID).
+        #[arg(long)]
+        target_agent: Option<String>,
+        /// Clear the target agent (revert to owner routing).
+        #[arg(long)]
+        clear_target_agent: bool,
     },
     /// Enable a trigger.
     #[command(
@@ -1924,6 +1930,8 @@ fn main() {
                 clear_cooldown,
                 session_mode,
                 clear_session_mode,
+                target_agent,
+                clear_target_agent,
             } => cmd_trigger_update(
                 &trigger_id,
                 pattern.as_deref(),
@@ -1934,6 +1942,8 @@ fn main() {
                 clear_cooldown,
                 session_mode.as_deref(),
                 clear_session_mode,
+                target_agent.as_deref(),
+                clear_target_agent,
             ),
             TriggerCommands::Enable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, true),
             TriggerCommands::Disable { trigger_id } => cmd_trigger_set_enabled(&trigger_id, false),
@@ -5991,6 +6001,8 @@ fn cmd_trigger_update(
     clear_cooldown: bool,
     session_mode: Option<&str>,
     clear_session_mode: bool,
+    target_agent: Option<&str>,
+    clear_target_agent: bool,
 ) {
     let base = require_daemon("trigger update");
     let client = daemon_client();
@@ -6021,6 +6033,11 @@ fn cmd_trigger_update(
         payload["session_mode"] = serde_json::Value::Null;
     } else if let Some(m) = session_mode {
         payload["session_mode"] = serde_json::json!(m);
+    }
+    if clear_target_agent {
+        payload["target_agent_id"] = serde_json::Value::Null;
+    } else if let Some(a) = target_agent {
+        payload["target_agent_id"] = serde_json::json!(a);
     }
 
     let body = daemon_json(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3003,7 +3003,12 @@ system_prompt = "You are a helpful assistant."
             }),
         );
         // Evaluate triggers synchronously (we can't await in a sync fn, so just evaluate)
-        let _triggered = self.triggers.evaluate(&event);
+        let triggered = self.triggers.evaluate(&event);
+        if !triggered.is_empty() {
+            if let Err(e) = self.triggers.persist() {
+                warn!("Failed to persist trigger jobs after spawn event: {e}");
+            }
+        }
 
         Ok(agent_id)
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2969,15 +2969,26 @@ system_prompt = "You are a helpful assistant."
             "ok",
         );
 
-        // For proactive agents spawned at runtime, auto-register triggers
+        // For proactive agents spawned at runtime, auto-register triggers.
+        // Skip any pattern already present (e.g. reloaded from trigger_jobs.json on restart).
         if let ScheduleMode::Proactive { conditions } = &entry.manifest.schedule {
+            let mut registered = false;
             for condition in conditions {
                 if let Some(pattern) = background::parse_condition(condition) {
+                    if self.triggers.agent_has_pattern(agent_id, &pattern) {
+                        continue;
+                    }
                     let prompt = format!(
                         "[PROACTIVE ALERT] Condition '{condition}' matched: {{{{event}}}}. \
                          Review and take appropriate action. Agent: {name}"
                     );
                     self.triggers.register(agent_id, pattern, prompt, 0);
+                    registered = true;
+                }
+            }
+            if registered {
+                if let Err(e) = self.triggers.persist() {
+                    warn!(agent = %name, "Failed to persist proactive triggers: {e}");
                 }
             }
         }
@@ -9319,18 +9330,29 @@ system_prompt = "You are a helpful assistant."
         name: &str,
         schedule: &ScheduleMode,
     ) {
-        // For proactive agents, auto-register triggers from conditions
+        // For proactive agents, auto-register triggers from conditions.
+        // Skip patterns already present (loaded from trigger_jobs.json on restart).
         if let ScheduleMode::Proactive { conditions } = schedule {
+            let mut registered = false;
             for condition in conditions {
                 if let Some(pattern) = background::parse_condition(condition) {
+                    if self.triggers.agent_has_pattern(agent_id, &pattern) {
+                        continue;
+                    }
                     let prompt = format!(
                         "[PROACTIVE ALERT] Condition '{condition}' matched: {{{{event}}}}. \
                          Review and take appropriate action. Agent: {name}"
                     );
                     self.triggers.register(agent_id, pattern, prompt, 0);
+                    registered = true;
                 }
             }
-            info!(agent = %name, id = %agent_id, "Registered proactive triggers");
+            if registered {
+                if let Err(e) = self.triggers.persist() {
+                    warn!(agent = %name, id = %agent_id, "Failed to persist proactive triggers: {e}");
+                }
+                info!(agent = %name, id = %agent_id, "Registered proactive triggers");
+            }
         }
 
         // Start continuous/periodic loops

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3001,8 +3001,8 @@ system_prompt = "You are a helpful assistant."
             }),
         );
         // Evaluate triggers synchronously (we can't await in a sync fn, so just evaluate)
-        let triggered = self.triggers.evaluate(&event);
-        if !triggered.is_empty() {
+        let (triggered, trigger_state_mutated) = self.triggers.evaluate(&event);
+        if !triggered.is_empty() || trigger_state_mutated {
             if let Err(e) = self.triggers.persist() {
                 warn!("Failed to persist trigger jobs after spawn event: {e}");
             }
@@ -8101,8 +8101,8 @@ system_prompt = "You are a helpful assistant."
         let _guard = DepthGuard;
 
         // Evaluate triggers before publishing (so describe_event works on the event)
-        let triggered = self.triggers.evaluate(&event);
-        if !triggered.is_empty() {
+        let (triggered, trigger_state_mutated) = self.triggers.evaluate(&event);
+        if !triggered.is_empty() || trigger_state_mutated {
             if let Err(e) = self.triggers.persist() {
                 warn!("Failed to persist trigger jobs after fire: {e}");
             }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8199,6 +8199,26 @@ system_prompt = "You are a helpful assistant."
         }
     }
 
+    /// Get a single trigger by ID.
+    pub fn get_trigger(&self, trigger_id: TriggerId) -> Option<crate::triggers::Trigger> {
+        self.triggers.get_trigger(trigger_id)
+    }
+
+    /// Update mutable fields of an existing trigger.
+    pub fn update_trigger(
+        &self,
+        trigger_id: TriggerId,
+        patch: crate::triggers::TriggerPatch,
+    ) -> Option<crate::triggers::Trigger> {
+        let result = self.triggers.update(trigger_id, patch);
+        if result.is_some() {
+            if let Err(e) = self.triggers.persist() {
+                warn!(%trigger_id, "Failed to persist trigger jobs after update: {e}");
+            }
+        }
+        result
+    }
+
     /// Register a workflow definition.
     pub async fn register_workflow(&self, workflow: Workflow) -> WorkflowId {
         self.workflows.register(workflow).await

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2232,8 +2232,6 @@ impl LibreFangKernel {
 
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
-        let trigger_config = config.triggers.clone();
-        let trigger_home_dir = config.home_dir.clone();
         // Resolve the audit anchor path from `[audit].anchor_path`. When
         // unset, the default is `data_dir/audit.anchor` — good enough to
         // catch most casual tampering since it sits next to the SQLite

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2144,6 +2144,19 @@ impl LibreFangKernel {
             }
         }
 
+        // Initialize trigger engine and reload persisted triggers
+        let trigger_engine = TriggerEngine::with_config(&trigger_config, &trigger_home_dir);
+        match trigger_engine.load() {
+            Ok(count) => {
+                if count > 0 {
+                    info!("Loaded {count} trigger job(s) from disk");
+                }
+            }
+            Err(e) => {
+                warn!("Failed to load trigger jobs: {e}");
+            }
+        }
+
         // Initialize execution approval manager
         let approval_manager = crate::approval::ApprovalManager::new_with_db(
             config.approval.clone(),
@@ -2220,6 +2233,7 @@ impl LibreFangKernel {
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
         let trigger_config = config.triggers.clone();
+        let trigger_home_dir = config.home_dir.clone();
         // Resolve the audit anchor path from `[audit].anchor_path`. When
         // unset, the default is `data_dir/audit.anchor` — good enough to
         // catch most casual tampering since it sits next to the SQLite
@@ -2250,7 +2264,7 @@ impl LibreFangKernel {
             supervisor,
             workflows: WorkflowEngine::new_with_persistence(&workflow_home_dir),
             template_registry: WorkflowTemplateRegistry::new(),
-            triggers: TriggerEngine::with_config(&trigger_config),
+            triggers: trigger_engine,
             background,
             audit_log: Arc::new(AuditLog::with_db_anchored(
                 memory.usage_conn(),
@@ -7127,6 +7141,9 @@ system_prompt = "You are a helpful assistant."
         self.capabilities.revoke_all(agent_id);
         self.event_bus.unsubscribe_agent(agent_id);
         self.triggers.remove_agent_triggers(agent_id);
+        if let Err(e) = self.triggers.persist() {
+            warn!("Failed to persist trigger jobs after agent deletion: {e}");
+        }
 
         // Remove cron jobs so they don't linger as orphans (#504)
         let cron_removed = self.cron_scheduler.remove_agent_jobs(agent_id);
@@ -7544,6 +7561,9 @@ system_prompt = "You are a helpful assistant."
                         "Dropping saved triggers for removed hand role during reactivation"
                     );
                 }
+            }
+            if let Err(e) = self.triggers.persist() {
+                warn!("Failed to persist trigger jobs after hand reactivation: {e}");
             }
         }
 
@@ -8068,6 +8088,11 @@ system_prompt = "You are a helpful assistant."
 
         // Evaluate triggers before publishing (so describe_event works on the event)
         let triggered = self.triggers.evaluate(&event);
+        if !triggered.is_empty() {
+            if let Err(e) = self.triggers.persist() {
+                warn!("Failed to persist trigger jobs after fire: {e}");
+            }
+        }
 
         // Publish to the event bus
         self.event_bus.publish(event).await;
@@ -8131,23 +8156,39 @@ system_prompt = "You are a helpful assistant."
                 )));
             }
         }
-        Ok(self.triggers.register_with_target(
+        let id = self.triggers.register_with_target(
             agent_id,
             pattern,
             prompt_template,
             max_fires,
             target_agent,
-        ))
+        );
+        if let Err(e) = self.triggers.persist() {
+            warn!(trigger_id = %id, "Failed to persist trigger jobs after register: {e}");
+        }
+        Ok(id)
     }
 
     /// Remove a trigger by ID.
     pub fn remove_trigger(&self, trigger_id: TriggerId) -> bool {
-        self.triggers.remove(trigger_id)
+        let removed = self.triggers.remove(trigger_id);
+        if removed {
+            if let Err(e) = self.triggers.persist() {
+                warn!(%trigger_id, "Failed to persist trigger jobs after remove: {e}");
+            }
+        }
+        removed
     }
 
     /// Enable or disable a trigger. Returns true if found.
     pub fn set_trigger_enabled(&self, trigger_id: TriggerId, enabled: bool) -> bool {
-        self.triggers.set_enabled(trigger_id, enabled)
+        let found = self.triggers.set_enabled(trigger_id, enabled);
+        if found {
+            if let Err(e) = self.triggers.persist() {
+                warn!(%trigger_id, "Failed to persist trigger jobs after set_enabled: {e}");
+            }
+        }
+        found
     }
 
     /// List all triggers (optionally filtered by agent).
@@ -8358,6 +8399,11 @@ system_prompt = "You are a helpful assistant."
                                             migrated = t_migrated,
                                             "Reassigned triggers after restart"
                                         );
+                                        if let Err(e) = self.triggers.persist() {
+                                            warn!(
+                                                "Failed to persist trigger jobs after hand restore: {e}"
+                                            );
+                                        }
                                     }
                                 }
                             }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8152,6 +8152,8 @@ system_prompt = "You are a helpful assistant."
         prompt_template: String,
         max_fires: u64,
         target_agent: Option<AgentId>,
+        cooldown_secs: Option<u64>,
+        session_mode: Option<librefang_types::agent::SessionMode>,
     ) -> KernelResult<TriggerId> {
         // Verify owner agent exists
         if self.registry.get(agent_id).is_none() {
@@ -8173,6 +8175,8 @@ system_prompt = "You are a helpful assistant."
             prompt_template,
             max_fires,
             target_agent,
+            cooldown_secs,
+            session_mode,
         );
         if let Err(e) = self.triggers.persist() {
             warn!(trigger_id = %id, "Failed to persist trigger jobs after register: {e}");

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2145,7 +2145,7 @@ impl LibreFangKernel {
         }
 
         // Initialize trigger engine and reload persisted triggers
-        let trigger_engine = TriggerEngine::with_config(&trigger_config, &trigger_home_dir);
+        let trigger_engine = TriggerEngine::with_config(&config.triggers, &config.home_dir);
         match trigger_engine.load() {
             Ok(count) => {
                 if count > 0 {
@@ -8143,7 +8143,15 @@ system_prompt = "You are a helpful assistant."
         prompt_template: String,
         max_fires: u64,
     ) -> KernelResult<TriggerId> {
-        self.register_trigger_with_target(agent_id, pattern, prompt_template, max_fires, None)
+        self.register_trigger_with_target(
+            agent_id,
+            pattern,
+            prompt_template,
+            max_fires,
+            None,
+            None,
+            None,
+        )
     }
 
     /// Register a trigger with an optional cross-session target agent.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -123,6 +123,23 @@ pub struct TriggerMatch {
     pub session_mode_override: Option<librefang_types::agent::SessionMode>,
 }
 
+/// Patch payload for updating an existing trigger.
+///
+/// All fields are optional — `None` means "leave unchanged".
+/// `cooldown_secs` and `session_mode` use `Option<Option<T>>` so callers can
+/// explicitly clear a value by passing `Some(None)`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TriggerPatch {
+    pub pattern: Option<TriggerPattern>,
+    pub prompt_template: Option<String>,
+    pub enabled: Option<bool>,
+    pub max_fires: Option<u64>,
+    /// `Some(None)` clears the override (reverts to engine default).
+    pub cooldown_secs: Option<Option<u64>>,
+    /// `Some(None)` clears the override (inherits from agent manifest).
+    pub session_mode: Option<Option<librefang_types::agent::SessionMode>>,
+}
+
 /// The trigger engine manages event-to-agent routing.
 pub struct TriggerEngine {
     /// All registered triggers.
@@ -423,6 +440,39 @@ impl TriggerEngine {
         } else {
             false
         }
+    }
+
+    /// Patch mutable fields of an existing trigger.
+    ///
+    /// Only `Some` fields are updated; `None` leaves the current value intact.
+    /// Returns the updated trigger, or `None` if the ID was not found.
+    pub fn update(&self, trigger_id: TriggerId, patch: TriggerPatch) -> Option<Trigger> {
+        let mut entry = self.triggers.get_mut(&trigger_id)?;
+        let t = entry.value_mut();
+        if let Some(pattern) = patch.pattern {
+            t.pattern = pattern;
+        }
+        if let Some(prompt_template) = patch.prompt_template {
+            t.prompt_template = prompt_template;
+        }
+        if let Some(enabled) = patch.enabled {
+            t.enabled = enabled;
+        }
+        if let Some(max_fires) = patch.max_fires {
+            t.max_fires = max_fires;
+        }
+        if let Some(cooldown_secs) = patch.cooldown_secs {
+            t.cooldown_secs = cooldown_secs;
+        }
+        if let Some(session_mode) = patch.session_mode {
+            t.session_mode = session_mode;
+        }
+        Some(t.clone())
+    }
+
+    /// Get a single trigger by ID.
+    pub fn get_trigger(&self, trigger_id: TriggerId) -> Option<Trigger> {
+        self.triggers.get(&trigger_id).map(|t| t.clone())
     }
 
     /// List all triggers for an agent.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -7,8 +7,10 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use librefang_types::agent::AgentId;
+use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::event::{Event, EventPayload, LifecycleEvent, SystemEvent};
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -133,10 +135,13 @@ pub struct TriggerEngine {
     max_triggers_per_event: usize,
     /// Default cooldown duration (seconds) applied when a trigger has no override.
     default_cooldown_secs: u64,
+    /// Path to the persistence file (`<home>/trigger_jobs.json`).
+    /// `None` means no persistence (used in tests).
+    persist_path: Option<PathBuf>,
 }
 
 impl TriggerEngine {
-    /// Create a new trigger engine with default settings.
+    /// Create a new trigger engine with default settings and no persistence.
     pub fn new() -> Self {
         Self {
             triggers: DashMap::new(),
@@ -144,17 +149,22 @@ impl TriggerEngine {
             last_fired: DashMap::new(),
             max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
             default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
+            persist_path: None,
         }
     }
 
-    /// Create a trigger engine configured from a `TriggersConfig`.
-    pub fn with_config(config: &librefang_types::config::TriggersConfig) -> Self {
+    /// Create a trigger engine configured from a `TriggersConfig`, with persistence.
+    ///
+    /// `home_dir` is the LibreFang data directory; triggers are persisted to
+    /// `<home_dir>/trigger_jobs.json`.
+    pub fn with_config(config: &librefang_types::config::TriggersConfig, home_dir: &Path) -> Self {
         Self {
             triggers: DashMap::new(),
             agent_triggers: DashMap::new(),
             last_fired: DashMap::new(),
             max_triggers_per_event: config.max_per_event.max(1),
             default_cooldown_secs: config.cooldown_secs,
+            persist_path: Some(home_dir.join("trigger_jobs.json")),
         }
     }
 
@@ -168,6 +178,58 @@ impl TriggerEngine {
             max_triggers_per_event: max.max(1),
             ..Self::new()
         }
+    }
+
+    // -- Persistence ----------------------------------------------------------
+
+    /// Load persisted triggers from disk and rebuild the agent index.
+    ///
+    /// Returns the number of triggers loaded. Returns `Ok(0)` if the
+    /// persistence file does not exist or no path is configured.
+    pub fn load(&self) -> LibreFangResult<usize> {
+        let path = match &self.persist_path {
+            Some(p) => p,
+            None => return Ok(0),
+        };
+        if !path.exists() {
+            return Ok(0);
+        }
+        let data = std::fs::read_to_string(path)
+            .map_err(|e| LibreFangError::Internal(format!("Failed to read trigger jobs: {e}")))?;
+        let triggers: Vec<Trigger> = serde_json::from_str(&data)
+            .map_err(|e| LibreFangError::Internal(format!("Failed to parse trigger jobs: {e}")))?;
+        let count = triggers.len();
+        for trigger in triggers {
+            let id = trigger.id;
+            let agent_id = trigger.agent_id;
+            self.triggers.insert(id, trigger);
+            self.agent_triggers.entry(agent_id).or_default().push(id);
+        }
+        info!(count, "Loaded trigger jobs from disk");
+        Ok(count)
+    }
+
+    /// Persist all triggers to disk via atomic write (write to `.tmp`, then rename).
+    ///
+    /// Does nothing when no persistence path is configured.
+    pub fn persist(&self) -> LibreFangResult<()> {
+        let path = match &self.persist_path {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let triggers: Vec<Trigger> = self.triggers.iter().map(|e| e.value().clone()).collect();
+        let data = serde_json::to_string_pretty(&triggers).map_err(|e| {
+            LibreFangError::Internal(format!("Failed to serialize trigger jobs: {e}"))
+        })?;
+        let tmp_path = path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, data.as_bytes()).map_err(|e| {
+            LibreFangError::Internal(format!("Failed to write trigger jobs temp file: {e}"))
+        })?;
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            LibreFangError::Internal(format!("Failed to rename trigger jobs file: {e}"))
+        })?;
+        debug!(count = triggers.len(), "Persisted trigger jobs");
+        Ok(())
     }
 
     /// Register a new trigger.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -138,6 +138,9 @@ pub struct TriggerPatch {
     pub cooldown_secs: Option<Option<u64>>,
     /// `Some(None)` clears the override (inherits from agent manifest).
     pub session_mode: Option<Option<librefang_types::agent::SessionMode>>,
+    /// `Some(None)` clears the target (reverts to owner routing).
+    /// `Some(Some(id))` sets a new cross-session wake target.
+    pub target_agent: Option<Option<AgentId>>,
 }
 
 /// The trigger engine manages event-to-agent routing.
@@ -496,6 +499,9 @@ impl TriggerEngine {
         }
         if let Some(session_mode) = patch.session_mode {
             t.session_mode = session_mode;
+        }
+        if let Some(target_agent) = patch.target_agent {
+            t.target_agent = target_agent;
         }
         let id = t.id;
         drop(entry);

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -335,7 +335,7 @@ impl TriggerEngine {
         pattern: TriggerPattern,
         prompt_template: String,
     ) -> TriggerId {
-        self.register_with_target(owner, pattern, prompt_template, 0, Some(target))
+        self.register_with_target(owner, pattern, prompt_template, 0, Some(target), None, None)
     }
 
     /// Remove a trigger.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -880,7 +880,7 @@ mod tests {
             }),
         );
 
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].agent_id, watcher);
         assert!(matches[0].message.contains("new-agent"));
@@ -908,7 +908,7 @@ mod tests {
                 name: "coder".to_string(),
             }),
         );
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
 
         // This should NOT match
         let event2 = Event::new(
@@ -919,7 +919,7 @@ mod tests {
                 name: "researcher".to_string(),
             }),
         );
-        assert_eq!(engine.evaluate(&event2).len(), 0);
+        assert_eq!(engine.evaluate(&event2).0.len(), 0);
     }
 
     #[test]
@@ -944,10 +944,10 @@ mod tests {
         );
 
         // First two should match
-        assert_eq!(engine.evaluate(&event).len(), 1);
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
         // Third should not
-        assert_eq!(engine.evaluate(&event).len(), 0);
+        assert_eq!(engine.evaluate(&event).0.len(), 0);
     }
 
     #[test]
@@ -993,7 +993,7 @@ mod tests {
                 usage_percent: 85.0,
             }),
         );
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
     }
 
     // -- reassign_agent_triggers (#519) ------------------------------------
@@ -1019,7 +1019,7 @@ mod tests {
                 status: "ok".to_string(),
             }),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 2);
         assert!(matches.iter().all(|m| m.agent_id == new_agent));
     }
@@ -1140,7 +1140,7 @@ mod tests {
                 status: "ok".to_string(),
             }),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(
             matches[0].agent_id, owner,
@@ -1170,7 +1170,7 @@ mod tests {
                 status: "ok".to_string(),
             }),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(
             matches[0].agent_id, target,
@@ -1207,7 +1207,7 @@ mod tests {
                 name: "worker-1".to_string(),
             }),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].agent_id, target);
     }
@@ -1266,9 +1266,9 @@ mod tests {
         );
 
         // First evaluation fires
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
         // Immediate second evaluation should be suppressed by cooldown
-        assert_eq!(engine.evaluate(&event).len(), 0);
+        assert_eq!(engine.evaluate(&event).0.len(), 0);
     }
 
     #[test]
@@ -1292,9 +1292,9 @@ mod tests {
             }),
         );
 
-        assert_eq!(engine.evaluate(&event).len(), 1);
-        assert_eq!(engine.evaluate(&event).len(), 1);
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
     }
 
     #[test]
@@ -1324,7 +1324,7 @@ mod tests {
         );
 
         // Only 3 should fire due to budget
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 3);
     }
 
@@ -1449,7 +1449,7 @@ mod tests {
             EventTarget::Broadcast,
             EventPayload::Custom(payload),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(
             matches.len(),
             1,
@@ -1479,7 +1479,7 @@ mod tests {
                 agent_id: AgentId::new(),
             }),
         );
-        let matches = engine.evaluate(&event);
+        let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert!(matches[0].message.contains("user.prefs"));
     }
@@ -1507,7 +1507,7 @@ mod tests {
                 agent_id: AgentId::new(),
             }),
         );
-        assert_eq!(engine.evaluate(&event).len(), 1);
+        assert_eq!(engine.evaluate(&event).0.len(), 1);
 
         // Should NOT match (different key)
         let event2 = Event::new(
@@ -1523,6 +1523,6 @@ mod tests {
         for mut entry in engine.triggers.iter_mut() {
             entry.cooldown_secs = Some(0);
         }
-        assert_eq!(engine.evaluate(&event2).len(), 0);
+        assert_eq!(engine.evaluate(&event2).0.len(), 0);
     }
 }

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -220,7 +220,12 @@ impl TriggerEngine {
             let id = trigger.id;
             let agent_id = trigger.agent_id;
             self.triggers.insert(id, trigger);
-            self.agent_triggers.entry(agent_id).or_default().push(id);
+            // Guard against duplicate IDs in a corrupted file: only add to the
+            // per-agent index if this ID isn't already present.
+            let mut ids = self.agent_triggers.entry(agent_id).or_default();
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
         }
         info!(count, "Loaded trigger jobs from disk");
         Ok(count)
@@ -271,7 +276,15 @@ impl TriggerEngine {
         prompt_template: String,
         max_fires: u64,
     ) -> TriggerId {
-        self.register_with_target(agent_id, pattern, prompt_template, max_fires, None)
+        self.register_with_target(
+            agent_id,
+            pattern,
+            prompt_template,
+            max_fires,
+            None,
+            None,
+            None,
+        )
     }
 
     /// Register a trigger with an optional target agent for cross-session wake.
@@ -286,6 +299,8 @@ impl TriggerEngine {
         prompt_template: String,
         max_fires: u64,
         target_agent: Option<AgentId>,
+        cooldown_secs: Option<u64>,
+        session_mode: Option<librefang_types::agent::SessionMode>,
     ) -> TriggerId {
         let trigger = Trigger {
             id: TriggerId::new(),
@@ -297,8 +312,8 @@ impl TriggerEngine {
             fire_count: 0,
             max_fires,
             target_agent,
-            cooldown_secs: None,
-            session_mode: None,
+            cooldown_secs,
+            session_mode,
         };
         let id = trigger.id;
         self.triggers.insert(id, trigger);
@@ -463,6 +478,7 @@ impl TriggerEngine {
     pub fn update(&self, trigger_id: TriggerId, patch: TriggerPatch) -> Option<Trigger> {
         let mut entry = self.triggers.get_mut(&trigger_id)?;
         let t = entry.value_mut();
+        let pattern_changed = patch.pattern.is_some();
         if let Some(pattern) = patch.pattern {
             t.pattern = pattern;
         }
@@ -481,7 +497,13 @@ impl TriggerEngine {
         if let Some(session_mode) = patch.session_mode {
             t.session_mode = session_mode;
         }
-        Some(t.clone())
+        let id = t.id;
+        drop(entry);
+        // Pattern change means the trigger is logically new — clear any stale cooldown timer.
+        if pattern_changed {
+            self.last_fired.remove(&id);
+        }
+        self.triggers.get(&id).map(|t| t.clone())
     }
 
     /// Get a single trigger by ID.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for TriggerId {
 }
 
 /// What kind of events a trigger matches on.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerPattern {
     /// Match any lifecycle event (agent spawned, started, terminated, etc.).
@@ -250,6 +250,20 @@ impl TriggerEngine {
     }
 
     /// Register a new trigger.
+    /// Returns `true` if `agent_id` already has an enabled trigger with this exact pattern.
+    /// Used to skip duplicate registration of proactive triggers on restart.
+    pub fn agent_has_pattern(&self, agent_id: AgentId, pattern: &TriggerPattern) -> bool {
+        let Some(ids) = self.agent_triggers.get(&agent_id) else {
+            return false;
+        };
+        ids.iter().any(|id| {
+            self.triggers
+                .get(id)
+                .map(|t| &t.pattern == pattern)
+                .unwrap_or(false)
+        })
+    }
+
     pub fn register(
         &self,
         agent_id: AgentId,

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -543,9 +543,14 @@ impl TriggerEngine {
     ///    on a trigger to disable its cooldown.
     /// 2. **Per-event budget** — at most `max_triggers_per_event` triggers may fire
     ///    from a single event evaluation. Excess matches are dropped with a warning.
-    pub fn evaluate(&self, event: &Event) -> Vec<TriggerMatch> {
+    /// Returns `(matches, state_mutated)`. `state_mutated` is `true` when any
+    /// trigger's persistent state changed (fire_count increment or auto-disable
+    /// from max_fires), even if no match was produced. Callers should persist
+    /// whenever either the match list is non-empty or `state_mutated` is set.
+    pub fn evaluate(&self, event: &Event) -> (Vec<TriggerMatch>, bool) {
         let event_description = describe_event(event);
         let mut matches = Vec::new();
+        let mut state_mutated = false;
         let now = Instant::now();
 
         for mut entry in self.triggers.iter_mut() {
@@ -558,6 +563,8 @@ impl TriggerEngine {
             // Check max fires
             if trigger.max_fires > 0 && trigger.fire_count >= trigger.max_fires {
                 trigger.enabled = false;
+                // enabled=false must be persisted even if this event produces no match.
+                state_mutated = true;
                 continue;
             }
 
@@ -614,6 +621,7 @@ impl TriggerEngine {
                     session_mode_override: trigger.session_mode,
                 });
                 trigger.fire_count += 1;
+                state_mutated = true;
                 self.last_fired.insert(trigger.id, now);
 
                 debug!(
@@ -626,7 +634,7 @@ impl TriggerEngine {
             }
         }
 
-        matches
+        (matches, state_mutated)
     }
 
     /// Get a trigger by ID.

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -543,10 +543,6 @@ impl TriggerEngine {
     ///    on a trigger to disable its cooldown.
     /// 2. **Per-event budget** — at most `max_triggers_per_event` triggers may fire
     ///    from a single event evaluation. Excess matches are dropped with a warning.
-    /// Returns `(matches, state_mutated)`. `state_mutated` is `true` when any
-    /// trigger's persistent state changed (fire_count increment or auto-disable
-    /// from max_fires), even if no match was produced. Callers should persist
-    /// whenever either the match list is non-empty or `state_mutated` is set.
     pub fn evaluate(&self, event: &Event) -> (Vec<TriggerMatch>, bool) {
         let event_description = describe_event(event);
         let mut matches = Vec::new();

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -1151,6 +1151,8 @@ mod tests {
             "Cross-wake: {{event}}".to_string(),
             0,
             Some(target),
+            None,
+            None,
         );
 
         let event = Event::new(
@@ -1215,6 +1217,8 @@ mod tests {
             "sys: {{event}}".to_string(),
             0,
             Some(target),
+            None,
+            None,
         );
 
         let taken = engine.take_agent_triggers(old_owner);

--- a/docs/src/app/integrations/api/agents/page.mdx
+++ b/docs/src/app/integrations/api/agents/page.mdx
@@ -516,10 +516,21 @@ List all triggers. Optionally filter by agent.
     "enabled": true,
     "fire_count": 5,
     "max_fires": 0,
-    "created_at": "2025-01-15T10:30:00Z"
+    "created_at": "2025-01-15T10:30:00Z",
+    "cooldown_secs": 60,
+    "session_mode": "persistent",
+    "target_agent_id": null
   }
 ]
 ```
+
+### GET /api/triggers/&lbrace;id&rbrace;
+
+Retrieve a single trigger by ID.
+
+**Response** `200 OK`: same shape as a single item from the list above.
+
+**Response** `404 Not Found` if the trigger does not exist.
 
 ### POST /api/triggers
 
@@ -536,9 +547,24 @@ Create a new event trigger.
     }
   },
   "prompt_template": "A new agent was spawned: {&lbrace;event&rbrace;}. Review its capabilities.",
-  "max_fires": 0
+  "max_fires": 0,
+  "cooldown_secs": 60,
+  "session_mode": "persistent",
+  "target_agent_id": "b2c3d4e5-..."
 }
 ```
+
+All fields except `agent_id`, `pattern`, and `prompt_template` are optional.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `agent_id` | UUID | — | Owner agent. The trigger is registered under this agent. |
+| `pattern` | object | — | Event pattern that activates the trigger (see pattern types below). |
+| `prompt_template` | string | — | Message sent to the agent when the event fires. Supports `{&lbrace;event&rbrace;}` placeholder. |
+| `max_fires` | integer | `0` | Maximum times this trigger may fire. `0` = unlimited. |
+| `cooldown_secs` | integer | engine default | Minimum seconds between fires. Omit to use the engine default. |
+| `session_mode` | `"persistent"` \| `"new"` | agent default | Session continuity for each fire. Omit to inherit from the agent manifest. |
+| `target_agent_id` | UUID | `null` | Route the fired message to a different agent instead of the owner. |
 
 **Supported pattern types:**
 
@@ -558,28 +584,28 @@ Create a new event trigger.
 }
 ```
 
-### PUT /api/triggers/&lbrace;id&rbrace;
+### PATCH /api/triggers/&lbrace;id&rbrace;
 
-Update an existing trigger's configuration.
+Partially update a trigger. All fields are optional — only provided fields are changed.
+
+Pass `null` for `cooldown_secs`, `session_mode`, or `target_agent_id` to clear the override and revert to the default. Omitting a field leaves it unchanged.
 
 **Request Body**:
 
 ```json
 {
-  "prompt_template": "Updated template: {&lbrace;event&rbrace;}",
-  "enabled": false,
-  "max_fires": 10
+  "prompt_template": "Updated: {&lbrace;event&rbrace;}",
+  "enabled": true,
+  "max_fires": 10,
+  "cooldown_secs": 120,
+  "session_mode": "new",
+  "target_agent_id": "b2c3d4e5-..."
 }
 ```
 
-**Response** `200 OK`:
+**Response** `200 OK`: the full updated trigger object (same shape as GET /api/triggers/{id}).
 
-```json
-{
-  "status": "updated",
-  "trigger_id": "t1b2c3d4-..."
-}
-```
+**Response** `404 Not Found` if the trigger does not exist.
 
 ### DELETE /api/triggers/&lbrace;id&rbrace;
 

--- a/docs/src/app/integrations/api/agents/page.mdx
+++ b/docs/src/app/integrations/api/agents/page.mdx
@@ -603,7 +603,7 @@ Pass `null` for `cooldown_secs`, `session_mode`, or `target_agent_id` to clear t
 }
 ```
 
-**Response** `200 OK`: the full updated trigger object (same shape as GET /api/triggers/{id}).
+**Response** `200 OK`: the full updated trigger object (same shape as `GET /api/triggers/&lbrace;id&rbrace;`).
 
 **Response** `404 Not Found` if the trigger does not exist.
 

--- a/docs/src/app/integrations/api/page.mdx
+++ b/docs/src/app/integrations/api/page.mdx
@@ -199,9 +199,10 @@ The `Retry-After` header indicates the window duration in seconds.
 | POST | `/api/workflows/{id}/run` | Run workflow |
 | GET | `/api/workflows/{id}/runs` | List workflow runs |
 | **Triggers** | | |
-| GET | `/api/triggers` | List triggers |
+| GET | `/api/triggers` | List triggers (optional `?agent_id=`) |
 | POST | `/api/triggers` | Create trigger |
-| PUT | `/api/triggers/{id}` | Update trigger |
+| GET | `/api/triggers/{id}` | Get trigger detail |
+| PATCH | `/api/triggers/{id}` | Partially update trigger |
 | DELETE | `/api/triggers/{id}` | Delete trigger |
 | **Schedules** | | |
 | GET | `/api/schedules` | List schedules |

--- a/docs/src/app/integrations/cli/commands/page.mdx
+++ b/docs/src/app/integrations/cli/commands/page.mdx
@@ -470,7 +470,7 @@ librefang trigger list [--agent-id <ID>]
 Create an event trigger for an agent.
 
 ```
-librefang trigger create <AGENT_ID> <PATTERN_JSON> [--prompt <TEMPLATE>] [--max-fires <N>]
+librefang trigger create <AGENT_ID> <PATTERN_JSON> [options]
 ```
 
 **Arguments:**
@@ -478,29 +478,90 @@ librefang trigger create <AGENT_ID> <PATTERN_JSON> [--prompt <TEMPLATE>] [--max-
 | Argument | Description |
 |---|---|
 | `<AGENT_ID>` | UUID of the agent that owns the trigger. |
-| `<PATTERN_JSON>` | Trigger pattern as a JSON string. |
+| `<PATTERN_JSON>` | Trigger pattern as a JSON string (e.g. `'"lifecycle"'`). |
 
 **Options:**
 
 | Option | Default | Description |
 |---|---|---|
-| `--prompt <TEMPLATE>` | `"Event: {{event}}"` | Prompt template. Use `{{event}}` as a placeholder for the event data. |
-| `--max-fires <N>` | `0` (unlimited) | Maximum number of times the trigger will fire. |
+| `--prompt <TEMPLATE>` | `"Event: {{event}}"` | Prompt template sent to the agent. Use `{{event}}` as placeholder. |
+| `--max-fires <N>` | `0` (unlimited) | Maximum number of times the trigger can fire. |
+| `--target-agent <ID>` | *(owner)* | Route the triggered message to a different agent instead of the owner. |
+| `--cooldown <SECS>` | none | Minimum seconds between consecutive fires of this trigger. |
+| `--session-mode <MODE>` | agent default | Override session mode for triggered invocations (`persistent` or `new`). |
 
 **Pattern examples:**
 
 ```bash
 # Fire on any lifecycle event
-librefang trigger create <AGENT_ID> '{"lifecycle":{}}'
+librefang trigger create <AGENT_ID> '"lifecycle"'
 
-# Fire when a specific agent is spawned
-librefang trigger create <AGENT_ID> '{"agent_spawned":{"name_pattern":"*"}}'
+# Fire when any agent is spawned
+librefang trigger create <AGENT_ID> '"agent_spawned"'
 
-# Fire on agent termination
-librefang trigger create <AGENT_ID> '{"agent_terminated":{}}'
+# Fire on agent termination, max 5 times, 60s cooldown
+librefang trigger create <AGENT_ID> '"agent_terminated"' --max-fires 5 --cooldown 60
 
-# Fire on all events (limited to 10 fires)
-librefang trigger create <AGENT_ID> '{"all":{}}' --max-fires 10
+# Fire on all events, route message to a different agent
+librefang trigger create <AGENT_ID> '"all"' --target-agent <OTHER_AGENT_ID>
+
+# Custom pattern JSON
+librefang trigger create <AGENT_ID> '{"agent_spawned":{"name_pattern":"worker-*"}}'
+```
+
+---
+
+### librefang trigger get
+
+Show all details of a single trigger.
+
+```
+librefang trigger get <TRIGGER_ID>
+```
+
+---
+
+### librefang trigger update
+
+Partially update a trigger. Only the flags you supply are changed.
+
+```
+librefang trigger update <TRIGGER_ID> [options]
+```
+
+**Options:**
+
+| Option | Description |
+|---|---|
+| `--pattern <JSON>` | New event pattern (JSON string). |
+| `--prompt <TEMPLATE>` | New prompt template. |
+| `--enabled <true\|false>` | Enable or disable the trigger. |
+| `--max-fires <N>` | New maximum fires limit. |
+| `--cooldown <SECS>` | New cooldown in seconds. |
+| `--clear-cooldown` | Remove the cooldown limit entirely. |
+| `--session-mode <MODE>` | New session mode override (`persistent` or `new`). |
+| `--clear-session-mode` | Remove the session mode override (revert to agent default). |
+
+```bash
+# Change prompt and set a 30s cooldown
+librefang trigger update <TRIGGER_ID> --prompt "Alert: {{event}}" --cooldown 30
+
+# Remove the cooldown
+librefang trigger update <TRIGGER_ID> --clear-cooldown
+
+# Switch to new-session mode
+librefang trigger update <TRIGGER_ID> --session-mode new
+```
+
+---
+
+### librefang trigger enable / disable
+
+Enable or disable a trigger without deleting it.
+
+```
+librefang trigger enable <TRIGGER_ID>
+librefang trigger disable <TRIGGER_ID>
 ```
 
 ---

--- a/docs/src/app/integrations/cli/commands/page.mdx
+++ b/docs/src/app/integrations/cli/commands/page.mdx
@@ -541,6 +541,8 @@ librefang trigger update <TRIGGER_ID> [options]
 | `--clear-cooldown` | Remove the cooldown limit entirely. |
 | `--session-mode <MODE>` | New session mode override (`persistent` or `new`). |
 | `--clear-session-mode` | Remove the session mode override (revert to agent default). |
+| `--target-agent <ID>` | Route the triggered message to a different agent (UUID). |
+| `--clear-target-agent` | Remove the target agent override (revert to owner routing). |
 
 ```bash
 # Change prompt and set a 30s cooldown
@@ -551,6 +553,12 @@ librefang trigger update <TRIGGER_ID> --clear-cooldown
 
 # Switch to new-session mode
 librefang trigger update <TRIGGER_ID> --session-mode new
+
+# Redirect firing to a different agent
+librefang trigger update <TRIGGER_ID> --target-agent <OTHER_AGENT_ID>
+
+# Clear the target agent redirect
+librefang trigger update <TRIGGER_ID> --clear-target-agent
 ```
 
 ---

--- a/docs/src/app/zh/integrations/api/agents/page.mdx
+++ b/docs/src/app/zh/integrations/api/agents/page.mdx
@@ -603,7 +603,7 @@
 }
 ```
 
-**响应** `200 OK`：返回完整的更新后触发器对象（与 GET /api/triggers/{id} 格式相同）。
+**响应** `200 OK`：返回完整的更新后触发器对象（与 `GET /api/triggers/&lbrace;id&rbrace;` 格式相同）。
 
 **响应** `404 Not Found`：触发器不存在时返回。
 

--- a/docs/src/app/zh/integrations/api/agents/page.mdx
+++ b/docs/src/app/zh/integrations/api/agents/page.mdx
@@ -516,10 +516,21 @@
     "enabled": true,
     "fire_count": 5,
     "max_fires": 0,
-    "created_at": "2025-01-15T10:30:00Z"
+    "created_at": "2025-01-15T10:30:00Z",
+    "cooldown_secs": 60,
+    "session_mode": "persistent",
+    "target_agent_id": null
   }
 ]
 ```
+
+### GET /api/triggers/&lbrace;id&rbrace;
+
+获取单个触发器详情。
+
+**响应** `200 OK`：与列表中的单条记录格式相同。
+
+**响应** `404 Not Found`：触发器不存在时返回。
 
 ### POST /api/triggers
 
@@ -536,9 +547,24 @@
     }
   },
   "prompt_template": "A new agent was spawned: {&lbrace;event&rbrace;}. Review its capabilities.",
-  "max_fires": 0
+  "max_fires": 0,
+  "cooldown_secs": 60,
+  "session_mode": "persistent",
+  "target_agent_id": "b2c3d4e5-..."
 }
 ```
+
+除 `agent_id`、`pattern` 和 `prompt_template` 外，其余字段均为可选。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `agent_id` | UUID | — | 触发器归属的 Agent。 |
+| `pattern` | object | — | 激活触发器的事件模式（见下方模式类型）。 |
+| `prompt_template` | string | — | 事件触发时发送给 Agent 的提示，支持 `{&lbrace;event&rbrace;}` 占位符。 |
+| `max_fires` | integer | `0` | 最多触发次数，`0` 表示无限制。 |
+| `cooldown_secs` | integer | 引擎默认值 | 两次触发之间的最短间隔（秒）。省略则使用引擎默认值。 |
+| `session_mode` | `"persistent"` \| `"new"` | Agent 默认值 | 每次触发的会话连续性。省略则继承 Agent 配置。 |
+| `target_agent_id` | UUID | `null` | 将触发消息路由到指定 Agent，而非触发器所有者。 |
 
 **支持的模式类型：**
 
@@ -558,28 +584,28 @@
 }
 ```
 
-### PUT /api/triggers/&lbrace;id&rbrace;
+### PATCH /api/triggers/&lbrace;id&rbrace;
 
-更新已有触发器的配置。
+部分更新触发器配置。所有字段均为可选，仅更新提供的字段。
+
+将 `cooldown_secs`、`session_mode` 或 `target_agent_id` 设为 `null` 可清除覆盖值并恢复默认。省略字段则保持不变。
 
 **请求体**：
 
 ```json
 {
-  "prompt_template": "Updated template: {&lbrace;event&rbrace;}",
-  "enabled": false,
-  "max_fires": 10
+  "prompt_template": "Updated: {&lbrace;event&rbrace;}",
+  "enabled": true,
+  "max_fires": 10,
+  "cooldown_secs": 120,
+  "session_mode": "new",
+  "target_agent_id": "b2c3d4e5-..."
 }
 ```
 
-**响应** `200 OK`：
+**响应** `200 OK`：返回完整的更新后触发器对象（与 GET /api/triggers/{id} 格式相同）。
 
-```json
-{
-  "status": "updated",
-  "trigger_id": "t1b2c3d4-..."
-}
-```
+**响应** `404 Not Found`：触发器不存在时返回。
 
 ### DELETE /api/triggers/&lbrace;id&rbrace;
 

--- a/docs/src/app/zh/integrations/api/page.mdx
+++ b/docs/src/app/zh/integrations/api/page.mdx
@@ -199,9 +199,10 @@ Retry-After: 60
 | POST | `/api/workflows/{id}/run` | 运行工作流 |
 | GET | `/api/workflows/{id}/runs` | 列出工作流执行记录 |
 | **触发器** | | |
-| GET | `/api/triggers` | 列出触发器 |
+| GET | `/api/triggers` | 列出触发器（可选 `?agent_id=`） |
 | POST | `/api/triggers` | 创建触发器 |
-| PUT | `/api/triggers/{id}` | 更新触发器 |
+| GET | `/api/triggers/{id}` | 获取触发器详情 |
+| PATCH | `/api/triggers/{id}` | 部分更新触发器 |
 | DELETE | `/api/triggers/{id}` | 删除触发器 |
 | **调度** | | |
 | GET | `/api/schedules` | 列出调度 |

--- a/docs/src/app/zh/integrations/cli/commands/page.mdx
+++ b/docs/src/app/zh/integrations/cli/commands/page.mdx
@@ -541,6 +541,8 @@ librefang trigger update <TRIGGER_ID> [选项]
 | `--clear-cooldown` | 完全移除冷却限制。 |
 | `--session-mode <MODE>` | 新的会话模式覆盖（`persistent` 或 `new`）。 |
 | `--clear-session-mode` | 移除会话模式覆盖，恢复 Agent 默认值。 |
+| `--target-agent <ID>` | 将触发消息路由到另一个 Agent（UUID）。 |
+| `--clear-target-agent` | 移除目标 Agent 覆盖，恢复拥有者路由。 |
 
 ```bash
 # 修改提示并设置 30 秒冷却
@@ -551,6 +553,12 @@ librefang trigger update <TRIGGER_ID> --clear-cooldown
 
 # 切换到 new 会话模式
 librefang trigger update <TRIGGER_ID> --session-mode new
+
+# 将触发重定向到另一个 Agent
+librefang trigger update <TRIGGER_ID> --target-agent <OTHER_AGENT_ID>
+
+# 清除目标 Agent 重定向
+librefang trigger update <TRIGGER_ID> --clear-target-agent
 ```
 
 ---

--- a/docs/src/app/zh/integrations/cli/commands/page.mdx
+++ b/docs/src/app/zh/integrations/cli/commands/page.mdx
@@ -470,7 +470,7 @@ librefang trigger list [--agent-id <ID>]
 为 Agent 创建事件触发器。
 
 ```
-librefang trigger create <AGENT_ID> <PATTERN_JSON> [--prompt <TEMPLATE>] [--max-fires <N>]
+librefang trigger create <AGENT_ID> <PATTERN_JSON> [选项]
 ```
 
 **参数：**
@@ -478,29 +478,90 @@ librefang trigger create <AGENT_ID> <PATTERN_JSON> [--prompt <TEMPLATE>] [--max-
 | 参数 | 说明 |
 |---|---|
 | `<AGENT_ID>` | 拥有该触发器的 Agent 的 UUID。 |
-| `<PATTERN_JSON>` | 触发器模式，以 JSON 字符串形式提供。 |
+| `<PATTERN_JSON>` | 触发器模式，以 JSON 字符串形式提供（如 `'"lifecycle"'`）。 |
 
 **选项：**
 
 | 选项 | 默认值 | 说明 |
 |---|---|---|
-| `--prompt <TEMPLATE>` | `"Event: {{event}}"` | 提示模板。使用 `{{event}}` 作为事件数据的占位符。 |
+| `--prompt <TEMPLATE>` | `"Event: {{event}}"` | 提示模板，使用 `{{event}}` 作为事件数据占位符。 |
 | `--max-fires <N>` | `0`（无限制） | 触发器最大触发次数。 |
+| `--target-agent <ID>` | （拥有者自身） | 将触发消息路由到另一个 Agent 而非拥有者。 |
+| `--cooldown <SECS>` | 无 | 连续两次触发之间的最短间隔（秒）。 |
+| `--session-mode <MODE>` | Agent 默认值 | 覆盖触发调用的会话模式（`persistent` 或 `new`）。 |
 
 **模式示例：**
 
 ```bash
 # 在任何生命周期事件时触发
-librefang trigger create <AGENT_ID> '{"lifecycle":{}}'
+librefang trigger create <AGENT_ID> '"lifecycle"'
 
-# 在指定 Agent 生成时触发
-librefang trigger create <AGENT_ID> '{"agent_spawned":{"name_pattern":"*"}}'
+# 在任意 Agent 生成时触发
+librefang trigger create <AGENT_ID> '"agent_spawned"'
 
-# 在 Agent 终止时触发
-librefang trigger create <AGENT_ID> '{"agent_terminated":{}}'
+# 在 Agent 终止时触发，最多 5 次，冷却 60 秒
+librefang trigger create <AGENT_ID> '"agent_terminated"' --max-fires 5 --cooldown 60
 
-# 在所有事件时触发（限制触发 10 次）
-librefang trigger create <AGENT_ID> '{"all":{}}' --max-fires 10
+# 在所有事件时触发，消息路由给另一个 Agent
+librefang trigger create <AGENT_ID> '"all"' --target-agent <OTHER_AGENT_ID>
+
+# 自定义模式 JSON
+librefang trigger create <AGENT_ID> '{"agent_spawned":{"name_pattern":"worker-*"}}'
+```
+
+---
+
+### librefang trigger get
+
+查看单个触发器的完整详情。
+
+```
+librefang trigger get <TRIGGER_ID>
+```
+
+---
+
+### librefang trigger update
+
+部分更新触发器，只修改指定的字段。
+
+```
+librefang trigger update <TRIGGER_ID> [选项]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|---|---|
+| `--pattern <JSON>` | 新的事件模式（JSON 字符串）。 |
+| `--prompt <TEMPLATE>` | 新的提示模板。 |
+| `--enabled <true\|false>` | 启用或禁用触发器。 |
+| `--max-fires <N>` | 新的最大触发次数。 |
+| `--cooldown <SECS>` | 新的冷却时间（秒）。 |
+| `--clear-cooldown` | 完全移除冷却限制。 |
+| `--session-mode <MODE>` | 新的会话模式覆盖（`persistent` 或 `new`）。 |
+| `--clear-session-mode` | 移除会话模式覆盖，恢复 Agent 默认值。 |
+
+```bash
+# 修改提示并设置 30 秒冷却
+librefang trigger update <TRIGGER_ID> --prompt "告警：{{event}}" --cooldown 30
+
+# 移除冷却
+librefang trigger update <TRIGGER_ID> --clear-cooldown
+
+# 切换到 new 会话模式
+librefang trigger update <TRIGGER_ID> --session-mode new
+```
+
+---
+
+### librefang trigger enable / disable
+
+启用或禁用触发器，不会删除它。
+
+```
+librefang trigger enable <TRIGGER_ID>
+librefang trigger disable <TRIGGER_ID>
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #2827. Originally reported as a persistence bug — event triggers were lost on every daemon restart. While fixing persistence, a full feature audit revealed the trigger subsystem was incomplete in every layer. This PR brings triggers to feature parity with cron jobs.

## Changes

### Core: Persistence (`triggers.rs`, `kernel/mod.rs`)
- Add `persist_path: Option<PathBuf>` to `TriggerEngine` (`None` in tests, `Some(trigger_jobs.json)` in production)
- `load()` — reads JSON at startup, rebuilds `agent_triggers` index
- `persist()` — atomic write via `.tmp` rename, identical to `CronScheduler`
- `persist()` called after every write: register, remove, enable/disable, update, and on every fire (preserves `fire_count`)

### Kernel: New methods (`kernel/mod.rs`)
- `get_trigger(id)` — fetch a single trigger by ID
- `update_trigger(id, patch)` — partial update via `TriggerPatch`, calls `persist()` on success

### API: New endpoints (`routes/workflows.rs`)
- `GET /api/triggers/{id}` — fetch single trigger (id, pattern, prompt, enabled, fire_count, max_fires, cooldown_secs, session_mode, target_agent_id)
- `PATCH /api/triggers/{id}` — partial update via `TriggerPatch`; supports `null` to clear `cooldown_secs` / `session_mode`
- Existing `PUT /api/triggers/{id}` replaced with proper REST `PATCH`
- `trigger_to_json()` helper shared by list and get endpoints

### CLI: New subcommands (`main.rs`)
- `trigger get <ID>` — print all fields of a single trigger
- `trigger update <ID>` — patch any field; new flags: `--session-mode`, `--clear-cooldown`, `--clear-session-mode`
- `trigger enable <ID>` / `trigger disable <ID>` — shorthand toggles
- `trigger create` gains: `--target-agent`, `--cooldown`, `--session-mode`

### Dashboard
- **Types** (`api.ts`): `TriggerItem` extended with `target_agent_id`, `cooldown_secs`, `session_mode`; new `TriggerPatch` and `CreateTriggerPayload` interfaces
- **API functions** (`api.ts`): `getTrigger`, `createTrigger`; `updateTrigger` upgraded to full PATCH
- **Mutations** (`mutations/schedules.ts`): `useCreateTrigger`; `useUpdateTrigger` typed to `TriggerPatch`
- **Query keys** (`queries/keys.ts`): `triggerKeys.detail(id)` added
- **Scheduler page**: create modal has Schedule / Event Trigger tabs with pattern presets; trigger list rows show cooldown, session mode, target agent; edit (pencil) button per row opens an edit modal

## Test plan

- [ ] `librefang trigger create <AGENT_ID> '"lifecycle"' --prompt "Agent event: {{event}}" --max-fires 5` — verify `~/.librefang/trigger_jobs.json` is written
- [ ] `librefang stop && librefang start` — `librefang trigger list` still shows the trigger with correct fire_count
- [ ] Fire trigger twice with `max_fires=2`, restart daemon — confirm trigger stays disabled
- [ ] `librefang trigger get <ID>` — all fields printed
- [ ] `librefang trigger update <ID> --cooldown 30 --session-mode new`
- [ ] `librefang trigger update <ID> --clear-cooldown --clear-session-mode`
- [ ] `librefang trigger enable <ID>` / `librefang trigger disable <ID>`
- [ ] Dashboard: create trigger via Event Trigger tab, verify it appears in list with metadata
- [ ] Dashboard: click pencil icon, edit prompt + cooldown, save — list updates
- [ ] Agent deletion: trigger removed from `trigger_jobs.json`