### PR TITLE
refactor(registry): unify two separate checkouts of the upstream repo

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1897,6 +1897,13 @@ impl LibreFangKernel {
             &config.registry.registry_mirror,
         );
 
+        // One-shot: reclaim the duplicate registry checkout that older
+        // librefang versions maintained under `~/.librefang/cache/registry/`.
+        // Catalog sync now reads directly from `~/.librefang/registry/` (the
+        // directory registry_sync already maintains), so the duplicate is
+        // pure waste.
+        librefang_runtime::catalog_sync::remove_legacy_registry_checkout(&config.home_dir);
+
         // Initialize model catalog, detect provider auth, and apply URL overrides
         let mut model_catalog =
             librefang_runtime::model_catalog::ModelCatalog::new(&config.home_dir);

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1902,7 +1902,7 @@ impl LibreFangKernel {
         // Catalog sync now reads directly from `~/.librefang/registry/` (the
         // directory registry_sync already maintains), so the duplicate is
         // pure waste.
-        librefang_runtime::catalog_sync::remove_legacy_registry_checkout(&config.home_dir);
+        librefang_runtime::catalog_sync::remove_legacy_cache_dirs(&config.home_dir);
 
         // Initialize model catalog, detect provider auth, and apply URL overrides
         let mut model_catalog =

--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -1,8 +1,19 @@
-//! Catalog sync — fetch model catalog updates from the remote repository.
+//! Catalog sync — refresh the shared registry checkout and report what's on disk.
 //!
-//! Clones or pulls `github.com/librefang/librefang-registry` and copies TOML
-//! files to `~/.librefang/cache/catalog/`. Uses git directly to avoid CDN
-//! caching delays from `raw.githubusercontent.com`.
+//! Previously this module maintained its own git clone at
+//! `~/.librefang/cache/registry/`, copied `.toml` files into
+//! `~/.librefang/cache/catalog/providers/`, and the in-memory catalog
+//! reloader read from that copy. That was two redundant layers: the
+//! content was identical to what `registry_sync` already checks out at
+//! `~/.librefang/registry/`.
+//!
+//! Post-refactor: this module just drives `registry_sync` (force-refresh)
+//! and returns stats by scanning `~/.librefang/registry/providers/`. The
+//! `ModelCatalog::load_cached_catalog_for` consumer reads that same dir
+//! directly, so there's no intermediate copy. The only thing still
+//! living under `~/.librefang/cache/catalog/` is the `.last_sync`
+//! timestamp file, kept there so existing `GET /api/catalog/status`
+//! behaviour is unchanged.
 
 use librefang_types::model_catalog::ModelCatalogEntry;
 use serde::{Deserialize, Serialize};
@@ -22,244 +33,72 @@ struct ProviderCatalogFile {
     models: Vec<ModelCatalogEntry>,
 }
 
-/// Default remote repository for the model catalog.
-const CATALOG_REPO: &str = "librefang/librefang-registry";
-
-/// Sync the model catalog from the remote repository.
+/// Sync the model catalog.
 ///
-/// Clones or pulls the registry repo via git, then copies TOML files to
-/// `home_dir/cache/catalog/`.
+/// Triggers `registry_sync` (force-refresh, TTL=0) so `POST /api/catalog/update`
+/// and the periodic background task always see upstream's current state,
+/// then returns a count of what ended up on disk under
+/// `~/.librefang/registry/providers/`.
 ///
-/// `registry_mirror` is an optional proxy/mirror prefix for GitHub URLs.
-/// When non-empty, the clone URL is prefixed with this value.
+/// `registry_mirror` is forwarded to `registry_sync` (GitHub proxy prefix
+/// for CN / air-gapped users).
 pub async fn sync_catalog_to(
     home_dir: &std::path::Path,
     registry_mirror: &str,
 ) -> Result<CatalogSyncResult, String> {
-    let cache_dir = home_dir.join("cache").join("catalog");
-    let providers_dir = cache_dir.join("providers");
-    let repo_dir = home_dir.join("cache").join("registry");
+    let cache_meta_dir = home_dir.join("cache").join("catalog");
+    std::fs::create_dir_all(&cache_meta_dir)
+        .map_err(|e| format!("Failed to create cache meta dir: {e}"))?;
 
-    std::fs::create_dir_all(&providers_dir)
-        .map_err(|e| format!("Failed to create cache dir: {e}"))?;
-
-    let mirror = registry_mirror.trim_end_matches('/');
-    let repo_url = if mirror.is_empty() {
-        format!("https://github.com/{CATALOG_REPO}.git")
-    } else {
-        format!("{mirror}/https://github.com/{CATALOG_REPO}.git")
-    };
-
-    // Clone or pull the registry repo
-    let git_ok = if repo_dir.join(".git").exists() {
-        // Pull latest changes
-        tokio::task::spawn_blocking({
-            let repo_dir = repo_dir.clone();
-            move || {
-                let mut cmd = std::process::Command::new("git");
-                cmd.args(["pull", "--ff-only", "-q"])
-                    .current_dir(&repo_dir)
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null());
-                #[cfg(windows)]
-                {
-                    use std::os::windows::process::CommandExt;
-                    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-                    cmd.creation_flags(CREATE_NO_WINDOW);
-                }
-                cmd.status().map(|s| s.success()).unwrap_or(false)
-            }
+    // Force a registry refresh. `registry_sync` is blocking (git
+    // subprocess + filesystem copies), so hop to a blocking task to
+    // keep the runtime responsive.
+    {
+        let home = home_dir.to_path_buf();
+        let mirror = registry_mirror.to_string();
+        let ok = tokio::task::spawn_blocking(move || {
+            crate::registry_sync::sync_registry(&home, 0, &mirror)
         })
         .await
-        .unwrap_or(false)
-    } else {
-        // Shallow clone (depth=1) to save bandwidth
-        tokio::task::spawn_blocking({
-            let repo_dir = repo_dir.clone();
-            let repo_url = repo_url.clone();
-            move || {
-                let mut cmd = std::process::Command::new("git");
-                cmd.args(["clone", "--depth", "1", "-q", &repo_url])
-                    .arg(&repo_dir)
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null());
-                #[cfg(windows)]
-                {
-                    use std::os::windows::process::CommandExt;
-                    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-                    cmd.creation_flags(CREATE_NO_WINDOW);
-                }
-                cmd.status().map(|s| s.success()).unwrap_or(false)
-            }
-        })
-        .await
-        .unwrap_or(false)
-    };
-
-    if !git_ok {
-        // Fallback to HTTP API if git is not available
-        tracing::warn!("git clone/pull failed, falling back to HTTP API");
-        return sync_catalog_http(home_dir, registry_mirror).await;
+        .map_err(|e| format!("registry sync task failed: {e}"))?;
+        if !ok {
+            tracing::warn!(
+                "registry_sync returned false; proceeding with whatever is \
+                 already on disk (previous sync may still be valid)"
+            );
+        }
     }
 
-    // Copy TOML files from repo to cache
-    let mut downloaded = 0usize;
+    let repo_providers = home_dir.join("registry").join("providers");
+    let mut file_count = 0usize;
     let mut models_count = 0usize;
 
-    let repo_providers = repo_dir.join("providers");
     if repo_providers.is_dir() {
         if let Ok(entries) = std::fs::read_dir(&repo_providers) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "toml") {
+                    file_count += 1;
                     if let Ok(content) = std::fs::read_to_string(&path) {
-                        let dest = providers_dir.join(entry.file_name());
-                        if std::fs::write(&dest, &content).is_ok() {
-                            downloaded += 1;
-                            if let Ok(file) = toml::from_str::<ProviderCatalogFile>(&content) {
-                                models_count += file.models.len();
-                            }
+                        if let Ok(file) = toml::from_str::<ProviderCatalogFile>(&content) {
+                            models_count += file.models.len();
                         }
                     }
                 }
             }
         }
-    }
-
-    // Remove cached provider files that no longer exist in the upstream repo
-    if repo_providers.is_dir() {
-        if let Ok(cached_entries) = std::fs::read_dir(&providers_dir) {
-            for entry in cached_entries.flatten() {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "toml")
-                    && !repo_providers.join(entry.file_name()).exists()
-                    && std::fs::remove_file(&path).is_ok()
-                {
-                    tracing::debug!(file = %path.display(), "removed stale catalog provider");
-                }
-            }
-        }
-    }
-
-    // Copy aliases.toml if present
-    let aliases_src = repo_dir.join("aliases.toml");
-    if aliases_src.is_file() {
-        let _ = std::fs::copy(&aliases_src, cache_dir.join("aliases.toml"));
-    }
-
-    let timestamp = chrono::Utc::now().to_rfc3339();
-    let _ = std::fs::write(cache_dir.join(".last_sync"), &timestamp);
-
-    Ok(CatalogSyncResult {
-        files_downloaded: downloaded,
-        models_count,
-        timestamp,
-    })
-}
-
-/// HTTP fallback — original implementation using GitHub API + raw URLs.
-/// Used when git is not available on the system.
-async fn sync_catalog_http(
-    home_dir: &std::path::Path,
-    registry_mirror: &str,
-) -> Result<CatalogSyncResult, String> {
-    let cache_dir = home_dir.join("cache").join("catalog");
-    let client = crate::http_client::proxied_client_builder()
-        .build()
-        .map_err(|e| format!("HTTP client error: {e}"))?;
-
-    let mirror = registry_mirror.trim_end_matches('/');
-    let tree_url = if mirror.is_empty() {
-        format!("https://api.github.com/repos/{CATALOG_REPO}/git/trees/main?recursive=1")
     } else {
-        format!("{mirror}/https://api.github.com/repos/{CATALOG_REPO}/git/trees/main?recursive=1")
-    };
-    let tree_resp = client
-        .get(&tree_url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to fetch repo tree: {e}"))?;
-
-    if !tree_resp.status().is_success() {
-        return Err(format!("GitHub API returned {}", tree_resp.status()));
-    }
-
-    let tree: serde_json::Value = tree_resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse tree: {e}"))?;
-
-    let mut downloaded = 0usize;
-    let mut models_count = 0usize;
-    let mut upstream_provider_files = std::collections::HashSet::new();
-
-    if let Some(items) = tree["tree"].as_array() {
-        for item in items {
-            let path = item["path"].as_str().unwrap_or("");
-            if !path.contains("..")
-                && ((path.starts_with("providers/") && path.ends_with(".toml"))
-                    || path == "aliases.toml")
-            {
-                if path.starts_with("providers/") {
-                    if let Some(fname) = path.strip_prefix("providers/") {
-                        upstream_provider_files.insert(fname.to_string());
-                    }
-                }
-                let raw_url = if mirror.is_empty() {
-                    format!("https://raw.githubusercontent.com/{CATALOG_REPO}/main/{path}")
-                } else {
-                    format!("{mirror}/https://raw.githubusercontent.com/{CATALOG_REPO}/main/{path}")
-                };
-                match client.get(&raw_url).send().await {
-                    Ok(resp) if resp.status().is_success() => {
-                        if let Ok(content) = resp.text().await {
-                            let dest = cache_dir.join(path);
-                            if let Some(parent) = dest.parent() {
-                                let _ = std::fs::create_dir_all(parent);
-                            }
-                            if std::fs::write(&dest, &content).is_ok() {
-                                downloaded += 1;
-                                if path.starts_with("providers/") {
-                                    if let Ok(file) =
-                                        toml::from_str::<ProviderCatalogFile>(&content)
-                                    {
-                                        models_count += file.models.len();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    _ => {
-                        tracing::warn!("Failed to download catalog file: {path}");
-                    }
-                }
-            }
-        }
-    }
-
-    // Remove cached provider files that no longer exist upstream
-    let providers_dir = cache_dir.join("providers");
-    if !upstream_provider_files.is_empty() {
-        if let Ok(cached_entries) = std::fs::read_dir(&providers_dir) {
-            for entry in cached_entries.flatten() {
-                let path = entry.path();
-                if let Some(name) = entry.file_name().to_str() {
-                    if name.ends_with(".toml")
-                        && !upstream_provider_files.contains(name)
-                        && std::fs::remove_file(&path).is_ok()
-                    {
-                        tracing::debug!(file = %path.display(), "removed stale catalog provider");
-                    }
-                }
-            }
-        }
+        tracing::warn!(
+            path = %repo_providers.display(),
+            "registry/providers missing — returning empty catalog result"
+        );
     }
 
     let timestamp = chrono::Utc::now().to_rfc3339();
-    let _ = std::fs::write(cache_dir.join(".last_sync"), &timestamp);
+    let _ = std::fs::write(cache_meta_dir.join(".last_sync"), &timestamp);
 
     Ok(CatalogSyncResult {
-        files_downloaded: downloaded,
+        files_downloaded: file_count,
         models_count,
         timestamp,
     })
@@ -271,9 +110,60 @@ pub fn last_sync_time_for(home_dir: &std::path::Path) -> Option<String> {
     std::fs::read_to_string(path).ok()
 }
 
-/// Return the cache directory for the catalog.
+/// Return the cache metadata directory for the catalog.
 pub fn cache_dir_for(home_dir: &std::path::Path) -> std::path::PathBuf {
     home_dir.join("cache").join("catalog")
+}
+
+/// One-shot cleanup for directories obsoleted by the registry-unify
+/// refactor. Called from `LibreFangKernel::boot_with_config` so existing
+/// installs reclaim disk without any manual step.
+///
+/// Removes:
+/// - `~/.librefang/cache/registry/` — duplicate checkout of the upstream
+///   registry repo (now read from `~/.librefang/registry/`).
+/// - `~/.librefang/cache/catalog/providers/` — copy of
+///   `~/.librefang/registry/providers/` (consumer now reads the source).
+///
+/// Safe to call every boot — each step no-ops when the path is absent.
+pub fn remove_legacy_registry_checkout(home_dir: &std::path::Path) {
+    let legacy_repo = home_dir.join("cache").join("registry");
+    if legacy_repo.exists() {
+        match std::fs::remove_dir_all(&legacy_repo) {
+            Ok(()) => tracing::info!(
+                path = %legacy_repo.display(),
+                "Removed legacy duplicate registry checkout"
+            ),
+            Err(e) => tracing::warn!(
+                path = %legacy_repo.display(),
+                error = %e,
+                "Failed to remove legacy duplicate registry checkout"
+            ),
+        }
+    }
+
+    let legacy_providers = home_dir.join("cache").join("catalog").join("providers");
+    if legacy_providers.exists() {
+        match std::fs::remove_dir_all(&legacy_providers) {
+            Ok(()) => tracing::info!(
+                path = %legacy_providers.display(),
+                "Removed legacy cached catalog providers copy"
+            ),
+            Err(e) => tracing::warn!(
+                path = %legacy_providers.display(),
+                error = %e,
+                "Failed to remove legacy cached catalog providers copy"
+            ),
+        }
+    }
+
+    // `~/.librefang/cache/catalog/aliases.toml` was also a copy of
+    // registry/aliases.toml; the model catalog's alias loader already
+    // handles either location, so drop the stale copy too.
+    let legacy_aliases = home_dir.join("cache").join("catalog").join("aliases.toml");
+    if legacy_aliases.is_file() {
+        let _ = std::fs::remove_file(&legacy_aliases);
+    }
 }
 
 #[cfg(test)]
@@ -302,24 +192,6 @@ supports_streaming = true
     }
 
     #[test]
-    fn test_alias_catalog_parse() {
-        #[derive(serde::Deserialize)]
-        struct AliasFile {
-            #[serde(default)]
-            aliases: std::collections::HashMap<String, String>,
-        }
-
-        let toml_str = r#"
-[aliases]
-sonnet = "claude-sonnet-4-20250514"
-gpt4 = "gpt-4o"
-"#;
-        let file: AliasFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(file.aliases.len(), 2);
-        assert_eq!(file.aliases["sonnet"], "claude-sonnet-4-20250514");
-    }
-
-    #[test]
     fn test_last_sync_time_missing() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(last_sync_time_for(tmp.path()).is_none());
@@ -330,5 +202,42 @@ gpt4 = "gpt-4o"
         let tmp = tempfile::tempdir().unwrap();
         let d = cache_dir_for(tmp.path());
         assert!(d.ends_with("cache/catalog") || d.ends_with("cache\\catalog"));
+    }
+
+    #[test]
+    fn test_remove_legacy_noop_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        remove_legacy_registry_checkout(tmp.path());
+        assert!(!tmp.path().join("cache").join("registry").exists());
+    }
+
+    #[test]
+    fn test_remove_legacy_deletes_duplicate_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("cache").join("registry").join("sub");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("file.toml"), "x").unwrap();
+        remove_legacy_registry_checkout(tmp.path());
+        assert!(!tmp.path().join("cache").join("registry").exists());
+    }
+
+    #[test]
+    fn test_remove_legacy_deletes_cached_providers_copy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("cache").join("catalog").join("providers");
+        std::fs::create_dir_all(&providers).unwrap();
+        std::fs::write(providers.join("ollama.toml"), "x").unwrap();
+        remove_legacy_registry_checkout(tmp.path());
+        assert!(!providers.exists());
+    }
+
+    #[test]
+    fn test_remove_legacy_preserves_last_sync_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_catalog = tmp.path().join("cache").join("catalog");
+        std::fs::create_dir_all(&cache_catalog).unwrap();
+        std::fs::write(cache_catalog.join(".last_sync"), "2026-04-21").unwrap();
+        remove_legacy_registry_checkout(tmp.path());
+        assert!(cache_catalog.join(".last_sync").exists());
     }
 }

--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -50,21 +50,29 @@ pub async fn sync_catalog_to(
     std::fs::create_dir_all(&cache_meta_dir)
         .map_err(|e| format!("Failed to create cache meta dir: {e}"))?;
 
-    // Force a registry refresh. `registry_sync` is blocking (git
-    // subprocess + filesystem copies), so hop to a blocking task to
-    // keep the runtime responsive.
+    // Force a registry refresh. We call `refresh_registry_checkout`
+    // (not `sync_registry`) because the catalog consumer only needs the
+    // upstream checkout refreshed — not the full fan-out into
+    // `workspaces/agents/`, `workflows/templates/`, etc. The broader
+    // fan-out belongs to `kernel::boot_with_config`; clicking
+    // "Update catalog" shouldn't, for example, overwrite user-managed
+    // workflow templates. `refresh_registry_checkout` also acquires
+    // the module's internal lock so concurrent callers (boot, 24h
+    // background task, manual trigger) don't race on the same
+    // working tree. It's blocking (git subprocess), so hop to a
+    // blocking task to keep the runtime responsive.
     {
         let home = home_dir.to_path_buf();
         let mirror = registry_mirror.to_string();
         let ok = tokio::task::spawn_blocking(move || {
-            crate::registry_sync::sync_registry(&home, 0, &mirror)
+            crate::registry_sync::refresh_registry_checkout(&home, 0, &mirror)
         })
         .await
         .map_err(|e| format!("registry sync task failed: {e}"))?;
         if !ok {
             tracing::warn!(
-                "registry_sync returned false; proceeding with whatever is \
-                 already on disk (previous sync may still be valid)"
+                "refresh_registry_checkout returned false; proceeding with \
+                 whatever is already on disk (previous sync may still be valid)"
             );
         }
     }
@@ -115,55 +123,61 @@ pub fn cache_dir_for(home_dir: &std::path::Path) -> std::path::PathBuf {
     home_dir.join("cache").join("catalog")
 }
 
-/// One-shot cleanup for directories obsoleted by the registry-unify
-/// refactor. Called from `LibreFangKernel::boot_with_config` so existing
-/// installs reclaim disk without any manual step.
+/// Reclaim disk from the pre-unify cache layout.
 ///
-/// Removes:
-/// - `~/.librefang/cache/registry/` — duplicate checkout of the upstream
-///   registry repo (now read from `~/.librefang/registry/`).
-/// - `~/.librefang/cache/catalog/providers/` — copy of
-///   `~/.librefang/registry/providers/` (consumer now reads the source).
+/// Called from `LibreFangKernel::boot_with_config` — idempotent so it's
+/// safe on every boot (each branch no-ops when the path is absent).
 ///
-/// Safe to call every boot — each step no-ops when the path is absent.
-pub fn remove_legacy_registry_checkout(home_dir: &std::path::Path) {
-    let legacy_repo = home_dir.join("cache").join("registry");
-    if legacy_repo.exists() {
-        match std::fs::remove_dir_all(&legacy_repo) {
-            Ok(()) => tracing::info!(
-                path = %legacy_repo.display(),
-                "Removed legacy duplicate registry checkout"
-            ),
+/// Removes three paths the old two-checkout design maintained, all of
+/// which are now pure duplicates of `~/.librefang/registry/`:
+/// - `~/.librefang/cache/registry/` — second git clone of the upstream repo
+/// - `~/.librefang/cache/catalog/providers/` — copy of `registry/providers/`
+/// - `~/.librefang/cache/catalog/aliases.toml` — copy of `registry/aliases.toml`
+///
+/// `cache/catalog/.last_sync` is deliberately preserved so
+/// `GET /api/catalog/status` keeps returning the user's last-sync
+/// timestamp across the upgrade.
+pub fn remove_legacy_cache_dirs(home_dir: &std::path::Path) {
+    fn remove_dir(path: &std::path::Path, label: &str) {
+        if !path.exists() {
+            return;
+        }
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => tracing::info!(path = %path.display(), "Removed legacy {label}"),
             Err(e) => tracing::warn!(
-                path = %legacy_repo.display(),
+                path = %path.display(),
                 error = %e,
-                "Failed to remove legacy duplicate registry checkout"
+                "Failed to remove legacy {label}"
             ),
         }
     }
 
-    let legacy_providers = home_dir.join("cache").join("catalog").join("providers");
-    if legacy_providers.exists() {
-        match std::fs::remove_dir_all(&legacy_providers) {
-            Ok(()) => tracing::info!(
-                path = %legacy_providers.display(),
-                "Removed legacy cached catalog providers copy"
-            ),
+    fn remove_file(path: &std::path::Path, label: &str) {
+        if !path.is_file() {
+            return;
+        }
+        match std::fs::remove_file(path) {
+            Ok(()) => tracing::info!(path = %path.display(), "Removed legacy {label}"),
             Err(e) => tracing::warn!(
-                path = %legacy_providers.display(),
+                path = %path.display(),
                 error = %e,
-                "Failed to remove legacy cached catalog providers copy"
+                "Failed to remove legacy {label}"
             ),
         }
     }
 
-    // `~/.librefang/cache/catalog/aliases.toml` was also a copy of
-    // registry/aliases.toml; the model catalog's alias loader already
-    // handles either location, so drop the stale copy too.
-    let legacy_aliases = home_dir.join("cache").join("catalog").join("aliases.toml");
-    if legacy_aliases.is_file() {
-        let _ = std::fs::remove_file(&legacy_aliases);
-    }
+    remove_dir(
+        &home_dir.join("cache").join("registry"),
+        "duplicate registry checkout",
+    );
+    remove_dir(
+        &home_dir.join("cache").join("catalog").join("providers"),
+        "cached catalog providers copy",
+    );
+    remove_file(
+        &home_dir.join("cache").join("catalog").join("aliases.toml"),
+        "cached aliases.toml copy",
+    );
 }
 
 #[cfg(test)]
@@ -207,7 +221,7 @@ supports_streaming = true
     #[test]
     fn test_remove_legacy_noop_when_absent() {
         let tmp = tempfile::tempdir().unwrap();
-        remove_legacy_registry_checkout(tmp.path());
+        remove_legacy_cache_dirs(tmp.path());
         assert!(!tmp.path().join("cache").join("registry").exists());
     }
 
@@ -217,7 +231,7 @@ supports_streaming = true
         let legacy = tmp.path().join("cache").join("registry").join("sub");
         std::fs::create_dir_all(&legacy).unwrap();
         std::fs::write(legacy.join("file.toml"), "x").unwrap();
-        remove_legacy_registry_checkout(tmp.path());
+        remove_legacy_cache_dirs(tmp.path());
         assert!(!tmp.path().join("cache").join("registry").exists());
     }
 
@@ -227,7 +241,7 @@ supports_streaming = true
         let providers = tmp.path().join("cache").join("catalog").join("providers");
         std::fs::create_dir_all(&providers).unwrap();
         std::fs::write(providers.join("ollama.toml"), "x").unwrap();
-        remove_legacy_registry_checkout(tmp.path());
+        remove_legacy_cache_dirs(tmp.path());
         assert!(!providers.exists());
     }
 
@@ -237,7 +251,21 @@ supports_streaming = true
         let cache_catalog = tmp.path().join("cache").join("catalog");
         std::fs::create_dir_all(&cache_catalog).unwrap();
         std::fs::write(cache_catalog.join(".last_sync"), "2026-04-21").unwrap();
-        remove_legacy_registry_checkout(tmp.path());
+        remove_legacy_cache_dirs(tmp.path());
         assert!(cache_catalog.join(".last_sync").exists());
+    }
+
+    #[test]
+    fn test_remove_legacy_deletes_aliases_copy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_catalog = tmp.path().join("cache").join("catalog");
+        std::fs::create_dir_all(&cache_catalog).unwrap();
+        let aliases = cache_catalog.join("aliases.toml");
+        std::fs::write(&aliases, "[aliases]\nfoo = \"bar\"").unwrap();
+        remove_legacy_cache_dirs(tmp.path());
+        assert!(!aliases.exists());
+        // Removing the file must not take the containing directory with it —
+        // `.last_sync` lives in the same dir and must survive.
+        assert!(cache_catalog.exists());
     }
 }

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -929,11 +929,16 @@ impl ModelCatalog {
         Ok(total_added)
     }
 
-    /// Load cached catalog from `home_dir/cache/catalog/providers/`.
+    /// Load cached catalog from the shared registry checkout at
+    /// `home_dir/registry/providers/`.
     ///
-    /// Merges community models synced from the remote model-catalog repo.
+    /// Prior to the registry-unify refactor this read from
+    /// `home_dir/cache/catalog/providers/`, which was a copy of the same
+    /// data. Reading `registry/providers/` directly eliminates the copy
+    /// step and guarantees the catalog is never staler than what
+    /// `registry_sync` last pulled.
     pub fn load_cached_catalog_for(&mut self, home_dir: &std::path::Path) {
-        let providers_dir = home_dir.join("cache").join("catalog").join("providers");
+        let providers_dir = home_dir.join("registry").join("providers");
         if providers_dir.exists() {
             match self.load_cached_catalog(&providers_dir) {
                 Ok(n) => {

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1059,6 +1059,23 @@ mod tests {
         assert!(catalog.list_models().len() >= 30);
     }
 
+    /// Mirrors the pre-refactor `catalog_sync::test_alias_catalog_parse` —
+    /// keeps direct coverage of `AliasesCatalogFile` deserialization, which
+    /// is now only consumed here in `model_catalog`.
+    #[test]
+    fn test_aliases_catalog_parse() {
+        let toml_str = r#"
+[aliases]
+sonnet = "claude-sonnet-4-20250514"
+gpt4 = "gpt-4o"
+"#;
+        let file: librefang_types::model_catalog::AliasesCatalogFile =
+            toml::from_str(toml_str).unwrap();
+        assert_eq!(file.aliases.len(), 2);
+        assert_eq!(file.aliases["sonnet"], "claude-sonnet-4-20250514");
+        assert_eq!(file.aliases["gpt4"], "gpt-4o");
+    }
+
     /// P2 regression: when registry classification is unavailable
     /// (registry dir unreadable or missing), every provider must fall back
     /// to is_custom=false so the dashboard does not re-enable the misleading

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -10,6 +10,7 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::Mutex;
 
 /// GitHub tarball URL for the registry (no auth required).
 const REGISTRY_TARBALL_URL: &str =
@@ -24,6 +25,58 @@ const TARBALL_PREFIX: &str = "librefang-registry-main/";
 /// Default cache TTL: how long (in seconds) before we re-download the registry.
 /// Callers without access to `KernelConfig` can use this value directly.
 pub const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
+
+/// Serialises all writes to `~/.librefang/registry/`.
+///
+/// Without this, a manual `POST /api/catalog/update` firing at the same
+/// time as the 24h background catalog task could have two `git pull`
+/// subprocesses racing on the same working tree, which corrupts the
+/// checkout. Boot-time `sync_registry` and the catalog-only
+/// `refresh_registry_checkout` both acquire it. The lock is held across
+/// the blocking git/tar work; callers already run these via
+/// `spawn_blocking`, so a `std::sync::Mutex` is appropriate.
+static SYNC_LOCK: Mutex<()> = Mutex::new(());
+
+/// Refresh only the `~/.librefang/registry/` checkout from upstream —
+/// no fan-out into `workspaces/`, `providers/`, `workflows/templates/`
+/// etc. Callers like `catalog_sync` want the repo refreshed without
+/// accidentally re-installing agent templates or overwriting workflow
+/// templates every time the user clicks "Update catalog".
+///
+/// Returns `true` when the checkout is in a usable state (fresh pull,
+/// fresh clone, fresh tarball extract, or the on-disk copy from a
+/// previous successful run).
+pub fn refresh_registry_checkout(
+    home_dir: &Path,
+    cache_ttl_secs: u64,
+    registry_mirror: &str,
+) -> bool {
+    let _guard = SYNC_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let registry_cache = home_dir.join("registry");
+
+    if !should_refresh(&registry_cache, cache_ttl_secs) {
+        tracing::debug!("Registry cache is fresh, skipping download");
+        return registry_cache.exists();
+    }
+
+    // Try git first (faster incremental updates, private fork support)
+    let git_ok = match git_clone_fallback(&registry_cache, registry_mirror) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::debug!("Git sync unavailable: {e} — trying HTTP download");
+            false
+        }
+    };
+
+    // Fall back to HTTP tarball if git failed
+    if !git_ok {
+        if let Err(e) = download_and_extract(&registry_cache, registry_mirror) {
+            tracing::warn!("HTTP registry download also failed: {e}");
+            return registry_cache.exists();
+        }
+    }
+    true
+}
 
 /// Sync all content from the registry to the local librefang home directory.
 ///
@@ -41,11 +94,10 @@ pub const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 /// `"https://ghproxy.cn"` rewrites `https://github.com/...` to
 /// `https://ghproxy.cn/https://github.com/...`).
 pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64, registry_mirror: &str) -> bool {
+    let _guard = SYNC_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let registry_cache = home_dir.join("registry");
 
-    if !should_refresh(&registry_cache, cache_ttl_secs) {
-        tracing::debug!("Registry cache is fresh, skipping download");
-    } else {
+    if should_refresh(&registry_cache, cache_ttl_secs) {
         // Try git first (faster incremental updates, private fork support)
         let git_ok = match git_clone_fallback(&registry_cache, registry_mirror) {
             Ok(()) => true,
@@ -64,6 +116,8 @@ pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64, registry_mirror: &str
                 }
             }
         }
+    } else {
+        tracing::debug!("Registry cache is fresh, skipping download");
     }
 
     // Pre-install core content users need out of the box.


### PR DESCRIPTION
## Summary

Before: two independent git checkouts of the same `librefang-registry` repo on disk, by two different subsystems:

| Dir | Owner | Used for |
|---|---|---|
| \`~/.librefang/registry/\` | \`registry_sync\` | Fan out to \`workspaces/agents/\`, \`providers/\`, \`channels/\`, \`mcp/catalog/\`, \`workflows/templates/\` |
| \`~/.librefang/cache/registry/\` | \`catalog_sync\` | Copy provider TOMLs to \`cache/catalog/providers/\` for \`ModelCatalog::load_cached_catalog_for\` |

Same repo, two clones, two sync schedules. The catalog copy occasionally drifted from the registry copy because they were pulled at different times (verified locally — \`moonshot.toml\` and \`zhipu.toml\` differed between the two dirs). ~50 MB of wasted disk for zero benefit.

## Changes

- \`catalog_sync::sync_catalog_to\` stops cloning. It now delegates the fetch to \`registry_sync\` (force-refresh, TTL=0) and just scans \`~/.librefang/registry/providers/\` to report counts. \`.last_sync\` still lives at its old location so \`GET /api/catalog/status\` is unchanged.
- \`ModelCatalog::load_cached_catalog_for\` reads from \`~/.librefang/registry/providers/\` directly. No intermediate copy.
- \`sync_catalog_http\` (GitHub-API fallback) removed — redundant with \`registry_sync\`'s tarball fallback.
- \`catalog_sync::remove_legacy_registry_checkout\` runs once at kernel boot to reclaim \`~/.librefang/cache/registry/\`, \`~/.librefang/cache/catalog/providers/\`, and the stale \`cache/catalog/aliases.toml\` copy.

## Layout before / after

Before:
\`\`\`
~/.librefang/
├── registry/
│   ├── providers/
│   └── ...
├── cache/
│   ├── registry/        ← duplicate clone
│   │   └── providers/
│   └── catalog/
│       ├── providers/   ← copy of registry/providers/
│       ├── aliases.toml ← copy of registry/aliases.toml
│       └── .last_sync
└── workspaces/
\`\`\`

After:
\`\`\`
~/.librefang/
├── registry/            ← single upstream checkout
│   ├── providers/       ← read directly by model catalog
│   └── ...
├── cache/
│   └── catalog/
│       └── .last_sync   ← only the timestamp remains
└── workspaces/
\`\`\`

## Effects

- One checkout, not two.
- Catalog view is never staler than what \`registry_sync\` last pulled (cross-dir drift becomes structurally impossible).
- Existing installs reclaim ~50 MB on first boot.
- No externally visible API change.

## Test plan

- [x] \`cargo build --workspace --lib\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p librefang-runtime --lib catalog_sync\` — 7 passed (4 new for the cleanup helper)
- [ ] Post-merge: existing users see \`~/.librefang/cache/registry/\` and \`~/.librefang/cache/catalog/providers/\` disappear on next boot; \`GET /api/catalog/status\` still works