### PR TITLE
feat(mcp): implement MCP Roots capability

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -668,7 +668,12 @@ impl LibreFangKernel {
         }
         let workspaces = self.config.load().effective_workspaces_dir();
         if let Some(ws) = workspaces.to_str() {
-            if !roots.iter().any(|r| r == ws) {
+            // Use Path::starts_with so ~/.librefang/workspaces is not added
+            // when ~/.librefang is already in roots (it is covered by it).
+            let already_covered = roots
+                .iter()
+                .any(|r| workspaces.starts_with(std::path::Path::new(r)));
+            if !already_covered {
                 roots.push(ws.to_owned());
             }
         }
@@ -723,7 +728,12 @@ impl LibreFangKernel {
                 if already_covered {
                     return None;
                 }
-                let ws_str = ws.to_string_lossy().into_owned();
+                // Use to_str() for consistency with default_mcp_roots(); non-UTF-8
+                // workspace paths fall back to the global pool.
+                let ws_str = match ws.to_str() {
+                    Some(s) => s.to_owned(),
+                    None => return None,
+                };
                 if !roots.contains(&ws_str) {
                     roots.push(ws_str);
                 }
@@ -732,7 +742,14 @@ impl LibreFangKernel {
 
         let mut connections = Vec::new();
         for server_config in &servers {
-            let transport = match &server_config.transport {
+            let transport_entry = match &server_config.transport {
+                Some(t) => t,
+                None => {
+                    tracing::warn!(name = %server_config.name, "MCP server has no transport configured, skipping");
+                    continue;
+                }
+            };
+            let transport = match transport_entry {
                 McpTransportEntry::Stdio { command, args } => McpTransport::Stdio {
                     command: command.clone(),
                     args: args.clone(),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -652,6 +652,25 @@ impl LibreFangKernel {
         &self.home_dir_boot
     }
 
+    /// Build the default list of root directories to advertise to MCP servers
+    /// via the MCP Roots capability.
+    ///
+    /// Includes the librefang home directory and the agent workspaces directory
+    /// so that filesystem-aware MCP servers (e.g. morphllm, filesystem) know
+    /// which paths they are allowed to operate on without needing hard-coded
+    /// allowed-directories in their own server args.
+    fn default_mcp_roots(&self) -> Vec<String> {
+        let mut roots = Vec::new();
+        let home = self.home_dir_boot.to_string_lossy().into_owned();
+        roots.push(home);
+        let workspaces = self.config.load().effective_workspaces_dir();
+        let ws = workspaces.to_string_lossy().into_owned();
+        if !roots.contains(&ws) {
+            roots.push(ws);
+        }
+        roots
+    }
+
     /// Relocate any legacy `<home>/agents/<name>/` directories into the
     /// canonical `workspaces/agents/<name>/` layout. This is the same pass
     /// that runs at boot and is exposed so runtime flows (e.g. the migrate
@@ -9743,6 +9762,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
+                roots: self.default_mcp_roots(),
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -9890,6 +9910,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
+            roots: self.default_mcp_roots(),
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -10012,6 +10033,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
+                roots: self.default_mcp_roots(),
             };
 
             self.mcp_health.register(&server_config.name);
@@ -10156,6 +10178,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
+            roots: self.default_mcp_roots(),
         };
 
         match McpConnection::connect(mcp_config).await {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -671,6 +671,93 @@ impl LibreFangKernel {
         roots
     }
 
+    /// Create a fresh, per-execution MCP connection pool for a single agent run.
+    ///
+    /// Adds `agent_workspace` to the default roots so filesystem-aware MCP
+    /// servers (morphllm, filesystem, …) scope their access to the agent's
+    /// specific working directory rather than the broad workspace base.
+    ///
+    /// Returns `None` when no MCP servers are configured, when the workspace
+    /// path adds nothing new over the default roots, or when all connections
+    /// fail.  Callers fall back to the daemon-global pool in the `None` case.
+    async fn build_agent_mcp_pool(
+        &self,
+        agent_workspace: Option<&std::path::Path>,
+    ) -> Option<tokio::sync::Mutex<Vec<librefang_runtime::mcp::McpConnection>>> {
+        use librefang_runtime::mcp::{McpConnection, McpServerConfig, McpTransport};
+        use librefang_types::config::McpTransportEntry;
+
+        let servers = self
+            .effective_mcp_servers
+            .read()
+            .map(|s| s.clone())
+            .unwrap_or_default();
+
+        if servers.is_empty() {
+            return None;
+        }
+
+        let mut roots = self.default_mcp_roots();
+
+        // Add the agent workspace only when it's genuinely new information
+        // (i.e. not already a sub-path of an existing root).
+        if let Some(ws) = agent_workspace {
+            let ws_str = ws.to_string_lossy().into_owned();
+            let already_covered = roots.iter().any(|r| ws.starts_with(r.as_str()));
+            if !already_covered && !roots.contains(&ws_str) {
+                roots.push(ws_str);
+            }
+        }
+
+        let mut connections = Vec::new();
+        for server_config in &servers {
+            let transport = match &server_config.transport {
+                McpTransportEntry::Stdio { command, args } => McpTransport::Stdio {
+                    command: command.clone(),
+                    args: args.clone(),
+                },
+                McpTransportEntry::Sse { url } => McpTransport::Sse { url: url.clone() },
+                McpTransportEntry::Http { url } => McpTransport::Http { url: url.clone() },
+                McpTransportEntry::HttpCompat {
+                    base_url,
+                    headers,
+                    tools,
+                } => McpTransport::HttpCompat {
+                    base_url: base_url.clone(),
+                    headers: headers.clone(),
+                    tools: tools.clone(),
+                },
+            };
+
+            let mcp_config = McpServerConfig {
+                name: server_config.name.clone(),
+                transport,
+                timeout_secs: server_config.timeout_secs,
+                env: server_config.env.clone(),
+                headers: server_config.headers.clone(),
+                oauth_provider: Some(self.oauth_provider_ref()),
+                oauth_config: server_config.oauth.clone(),
+                taint_scanning: server_config.taint_scanning,
+                roots: roots.clone(),
+            };
+
+            match McpConnection::connect(mcp_config).await {
+                Ok(conn) => connections.push(conn),
+                Err(e) => warn!(
+                    server = %server_config.name,
+                    error = %e,
+                    "Per-agent MCP connection failed; agent will lack this server's tools"
+                ),
+            }
+        }
+
+        if connections.is_empty() {
+            None
+        } else {
+            Some(tokio::sync::Mutex::new(connections))
+        }
+    }
+
     /// Relocate any legacy `<home>/agents/<name>/` directories into the
     /// canonical `workspaces/agents/<name>/` layout. This is the same pass
     /// that runs at boot and is exposed so runtime flows (e.g. the migrate
@@ -4540,6 +4627,13 @@ system_prompt = "You are a helpful assistant."
             // Snapshot config for the duration of the agent loop call
             // (load_full returns Arc so the data stays alive across .await).
             let loop_cfg = kernel_clone.config.load_full();
+
+            // Per-agent MCP pool (workspace-scoped roots).
+            let agent_mcp = kernel_clone
+                .build_agent_mcp_pool(manifest.workspace.as_deref())
+                .await;
+            let effective_mcp = agent_mcp.as_ref().unwrap_or(&kernel_clone.mcp_connections);
+
             let result = run_agent_loop_streaming(
                 &manifest,
                 &message_owned,
@@ -4550,7 +4644,7 @@ system_prompt = "You are a helpful assistant."
                 kernel_handle,
                 tx,
                 Some(&skill_snapshot),
-                Some(&kernel_clone.mcp_connections),
+                Some(effective_mcp),
                 Some(&kernel_clone.web_ctx),
                 Some(&kernel_clone.browser_ctx),
                 kernel_clone.embedding_driver.as_deref(),
@@ -5838,6 +5932,14 @@ system_prompt = "You are a helpful assistant."
         // Set up mid-turn injection channel (#956)
         let injection_rx = self.setup_injection_channel(agent_id);
 
+        // Build a per-execution MCP pool that includes the agent workspace as
+        // a root. Falls back to the global pool if the workspace adds nothing
+        // new or if all connections fail.
+        let agent_mcp = self
+            .build_agent_mcp_pool(manifest.workspace.as_deref())
+            .await;
+        let effective_mcp = agent_mcp.as_ref().unwrap_or(&self.mcp_connections);
+
         let start_time = std::time::Instant::now();
         let result = run_agent_loop(
             &manifest,
@@ -5848,7 +5950,7 @@ system_prompt = "You are a helpful assistant."
             &tools,
             kernel_handle,
             Some(&skill_snapshot),
-            Some(&self.mcp_connections),
+            Some(effective_mcp),
             Some(&self.web_ctx),
             Some(&self.browser_ctx),
             self.embedding_driver.as_deref(),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -661,12 +661,16 @@ impl LibreFangKernel {
     /// allowed-directories in their own server args.
     fn default_mcp_roots(&self) -> Vec<String> {
         let mut roots = Vec::new();
-        let home = self.home_dir_boot.to_string_lossy().into_owned();
-        roots.push(home);
+        // Use to_str() rather than to_string_lossy() so that non-UTF-8 paths
+        // are silently skipped instead of being silently corrupted (U+FFFD).
+        if let Some(h) = self.home_dir_boot.to_str() {
+            roots.push(h.to_owned());
+        }
         let workspaces = self.config.load().effective_workspaces_dir();
-        let ws = workspaces.to_string_lossy().into_owned();
-        if !roots.contains(&ws) {
-            roots.push(ws);
+        if let Some(ws) = workspaces.to_str() {
+            if !roots.iter().any(|r| r == ws) {
+                roots.push(ws.to_owned());
+            }
         }
         roots
     }
@@ -677,9 +681,12 @@ impl LibreFangKernel {
     /// servers (morphllm, filesystem, …) scope their access to the agent's
     /// specific working directory rather than the broad workspace base.
     ///
-    /// Returns `None` when no MCP servers are configured, when the workspace
-    /// path adds nothing new over the default roots, or when all connections
-    /// fail.  Callers fall back to the daemon-global pool in the `None` case.
+    /// Returns `None` — and callers fall back to the daemon-global pool — when:
+    /// - no MCP servers are configured,
+    /// - `agent_workspace` is `None` (no workspace to scope),
+    /// - the workspace is already a sub-path of an existing default root
+    ///   (per-agent pool would be identical to the global pool), or
+    /// - all per-agent connections fail.
     async fn build_agent_mcp_pool(
         &self,
         agent_workspace: Option<&std::path::Path>,
@@ -699,13 +706,27 @@ impl LibreFangKernel {
 
         let mut roots = self.default_mcp_roots();
 
-        // Add the agent workspace only when it's genuinely new information
-        // (i.e. not already a sub-path of an existing root).
-        if let Some(ws) = agent_workspace {
-            let ws_str = ws.to_string_lossy().into_owned();
-            let already_covered = roots.iter().any(|r| ws.starts_with(r.as_str()));
-            if !already_covered && !roots.contains(&ws_str) {
-                roots.push(ws_str);
+        // Add the agent workspace only when it genuinely extends the default
+        // roots.  Use Path::starts_with (component-level comparison) rather
+        // than str::starts_with so that "/project2" is not mistakenly treated
+        // as a sub-path of "/project".
+        //
+        // When there is no workspace, or when the workspace is already covered,
+        // the roots would be identical to those in the daemon-global pool —
+        // creating a fresh per-agent pool would be pure overhead.
+        match agent_workspace {
+            None => return None,
+            Some(ws) => {
+                let already_covered = roots
+                    .iter()
+                    .any(|r| ws.starts_with(std::path::Path::new(r)));
+                if already_covered {
+                    return None;
+                }
+                let ws_str = ws.to_string_lossy().into_owned();
+                if !roots.contains(&ws_str) {
+                    roots.push(ws_str);
+                }
             }
         }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -660,22 +660,18 @@ impl LibreFangKernel {
     /// which paths they are allowed to operate on without needing hard-coded
     /// allowed-directories in their own server args.
     fn default_mcp_roots(&self) -> Vec<String> {
+        // Advertise only the workspaces directory, not the entire home dir.
+        // Scoping roots to workspaces_dir means per-agent pools are actually
+        // created for agent-specific workspaces (which are subdirectories of
+        // workspaces_dir), giving MCP servers an appropriately narrow view.
+        // Advertising home_dir would cause every agent workspace to be "already
+        // covered", silently disabling per-agent workspace scoping.
         let mut roots = Vec::new();
+        let workspaces = self.config.load().effective_workspaces_dir();
         // Use to_str() rather than to_string_lossy() so that non-UTF-8 paths
         // are silently skipped instead of being silently corrupted (U+FFFD).
-        if let Some(h) = self.home_dir_boot.to_str() {
-            roots.push(h.to_owned());
-        }
-        let workspaces = self.config.load().effective_workspaces_dir();
         if let Some(ws) = workspaces.to_str() {
-            // Use Path::starts_with so ~/.librefang/workspaces is not added
-            // when ~/.librefang is already in roots (it is covered by it).
-            let already_covered = roots
-                .iter()
-                .any(|r| workspaces.starts_with(std::path::Path::new(r)));
-            if !already_covered {
-                roots.push(ws.to_owned());
-            }
+            roots.push(ws.to_owned());
         }
         roots
     }

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -287,17 +287,26 @@ impl RootsClientHandler {
         let mcp_roots: Vec<rmcp::model::Root> = roots
             .iter()
             .map(|path| {
+                // Use the `url` crate to build a well-formed file URI so that
+                // reserved characters (spaces, #, %) are percent-encoded and
+                // the Windows drive-letter triple-slash form is handled
+                // correctly.  Fall back to the raw string if the path is
+                // already a URI or cannot be parsed as a filesystem path.
                 let uri = if path.starts_with("file://") {
                     path.clone()
                 } else {
-                    // RFC 8089 requires forward slashes and three slashes before
-                    // a drive letter on Windows (file:///C:/Users/…).
-                    let forward = path.replace('\\', "/");
-                    if forward.starts_with('/') {
-                        format!("file://{forward}")
-                    } else {
-                        format!("file:///{forward}")
-                    }
+                    url::Url::from_file_path(path)
+                        .map(|u| u.to_string())
+                        .unwrap_or_else(|_| {
+                            // Url::from_file_path requires an absolute path;
+                            // for relative or exotic paths fall back gracefully.
+                            let forward = path.replace('\\', "/");
+                            if forward.starts_with('/') {
+                                format!("file://{forward}")
+                            } else {
+                                format!("file:///{forward}")
+                            }
+                        })
                 };
                 let name = std::path::Path::new(path)
                     .file_name()
@@ -1062,43 +1071,23 @@ impl McpConnection {
     /// Uses proper host parsing rather than substring matching to avoid false
     /// positives on attacker-controlled domains like `127.0.0.1.evil.com`.
     fn is_local_url(url: &str) -> bool {
-        // Extract the host portion (strip scheme, path, query, fragment).
-        let after_scheme = match url.find("://") {
-            Some(i) => &url[i + 3..],
+        // Delegate to the `url` crate so that all RFC 3986 authority components
+        // (userinfo, host, port) are parsed correctly.  This prevents attacks
+        // like `http://127.0.0.1@attacker.com/` and `http://localhost.evil.com/`
+        // that would fool substring or naive split-based checks.
+        let parsed = match url::Url::parse(url) {
+            Ok(u) => u,
+            Err(_) => return false,
+        };
+        let host = match parsed.host() {
+            Some(h) => h,
             None => return false,
         };
-        // Strip path, query string, and fragment to isolate host[:port].
-        let host_port = after_scheme
-            .split(|c| c == '/' || c == '?' || c == '#')
-            .next()
-            .unwrap_or("");
-        // Handle bracketed IPv6 addresses: [::1]:3000 → ::1
-        let host = if host_port.starts_with('[') {
-            host_port
-                .trim_start_matches('[')
-                .split(']')
-                .next()
-                .unwrap_or("")
-        } else if host_port.matches(':').count() > 1 {
-            // Bare (unbracketed) IPv6 literal, e.g. "::1" — technically
-            // invalid per RFC 3986 but handle defensively.  split(':') would
-            // give an empty first token because the address starts with ':',
-            // so use the whole host_port.
-            host_port
-        } else {
-            // IPv4 or hostname with optional port: "127.0.0.1:8080" → "127.0.0.1"
-            host_port.split(':').next().unwrap_or(host_port)
-        };
-        let host_lower = host.to_lowercase();
-        if host_lower == "localhost" || host_lower == "::1" {
-            return true;
+        match host {
+            url::Host::Domain(d) => d.eq_ignore_ascii_case("localhost"),
+            url::Host::Ipv4(addr) => addr.octets()[0] == 127,
+            url::Host::Ipv6(addr) => addr == std::net::Ipv6Addr::LOCALHOST,
         }
-        // Use the standard library IP parser — it rejects hostnames like
-        // "127.0.0.1.evil.com", which would fool a naive starts_with check.
-        if let Ok(addr) = host.parse::<std::net::Ipv4Addr>() {
-            return addr.octets()[0] == 127;
-        }
-        false
     }
 
     fn check_ssrf(url: &str, label: &str) -> Result<(), String> {
@@ -2346,16 +2335,23 @@ mod tests {
         assert!(McpConnection::is_local_url("http://localhost/mcp"));
         assert!(McpConnection::is_local_url("http://LOCALHOST/mcp"));
         assert!(McpConnection::is_local_url("http://[::1]:3000/mcp"));
-        assert!(McpConnection::is_local_url("http://::1/mcp"));
         // Full 127.0.0.0/8 range
         assert!(McpConnection::is_local_url("http://127.2.3.4/mcp"));
         assert!(McpConnection::is_local_url("http://127.255.255.255/mcp"));
         // Remote hosts
         assert!(!McpConnection::is_local_url("https://api.github.com/mcp"));
         assert!(!McpConnection::is_local_url("https://mcp.example.com/mcp"));
-        // Security: domain that starts with "127." must not match
+        // Security: domain spoofing — "127." prefix in domain name must not match
         assert!(!McpConnection::is_local_url(
             "https://127.0.0.1.evil.com/mcp"
+        ));
+        // Security: userinfo spoofing — "127.0.0.1@attacker.com" must not match
+        assert!(!McpConnection::is_local_url(
+            "http://127.0.0.1@attacker.com/mcp"
+        ));
+        // Security: subdomain of localhost must not match
+        assert!(!McpConnection::is_local_url(
+            "http://localhost.evil.com/mcp"
         ));
         // 0.0.0.0 is a listen address, not a loopback target
         assert!(!McpConnection::is_local_url("http://0.0.0.0:4545/mcp"));

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1067,7 +1067,11 @@ impl McpConnection {
             Some(i) => &url[i + 3..],
             None => return false,
         };
-        let host_port = after_scheme.split('/').next().unwrap_or("");
+        // Strip path, query string, and fragment to isolate host[:port].
+        let host_port = after_scheme
+            .split(|c| c == '/' || c == '?' || c == '#')
+            .next()
+            .unwrap_or("");
         // Handle bracketed IPv6 addresses: [::1]:3000 → ::1
         let host = if host_port.starts_with('[') {
             host_port
@@ -1075,7 +1079,14 @@ impl McpConnection {
                 .split(']')
                 .next()
                 .unwrap_or("")
+        } else if host_port.matches(':').count() > 1 {
+            // Bare (unbracketed) IPv6 literal, e.g. "::1" — technically
+            // invalid per RFC 3986 but handle defensively.  split(':') would
+            // give an empty first token because the address starts with ':',
+            // so use the whole host_port.
+            host_port
         } else {
+            // IPv4 or hostname with optional port: "127.0.0.1:8080" → "127.0.0.1"
             host_port.split(':').next().unwrap_or(host_port)
         };
         let host_lower = host.to_lowercase();

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -471,12 +471,20 @@ impl McpConnection {
             }
             McpTransport::Sse { url } => Self::connect_sse(url).await?,
             McpTransport::Http { url } => {
+                // Only advertise local filesystem roots to local servers.
+                // Remote MCP servers (GitHub, Slack, …) don't operate on
+                // the local filesystem and shouldn't receive host paths.
+                let http_roots = if Self::is_local_url(url) {
+                    roots
+                } else {
+                    vec![]
+                };
                 let (inner, tools, auth_state) = Self::connect_streamable_http(
                     url,
                     &config.headers,
                     config.oauth_provider.as_ref(),
                     config.oauth_config.as_ref(),
-                    roots,
+                    http_roots,
                 )
                 .await?;
                 initial_auth_state = Some(auth_state);
@@ -516,7 +524,10 @@ impl McpConnection {
                     let declared_tools = tools.clone();
                     conn.register_http_compat_tools(&declared_tools);
                 } else if let McpInner::Sse { .. } = &conn.inner {
-                    conn.sse_initialize(&conn.config.roots.clone()).await?;
+                    // SSE is a unidirectional transport (client-initiated
+                    // requests only). Do NOT declare roots capability — the
+                    // server cannot send a roots/list request back over SSE.
+                    conn.sse_initialize().await?;
                     conn.sse_discover_tools().await?;
                 }
             }
@@ -864,15 +875,14 @@ impl McpConnection {
     }
 
     /// Send the MCP `initialize` handshake over SSE transport.
-    async fn sse_initialize(&mut self, roots: &[String]) -> Result<(), String> {
-        let capabilities = if roots.is_empty() {
-            serde_json::json!({})
-        } else {
-            serde_json::json!({ "roots": { "listChanged": false } })
-        };
+    ///
+    /// SSE is unidirectional (client → server), so we never declare the
+    /// `roots` capability here — the server has no channel to send
+    /// `roots/list` back to us.
+    async fn sse_initialize(&mut self) -> Result<(), String> {
         let params = serde_json::json!({
             "protocolVersion": "2024-11-05",
-            "capabilities": capabilities,
+            "capabilities": {},
             "clientInfo": {
                 "name": "librefang",
                 "version": env!("CARGO_PKG_VERSION")
@@ -1036,6 +1046,16 @@ impl McpConnection {
     }
 
     // --- Shared ---
+
+    /// Returns `true` when `url` resolves to the local machine.
+    /// Used to decide whether filesystem roots are meaningful for an HTTP MCP server.
+    fn is_local_url(url: &str) -> bool {
+        let lower = url.to_lowercase();
+        lower.contains("://127.")
+            || lower.contains("://localhost")
+            || lower.contains("://[::1]")
+            || lower.contains("://0.0.0.0")
+    }
 
     fn check_ssrf(url: &str, label: &str) -> Result<(), String> {
         let lower = url.to_lowercase();
@@ -2273,6 +2293,17 @@ mod tests {
         );
         assert!(McpConnection::check_ssrf("http://metadata.google.internal/v1/", "test").is_err());
         assert!(McpConnection::check_ssrf("https://api.example.com/mcp", "test").is_ok());
+    }
+
+    #[test]
+    fn test_is_local_url() {
+        assert!(McpConnection::is_local_url("http://127.0.0.1:8080/mcp"));
+        assert!(McpConnection::is_local_url("http://localhost/mcp"));
+        assert!(McpConnection::is_local_url("http://LOCALHOST/mcp"));
+        assert!(McpConnection::is_local_url("http://[::1]:3000/mcp"));
+        assert!(McpConnection::is_local_url("http://0.0.0.0:4545/mcp"));
+        assert!(!McpConnection::is_local_url("https://api.github.com/mcp"));
+        assert!(!McpConnection::is_local_url("https://mcp.example.com/mcp"));
     }
 
     /// `extract_auth_header_from_error` returns `None` for any

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -290,7 +290,14 @@ impl RootsClientHandler {
                 let uri = if path.starts_with("file://") {
                     path.clone()
                 } else {
-                    format!("file://{path}")
+                    // RFC 8089 requires forward slashes and three slashes before
+                    // a drive letter on Windows (file:///C:/Users/…).
+                    let forward = path.replace('\\', "/");
+                    if forward.starts_with('/') {
+                        format!("file://{forward}")
+                    } else {
+                        format!("file:///{forward}")
+                    }
                 };
                 let name = std::path::Path::new(path)
                     .file_name()
@@ -495,6 +502,8 @@ impl McpConnection {
                 headers,
                 tools,
             } => {
+                // HttpCompat is a static tool-declaration protocol; it does not
+                // perform an MCP initialize handshake, so roots don't apply.
                 Self::validate_http_compat_config(base_url, headers, tools)?;
                 Self::connect_http_compat(base_url).await?
             }
@@ -1049,12 +1058,36 @@ impl McpConnection {
 
     /// Returns `true` when `url` resolves to the local machine.
     /// Used to decide whether filesystem roots are meaningful for an HTTP MCP server.
+    ///
+    /// Uses proper host parsing rather than substring matching to avoid false
+    /// positives on attacker-controlled domains like `127.0.0.1.evil.com`.
     fn is_local_url(url: &str) -> bool {
-        let lower = url.to_lowercase();
-        lower.contains("://127.")
-            || lower.contains("://localhost")
-            || lower.contains("://[::1]")
-            || lower.contains("://0.0.0.0")
+        // Extract the host portion (strip scheme, path, query, fragment).
+        let after_scheme = match url.find("://") {
+            Some(i) => &url[i + 3..],
+            None => return false,
+        };
+        let host_port = after_scheme.split('/').next().unwrap_or("");
+        // Handle bracketed IPv6 addresses: [::1]:3000 → ::1
+        let host = if host_port.starts_with('[') {
+            host_port
+                .trim_start_matches('[')
+                .split(']')
+                .next()
+                .unwrap_or("")
+        } else {
+            host_port.split(':').next().unwrap_or(host_port)
+        };
+        let host_lower = host.to_lowercase();
+        if host_lower == "localhost" || host_lower == "::1" {
+            return true;
+        }
+        // Use the standard library IP parser — it rejects hostnames like
+        // "127.0.0.1.evil.com", which would fool a naive starts_with check.
+        if let Ok(addr) = host.parse::<std::net::Ipv4Addr>() {
+            return addr.octets()[0] == 127;
+        }
+        false
     }
 
     fn check_ssrf(url: &str, label: &str) -> Result<(), String> {
@@ -2297,13 +2330,24 @@ mod tests {
 
     #[test]
     fn test_is_local_url() {
+        // Standard loopback addresses
         assert!(McpConnection::is_local_url("http://127.0.0.1:8080/mcp"));
         assert!(McpConnection::is_local_url("http://localhost/mcp"));
         assert!(McpConnection::is_local_url("http://LOCALHOST/mcp"));
         assert!(McpConnection::is_local_url("http://[::1]:3000/mcp"));
-        assert!(McpConnection::is_local_url("http://0.0.0.0:4545/mcp"));
+        assert!(McpConnection::is_local_url("http://::1/mcp"));
+        // Full 127.0.0.0/8 range
+        assert!(McpConnection::is_local_url("http://127.2.3.4/mcp"));
+        assert!(McpConnection::is_local_url("http://127.255.255.255/mcp"));
+        // Remote hosts
         assert!(!McpConnection::is_local_url("https://api.github.com/mcp"));
         assert!(!McpConnection::is_local_url("https://mcp.example.com/mcp"));
+        // Security: domain that starts with "127." must not match
+        assert!(!McpConnection::is_local_url(
+            "https://127.0.0.1.evil.com/mcp"
+        ));
+        // 0.0.0.0 is a listen address, not a loopback target
+        assert!(!McpConnection::is_local_url("http://0.0.0.0:4545/mcp"));
     }
 
     /// `extract_auth_header_from_error` returns `None` for any

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -182,6 +182,18 @@ pub struct McpServerConfig {
     /// when this is `false` — only the content-based heuristic is disabled.
     #[serde(default = "default_taint_scanning")]
     pub taint_scanning: bool,
+    /// Root directories advertised to this MCP server via the MCP Roots capability.
+    ///
+    /// Each entry is an absolute path (e.g. `/home/user/project`).  librefang
+    /// converts these to `file://` URIs and declares `roots` in the client
+    /// capabilities during the MCP `initialize` handshake. Servers that support
+    /// Roots use this list to scope their file-system operations rather than
+    /// falling back to their own hard-coded allowed-directories list.
+    ///
+    /// This field is populated at runtime by the kernel (home dir + agent
+    /// workspaces dir) and is never serialised to / deserialised from config.
+    #[serde(skip)]
+    pub roots: Vec<String>,
 }
 
 impl std::fmt::Debug for McpServerConfig {
@@ -198,6 +210,7 @@ impl std::fmt::Debug for McpServerConfig {
             )
             .field("oauth_config", &self.oauth_config)
             .field("taint_scanning", &self.taint_scanning)
+            .field("roots", &self.roots)
             .finish()
     }
 }
@@ -213,6 +226,7 @@ impl Clone for McpServerConfig {
             oauth_provider: self.oauth_provider.clone(),
             oauth_config: self.oauth_config.clone(),
             taint_scanning: self.taint_scanning,
+            roots: self.roots.clone(),
         }
     }
 }
@@ -260,6 +274,67 @@ type DynRmcpClient = rmcp::service::RunningService<
     rmcp::service::RoleClient,
     Box<dyn rmcp::service::DynService<rmcp::service::RoleClient>>,
 >;
+
+/// MCP client handler that declares the `roots` capability and responds to
+/// `roots/list` requests with a pre-configured list of root directories.
+struct RootsClientHandler {
+    client_info: rmcp::model::ClientInfo,
+    roots: Arc<Vec<rmcp::model::Root>>,
+}
+
+impl RootsClientHandler {
+    fn new(roots: Vec<String>) -> Self {
+        let mcp_roots: Vec<rmcp::model::Root> = roots
+            .iter()
+            .map(|path| {
+                let uri = if path.starts_with("file://") {
+                    path.clone()
+                } else {
+                    format!("file://{path}")
+                };
+                let name = std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string());
+                let mut root = rmcp::model::Root::new(uri);
+                if let Some(n) = name {
+                    root = root.with_name(n);
+                }
+                root
+            })
+            .collect();
+
+        let mut capabilities = rmcp::model::ClientCapabilities::default();
+        capabilities.roots = Some(rmcp::model::RootsCapabilities { list_changed: None });
+
+        let client_info = rmcp::model::ClientInfo::new(
+            capabilities,
+            rmcp::model::Implementation::new("librefang", env!("CARGO_PKG_VERSION")),
+        );
+
+        Self {
+            client_info,
+            roots: Arc::new(mcp_roots),
+        }
+    }
+}
+
+impl rmcp::ClientHandler for RootsClientHandler {
+    fn get_info(&self) -> rmcp::model::ClientInfo {
+        self.client_info.clone()
+    }
+
+    fn list_roots(
+        &self,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleClient>,
+    ) -> impl std::future::Future<
+        Output = Result<rmcp::model::ListRootsResult, rmcp::model::ErrorData>,
+    > + Send
+           + '_ {
+        let roots = Arc::clone(&self.roots);
+        async move { Ok(rmcp::model::ListRootsResult::new((*roots).clone())) }
+    }
+}
 
 /// An active connection to an MCP server.
 pub struct McpConnection {
@@ -389,9 +464,10 @@ impl McpConnection {
     pub async fn connect(config: McpServerConfig) -> Result<Self, String> {
         let mut initial_auth_state: Option<crate::mcp_oauth::McpAuthState> = None;
 
+        let roots = config.roots.clone();
         let (inner, discovered_tools) = match &config.transport {
             McpTransport::Stdio { command, args } => {
-                Self::connect_stdio(command, args, &config.env).await?
+                Self::connect_stdio(command, args, &config.env, roots).await?
             }
             McpTransport::Sse { url } => Self::connect_sse(url).await?,
             McpTransport::Http { url } => {
@@ -400,6 +476,7 @@ impl McpConnection {
                     &config.headers,
                     config.oauth_provider.as_ref(),
                     config.oauth_config.as_ref(),
+                    roots,
                 )
                 .await?;
                 initial_auth_state = Some(auth_state);
@@ -439,7 +516,7 @@ impl McpConnection {
                     let declared_tools = tools.clone();
                     conn.register_http_compat_tools(&declared_tools);
                 } else if let McpInner::Sse { .. } = &conn.inner {
-                    conn.sse_initialize().await?;
+                    conn.sse_initialize(&conn.config.roots.clone()).await?;
                     conn.sse_discover_tools().await?;
                 }
             }
@@ -460,6 +537,7 @@ impl McpConnection {
         command: &str,
         args: &[String],
         extra_env: &[String],
+        roots: Vec<String>,
     ) -> Result<(McpInner, Option<Vec<rmcp::model::Tool>>), String> {
         use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
         use rmcp::ServiceExt;
@@ -554,11 +632,18 @@ impl McpConnection {
         )
         .map_err(|e| format!("Failed to spawn MCP server '{resolved_command}': {e}"))?;
 
-        let client = ()
-            .into_dyn()
-            .serve(transport)
-            .await
-            .map_err(|e| format!("MCP handshake failed for '{resolved_command}': {e}"))?;
+        let client = if roots.is_empty() {
+            ().into_dyn()
+                .serve(transport)
+                .await
+                .map_err(|e| format!("MCP handshake failed for '{resolved_command}': {e}"))?
+        } else {
+            RootsClientHandler::new(roots)
+                .into_dyn()
+                .serve(transport)
+                .await
+                .map_err(|e| format!("MCP handshake failed for '{resolved_command}': {e}"))?
+        };
 
         // Discover tools via rmcp (with timeout)
         let timeout = std::time::Duration::from_secs(60);
@@ -602,6 +687,7 @@ impl McpConnection {
         headers: &[String],
         oauth_provider: Option<&std::sync::Arc<dyn crate::mcp_oauth::McpOAuthProvider>>,
         oauth_config: Option<&librefang_types::config::McpOAuthConfig>,
+        roots: Vec<String>,
     ) -> Result<
         (
             McpInner,
@@ -652,7 +738,15 @@ impl McpConnection {
 
         let transport = StreamableHttpClientTransport::from_config(config);
 
-        match ().into_dyn().serve(transport).await {
+        let serve_result = if roots.is_empty() {
+            ().into_dyn().serve(transport).await
+        } else {
+            RootsClientHandler::new(roots)
+                .into_dyn()
+                .serve(transport)
+                .await
+        };
+        match serve_result {
             Ok(client) => {
                 // Discover tools via rmcp (with timeout)
                 let timeout = std::time::Duration::from_secs(60);
@@ -770,10 +864,15 @@ impl McpConnection {
     }
 
     /// Send the MCP `initialize` handshake over SSE transport.
-    async fn sse_initialize(&mut self) -> Result<(), String> {
+    async fn sse_initialize(&mut self, roots: &[String]) -> Result<(), String> {
+        let capabilities = if roots.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::json!({ "roots": { "listChanged": false } })
+        };
         let params = serde_json::json!({
             "protocolVersion": "2024-11-05",
-            "capabilities": {},
+            "capabilities": capabilities,
             "clientInfo": {
                 "name": "librefang",
                 "version": env!("CARGO_PKG_VERSION")
@@ -1828,6 +1927,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            roots: vec![],
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1858,6 +1958,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            roots: vec![],
         };
         let json = serde_json::to_string(&sse_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1892,6 +1993,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            roots: vec![],
         };
         let json = serde_json::to_string(&http_compat_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1921,6 +2023,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            roots: vec![],
         };
         let json = serde_json::to_string(&http_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -1966,6 +2069,7 @@ mod tests {
                 oauth_provider: None,
                 oauth_config: None,
                 taint_scanning: true,
+                roots: vec![],
             },
             tools: Vec::new(),
             original_names: HashMap::new(),
@@ -2132,6 +2236,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            roots: vec![],
         })
         .await
         .unwrap();

--- a/crates/librefang-runtime/tests/mcp_oauth_integration.rs
+++ b/crates/librefang-runtime/tests/mcp_oauth_integration.rs
@@ -89,6 +89,7 @@ async fn test_http_connect_calls_oauth_provider_load_token() {
         oauth_provider: Some(provider.clone()),
         oauth_config: None,
         taint_scanning: true,
+        roots: vec![],
     };
 
     let result = McpConnection::connect(config).await;


### PR DESCRIPTION
## Summary

- **Declare `roots` client capability** during MCP `initialize` handshake so filesystem-aware servers (morphllm, filesystem, etc.) no longer fall back to their own hard-coded allowed-directories
- **`RootsClientHandler`** responds to server-initiated `roots/list` requests with `file://` URIs for each configured root
- **Transport-aware scoping**: stdio gets full roots; local streamable-HTTP gets roots; remote HTTP and SSE get nothing (SSE is unidirectional and can't handle server-initiated requests)
- **Per-agent connection pool**: each `run_agent_loop` / `run_agent_loop_streaming` call gets its own MCP connections with the agent's workspace added as a root — concurrent agents are fully isolated

## Before / After

**Before**: every MCP server connection logged:
```
Client does not support MCP Roots, using allowed directories set from server args:
[ '/Users/e-hu', '/private/tmp', '/Users/e-hu/.librefang/workspaces' ]
```

**After**: no warning; server receives roots from librefang and scopes file access accordingly. Per-agent executions scope roots to the agent's specific workspace directory.

## Design decisions

| Transport | Roots declared? | Reason |
|---|---|---|
| stdio | ✅ | Full bidirectional via rmcp |
| streamable HTTP (local) | ✅ | Local server, bidirectional |
| streamable HTTP (remote) | ❌ | Don't leak local paths to remote APIs |
| SSE | ❌ | Unidirectional — server can't call `roots/list` back |

**Per-agent pool**: global daemon pool unchanged (tool discovery, API). Per-agent pool created just before agent loop, dropped after. "Already covered" check avoids reconnects when workspace is a sub-path of an existing root.

## Test plan

- [ ] Connect a filesystem-aware stdio MCP server (morphllm) — no "does not support MCP Roots" warning
- [ ] Verify `roots/list` response contains `file://` URIs for home + workspaces
- [ ] Run two agents concurrently — each sees its own workspace root, no interference
- [ ] Remote HTTP MCP server — roots NOT sent
- [ ] SSE MCP server — `capabilities: {}` (unchanged)