### PR TITLE
fix(init): use main as default branch for ~/.librefang git repo

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2523,7 +2523,7 @@ fn init_git_if_missing(librefang_dir: &std::path::Path) {
     }
 
     let Ok(status) = std::process::Command::new("git")
-        .args(["init", "-q"])
+        .args(["init", "-q", "-b", "main"])
         .current_dir(librefang_dir)
         .status()
     else {

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -93,7 +93,7 @@ pub(super) fn init_git_if_missing(home_dir: &Path) {
         return;
     }
     let ok = std::process::Command::new("git")
-        .args(["init", "-q"])
+        .args(["init", "-q", "-b", "main"])
         .current_dir(home_dir)
         .status()
         .is_ok_and(|s| s.success());


### PR DESCRIPTION
## Summary
- Pass `-b main` to `git init` in both `init_git_if_missing()` call sites so the repo LibreFang creates under `~/.librefang/` uses `main` instead of the Git built-in default (`master` on Git ≤ 2.43 with no `init.defaultBranch` configured).
- Affected sites:
  - `crates/librefang-kernel/src/kernel/workspace_setup.rs` (daemon startup path)
  - `crates/librefang-cli/src/main.rs` (`librefang init` subcommand)

## Test plan
- [ ] On a clean host with no `init.defaultBranch` set, remove `~/.librefang/.git` and start the daemon; confirm the recreated repo is on branch `main`.
- [ ] Same clean state, run `librefang init`; confirm the resulting repo is on branch `main`.
- [ ] On an existing `~/.librefang` already on `master` (or `main`), confirm no re-init happens — the early `.git` existence check still short-circuits.

## Notes
`-b` / `--initial-branch` requires Git ≥ 2.28 (released Jul 2020), which is already the effective floor for modern distros.