### PR TITLE
fix(dashboard): type-safety and RC-safe fixes

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -1,7 +1,44 @@
 import { Link, Outlet } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Globe, Sun, Moon, Search, ChevronLeft, ChevronRight, ChevronDown, Menu, Home, Layers, MessageCircle, CheckCircle, Calendar, Shield, Users, User, Server, Network, Bell, Hand, BarChart3, Database, Activity, FileText, Settings, Puzzle, Cpu, Lock, Share2, Gauge, LogOut, UserCircle, X, Sparkles, Terminal, Plug } from "lucide-react";
+import {
+  Globe,
+  Sun,
+  Moon,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  Menu,
+  Home,
+  Layers,
+  MessageCircle,
+  CheckCircle,
+  Calendar,
+  Shield,
+  Users,
+  User,
+  Server,
+  Network,
+  Bell,
+  Hand,
+  BarChart3,
+  Database,
+  Activity,
+  FileText,
+  Settings,
+  Puzzle,
+  Cpu,
+  Lock,
+  Share2,
+  Gauge,
+  LogOut,
+  UserCircle,
+  X,
+  Sparkles,
+  Terminal,
+  Plug,
+} from "lucide-react";
 import { useUIStore } from "./lib/store";
 import { CommandPalette, useCommandPalette } from "./components/ui/CommandPalette";
 import { ShortcutsHelp } from "./components/ui/ShortcutsHelp";
@@ -208,6 +245,8 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
   );
 }
 
+const INPUT_CLASS = "w-full rounded-xl border border-border-subtle bg-main px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors placeholder:text-text-dim/40";
+
 function ChangePasswordModal({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
   const [currentUsername, setCurrentUsername] = useState("");
@@ -219,10 +258,13 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     getDashboardUsername().then((u) => {
+      if (cancelled) return;
       setCurrentUsername(u);
       setNewUsername(u);
     });
+    return () => { cancelled = true; };
   }, []);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -267,13 +309,10 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
     }
   }
 
-  const inputClass = "w-full rounded-xl border border-border-subtle bg-main px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors placeholder:text-text-dim/40";
-
   return (
     <div className="fixed inset-0 z-200 flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div className="w-full max-w-md mx-4 animate-fade-in-scale">
         <div className="rounded-2xl border border-border-subtle bg-surface shadow-2xl">
-          {/* Header */}
           <div className="flex items-center justify-between px-6 pt-6 pb-4">
             <h2 className="text-base font-black tracking-tight">{t("settings.change_credentials")}</h2>
             <button
@@ -286,7 +325,6 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
 
           <form onSubmit={handleSubmit}>
             <div className="px-6 space-y-5">
-              {/* Username */}
               <div>
                 <label className="block text-xs font-semibold text-text-dim mb-1.5">{t("settings.new_username")}</label>
                 <input
@@ -295,11 +333,10 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
                   onChange={(e) => { setNewUsername(e.target.value); setMessage(null); }}
                   autoComplete="username"
                   autoFocus
-                  className={inputClass}
+                  className={INPUT_CLASS}
                 />
               </div>
 
-              {/* New password */}
               <div>
                 <div className="flex items-baseline justify-between mb-1.5">
                   <label className="text-xs font-semibold text-text-dim">{t("settings.pw_new")}</label>
@@ -311,11 +348,10 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
                   onChange={(e) => { setNewPassword(e.target.value); setMessage(null); }}
                   placeholder="••••••••"
                   autoComplete="new-password"
-                  className={inputClass}
+                  className={INPUT_CLASS}
                 />
               </div>
 
-              {/* Confirm password — always visible, grayed out when no new password */}
               <div className={newPassword ? "" : "opacity-40 pointer-events-none"}>
                 <label className="block text-xs font-semibold text-text-dim mb-1.5">{t("settings.pw_confirm")}</label>
                 <input
@@ -325,12 +361,11 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
                   placeholder="••••••••"
                   autoComplete="new-password"
                   tabIndex={newPassword ? 0 : -1}
-                  className={`${inputClass} ${newPassword && confirmPassword && newPassword !== confirmPassword ? "border-error focus:border-error focus:ring-error/10" : ""}`}
+                  className={`${INPUT_CLASS} ${newPassword && confirmPassword && newPassword !== confirmPassword ? "border-error focus:border-error focus:ring-error/10" : ""}`}
                 />
               </div>
             </div>
 
-            {/* Verify identity section */}
             <div className="mx-6 mt-5 rounded-xl bg-surface-hover/60 border border-border-subtle px-4 py-3.5">
               <label className="block text-[10px] font-bold uppercase tracking-widest text-text-dim mb-2">{t("settings.pw_verify_identity")}</label>
               <input
@@ -339,18 +374,16 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
                 onChange={(e) => { setCurrentPassword(e.target.value); setMessage(null); }}
                 placeholder={t("settings.pw_current_placeholder")}
                 autoComplete="current-password"
-                className={inputClass}
+                className={INPUT_CLASS}
               />
             </div>
 
-            {/* Error / success */}
             {message && (
               <p className={`mx-6 mt-3 text-xs font-semibold ${message.type === "success" ? "text-success" : "text-error"}`}>
                 {message.text}
               </p>
             )}
 
-            {/* Actions */}
             <div className="flex gap-3 px-6 py-5">
               <button
                 type="button"
@@ -442,7 +475,7 @@ export function App() {
     getVersionInfo().then((v) => {
       setAppVersion(v.version ?? "");
       setHostname(v.hostname ?? "");
-    }).catch(() => {});
+    }).catch(() => { /* Version info is non-essential; silently ignore failure. */ });
 
     getStatus().then((s) => {
       setTerminalEnabled(s.terminal_enabled !== false);
@@ -547,7 +580,6 @@ export function App() {
 
   return (
     <div className="flex h-screen flex-col bg-main text-slate-900 dark:text-slate-100 lg:flex-row transition-colors duration-300 overflow-hidden">
-      {/* Skip to content — visible only when focused (keyboard users) */}
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:rounded-lg focus:bg-brand focus:px-4 focus:py-2 focus:text-sm focus:font-bold focus:text-white focus:shadow-lg focus:outline-none"
@@ -555,7 +587,6 @@ export function App() {
         {t("nav.skip_to_content", { defaultValue: "Skip to content" })}
       </a>
 
-      {/* Sidebar Overlay (Mobile) */}
       {isMobileMenuOpen && (
         <div 
           className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm lg:hidden"
@@ -563,14 +594,12 @@ export function App() {
         />
       )}
 
-      {/* Sidebar */}
       <aside className={`
         fixed inset-y-0 left-0 z-50 flex w-[220px] flex-col border-r border-border-subtle bg-surface lg:static lg:translate-x-0
         transition-[width,transform] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]
         ${isMobileMenuOpen ? "translate-x-0 shadow-2xl" : "-translate-x-full"}
         ${isSidebarCollapsed ? "lg:w-24" : "lg:w-[280px]"}
       `}>
-        {/* Sidebar Header */}
         <div className={`flex h-16 items-center border-b border-border-subtle transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] ${
           isSidebarCollapsed ? "lg:justify-center lg:px-0" : "justify-between px-4"
         }`}>
@@ -594,9 +623,7 @@ export function App() {
           </button>
         </div>
 
-        {/* Navigation */}
-        <nav className="overflow-y-auto overflow-x-hidden p-4 scrollbar-thin" style={{ maxHeight: "calc(100vh - 160px)" }}>
-          {/* Search Button */}
+        <nav className="overflow-y-auto overflow-x-hidden p-4 scrollbar-thin max-h-[calc(100vh-160px)]">
           <button
             onClick={() => setPaletteOpen(true)}
             className={`mb-4 flex w-full items-center gap-2 rounded-xl border border-border-subtle bg-surface-hover px-3 py-2.5 text-text-dim hover:border-brand/30 hover:text-brand ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-20 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}
@@ -665,7 +692,6 @@ export function App() {
           </div>
         </nav>
 
-        {/* Sidebar Footer */}
         <div className={`border-t border-border-subtle p-4 ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-28 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
           <div className="rounded-xl bg-linear-to-r from-success/5 to-transparent p-3 border border-success/10">
             <p className="text-[10px] font-bold text-text-dim uppercase tracking-wider">{t("common.status")}</p>
@@ -686,9 +712,7 @@ export function App() {
         </div>
       </aside>
 
-      {/* Main Content Area */}
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Top Header */}
         <header className="flex h-14 sm:h-16 shrink-0 items-center justify-between border-b border-border-subtle bg-surface px-3 sm:px-6">
           <div className="flex items-center gap-2">
             <button
@@ -770,7 +794,6 @@ export function App() {
           </div>
         </header>
 
-        {/* Main Content */}
         <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden bg-main" tabIndex={-1}>
           <div className="w-full p-3 sm:p-4 lg:p-8">
             <Outlet />

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -346,7 +346,7 @@ export interface WorkflowItem {
   description?: string;
   steps?: number | WorkflowStep[];
   created_at?: string;
-  layout?: any;
+  layout?: unknown;
 }
 
 export interface WorkflowRunItem {
@@ -1394,7 +1394,7 @@ export async function createWorkflow(payload: {
     prompt: string;
     timeout_secs?: number;
   }>;
-  layout?: any;
+  layout?: unknown;
 }): Promise<ApiActionResponse> {
   return post<ApiActionResponse>("/api/workflows", payload);
 }
@@ -1423,7 +1423,7 @@ export async function updateWorkflow(workflowId: string, payload: {
     prompt: string;
     timeout_secs?: number;
   }>;
-  layout?: any;
+  layout?: unknown;
 }): Promise<ApiActionResponse> {
   return put<ApiActionResponse>(`/api/workflows/${encodeURIComponent(workflowId)}`, payload);
 }

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -346,6 +346,7 @@ export interface WorkflowItem {
   description?: string;
   steps?: number | WorkflowStep[];
   created_at?: string;
+  layout?: any;
 }
 
 export interface WorkflowRunItem {
@@ -912,12 +913,7 @@ export async function listAgentTemplates(): Promise<AgentTemplate[]> {
 }
 
 export async function getAgentTemplateToml(name: string): Promise<string> {
-  const response = await fetch(`/api/templates/${encodeURIComponent(name)}/toml`);
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(text || `Failed to fetch template: ${response.status}`);
-  }
-  return response.text();
+  return getText(`/api/templates/${encodeURIComponent(name)}/toml`);
 }
 
 export async function deleteAgent(agentId: string): Promise<ApiActionResponse> {
@@ -1403,14 +1399,14 @@ export async function createWorkflow(payload: {
   return post<ApiActionResponse>("/api/workflows", payload);
 }
 
-export async function getWorkflow(workflowId: string): Promise<any> {
-  return get<any>(`/api/workflows/${encodeURIComponent(workflowId)}`);
+export async function getWorkflow(workflowId: string): Promise<WorkflowItem> {
+  return get<WorkflowItem>(`/api/workflows/${encodeURIComponent(workflowId)}`);
 }
 
 export async function runWorkflow(workflowId: string, input: string): Promise<ApiActionResponse> {
   return post<ApiActionResponse>(`/api/workflows/${encodeURIComponent(workflowId)}/run`, {
     input
-  }, 300000); // 5 min timeout — workflows run multiple LLM steps
+  }, LONG_RUNNING_TIMEOUT_MS); // 5 min timeout — workflows run multiple LLM steps
 }
 
 export async function deleteWorkflow(workflowId: string): Promise<ApiActionResponse> {
@@ -1540,8 +1536,8 @@ export async function runSchedule(scheduleId: string): Promise<ApiActionResponse
 }
 
 export async function listTriggers(): Promise<TriggerItem[]> {
-  const data = await get<any>("/api/triggers");
-  return data.triggers ?? data ?? [];
+  const data = await get<{ triggers?: TriggerItem[] }>("/api/triggers");
+  return data.triggers ?? [];
 }
 
 export async function updateTrigger(
@@ -2427,8 +2423,8 @@ export async function dashboardLogin(username: string, password: string, totpCod
       setApiKey(data.token);
     }
     return data;
-  } catch (e: any) {
-    return { ok: false, error: e.message || "Network error" };
+  } catch (e: unknown) {
+    return { ok: false, error: e instanceof Error ? e.message : "Network error" };
   }
 }
 

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -1179,9 +1179,10 @@ function CanvasPageInner() {
     const detail = await getWorkflow(workflowId);
     let wfNodes: Node[];
     let wfEdges: Edge[];
-    if (detail.layout?.nodes) {
-      wfNodes = detail.layout.nodes;
-      wfEdges = detail.layout.edges || [];
+    const layout = detail.layout as { nodes?: Node[]; edges?: Edge[] } | undefined;
+    if (layout?.nodes) {
+      wfNodes = layout.nodes;
+      wfEdges = layout.edges || [];
     } else {
       const steps = Array.isArray(detail.steps) ? detail.steps : [];
       wfNodes = steps.map((s: any, idx: number) => ({


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Dashboard hardening: fix missing auth header, eliminate `any` types, fix memory leak in ChangePasswordModal, and clean up boilerplate.

## Changes

- Fix auth header missing in `getAgentTemplateToml` — switch to `getText()` helper
- Replace `layout?: any` with `layout?: unknown` in `WorkflowItem`, `createWorkflow`, `updateWorkflow`
- Add safe type assertion for layout access in `CanvasPage`
- Type `getWorkflow` return as `WorkflowItem`, `listTriggers` as `{ triggers?: TriggerItem[] }`
- Type `dashboardLogin` catch as `unknown` with `instanceof Error` guard
- Replace magic `300000` with `LONG_RUNNING_TIMEOUT_MS` constant
- Fix memory leak in `ChangePasswordModal` — cancel stale `getDashboardUsername` on unmount
- Hoist `inputClass` to module-level `INPUT_CLASS` constant
- Remove redundant structural comments (`{/* Header */}`, `{/* Sidebar */}`, etc.)
- Reformat imports and inline style → Tailwind class

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Testing

- [x] `pnpm typecheck` passes

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries