### PR TITLE
fix(dashboard/overview): populate Hostname row via authenticated endpoints

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -21,6 +21,10 @@ export interface StatusResponse {
   api_listen?: string;
   home_dir?: string;
   log_level?: string;
+  /** Machine hostname. Only populated on authenticated endpoints
+   *  (`/api/status`, `/api/dashboard/snapshot`) — `/api/version` is public
+   *  and deliberately omits it. */
+  hostname?: string;
   network_enabled?: boolean;
   terminal_enabled?: boolean;
   session_count?: number;

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -359,7 +359,16 @@ export function OverviewPage() {
               <div className="flex items-center gap-3 p-2.5 rounded-lg bg-main/40">
                 <div className="w-8 h-8 rounded-lg bg-brand/10 flex items-center justify-center shrink-0"><Globe className="w-4 h-4 text-brand" /></div>
                 <span className="text-xs text-text-dim flex-1">Hostname</span>
-                <span className="text-sm font-mono font-black truncate max-w-[140px]" title={versionInfo?.hostname}>{versionInfo?.hostname || "-"}</span>
+                {/* `/api/version` is public and deliberately omits
+                    hostname (per-machine identifier). Read from the
+                    authenticated snapshot first; fall back to versionInfo
+                    for older daemons. */}
+                <span
+                  className="text-sm font-mono font-black truncate max-w-[140px]"
+                  title={snapshot?.status?.hostname || versionInfo?.hostname}
+                >
+                  {snapshot?.status?.hostname || versionInfo?.hostname || "-"}
+                </span>
               </div>
               <div className="flex items-center gap-3 p-2.5 rounded-lg bg-main/40">
                 <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0"><User className="w-4 h-4 text-accent" /></div>

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -37,6 +37,44 @@ use axum::response::IntoResponse;
 use axum::Json;
 use std::sync::Arc;
 
+/// Best-effort host identifier for the machine running the daemon.
+///
+/// Exposed only via authenticated endpoints (`/api/status`,
+/// `/api/dashboard/snapshot`) — deliberately **not** surfaced on the
+/// public `/api/version` endpoint, because hostname is a per-machine
+/// identifier that a remote scanner could correlate to a specific
+/// deployment target. `$HOSTNAME` is honoured first for parity with
+/// containers that synthesise it; `hostname(1)` is the POSIX fallback.
+/// Returns `None` only when both fail (rare).
+fn system_hostname() -> Option<String> {
+    if let Ok(h) = std::env::var("HOSTNAME") {
+        let trimmed = h.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    #[cfg(unix)]
+    {
+        std::process::Command::new("hostname")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMPUTERNAME")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
+}
+
 /// Best-effort RSS memory probe for the running process, in MB.
 ///
 /// Shared between `/api/status` and `/api/dashboard/snapshot` so both
@@ -152,6 +190,7 @@ pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         "api_listen": cfg.api_listen,
         "home_dir": state.kernel.home_dir().display().to_string(),
         "log_level": cfg.log_level,
+        "hostname": system_hostname(),
         "network_enabled": cfg.network_enabled,
         "terminal_enabled": cfg.terminal.enabled,
         "config_exists": state.kernel.home_dir().join("config.toml").exists(),
@@ -2183,6 +2222,7 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         "api_listen": cfg.api_listen,
         "home_dir": state.kernel.home_dir().display().to_string(),
         "log_level": cfg.log_level,
+        "hostname": system_hostname(),
         "network_enabled": cfg.network_enabled,
         "terminal_enabled": cfg.terminal.enabled,
     });


### PR DESCRIPTION
## Summary

OverviewPage's \"Hostname\" row renders as \`-\`. OverviewPage reads \`versionInfo?.hostname\` from \`/api/version\`, but \`/api/version\` is **public** and the existing handler comment explicitly omits hostname:

> \`hostname\` — a per-machine identifier that helps a remote probe correlate a daemon to a specific deployment target. Operators who need the hostname should read it from the daemon's shell environment rather than pulling it over an unauthenticated HTTP endpoint.

So the field is intentionally blank there. But the authenticated endpoints (\`/api/status\`, \`/api/dashboard/snapshot\`) never exposed it either — which is the gap.

## Fix

- Add a small \`system_hostname()\` helper in \`config.rs\`: checks \`\$HOSTNAME\`, then \`hostname(1)\` on unix or \`%COMPUTERNAME%\` on windows.
- Include the value in \`/api/status\` and the snapshot's \`status\` object. \`/api/version\` stays unchanged (public, still omits).
- \`StatusResponse\` in \`api.ts\` gets \`hostname?: string\` with a comment explaining the public-vs-auth split.
- OverviewPage reads \`snapshot?.status?.hostname || versionInfo?.hostname\` — snapshot wins; versionInfo stays as fallback (a historical no-op, kept for back-compat if anyone ever populates it on \`/api/version\`).

## Test plan

- [x] \`cargo build -p librefang-api --lib\` clean
- [ ] Post-deploy: \`curl /api/dashboard/snapshot | jq .status.hostname\` returns the hostname; Overview page shows it in the Hostname row
- [ ] \`curl /api/version\` still omits hostname (public endpoint unchanged)