### PR TITLE
feat(dashboard/terminal): Ctrl+L clear, tab overflow arrows, cursor inactive style, auto-dismiss reconnect toast

### DIFF
--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -7,7 +7,7 @@ import {
   type RefObject,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { Plus, X, HelpCircle } from "lucide-react";
+import { Plus, X, HelpCircle, ChevronLeft, ChevronRight } from "lucide-react";
 import { useUIStore } from "../lib/store";
 import { useTerminalWindows } from "../lib/queries/terminal";
 import {
@@ -213,6 +213,31 @@ export function TerminalTabs({
     [deleteMutation, displayedActiveWindowId, ws, onSwitchWindow, addToast, t]
   );
 
+  // ── Tab overflow indicators ───────────────────────────────────────────────
+  const tabScrollRef = useRef<HTMLDivElement>(null);
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(false);
+
+  const updateOverflowArrows = useCallback(() => {
+    const el = tabScrollRef.current;
+    if (!el) return;
+    setShowLeftArrow(el.scrollLeft > 0);
+    setShowRightArrow(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = tabScrollRef.current;
+    if (!el) return;
+    updateOverflowArrows();
+    el.addEventListener("scroll", updateOverflowArrows, { passive: true });
+    const ro = new ResizeObserver(updateOverflowArrows);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateOverflowArrows);
+      ro.disconnect();
+    };
+  }, [updateOverflowArrows]);
+
   const [showHelp, setShowHelp] = useState(false);
   const helpRef = useRef<HTMLDivElement>(null);
 
@@ -236,6 +261,11 @@ export function TerminalTabs({
     });
   }, [windows, tabOrder]);
 
+  // Re-check arrows when the windows list changes (tabs added/removed).
+  useEffect(() => {
+    updateOverflowArrows();
+  }, [sortedWindows, updateOverflowArrows]);
+
   if (!tmuxAvailable) return null;
 
   const atLimit = windows.length >= maxWindows;
@@ -243,7 +273,18 @@ export function TerminalTabs({
 
   return (
     <div className="flex items-end bg-[#161b22] border-b border-gray-700/60 shrink-0">
-      <div className="flex items-end gap-0.5 px-2 pt-1.5 overflow-x-auto flex-1 scrollbar-thin">
+      <div className="relative flex-1 min-w-0">
+        {showLeftArrow && (
+          <div className="pointer-events-none absolute left-0 inset-y-0 flex items-center pl-0.5 z-10">
+            <ChevronLeft className="h-3 w-3 text-gray-500" />
+          </div>
+        )}
+        {showRightArrow && (
+          <div className="pointer-events-none absolute right-0 inset-y-0 flex items-center pr-0.5 z-10">
+            <ChevronRight className="h-3 w-3 text-gray-500" />
+          </div>
+        )}
+      <div ref={tabScrollRef} className="flex items-end gap-0.5 px-2 pt-1.5 overflow-x-auto flex-1 scrollbar-thin">
       {sortedWindows.map((w) => {
         const isActive = w.id === displayedActiveWindowId;
         const isEditing = editingId === w.id;
@@ -343,6 +384,7 @@ export function TerminalTabs({
       >
         <Plus className="h-3.5 w-3.5" />
       </button>
+      </div>
       </div>
 
       <div className="flex items-center gap-1 shrink-0 self-center pr-2 pb-0.5">

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2387,7 +2387,8 @@
       "help_new": "New tab",
       "help_new_key": "＋"
     },
-    "install_tmux": "Install tmux"
+    "install_tmux": "Install tmux",
+    "reconnected": "Reconnected"
   },
   "mcp": {
     "title": "MCP Servers",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2390,7 +2390,8 @@
       "help_new": "新建标签",
       "help_new_key": "＋"
     },
-    "install_tmux": "安装 tmux"
+    "install_tmux": "安装 tmux",
+    "reconnected": "已重新连接"
   },
   "mcp": {
     "title": "MCP 服务器",

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -95,6 +95,7 @@ export function TerminalPage() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const intentionalDisconnectRef = useRef(false);
   const connectRef = useRef<() => void>(() => {});
   const attemptRef = useRef(0);
@@ -186,7 +187,13 @@ export function TerminalPage() {
         const toasts = useUIStore.getState().toasts;
         const latest = toasts[toasts.length - 1];
         if (latest) {
-          setTimeout(() => removeToast(latest.id), 3000);
+          if (toastDismissTimerRef.current) {
+            clearTimeout(toastDismissTimerRef.current);
+          }
+          toastDismissTimerRef.current = setTimeout(() => {
+            removeToast(latest.id);
+            toastDismissTimerRef.current = null;
+          }, 3000);
         }
       }
       const hintKey = "terminal.copyPasteHintShown";
@@ -460,6 +467,9 @@ export function TerminalPage() {
       ro.disconnect();
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+      }
+      if (toastDismissTimerRef.current) {
+        clearTimeout(toastDismissTimerRef.current);
       }
       if (wsRef.current) {
         intentionalDisconnectRef.current = true;

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -118,6 +118,7 @@ export function TerminalPage() {
 
   const terminalEnabled = useUIStore((s) => s.terminalEnabled);
   const addToast = useUIStore((s) => s.addToast);
+  const removeToast = useUIStore((s) => s.removeToast);
   const {
     data: terminalHealth,
     isError: terminalHealthError,
@@ -166,6 +167,7 @@ export function TerminalPage() {
     wsRef.current = ws;
 
     ws.onopen = () => {
+      const wasReconnect = attemptRef.current > 0;
       setIsConnecting(false);
       setIsConnected(true);
       attemptRef.current = 0;
@@ -177,6 +179,15 @@ export function TerminalPage() {
       }
       if (desiredWindowIdRef.current) {
         ws.send(JSON.stringify({ type: "switch_window", window: desiredWindowIdRef.current }));
+      }
+      if (wasReconnect) {
+        addToast(t("terminal.reconnected"), "success");
+        // Grab the id that addToast just inserted (it uses Date.now() as id).
+        const toasts = useUIStore.getState().toasts;
+        const latest = toasts[toasts.length - 1];
+        if (latest) {
+          setTimeout(() => removeToast(latest.id), 3000);
+        }
       }
       const hintKey = "terminal.copyPasteHintShown";
       if (!localStorage.getItem(hintKey)) {
@@ -385,6 +396,9 @@ export function TerminalPage() {
       lineHeight: 1.2,
       cursorBlink: true,
       cursorStyle: "block",
+      // Show a dimmed underline cursor when the terminal loses focus (xterm v5.5+).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...({"cursorInactiveStyle": "underline"} as any),
       scrollback: 5000,
     });
 
@@ -405,6 +419,15 @@ export function TerminalPage() {
       if (e.ctrlKey && e.key === "f") {
         setSearchVisible(true);
         return false; // prevent xterm default
+      }
+      // Ctrl+L: clear the visible terminal buffer and forward \x0c to the shell
+      // so the shell's own clear handler also runs (e.g. bash/zsh clear scrollback).
+      if (e.type === "keydown" && e.ctrlKey && e.key === "l") {
+        term.clear();
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify({ type: "input", data: "\x0c" }));
+        }
+        return false; // prevent xterm from passing the keystroke a second time
       }
       return true;
     });


### PR DESCRIPTION
## Summary

- **Ctrl+L clear**: `attachCustomKeyEventHandler` intercepts `Ctrl+L`, calls `term.clear()` to wipe the xterm buffer, then sends `\x0c` over WebSocket so the shell also executes its own clear handler. Returns `false` to prevent xterm from double-sending the key.
- **Tab overflow arrows**: `TerminalTabs` wraps the `overflow-x-auto` scroll container in a `relative` div. A `ResizeObserver` + `scroll` listener on the scroll container drives `showLeftArrow`/`showRightArrow` state; `ChevronLeft`/`ChevronRight` icons from `lucide-react` appear as `pointer-events-none absolute` overlays on the left/right edges when there is hidden content.
- **Cursor inactive style**: `Terminal` constructor receives `cursorInactiveStyle: "underline"` (xterm v5.5+ option, spread as `any` to avoid type error on older `@xterm/xterm` type definitions). The active cursor stays `block`; when the terminal is blurred xterm renders a dimmed underline instead of hiding the cursor entirely.
- **Auto-dismiss reconnect toast**: `ws.onopen` checks `attemptRef.current > 0` to detect a reconnect, calls `addToast(t("terminal.reconnected"), "success")`, then reads `useUIStore.getState().toasts` to grab the just-inserted toast id and schedules `removeToast` after 3 s. New `terminal.reconnected` key added to `en.json` and `zh.json`.

## Test plan

- [ ] Open terminal, type `ls`, then press Ctrl+L — buffer clears and shell prompt redraws
- [ ] Open enough tmux windows to overflow the tab bar, confirm left/right chevrons appear; scroll and confirm they disappear when at the edge
- [ ] Click outside the terminal — cursor should change to underline; click back in — cursor returns to block
- [ ] Disconnect the daemon, wait for reconnect, confirm a green "Reconnected" toast appears and auto-dismisses after ~3 s