### PR TITLE
feat(channels): add account_id to channel_send for explicit multi-bot routing

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3355,6 +3355,9 @@ pub async fn start_channel_bridge_with_config(
                 // by an earlier adapter in this batch.
                 if owns_plain_key {
                     kernel.channel_adapters_ref().remove(&name);
+                    // Release ownership so the next adapter of the same channel
+                    // type can claim the plain key as fallback.
+                    plain_key_owners.remove(&name);
                 }
                 if let Some(ref aid) = account_id {
                     kernel

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1974,7 +1974,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     ) -> Result<String, String> {
         use librefang_runtime::kernel_handle::KernelHandle;
         self.kernel
-            .send_channel_message(channel_type, recipient, message, thread_id)
+            .send_channel_message(channel_type, recipient, message, thread_id, None)
             .await
     }
 }
@@ -3320,12 +3320,25 @@ pub async fn start_channel_bridge_with_config(
     }
 
     let mut started_names = Vec::new();
-    for (adapter, _, _account_id) in adapters {
+    for (adapter, _, account_id) in adapters {
         let name = adapter.name().to_string();
-        // Register adapter in kernel so agents can use `channel_send` tool
-        kernel
-            .channel_adapters_ref()
-            .insert(name.clone(), adapter.clone());
+        // Register adapter in kernel so agents can use `channel_send` tool.
+        // First adapter for this channel type becomes the plain-key fallback for
+        // backward compatibility. Subsequent adapters are only reachable via the
+        // qualified "channel:account_id" key.
+        if !kernel.channel_adapters_ref().contains_key(&name) {
+            kernel
+                .channel_adapters_ref()
+                .insert(name.clone(), adapter.clone());
+        }
+        // Always register under qualified key when account_id is present so
+        // agents can explicitly route through a specific bot.
+        if let Some(ref aid) = account_id {
+            let qualified = format!("{name}:{aid}");
+            kernel
+                .channel_adapters_ref()
+                .insert(qualified, adapter.clone());
+        }
         match manager.start_adapter(adapter).await {
             Ok(()) => {
                 info!("{name} channel bridge started");
@@ -3334,6 +3347,11 @@ pub async fn start_channel_bridge_with_config(
             Err(e) => {
                 // Remove from kernel map if start failed
                 kernel.channel_adapters_ref().remove(&name);
+                if let Some(ref aid) = account_id {
+                    kernel
+                        .channel_adapters_ref()
+                        .remove(&format!("{name}:{aid}"));
+                }
                 error!("Failed to start {name} bridge: {e}");
             }
         }

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3320,13 +3320,18 @@ pub async fn start_channel_bridge_with_config(
     }
 
     let mut started_names = Vec::new();
+    // Track which plain keys were claimed by the first adapter in this batch.
+    // Using a per-batch set (not kernel.contains_key) ensures hot-reload always
+    // overwrites stale plain-key entries from a previous bridge cycle.
+    let mut plain_key_owners: std::collections::HashSet<String> = Default::default();
     for (adapter, _, account_id) in adapters {
         let name = adapter.name().to_string();
-        // Register adapter in kernel so agents can use `channel_send` tool.
-        // First adapter for this channel type becomes the plain-key fallback for
-        // backward compatibility. Subsequent adapters are only reachable via the
-        // qualified "channel:account_id" key.
-        if !kernel.channel_adapters_ref().contains_key(&name) {
+        // First adapter for this channel type in this reload batch claims the
+        // plain key (e.g. "telegram") as the backward-compat fallback.
+        // Later adapters for the same type are only reachable via their qualified
+        // "telegram:account_id" key.
+        let owns_plain_key = plain_key_owners.insert(name.clone());
+        if owns_plain_key {
             kernel
                 .channel_adapters_ref()
                 .insert(name.clone(), adapter.clone());
@@ -3345,8 +3350,12 @@ pub async fn start_channel_bridge_with_config(
                 started_names.push(name);
             }
             Err(e) => {
-                // Remove from kernel map if start failed
-                kernel.channel_adapters_ref().remove(&name);
+                // Only remove the plain key if this adapter owns it — removing
+                // it unconditionally would discard a working fallback inserted
+                // by an earlier adapter in this batch.
+                if owns_plain_key {
+                    kernel.channel_adapters_ref().remove(&name);
+                }
                 if let Some(ref aid) = account_id {
                     kernel
                         .channel_adapters_ref()

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4568,7 +4568,7 @@ pub async fn push_message(
             // No bridge manager — fall back to kernel's channel adapter registry
             state
                 .kernel
-                .send_channel_message(&req.channel, &req.recipient, &req.message, thread_id)
+                .send_channel_message(&req.channel, &req.recipient, &req.message, thread_id, None)
                 .await
         }
     };

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -273,6 +273,7 @@ pub trait KernelHandle: Send + Sync {
 
     /// Send a message to a user on a named channel adapter (e.g., "email", "telegram").
     /// When `thread_id` is provided, the message is sent as a thread reply.
+    /// When `account_id` is provided, routes through the specific configured bot with that ID.
     /// Returns a confirmation string on success.
     async fn send_channel_message(
         &self,
@@ -280,14 +281,16 @@ pub trait KernelHandle: Send + Sync {
         recipient: &str,
         message: &str,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
-        let _ = (channel, recipient, message, thread_id);
+        let _ = (channel, recipient, message, thread_id, account_id);
         Err("Channel send not available".to_string())
     }
 
     /// Send media content (image/file) to a user on a named channel adapter.
     /// `media_type` is "image" or "file", `media_url` is the URL, `caption` is optional text.
     /// When `thread_id` is provided, the media is sent as a thread reply.
+    /// When `account_id` is provided, routes through the specific configured bot with that ID.
     #[allow(clippy::too_many_arguments)]
     async fn send_channel_media(
         &self,
@@ -298,9 +301,10 @@ pub trait KernelHandle: Send + Sync {
         caption: Option<&str>,
         filename: Option<&str>,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
         let _ = (
-            channel, recipient, media_type, media_url, caption, filename, thread_id,
+            channel, recipient, media_type, media_url, caption, filename, thread_id, account_id,
         );
         Err("Channel media send not available".to_string())
     }
@@ -308,6 +312,8 @@ pub trait KernelHandle: Send + Sync {
     /// Send a local file (raw bytes) to a user on a named channel adapter.
     /// Used by the `channel_send` tool when `file_path` is provided.
     /// When `thread_id` is provided, the file is sent as a thread reply.
+    /// When `account_id` is provided, routes through the specific configured bot with that ID.
+    #[allow(clippy::too_many_arguments)]
     async fn send_channel_file_data(
         &self,
         channel: &str,
@@ -316,8 +322,11 @@ pub trait KernelHandle: Send + Sync {
         filename: &str,
         mime_type: &str,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
-        let _ = (channel, recipient, data, filename, mime_type, thread_id);
+        let _ = (
+            channel, recipient, data, filename, mime_type, thread_id, account_id,
+        );
         Err("Channel file data send not available".to_string())
     }
 
@@ -331,6 +340,7 @@ pub trait KernelHandle: Send + Sync {
         is_quiz: bool,
         correct_option_id: Option<u8>,
         explanation: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<(), String> {
         let _ = (
             channel,
@@ -340,6 +350,7 @@ pub trait KernelHandle: Send + Sync {
             is_quiz,
             correct_option_id,
             explanation,
+            account_id,
         );
         Err("Channel poll send not available".to_string())
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4908,7 +4908,7 @@ system_prompt = "You are a helpful assistant."
             for (channel, platform_id) in &bindings {
                 if kernel.channel_adapters.contains_key(channel.as_str()) {
                     if let Err(e) = kernel
-                        .send_channel_message(channel, platform_id, &message, None)
+                        .send_channel_message(channel, platform_id, &message, None, None)
                         .await
                     {
                         warn!(channel = %channel, error = %e, "Failed to send owner notification");
@@ -11582,7 +11582,7 @@ async fn cron_deliver_response(
                 .memory
                 .structured_set(agent_id, "delivery.last_channel", kv_val);
             if let Err(e) = kernel
-                .send_channel_message(channel, to, response, None)
+                .send_channel_message(channel, to, response, None, None)
                 .await
             {
                 tracing::warn!(channel = %channel, to = %to, error = %e, "Cron channel delivery failed");
@@ -11603,7 +11603,7 @@ async fn cron_deliver_response(
                             "Cron: delivering to last channel"
                         );
                         if let Err(e) = kernel
-                            .send_channel_message(channel, recipient, response, None)
+                            .send_channel_message(channel, recipient, response, None, None)
                             .await
                         {
                             tracing::warn!(channel = %channel, recipient = %recipient, error = %e, "Cron last_channel delivery failed");
@@ -11736,6 +11736,7 @@ impl LibreFangKernel {
                 &target.recipient,
                 message,
                 target.thread_id.as_deref(),
+                None,
             )
             .await
         {
@@ -12840,11 +12841,17 @@ impl KernelHandle for LibreFangKernel {
         recipient: &str,
         message: &str,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
         let cfg = self.config.load_full();
+        let lookup_key = account_id
+            .filter(|s| !s.is_empty())
+            .map(|aid| format!("{channel}:{aid}"))
+            .unwrap_or_else(|| channel.to_string());
         let adapter = self
             .channel_adapters
-            .get(channel)
+            .get(&lookup_key)
+            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
@@ -12904,10 +12911,16 @@ impl KernelHandle for LibreFangKernel {
         caption: Option<&str>,
         filename: Option<&str>,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
+        let lookup_key = account_id
+            .filter(|s| !s.is_empty())
+            .map(|aid| format!("{channel}:{aid}"))
+            .unwrap_or_else(|| channel.to_string());
         let adapter = self
             .channel_adapters
-            .get(channel)
+            .get(&lookup_key)
+            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
@@ -12962,6 +12975,7 @@ impl KernelHandle for LibreFangKernel {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn send_channel_file_data(
         &self,
         channel: &str,
@@ -12970,10 +12984,16 @@ impl KernelHandle for LibreFangKernel {
         filename: &str,
         mime_type: &str,
         thread_id: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<String, String> {
+        let lookup_key = account_id
+            .filter(|s| !s.is_empty())
+            .map(|aid| format!("{channel}:{aid}"))
+            .unwrap_or_else(|| channel.to_string());
         let adapter = self
             .channel_adapters
-            .get(channel)
+            .get(&lookup_key)
+            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
@@ -13026,10 +13046,16 @@ impl KernelHandle for LibreFangKernel {
         is_quiz: bool,
         correct_option_id: Option<u8>,
         explanation: Option<&str>,
+        account_id: Option<&str>,
     ) -> Result<(), String> {
+        let lookup_key = account_id
+            .filter(|s| !s.is_empty())
+            .map(|aid| format!("{channel}:{aid}"))
+            .unwrap_or_else(|| channel.to_string());
         let adapter = self
             .channel_adapters
-            .get(channel)
+            .get(&lookup_key)
+            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| format!("Channel adapter '{channel}' not found"))?
             .clone();
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12851,17 +12851,22 @@ impl KernelHandle for LibreFangKernel {
         let adapter = self
             .channel_adapters
             .get(&lookup_key)
-            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
                     .iter()
                     .map(|e| e.key().clone())
                     .collect();
-                format!(
-                    "Channel '{}' not found. Available channels: {:?}",
-                    channel, available
-                )
+                match account_id.filter(|s| !s.is_empty()) {
+                    Some(aid) => format!(
+                        "Channel '{}' with account_id '{}' not found. Available: {:?}",
+                        channel, aid, available
+                    ),
+                    None => format!(
+                        "Channel '{}' not found. Available channels: {:?}",
+                        channel, available
+                    ),
+                }
             })?
             .clone();
 
@@ -12920,17 +12925,22 @@ impl KernelHandle for LibreFangKernel {
         let adapter = self
             .channel_adapters
             .get(&lookup_key)
-            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
                     .iter()
                     .map(|e| e.key().clone())
                     .collect();
-                format!(
-                    "Channel '{}' not found. Available channels: {:?}",
-                    channel, available
-                )
+                match account_id.filter(|s| !s.is_empty()) {
+                    Some(aid) => format!(
+                        "Channel '{}' with account_id '{}' not found. Available: {:?}",
+                        channel, aid, available
+                    ),
+                    None => format!(
+                        "Channel '{}' not found. Available channels: {:?}",
+                        channel, available
+                    ),
+                }
             })?
             .clone();
 
@@ -12993,17 +13003,22 @@ impl KernelHandle for LibreFangKernel {
         let adapter = self
             .channel_adapters
             .get(&lookup_key)
-            .or_else(|| self.channel_adapters.get(channel))
             .ok_or_else(|| {
                 let available: Vec<String> = self
                     .channel_adapters
                     .iter()
                     .map(|e| e.key().clone())
                     .collect();
-                format!(
-                    "Channel '{}' not found. Available channels: {:?}",
-                    channel, available
-                )
+                match account_id.filter(|s| !s.is_empty()) {
+                    Some(aid) => format!(
+                        "Channel '{}' with account_id '{}' not found. Available: {:?}",
+                        channel, aid, available
+                    ),
+                    None => format!(
+                        "Channel '{}' not found. Available channels: {:?}",
+                        channel, available
+                    ),
+                }
             })?
             .clone();
 
@@ -13055,8 +13070,12 @@ impl KernelHandle for LibreFangKernel {
         let adapter = self
             .channel_adapters
             .get(&lookup_key)
-            .or_else(|| self.channel_adapters.get(channel))
-            .ok_or_else(|| format!("Channel adapter '{channel}' not found"))?
+            .ok_or_else(|| match account_id.filter(|s| !s.is_empty()) {
+                Some(aid) => {
+                    format!("Channel adapter '{channel}' with account_id '{aid}' not found")
+                }
+                None => format!("Channel adapter '{channel}' not found"),
+            })?
             .clone();
 
         let user = librefang_channels::types::ChannelUser {

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -1632,6 +1632,7 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
                     "file_path": { "type": "string", "description": "Local file path to send as attachment (reads from disk; use instead of file_url for local files)" },
                     "filename": { "type": "string", "description": "Filename for file attachments (defaults to the basename of file_path, or 'file')" },
                     "thread_id": { "type": "string", "description": "Thread/topic ID to reply in (e.g., Telegram message_thread_id, Slack thread_ts)" },
+                    "account_id": { "type": "string", "description": "Optional account_id of the specific configured bot to send through (e.g., 'admin-bot'). When omitted, uses the first configured adapter for this channel." },
                     "poll_question": { "type": "string", "description": "Question for a poll (starts a poll, mutually exclusive with image_url/file_url/file_path)" },
                     "poll_options": { "type": "array", "items": { "type": "string" }, "description": "Answer options for the poll (2-10 items, required with poll_question)" },
                     "poll_is_quiz": { "type": "boolean", "description": "Set to true for a quiz mode (one correct answer)" },
@@ -3200,6 +3201,7 @@ async fn tool_channel_send(
     }
 
     let thread_id = input["thread_id"].as_str().filter(|s| !s.is_empty());
+    let account_id = input["account_id"].as_str().filter(|s| !s.is_empty());
 
     // Check for media content (image_url, file_url, or file_path)
     let image_url = input["image_url"].as_str().filter(|s| !s.is_empty());
@@ -3214,7 +3216,9 @@ async fn tool_channel_send(
             }
         }
         return kh
-            .send_channel_media(&channel, recipient, "image", url, caption, None, thread_id)
+            .send_channel_media(
+                &channel, recipient, "image", url, caption, None, thread_id, account_id,
+            )
             .await;
     }
 
@@ -3228,7 +3232,7 @@ async fn tool_channel_send(
         }
         return kh
             .send_channel_media(
-                &channel, recipient, "file", url, caption, filename, thread_id,
+                &channel, recipient, "file", url, caption, filename, thread_id, account_id,
             )
             .await;
     }
@@ -3284,7 +3288,9 @@ async fn tool_channel_send(
         };
 
         return kh
-            .send_channel_file_data(&channel, recipient, data, &filename, mime_type, thread_id)
+            .send_channel_file_data(
+                &channel, recipient, data, &filename, mime_type, thread_id, account_id,
+            )
             .await;
     }
 
@@ -3352,6 +3358,7 @@ async fn tool_channel_send(
             is_quiz,
             correct_option_id,
             explanation,
+            account_id,
         )
         .await?;
 
@@ -3394,7 +3401,7 @@ async fn tool_channel_send(
         return Err(violation);
     }
 
-    kh.send_channel_message(&channel, recipient, &final_message, thread_id)
+    kh.send_channel_message(&channel, recipient, &final_message, thread_id, account_id)
         .await
 }
 


### PR DESCRIPTION
Fixes #2842.

## Problem

In multi-bot configurations (e.g. 3 Telegram bots sharing the same `allowed_users`), agents in trigger-fired sessions had no way to specify which configured bot to send through. Messages were routed through whichever adapter happened to be registered last — not necessarily the agent's designated bot.

## Solution

### New `account_id` parameter in `channel_send`

```
channel_send(
    channel="telegram",
    recipient="23244855",
    message="Hello",
    account_id="admin-bot"
)
```

When `account_id` is omitted, behavior is unchanged (first registered adapter for the channel type).

### Adapter registration (bridge)

Previously all Telegram adapters were inserted under the same "telegram" key, so only the last one survived in the kernel map. Now:
- First adapter for a channel type → plain key "telegram" (backward-compat fallback)
- All adapters with account_id → also qualified key "telegram:admin-bot"

### Lookup (kernel)

Tries "telegram:admin-bot" first, falls back to plain "telegram".

## Files changed

- `librefang-kernel-handle/src/lib.rs` — add `account_id: Option<&str>` to all 4 `send_channel_*` trait methods
- `librefang-kernel/src/kernel/mod.rs` — implement qualified-key lookup; existing internal call sites pass `None`
- `librefang-api/src/channel_bridge.rs` — first-wins plain key + qualified key registration
- `librefang-api/src/routes/agents.rs` — pass `None` at existing call site
- `librefang-runtime/src/tool_runner.rs` — parse `account_id` from input; add to tool schema