### PR TITLE
chore(gitignore): ignore rust_out build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ crates/librefang-api/static/react/
 *.pdb
 dist
 sdk/**/target
+# Default `rustc foo.rs` output when run without `-o` — never a tracked artifact.
+/rust_out
 
 # Cloudflare Wrangler
 .wrangler/


### PR DESCRIPTION
## Summary

- A stray 3.9 MB ELF binary `rust_out` has been sitting at the repo root since March — the default output name `rustc foo.rs` produces when invoked without `-o`.
- It shows up as untracked on every `git status` and triggers `Warning: 1 uncommitted change` on `gh pr create` (observed while opening #2835).
- Add `/rust_out` to `.gitignore` under the existing Build section.

## Test plan

- [x] `git check-ignore -v rust_out` → `.gitignore:11:/rust_out`
- [x] `git status` is clean with no tracked files affected