### PR TITLE
release: v2026.4.21-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.21] - 2026-04-21
+
+### Added
+
+- Complete trigger feature — persistence, CRUD API, CLI subcommands, dashboard UI (#2827) (#2830) (@houko)
+- Add account_id to channel_send for explicit multi-bot routing (#2845) (@houko)
+- Add per-agent auto_evolve flag to skip background skill review (#2846) (@houko)
+- Implement MCP Roots capability (#2847) (@houko)
+
+### Fixed
+
+- Correct query invalidation and missing data flow across mutations (#2770) (@leszek3737)
+- Harden workflow save and draft state (#2781) (@leszek3737)
+- Align mutation flows across config channels goals and hands (#2782) (@leszek3737)
+- Unify dashboard query hooks and flow guards (#2783) (@leszek3737)
+- Exempt Unix/Slack-style timestamps from PII phone check (#2795) (@neo-wanderer)
+- Change wizard default ollama model to gemma3:4b (#2811) (@houko)
+- Strip empty assistant messages unconditionally (#2812) (@houko)
+- Auto-delete At-schedule jobs after execution (#2808) (#2814) (@houko)
+- Reimplement apply_seccomp_allowlist with libc::SYS_* constants (#2817) (@houko)
+- Allow dashboard static assets through auth gate (#2824) (@leszek3737)
+- Force wildcard bind for api_listen in Docker (#2825) (@leszek3737)
+- Resolve channel_bridge test deadlock that blocked CI for 6h (#2829) (@houko)
+- ChatPage — type safety, cache correctness, cleanup (#2832) (@leszek3737)
+- Correct event sequence in show_progress=false test (#2834) (@houko)
+- Exempt dashboard and static paths from GCRA rate limiter (#2835) (@houko)
+- Use main as default branch for ~/.librefang git repo (#2837) (@houko)
+- Task_claim() now matches assigned_to by name as well as UUID (#2844) (@houko)
+- Dashboard refresh no longer drops history — unify webui session with canonical (#2848) (@houko)
+- Type-safety and RC-safe fixes (#2849) (@leszek3737)
+- Unbreak --all-features build + stop warning on local LLM providers (#2850) (@houko)
+- Per-job session_mode override to fix context accumulation (#2647) (#2851) (@houko)
+- Proactive extraction loses JSON mode through fork path + log noise cleanup (#2852) (@houko)
+
+### Changed
+
+- RC cleanup for ModelsPage (#2833) (@leszek3737)
+- Relocate config backups under ~/.librefang/backups/ (#2838) (@houko)
+- Move stray state/log files out of ~/.librefang root (#2840) (@houko)
+
+### Documentation
+
+- Add unofficial wiki link and DeepWiki badge to READMEs (#2821) (@leszek3737)
+
+### Maintenance
+
+- Run Windows and macOS tests on affected crates for every Rust PR (#2819) (@houko)
+- Follow-up cleanup from #2783 review (#2820) (@houko)
+- Ignore rust_out build artifact (#2836) (@houko)
+
+
 ## [2026.4.20] - 2026-04-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "chrono",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "axum",
  "clap",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10997,7 +10997,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32205",
+  "version": "26.4.32211",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.20-rc1",
+  "version": "2026.4.21-beta1",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.20-rc1",
+  "version": "2026.4.21-beta1",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.20rc1",
+    version="2026.4.21b1",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.20-rc1"
+version = "2026.4.21-beta1"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.21-beta1 -->
## Release v2026.4.21-beta1

### Added

- Complete trigger feature — persistence, CRUD API, CLI subcommands, dashboard UI (#2827) (#2830) (@houko)
- Add account_id to channel_send for explicit multi-bot routing (#2845) (@houko)
- Add per-agent auto_evolve flag to skip background skill review (#2846) (@houko)
- Implement MCP Roots capability (#2847) (@houko)

### Fixed

- Correct query invalidation and missing data flow across mutations (#2770) (@leszek3737)
- Harden workflow save and draft state (#2781) (@leszek3737)
- Align mutation flows across config channels goals and hands (#2782) (@leszek3737)
- Unify dashboard query hooks and flow guards (#2783) (@leszek3737)
- Exempt Unix/Slack-style timestamps from PII phone check (#2795) (@neo-wanderer)
- Change wizard default ollama model to gemma3:4b (#2811) (@houko)
- Strip empty assistant messages unconditionally (#2812) (@houko)
- Auto-delete At-schedule jobs after execution (#2808) (#2814) (@houko)
- Reimplement apply_seccomp_allowlist with libc::SYS_* constants (#2817) (@houko)
- Allow dashboard static assets through auth gate (#2824) (@leszek3737)
- Force wildcard bind for api_listen in Docker (#2825) (@leszek3737)
- Resolve channel_bridge test deadlock that blocked CI for 6h (#2829) (@houko)
- ChatPage — type safety, cache correctness, cleanup (#2832) (@leszek3737)
- Correct event sequence in show_progress=false test (#2834) (@houko)
- Exempt dashboard and static paths from GCRA rate limiter (#2835) (@houko)
- Use main as default branch for ~/.librefang git repo (#2837) (@houko)
- Task_claim() now matches assigned_to by name as well as UUID (#2844) (@houko)
- Dashboard refresh no longer drops history — unify webui session with canonical (#2848) (@houko)
- Type-safety and RC-safe fixes (#2849) (@leszek3737)
- Unbreak --all-features build + stop warning on local LLM providers (#2850) (@houko)
- Per-job session_mode override to fix context accumulation (#2647) (#2851) (@houko)
- Proactive extraction loses JSON mode through fork path + log noise cleanup (#2852) (@houko)

### Changed

- RC cleanup for ModelsPage (#2833) (@leszek3737)
- Relocate config backups under ~/.librefang/backups/ (#2838) (@houko)
- Move stray state/log files out of ~/.librefang root (#2840) (@houko)

### Documentation

- Add unofficial wiki link and DeepWiki badge to READMEs (#2821) (@leszek3737)

### Maintenance

- Run Windows and macOS tests on affected crates for every Rust PR (#2819) (@houko)
- Follow-up cleanup from #2783 review (#2820) (@houko)
- Ignore rust_out build artifact (#2836) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.20-rc1...v2026.4.21-beta1