### PR TITLE
fix(terminal): allow Unicode (CJK, emoji, accented) in window names

### DIFF
--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -41,7 +41,8 @@ interface TerminalTabsProps {
   fitAddonRef: RefObject<FitAddon | null>;
 }
 
-const WINDOW_NAME_RE = /^[A-Za-z0-9 ._-]{1,64}$/;
+// Match backend validate_window_name: any Unicode except control chars and '|', 1–64 chars.
+const WINDOW_NAME_RE = /^[^|\x00-\x1f\x7f]{1,64}$/u;
 
 export function TerminalTabs({
   ws,

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2223,7 +2223,7 @@
       "rename_hint": "Double-click to rename",
       "tmux_unavailable": "tmux is not available on this host",
       "name_label": "Window name",
-      "name_invalid": "Only letters, digits, space, . _ - are allowed (1–64 chars).",
+      "name_invalid": "Name must be 1–64 characters and cannot contain | or control characters.",
       "counter": "{{used}} / {{total}}",
       "help": "Keyboard shortcuts",
       "help_title": "Tab shortcuts",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2230,7 +2230,7 @@
       "rename_hint": "双击可重命名",
       "tmux_unavailable": "此主机不支持 tmux",
       "name_label": "窗口名称",
-      "name_invalid": "只允许字母、数字、空格和 . _ -（1–64 个字符）。",
+      "name_invalid": "名称须为 1–64 个字符，不能包含 | 或控制字符。",
       "counter": "{{used}} / {{total}}",
       "help": "快捷操作说明",
       "help_title": "标签页快捷操作",

--- a/crates/librefang-api/src/terminal_tmux.rs
+++ b/crates/librefang-api/src/terminal_tmux.rs
@@ -345,16 +345,25 @@ pub fn validate_window_id(id: &str) -> bool {
 }
 
 /// Return `true` if `name` is a safe tmux window name.
+/// Validate a tmux window name.
 ///
-/// Allowed: ASCII alphanumerics, space, `.`, `_`, `-`; length 1–64.
-/// Rejected: empty, > 64 chars, non-ASCII (including emoji), control chars,
-/// shell-special chars (`;`, `&`, `|`, `` ` ``, `$`, etc.).
+/// Allowed: any Unicode character except control characters and `|`.
+/// Length is measured in Unicode scalar values (chars), 1–64.
+///
+/// The `|` character is forbidden because it is used as the field separator
+/// in our `list-windows -F` format string; allowing it would corrupt parsing.
+/// Control characters (including newlines and null bytes) are rejected because
+/// they cannot appear in tmux window names meaningfully.
+///
+/// Since window names are passed via `Command::arg` (not a shell), there is no
+/// shell-injection risk — we only need to guard against chars that break our
+/// own tmux output parsing.
 pub fn validate_window_name(name: &str) -> bool {
-    if name.is_empty() || name.len() > 64 {
+    let len = name.chars().count();
+    if len == 0 || len > 64 {
         return false;
     }
-    name.bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b' ' || b == b'.' || b == b'_' || b == b'-')
+    !name.chars().any(|c| c.is_control() || c == '|')
 }
 
 // ── internal parser ───────────────────────────────────────────────────────────
@@ -550,9 +559,18 @@ mod tests {
         assert!(validate_window_name("my-app_01"));
         assert!(validate_window_name("build 1"));
         assert!(validate_window_name("a")); // minimum length
-                                            // 64-character string — maximum
+                                            // 64-char string — maximum (measured in Unicode scalar values)
         let max_name = "a".repeat(64);
         assert!(validate_window_name(&max_name));
+        // Unicode / CJK / emoji are allowed
+        assert!(validate_window_name("终端"));
+        assert!(validate_window_name("开发环境"));
+        assert!(validate_window_name("hello🦊"));
+        assert!(validate_window_name("café"));
+        assert!(validate_window_name("日本語"));
+        // 64 Chinese chars — right at the limit
+        let max_cjk = "终".repeat(64);
+        assert!(validate_window_name(&max_cjk));
     }
 
     #[test]
@@ -561,35 +579,28 @@ mod tests {
     }
 
     #[test]
-    fn invalid_window_name_shell_injection() {
-        assert!(!validate_window_name("a;rm -rf /"));
-        assert!(!validate_window_name("$(evil)"));
-        assert!(!validate_window_name("a&b"));
+    fn invalid_window_name_pipe_separator() {
+        // '|' is our list-windows format separator — must be rejected.
         assert!(!validate_window_name("a|b"));
-        assert!(!validate_window_name("`cmd`"));
+        assert!(!validate_window_name("|"));
     }
 
     #[test]
     fn invalid_window_name_too_long() {
+        // 65 chars in Unicode scalar values
         let long = "a".repeat(65);
         assert!(!validate_window_name(&long));
+        // 65 CJK chars (each is one scalar value but 3 UTF-8 bytes)
+        let long_cjk = "终".repeat(65);
+        assert!(!validate_window_name(&long_cjk));
     }
 
     #[test]
-    fn invalid_window_name_unicode_emoji() {
-        assert!(!validate_window_name("hello🦊"));
-        assert!(!validate_window_name("café"));
-    }
-
-    #[test]
-    fn invalid_window_name_newline() {
+    fn invalid_window_name_control_chars() {
         assert!(!validate_window_name("foo\nbar"));
         assert!(!validate_window_name("foo\r\nbar"));
-    }
-
-    #[test]
-    fn invalid_window_name_tab() {
         assert!(!validate_window_name("foo\tbar"));
+        assert!(!validate_window_name("foo\x00bar"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The previous `validate_window_name` used an ASCII-only byte allowlist (`[A-Za-z0-9 ._-]`), silently rejecting Chinese characters, Japanese, emoji, and any non-ASCII input. This is a UX regression for non-English users.

**Root cause**: The restriction was overly conservative. Window names are passed via `Command::arg` (separate OS argument, not shell-expanded), so Unicode poses no injection risk. The only characters that genuinely break things are:
- `|` — used as field separator in our `list-windows -F` format string
- Control characters — meaningless in window names and harmful to terminal display

**Changes**:
- **Backend** (`terminal_tmux.rs`): rewrite `validate_window_name` to measure length in Unicode scalar values (`chars().count()`), and reject only `c.is_control() || c == '|'`
- **Frontend** (`TerminalTabs.tsx`): replace `/^[A-Za-z0-9 ._-]{1,64}$/` with `/^[^|\x00-\x1f\x7f]{1,64}$/u`
- **i18n**: update error messages in `en.json` and `zh.json`
- **Tests**: update test suite — `"hello🦊"`, `"café"`, `"终端"` etc. are now valid; add explicit `|` and control char rejection tests

## Test plan

- [ ] Double-click a terminal tab and rename it to `终端` — should save successfully
- [ ] Rename to `开发-🦊` — should save successfully  
- [ ] Rename to `a|b` — should be rejected with error toast
- [ ] Rename to a 65-char string — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)