### PR TITLE
fix(chat): dashboard refresh no longer drops history — unify webui session with canonical

### DIFF
--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1036,7 +1036,7 @@ fn trigger_to_json(t: &Trigger) -> serde_json::Value {
         "max_fires": t.max_fires,
         "created_at": t.created_at.to_rfc3339(),
         "cooldown_secs": t.cooldown_secs,
-        "session_mode": serde_json::to_value(&t.session_mode).unwrap_or(serde_json::Value::Null),
+        "session_mode": serde_json::to_value(t.session_mode).unwrap_or(serde_json::Value::Null),
     });
     if let Some(target) = &t.target_agent {
         v["target_agent_id"] = serde_json::json!(target.to_string());

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -735,6 +735,10 @@ async fn handle_text_message(
                 was_mentioned: false,
                 thread_id: None,
                 account_id: None,
+                // Dashboard chat shares storage with canonical `entry.session_id`
+                // so GET /session, list_agent_sessions, switch_agent_session,
+                // and agent_send all see the same conversation history.
+                use_canonical_session: true,
                 ..Default::default()
             };
             match state

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1717,6 +1717,9 @@ fn build_sender_context(
         // sock.groupMetadata). Empty for non-WhatsApp channels — addressee
         // guard then becomes a no-op (BC-01).
         group_participants: extract_group_participants(message),
+        // Channel bridges land in per-channel sessions (the default); only
+        // the dashboard WS opts into canonical storage.
+        use_canonical_session: false,
     }
 }
 

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -316,6 +316,17 @@ pub struct SenderContext {
     /// this field still deserialize cleanly.
     #[serde(default)]
     pub group_participants: Vec<ParticipantRef>,
+    /// When true, the kernel session resolver treats this invocation as
+    /// non-channel for *storage* purposes: messages persist to
+    /// `entry.session_id` instead of `SessionId::for_channel(agent, channel)`.
+    /// `channel` itself is still used for routing cache keys so the assistant
+    /// auto-router stays per-surface (`webui` vs `telegram` etc.).
+    ///
+    /// Set by the dashboard WebSocket handler so the webui chat view shares a
+    /// session with `agent_send` / triggers and so `list_agent_sessions` /
+    /// `switch_agent_session` actually affect what the user sees.
+    #[serde(default)]
+    pub use_canonical_session: bool,
 }
 
 /// Reference to a participant in a group chat.

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -6016,6 +6016,7 @@ fn cmd_trigger_get(trigger_id: &str) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_trigger_update(
     trigger_id: &str,
     pattern: Option<&str>,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2682,13 +2682,29 @@ impl LibreFangKernel {
                 if webui_msgs == 0 {
                     continue;
                 }
-                let canonical_msgs = kernel
+                // Inspect canonical: if the user has deliberately labeled it
+                // (via create_agent_session / switch_agent_session from the
+                // sessions UI), treat that as an explicit choice and don't
+                // override it — they can still find the orphaned webui session
+                // in `list_agent_sessions` and switch manually if desired.
+                let canonical_session = kernel
                     .memory
                     .get_session(canonical_session_id)
                     .ok()
-                    .flatten()
-                    .map(|s| s.messages.len())
-                    .unwrap_or(0);
+                    .flatten();
+                if canonical_session
+                    .as_ref()
+                    .and_then(|s| s.label.as_ref())
+                    .is_some()
+                {
+                    info!(
+                        agent_id = %agent_id,
+                        webui_messages = webui_msgs,
+                        "Skipping webui adoption — canonical session is labeled (user-managed)"
+                    );
+                    continue;
+                }
+                let canonical_msgs = canonical_session.map(|s| s.messages.len()).unwrap_or(0);
                 if webui_msgs <= canonical_msgs {
                     continue;
                 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2651,6 +2651,68 @@ impl LibreFangKernel {
             }
         }
 
+        // One-time webui → canonical session migration.
+        //
+        // Before the unify fix, the dashboard WS wrote to
+        // `SessionId::for_channel(agent, "webui")` while GET /session and the
+        // sessions management endpoints read `entry.session_id`. Any agent
+        // with recent dashboard chat therefore has two sessions: the stale
+        // canonical and the active webui one. Adopt the webui session as the
+        // canonical pointer when it has strictly more messages, so existing
+        // conversations show up after the fix.
+        //
+        // Idempotent: once `entry.session_id` matches the webui session id
+        // (or canonical overtakes it), this is a no-op on subsequent boots.
+        {
+            let registry_snapshot: Vec<(AgentId, SessionId)> = kernel
+                .registry
+                .list()
+                .iter()
+                .map(|e| (e.id, e.session_id))
+                .collect();
+            for (agent_id, canonical_session_id) in registry_snapshot {
+                let webui_session_id = SessionId::for_channel(agent_id, "webui");
+                if webui_session_id == canonical_session_id {
+                    continue;
+                }
+                let webui_msgs = match kernel.memory.get_session(webui_session_id) {
+                    Ok(Some(s)) => s.messages.len(),
+                    _ => continue,
+                };
+                if webui_msgs == 0 {
+                    continue;
+                }
+                let canonical_msgs = kernel
+                    .memory
+                    .get_session(canonical_session_id)
+                    .ok()
+                    .flatten()
+                    .map(|s| s.messages.len())
+                    .unwrap_or(0);
+                if webui_msgs <= canonical_msgs {
+                    continue;
+                }
+                if let Err(e) = kernel
+                    .registry
+                    .update_session_id(agent_id, webui_session_id)
+                {
+                    warn!(agent_id = %agent_id, "Failed to adopt webui session: {e}");
+                    continue;
+                }
+                if let Some(entry) = kernel.registry.get(agent_id) {
+                    if let Err(e) = kernel.memory.save_agent(&entry) {
+                        warn!(agent_id = %agent_id, "Failed to persist webui adoption: {e}");
+                    }
+                }
+                info!(
+                    agent_id = %agent_id,
+                    webui_messages = webui_msgs,
+                    canonical_messages = canonical_msgs,
+                    "Adopted webui channel session as canonical (one-time migration)"
+                );
+            }
+        }
+
         // If no agents exist (fresh install), spawn a default assistant.
         if kernel.registry.list().is_empty() {
             info!("No agents found — spawning default assistant");
@@ -4165,8 +4227,13 @@ system_prompt = "You are a helpful assistant."
         // (channel, chat_id). Including chat_id prevents context bleed between
         // a group and a DM that share the same (agent, channel). For non-channel
         // invocations, respect the agent's session_mode.
+        //
+        // `use_canonical_session` short-circuits the channel branch: the sender
+        // wants routing-cache scoping (per-channel assistant auto-router) but
+        // storage to land in `entry.session_id`. Used by the dashboard WS so
+        // webui chat shares history with agent_send / session management.
         let effective_session_id = match sender_context {
-            Some(ctx) if !ctx.channel.is_empty() => {
+            Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
                 let scope = match &ctx.chat_id {
                     Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
                     _ => ctx.channel.clone(),
@@ -5415,8 +5482,12 @@ system_prompt = "You are a helpful assistant."
         // a group and a DM that share the same (agent, channel). For non-channel
         // invocations (background ticks, triggers, agent_send), resolve the
         // effective session mode: per-trigger override > agent manifest default.
+        //
+        // `use_canonical_session` short-circuits the channel branch so the
+        // dashboard WS (channel="webui") persists to `entry.session_id` while
+        // still scoping routing caches per-surface.
         let effective_session_id = match sender_context {
-            Some(ctx) if !ctx.channel.is_empty() => {
+            Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
                 let scope = match &ctx.chat_id {
                     Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
                     _ => ctx.channel.clone(),
@@ -8177,6 +8248,7 @@ system_prompt = "You are a helpful assistant."
     ///
     /// When `target_agent` is `Some`, the triggered message is routed to that
     /// agent instead of the owner. Both owner and target must exist.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_trigger_with_target(
         &self,
         agent_id: AgentId,

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -295,6 +295,7 @@ impl TriggerEngine {
     /// When `target_agent` is `Some`, the triggered message is routed to that
     /// agent instead of the owner (`agent_id`). The owner still "owns" the
     /// trigger for management purposes (list, remove, etc.).
+    #[allow(clippy::too_many_arguments)]
     pub fn register_with_target(
         &self,
         agent_id: AgentId,

--- a/crates/librefang-runtime/src/pii_filter.rs
+++ b/crates/librefang-runtime/src/pii_filter.rs
@@ -122,6 +122,7 @@ impl PiiFilter {
                     .account_id
                     .as_ref()
                     .map(|_| REDACTED_PLACEHOLDER.to_string()),
+                use_canonical_session: sender.use_canonical_session,
                 ..Default::default()
             },
             PrivacyMode::Pseudonymize => {
@@ -138,6 +139,7 @@ impl PiiFilter {
                         .account_id
                         .as_ref()
                         .map(|id| self.get_or_create_pseudonym(id, "account")),
+                    use_canonical_session: sender.use_canonical_session,
                     ..Default::default()
                 }
             }


### PR DESCRIPTION
## Summary

- **Bug**: Dashboard chat history disappeared on page refresh. Root cause: WS wrote to `SessionId::for_channel(agent, "webui")` while `GET /session` / `list_agent_sessions` / `switch_agent_session` / `agent_send` all read `entry.session_id`. Two disjoint sessions.
- **Fix**: Add `use_canonical_session: bool` to `SenderContext`. WS sets it; kernel session resolver short-circuits the channel branch when set, falling through to `entry.session_id`. Routing cache keys still use `channel="webui"` so Telegram/Discord auto-router scoping is unchanged.
- **Migration**: One-time boot adoption — when `for_channel(agent, "webui")` has more messages than `entry.session_id`, that session becomes the new canonical. Idempotent on subsequent boots.
- **Side scope**: resolved 4 pre-existing clippy warnings blocking `-D warnings` on main (from #2827).

## Why this design

Alternatives considered:
- **B**: change `GET /session` default to read webui — breaks SDK symmetry (`POST /message` without sender writes canonical).
- **C**: mutate `entry.session_id` from WS — pollutes non-channel invocations (triggers, agent_send).
- **A (picked)**: let the WS opt into canonical storage via a flag, while channel bridges keep their deterministic per-(channel,chat) sessions.

After the fix, dashboard webui and `agent_send` share `entry.session_id`. Telegram / Discord / Slack / cron / event triggers remain per-channel-isolated (they don't set the flag).

## Test plan

- [x] `cargo build --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean; also fixes 4 pre-existing warnings)
- [x] `cargo test --workspace` — 1073 passed, 1 pre-existing failure (`transcode_empty_input_errors`, ffmpeg version-dependent error string, exists on main)
- [x] Live integration: restart daemon against existing ~/.librefang, observe:
  - Agent `f4381f84` `session_id` migrated `b31a28d2` (178B stale) → `a0c78694` (8333B, today's webui chat).
  - `GET /api/agents/{id}/session` now returns 11 real messages instead of 2 stale ones.
- [ ] User verification: open the dashboard, chat with an agent, hit refresh — history should stay.

## Files touched

**Core fix**
- `crates/librefang-channels/src/types.rs` — new field
- `crates/librefang-api/src/ws.rs` — set flag in webui `SenderContext`
- `crates/librefang-kernel/src/kernel/mod.rs` — 2× session resolver guards + boot migration block
- `crates/librefang-channels/src/bridge.rs` — explicit false for channel bridges
- `crates/librefang-runtime/src/pii_filter.rs` — forward flag through PII filter (latent bug prevention)

**Piggyback clippy fixes (from #2827 merge drift)**
- `crates/librefang-api/src/routes/workflows.rs` — drop needless `&` on `Copy` value
- `crates/librefang-kernel/src/kernel/mod.rs` / `triggers.rs` / `crates/librefang-cli/src/main.rs` — `#[allow(clippy::too_many_arguments)]` on 3 trigger-management fns