### PR TITLE
feat(dashboard/terminal): search, font size, tab drag reorder, copy/paste hint

### DIFF
--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.167.4",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.15.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.1",
     "cmdk": "^1.1.1",

--- a/crates/librefang-api/dashboard/pnpm-lock.yaml
+++ b/crates/librefang-api/dashboard/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-search':
+        specifier: ^0.15.0
+        version: 0.15.0(@xterm/xterm@6.0.0)
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1115,6 +1118,11 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-search@0.15.0':
+    resolution: {integrity: sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -3339,6 +3347,10 @@ snapshots:
       tinyrainbow: 3.1.0
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-search@0.15.0(@xterm/xterm@6.0.0)':
+    dependencies:
+      '@xterm/xterm': 6.0.0
 
   '@xterm/xterm@6.0.0': {}
 

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useRef,
   useEffect,
+  useMemo,
   type RefObject,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,6 +45,15 @@ interface TerminalTabsProps {
 // Match backend validate_window_name: any Unicode except control chars and '|', 1–64 chars.
 const WINDOW_NAME_RE = /^[^|\x00-\x1f\x7f]{1,64}$/u;
 
+const ORDER_KEY = "terminal.tabOrder";
+
+function loadOrder(): string[] {
+  try { return JSON.parse(localStorage.getItem(ORDER_KEY) ?? "[]"); } catch { return []; }
+}
+function saveOrder(ids: string[]) {
+  localStorage.setItem(ORDER_KEY, JSON.stringify(ids));
+}
+
 export function TerminalTabs({
   ws,
   tmuxAvailable,
@@ -59,6 +69,8 @@ export function TerminalTabs({
   const renameMutation = useRenameTerminalWindow();
   const deleteMutation = useDeleteTerminalWindow();
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [tabOrder, setTabOrder] = useState<string[]>(loadOrder);
+  const [dragId, setDragId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const editInputRef = useRef<HTMLInputElement>(null);
   const settleTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -66,6 +78,18 @@ export function TerminalTabs({
 
   useEffect(() => {
     windowsRef.current = windows;
+  }, [windows]);
+
+  // Keep tab order in sync with server windows list.
+  useEffect(() => {
+    setTabOrder(prev => {
+      const existing = new Set(windows.map(w => w.id));
+      const filtered = prev.filter(id => existing.has(id));
+      const newIds = windows.map(w => w.id).filter(id => !filtered.includes(id));
+      const next = [...filtered, ...newIds];
+      saveOrder(next);
+      return next;
+    });
   }, [windows]);
 
   const addToast = useUIStore((s) => s.addToast);
@@ -201,6 +225,15 @@ export function TerminalTabs({
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [showHelp]);
 
+  const sortedWindows = useMemo(() => {
+    const orderMap = new Map(tabOrder.map((id, i) => [id, i]));
+    return [...windows].sort((a, b) => {
+      const ai = orderMap.get(a.id) ?? Infinity;
+      const bi = orderMap.get(b.id) ?? Infinity;
+      return ai - bi;
+    });
+  }, [windows, tabOrder]);
+
   if (!tmuxAvailable) return null;
 
   const atLimit = windows.length >= maxWindows;
@@ -208,7 +241,7 @@ export function TerminalTabs({
 
   return (
     <div className="flex items-end gap-0.5 px-2 pt-1.5 bg-[#161b22] border-b border-gray-700/60 overflow-x-auto shrink-0 scrollbar-thin">
-      {windows.map((w) => {
+      {sortedWindows.map((w) => {
         const isActive = w.id === displayedActiveWindowId;
         const isEditing = editingId === w.id;
         return (
@@ -225,12 +258,31 @@ export function TerminalTabs({
                 void handleCloseTab(w.id, e);
               }
             }}
+            draggable={!isEditing}
+            onDragStart={(e) => { e.dataTransfer.effectAllowed = "move"; setDragId(w.id); }}
+            onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; }}
+            onDrop={(e) => {
+              e.preventDefault();
+              if (!dragId || dragId === w.id) return;
+              setTabOrder(prev => {
+                const next = [...prev];
+                const fromIdx = next.indexOf(dragId);
+                const toIdx = next.indexOf(w.id);
+                if (fromIdx < 0 || toIdx < 0) return prev;
+                next.splice(fromIdx, 1);
+                next.splice(toIdx, 0, dragId);
+                saveOrder(next);
+                return next;
+              });
+              setDragId(null);
+            }}
+            onDragEnd={() => setDragId(null)}
             title={isEditing ? undefined : t("terminal.tabs.rename_hint")}
             className={`group flex items-center gap-1.5 px-3 py-1.5 text-xs whitespace-nowrap transition-colors cursor-pointer select-none rounded-t-md border-t border-x ${
               isActive
                 ? "bg-[#0d1117] text-gray-200 border-gray-700/70 -mb-px pb-[7px]"
                 : "text-gray-500 border-transparent hover:text-gray-300 hover:bg-gray-800/40 mb-0"
-            }`}
+            } ${dragId === w.id ? "opacity-50" : ""}`}
           >
             {isEditing ? (
               <input

--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -81,7 +81,9 @@ export function TerminalTabs({
   }, [windows]);
 
   // Keep tab order in sync with server windows list.
+  // Skip when windows is empty (query still loading) to avoid wiping persisted order.
   useEffect(() => {
+    if (windows.length === 0) return;
     setTabOrder(prev => {
       const existing = new Set(windows.map(w => w.id));
       const filtered = prev.filter(id => existing.has(id));

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2211,6 +2211,13 @@
     "enter_fullscreen": "Enter fullscreen",
     "exit_fullscreen": "Exit fullscreen (Esc)",
     "dismiss_error": "Dismiss",
+    "search_placeholder": "Search… (Enter: next, Shift+Enter: prev)",
+    "search_prev": "Previous match",
+    "search_next": "Next match",
+    "search_close": "Close search",
+    "font_decrease": "Decrease font size",
+    "font_increase": "Increase font size",
+    "copy_paste_hint": "Tip: use Ctrl+Shift+C / Ctrl+Shift+V to copy and paste in the terminal",
     "tabs": {
       "new": "New tab",
       "unnamed": "Unnamed",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2218,6 +2218,13 @@
     "enter_fullscreen": "全屏",
     "exit_fullscreen": "退出全屏（Esc）",
     "dismiss_error": "关闭",
+    "search_placeholder": "搜索… (Enter: 下一个，Shift+Enter: 上一个)",
+    "search_prev": "上一个匹配",
+    "search_next": "下一个匹配",
+    "search_close": "关闭搜索",
+    "font_decrease": "减小字号",
+    "font_increase": "增大字号",
+    "copy_paste_hint": "提示：在终端中使用 Ctrl+Shift+C / Ctrl+Shift+V 复制和粘贴",
     "tabs": {
       "new": "新标签页",
       "unnamed": "未命名",

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -1,8 +1,10 @@
 import "@xterm/xterm/css/xterm.css";
+import "@xterm/addon-search/css/xterm-search.css";
 
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { SearchAddon } from "@xterm/addon-search";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
@@ -90,6 +92,8 @@ export function TerminalPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const searchAddonRef = useRef<SearchAddon | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const intentionalDisconnectRef = useRef(false);
@@ -105,8 +109,16 @@ export function TerminalPage() {
   const [pendingWindowId, setPendingWindowId] = useState<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
+  const [searchVisible, setSearchVisible] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [fontSize, setFontSize] = useState<number>(() => {
+    const stored = localStorage.getItem("terminal.fontSize");
+    const parsed = stored ? parseInt(stored, 10) : NaN;
+    return Number.isFinite(parsed) ? Math.max(10, Math.min(20, parsed)) : 13;
+  });
 
   const terminalEnabled = useUIStore((s) => s.terminalEnabled);
+  const addToast = useUIStore((s) => s.addToast);
   const {
     data: terminalHealth,
     isError: terminalHealthError,
@@ -166,6 +178,11 @@ export function TerminalPage() {
       }
       if (desiredWindowIdRef.current) {
         ws.send(JSON.stringify({ type: "switch_window", window: desiredWindowIdRef.current }));
+      }
+      const hintKey = "terminal.copyPasteHintShown";
+      if (!localStorage.getItem(hintKey)) {
+        localStorage.setItem(hintKey, "1");
+        addToast(t("terminal.copy_paste_hint"), "info");
       }
     };
 
@@ -301,6 +318,29 @@ export function TerminalPage() {
     setIsFullscreen((v) => !v);
   }, []);
 
+  // Focus search input when search bar becomes visible.
+  useEffect(() => {
+    if (!searchVisible) return;
+    const raf = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [searchVisible]);
+
+  // Update terminal font size when fontSize state changes.
+  useEffect(() => {
+    const term = terminalRef.current;
+    const fit = fitAddonRef.current;
+    if (!term || !fit) return;
+    term.options.fontSize = fontSize;
+    try { fit.fit(); } catch { /* ignore */ }
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      const size = clampTermSize(term.cols, term.rows);
+      if (size) ws.send(JSON.stringify({ type: "resize", ...size }));
+    }
+  }, [fontSize]);
+
   // Refit the terminal after fullscreen toggles.
   useEffect(() => {
     if (!terminalRef.current || !fitAddonRef.current) return;
@@ -340,7 +380,7 @@ export function TerminalPage() {
 
     const term = new Terminal({
       theme: TERMINAL_THEME,
-      fontSize: 13,
+      fontSize: fontSize,
       fontFamily:
         "'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, 'Liberation Mono', monospace",
       lineHeight: 1.2,
@@ -351,11 +391,24 @@ export function TerminalPage() {
 
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
+
+    const searchAddon = new SearchAddon();
+    term.loadAddon(searchAddon);
+    searchAddonRef.current = searchAddon;
+
     term.open(containerRef.current);
     fitAddon.fit();
 
     terminalRef.current = term;
     fitAddonRef.current = fitAddon;
+
+    term.attachCustomKeyEventHandler((e) => {
+      if (e.ctrlKey && e.key === "f") {
+        setSearchVisible(true);
+        return false; // prevent xterm default
+      }
+      return true;
+    });
 
     term.onData((data) => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -428,6 +481,18 @@ export function TerminalPage() {
           {t("terminal.install_tmux")}
         </Button>
       )}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => setFontSize(s => { const n = Math.max(10, s - 1); localStorage.setItem("terminal.fontSize", String(n)); return n; })}
+          className="flex items-center justify-center w-6 h-6 rounded text-gray-500 hover:text-gray-300 hover:bg-gray-700/40 transition-colors text-xs font-mono"
+          title={t("terminal.font_decrease")}
+        >A-</button>
+        <button
+          onClick={() => setFontSize(s => { const n = Math.min(20, s + 1); localStorage.setItem("terminal.fontSize", String(n)); return n; })}
+          className="flex items-center justify-center w-7 h-6 rounded text-gray-500 hover:text-gray-300 hover:bg-gray-700/40 transition-colors text-xs font-mono"
+          title={t("terminal.font_increase")}
+        >A+</button>
+      </div>
       {isConnected ? (
         <Button onClick={disconnect} variant="secondary" size="sm">
           {t("terminal.disconnect")}
@@ -480,6 +545,48 @@ export function TerminalPage() {
           >
             <X className="h-3.5 w-3.5" />
           </button>
+        </div>
+      )}
+      {searchVisible && (
+        <div className="shrink-0 flex items-center gap-2 px-3 py-1.5 bg-[#1c2128] border-b border-gray-700/50">
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              searchAddonRef.current?.findNext(e.target.value, { incremental: true });
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.shiftKey
+                  ? searchAddonRef.current?.findPrevious(searchQuery)
+                  : searchAddonRef.current?.findNext(searchQuery);
+              }
+              if (e.key === "Escape") {
+                setSearchVisible(false);
+                terminalRef.current?.focus();
+              }
+              e.stopPropagation();
+            }}
+            placeholder={t("terminal.search_placeholder")}
+            className="flex-1 min-w-0 bg-gray-900/60 text-gray-200 text-xs px-2 py-1 rounded border border-gray-700/60 outline-none focus:border-blue-500/60 placeholder:text-gray-600"
+          />
+          <button
+            onClick={() => searchAddonRef.current?.findPrevious(searchQuery)}
+            className="text-gray-500 hover:text-gray-300 transition-colors text-xs px-1.5 py-1 rounded hover:bg-gray-700/40"
+            title={t("terminal.search_prev")}
+          >↑</button>
+          <button
+            onClick={() => searchAddonRef.current?.findNext(searchQuery)}
+            className="text-gray-500 hover:text-gray-300 transition-colors text-xs px-1.5 py-1 rounded hover:bg-gray-700/40"
+            title={t("terminal.search_next")}
+          >↓</button>
+          <button
+            onClick={() => { setSearchVisible(false); terminalRef.current?.focus(); }}
+            className="text-gray-500 hover:text-gray-300 transition-colors"
+            aria-label={t("terminal.search_close")}
+          ><X className="h-3.5 w-3.5" /></button>
         </div>
       )}
       <TerminalTabs

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -272,7 +272,7 @@ export function TerminalPage() {
         }
       }, delay);
     };
-  }, [t, terminalEnabled, queryClient]);
+  }, [t, terminalEnabled, queryClient, addToast]);
 
   connectRef.current = connect;
 
@@ -547,6 +547,15 @@ export function TerminalPage() {
           </button>
         </div>
       )}
+      <TerminalTabs
+        ws={wsRef.current}
+        tmuxAvailable={tmuxAvailable}
+        maxWindows={maxWindows}
+        displayedActiveWindowId={displayedActiveWindowId}
+        onSwitchWindow={handleSwitchWindow}
+        terminalRef={terminalRef}
+        fitAddonRef={fitAddonRef}
+      />
       {searchVisible && (
         <div className="shrink-0 flex items-center gap-2 px-3 py-1.5 bg-[#1c2128] border-b border-gray-700/50">
           <input
@@ -589,15 +598,6 @@ export function TerminalPage() {
           ><X className="h-3.5 w-3.5" /></button>
         </div>
       )}
-      <TerminalTabs
-        ws={wsRef.current}
-        tmuxAvailable={tmuxAvailable}
-        maxWindows={maxWindows}
-        displayedActiveWindowId={displayedActiveWindowId}
-        onSwitchWindow={handleSwitchWindow}
-        terminalRef={terminalRef}
-        fitAddonRef={fitAddonRef}
-      />
       <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden" />
     </div>
   );


### PR DESCRIPTION
## Summary

Five UX improvements to the terminal page:

### 🔍 In-terminal search (Ctrl+F)
- Integrates `@xterm/addon-search` — highlights all matches in the scrollback buffer
- Overlay search bar with incremental matching as you type
- Enter / Shift+Enter navigate next/previous; Esc closes and returns focus to terminal

### 🔤 Font size controls (A- / A+)
- Two buttons in the terminal header, range 10–20px
- Persisted to `localStorage("terminal.fontSize")` — survives page reload
- Updates `terminal.options.fontSize` live, re-fits the addon and sends a resize message

### ↔️ Tab drag-and-drop reorder
- HTML5 drag-and-drop on tab items; dragging tab shows 50% opacity
- Custom display order persisted to `localStorage("terminal.tabOrder")`
- New windows append to the end; deleted windows are pruned automatically
- No backend changes needed — order is a pure display concern

### 📋 Copy/paste one-time hint
- Info toast after first successful WebSocket connection
- `Ctrl+Shift+C` / `Ctrl+Shift+V` hint for users unfamiliar with xterm key bindings
- Guarded by `localStorage("terminal.copyPasteHintShown")` — shows only once ever

### 🌏 Unicode window names (bonus fix from #2863)
- `WINDOW_NAME_RE` updated to `/^[^|\x00-\x1f\x7f]{1,64}$/u` matching backend validation

## Test plan

- [ ] Press Ctrl+F inside terminal → search bar appears, typing highlights matches
- [ ] Enter navigates to next match; Shift+Enter goes back; Esc closes
- [ ] Click A- / A+ → font size changes live; reload page → size is restored
- [ ] Drag a tab to a new position → order persists on reload
- [ ] First connection after clearing localStorage → copy/paste hint toast appears once
- [ ] Rename tab to `终端` → accepted; rename to `a|b` → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)