### PR TITLE
fix(runtime): use slice instead of vec in enforce_turn_budget

### DIFF
--- a/crates/librefang-runtime/src/tool_budget.rs
+++ b/crates/librefang-runtime/src/tool_budget.rs
@@ -132,7 +132,7 @@ impl ToolBudgetEnforcer {
     /// Already-persisted results (those whose content starts with the
     /// [`PERSISTED_MARKER`]) are counted toward the total but are never
     /// re-persisted.
-    pub fn enforce_turn_budget(&self, results: &mut Vec<ToolResultEntry>) {
+    pub fn enforce_turn_budget(&self, results: &mut [ToolResultEntry]) {
         let total: usize = results.iter().map(|r| r.content.len()).sum();
         if total <= self.per_turn_budget {
             return;


### PR DESCRIPTION
## Fix CI failure on main

**Problem**: `tool_budget.rs:135` - clippy `ptr_arg` error: `&mut Vec<ToolResultEntry>` should be `&mut [ToolResultEntry]`

**Fix**: Change `&mut Vec` to `&mut [ToolResultEntry]` (slice).

