### PR TITLE
refactor(backup): relocate config backups under ~/.librefang/backups/

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1984,10 +1984,14 @@ pub async fn config_set(
         );
     }
 
-    // Backup before write
-    let backup_path = config_path.with_extension("toml.bak");
+    // Backup under backups/ before write (single rolling copy).
     if config_path.exists() {
-        let _ = std::fs::copy(&config_path, &backup_path);
+        if let Some(home_dir) = config_path.parent() {
+            let backups_dir = home_dir.join("backups");
+            if std::fs::create_dir_all(&backups_dir).is_ok() {
+                let _ = std::fs::copy(&config_path, backups_dir.join("config.toml.prev"));
+            }
+        }
     }
 
     // Write back — preserves comments, whitespace, and key ordering

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2224,15 +2224,21 @@ fn cmd_init_upgrade() {
     ui::blank();
     ui::section("Upgrading LibreFang installation");
 
-    // 2. Backup existing config with timestamp
-    let backup_name = format!("config.toml.bak.{}", format_local_timestamp());
-    let backup_path = librefang_dir.join(&backup_name);
+    // 2. Backup existing config under backups/ (keep last 3)
+    let backups_dir = librefang_dir.join("backups");
+    if let Err(e) = std::fs::create_dir_all(&backups_dir) {
+        ui::error(&format!("Failed to create backups dir: {e}"));
+        std::process::exit(1);
+    }
+    let backup_name = format!("config-{}.toml", format_local_timestamp());
+    let backup_path = backups_dir.join(&backup_name);
     if let Err(e) = std::fs::copy(&config_path, &backup_path) {
         ui::error(&format!("Failed to backup config: {e}"));
         std::process::exit(1);
     }
     restrict_file_permissions(&backup_path);
-    ui::success(&format!("Backed up config to {backup_name}"));
+    prune_old_config_backups(&backups_dir, 3);
+    ui::success(&format!("Backed up config to backups/{backup_name}"));
 
     // 3. Sync registry (TTL=0 forces refresh regardless of last sync time)
     ui::hint("Syncing registry...");
@@ -2250,12 +2256,12 @@ fn cmd_init_upgrade() {
     init_vault_if_missing(&librefang_dir);
     init_git_if_missing(&librefang_dir);
 
-    // Ensure .gitignore excludes backup files (may be missing in older installations)
+    // Ensure .gitignore excludes the backups/ directory (may be missing in older installations)
     let gitignore = librefang_dir.join(".gitignore");
     if gitignore.exists() {
         if let Ok(content) = std::fs::read_to_string(&gitignore) {
-            if !content.contains("*.bak.*") {
-                let _ = std::fs::write(&gitignore, format!("{content}*.bak.*\n"));
+            if !content.lines().any(|l| l.trim() == "backups/") {
+                let _ = std::fs::write(&gitignore, format!("{content}backups/\n"));
             }
         }
     }
@@ -2273,7 +2279,9 @@ fn cmd_init_upgrade() {
         Ok(v) => v,
         Err(e) => {
             ui::error(&format!("Failed to parse config.toml: {e}"));
-            ui::hint(&format!("Your original config was saved to {backup_name}"));
+            ui::hint(&format!(
+                "Your original config was saved to backups/{backup_name}"
+            ));
             std::process::exit(1);
         }
     };
@@ -2345,7 +2353,9 @@ fn cmd_init_upgrade() {
 
         if let Err(e) = std::fs::write(&config_path, &content) {
             ui::error(&format!("Failed to write config: {e}"));
-            ui::hint(&format!("Your original config was saved to {backup_name}"));
+            ui::hint(&format!(
+                "Your original config was saved to backups/{backup_name}"
+            ));
             std::process::exit(1);
         }
         restrict_file_permissions(&config_path);
@@ -2394,11 +2404,38 @@ fn cmd_init_upgrade() {
     // 8. Summary
     ui::blank();
     ui::success("Upgrade complete!");
-    ui::kv("Backup", &backup_name);
+    ui::kv("Backup", &format!("backups/{backup_name}"));
     if !added.is_empty() {
         ui::kv("New fields", &added.len().to_string());
     }
     ui::blank();
+}
+
+/// Keep only the `keep` most recent `config-*.toml` backups under `backups_dir`.
+/// The embedded `YYYYMMDD-HHMMSS` timestamp sorts lexicographically, so a
+/// filename sort gives the same order as a chronological sort.
+fn prune_old_config_backups(backups_dir: &std::path::Path, keep: usize) {
+    let Ok(entries) = std::fs::read_dir(backups_dir) else {
+        return;
+    };
+    let mut files: Vec<std::path::PathBuf> = entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            let name = path.file_name()?.to_str()?;
+            if name.starts_with("config-") && name.ends_with(".toml") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    files.sort();
+    if files.len() > keep {
+        for old in &files[..files.len() - keep] {
+            let _ = std::fs::remove_file(old);
+        }
+    }
 }
 
 /// Generate a local timestamp string in YYYYMMDD-HHMMSS format without external deps.
@@ -2540,7 +2577,7 @@ fn init_git_if_missing(librefang_dir: &std::path::Path) {
     if !gitignore.exists() {
         let _ = std::fs::write(
             &gitignore,
-            "secrets.env\nvault.enc\ndaemon.json\nlogs/\ncache/\nregistry/\ndata/\n*.db\n*.db-shm\n*.db-wal\n*.bak.*\n",
+            "secrets.env\nvault.enc\ndaemon.json\nlogs/\ncache/\nregistry/\ndata/\nbackups/\n*.db\n*.db-shm\n*.db-wal\n",
         );
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1362,6 +1362,7 @@ impl LibreFangKernel {
         // Migrate old directory layout (hands/, workspaces/<agent>/) to unified layout
         ensure_workspaces_layout(&config.home_dir)?;
         migrate_legacy_agent_dirs(&config.home_dir, &config.effective_agent_workspaces_dir());
+        migrate_root_backups(&config.home_dir);
 
         // Initialize memory substrate
         let db_path = config

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -87,6 +87,55 @@ pub(super) fn migrate_legacy_agent_dirs(home_dir: &Path, workspaces_agents_dir: 
     }
 }
 
+/// One-shot migration: relocate stray `*.bak*` files left behind by older
+/// versions at the home-dir root into `backups/`. Known producers:
+/// `config.toml.bak`, `config.toml.bak.<ts>`, `integrations.toml.bak.<ts>`.
+pub(super) fn migrate_root_backups(home_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(home_dir) else {
+        return;
+    };
+    let candidates: Vec<PathBuf> = entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if !path.is_file() {
+                return None;
+            }
+            let name = path.file_name()?.to_str()?;
+            if name.starts_with("config.toml.bak") || name.starts_with("integrations.toml.bak") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if candidates.is_empty() {
+        return;
+    }
+    let backups_dir = home_dir.join("backups");
+    if std::fs::create_dir_all(&backups_dir).is_err() {
+        return;
+    }
+    for src in candidates {
+        let Some(name) = src.file_name().map(|n| n.to_os_string()) else {
+            continue;
+        };
+        let dest = backups_dir.join(&name);
+        if dest.exists() {
+            // Already relocated in a prior run — discard the stray duplicate.
+            let _ = std::fs::remove_file(&src);
+            continue;
+        }
+        if let Err(e) = std::fs::rename(&src, &dest) {
+            tracing::warn!(
+                src = %src.display(),
+                dest = %dest.display(),
+                "Failed to relocate backup: {e}"
+            );
+        }
+    }
+}
+
 /// Initialize a git repo in the home directory for config version control.
 pub(super) fn init_git_if_missing(home_dir: &Path) {
     if home_dir.join(".git").exists() {


### PR DESCRIPTION
## Summary
- `librefang init --upgrade` previously wrote `config.toml.bak.<ts>` into `~/.librefang/` root on every run with no rotation, so repeat upgrades piled up top-level `.bak` files next to the active config. The API config editor and the MCP one-shot migration each added their own `.bak` variant at root.
- This PR routes all of them under a dedicated `backups/` directory, prunes the CLI upgrade backups to the most recent 3, and relocates pre-existing stray backup files on daemon boot.

## Changes
- **`librefang-cli` upgrade** (`crates/librefang-cli/src/main.rs`): write to `backups/config-<ts>.toml` and keep only the most recent 3 via filename-sorted pruning (the embedded `YYYYMMDD-HHMMSS` timestamp sorts chronologically, so a plain filename sort equals chronological order).
- **`librefang-api` config_set** (`crates/librefang-api/src/routes/config.rs`): write the rolling single-file backup to `backups/config.toml.prev` instead of `config.toml.bak` at root.
- **`librefang-kernel` boot** (`crates/librefang-kernel/src/kernel/{mod.rs,workspace_setup.rs}`): add `migrate_root_backups()` that relocates any stray `config.toml.bak*` / `integrations.toml.bak*` files from the home root into `backups/`. Idempotent — if the destination already exists, the stray is removed.
- **`.gitignore`**: CLI `init_git_if_missing` now writes `backups/` instead of `*.bak.*`; the upgrade path also appends `backups/` to an existing `.gitignore` if missing. The kernel-side `.gitignore` already listed `backups/` — this aligns the CLI copy with it.

## Test plan
- [ ] Run `librefang init --upgrade` on a config with no existing `backups/`: confirm a new `backups/config-<ts>.toml` appears and no `config.toml.bak.*` in root.
- [ ] Run `librefang init --upgrade` 4 times in a row: confirm only the 3 newest backups are retained under `backups/`.
- [ ] Pre-seed `~/.librefang/` with `config.toml.bak.OLDTS` and start the daemon: confirm the file is moved into `backups/` and the root is cleaned up.
- [ ] API config edit: confirm `backups/config.toml.prev` is created; no new `config.toml.bak` at root.
- [ ] Fresh `librefang init` on a clean host: confirm the generated `.gitignore` contains `backups/` and no `*.bak.*`.