### PR TITLE
fix: use slice instead of vec in enforce_turn_budget + update terminal tests

### DIFF
--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -1374,9 +1374,11 @@ mod tests {
 
     #[test]
     fn window_name_rejects_shell_injection_in_create() {
-        assert!(!crate::terminal_tmux::validate_window_name("a;rm -rf /"));
-        assert!(!crate::terminal_tmux::validate_window_name("$(evil)"));
-        assert!(!crate::terminal_tmux::validate_window_name("`cmd`"));
+        // After 5d271afa, validate_window_name only rejects control chars and pipe.
+        // Shell metacharacters like ;, $(), `` are NOT rejected — they are allowed.
+        // The test name is now a misnomer; the function no longer provides injection protection.
+        assert!(!crate::terminal_tmux::validate_window_name("a|b"));
+        assert!(!crate::terminal_tmux::validate_window_name("foo\0bar"));
     }
 
     #[test]
@@ -1393,10 +1395,9 @@ mod tests {
 
     #[test]
     fn window_name_rejects_all_special_chars() {
-        for bad in &[
-            "a;b", "a&b", "a|b", "a`b", "a$b", "a(b)", "a{b}", "a<b>", "a>b", "a/b", "a\\b",
-            "a\"b", "a'b", "a#b", "a!b", "a@b", "a=b", "a+b", "a~b",
-        ] {
+        // validate_window_name only rejects control chars and pipe character.
+        // After 5d271afa, semicolon, ampersand, parens, braces, angle brackets, etc. are ALLOWED.
+        for bad in &["a|b", "foo\0bar", "foo\x1fbar"] {
             assert!(
                 !crate::terminal_tmux::validate_window_name(bad),
                 "should reject: {bad:?}"

--- a/crates/librefang-runtime/src/tool_budget.rs
+++ b/crates/librefang-runtime/src/tool_budget.rs
@@ -132,7 +132,7 @@ impl ToolBudgetEnforcer {
     /// Already-persisted results (those whose content starts with the
     /// [`PERSISTED_MARKER`]) are counted toward the total but are never
     /// re-persisted.
-    pub fn enforce_turn_budget(&self, results: &mut Vec<ToolResultEntry>) {
+    pub fn enforce_turn_budget(&self, results: &mut [ToolResultEntry]) {
         let total: usize = results.iter().map(|r| r.content.len()).sum();
         if total <= self.per_turn_budget {
             return;


### PR DESCRIPTION
## Fixes CI failures on main

**Changes:**

1. **clippy fix** (`tool_budget.rs:135`): `&mut Vec<ToolResultEntry>` → `&mut [ToolResultEntry]` (ptr_arg error)

2. **terminal tests** (`terminal.rs`): Update tests to match commit `5d271afa` which narrowed `validate_window_name` to only reject control chars and pipe character. Removed assertions for shell metacharacters (; $ & etc.) that are now allowed.