### PR TITLE
fix(memory): proactive extraction loses JSON mode through fork path + log noise cleanup

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2766,7 +2766,10 @@ pub async fn run_agent_loop(
                     }
                     Some(EndTurnRetry::HallucinatedAction) => {
                         hallucination_retried = true;
-                        warn!(
+                        // One-shot corrective retry — expected in mixed-capability
+                        // model fleets and not an error condition. Keep as info
+                        // so operators can still see how often it fires.
+                        info!(
                             agent = %manifest.name,
                             iteration,
                             "Detected hallucinated action — agent claimed action without tool calls, retrying"
@@ -2780,7 +2783,7 @@ pub async fn run_agent_loop(
                     }
                     Some(EndTurnRetry::ActionIntent) => {
                         action_nudge_retried = true;
-                        warn!(
+                        info!(
                             agent = %manifest.name,
                             iteration,
                             "User requested action but LLM responded without tool calls — nudging retry"
@@ -3818,7 +3821,7 @@ pub async fn run_agent_loop_streaming(
                     }
                     Some(EndTurnRetry::HallucinatedAction) => {
                         hallucination_retried = true;
-                        warn!(
+                        info!(
                             agent = %manifest.name,
                             iteration,
                             "Detected hallucinated action (streaming) — agent claimed action without tool calls, retrying"
@@ -3832,7 +3835,7 @@ pub async fn run_agent_loop_streaming(
                     }
                     Some(EndTurnRetry::ActionIntent) => {
                         action_nudge_retried = true;
-                        warn!(
+                        info!(
                             agent = %manifest.name,
                             iteration,
                             "User requested action but LLM responded without tool calls (streaming) — nudging retry"

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -269,21 +269,12 @@ If nothing matches, default to ADD."#;
 pub struct LlmMemoryExtractor {
     driver: Arc<dyn crate::llm_driver::LlmDriver>,
     model: String,
-    /// Late-bound kernel handle — populated after the kernel is wrapped
-    /// in `Arc` (in `LibreFangKernel::set_self_handle`). Before that
-    /// point, the extractor falls back to the standalone `driver.complete()`
-    /// path. `RwLock` (not `Mutex`) because reads dominate — one write at
-    /// kernel init, many reads during `extract_memories_with_agent_id`.
-    kernel_handle:
-        std::sync::RwLock<Option<std::sync::Weak<dyn crate::kernel_handle::KernelHandle>>>,
-    /// Whether to stamp `prompt_caching = true` on the standalone
-    /// fallback `driver.complete()` request. Mirrors the global
+    /// Whether to stamp `prompt_caching = true` on the extraction
+    /// `driver.complete()` request. Mirrors the global
     /// `KernelConfig.prompt_caching` toggle — operators who disable
     /// caching at the kernel level (compatibility, cost accounting,
     /// debugging) should see proactive-memory requests also skip
-    /// `cache_control`. The fork path inherits this automatically
-    /// because it runs through agent_loop which reads the per-agent
-    /// manifest metadata that the kernel derives from the same global.
+    /// `cache_control`.
     prompt_caching: bool,
 }
 
@@ -293,7 +284,7 @@ impl LlmMemoryExtractor {
     }
 
     /// Explicit variant for callers that want to control the
-    /// fallback-path `prompt_caching` flag — typically the kernel,
+    /// extraction `prompt_caching` flag — typically the kernel,
     /// which passes `KernelConfig.prompt_caching` through so the
     /// extractor honours the same global toggle as the main loop.
     pub fn with_prompt_caching(
@@ -304,65 +295,18 @@ impl LlmMemoryExtractor {
         Self {
             driver,
             model,
-            kernel_handle: std::sync::RwLock::new(None),
             prompt_caching,
         }
     }
 
-    /// Install the kernel handle used for fork-based extraction. Called
-    /// by `LibreFangKernel::set_self_handle` — by then `Arc<LibreFangKernel>`
-    /// exists so the weak ref can actually be formed. Idempotent: a second
-    /// install overwrites the first (harmless; the upgrade path handles
-    /// stale weaks gracefully).
+    /// No-op kept for backwards compatibility with kernel init which still
+    /// calls this on every extractor it constructs. Previous fork-based
+    /// extraction pathway was removed because it bypassed JSON mode; see
+    /// `extract_memories_with_agent_id` for details.
     pub fn install_kernel_handle(
         &self,
-        handle: std::sync::Weak<dyn crate::kernel_handle::KernelHandle>,
+        _handle: std::sync::Weak<dyn crate::kernel_handle::KernelHandle>,
     ) {
-        if let Ok(mut slot) = self.kernel_handle.write() {
-            *slot = Some(handle);
-        }
-    }
-
-    /// Attempt the fork path: embed the extraction instructions into a
-    /// fork user message and invoke `run_forked_agent_oneshot`. Returns
-    /// `Ok(Some(text))` on success, `Ok(None)` when no kernel handle is
-    /// configured (caller falls back to direct driver call), or
-    /// `Ok(Some(""))` when the kernel Arc is stale (shutting down).
-    async fn try_forked_extract(
-        &self,
-        conversation_text: &str,
-        agent_id: &str,
-        categories: &[String],
-    ) -> Result<Option<String>, LibreFangError> {
-        let weak = {
-            let guard = self
-                .kernel_handle
-                .read()
-                .map_err(|e| LibreFangError::Internal(format!("kernel_handle lock: {e}")))?;
-            guard.clone()
-        };
-        let Some(weak) = weak else {
-            return Ok(None);
-        };
-        let Some(kernel) = weak.upgrade() else {
-            tracing::debug!("LlmMemoryExtractor: kernel Arc stale during extract, skipping");
-            return Ok(Some(String::new()));
-        };
-        let prompt = format!(
-            "{}\n\nExtract memories from this conversation. \
-             Return JSON only, no commentary.\n\n{conversation_text}",
-            build_extraction_prompt(categories)
-        );
-        match kernel
-            .run_forked_agent_oneshot(agent_id, &prompt, Some(Vec::new()))
-            .await
-        {
-            Ok(text) => Ok(Some(text)),
-            Err(e) => {
-                tracing::warn!(error = %e, "LlmMemoryExtractor fork extract failed, falling back to direct driver call");
-                Ok(None)
-            }
-        }
     }
 }
 
@@ -554,31 +498,22 @@ impl MemoryExtractor for LlmMemoryExtractor {
             });
         }
 
-        // Try the fork path. Falls back to standalone if no kernel
-        // handle is configured or the fork call fails (transient provider
-        // error, rate limit, etc). Standalone path has `prompt_caching =
-        // true` so the system prompt still caches across calls.
-        match self
-            .try_forked_extract(&conversation_text, agent_id, categories)
-            .await
-        {
-            Ok(Some(text)) if text.is_empty() => Ok(ExtractionResult {
-                has_content: false,
-                memories: Vec::new(),
-                relations: Vec::new(),
-                trigger: "llm_extractor_fork_skipped".to_string(),
-                conflicts: Vec::new(),
-            }),
-            Ok(Some(text)) => {
-                let mut parsed = parse_llm_extraction_response(&text)?;
-                parsed.trigger = "llm_extractor_forked".to_string();
-                Ok(parsed)
-            }
-            // No kernel handle configured (init didn't wire it) or fork
-            // call failed — fall back to the standalone path so we still
-            // get extraction, just without cache alignment.
-            Ok(None) | Err(_) => self.extract_memories(messages, categories).await,
-        }
+        // Always use the standalone path. The fork path cannot thread
+        // `response_format: json_object` through `run_forked_agent_oneshot`,
+        // so providers that honour JSON mode (ollama, OpenAI-compat,
+        // Anthropic with json schemas, …) lose that guarantee and weak
+        // models reply in prose, causing `Failed to parse extraction
+        // response JSON` warnings with no memory extracted.
+        //
+        // Standalone gives us JSON mode + dedicated EXTRACTION_SYSTEM_PROMPT
+        // + per-call system-block caching (`prompt_caching = true`). The
+        // cross-call parent-child cache sharing that fork was supposed to
+        // enable was never fully wired (see the "separate PR" note in
+        // `extract_memories`), so there is no real regression from
+        // skipping fork here.
+        let _ = agent_id; // kept in signature for forward compat
+        let _ = conversation_text;
+        self.extract_memories(messages, categories).await
     }
 
     /// LLM-powered conflict resolution: decide ADD/UPDATE/NOOP.
@@ -627,7 +562,10 @@ impl MemoryExtractor for LlmMemoryExtractor {
             system: Some(DECISION_SYSTEM_PROMPT.to_string()),
             thinking: None,
             prompt_caching: self.prompt_caching,
-            response_format: None,
+            // DECISION_SYSTEM_PROMPT asks for `{"action": "...", "existing_id": "..."}`
+            // — tell JSON-mode-capable providers to honour it so weak models
+            // can't drift into prose.
+            response_format: Some(ResponseFormat::Json),
             timeout_secs: Some(15),
             extra_body: None,
             agent_id: None,
@@ -711,7 +649,11 @@ fn parse_decision_response(
     let parsed: serde_json::Value = match serde_json::from_str(json_str) {
         Ok(val) => val,
         Err(e) => {
-            tracing::warn!("Failed to parse decision response JSON: {e}, input: {json_str}");
+            // Weak / local models routinely reply in prose instead of JSON.
+            // The caller already falls back to the default ADD action, so
+            // this is expected fallback behavior and should not warn on
+            // every post-turn memory decision.
+            tracing::debug!("Failed to parse decision response JSON: {e}, input: {json_str}");
             serde_json::Value::Null
         }
     };
@@ -781,7 +723,11 @@ fn parse_llm_extraction_response(
     let parsed: serde_json::Value = match serde_json::from_str(json_str) {
         Ok(val) => val,
         Err(e) => {
-            tracing::warn!("Failed to parse extraction response JSON: {e}, input: {json_str}");
+            // Weak / local models routinely reply in prose instead of JSON.
+            // Extraction is best-effort — falling back to Null just skips
+            // this turn's memory/relation updates rather than failing the
+            // conversation, so WARN is overkill.
+            tracing::debug!("Failed to parse extraction response JSON: {e}, input: {json_str}");
             serde_json::Value::Null
         }
     };


### PR DESCRIPTION
## Summary

Fixes the WARN storm on every turn:
```
WARN Failed to parse extraction response JSON: expected value at line 1 column 1, input: 我明白了！谢谢您的提醒 ...
```

### Root cause (real bug, not just noisy logs)

`LlmMemoryExtractor::extract_memories` correctly sets `response_format: Some(ResponseFormat::Json)` — but the fork code path `extract_memories_with_agent_id` → `try_forked_extract` → `run_forked_agent_oneshot` **drops that field** because `LoopOptions` doesn't carry `response_format`.

Kernel init always installs the fork handle in production, so the fork path always won. Providers that honour JSON mode (OpenAI-compat, ollama `/v1`, Anthropic json schema) never got the instruction. Weak / local models (gemma4, small llama / qwen) then drifted into prose; `serde_json::from_str` panicked; extraction fell back to `Null` with no memory saved.

The fork path was meant to buy parent-prompt cache alignment, but as the pre-existing comment in `extract_memories` already admitted, that alignment was **never actually wired**:

> Cross-call parent-child cache sharing would require rewriting the extractor to use the forkedAgent pattern + tool calls; that's a separate PR.

So fork cost us JSON mode and gained us nothing.

### Verification

Direct curl against ollama/gemma4 confirms the endpoint honours JSON mode when the request has it:

```
$ curl http://localhost:11434/v1/chat/completions -d '{..., "response_format": {"type":"json_object"}, ...}'
{"memories":[{"content":"User: 你好"},{"content":"Assistant: hello."}],"relations":[]}
```

## Fix

- **`extract_memories_with_agent_id`** always delegates to standalone `extract_memories` (which already has JSON mode + `EXTRACTION_SYSTEM_PROMPT` + system-block caching).
- **Fork path code removed**: `try_forked_extract` + `kernel_handle` field dropped. `install_kernel_handle` kept as no-op to keep the kernel call site intact without an API cascade.
- **Decision path (`decide_action`) also gets `ResponseFormat::Json`** — `DECISION_SYSTEM_PROMPT` asks for `{"action": ..., "existing_id": ...}` and the same JSON mode guarantee should apply.
- **Log levels dropped** for cases that are expected / corrective, not errors:
  - `Failed to parse extraction/decision response JSON` → `debug!` (still surfaces with `RUST_LOG=debug`, no longer spamming WARN)
  - `Detected hallucinated action ...` → `info!`
  - `User requested action but LLM responded without tool calls — nudging retry` → `info!`

## Test plan

- [x] `cargo build -p librefang-runtime --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-runtime --lib proactive_memory` — 50 passed
- [x] curl ollama directly to confirm `response_format: {"type":"json_object"}` honoured
- [ ] Live test: refresh dashboard, chat with gemma4-backed agent, observe no `Failed to parse extraction response JSON` warn