### PR TITLE
fix(dashboard/terminal): fix height overflow, invalid resize errors, and polish UI

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from "@tanstack/react-router";
+import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -407,10 +407,15 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
   );
 }
 
+// Routes that must fill the remaining viewport height without scrolling.
+const FULL_HEIGHT_ROUTES = new Set(["/terminal"]);
+
 export function App() {
   const { t } = useTranslation();
   const theme = useUIStore((s) => s.theme);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
+  const { location } = useRouterState();
+  const isFullHeightPage = FULL_HEIGHT_ROUTES.has(location.pathname);
   const language = useUIStore((s) => s.language);
   const setLanguage = useUIStore((s) => s.setLanguage);
   const isMobileMenuOpen = useUIStore((s) => s.isMobileMenuOpen);
@@ -794,10 +799,20 @@ export function App() {
           </div>
         </header>
 
-        <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden bg-main" tabIndex={-1}>
-          <div className="w-full p-3 sm:p-4 lg:p-8">
-            <Outlet />
-          </div>
+        <main
+          id="main-content"
+          className={`bg-main ${isFullHeightPage ? "flex flex-col flex-1 overflow-hidden" : "flex-1 overflow-y-auto overflow-x-hidden"}`}
+          tabIndex={-1}
+        >
+          {isFullHeightPage ? (
+            <div className="flex flex-col flex-1 min-h-0">
+              <Outlet />
+            </div>
+          ) : (
+            <div className="w-full p-3 sm:p-4 lg:p-8">
+              <Outlet />
+            </div>
+          )}
         </main>
       </div>
 

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -18,6 +18,19 @@ import { ApiError, type TerminalWindow } from "../lib/http/client";
 import type { Terminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 
+// Must match the server-side MAX_COLS / MAX_ROWS constants in routes/terminal.rs.
+const TERM_MIN_COLS = 1;
+const TERM_MAX_COLS = 1000;
+const TERM_MIN_ROWS = 1;
+const TERM_MAX_ROWS = 500;
+
+function clampTermSize(cols: number, rows: number): { cols: number; rows: number } | null {
+  const c = Math.max(TERM_MIN_COLS, Math.min(TERM_MAX_COLS, Math.floor(cols)));
+  const r = Math.max(TERM_MIN_ROWS, Math.min(TERM_MAX_ROWS, Math.floor(rows)));
+  if (!Number.isFinite(c) || !Number.isFinite(r)) return null;
+  return { cols: c, rows: r };
+}
+
 interface TerminalTabsProps {
   ws: WebSocket | null;
   tmuxAvailable: boolean;
@@ -71,7 +84,8 @@ export function TerminalTabs({
         const fit = fitAddonRef.current;
         if (!term || !fit || !ws || ws.readyState !== WebSocket.OPEN) return;
         fit.fit();
-        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+        const size = clampTermSize(term.cols, term.rows);
+        if (size) ws.send(JSON.stringify({ type: "resize", ...size }));
       }, 100);
       settleTimeoutsRef.current = [tid];
     },
@@ -127,7 +141,6 @@ export function TerminalTabs({
     if (!editingId) return;
     const name = editValue.trim();
     const current = windowsRef.current.find((w) => w.id === editingId);
-    // Nothing changed or empty → just close the editor.
     if (!current || name === "" || name === current.name) {
       cancelRename();
       return;
@@ -142,7 +155,7 @@ export function TerminalTabs({
       { windowId: idToRename, name },
       {
         onError: () => addToast(t("terminal.tabs.rename_failed"), "error"),
-      },
+      }
     );
   }, [editingId, editValue, renameMutation, cancelRename, addToast, t]);
 
@@ -176,9 +189,10 @@ export function TerminalTabs({
   if (!tmuxAvailable) return null;
 
   const atLimit = windows.length >= maxWindows;
+  const nearLimit = windows.length >= Math.max(2, maxWindows - 2);
 
   return (
-    <div className="flex items-center gap-1 px-2 py-1 bg-gray-900/80 border-b border-gray-700/50 overflow-x-auto shrink-0">
+    <div className="flex items-end gap-0.5 px-2 pt-1.5 bg-[#161b22] border-b border-gray-700/60 overflow-x-auto shrink-0 scrollbar-thin">
       {windows.map((w) => {
         const isActive = w.id === displayedActiveWindowId;
         const isEditing = editingId === w.id;
@@ -191,17 +205,16 @@ export function TerminalTabs({
               startRename(w);
             }}
             onAuxClick={(e) => {
-              // Middle-click closes, matching VS Code / browser tab behavior.
               if (e.button === 1 && windows.length > 1) {
                 e.preventDefault();
                 void handleCloseTab(w.id, e);
               }
             }}
             title={isEditing ? undefined : t("terminal.tabs.rename_hint")}
-            className={`group flex items-center gap-1 px-3 py-1 rounded-t text-sm whitespace-nowrap transition-colors cursor-pointer select-none ${
+            className={`group flex items-center gap-1.5 px-3 py-1.5 text-xs whitespace-nowrap transition-colors cursor-pointer select-none rounded-t-md border-t border-x ${
               isActive
-                ? "bg-[#1a1a2e] text-white border-t border-x border-gray-600"
-                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/50"
+                ? "bg-[#0d1117] text-gray-200 border-gray-700/70 -mb-px pb-[7px]"
+                : "text-gray-500 border-transparent hover:text-gray-300 hover:bg-gray-800/40 mb-0"
             }`}
           >
             {isEditing ? (
@@ -224,21 +237,23 @@ export function TerminalTabs({
                 onDoubleClick={(e) => e.stopPropagation()}
                 maxLength={64}
                 aria-label={t("terminal.tabs.name_label")}
-                className="bg-gray-800 text-white text-sm px-1 py-0 rounded border border-blue-500 outline-none w-32"
+                className="bg-gray-900 text-gray-200 text-xs px-1.5 py-0.5 rounded border border-blue-500/70 outline-none w-28"
               />
             ) : (
-              <span>{w.name || t("terminal.tabs.unnamed")}</span>
+              <span className="max-w-[120px] truncate">
+                {w.name || t("terminal.tabs.unnamed")}
+              </span>
             )}
             {!isEditing && windows.length > 1 && (
               <span
                 role="button"
                 tabIndex={0}
                 aria-label={t("terminal.tabs.close")}
-                onClick={(e) => handleCloseTab(w.id, e)}
+                onClick={(e) => void handleCloseTab(w.id, e)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") handleCloseTab(w.id, e);
+                  if (e.key === "Enter" || e.key === " ") void handleCloseTab(w.id, e);
                 }}
-                className={`text-gray-500 hover:text-red-400 cursor-pointer transition-opacity ${
+                className={`text-gray-600 hover:text-red-400 cursor-pointer transition-colors rounded ${
                   isActive ? "opacity-100" : "opacity-0 group-hover:opacity-100"
                 }`}
               >
@@ -248,25 +263,22 @@ export function TerminalTabs({
           </div>
         );
       })}
+
       <button
         onClick={() => void handleCreate()}
         disabled={atLimit || createMutation.isPending}
         aria-label={t("terminal.tabs.new")}
-        className="p-1 text-gray-500 hover:text-gray-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-500"
-        title={
-          atLimit
-            ? t("terminal.tabs.limit_reached")
-            : t("terminal.tabs.new")
-        }
+        title={atLimit ? t("terminal.tabs.limit_reached") : t("terminal.tabs.new")}
+        className="mb-0.5 flex items-center justify-center w-6 h-6 rounded text-gray-600 hover:text-gray-300 hover:bg-gray-800/50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-gray-600 disabled:hover:bg-transparent"
       >
-        <Plus className="h-4 w-4" />
+        <Plus className="h-3.5 w-3.5" />
       </button>
-      <span className="ml-auto pr-1 text-xs text-gray-500 shrink-0 tabular-nums">
-        {t("terminal.tabs.counter", {
-          used: windows.length,
-          total: maxWindows,
-        })}
-      </span>
+
+      {nearLimit && (
+        <span className="ml-auto pr-1 pb-1 text-[10px] text-gray-600 shrink-0 tabular-nums self-center">
+          {windows.length}/{maxWindows}
+        </span>
+      )}
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -6,7 +6,7 @@ import {
   type RefObject,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { Plus, X } from "lucide-react";
+import { Plus, X, HelpCircle } from "lucide-react";
 import { useUIStore } from "../lib/store";
 import { useTerminalWindows } from "../lib/queries/terminal";
 import {
@@ -186,6 +186,20 @@ export function TerminalTabs({
     [deleteMutation, displayedActiveWindowId, ws, onSwitchWindow, addToast, t]
   );
 
+  const [showHelp, setShowHelp] = useState(false);
+  const helpRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showHelp) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (helpRef.current && !helpRef.current.contains(e.target as Node)) {
+        setShowHelp(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [showHelp]);
+
   if (!tmuxAvailable) return null;
 
   const atLimit = windows.length >= maxWindows;
@@ -274,11 +288,42 @@ export function TerminalTabs({
         <Plus className="h-3.5 w-3.5" />
       </button>
 
-      {nearLimit && (
-        <span className="ml-auto pr-1 pb-1 text-[10px] text-gray-600 shrink-0 tabular-nums self-center">
-          {windows.length}/{maxWindows}
-        </span>
-      )}
+      <div className="ml-auto flex items-center gap-1 shrink-0 self-center pr-1 pb-0.5">
+        {nearLimit && (
+          <span className="text-[10px] text-gray-600 tabular-nums">
+            {windows.length}/{maxWindows}
+          </span>
+        )}
+
+        <div ref={helpRef} className="relative">
+          <button
+            onClick={() => setShowHelp((v) => !v)}
+            aria-label={t("terminal.tabs.help")}
+            className="flex items-center justify-center w-5 h-5 rounded text-gray-600 hover:text-gray-400 transition-colors"
+          >
+            <HelpCircle className="h-3.5 w-3.5" />
+          </button>
+
+          {showHelp && (
+            <div className="absolute right-0 bottom-full mb-2 z-50 w-56 rounded-lg border border-gray-700/80 bg-[#1c2128] shadow-xl text-xs text-gray-300 p-3 space-y-2">
+              <p className="font-semibold text-gray-200 mb-1">{t("terminal.tabs.help_title")}</p>
+              {([
+                ["terminal.tabs.help_switch",  "terminal.tabs.help_switch_key"],
+                ["terminal.tabs.help_rename",  "terminal.tabs.help_rename_key"],
+                ["terminal.tabs.help_close",   "terminal.tabs.help_close_key"],
+                ["terminal.tabs.help_new",     "terminal.tabs.help_new_key"],
+              ] as const).map(([desc, key]) => (
+                <div key={key} className="flex items-start justify-between gap-2">
+                  <span className="text-gray-400 leading-snug">{t(desc)}</span>
+                  <kbd className="shrink-0 px-1.5 py-0.5 rounded bg-gray-700/60 text-[10px] text-gray-300 font-mono leading-tight whitespace-nowrap">
+                    {t(key)}
+                  </kbd>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2196,6 +2196,8 @@
     "title": "Terminal",
     "subtitle_connected": "Connected",
     "subtitle_disconnected": "Disconnected",
+    "subtitle_connecting": "Connecting…",
+    "subtitle_reconnecting": "Reconnecting… ({{attempt}}/{{max}})",
     "subtitle_error": "Error: {{error}}",
     "connect": "Connect",
     "disconnect": "Disconnect",
@@ -2208,6 +2210,7 @@
     "root_warning": "Warning: The daemon is running as root. Terminal commands execute with full privileges.",
     "enter_fullscreen": "Enter fullscreen",
     "exit_fullscreen": "Exit fullscreen (Esc)",
+    "dismiss_error": "Dismiss",
     "tabs": {
       "new": "New tab",
       "unnamed": "Unnamed",

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2224,7 +2224,17 @@
       "tmux_unavailable": "tmux is not available on this host",
       "name_label": "Window name",
       "name_invalid": "Only letters, digits, space, . _ - are allowed (1–64 chars).",
-      "counter": "{{used}} / {{total}}"
+      "counter": "{{used}} / {{total}}",
+      "help": "Keyboard shortcuts",
+      "help_title": "Tab shortcuts",
+      "help_switch": "Switch tab",
+      "help_switch_key": "Click",
+      "help_rename": "Rename tab",
+      "help_rename_key": "Double-click",
+      "help_close": "Close tab",
+      "help_close_key": "Middle-click / ✕",
+      "help_new": "New tab",
+      "help_new_key": "＋"
     },
     "install_tmux": "Install tmux"
   },

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2231,7 +2231,17 @@
       "tmux_unavailable": "此主机不支持 tmux",
       "name_label": "窗口名称",
       "name_invalid": "只允许字母、数字、空格和 . _ -（1–64 个字符）。",
-      "counter": "{{used}} / {{total}}"
+      "counter": "{{used}} / {{total}}",
+      "help": "快捷操作说明",
+      "help_title": "标签页快捷操作",
+      "help_switch": "切换标签",
+      "help_switch_key": "单击",
+      "help_rename": "重命名标签",
+      "help_rename_key": "双击",
+      "help_close": "关闭标签",
+      "help_close_key": "中键单击 / ✕",
+      "help_new": "新建标签",
+      "help_new_key": "＋"
     },
     "install_tmux": "安装 tmux"
   },

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2203,6 +2203,8 @@
     "title": "终端",
     "subtitle_connected": "已连接",
     "subtitle_disconnected": "未连接",
+    "subtitle_connecting": "连接中…",
+    "subtitle_reconnecting": "重连中… ({{attempt}}/{{max}})",
     "subtitle_error": "错误: {{error}}",
     "connect": "连接",
     "disconnect": "断开",
@@ -2215,6 +2217,7 @@
     "root_warning": "警告：守护进程以 root 身份运行。终端命令将以完整权限执行。",
     "enter_fullscreen": "全屏",
     "exit_fullscreen": "退出全屏（Esc）",
+    "dismiss_error": "关闭",
     "tabs": {
       "new": "新标签页",
       "unnamed": "未命名",

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -11,13 +11,12 @@ import {
   Terminal as TerminalIcon,
   Maximize2,
   Minimize2,
+  AlertCircle,
+  X,
 } from "lucide-react";
 import { useUIStore } from "../lib/store";
 import { buildAuthenticatedWebSocketUrl } from "../api";
-import { PageHeader } from "../components/ui/PageHeader";
-import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
-import { EmptyState } from "../components/ui/EmptyState";
 import { TerminalTabs } from "../components/TerminalTabs";
 import { useTerminalHealth } from "../lib/queries/terminal";
 
@@ -37,6 +36,19 @@ interface ServerMessage {
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_ATTEMPTS = 10;
 
+// Must match the server-side MAX_COLS / MAX_ROWS constants in routes/terminal.rs.
+const TERM_MIN_COLS = 1;
+const TERM_MAX_COLS = 1000;
+const TERM_MIN_ROWS = 1;
+const TERM_MAX_ROWS = 500;
+
+function clampTermSize(cols: number, rows: number): { cols: number; rows: number } | null {
+  const c = Math.max(TERM_MIN_COLS, Math.min(TERM_MAX_COLS, Math.floor(cols)));
+  const r = Math.max(TERM_MIN_ROWS, Math.min(TERM_MAX_ROWS, Math.floor(rows)));
+  if (!Number.isFinite(c) || !Number.isFinite(r)) return null;
+  return { cols: c, rows: r };
+}
+
 function getTmuxInstallCommand(os: string): string {
   switch (os) {
     case "macos":
@@ -45,6 +57,31 @@ function getTmuxInstallCommand(os: string): string {
       return "sudo apt-get update && sudo apt-get install -y tmux || sudo dnf install -y tmux || sudo yum install -y tmux || sudo pacman -S --noconfirm tmux || sudo apk add tmux";
   }
 }
+
+// GitHub Dark-inspired terminal theme.
+const TERMINAL_THEME = {
+  background: "#0d1117",
+  foreground: "#e6edf3",
+  cursor: "#58a6ff",
+  cursorAccent: "#0d1117",
+  selectionBackground: "rgba(88,166,255,0.25)",
+  black: "#21262d",
+  red: "#ff7b72",
+  green: "#3fb950",
+  yellow: "#d29922",
+  blue: "#58a6ff",
+  magenta: "#bc8cff",
+  cyan: "#39c5cf",
+  white: "#b1bac4",
+  brightBlack: "#6e7681",
+  brightRed: "#ffa198",
+  brightGreen: "#56d364",
+  brightYellow: "#e3b341",
+  brightBlue: "#79c0ff",
+  brightMagenta: "#d2a8ff",
+  brightCyan: "#56d4dd",
+  brightWhite: "#f0f6fc",
+} as const;
 
 export function TerminalPage() {
   const { t } = useTranslation();
@@ -67,6 +104,8 @@ export function TerminalPage() {
   const [activeWindowId, setActiveWindowId] = useState<string | null>(null);
   const [pendingWindowId, setPendingWindowId] = useState<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
+
   const terminalEnabled = useUIStore((s) => s.terminalEnabled);
   const {
     data: terminalHealth,
@@ -95,9 +134,7 @@ export function TerminalPage() {
   }, []);
 
   const connect = useCallback(() => {
-    if (terminalEnabled !== true) {
-      return;
-    }
+    if (terminalEnabled !== true) return;
 
     if (wsRef.current) {
       wsRef.current.close();
@@ -108,8 +145,11 @@ export function TerminalPage() {
     setIsRoot(false);
     const url = new URL(buildAuthenticatedWebSocketUrl("/api/terminal/ws"));
     if (terminalRef.current) {
-      url.searchParams.set("cols", String(terminalRef.current.cols));
-      url.searchParams.set("rows", String(terminalRef.current.rows));
+      const size = clampTermSize(terminalRef.current.cols, terminalRef.current.rows);
+      if (size) {
+        url.searchParams.set("cols", String(size.cols));
+        url.searchParams.set("rows", String(size.rows));
+      }
     }
     const ws = new WebSocket(url.toString());
     wsRef.current = ws;
@@ -118,10 +158,11 @@ export function TerminalPage() {
       setIsConnecting(false);
       setIsConnected(true);
       attemptRef.current = 0;
+      setReconnectAttempt(0);
       setError(null);
       if (terminalRef.current && fitAddonRef.current) {
-        const { cols, rows } = terminalRef.current;
-        ws.send(JSON.stringify({ type: "resize", cols, rows }));
+        const size = clampTermSize(terminalRef.current.cols, terminalRef.current.rows);
+        if (size) ws.send(JSON.stringify({ type: "resize", ...size }));
       }
       if (desiredWindowIdRef.current) {
         ws.send(JSON.stringify({ type: "switch_window", window: desiredWindowIdRef.current }));
@@ -193,7 +234,6 @@ export function TerminalPage() {
         return;
       }
 
-      // Non-transient close codes: stop reconnecting
       const isAppError = event.code >= 4000 && event.code <= 4999;
       const isNonTransient = event.code === 1008 || event.code === 1011 || isAppError;
       if (isNonTransient) {
@@ -207,11 +247,10 @@ export function TerminalPage() {
       }
       const delay = Math.min(RECONNECT_DELAY_MS * 2 ** attemptRef.current, 30_000) + Math.random() * 1000;
       attemptRef.current += 1;
+      setReconnectAttempt(attemptRef.current);
+      setIsConnecting(true);
       reconnectTimeoutRef.current = setTimeout(() => {
-        if (
-          wsRef.current === null ||
-          wsRef.current.readyState === WebSocket.CLOSED
-        ) {
+        if (wsRef.current === null || wsRef.current.readyState === WebSocket.CLOSED) {
           connect();
         }
       }, delay);
@@ -225,7 +264,6 @@ export function TerminalPage() {
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = null;
     }
-
     if (wsRef.current) {
       intentionalDisconnectRef.current = true;
       sendCloseMessage(wsRef.current);
@@ -238,6 +276,7 @@ export function TerminalPage() {
     setPendingWindowId(null);
     setIsConnected(false);
     setIsConnecting(false);
+    setReconnectAttempt(0);
   }, [sendCloseMessage, activeWindowId]);
 
   useEffect(() => {
@@ -249,7 +288,7 @@ export function TerminalPage() {
   const handleInstallTmux = useCallback(() => {
     const cmd = getTmuxInstallCommand(serverOs);
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ type: "input", data: cmd }));
+      wsRef.current.send(JSON.stringify({ type: "input", data: cmd + "\n" }));
     }
   }, [serverOs]);
 
@@ -262,21 +301,19 @@ export function TerminalPage() {
     setIsFullscreen((v) => !v);
   }, []);
 
-  // Refit the terminal after fullscreen toggles, and notify the remote pty of
-  // the new size. We rAF twice so layout has actually settled before we measure.
+  // Refit the terminal after fullscreen toggles.
   useEffect(() => {
     if (!terminalRef.current || !fitAddonRef.current) return;
     const raf1 = requestAnimationFrame(() => {
       const raf2 = requestAnimationFrame(() => {
         try {
           fitAddonRef.current?.fit();
-        } catch {
-          /* xterm not attached yet */
-        }
+        } catch { /* xterm not attached yet */ }
         const term = terminalRef.current;
         const ws = wsRef.current;
         if (term && ws?.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+          const size = clampTermSize(term.cols, term.rows);
+          if (size) ws.send(JSON.stringify({ type: "resize", ...size }));
         }
       });
       return () => cancelAnimationFrame(raf2);
@@ -284,8 +321,7 @@ export function TerminalPage() {
     return () => cancelAnimationFrame(raf1);
   }, [isFullscreen]);
 
-  // ESC exits fullscreen — but not when focus is inside the terminal, since
-  // vim/less/tmux all use Escape as a meaningful key.
+  // ESC exits fullscreen, but not when focus is inside the terminal.
   useEffect(() => {
     if (!isFullscreen) return;
     const onKey = (e: KeyboardEvent) => {
@@ -299,25 +335,22 @@ export function TerminalPage() {
   }, [isFullscreen]);
 
   useEffect(() => {
-    if (terminalEnabled !== true) {
-      return;
-    }
-
+    if (terminalEnabled !== true) return;
     if (!containerRef.current) return;
 
     const term = new Terminal({
-      theme: {
-        background: "#1a1a2e",
-        foreground: "#eee",
-        cursor: "#f00",
-      },
-      fontSize: 14,
-      fontFamily: "monospace",
+      theme: TERMINAL_THEME,
+      fontSize: 13,
+      fontFamily:
+        "'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, 'Liberation Mono', monospace",
+      lineHeight: 1.2,
+      cursorBlink: true,
+      cursorStyle: "block",
+      scrollback: 5000,
     });
 
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
-
     term.open(containerRef.current);
     fitAddon.fit();
 
@@ -332,7 +365,8 @@ export function TerminalPage() {
 
     term.onResize(({ cols, rows }) => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify({ type: "resize", cols, rows }));
+        const size = clampTermSize(cols, rows);
+        if (size) wsRef.current.send(JSON.stringify({ type: "resize", ...size }));
       }
     });
 
@@ -341,14 +375,8 @@ export function TerminalPage() {
     const handleResize = () => fitAddon.fit();
     window.addEventListener("resize", handleResize);
 
-    // Also refit when the container itself changes size (sidebar toggle,
-    // parent layout changes, etc) so we don't get a mismatched pty size.
     const ro = new ResizeObserver(() => {
-      try {
-        fitAddon.fit();
-      } catch {
-        /* ignore */
-      }
+      try { fitAddon.fit(); } catch { /* ignore */ }
     });
     ro.observe(containerRef.current);
 
@@ -370,78 +398,88 @@ export function TerminalPage() {
     };
   }, [sendCloseMessage, terminalEnabled]);
 
-  if (terminalEnabled === null) {
-    return (
-      <div className="flex flex-col h-full">
-        <PageHeader
-          badge={t("terminal.badge")}
-          title={t("nav.terminal")}
-          subtitle={t("common.loading")}
-          icon={<TerminalIcon className="h-4 w-4" />}
-        />
-        <div className="flex-1 p-4">
-          <Card className="h-full flex items-center justify-center">
-            <EmptyState title={t("common.loading")} icon={<TerminalIcon className="h-6 w-6" />} />
-          </Card>
-        </div>
-      </div>
-    );
-  }
+  // ── Derived UI state ─────────────────────────────────────────────────────────
 
-  const statusLabel = error
-    ? t("terminal.subtitle_error", { error })
+  const statusDotClass = error
+    ? "bg-red-400"
+    : isConnecting
+      ? "bg-amber-400 animate-pulse"
+      : isConnected
+        ? "bg-emerald-400"
+        : "bg-gray-500";
+
+  const statusLabel = isConnecting
+    ? reconnectAttempt > 0
+      ? t("terminal.subtitle_reconnecting", {
+          attempt: reconnectAttempt,
+          max: MAX_RECONNECT_ATTEMPTS,
+        })
+      : t("terminal.subtitle_connecting")
     : isConnected
       ? t("terminal.subtitle_connected")
       : t("terminal.subtitle_disconnected");
 
+  // ── Actions ──────────────────────────────────────────────────────────────────
+
   const actions = (
-    <>
+    <div className="flex items-center gap-2">
       {!tmuxAvailable && isConnected && (
-        <Button onClick={handleInstallTmux} variant="secondary">
+        <Button onClick={handleInstallTmux} variant="secondary" size="sm">
           {t("terminal.install_tmux")}
         </Button>
       )}
-      <Button onClick={connect} disabled={isConnected || isConnecting}>
-        {isConnected
-          ? t("terminal.subtitle_connected")
-          : t("terminal.connect")}
-      </Button>
-      {isConnected && (
-        <Button onClick={disconnect} variant="secondary">
+      {isConnected ? (
+        <Button onClick={disconnect} variant="secondary" size="sm">
           {t("terminal.disconnect")}
         </Button>
+      ) : (
+        <Button
+          onClick={connect}
+          isLoading={isConnecting}
+          disabled={isConnecting}
+          size="sm"
+        >
+          {t("terminal.connect")}
+        </Button>
       )}
-      <Button
+      <button
         onClick={toggleFullscreen}
-        variant="secondary"
+        className="flex items-center justify-center w-8 h-8 rounded-xl border border-border-subtle bg-surface text-text-dim hover:text-brand hover:border-brand/30 transition-colors shadow-sm"
         aria-label={
-          isFullscreen
-            ? t("terminal.exit_fullscreen")
-            : t("terminal.enter_fullscreen")
+          isFullscreen ? t("terminal.exit_fullscreen") : t("terminal.enter_fullscreen")
         }
-        title={
-          isFullscreen
-            ? t("terminal.exit_fullscreen")
-            : t("terminal.enter_fullscreen")
-        }
+        title={isFullscreen ? t("terminal.exit_fullscreen") : t("terminal.enter_fullscreen")}
       >
         {isFullscreen ? (
-          <Minimize2 className="h-4 w-4" />
+          <Minimize2 className="h-3.5 w-3.5" />
         ) : (
-          <Maximize2 className="h-4 w-4" />
+          <Maximize2 className="h-3.5 w-3.5" />
         )}
-      </Button>
-    </>
+      </button>
+    </div>
   );
 
-  // The terminal body. Rendered identically in normal and fullscreen modes so
-  // xterm never unmounts — otherwise the pty session would be torn down every
-  // time we toggle fullscreen.
+  // ── Terminal body ─────────────────────────────────────────────────────────────
+
   const terminalBody = (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {isRoot && (
-        <div className="bg-red-500/20 border border-red-500/50 text-red-300 px-4 py-2 text-sm shrink-0">
-          {t("terminal.root_warning")}
+        <div className="shrink-0 flex items-center gap-2 bg-red-950/60 border-b border-red-800/50 px-4 py-2 text-xs text-red-400">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span>{t("terminal.root_warning")}</span>
+        </div>
+      )}
+      {error && (
+        <div className="shrink-0 flex items-center gap-2 bg-red-950/40 border-b border-red-800/40 px-4 py-2 text-xs text-red-400">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1 truncate min-w-0">{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="shrink-0 ml-1 hover:text-red-300 transition-colors"
+            aria-label={t("terminal.dismiss_error")}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
       <TerminalTabs
@@ -453,12 +491,65 @@ export function TerminalPage() {
         terminalRef={terminalRef}
         fitAddonRef={fitAddonRef}
       />
-      <div
-        ref={containerRef}
-        className="flex-1 bg-[#1a1a2e] p-2 overflow-hidden min-h-0"
-      />
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden" />
     </div>
   );
+
+  // ── Loading state ─────────────────────────────────────────────────────────────
+
+  if (terminalEnabled === null) {
+    return (
+      <div className="flex flex-col flex-1 min-h-0">
+        <header className="shrink-0 flex items-center gap-3 px-4 sm:px-6 py-3 bg-surface border-b border-border-subtle">
+          <div className="p-1.5 rounded-lg bg-brand/10 text-brand shrink-0">
+            <TerminalIcon className="h-4 w-4" />
+          </div>
+          <h1 className="text-sm font-extrabold tracking-tight">{t("nav.terminal")}</h1>
+        </header>
+        <div className="flex-1 min-h-0 flex items-center justify-center bg-[#0d1117] text-gray-500 text-sm">
+          {t("common.loading")}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Headers ───────────────────────────────────────────────────────────────────
+
+  const normalHeader = (
+    <header className="shrink-0 flex items-center justify-between gap-3 px-4 sm:px-6 py-3 bg-surface border-b border-border-subtle">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="p-1.5 rounded-lg bg-brand/10 text-brand shrink-0">
+          <TerminalIcon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0">
+          <h1 className="text-sm font-extrabold tracking-tight leading-tight">
+            {t("nav.terminal")}
+          </h1>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusDotClass}`} />
+            <p className="text-[11px] text-text-dim truncate">{statusLabel}</p>
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">{actions}</div>
+    </header>
+  );
+
+  const fullscreenHeader = (
+    <header className="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[#161b22] border-b border-gray-700/50">
+      <div className="flex items-center gap-2 min-w-0">
+        <TerminalIcon className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+        <span className="text-sm font-semibold text-gray-200 truncate">
+          {t("nav.terminal")}
+        </span>
+        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusDotClass}`} />
+        <span className="text-xs text-gray-400 truncate">{statusLabel}</span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">{actions}</div>
+    </header>
+  );
+
+  // ── Main render ───────────────────────────────────────────────────────────────
 
   // Single tree in both modes so React doesn't unmount the xterm container
   // when toggling fullscreen. Only the header chrome and outer className swap.
@@ -466,34 +557,17 @@ export function TerminalPage() {
     <div
       className={
         isFullscreen
-          ? "fixed inset-0 z-50 flex flex-col bg-[#1a1a2e]"
-          : "flex flex-col h-full"
+          ? "fixed inset-0 z-50 flex flex-col bg-[#0d1117]"
+          : "flex flex-col flex-1 min-h-0"
       }
     >
-      {isFullscreen ? (
-        <div className="flex items-center justify-between gap-3 px-4 py-2 bg-surface border-b border-border-subtle shrink-0">
-          <div className="flex items-center gap-2 min-w-0">
-            <TerminalIcon className="h-4 w-4 text-text-dim shrink-0" />
-            <span className="font-semibold truncate">{t("nav.terminal")}</span>
-            <span className="text-xs text-text-dim truncate">· {statusLabel}</span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">{actions}</div>
-        </div>
-      ) : (
-        <PageHeader
-          badge={t("terminal.badge")}
-          title={t("nav.terminal")}
-          subtitle={statusLabel}
-          icon={<TerminalIcon className="h-4 w-4" />}
-          actions={actions}
-        />
-      )}
-      <div className={isFullscreen ? "flex-1 min-h-0" : "flex-1 p-4 min-h-0"}>
+      {isFullscreen ? fullscreenHeader : normalHeader}
+      <div className={isFullscreen ? "flex-1 min-h-0" : "flex-1 px-4 pb-4 pt-3 min-h-0"}>
         <div
           className={
             isFullscreen
-              ? "h-full flex flex-col overflow-hidden"
-              : "h-full flex flex-col overflow-hidden rounded-xl sm:rounded-2xl border border-border-subtle bg-surface shadow-sm"
+              ? "flex flex-col flex-1 min-h-0 overflow-hidden"
+              : "flex flex-col flex-1 min-h-0 overflow-hidden rounded-xl sm:rounded-2xl border border-gray-800 bg-[#0d1117] shadow-lg"
           }
         >
           {terminalBody}


### PR DESCRIPTION
## Summary

- **Height overflow fixed**: Introduced `FULL_HEIGHT_ROUTES` in `App.tsx` so `/terminal` gets a dedicated `flex-col flex-1 overflow-hidden` layout instead of the padded auto-height wrapper shared by scrollable pages. The entire `flex-1 min-h-0` chain now propagates correctly down to the xterm container.
- **Invalid resize errors eliminated**: Added `clampTermSize()` in both `TerminalPage` and `TerminalTabs` to clamp FitAddon-computed cols/rows to the server-side limits (`MAX_COLS=1000` / `MAX_ROWS=500`) before sending WebSocket resize messages — stopping the constant "Invalid rows: 1414" error spam.
- **UI/UX polish**: GitHub Dark xterm theme, coloured status dot (green connected / amber-pulse connecting / red error), dismissible error banner inside the terminal card, reconnecting state with attempt counter (`Reconnecting… 2/10`), VS Code-style tab bar where the active tab visually connects to the terminal surface, better font stack (`Cascadia Code`, `JetBrains Mono`, …).

## Test plan

- [ ] Open `/dashboard/terminal` — terminal fits within viewport, no height overflow
- [ ] Resize browser window — terminal refits without "Invalid rows/cols" errors in server logs
- [ ] Disconnect network / kill daemon — status dot turns amber and pulses, reconnect attempt counter increments
- [ ] Trigger an error — dismissible red banner appears inside the terminal card
- [ ] Toggle fullscreen (`⤢` button) — terminal stays mounted, no flash, ESC exits fullscreen
- [ ] tmux available: tab bar renders, tabs switchable, middle-click closes, double-click renames
- [ ] Root user session: red "running as root" warning banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)