### PR TITLE
fix(ci): unbreak --all-features build + stop warning on local LLM providers

### DIFF
--- a/crates/librefang-channels/src/mqtt.rs
+++ b/crates/librefang-channels/src/mqtt.rs
@@ -29,11 +29,12 @@ const DEFAULT_KEEP_ALIVE_SECS: u64 = 30;
 const EVENT_CHANNEL_CAPACITY: usize = 128;
 
 /// Quality of Service level for MQTT operations.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum MqttQoS {
     /// At most once (fire and forget).
     AtMostOnce,
     /// At least once (acknowledged delivery).
+    #[default]
     AtLeastOnce,
     /// Exactly once (assured delivery).
     ExactlyOnce,
@@ -46,12 +47,6 @@ impl MqttQoS {
             MqttQoS::AtLeastOnce => QoS::AtLeastOnce,
             MqttQoS::ExactlyOnce => QoS::ExactlyOnce,
         }
-    }
-}
-
-impl Default for MqttQoS {
-    fn default() -> Self {
-        MqttQoS::AtLeastOnce
     }
 }
 
@@ -236,7 +231,12 @@ impl MqttAdapter {
                 librefang_user: None,
             },
             content,
-            target_agent: target_agent.map(|id| id.into()),
+            // `agent` field carries a UUID string; reject anything that doesn't
+            // parse so we don't silently turn garbage into a bogus AgentId.
+            target_agent: target_agent
+                .as_deref()
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .map(librefang_types::agent::AgentId),
             timestamp: Utc::now(),
             is_group: false,
             thread_id: None,
@@ -264,8 +264,10 @@ impl ChannelAdapter for MqttAdapter {
 
     async fn start(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>, Box<dyn std::error::Error>>
-    {
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>,
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
         info!(
             "MQTT adapter connecting to {}:{} (client_id={})",
             self.host, self.port, self.client_id
@@ -345,7 +347,7 @@ impl ChannelAdapter for MqttAdapter {
         &self,
         _user: &ChannelUser,
         content: ChannelContent,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let text = match content {
             ChannelContent::Text(t) => t,
             ChannelContent::Command { name, args } => {
@@ -372,7 +374,10 @@ impl ChannelAdapter for MqttAdapter {
         Ok(())
     }
 
-    async fn send_typing(&self, _user: &ChannelUser) -> Result<(), Box<dyn std::error::Error>> {
+    async fn send_typing(
+        &self,
+        _user: &ChannelUser,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // MQTT has no typing indicator concept.
         Ok(())
     }
@@ -382,12 +387,12 @@ impl ChannelAdapter for MqttAdapter {
         _user: &ChannelUser,
         _message_id: &str,
         _reaction: &LifecycleReaction,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // MQTT has no reaction concept.
         Ok(())
     }
 
-    async fn stop(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let _ = self.shutdown_tx.send(true);
 
         // Disconnect MQTT client gracefully
@@ -483,12 +488,26 @@ mod tests {
     #[test]
     fn test_parse_payload_json_with_agent() {
         let topic = "commands/input";
-        let payload =
-            br#"{"sender": "controller", "message": "turn on lights", "agent": "home-agent-1"}"#;
+        // `agent` must be a UUID — other adapters (Telegram, Discord) route by
+        // AgentId too, and accepting free-form strings here would produce
+        // routing mismatches.
+        let payload = br#"{"sender": "controller", "message": "turn on lights", "agent": "550e8400-e29b-41d4-a716-446655440000"}"#;
         let msg = MqttAdapter::parse_payload(topic, payload, &None);
         assert!(msg.is_some());
         let msg = msg.unwrap();
         assert!(msg.target_agent.is_some());
+    }
+
+    #[test]
+    fn test_parse_payload_json_with_non_uuid_agent_ignored() {
+        let topic = "commands/input";
+        let payload =
+            br#"{"sender": "controller", "message": "turn on lights", "agent": "not-a-uuid"}"#;
+        let msg = MqttAdapter::parse_payload(topic, payload, &None);
+        assert!(msg.is_some());
+        // Non-UUID agent strings must be dropped rather than producing a
+        // corrupt AgentId — the message still goes through, just unrouted.
+        assert!(msg.unwrap().target_agent.is_none());
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8767,21 +8767,28 @@ system_prompt = "You are a helpful assistant."
         {
             let mut missing: Vec<String> = Vec::new();
 
-            // Default LLM provider — prefer explicit api_key_env, then resolve
-            let llm_env = if !cfg.default_model.api_key_env.is_empty() {
-                cfg.default_model.api_key_env.clone()
-            } else {
-                cfg.resolve_api_key_env(&cfg.default_model.provider)
-            };
-            if std::env::var(&llm_env).unwrap_or_default().is_empty() {
-                missing.push(format!(
-                    "LLM ({}): ${}",
-                    cfg.default_model.provider, llm_env
-                ));
+            // Default LLM provider — prefer explicit api_key_env, then resolve.
+            // Skip providers that run locally (ollama, vllm, lmstudio, …) —
+            // they don't need a key and flagging them confuses operators.
+            if !librefang_runtime::provider_health::is_local_provider(&cfg.default_model.provider) {
+                let llm_env = if !cfg.default_model.api_key_env.is_empty() {
+                    cfg.default_model.api_key_env.clone()
+                } else {
+                    cfg.resolve_api_key_env(&cfg.default_model.provider)
+                };
+                if std::env::var(&llm_env).unwrap_or_default().is_empty() {
+                    missing.push(format!(
+                        "LLM ({}): ${}",
+                        cfg.default_model.provider, llm_env
+                    ));
+                }
             }
 
-            // Fallback LLM providers — prefer explicit api_key_env, then resolve
+            // Fallback LLM providers — same local-provider exemption.
             for fb in &cfg.fallback_providers {
+                if librefang_runtime::provider_health::is_local_provider(&fb.provider) {
+                    continue;
+                }
                 let env_var = if !fb.api_key_env.is_empty() {
                     fb.api_key_env.clone()
                 } else {


### PR DESCRIPTION
## Summary

Two independent cleanups unblocking the CI Quality check and the boot log.

### 1. `librefang-channels/src/mqtt.rs` — restore `channel-mqtt` compile

Main's CI Quality has been red since #2827 because the MQTT adapter stopped compiling under `--all-features`:

- `target_agent.map(|id| id.into())` expected `String: Into<AgentId>`, which doesn't exist. Now parses the `agent` field as a UUID and drops invalid strings so we don't synthesize a bogus `AgentId`. A new test covers the non-UUID branch.
- 5 `ChannelAdapter` trait method impls returned `Box<dyn Error>` instead of the required `Box<dyn Error + Send + Sync>`.
- `MqttQoS` had a manual `Default` impl; clippy wants `#[derive(Default)]`.

After: `cargo clippy -p librefang-channels --all-targets --all-features -- -D warnings` is clean. CI Quality should pass once merged.

### 2. `librefang-kernel/src/kernel/mod.rs` — stop warning about local LLM keys

On every boot you'd see:

```
WARN Startup health check: missing API keys — affected services may fail count=1
WARN   ↳ LLM (ollama): $OLLAMA_API_KEY
```

Ollama (and vllm / lmstudio / lemonade) runs locally and needs no API key. Project already has `librefang_runtime::provider_health::is_local_provider` for exactly this distinction; the health check wasn't calling it. Now does.

## Test plan

- [x] `cargo build -p librefang-channels --features channel-mqtt` clean
- [x] `cargo clippy -p librefang-channels --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p librefang-channels --features channel-mqtt mqtt` passes including the new non-UUID-agent test
- [ ] CI Quality turns green