### PR TITLE
fix(tasks): task_claim() now matches assigned_to by name as well as UUID

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12124,14 +12124,18 @@ impl KernelHandle for LibreFangKernel {
     }
 
     async fn task_claim(&self, agent_id: &str) -> Result<Option<serde_json::Value>, String> {
-        // Resolve `agent_id` as either a UUID (used directly) or an agent
-        // name (looked up via the registry → its UUID). Tasks are stored
-        // under the canonical UUID, so name-based callers used to silently
-        // get zero matches. Issue #2330.
-        let resolved = match librefang_types::agent::AgentId::from_str(agent_id) {
-            Ok(_) => agent_id.to_string(),
+        // Resolve `agent_id` to a canonical UUID and also capture the name.
+        // Both are forwarded to `memory.task_claim` so that tasks whose
+        // `assigned_to` field was stored as either a UUID *or* a name string
+        // are correctly matched (issue #2841).
+        let (resolved, resolved_name) = match librefang_types::agent::AgentId::from_str(agent_id) {
+            Ok(parsed_id) => {
+                // Caller passed a UUID — look up the name from the registry.
+                let name = self.registry.get(parsed_id).map(|e| e.name.clone());
+                (agent_id.to_string(), name)
+            }
             Err(_) => match self.registry.find_by_name(agent_id) {
-                Some(entry) => entry.id.to_string(),
+                Some(entry) => (entry.id.to_string(), Some(agent_id.to_string())),
                 None => {
                     return Err(format!(
                         "Task claim failed: agent {agent_id:?} not found by UUID or name"
@@ -12141,7 +12145,7 @@ impl KernelHandle for LibreFangKernel {
         };
         let result = self
             .memory
-            .task_claim(&resolved)
+            .task_claim(&resolved, resolved_name.as_deref())
             .await
             .map_err(|e| format!("Task claim failed: {e}"))?;
 

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -689,22 +689,35 @@ impl MemorySubstrate {
     }
 
     /// Claim the next pending task (optionally for a specific assignee). Returns task JSON or None.
-    pub async fn task_claim(&self, agent_id: &str) -> LibreFangResult<Option<serde_json::Value>> {
+    ///
+    /// `agent_id` must be the canonical UUID. `agent_name` is the human-readable
+    /// name for the same agent; tasks posted with a name (rather than UUID) in
+    /// `assigned_to` are also matched so that name-based assignments are never
+    /// silently dropped (fixes issue #2841).
+    pub async fn task_claim(
+        &self,
+        agent_id: &str,
+        agent_name: Option<&str>,
+    ) -> LibreFangResult<Option<serde_json::Value>> {
         let conn = Arc::clone(&self.conn);
         let agent_id = agent_id.to_string();
+        let agent_name = agent_name.unwrap_or("").to_string();
 
         tokio::task::spawn_blocking(move || {
             let db = conn.lock().map_err(|e| LibreFangError::Internal(e.to_string()))?;
-            // Find first pending task assigned to this agent, or any unassigned pending task
+            // Match tasks assigned to this agent by UUID *or* by name (tasks posted
+            // via the API or bridge tools may store the name rather than the UUID),
+            // plus any unassigned (empty assigned_to) pending tasks.
             let mut stmt = db.prepare(
                 "SELECT id, title, description, assigned_to, created_by, created_at
                  FROM task_queue
-                 WHERE status = 'pending' AND (assigned_to = ?1 OR assigned_to = '')
+                 WHERE status = 'pending'
+                   AND (assigned_to = ?1 OR assigned_to = ?2 OR assigned_to = '')
                  ORDER BY priority DESC, created_at ASC
                  LIMIT 1"
             ).map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-            let result = stmt.query_row(rusqlite::params![agent_id], |row| {
+            let result = stmt.query_row(rusqlite::params![agent_id, agent_name], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
@@ -1033,8 +1046,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Claim the task
-        let claimed = substrate.task_claim("auditor").await.unwrap();
+        // Claim the task (name stored in assigned_to; pass matching name param)
+        let claimed = substrate
+            .task_claim("auditor", Some("auditor"))
+            .await
+            .unwrap();
         assert!(claimed.is_some());
         let claimed = claimed.unwrap();
         assert_eq!(claimed["id"], task_id);
@@ -1055,8 +1071,49 @@ mod tests {
     #[tokio::test]
     async fn test_task_claim_empty() {
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
-        let claimed = substrate.task_claim("nobody").await.unwrap();
+        let claimed = substrate.task_claim("nobody", None).await.unwrap();
         assert!(claimed.is_none());
+    }
+
+    /// Tasks posted with an agent *name* in assigned_to must be claimable when
+    /// the claimer passes the corresponding UUID + name (issue #2841).
+    #[tokio::test]
+    async fn test_task_claim_by_name_when_posted_with_name() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        // External actor posts task using agent name (not UUID)
+        let task_id = substrate
+            .task_post(
+                "Analyse logs",
+                "Check for anomalies",
+                Some("researcher"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let fake_uuid = "4c549884-2aa1-4860-a5bb-f0aa35a1bf7e";
+
+        // Claim with UUID only — should NOT match name-stored task
+        let not_claimed = substrate.task_claim(fake_uuid, None).await.unwrap();
+        assert!(
+            not_claimed.is_none(),
+            "UUID-only claim should not match name-assigned task"
+        );
+
+        // Claim with UUID + matching name — should match
+        let claimed = substrate
+            .task_claim(fake_uuid, Some("researcher"))
+            .await
+            .unwrap();
+        assert!(
+            claimed.is_some(),
+            "UUID+name claim must match name-assigned task"
+        );
+        let claimed = claimed.unwrap();
+        assert_eq!(claimed["id"], task_id);
+        assert_eq!(claimed["status"], "in_progress");
+        // assigned_to should be normalised to the claimer's UUID after claim
+        assert_eq!(claimed["assigned_to"], fake_uuid);
     }
 
     #[tokio::test]

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -741,7 +741,7 @@ impl MemorySubstrate {
                         "title": title,
                         "description": description,
                         "status": "in_progress",
-                        "assigned_to": if assigned.is_empty() { &agent_id } else { &assigned },
+                        "assigned_to": agent_id,
                         "created_by": created_by,
                         "created_at": created_at,
                     })))

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -729,7 +729,7 @@ impl MemorySubstrate {
             });
 
             match result {
-                Ok((id, title, description, assigned, created_by, created_at)) => {
+                Ok((id, title, description, _assigned, created_by, created_at)) => {
                     // Update status to in_progress
                     db.execute(
                         "UPDATE task_queue SET status = 'in_progress', assigned_to = ?2 WHERE id = ?1",


### PR DESCRIPTION
## Summary

Fixes #2841.

`task_queue.assigned_to` accepts both agent UUIDs and agent names (e.g. `"auditor"`), but `task_claim()` only matched by UUID. Tasks posted with a name-string `assigned_to` were silently skipped and never claimed.

- **`substrate.rs`**: Changed `task_claim(agent_id: &str)` → `task_claim(agent_id: &str, agent_name: Option<&str>)`. SQL `WHERE` clause now uses `OR assigned_to = ?2` so name-based rows are also matched.
- **`kernel/mod.rs`**: Updated `task_claim` call site to resolve the agent's name from the registry and pass it alongside the UUID. Handles both UUID and name as input.
- Added regression test `test_task_claim_by_name_when_posted_with_name` to `substrate.rs`.

## Test plan

- [ ] `cargo test -p librefang-memory` — new regression test passes
- [ ] `cargo test -p librefang-kernel` — no regressions
- [ ] Manually: post a task with `assigned_to = "<agent-name>"`, trigger claim; verify task is picked up