### PR TITLE
fix(cron): per-job session_mode override to fix context accumulation (#2647)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1256,6 +1256,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                     },
                     delivery: librefang_types::scheduler::CronDelivery::None,
                     peer_id: None,
+                    session_mode: None,
                     created_at: chrono::Utc::now(),
                     last_run: None,
                     next_run: None,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1442,6 +1442,7 @@ pub async fn create_schedule(
         action,
         delivery: librefang_types::scheduler::CronDelivery::None,
         peer_id: None,
+        session_mode: None,
         created_at: chrono::Utc::now(),
         last_run: None,
         next_run: None,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1442,7 +1442,9 @@ pub async fn create_schedule(
         action,
         delivery: librefang_types::scheduler::CronDelivery::None,
         peer_id: None,
-        session_mode: None,
+        session_mode: req["session_mode"]
+            .as_str()
+            .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_string())).ok()),
         created_at: chrono::Utc::now(),
         last_run: None,
         next_run: None,

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -580,6 +580,7 @@ mod tests {
             },
             delivery: CronDelivery::None,
             peer_id: None,
+            session_mode: None,
             created_at: Utc::now(),
             last_run: None,
             next_run: None,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9020,21 +9020,22 @@ system_prompt = "You are a helpful assistant."
                                 // receives its own fresh SessionId.
                                 let wants_new_session = job.session_mode
                                     == Some(librefang_types::agent::SessionMode::New);
-                                let cron_sender = SenderContext {
-                                    channel: "cron".to_string(),
-                                    user_id: job.peer_id.clone().unwrap_or_default(),
-                                    display_name: "cron".to_string(),
-                                    is_group: false,
-                                    was_mentioned: false,
-                                    thread_id: None,
-                                    account_id: None,
-                                    ..Default::default()
-                                };
-                                let (sender_ctx, mode_override) = if wants_new_session {
+                                let (sender_ctx_owned, mode_override) = if wants_new_session {
                                     (None, Some(librefang_types::agent::SessionMode::New))
                                 } else {
-                                    (Some(&cron_sender), None)
+                                    let cron_sender = SenderContext {
+                                        channel: "cron".to_string(),
+                                        user_id: job.peer_id.clone().unwrap_or_default(),
+                                        display_name: "cron".to_string(),
+                                        is_group: false,
+                                        was_mentioned: false,
+                                        thread_id: None,
+                                        account_id: None,
+                                        ..Default::default()
+                                    };
+                                    (Some(cron_sender), None)
                                 };
+                                let sender_ctx = sender_ctx_owned.as_ref();
                                 match tokio::time::timeout(
                                     timeout,
                                     kernel.send_message_full(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9012,6 +9012,14 @@ system_prompt = "You are a helpful assistant."
                                 > = kernel.clone();
                                 // Cron jobs use a synthetic SenderContext so they
                                 // get their own isolated session (channel="cron").
+                                //
+                                // Exception: when `session_mode = "new"` the job
+                                // requested per-fire isolation. In that case we
+                                // skip the fixed channel session and instead pass
+                                // a `session_mode_override` of `New` so each fire
+                                // receives its own fresh SessionId.
+                                let wants_new_session = job.session_mode
+                                    == Some(librefang_types::agent::SessionMode::New);
                                 let cron_sender = SenderContext {
                                     channel: "cron".to_string(),
                                     user_id: job.peer_id.clone().unwrap_or_default(),
@@ -9022,6 +9030,11 @@ system_prompt = "You are a helpful assistant."
                                     account_id: None,
                                     ..Default::default()
                                 };
+                                let (sender_ctx, mode_override) = if wants_new_session {
+                                    (None, Some(librefang_types::agent::SessionMode::New))
+                                } else {
+                                    (Some(&cron_sender), None)
+                                };
                                 match tokio::time::timeout(
                                     timeout,
                                     kernel.send_message_full(
@@ -9029,8 +9042,8 @@ system_prompt = "You are a helpful assistant."
                                         message,
                                         Some(kh),
                                         None,
-                                        Some(&cron_sender),
-                                        None,
+                                        sender_ctx,
+                                        mode_override,
                                         None,
                                     ),
                                 )
@@ -12427,6 +12440,14 @@ impl KernelHandle for LibreFangKernel {
             uuid::Uuid::parse_str(agent_id).map_err(|e| format!("Invalid agent ID: {e}"))?,
         );
 
+        let session_mode: Option<librefang_types::agent::SessionMode> =
+            if job_json["session_mode"].is_string() {
+                serde_json::from_value(job_json["session_mode"].clone())
+                    .map_err(|e| format!("Invalid session_mode: {e}"))?
+            } else {
+                None
+            };
+
         let job = CronJob {
             id: CronJobId::new(),
             agent_id: aid,
@@ -12435,6 +12456,7 @@ impl KernelHandle for LibreFangKernel {
             action,
             delivery,
             peer_id: None,
+            session_mode,
             enabled: true,
             created_at: chrono::Utc::now(),
             next_run: None,

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -1592,7 +1592,8 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
                         "type": "object",
                         "description": "Delivery target: {\"kind\":\"none\"} or {\"kind\":\"channel\",\"channel\":\"telegram\"} or {\"kind\":\"last_channel\"}"
                     },
-                    "one_shot": { "type": "boolean", "description": "If true, auto-delete after execution. Default: false" }
+                    "one_shot": { "type": "boolean", "description": "If true, auto-delete after execution. Default: false" },
+                    "session_mode": { "type": "string", "enum": ["persistent", "new"], "description": "Session behaviour for AgentTurn actions. 'persistent' (default): all fires share one dedicated cron session, preserving history across runs. 'new': each fire gets a fresh isolated session with no memory of previous runs." }
                 },
                 "required": ["name", "schedule", "action"]
             }),

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -3,7 +3,7 @@
 //! Defines the core types for recurring and one-shot scheduled jobs that can
 //! trigger agent turns, system events, or webhook deliveries.
 
-use crate::agent::AgentId;
+use crate::agent::{AgentId, SessionMode};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -191,6 +191,15 @@ pub struct CronJob {
     /// (empty user_id — backward-compatible behaviour).
     #[serde(default)]
     pub peer_id: Option<String>,
+    /// Per-job session mode override.
+    ///
+    /// * `None` / `Some(Persistent)` — all fires for this job share one
+    ///   dedicated session (`channel="cron"`), matching the historical
+    ///   default.
+    /// * `Some(New)` — every fire creates a fresh, isolated session so
+    ///   history from previous fires cannot influence the current run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_mode: Option<SessionMode>,
     /// When the job was created.
     pub created_at: DateTime<Utc>,
     /// When the job last fired (if ever).
@@ -431,6 +440,7 @@ mod tests {
             },
             delivery: CronDelivery::None,
             peer_id: None,
+            session_mode: None,
             created_at: Utc::now(),
             last_run: None,
             next_run: None,


### PR DESCRIPTION
## Summary

- Adds `session_mode: Option<SessionMode>` to `CronJob` (backward-compatible, defaults to `None`)
- When `session_mode = "new"`, each cron fire creates a fresh `SessionId::new()` — no accumulated history from previous runs
- When `session_mode` is `None` or `"persistent"`, keeps the existing behaviour: all fires share one dedicated `SessionId::for_channel(agent, "cron")` session

## Root cause (issue #2647)

The cron dispatcher synthesises a `SenderContext { channel: "cron", … }` and passes it to `send_message_full`. Session resolution checks `sender_context.channel` first, so it always hits the `SessionId::for_channel` branch and never reaches the `session_mode` field on the agent manifest. All cron fires for an agent accumulate into one session that grows unboundedly.

## Fix

In the cron `AgentTurn` dispatch branch:
- Reads `job.session_mode`
- If `Some(New)`: passes `sender_context = None` and `session_mode_override = Some(New)` → `execute_agent_inner` hits the `_ =>` branch, calls `SessionId::new()` per fire
- Otherwise: unchanged (passes `Some(&cron_sender)`)

Also exposes the field in the `cron_create` tool schema so agents can set it when creating jobs.

## Test plan

- [ ] Existing cron integration tests still pass (no regression in default persistent behaviour)
- [ ] New job created with `session_mode: "new"` via `cron_create` tool gets fresh session on each fire
- [ ] Serialisation roundtrip: `session_mode` is omitted from JSON when `None` (`skip_serializing_if`)
- [ ] Persisted jobs without `session_mode` field deserialise to `None` via `#[serde(default)]`