### PR TITLE
feat(kernel): add per-agent auto_evolve flag to skip background skill review

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3657,7 +3657,18 @@ system_prompt = "You are a helpful assistant."
                 // Cooldown: per-agent, at most one review every SKILL_REVIEW_COOLDOWN_SECS.
                 let now_epoch = chrono::Utc::now().timestamp();
                 let agent_id_str = agent_id.to_string();
-                // Pre-claim gate 0: Stable mode / frozen registry. Skip
+                // Pre-claim gate 0a: per-agent opt-out. A2A worker agents
+                // and any agent where trigger responsiveness matters more
+                // than automatic skill distillation can set
+                // `auto_evolve = false` in agent.toml to skip the review
+                // entirely — no LLM call, no semaphore, no cooldown slot.
+                if !entry.manifest.auto_evolve {
+                    tracing::debug!(
+                        agent_id = %agent_id,
+                        "Skipping background skill review — auto_evolve disabled for this agent"
+                    );
+                }
+                // Pre-claim gate 0b: Stable mode / frozen registry. Skip
                 // spawning a review task entirely when the operator
                 // chose a no-skill-mutations posture — the review would
                 // write to disk and the reload_skills() call afterwards
@@ -3671,9 +3682,11 @@ system_prompt = "You are a helpful assistant."
                 // Pre-claim gate 1: eligibility. Only consider claiming
                 // the cooldown slot if this loop actually suggested a
                 // review AND the agent didn't already evolve a skill
-                // AND the registry isn't frozen.
-                let eligible =
-                    result.skill_evolution_suggested && !used_evolution_tool && !registry_frozen;
+                // AND the registry isn't frozen AND auto_evolve is on.
+                let eligible = result.skill_evolution_suggested
+                    && !used_evolution_tool
+                    && !registry_frozen
+                    && entry.manifest.auto_evolve;
                 // Pre-claim gate 2: budget. Background reviews are
                 // optional work — if the global budget is exhausted we
                 // want to skip WITHOUT burning the 5-minute cooldown

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -194,6 +194,7 @@ impl SetupWizard {
             auto_dream_min_hours: None,
             auto_dream_min_sessions: None,
             show_progress: true,
+            auto_evolve: true,
         };
 
         let skills_to_install: Vec<String> = intent

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -713,6 +713,13 @@ pub struct AgentManifest {
     /// are consumed by downstream parsers that would choke on the markers.
     #[serde(default = "default_true")]
     pub show_progress: bool,
+    /// Whether background skill evolution review runs after each turn.
+    /// Defaults to `true`. Set to `false` for A2A worker agents or any
+    /// agent where responsiveness to triggers matters more than automatic
+    /// skill distillation — skipping evolution means the agent never holds
+    /// the background LLM budget or concurrency semaphore after a turn.
+    #[serde(default = "default_true")]
+    pub auto_evolve: bool,
 }
 
 fn default_true() -> bool {
@@ -762,6 +769,7 @@ impl Default for AgentManifest {
             auto_dream_min_hours: None,
             auto_dream_min_sessions: None,
             show_progress: true,
+            auto_evolve: true,
         }
     }
 }


### PR DESCRIPTION
Fixes #2826

## Root cause

`send_message_with_session_mode` (the path used by trigger dispatch and A2A tasks) holds a per-agent mutex for the entire LLM turn. A long research session (e.g. 19 messages, ~21 min) keeps this mutex locked, queuing any incoming `task_posted` or other triggers for the full duration.

Background skill review is spawned **after** the turn via `tokio::spawn` (it does not itself hold the mutex), but A2A worker agents don't need skill distillation and pay unnecessary LLM cost + semaphore pressure for no benefit.

## Fix

Add `auto_evolve: bool` (default `true`) to `AgentManifest`. When `false`, the `eligible` gate short-circuits before the concurrency semaphore, cooldown slot, or any LLM call is touched.

**agent.toml usage:**
```toml
auto_evolve = false   # skip background skill review — for A2A workers
```

## What changes

- `librefang-types`: new `auto_evolve` field in `AgentManifest` (serde default = `true`, backward-compatible)
- `librefang-kernel/kernel/mod.rs`: `eligible` now includes `&& entry.manifest.auto_evolve`
- `librefang-kernel/wizard.rs`: wizard-created agents default to `auto_evolve = true`