### PR TITLE
refactor(home-layout): move stray state/log files out of ~/.librefang root

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -5200,7 +5200,9 @@ mod monitoring_tests {
             skillhub_cache: dashmap::DashMap::new(),
             provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
             provider_test_cache: dashmap::DashMap::new(),
-            webhook_store: crate::webhook_store::WebhookStore::load(home_dir.join("webhooks.json")),
+            webhook_store: crate::webhook_store::WebhookStore::load(
+                home_dir.join("data").join("webhooks.json"),
+            ),
             active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
             #[cfg(feature = "telemetry")]
             prometheus_handle: None,

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -317,7 +317,11 @@ pub async fn set_model_overrides(
     Path(id): Path<String>,
     Json(body): Json<librefang_types::model_catalog::ModelOverrides>,
 ) -> impl IntoResponse {
-    let overrides_path = state.kernel.home_dir().join("model_overrides.json");
+    let overrides_path = state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("model_overrides.json");
     let mut catalog = state
         .kernel
         .model_catalog_ref()
@@ -345,7 +349,11 @@ pub async fn delete_model_overrides(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let overrides_path = state.kernel.home_dir().join("model_overrides.json");
+    let overrides_path = state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("model_overrides.json");
     let mut catalog = state
         .kernel
         .model_catalog_ref()
@@ -758,7 +766,11 @@ pub async fn add_custom_model(
     // Persist to disk. If save fails, roll back the in-memory add so the
     // catalog stays consistent with what's on disk — otherwise the caller
     // sees "added" now but the model vanishes on the next daemon restart.
-    let custom_path = state.kernel.home_dir().join("custom_models.json");
+    let custom_path = state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("custom_models.json");
     if let Err(e) = catalog.save_custom_models(&custom_path) {
         tracing::warn!("Failed to persist custom models: {e}");
         catalog.remove_custom_model(&id);
@@ -797,7 +809,11 @@ pub async fn remove_custom_model(
             .into_json_tuple();
     }
 
-    let custom_path = state.kernel.home_dir().join("custom_models.json");
+    let custom_path = state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("custom_models.json");
     if let Err(e) = catalog.save_custom_models(&custom_path) {
         tracing::warn!("Failed to persist custom models: {e}");
         if let Some(entry) = snapshot {
@@ -864,7 +880,13 @@ pub async fn set_provider_key(
             .write()
             .unwrap_or_else(|e| e.into_inner());
         catalog.unsuppress_provider(&name);
-        catalog.save_suppressed(&state.kernel.home_dir().join("suppressed_providers.json"));
+        catalog.save_suppressed(
+            &state
+                .kernel
+                .home_dir()
+                .join("data")
+                .join("suppressed_providers.json"),
+        );
         catalog.detect_auth();
     }
 
@@ -1057,7 +1079,13 @@ pub async fn delete_provider_key(
             .write()
             .unwrap_or_else(|e| e.into_inner());
         catalog.suppress_provider(&name);
-        catalog.save_suppressed(&state.kernel.home_dir().join("suppressed_providers.json"));
+        catalog.save_suppressed(
+            &state
+                .kernel
+                .home_dir()
+                .join("data")
+                .join("suppressed_providers.json"),
+        );
         catalog.detect_auth();
     }
 

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2773,30 +2773,30 @@ pub async fn create_backup(
         }
     }
 
-    // 2. cron_jobs.json
-    let cron_path = home_dir.join("cron_jobs.json");
+    // 2. data/cron_jobs.json
+    let cron_path = home_dir.join("data").join("cron_jobs.json");
     if cron_path.exists() {
-        if let Err(e) = add_file(&mut zip, &cron_path, "cron_jobs.json") {
+        if let Err(e) = add_file(&mut zip, &cron_path, "data/cron_jobs.json") {
             tracing::warn!("Backup: skipping cron_jobs.json: {e}");
         } else {
             components.push("cron_jobs".to_string());
         }
     }
 
-    // 3. hand_state.json
-    let hand_state_path = home_dir.join("hand_state.json");
+    // 3. data/hand_state.json
+    let hand_state_path = home_dir.join("data").join("hand_state.json");
     if hand_state_path.exists() {
-        if let Err(e) = add_file(&mut zip, &hand_state_path, "hand_state.json") {
+        if let Err(e) = add_file(&mut zip, &hand_state_path, "data/hand_state.json") {
             tracing::warn!("Backup: skipping hand_state.json: {e}");
         } else {
             components.push("hand_state".to_string());
         }
     }
 
-    // 4. custom_models.json
-    let custom_models_path = home_dir.join("custom_models.json");
+    // 4. data/custom_models.json
+    let custom_models_path = home_dir.join("data").join("custom_models.json");
     if custom_models_path.exists() {
-        if let Err(e) = add_file(&mut zip, &custom_models_path, "custom_models.json") {
+        if let Err(e) = add_file(&mut zip, &custom_models_path, "data/custom_models.json") {
             tracing::warn!("Backup: skipping custom_models.json: {e}");
         } else {
             components.push("custom_models".to_string());

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -706,7 +706,7 @@ async fn change_password(
 
 /// Path to the file where active sessions are persisted across restarts.
 fn sessions_path(home_dir: &std::path::Path) -> std::path::PathBuf {
-    home_dir.join("sessions.json")
+    home_dir.join("data").join("sessions.json")
 }
 
 /// Load persisted sessions from disk, dropping any that have already expired.
@@ -805,7 +805,7 @@ pub async fn build_router(
         provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
         provider_test_cache: dashmap::DashMap::new(),
         webhook_store: crate::webhook_store::WebhookStore::load(
-            kernel.home_dir().join("webhooks.json"),
+            kernel.home_dir().join("data").join("webhooks.json"),
         ),
         active_sessions: active_sessions.clone(),
         api_key_lock: api_key_lock.clone(),

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1580,22 +1580,12 @@ fn init_tracing_stderr(log_level: &str) {
 
     // Compact stderr format: in a one-shot CLI context the user cares about
     // the WARN/ERROR text, not the timestamp or the fully-qualified target.
-    // `daemon.log` keeps the full default format via the file layer below.
+    // One-shot CLI runs are transient — stderr is the only sink; the daemon
+    // has its own file appender under `logs/daemon.log`.
     let fmt_layer = tracing_subscriber::fmt::layer()
         .without_time()
         .with_target(false)
         .compact();
-
-    // Also write logs to ~/.librefang/daemon.log
-    let log_dir = cli_librefang_home();
-    let _ = std::fs::create_dir_all(&log_dir);
-    let file_layer = std::fs::File::create(log_dir.join("daemon.log"))
-        .ok()
-        .map(|file| {
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .with_writer(std::sync::Mutex::new(file))
-        });
 
     // Register a no-op reload slot so `init_otel_tracing` can swap a real
     // OTel layer in later without needing to claim the global dispatcher.
@@ -1607,11 +1597,7 @@ fn init_tracing_stderr(log_level: &str) {
     #[cfg(not(feature = "telemetry"))]
     let registry = tracing_subscriber::registry();
 
-    registry
-        .with(env_filter)
-        .with(fmt_layer)
-        .with(file_layer)
-        .init();
+    registry.with(env_filter).with(fmt_layer).init();
 }
 
 /// Get the LibreFang home directory, respecting LIBREFANG_HOME env var.
@@ -1650,9 +1636,11 @@ fn daemon_config_context(config: Option<&std::path::Path>) -> DaemonConfigContex
 
 /// Redirect tracing to a log file so it doesn't corrupt the ratatui TUI.
 fn init_tracing_file(log_level: &str, custom_log_dir: Option<&std::path::Path>) {
+    // `custom_log_dir` is already a log directory (typically `daemon.log_dir`
+    // from config); use it as-is. Otherwise default to `<home>/logs/`.
     let log_dir = custom_log_dir
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(cli_librefang_home);
+        .unwrap_or_else(|| cli_librefang_home().join("logs"));
     let _ = std::fs::create_dir_all(&log_dir);
     let log_path = log_dir.join("tui.log");
 
@@ -9554,8 +9542,10 @@ fn cmd_logs(config: Option<PathBuf>, lines: usize, follow: bool) {
         return;
     }
 
-    let tui_log_dir = daemon.log_dir.as_deref().unwrap_or(&daemon.home_dir);
-    let tui_log = tui_log_dir.join("tui.log");
+    let tui_log = match daemon.log_dir.as_deref() {
+        Some(dir) => dir.join("tui.log"),
+        None => daemon.home_dir.join("logs").join("tui.log"),
+    };
     if tui_log.exists() {
         ui::hint(&format!(
             "Daemon log not found; showing TUI log at {}",

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -124,6 +124,11 @@ impl CronScheduler {
         let metas: Vec<JobMeta> = self.jobs.iter().map(|r| r.value().clone()).collect();
         let data = serde_json::to_string_pretty(&metas)
             .map_err(|e| LibreFangError::Internal(format!("Failed to serialize cron jobs: {e}")))?;
+        if let Some(parent) = self.persist_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                LibreFangError::Internal(format!("Failed to create cron jobs dir: {e}"))
+            })?;
+        }
         let tmp_path = self.persist_path.with_extension("json.tmp");
         std::fs::write(&tmp_path, data.as_bytes()).map_err(|e| {
             LibreFangError::Internal(format!("Failed to write cron jobs temp file: {e}"))

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -81,13 +81,13 @@ pub struct CronScheduler {
 impl CronScheduler {
     /// Create a new scheduler.
     ///
-    /// `home_dir` is the LibreFang data directory; jobs are persisted to
-    /// `<home_dir>/cron_jobs.json`. `max_total_jobs` caps the total number
-    /// of jobs across all agents.
+    /// `home_dir` is the LibreFang home directory; jobs are persisted to
+    /// `<home_dir>/data/cron_jobs.json`. `max_total_jobs` caps the total
+    /// number of jobs across all agents.
     pub fn new(home_dir: &Path, max_total_jobs: usize) -> Self {
         Self {
             jobs: DashMap::new(),
-            persist_path: home_dir.join("cron_jobs.json"),
+            persist_path: home_dir.join("data").join("cron_jobs.json"),
             max_total_jobs: AtomicUsize::new(max_total_jobs),
         }
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1363,6 +1363,8 @@ impl LibreFangKernel {
         ensure_workspaces_layout(&config.home_dir)?;
         migrate_legacy_agent_dirs(&config.home_dir, &config.effective_agent_workspaces_dir());
         migrate_root_backups(&config.home_dir);
+        migrate_root_state_files(&config.home_dir);
+        cleanup_legacy_root_logs(&config.home_dir);
 
         // Initialize memory substrate
         let db_path = config
@@ -1758,8 +1760,13 @@ impl LibreFangKernel {
         // Initialize model catalog, detect provider auth, and apply URL overrides
         let mut model_catalog =
             librefang_runtime::model_catalog::ModelCatalog::new(&config.home_dir);
-        model_catalog.load_suppressed(&config.home_dir.join("suppressed_providers.json"));
-        model_catalog.load_overrides(&config.home_dir.join("model_overrides.json"));
+        model_catalog.load_suppressed(
+            &config
+                .home_dir
+                .join("data")
+                .join("suppressed_providers.json"),
+        );
+        model_catalog.load_overrides(&config.home_dir.join("data").join("model_overrides.json"));
         model_catalog.detect_auth();
         // Apply region selections first (lower priority than explicit provider_urls)
         if !config.provider_regions.is_empty() {
@@ -1794,8 +1801,8 @@ impl LibreFangKernel {
                 config.provider_proxy_urls.len()
             );
         }
-        // Load user's custom models from ~/.librefang/custom_models.json (highest priority)
-        let custom_models_path = config.home_dir.join("custom_models.json");
+        // Load user's custom models from ~/.librefang/data/custom_models.json (highest priority)
+        let custom_models_path = config.home_dir.join("data").join("custom_models.json");
         model_catalog.load_custom_models(&custom_models_path);
         let available_count = model_catalog.available_models().len();
         let total_count = model_catalog.list_models().len();
@@ -7621,7 +7628,7 @@ system_prompt = "You are a helpful assistant."
 
     /// Persist active hand state to disk.
     pub fn persist_hand_state(&self) {
-        let state_path = self.home_dir_boot.join("hand_state.json");
+        let state_path = self.home_dir_boot.join("data").join("hand_state.json");
         if let Err(e) = self.hand_registry.persist_state(&state_path) {
             warn!(error = %e, "Failed to persist hand state");
         }
@@ -8276,7 +8283,7 @@ system_prompt = "You are a helpful assistant."
     pub async fn start_background_agents(self: &Arc<Self>) {
         let cfg = self.config.load_full();
         // Restore previously active hands from persisted state
-        let state_path = self.home_dir_boot.join("hand_state.json");
+        let state_path = self.home_dir_boot.join("data").join("hand_state.json");
         let saved_hands = librefang_hands::registry::HandRegistry::load_state(&state_path);
         if !saved_hands.is_empty() {
             info!("Restoring {} persisted hand(s)", saved_hands.len());

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -136,6 +136,65 @@ pub(super) fn migrate_root_backups(home_dir: &Path) {
     }
 }
 
+/// One-shot cleanup: remove stray log files left at the home-dir root by
+/// older CLI builds. Both were created (and truncated) by every CLI
+/// invocation via a `tracing_subscriber` file layer, so they never held
+/// useful history — modern CLI builds write to `logs/` (or drop the layer
+/// entirely for one-shot commands) and the real daemon logs already live
+/// in `logs/daemon.log`.
+pub(super) fn cleanup_legacy_root_logs(home_dir: &Path) {
+    for name in ["daemon.log", "tui.log"] {
+        let path = home_dir.join(name);
+        if path.is_file() {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+/// One-shot migration: relocate runtime state JSON files that older versions
+/// wrote at the home-dir root into `data/`. Moves only the filenames LibreFang
+/// is known to produce; unknown files are left alone.
+pub(super) fn migrate_root_state_files(home_dir: &Path) {
+    const STATE_FILES: &[&str] = &[
+        "cron_jobs.json",
+        "hand_state.json",
+        "sessions.json",
+        "workflow_runs.json",
+        "custom_models.json",
+        "model_overrides.json",
+        "suppressed_providers.json",
+        "webhooks.json",
+    ];
+    let data_dir = home_dir.join("data");
+    let mut created_data_dir = false;
+    for name in STATE_FILES {
+        let src = home_dir.join(name);
+        if !src.is_file() {
+            continue;
+        }
+        if !created_data_dir {
+            if std::fs::create_dir_all(&data_dir).is_err() {
+                return;
+            }
+            created_data_dir = true;
+        }
+        let dest = data_dir.join(name);
+        if dest.exists() {
+            // Newer version already wrote the canonical copy — discard the
+            // stale root duplicate.
+            let _ = std::fs::remove_file(&src);
+            continue;
+        }
+        if let Err(e) = std::fs::rename(&src, &dest) {
+            tracing::warn!(
+                src = %src.display(),
+                dest = %dest.display(),
+                "Failed to relocate state file: {e}"
+            );
+        }
+    }
+}
+
 /// Initialize a git repo in the home directory for config version control.
 pub(super) fn init_git_if_missing(home_dir: &Path) {
     if home_dir.join(".git").exists() {
@@ -153,7 +212,7 @@ pub(super) fn init_git_if_missing(home_dir: &Path) {
     if !gitignore.exists() {
         let _ = std::fs::write(
             &gitignore,
-            "secrets.env\nvault.enc\ndaemon.json\ndaemon.log\nhand_state.json\nsessions.json\nworkflow_runs.json\nlogs/\ncache/\nregistry/\ndata/\ndashboard/\nbackups/\ninbox/\n.vscode/\n*.db\n*.db-shm\n*.db-wal\n",
+            "secrets.env\nvault.enc\ndaemon.json\nlogs/\ncache/\nregistry/\ndata/\ndashboard/\nbackups/\ninbox/\n.vscode/\n*.db\n*.db-shm\n*.db-wal\n",
         );
     }
     let _ = std::process::Command::new("git")

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -422,6 +422,12 @@ impl WorkflowEngine {
             }
         };
         drop(runs);
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                warn!("Failed to create workflow runs dir: {e}");
+                return;
+            }
+        }
         let tmp_path = path.with_extension("json.tmp");
         if let Err(e) = std::fs::write(&tmp_path, data.as_bytes()) {
             warn!("Failed to write workflow runs temp file: {e}");

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -361,12 +361,12 @@ impl WorkflowEngine {
 
     /// Create a new workflow engine with run persistence.
     ///
-    /// Completed and failed runs are persisted to `<home_dir>/workflow_runs.json`.
+    /// Completed and failed runs are persisted to `<home_dir>/data/workflow_runs.json`.
     pub fn new_with_persistence(home_dir: &Path) -> Self {
         Self {
             workflows: Arc::new(RwLock::new(HashMap::new())),
             runs: Arc::new(RwLock::new(HashMap::new())),
-            persist_path: Some(home_dir.join("workflow_runs.json")),
+            persist_path: Some(home_dir.join("data").join("workflow_runs.json")),
         }
     }
 

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -339,7 +339,7 @@ fn test_deactivate_nonexistent_instance_fails() {
 #[test]
 fn test_hand_state_persistence() {
     let config = test_config("persistence");
-    let state_path = config.home_dir.join("hand_state.json");
+    let state_path = config.home_dir.join("data").join("hand_state.json");
 
     let kernel = LibreFangKernel::boot_with_config(config).unwrap();
     install_hand(&kernel, HAND_A);
@@ -390,7 +390,7 @@ fn test_hand_state_persistence() {
 #[test]
 fn test_multi_agent_hand_state_persists_coordinator_role() {
     let config = test_config("multi-persistence");
-    let state_path = config.home_dir.join("hand_state.json");
+    let state_path = config.home_dir.join("data").join("hand_state.json");
 
     let kernel = LibreFangKernel::boot_with_config(config).unwrap();
     install_hand(&kernel, HAND_C);


### PR DESCRIPTION
## Summary
`~/.librefang/` root had been collecting runtime state and log files that drifted from the canonical layout. This PR moves them into the directories that already exist for their category, migrates existing installs on daemon boot, and drops the orphan CLI-side file layer that kept dropping a useless `daemon.log` next to the real one.

## Changes

### Logs
- **`daemon.log` at root** — deleted. The CLI's one-shot `init_tracing_stderr` opened a file layer at `<home>/daemon.log` and *truncated it on every CLI invocation*, so the file never held useful history and shared a name with the real daemon log at `logs/daemon.log`. Drop the file layer entirely — stderr is the only sink a transient CLI command needs.
- **`tui.log`** — move writer and reader to `logs/tui.log`:
  - Writer: `librefang-cli` `init_tracing_file` at `main.rs:1638`
  - Reader hint: `cmd_logs` at `main.rs:9544`

### Runtime state JSON files → `data/`
All moved from `<home>/<name>.json` to `<home>/data/<name>.json`:
- `cron_jobs.json` — `librefang-kernel/src/cron.rs`
- `workflow_runs.json` — `librefang-kernel/src/workflow.rs`
- `hand_state.json` — `librefang-kernel/src/kernel/mod.rs` (persist + load)
- `sessions.json` — `librefang-api/src/server.rs` `sessions_path()`
- `custom_models.json` — `librefang-kernel/src/kernel/mod.rs`, `librefang-api/src/routes/providers.rs` (2 sites)
- `model_overrides.json` — `librefang-kernel/src/kernel/mod.rs`, `librefang-api/src/routes/providers.rs` (2 sites)
- `suppressed_providers.json` — `librefang-kernel/src/kernel/mod.rs`, `librefang-api/src/routes/providers.rs` (2 sites)
- `webhooks.json` — `librefang-api/src/server.rs`, `librefang-api/src/routes/agents.rs`

### Boot-time migration (kernel)
Two new helpers in `crates/librefang-kernel/src/kernel/workspace_setup.rs`, wired from `LibreFangKernel::boot_with_config`:
- `migrate_root_state_files(home_dir)` — renames the known JSON state files from `<home>/` into `<home>/data/`. Idempotent: if the canonical copy already exists, the stale root duplicate is deleted.
- `cleanup_legacy_root_logs(home_dir)` — removes stray `daemon.log` and `tui.log` at the root. Both were always truncated-on-write, so there is no history worth preserving.

### Backup / restore
Entries in the backup zip for the relocated JSON files now use `data/<name>` paths, so restore extracts them directly to the new location. Older backups that still contain root-level entries will land at root on restore, but the next-boot migration will relocate them automatically.

### Gitignore template
Drop the now-obsolete state-file entries (`hand_state.json`, `sessions.json`, `workflow_runs.json`) and `daemon.log` from the kernel-side `.gitignore` template — they are all covered by `data/` and `logs/` which remain listed.

### Intentionally left at root
`daemon.json` stays at the root: it is the daemon PID / port lock file and external tooling (systemd units, health checks, docker wrappers) expects it there. Moving it is a separate, higher-risk change.

## Test plan
- [x] `cargo check -p librefang-cli -p librefang-kernel -p librefang-api` — clean
- [x] `cargo test -p librefang-kernel --test multi_agent_test` — 23/23 pass (includes `test_hand_state_persistence` and `test_multi_agent_hand_state_persists_coordinator_role`, both updated to read from `data/`)
- [ ] Pre-seed `~/.librefang/` with `cron_jobs.json`, `hand_state.json`, `sessions.json`, `daemon.log`, `tui.log` at root; start the daemon; confirm the JSON files appear under `data/`, the log files are gone, and nothing errored.
- [ ] Run `librefang logs` — confirm `logs/daemon.log` still resolves.
- [ ] TUI mode (`librefang tui`) — confirm a fresh `logs/tui.log` is created and no new root-level `tui.log` appears.
- [ ] Backup → restore roundtrip — confirm new backups contain `data/<name>` entries and restore produces files in `data/`.