### PR TITLE
fix(channel_bridge): suppress NO_REPLY sentinel in streaming text bridge

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -428,6 +428,11 @@ fn start_stream_text_bridge_with_status(
                             debug!("Streaming bridge: filtered tool-use-adjacent text");
                         } else if looks_like_tool_call(&iter_buf) {
                             debug!("Streaming bridge: filtered leaked tool call text at ContentComplete");
+                        } else if librefang_runtime::silent_response::is_silent_response(&iter_buf)
+                        {
+                            debug!(
+                                "Streaming bridge: suppressed NO_REPLY sentinel at ContentComplete"
+                            );
                         } else if tx.send(std::mem::take(&mut iter_buf)).await.is_err() {
                             break;
                         }
@@ -494,10 +499,12 @@ fn start_stream_text_bridge_with_status(
         }
 
         if !iter_buf.is_empty() && !saw_tool_use {
-            if !looks_like_tool_call(&iter_buf) {
-                let _ = tx.send(iter_buf).await;
-            } else {
+            if looks_like_tool_call(&iter_buf) {
                 debug!("Streaming bridge: filtered leaked tool call text in final flush");
+            } else if librefang_runtime::silent_response::is_silent_response(&iter_buf) {
+                debug!("Streaming bridge: suppressed NO_REPLY sentinel in final flush");
+            } else {
+                let _ = tx.send(iter_buf).await;
             }
         }
     });


### PR DESCRIPTION
## Summary

- **Root cause**: `start_stream_text_bridge_with_status` buffers `TextDelta` events into `iter_buf` and flushes at `ContentComplete` without checking whether the text is a silent-response sentinel. The kernel's `result.silent` flag is only available *after* the stream drains — by then the Telegram adapter has already sent the "NO_REPLY" string to the user.
- **Fix**: Add `is_silent_response(&iter_buf)` guards at both flush sites (the `ContentComplete` branch and the post-loop final flush), mirroring the existing `looks_like_tool_call` filter.
- The non-streaming path (`send_message_with_sender`) already checked `result.silent` correctly; this brings the streaming path to parity.

## Test plan

- [ ] Agent configured with a group trigger sends `NO_REPLY` → Telegram receives no message (previously received literal "NO_REPLY")
- [ ] Normal agent responses still stream through unaffected
- [ ] Tool-use-adjacent text and raw tool-call text still filtered by existing guards
- [ ] `is_silent_response` unit tests in `librefang-runtime/src/silent_response.rs` continue to pass

Fixes #2649