### PR TITLE
fix(dashboard/runtime): audit badge width + verify chain button always clickable

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -479,9 +479,14 @@ export function RuntimePage() {
                 <div className="space-y-1.5 max-h-64 overflow-y-auto">
                   {auditEntries.map((entry: AuditEntry, i: number) => (
                     <div key={entry.seq ?? i} className="flex items-start gap-2 text-xs py-1.5 px-2 rounded-lg bg-main/30">
-                      <Badge variant={entry.outcome === "ok" ? "success" : entry.outcome === "denied" ? "error" : "warning"}>
-                        {entry.outcome || "-"}
-                      </Badge>
+                      {/* Fixed-width badge column so "ok" / "completed" /
+                          "denied" outcomes of different lengths don't shift
+                          the action column — the log now reads as a table. */}
+                      <div className="w-20 shrink-0 flex justify-start pt-0.5">
+                        <Badge variant={entry.outcome === "ok" ? "success" : entry.outcome === "denied" ? "error" : "warning"}>
+                          {entry.outcome || "-"}
+                        </Badge>
+                      </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <span className="font-bold text-[10px] truncate">{entry.action || "-"}</span>
@@ -501,14 +506,30 @@ export function RuntimePage() {
                 <p className="text-xs text-text-dim">{t("runtime.no_audit")}</p>
               )}
 
-              {auditVerifyQuery.data && (
-                <div className="mt-3 pt-3 border-t border-border-subtle flex items-center justify-between">
-                  <span className="text-xs text-text-dim">{t("runtime.audit_entries", { count: auditVerifyQuery.data.entries ?? 0 })}</span>
-                  <Button variant="ghost" size="sm" onClick={() => auditVerifyQuery.refetch()}>
-                    {t("runtime.audit_verify")}
-                  </Button>
-                </div>
-              )}
+              {/* Verify button is always rendered so the user can trigger a
+                  chain verification even before any automatic fetch has
+                  landed. `refetchInterval: false` means the query no longer
+                  polls in the background, so the previous "hidden until
+                  data arrives" gating left the button invisible on first
+                  paint. `isFetching` also provides a visible loading state
+                  so repeated clicks don't look like they did nothing. */}
+              <div className="mt-3 pt-3 border-t border-border-subtle flex items-center justify-between">
+                <span className="text-xs text-text-dim">
+                  {auditVerifyQuery.data
+                    ? t("runtime.audit_entries", { count: auditVerifyQuery.data.entries ?? 0 })
+                    : t("runtime.audit_not_verified", { defaultValue: "Chain not verified yet" })}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={auditVerifyQuery.isFetching}
+                  onClick={() => auditVerifyQuery.refetch()}
+                >
+                  {auditVerifyQuery.isFetching
+                    ? t("common.loading")
+                    : t("runtime.audit_verify")}
+                </Button>
+              </div>
             </Card>
           </div>
 


### PR DESCRIPTION
## Summary

Two paired issues on the Runtime page's audit log card.

### 1. Badge widths don't align
Outcomes render as \`ok\` / \`completed\` / \`denied\` (and more), each different pixel widths. With the badges flowing inline the action column shifts left or right per row and the list reads as noise.

**Fix**: put each badge in a \`w-20 shrink-0\` wrapper so the outcome sits in its own fixed gutter. Action text now aligns across rows.

### 2. \"Verify chain\" button invisible / looks non-responsive
The entire verify row was gated behind \`{auditVerifyQuery.data && ...}\`. Since #2856 (\`refetchInterval: false\` on \`useAuditVerify\`), there is no automatic re-fetch after the initial load — if the user arrives before the first fetch resolves, or the query gets evicted, **there is no button to click**. If the button is present, clicking re-runs the same query and returns instantly with no visible state change, so it looks like the click didn't register.

**Fix**:
- Always render the verify row.
- Show \"Chain not verified yet\" as the left-side label when no data yet.
- Disable the button while \`isFetching\` and swap its label to \`common.loading\` so repeated clicks obviously register.

## Test plan

- [x] Syntactic edit review: outcome column is now \`<div className=\"w-20 shrink-0\">\`, button always rendered, \`isFetching\`-driven state
- [ ] After deploy: outcome badges align visually, verify-chain button visible on first paint and shows a loading state during refetch