### PR TITLE
fix(ci): correct event sequence in show_progress=false test

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3693,6 +3693,7 @@ mod tests {
             "en",
         );
 
+        // Iteration 1: the tool-call content block.
         event_tx
             .send(StreamEvent::ToolUseStart {
                 id: "tool_1".to_string(),
@@ -3701,6 +3702,14 @@ mod tests {
             .await
             .unwrap();
         event_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: librefang_types::message::StopReason::ToolUse,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        // Tool executes; result feeds back into the next LLM iteration.
+        event_tx
             .send(StreamEvent::ToolExecutionResult {
                 name: "web_search".to_string(),
                 result_preview: "irrelevant".to_string(),
@@ -3708,6 +3717,7 @@ mod tests {
             })
             .await
             .unwrap();
+        // Iteration 2: model's prose response after seeing the tool result.
         event_tx
             .send(StreamEvent::TextDelta {
                 text: "Final answer.".to_string(),


### PR DESCRIPTION
## Summary

- `test_stream_bridge_show_progress_false_suppresses_all_markers` was sending `ToolUseStart` → `ToolExecutionResult` → `TextDelta` → `ContentComplete` all in one iteration
- The bridge sets `saw_tool_use = true` on `ToolUseStart` and suppresses any buffered text at `ContentComplete` when that flag is set (to filter provider-echoed tool-call content)
- Result: "Final answer." was silently dropped, assertion failed with `got: ""`

## Fix

Split the sequence into two proper iterations matching the real event flow:
1. `ToolUseStart` → `ContentComplete(ToolUse)` — tool-call block ends, `saw_tool_use` resets
2. `ToolExecutionResult` → `TextDelta` → `ContentComplete(EndTurn)` — model response flows through

No production code changed; test-only fix.