### PR TITLE
fix(dashboard/runtime): audit card readability + visible verify-chain feedback

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useUIStore } from "../lib/store";
 import type { HealthCheck, AuditEntry, BackupItem, TaskQueueItem } from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -86,6 +87,7 @@ function ProtectionBadge({ name, enabled }: { name: string; enabled: boolean }) 
 
 export function RuntimePage() {
   const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
   const [showShutdownConfirm, setShowShutdownConfirm] = useState(false);
   const [reloadResult, setReloadResult] = useState<string | null>(null);
 
@@ -476,29 +478,42 @@ export function RuntimePage() {
               </div>
 
               {auditEntries.length > 0 ? (
-                <div className="space-y-1.5 max-h-64 overflow-y-auto">
+                <div className="max-h-80 overflow-y-auto rounded-lg border border-border-subtle/60 divide-y divide-border-subtle/40">
                   {auditEntries.map((entry: AuditEntry, i: number) => (
-                    <div key={entry.seq ?? i} className="flex items-start gap-2 text-xs py-1.5 px-2 rounded-lg bg-main/30">
-                      {/* Fixed-width badge column so "ok" / "completed" /
-                          "denied" outcomes of different lengths don't shift
-                          the action column — the log now reads as a table. */}
-                      <div className="w-20 shrink-0 flex justify-start pt-0.5">
-                        <Badge variant={entry.outcome === "ok" ? "success" : entry.outcome === "denied" ? "error" : "warning"}>
-                          {entry.outcome || "-"}
-                        </Badge>
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-bold text-[10px] truncate">{entry.action || "-"}</span>
-                          {entry.agent_id && entry.agent_id !== "system" && (
-                            <span className="text-[9px] text-text-dim truncate">@{entry.agent_id.slice(0, 8)}</span>
-                          )}
+                    <div
+                      key={entry.seq ?? i}
+                      className="px-3 py-2.5 hover:bg-main/20 transition-colors"
+                    >
+                      {/* Header row: outcome badge (fixed gutter so entries
+                          stay column-aligned regardless of word length) +
+                          action + agent + timestamp on one line. */}
+                      <div className="flex items-center gap-3">
+                        <div className="w-20 shrink-0">
+                          <Badge variant={entry.outcome === "ok" ? "success" : entry.outcome === "denied" ? "error" : "warning"}>
+                            {entry.outcome || "-"}
+                          </Badge>
                         </div>
-                        <p className="text-[10px] text-text-dim truncate">{entry.detail || "-"}</p>
+                        <span className="flex-1 font-mono text-[11px] font-bold truncate">
+                          {entry.action || "-"}
+                        </span>
+                        {entry.agent_id && entry.agent_id !== "system" && (
+                          <span className="text-[10px] text-text-dim font-mono shrink-0">
+                            @{entry.agent_id.slice(0, 8)}
+                          </span>
+                        )}
+                        <span className="text-[10px] text-text-dim shrink-0 tabular-nums">
+                          {entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "-"}
+                        </span>
                       </div>
-                      <span className="text-[9px] text-text-dim shrink-0">
-                        {entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "-"}
-                      </span>
+                      {/* Detail gets its own line under the badge column so
+                          long messages wrap cleanly instead of fighting for
+                          space on the header row. `ml-[5.75rem]` matches
+                          the 5rem badge gutter plus the 0.75rem gap above. */}
+                      {entry.detail && (
+                        <p className="mt-1 ml-[5.75rem] text-[11px] text-text-dim leading-snug line-clamp-2">
+                          {entry.detail}
+                        </p>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -523,7 +538,35 @@ export function RuntimePage() {
                   variant="ghost"
                   size="sm"
                   disabled={auditVerifyQuery.isFetching}
-                  onClick={() => auditVerifyQuery.refetch()}
+                  onClick={async () => {
+                    // Fire a toast on completion so the user gets obvious
+                    // feedback — the `valid` badge at the top of the card
+                    // already updates, but it's easy to miss when the
+                    // result didn't change. `refetch()` resolves with the
+                    // fresh query state whether the request succeeded
+                    // or errored; react-query never throws from it.
+                    const res = await auditVerifyQuery.refetch();
+                    if (res.isSuccess) {
+                      const valid = res.data?.valid;
+                      const count = res.data?.entries ?? 0;
+                      addToast(
+                        valid
+                          ? t("runtime.audit_verified_ok", {
+                              defaultValue: `Audit chain verified (${count} entries)`,
+                              count,
+                            })
+                          : t("runtime.audit_verified_invalid", {
+                              defaultValue: "Audit chain INVALID — tampering detected",
+                            }),
+                        valid ? "success" : "error",
+                      );
+                    } else if (res.isError) {
+                      addToast(
+                        res.error instanceof Error ? res.error.message : t("common.error"),
+                        "error",
+                      );
+                    }
+                  }}
                 >
                   {auditVerifyQuery.isFetching
                     ? t("common.loading")


### PR DESCRIPTION
## Summary

Follow-up to #2892 — the previous fix aligned the outcome badges but entries still looked \"stuck together\" and the verify-chain button felt unresponsive because clicking it produced no visible change.

### Readability
- Rows live in a single bordered container with divider lines instead of per-row rounded pills — reads as a proper table.
- Two-line layout per entry: header (outcome / action / agent / timestamp) on top, detail line below, indented to the badge gutter. \`line-clamp-2\` lets long messages wrap instead of truncating to a single cramped line.
- Typography bumped from 9–10 px to 10–11 px; timestamp gets \`tabular-nums\` so the time column stays aligned.

### Verify-chain feedback
\`refetch()\` returning the same \`valid\` result produced no visible change on click (the \`auditValid\` badge at the top of the card updates, but it's easy to miss). Now also fires a toast with the entry count on success, or a tampering warning on invalid, or the raw error message on failure.

## Test plan

- [x] Editor review: badge gutter fixed at \`w-20\`, detail line indented via \`ml-[5.75rem]\` to match, toast fires on all three branches (success / invalid / error).
- [ ] Post-deploy: audit log reads like a table, verify button shows a toast every click.