### PR TITLE
fix(dashboard/terminal): fix terminal height collapse and tmux duplicate session race

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -562,7 +562,7 @@ export function TerminalPage() {
       }
     >
       {isFullscreen ? fullscreenHeader : normalHeader}
-      <div className={isFullscreen ? "flex-1 min-h-0" : "flex-1 px-4 pb-4 pt-3 min-h-0"}>
+      <div className={isFullscreen ? "flex flex-col flex-1 min-h-0" : "flex flex-col flex-1 px-4 pb-4 pt-3 min-h-0"}>
         <div
           className={
             isFullscreen

--- a/crates/librefang-api/src/terminal_tmux.rs
+++ b/crates/librefang-api/src/terminal_tmux.rs
@@ -136,7 +136,10 @@ impl TmuxController {
 
     /// Ensure the named session exists, creating it detached if it does not.
     ///
-    /// Idempotent — safe to call every time the API starts.
+    /// Idempotent — safe to call concurrently. The `has-session` → `new-session`
+    /// sequence is inherently racy when multiple requests arrive simultaneously;
+    /// a "duplicate session" error from `new-session` means another concurrent
+    /// caller already created the session, which is a success condition.
     pub async fn ensure_session(&self) -> anyhow::Result<()> {
         // Check whether the session already exists.
         let mut check = self.base_cmd();
@@ -163,15 +166,39 @@ impl TmuxController {
             return Ok(());
         }
 
-        // Create a new detached session.
+        // Create a new detached session. If this races with another caller and
+        // tmux reports "duplicate session", the session exists — treat as success.
         let mut create = self.base_cmd();
         create
             .arg("new-session")
             .arg("-d")
             .arg("-s")
-            .arg(&self.session_name);
+            .arg(&self.session_name)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
 
-        self.run(create).await?;
+        let child = create
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn tmux new-session: {e}"))?;
+
+        let out = tokio::time::timeout(TMUX_TIMEOUT, child.wait_with_output())
+            .await
+            .map_err(|_| anyhow::anyhow!("tmux new-session timed out"))?
+            .map_err(|e| anyhow::anyhow!("tmux I/O error: {e}"))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // A concurrent ensure_session already created the session — not an error.
+            if stderr.contains("duplicate session") {
+                return Ok(());
+            }
+            return Err(anyhow::anyhow!(
+                "tmux exited with {}: {}",
+                out.status,
+                stderr.trim()
+            ));
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- **Terminal height collapse**: The padding wrapper `div` in `TerminalPage` had `flex-1` but no `flex flex-col`, so the inner card's `flex-1` resolved against an auto-height block parent and collapsed. Added `flex flex-col` to restore the correct height chain.
- **tmux 503 / duplicate session race**: `ensure_session` uses a non-atomic `has-session` → `new-session` sequence. When `WebSocket connect` and `GET /api/terminal/windows` arrive simultaneously, both pass the `has-session` check and both call `new-session`, causing tmux to report `duplicate session: main` → the handler returned 503. Now detects this specific stderr message and treats it as success — the session was created by the racing caller.

## Test plan

- [ ] Open `/dashboard/terminal` — terminal fills the available viewport height
- [ ] Resize browser window — terminal refits correctly
- [ ] Reload the page rapidly / open multiple tabs to `/terminal` — no 503 errors in daemon logs, no "duplicate session" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)