### PR TITLE
fix(api): dashboard snapshot also exposes api_listen / home_dir / log_level

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2166,8 +2166,8 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         .unwrap_or(0);
     let cfg = state.kernel.config_snapshot();
     // Runtime stats shared with `/api/status` — the dashboard RuntimePage
-    // reads `uptime_seconds` / `memory_used_mb` out of this snapshot, so
-    // leaving them out renders the KPI tiles as "-".
+    // reads these out of the snapshot for its info panel and KPI tiles.
+    // Anything missing here renders as "-" on the page.
     let uptime_seconds = state.started_at.elapsed().as_secs();
     let memory_used_mb = current_process_rss_mb();
     let status = serde_json::json!({
@@ -2180,6 +2180,9 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         "default_provider": cfg.default_model.provider,
         "default_model": cfg.default_model.model,
         "config_exists": state.kernel.home_dir().join("config.toml").exists(),
+        "api_listen": cfg.api_listen,
+        "home_dir": state.kernel.home_dir().display().to_string(),
+        "log_level": cfg.log_level,
         "network_enabled": cfg.network_enabled,
         "terminal_enabled": cfg.terminal.enabled,
     });


### PR DESCRIPTION
## Summary

Follow-up on #2877 — the same drift between \`/api/status\` and \`/api/dashboard/snapshot\` left three more RuntimePage info rows blank:

- **API Listen Address** (\`status.api_listen\`)
- **Home Directory** (\`status.home_dir\`)
- **Log Level** (\`status.log_level\`)

All three are read by \`RuntimePage.tsx\` out of the snapshot; the snapshot just wasn't producing them.

## Fix

Mirror the same three fields into the snapshot's status object (next to the existing \`network_enabled\` / \`terminal_enabled\`). \`/api/status\` stays authoritative.

Frontend \`StatusResponse\` in \`api.ts\` already declares all three as optional, so no TS change needed.

## Test plan

- [x] \`cargo build -p librefang-api --lib\` clean
- [ ] After deploy: \`/dashboard/runtime\` info panel shows non-dash values for API listen, home dir, log level