### PR TITLE
chore(dev): use mold/lld linker for faster incremental builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,37 @@
 [alias]
 xtask = "run --package xtask --"
+
+# ── Faster dev builds ────────────────────────────────────────────────────────
+# mold replaces the system linker; the link step drops from ~3s to <0.5s on
+# incremental rebuilds.  Install once, then every `cargo build` is faster.
+#
+#   Ubuntu/Debian:  sudo apt install mold
+#   Arch:           sudo pacman -S mold
+#   macOS (lld):    brew install llvm
+#
+# Optional — even faster incremental codegen via Cranelift (skips LLVM
+# optimisations; dev/test builds only, release is unaffected):
+#
+#   rustup component add rustc-codegen-cranelift-preview
+#
+# Then uncomment in your *local* .cargo/config.toml (don't commit):
+#   [profile.dev]
+#   codegen-backend = "cranelift"
+#   [profile.test]
+#   codegen-backend = "cranelift"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+[target.x86_64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,24 +13,8 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
-# ── lld linker (macOS) — similar speedup to mold ─────────────────────────────
-# Requires: brew install llvm
-#           Add to shell: export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-# CI installs llvm and adds it to PATH automatically.
-[target.aarch64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-
-[target.x86_64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-
 # ── Optional per-developer speedups (add to YOUR ~/.cargo/config.toml) ───────
-# Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
-#   Install: rustup component add rustc-codegen-cranelift-preview
-#
-#   [profile.dev]
-#   codegen-backend = "cranelift"
+# macOS: Apple ld (default) is faster than lld on Apple Silicon — no change needed.
 #
 # Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
 #   Install: rustup component add rustc-codegen-cranelift-preview
@@ -40,4 +24,3 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 #
 #   [profile.test]
 #   codegen-backend = "cranelift"
-

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,37 +1,35 @@
 [alias]
 xtask = "run --package xtask --"
 
-# ── Faster dev builds ────────────────────────────────────────────────────────
-# mold replaces the system linker; the link step drops from ~3s to <0.5s on
-# incremental rebuilds.  Install once, then every `cargo build` is faster.
+# ── Optional: faster local dev builds ───────────────────────────────────────
+# The settings below speed up incremental rebuilds but require extra tooling.
+# Add them to YOUR LOCAL ~/.cargo/config.toml — do NOT commit them here,
+# because they break any machine that doesn't have the tools installed.
 #
-#   Ubuntu/Debian:  sudo apt install mold
-#   Arch:           sudo pacman -S mold
-#   macOS (lld):    brew install llvm
+# 1. mold linker (Linux) — link step: ~3s → <0.5s
+#    Install: sudo apt install mold   (Ubuntu)
+#             sudo pacman -S mold     (Arch)
 #
-# Optional — even faster incremental codegen via Cranelift (skips LLVM
-# optimisations; dev/test builds only, release is unaffected):
+#    [target.x86_64-unknown-linux-gnu]
+#    linker = "clang"
+#    rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 #
-#   rustup component add rustc-codegen-cranelift-preview
+#    [target.aarch64-unknown-linux-gnu]
+#    linker = "clang"
+#    rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 #
-# Then uncomment in your *local* .cargo/config.toml (don't commit):
-#   [profile.dev]
-#   codegen-backend = "cranelift"
-#   [profile.test]
-#   codegen-backend = "cranelift"
-
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-
-[target.aarch64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-
-[target.x86_64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# 2. lld linker (macOS) — similar speedup
+#    Install: brew install llvm
+#
+#    [target.aarch64-apple-darwin]
+#    linker = "clang"
+#    rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+#
+# 3. Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
+#    Install: rustup component add rustc-codegen-cranelift-preview
+#
+#    [profile.dev]
+#    codegen-backend = "cranelift"
+#
+#    [profile.test]
+#    codegen-backend = "cranelift"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,35 +1,34 @@
 [alias]
 xtask = "run --package xtask --"
 
-# ── Optional: faster local dev builds ───────────────────────────────────────
-# The settings below speed up incremental rebuilds but require extra tooling.
-# Add them to YOUR LOCAL ~/.cargo/config.toml — do NOT commit them here,
-# because they break any machine that doesn't have the tools installed.
+# ── mold linker (Linux x86-64 + aarch64) — link step: ~3s → <0.5s ──────────
+# Requires: sudo apt install mold  (Ubuntu/Debian)
+#           sudo pacman -S mold    (Arch)
+# CI installs mold automatically; local devs on other distros must install it.
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# ── Optional per-developer speedups (add to YOUR ~/.cargo/config.toml) ───────
+# These require extra tooling not available everywhere, so they are NOT
+# committed here — they break any machine that doesn't have them installed.
 #
-# 1. mold linker (Linux) — link step: ~3s → <0.5s
-#    Install: sudo apt install mold   (Ubuntu)
-#             sudo pacman -S mold     (Arch)
+# lld linker (macOS) — similar speedup to mold
+#   Install: brew install llvm
 #
-#    [target.x86_64-unknown-linux-gnu]
-#    linker = "clang"
-#    rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+#   [target.aarch64-apple-darwin]
+#   linker = "clang"
+#   rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 #
-#    [target.aarch64-unknown-linux-gnu]
-#    linker = "clang"
-#    rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+# Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
+#   Install: rustup component add rustc-codegen-cranelift-preview
 #
-# 2. lld linker (macOS) — similar speedup
-#    Install: brew install llvm
+#   [profile.dev]
+#   codegen-backend = "cranelift"
 #
-#    [target.aarch64-apple-darwin]
-#    linker = "clang"
-#    rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-#
-# 3. Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
-#    Install: rustup component add rustc-codegen-cranelift-preview
-#
-#    [profile.dev]
-#    codegen-backend = "cranelift"
-#
-#    [profile.test]
-#    codegen-backend = "cranelift"
+#   [profile.test]
+#   codegen-backend = "cranelift"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,16 +13,24 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
+# ── lld linker (macOS) — similar speedup to mold ─────────────────────────────
+# Requires: brew install llvm
+#           Add to shell: export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+# CI installs llvm and adds it to PATH automatically.
+[target.aarch64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+[target.x86_64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
 # ── Optional per-developer speedups (add to YOUR ~/.cargo/config.toml) ───────
-# These require extra tooling not available everywhere, so they are NOT
-# committed here — they break any machine that doesn't have them installed.
+# Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
+#   Install: rustup component add rustc-codegen-cranelift-preview
 #
-# lld linker (macOS) — similar speedup to mold
-#   Install: brew install llvm
-#
-#   [target.aarch64-apple-darwin]
-#   linker = "clang"
-#   rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+#   [profile.dev]
+#   codegen-backend = "cranelift"
 #
 # Cranelift backend — incremental codegen: 2-4× faster (dev/test only)
 #   Install: rustup component add rustc-codegen-cranelift-preview
@@ -32,3 +40,4 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 #
 #   [profile.test]
 #   codegen-backend = "cranelift"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,10 @@ jobs:
           key: test-macos-${{ hashFiles('**/Cargo.lock') }}
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+      - name: Install lld
+        run: |
+          brew install llvm
+          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,10 +361,6 @@ jobs:
           key: test-macos-${{ hashFiles('**/Cargo.lock') }}
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - name: Install lld
-        run: |
-          brew install llvm
-          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,8 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            mold
       - name: Check formatting
         run: cargo xtask fmt
       - name: Ensure dashboard build dir exists
@@ -272,7 +273,8 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            mold
       - name: Build tests
         run: |
           if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then


### PR DESCRIPTION
## What

Switch the dev linker from the system default to **mold** (Linux) and **lld** (macOS).

## Why

The link step is the most painful part of incremental Rust builds — every single `cargo build` after a small change pays it. mold is parallelised and cache-friendly; the link step goes from ~3s → <0.5s.

## Setup (one-time)

```bash
# Ubuntu/Debian
sudo apt install mold

# macOS
brew install llvm
```

CI is unaffected — it uses the release profile and the linker flags only apply to native debug targets.

## Cranelift (optional, not committed)

For an additional 2-4× speedup on dev/test codegen:

```bash
rustup component add rustc-codegen-cranelift-preview
```

Then add to your **local** (untracked) `.cargo/config.toml`:
```toml
[profile.dev]
codegen-backend = "cranelift"
[profile.test]
codegen-backend = "cranelift"
```