### PR TITLE
fix(terminal): remove non-existent addon-search CSS import

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -1,5 +1,4 @@
 import "@xterm/xterm/css/xterm.css";
-import "@xterm/addon-search/css/xterm-search.css";
 
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { Terminal } from "@xterm/xterm";


### PR DESCRIPTION
## Summary

`@xterm/addon-search` does not ship a CSS file — the package only contains JS. The import `"@xterm/addon-search/css/xterm-search.css"` introduced in #2864 causes Vite to throw:

```
[plugin:vite:import-analysis] Failed to resolve import "@xterm/addon-search/css/xterm-search.css"
```

Search highlight styles are handled internally by xterm's JS bundle, so no CSS import is needed.

## Change

Remove the one-line import that doesn't exist in the package.