### PR TITLE
feat(runtime): checkpoint manager with shadow git repos for transparent file snapshots

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1008,6 +1008,7 @@ pub async fn mcp_http(
             Some(state.kernel.processes()),
             None, // sender_id (MCP HTTP has no sender context)
             None, // channel
+            None, // checkpoint_manager (network bridge doesn't run agent tools)
         )
         .await;
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -485,6 +485,11 @@ pub struct LibreFangKernel {
     budget_config: std::sync::RwLock<librefang_types::config::BudgetConfig>,
     /// Shutdown signal sender for background tasks (e.g., approval expiry sweep).
     shutdown_tx: tokio::sync::watch::Sender<bool>,
+    /// Checkpoint manager — takes automatic shadow-git snapshots before every
+    /// `file_write` / `apply_patch` tool call.  `None` when the base
+    /// directory could not be resolved at boot.
+    pub(crate) checkpoint_manager:
+        Option<Arc<librefang_runtime::checkpoint_manager::CheckpointManager>>,
 }
 
 /// Bounded in-memory delivery receipt tracker.
@@ -2480,6 +2485,14 @@ impl LibreFangKernel {
             budget_config: std::sync::RwLock::new(initial_budget),
             approval_sweep_started: AtomicBool::new(false),
             shutdown_tx: tokio::sync::watch::channel(false).0,
+            checkpoint_manager: {
+                let cp_dir = config
+                    .home_dir
+                    .join(librefang_runtime::checkpoint_manager::CHECKPOINT_BASE);
+                Some(Arc::new(
+                    librefang_runtime::checkpoint_manager::CheckpointManager::new(cp_dir),
+                ))
+            },
         };
 
         // Initialize proactive memory system (mem0-style) from config.
@@ -14047,6 +14060,7 @@ impl LibreFangKernel {
             process_manager: Some(&self.process_manager),
             sender_id: deferred.sender_id.as_deref(),
             channel: deferred.channel.as_deref(),
+            checkpoint_manager: self.checkpoint_manager.as_ref(),
         }
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3660,6 +3660,7 @@ system_prompt = "You are a helpful assistant."
             None, // no hooks
             ctx_window,
             None, // no process manager
+            None, // no checkpoint manager (ephemeral /btw — side questions only)
             None, // no content blocks
             None, // no proactive memory
             None, // no context engine
@@ -4808,6 +4809,7 @@ system_prompt = "You are a helpful assistant."
                 Some(&kernel_clone.hooks),
                 ctx_window,
                 Some(&kernel_clone.process_manager),
+                kernel_clone.checkpoint_manager.clone(),
                 None, // content_blocks (streaming path uses text only for now)
                 kernel_clone.proactive_memory.get().cloned(),
                 kernel_clone.context_engine_for_agent(&manifest),
@@ -6118,6 +6120,7 @@ system_prompt = "You are a helpful assistant."
             Some(&self.hooks),
             ctx_window,
             Some(&self.process_manager),
+            self.checkpoint_manager.clone(),
             content_blocks,
             proactive_memory,
             self.context_engine_for_agent(&manifest),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2385,6 +2385,7 @@ impl LibreFangKernel {
 
         let workflow_home_dir = config.home_dir.clone();
         let oauth_home_dir = config.home_dir.clone();
+        let checkpoint_base_dir = config.home_dir.clone();
         // Resolve the audit anchor path from `[audit].anchor_path`. When
         // unset, the default is `data_dir/audit.anchor` — good enough to
         // catch most casual tampering since it sits next to the SQLite
@@ -2486,8 +2487,7 @@ impl LibreFangKernel {
             approval_sweep_started: AtomicBool::new(false),
             shutdown_tx: tokio::sync::watch::channel(false).0,
             checkpoint_manager: {
-                let cp_dir = config
-                    .home_dir
+                let cp_dir = checkpoint_base_dir
                     .join(librefang_runtime::checkpoint_manager::CHECKPOINT_BASE);
                 Some(Arc::new(
                     librefang_runtime::checkpoint_manager::CheckpointManager::new(cp_dir),

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -4,6 +4,7 @@
 //! calling the LLM, executing tool calls, and saving the conversation.
 
 use crate::auth_cooldown::{CooldownVerdict, ProviderCooldown};
+use crate::checkpoint_manager::CheckpointManager;
 use crate::context_budget::{apply_context_guard, truncate_tool_result_dynamic, ContextBudget};
 use crate::context_engine::ContextEngine;
 use crate::context_overflow::{recover_from_overflow, RecoveryStage};
@@ -558,6 +559,7 @@ struct ToolExecutionContext<'a> {
     process_manager: Option<&'a crate::process_manager::ProcessManager>,
     sender_user_id: Option<&'a str>,
     sender_channel: Option<&'a str>,
+    checkpoint_manager: Option<&'a Arc<CheckpointManager>>,
     context_budget: &'a ContextBudget,
     context_engine: Option<&'a dyn ContextEngine>,
     context_window_tokens: usize,
@@ -731,6 +733,7 @@ async fn execute_single_tool_call(
             ctx.process_manager,
             ctx.sender_user_id,
             ctx.sender_channel,
+            ctx.checkpoint_manager,
         ),
     )
     .await
@@ -2385,6 +2388,7 @@ pub async fn run_agent_loop(
     hooks: Option<&crate::hooks::HookRegistry>,
     context_window_tokens: Option<usize>,
     process_manager: Option<&crate::process_manager::ProcessManager>,
+    checkpoint_manager: Option<Arc<CheckpointManager>>,
     user_content_blocks: Option<Vec<ContentBlock>>,
     proactive_memory: Option<Arc<librefang_memory::ProactiveMemoryStore>>,
     context_engine: Option<&dyn ContextEngine>,
@@ -2882,6 +2886,7 @@ pub async fn run_agent_loop(
                         process_manager,
                         sender_user_id: sender_user_id.as_deref(),
                         sender_channel: sender_channel.as_deref(),
+                        checkpoint_manager: checkpoint_manager.as_ref(),
                         context_budget: &context_budget,
                         context_engine,
                         context_window_tokens: ctx_window,
@@ -3379,6 +3384,7 @@ pub async fn run_agent_loop_streaming(
     hooks: Option<&crate::hooks::HookRegistry>,
     context_window_tokens: Option<usize>,
     process_manager: Option<&crate::process_manager::ProcessManager>,
+    checkpoint_manager: Option<Arc<CheckpointManager>>,
     user_content_blocks: Option<Vec<ContentBlock>>,
     proactive_memory: Option<Arc<librefang_memory::ProactiveMemoryStore>>,
     context_engine: Option<&dyn ContextEngine>,
@@ -3932,6 +3938,7 @@ pub async fn run_agent_loop_streaming(
                         process_manager,
                         sender_user_id: sender_user_id.as_deref(),
                         sender_channel: sender_channel.as_deref(),
+                        checkpoint_manager: checkpoint_manager.as_ref(),
                         context_budget: &context_budget,
                         context_engine,
                         context_window_tokens: ctx_window,

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -1,0 +1,689 @@
+//! Checkpoint Manager — Transparent filesystem snapshots via shadow git repos.
+//!
+//! Creates automatic snapshots of working directories before file-mutating
+//! operations (`file_write`, `apply_patch`), providing rollback to any previous
+//! checkpoint.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ~/.librefang/checkpoints/{sha256(abs_dir)[:16]}/   — shadow git repo
+//!     HEAD, refs/, objects/                            — standard git internals
+//!     LIBREFANG_WORKDIR                               — original dir path
+//!     info/exclude                                    — default excludes
+//! ```
+//!
+//! The shadow repo uses `GIT_DIR` + `GIT_WORK_TREE` so no git state leaks
+//! into the user's project directory.  All git operations use isolated
+//! config (no user `~/.gitconfig`, no GPG signing).
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of files to snapshot.  Directories exceeding this are
+/// skipped to prevent slowdowns on large repositories.
+pub const MAX_FILES: usize = 50_000;
+
+/// Sub-directory under `~/.librefang/` where shadow repos are stored.
+pub const CHECKPOINT_BASE: &str = "checkpoints";
+
+/// Git subprocess timeout in seconds.
+const GIT_TIMEOUT_SECS: u64 = 30;
+
+/// Default exclude patterns written into each shadow repo's `info/exclude`.
+const DEFAULT_EXCLUDES: &[&str] = &[
+    "node_modules/",
+    "dist/",
+    "build/",
+    ".env",
+    ".env.*",
+    ".env.local",
+    ".env.*.local",
+    "__pycache__/",
+    "*.pyc",
+    "*.pyo",
+    ".DS_Store",
+    "*.log",
+    ".cache/",
+    ".next/",
+    ".nuxt/",
+    "coverage/",
+    ".pytest_cache/",
+    ".venv/",
+    "venv/",
+    "target/",
+    ".git/",
+];
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum CheckpointError {
+    #[error("Shadow repo initialisation failed: {0}")]
+    InitFailed(String),
+
+    #[error("Working directory not found or not a directory: {0}")]
+    BadWorkDir(PathBuf),
+
+    #[error("Directory is too large to snapshot (>{MAX_FILES} files)")]
+    TooManyFiles,
+
+    #[error("git executable not found")]
+    GitNotFound,
+
+    #[error("git command failed: {0}")]
+    GitFailed(String),
+
+    #[error("Invalid commit hash: {0}")]
+    InvalidHash(String),
+
+    #[error("No snapshots found for this directory")]
+    NoSnapshots,
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Public data types
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single snapshot commit.
+#[derive(Debug, Clone)]
+pub struct SnapshotEntry {
+    /// Full 40-character SHA-1 commit hash.
+    pub hash: String,
+    /// Short 7-character hash for display.
+    pub short_hash: String,
+    /// Commit subject (the reason string passed to `snapshot()`).
+    pub message: String,
+    /// Approximate creation time (parsed from the git author timestamp).
+    pub timestamp: SystemTime,
+}
+
+// ---------------------------------------------------------------------------
+// CheckpointManager
+// ---------------------------------------------------------------------------
+
+/// Manages automatic filesystem checkpoints backed by shadow git repositories.
+///
+/// Designed to be held as an `Arc<CheckpointManager>` and shared across the
+/// agent runtime.  All public methods are `&self` (interior mutability is not
+/// required).
+///
+/// # Usage
+///
+/// ```ignore
+/// let mgr = CheckpointManager::new(home_dir.join("checkpoints"));
+/// // Before mutating a file:
+/// if let Err(e) = mgr.snapshot(workspace_root, "pre file_write") {
+///     warn!("checkpoint failed (non-fatal): {e}");
+/// }
+/// ```
+#[derive(Debug)]
+pub struct CheckpointManager {
+    /// `~/.librefang/checkpoints/` — base directory for all shadow repos.
+    base_dir: PathBuf,
+}
+
+impl CheckpointManager {
+    /// Create a `CheckpointManager` rooted at `base_dir`.
+    ///
+    /// `base_dir` is typically `~/.librefang/checkpoints/`.  The directory
+    /// is created on first use.
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /// Create a snapshot of the given working directory.
+    ///
+    /// Returns the full commit hash on success.  If there are no changes since
+    /// the last snapshot the call succeeds and returns the most recent commit
+    /// hash (or a sentinel `"no-op"` string when the repo is brand-new and
+    /// empty).
+    ///
+    /// Fails with [`CheckpointError::TooManyFiles`] when the directory
+    /// contains more than [`MAX_FILES`] files, to avoid freezing the daemon
+    /// on huge work trees.
+    pub fn snapshot(&self, work_dir: &Path, reason: &str) -> Result<String, CheckpointError> {
+        let work_dir = normalize_path(work_dir)?;
+        let shadow = self.shadow_repo_dir(&work_dir);
+
+        self.init_shadow_repo_if_needed(&shadow, &work_dir)?;
+
+        // Size guard
+        if count_files_up_to(&work_dir, MAX_FILES + 1) > MAX_FILES {
+            return Err(CheckpointError::TooManyFiles);
+        }
+
+        // Stage everything
+        let (ok, _, stderr) = run_git(
+            &["add", "-A"],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS * 2,
+            &[],
+        );
+        if !ok {
+            return Err(CheckpointError::GitFailed(format!("git add -A: {stderr}")));
+        }
+
+        // Check if there is anything new to commit
+        let (no_changes, _, _) = run_git(
+            &["diff", "--cached", "--quiet"],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS,
+            &[1], // exit 1 = there ARE staged changes
+        );
+        if no_changes {
+            // Nothing to commit — return the current HEAD hash if available.
+            let (ok_head, head_hash, _) = run_git(
+                &["rev-parse", "HEAD"],
+                &shadow,
+                &work_dir,
+                GIT_TIMEOUT_SECS,
+                &[],
+            );
+            if ok_head && !head_hash.is_empty() {
+                return Ok(head_hash);
+            }
+            return Ok("no-op".to_string());
+        }
+
+        // Commit
+        let (ok, _, stderr) = run_git(
+            &[
+                "commit",
+                "-m",
+                reason,
+                "--allow-empty-message",
+                "--no-gpg-sign",
+            ],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS * 2,
+            &[],
+        );
+        if !ok {
+            return Err(CheckpointError::GitFailed(format!("git commit: {stderr}")));
+        }
+
+        // Return the new commit hash
+        let (ok_hash, hash, _) = run_git(
+            &["rev-parse", "HEAD"],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS,
+            &[],
+        );
+        if ok_hash && !hash.is_empty() {
+            debug!(hash, reason, "checkpoint taken for {}", work_dir.display());
+            Ok(hash)
+        } else {
+            Ok("unknown".to_string())
+        }
+    }
+
+    /// Restore working directory to a previous snapshot.
+    ///
+    /// Uses `git checkout <commit_hash> -- .` which restores tracked files
+    /// without moving `HEAD` — safe and reversible (a pre-rollback snapshot
+    /// is taken automatically).
+    pub fn restore(&self, work_dir: &Path, commit_hash: &str) -> Result<(), CheckpointError> {
+        Self::validate_commit_hash(commit_hash)?;
+        let work_dir = normalize_path(work_dir)?;
+        let shadow = self.shadow_repo_dir(&work_dir);
+
+        if !shadow.join("HEAD").exists() {
+            return Err(CheckpointError::NoSnapshots);
+        }
+
+        // Verify the commit exists
+        let (ok, _, _) = run_git(
+            &["cat-file", "-t", commit_hash],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS,
+            &[],
+        );
+        if !ok {
+            return Err(CheckpointError::InvalidHash(format!(
+                "commit '{commit_hash}' not found in shadow repo"
+            )));
+        }
+
+        // Take a pre-rollback snapshot so the user can undo the undo.
+        let pre_reason = format!("pre-rollback snapshot (restoring to {})", &commit_hash[..8]);
+        if let Err(e) = self.snapshot(&work_dir, &pre_reason) {
+            // Non-fatal: warn but continue with the restore.
+            warn!("pre-rollback snapshot failed (continuing): {e}");
+        }
+
+        let (ok, _, stderr) = run_git(
+            &["checkout", commit_hash, "--", "."],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS * 2,
+            &[],
+        );
+        if !ok {
+            return Err(CheckpointError::GitFailed(format!(
+                "git checkout {commit_hash}: {stderr}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// List snapshots for a working directory, newest first.
+    ///
+    /// Returns an empty `Vec` (not an error) when no shadow repo exists yet.
+    pub fn list_snapshots(&self, work_dir: &Path) -> Result<Vec<SnapshotEntry>, CheckpointError> {
+        let work_dir = normalize_path(work_dir)?;
+        let shadow = self.shadow_repo_dir(&work_dir);
+
+        if !shadow.join("HEAD").exists() {
+            return Ok(vec![]);
+        }
+
+        // Format: <full-hash>|<short-hash>|<unix-timestamp>|<subject>
+        let (ok, stdout, _) = run_git(
+            &["log", "--format=%H|%h|%at|%s", "-n", "50"],
+            &shadow,
+            &work_dir,
+            GIT_TIMEOUT_SECS,
+            &[],
+        );
+        if !ok || stdout.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let entries = stdout
+            .lines()
+            .filter_map(|line| {
+                let mut parts = line.splitn(4, '|');
+                let hash = parts.next()?.to_string();
+                let short_hash = parts.next()?.to_string();
+                let unix_str = parts.next()?;
+                let message = parts.next().unwrap_or("").to_string();
+
+                let secs: u64 = unix_str.parse().ok()?;
+                let timestamp = UNIX_EPOCH + std::time::Duration::from_secs(secs);
+
+                Some(SnapshotEntry {
+                    hash,
+                    short_hash,
+                    message,
+                    timestamp,
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Return the shadow repo path for a working directory.
+    ///
+    /// The name is the first 16 hex characters of `SHA-256(abs_path_utf8)`,
+    /// giving a deterministic, collision-resistant, injection-safe identifier.
+    fn shadow_repo_dir(&self, work_dir: &Path) -> PathBuf {
+        let path_str = work_dir.to_string_lossy();
+        let mut hasher = Sha256::new();
+        hasher.update(path_str.as_bytes());
+        let digest = hasher.finalize();
+        // Format as lowercase hex and take the first 16 chars (8 bytes).
+        let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+        self.base_dir.join(&hex[..16])
+    }
+
+    /// Initialise the shadow repo at `shadow` if it does not already exist.
+    fn init_shadow_repo_if_needed(
+        &self,
+        shadow: &Path,
+        work_dir: &Path,
+    ) -> Result<(), CheckpointError> {
+        if shadow.join("HEAD").exists() {
+            return Ok(());
+        }
+
+        std::fs::create_dir_all(shadow)?;
+
+        // `git init` inside the shadow dir (bare-style via GIT_DIR env var)
+        let (ok, _, err) = run_git(&["init"], shadow, work_dir, GIT_TIMEOUT_SECS, &[]);
+        if !ok {
+            return Err(CheckpointError::InitFailed(err));
+        }
+
+        // Per-repo config: identity + disable signing
+        for args in &[
+            vec!["config", "user.email", "librefang@local"],
+            vec!["config", "user.name", "LibreFang Checkpoint"],
+            vec!["config", "commit.gpgsign", "false"],
+            vec!["config", "tag.gpgSign", "false"],
+        ] {
+            run_git(args, shadow, work_dir, GIT_TIMEOUT_SECS, &[]);
+        }
+
+        // Write default excludes
+        let info_dir = shadow.join("info");
+        std::fs::create_dir_all(&info_dir)?;
+        std::fs::write(info_dir.join("exclude"), DEFAULT_EXCLUDES.join("\n") + "\n")?;
+
+        // Record the canonical working directory path for introspection
+        std::fs::write(
+            shadow.join("LIBREFANG_WORKDIR"),
+            work_dir.to_string_lossy().as_bytes(),
+        )?;
+
+        debug!(
+            shadow = %shadow.display(),
+            workdir = %work_dir.display(),
+            "initialised checkpoint repo"
+        );
+        Ok(())
+    }
+
+    /// Validate a commit hash to prevent git argument injection.
+    ///
+    /// Accepts 4–64 lowercase or uppercase hex characters.  Values starting
+    /// with `-` would be misinterpreted as git flags.
+    fn validate_commit_hash(hash: &str) -> Result<(), CheckpointError> {
+        if hash.is_empty() {
+            return Err(CheckpointError::InvalidHash("empty hash".to_string()));
+        }
+        if hash.starts_with('-') {
+            return Err(CheckpointError::InvalidHash(format!(
+                "hash must not start with '-': {hash:?}"
+            )));
+        }
+        let len = hash.len();
+        if !(4..=64).contains(&len) {
+            return Err(CheckpointError::InvalidHash(format!(
+                "hash length {len} not in 4–64 range"
+            )));
+        }
+        if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(CheckpointError::InvalidHash(format!(
+                "hash contains non-hex characters: {hash:?}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Git subprocess helpers
+// ---------------------------------------------------------------------------
+
+/// Build the environment map for a git command targeting the shadow repo.
+///
+/// - Sets `GIT_DIR` to the shadow repo path.
+/// - Sets `GIT_WORK_TREE` to the real working directory.
+/// - Isolates from the user's global/system git config to prevent
+///   `commit.gpgsign`, credential helpers, etc. from interfering.
+fn git_env(shadow: &Path, work_dir: &Path) -> Vec<(String, String)> {
+    // Start from the current process environment and override the
+    // git-relevant variables.
+    let mut env: Vec<(String, String)> = std::env::vars()
+        .filter(|(k, _)| {
+            !matches!(
+                k.as_str(),
+                "GIT_DIR"
+                    | "GIT_WORK_TREE"
+                    | "GIT_INDEX_FILE"
+                    | "GIT_NAMESPACE"
+                    | "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+                    | "GIT_CONFIG_GLOBAL"
+                    | "GIT_CONFIG_SYSTEM"
+                    | "GIT_CONFIG_NOSYSTEM"
+            )
+        })
+        .collect();
+
+    env.push(("GIT_DIR".to_string(), shadow.to_string_lossy().into_owned()));
+    env.push((
+        "GIT_WORK_TREE".to_string(),
+        work_dir.to_string_lossy().into_owned(),
+    ));
+    // Isolate from the user's global/system config (git ≥ 2.32 honours these).
+    env.push(("GIT_CONFIG_GLOBAL".to_string(), "/dev/null".to_string()));
+    env.push(("GIT_CONFIG_SYSTEM".to_string(), "/dev/null".to_string()));
+    env.push(("GIT_CONFIG_NOSYSTEM".to_string(), "1".to_string()));
+
+    env
+}
+
+/// Run a git command against the shadow repo.
+///
+/// Returns `(ok, stdout, stderr)`.  `allowed_non_zero` lists exit codes that
+/// are expected (e.g. `1` from `git diff --quiet` when there are changes) and
+/// should not be logged as errors.
+fn run_git(
+    args: &[&str],
+    shadow: &Path,
+    work_dir: &Path,
+    timeout_secs: u64,
+    allowed_non_zero: &[i32],
+) -> (bool, String, String) {
+    if !work_dir.exists() || !work_dir.is_dir() {
+        warn!(
+            path = %work_dir.display(),
+            "git command skipped: working directory not found"
+        );
+        return (
+            false,
+            String::new(),
+            "working directory not found".to_string(),
+        );
+    }
+
+    let env = git_env(shadow, work_dir);
+
+    // Build owned copies of the path strings so we can move them into a
+    // thread without lifetime issues.
+    let shadow_str = shadow.to_string_lossy().into_owned();
+    let work_dir_str = work_dir.to_string_lossy().into_owned();
+    let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let env_owned: Vec<(String, String)> = env;
+    let allowed_owned: Vec<i32> = allowed_non_zero.to_vec();
+
+    // Spawn a thread so we can join with a timeout — std::process::Command
+    // has no native timeout support.
+    use std::sync::mpsc;
+    let (tx, rx) = mpsc::channel::<Result<std::process::Output, std::io::Error>>();
+
+    std::thread::spawn(move || {
+        let mut cmd = Command::new("git");
+        cmd.args(&args_owned)
+            .current_dir(&work_dir_str)
+            .env_clear()
+            .envs(env_owned.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+        let _ = tx.send(cmd.output());
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            warn!("git executable not found (shadow={})", shadow_str);
+            return (false, String::new(), "git not found".to_string());
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            warn!(error = %msg, "git command spawn failed");
+            return (false, String::new(), msg);
+        }
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let code = output.status.code().unwrap_or(-1);
+            let ok = output.status.success();
+
+            if !ok && !allowed_owned.contains(&code) {
+                warn!(
+                    args = ?args,
+                    exit_code = code,
+                    stderr = %stderr,
+                    "git command failed"
+                );
+            }
+            (ok, stdout, stderr)
+        }
+        Err(_) => {
+            warn!(args = ?args, timeout_secs, "git command timed out");
+            (
+                false,
+                String::new(),
+                format!("timed out after {timeout_secs}s"),
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File-count helper
+// ---------------------------------------------------------------------------
+
+/// Count files under `dir`, stopping early once `limit` is exceeded.
+///
+/// Ignores permission errors and skips `.git/` directories.
+fn count_files_up_to(dir: &Path, limit: usize) -> usize {
+    let mut count = 0usize;
+    count_recursive(dir, limit, &mut count);
+    count
+}
+
+fn count_recursive(dir: &Path, limit: usize, count: &mut usize) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if *count >= limit {
+            return;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip well-known large / irrelevant directories.
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if matches!(
+                name,
+                ".git" | "node_modules" | "target" | "venv" | ".venv" | "__pycache__"
+            ) {
+                continue;
+            }
+            count_recursive(&path, limit, count);
+        } else {
+            *count += 1;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path normalisation
+// ---------------------------------------------------------------------------
+
+fn normalize_path(path: &Path) -> Result<PathBuf, CheckpointError> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|_| CheckpointError::BadWorkDir(path.to_path_buf()))?;
+    if !canonical.is_dir() {
+        return Err(CheckpointError::BadWorkDir(canonical));
+    }
+    Ok(canonical)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_commit_hashes_are_accepted() {
+        assert!(CheckpointManager::validate_commit_hash("abcdef01").is_ok());
+        assert!(CheckpointManager::validate_commit_hash("ABCDEF01").is_ok());
+        assert!(CheckpointManager::validate_commit_hash(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        )
+        .is_ok());
+        assert!(CheckpointManager::validate_commit_hash("deadbeef1234567890abcdef").is_ok());
+    }
+
+    #[test]
+    fn invalid_commit_hashes_are_rejected() {
+        // Too short
+        assert!(CheckpointManager::validate_commit_hash("abc").is_err());
+        // Starts with dash (injection)
+        assert!(CheckpointManager::validate_commit_hash("--patch").is_err());
+        assert!(CheckpointManager::validate_commit_hash("-p").is_err());
+        // Non-hex characters
+        assert!(CheckpointManager::validate_commit_hash("xyz12345").is_err());
+        // Empty
+        assert!(CheckpointManager::validate_commit_hash("").is_err());
+        // Too long (65 chars)
+        assert!(CheckpointManager::validate_commit_hash(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2a1b2c3d4e5f6a1b2c3d4e5f6"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn shadow_repo_dir_is_deterministic() {
+        let mgr = CheckpointManager::new(PathBuf::from("/tmp/cp_test_base"));
+        let a = mgr.shadow_repo_dir(Path::new("/home/user/project"));
+        let b = mgr.shadow_repo_dir(Path::new("/home/user/project"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn shadow_repo_dir_differs_for_different_paths() {
+        let mgr = CheckpointManager::new(PathBuf::from("/tmp/cp_test_base"));
+        let a = mgr.shadow_repo_dir(Path::new("/home/user/project_a"));
+        let b = mgr.shadow_repo_dir(Path::new("/home/user/project_b"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn shadow_repo_dir_name_is_16_hex_chars() {
+        let mgr = CheckpointManager::new(PathBuf::from("/tmp/cp_test_base"));
+        let dir = mgr.shadow_repo_dir(Path::new("/some/path"));
+        let name = dir.file_name().unwrap().to_string_lossy();
+        assert_eq!(name.len(), 16);
+        assert!(name.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn count_files_up_to_returns_zero_for_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(count_files_up_to(dir.path(), MAX_FILES + 1), 0);
+    }
+
+    #[test]
+    fn count_files_up_to_counts_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            std::fs::write(dir.path().join(format!("f{i}.txt")), "x").unwrap();
+        }
+        assert_eq!(count_files_up_to(dir.path(), MAX_FILES + 1), 5);
+    }
+}

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -523,12 +523,12 @@ fn run_git(
     match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
         Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
             warn!("git executable not found (shadow={})", shadow_str);
-            return (false, String::new(), "git not found".to_string());
+            (false, String::new(), "git not found".to_string())
         }
         Ok(Err(e)) => {
             let msg = e.to_string();
             warn!(error = %msg, "git command spawn failed");
-            return (false, String::new(), msg);
+            (false, String::new(), msg)
         }
         Ok(Ok(output)) => {
             let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod auth_cooldown;
 pub mod browser;
 pub mod catalog_sync;
 pub mod channel_registry;
+pub mod checkpoint_manager;
 pub use librefang_runtime_oauth::chatgpt_oauth;
 pub mod command_lane;
 pub mod compactor;

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -54,26 +54,25 @@ pub fn refresh_registry_checkout(
     let _guard = SYNC_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let registry_cache = home_dir.join("registry");
 
-    if !should_refresh(&registry_cache, cache_ttl_secs) {
+    if should_refresh(&registry_cache, cache_ttl_secs) {
+        // Try git first (faster incremental updates, private fork support)
+        let git_ok = match git_clone_fallback(&registry_cache, registry_mirror) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::debug!("Git sync unavailable: {e} — trying HTTP download");
+                false
+            }
+        };
+
+        // Fall back to HTTP tarball if git failed
+        if !git_ok {
+            if let Err(e) = download_and_extract(&registry_cache, registry_mirror) {
+                tracing::warn!("HTTP registry download also failed: {e}");
+                return registry_cache.exists();
+            }
+        }
+    } else {
         tracing::debug!("Registry cache is fresh, skipping download");
-        return registry_cache.exists();
-    }
-
-    // Try git first (faster incremental updates, private fork support)
-    let git_ok = match git_clone_fallback(&registry_cache, registry_mirror) {
-        Ok(()) => true,
-        Err(e) => {
-            tracing::debug!("Git sync unavailable: {e} — trying HTTP download");
-            false
-        }
-    };
-
-    // Fall back to HTTP tarball if git failed
-    if !git_ok {
-        if let Err(e) = download_and_extract(&registry_cache, registry_mirror) {
-            tracing::warn!("HTTP registry download also failed: {e}");
-            return registry_cache.exists();
-        }
     }
     true
 }

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -43,7 +43,7 @@ pub const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64, registry_mirror: &str) -> bool {
     let registry_cache = home_dir.join("registry");
 
-    if !should_refresh(&registry_cache, cache_ttl_secs) {
+    if should_refresh(&registry_cache, cache_ttl_secs) {
         tracing::debug!("Registry cache is fresh, skipping download");
     } else {
         // Try git first (faster incremental updates, private fork support)

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -44,8 +44,6 @@ pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64, registry_mirror: &str
     let registry_cache = home_dir.join("registry");
 
     if should_refresh(&registry_cache, cache_ttl_secs) {
-        tracing::debug!("Registry cache is fresh, skipping download");
-    } else {
         // Try git first (faster incremental updates, private fork support)
         let git_ok = match git_clone_fallback(&registry_cache, registry_mirror) {
             Ok(()) => true,
@@ -64,6 +62,8 @@ pub fn sync_registry(home_dir: &Path, cache_ttl_secs: u64, registry_mirror: &str
                 }
             }
         }
+    } else {
+        tracing::debug!("Registry cache is fresh, skipping download");
     }
 
     // Pre-install core content users need out of the box.

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -882,6 +882,7 @@ pub async fn execute_tool(
     process_manager: Option<&crate::process_manager::ProcessManager>,
     sender_id: Option<&str>,
     channel: Option<&str>,
+    checkpoint_manager: Option<&Arc<crate::checkpoint_manager::CheckpointManager>>,
 ) -> ToolResult {
     // Normalize the tool name through compat mappings so LLM-hallucinated aliases
     // (e.g. "fs-write" → "file_write") resolve to the canonical LibreFang name.
@@ -1025,9 +1026,7 @@ pub async fn execute_tool(
         process_manager,
         sender_id,
         channel,
-        // The checkpoint_manager is injected from the kernel layer
-        // (librefang-kernel); at this level we default to None.
-        checkpoint_manager: None,
+        checkpoint_manager,
     };
     execute_tool_raw(tool_use_id, tool_name, input, &ctx).await
 }
@@ -5827,6 +5826,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -5861,6 +5861,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -5892,6 +5893,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -5923,6 +5925,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -5953,6 +5956,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         // web_search now attempts a real fetch; may succeed or fail depending on network
@@ -5983,6 +5987,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6013,6 +6018,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6044,6 +6050,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6076,6 +6083,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         // Should fail for path resolution, NOT for permission denied
@@ -6134,6 +6142,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -6170,6 +6179,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6213,6 +6223,7 @@ mod tests {
             None,
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
 
@@ -6257,6 +6268,7 @@ mod tests {
             None,
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
 
@@ -6312,6 +6324,7 @@ mod tests {
             None,
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
 
@@ -6503,6 +6516,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6556,6 +6570,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -6768,6 +6783,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -6806,6 +6822,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -6844,6 +6861,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -6891,6 +6909,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -6942,6 +6961,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -7036,6 +7056,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -7073,6 +7094,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         // Should fail for "MCP not available", not "Permission denied"
@@ -7119,6 +7141,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         // Should NOT be a permission-denied error
@@ -7155,6 +7178,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(result.is_error);
@@ -7191,6 +7215,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -7226,6 +7251,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         assert!(
@@ -7261,6 +7287,7 @@ mod tests {
             None, // process_manager
             None, // sender_id
             None, // channel
+            None, // checkpoint_manager
         )
         .await;
         // Should fail for "MCP not available", not "Permission denied"

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -319,6 +319,10 @@ pub struct ToolExecContext<'a> {
     pub process_manager: Option<&'a crate::process_manager::ProcessManager>,
     pub sender_id: Option<&'a str>,
     pub channel: Option<&'a str>,
+    /// Optional checkpoint manager.  When `Some`, a snapshot is taken
+    /// automatically before every `file_write` and `apply_patch` call.
+    /// Snapshot failures are non-fatal (logged as warnings only).
+    pub checkpoint_manager: Option<&'a Arc<crate::checkpoint_manager::CheckpointManager>>,
 }
 
 /// Execute a tool without running the approval / capability / taint gate.
@@ -353,14 +357,21 @@ pub async fn execute_tool_raw(
         process_manager,
         sender_id,
         channel: _,
+        checkpoint_manager,
     } = ctx;
 
     let result = match tool_name {
         // Filesystem tools
         "file_read" => tool_file_read(input, *workspace_root).await,
-        "file_write" => tool_file_write(input, *workspace_root).await,
+        "file_write" => {
+            maybe_snapshot(checkpoint_manager, *workspace_root, "pre file_write");
+            tool_file_write(input, *workspace_root).await
+        }
         "file_list" => tool_file_list(input, *workspace_root).await,
-        "apply_patch" => tool_apply_patch(input, *workspace_root).await,
+        "apply_patch" => {
+            maybe_snapshot(checkpoint_manager, *workspace_root, "pre apply_patch");
+            tool_apply_patch(input, *workspace_root).await
+        }
 
         // Web tools (upgraded: multi-provider search, SSRF-protected fetch)
         "web_fetch" => match input["url"].as_str() {
@@ -1014,6 +1025,9 @@ pub async fn execute_tool(
         process_manager,
         sender_id,
         channel,
+        // The checkpoint_manager is injected from the kernel layer
+        // (librefang-kernel); at this level we default to None.
+        checkpoint_manager: None,
     };
     execute_tool_raw(tool_use_id, tool_name, input, &ctx).await
 }
@@ -1972,6 +1986,51 @@ fn resolve_file_path(raw_path: &str, workspace_root: Option<&Path>) -> Result<Pa
     )?;
     crate::workspace_sandbox::resolve_sandbox_path(raw_path, root)
 }
+
+// ---------------------------------------------------------------------------
+// Checkpoint helper
+// ---------------------------------------------------------------------------
+
+/// Take a snapshot of `workspace_root` before a file-mutating operation.
+///
+/// If an explicit `CheckpointManager` is provided (injected from the kernel),
+/// it is used.  Otherwise, a transient manager is derived from the standard
+/// home directory (`~/.librefang/checkpoints/`).
+///
+/// Failures are **non-fatal**: they are logged as warnings and the calling
+/// tool proceeds normally.
+fn maybe_snapshot(
+    mgr: &Option<&Arc<crate::checkpoint_manager::CheckpointManager>>,
+    workspace_root: Option<&Path>,
+    reason: &str,
+) {
+    let Some(root) = workspace_root else {
+        return;
+    };
+
+    let snapshot_result = if let Some(m) = mgr {
+        m.snapshot(root, reason)
+    } else {
+        // No injected manager — derive the checkpoint directory from the
+        // standard home layout so file_write always has snapshot coverage.
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let base = home
+            .join(".librefang")
+            .join(crate::checkpoint_manager::CHECKPOINT_BASE);
+        let transient_mgr = crate::checkpoint_manager::CheckpointManager::new(base);
+        transient_mgr.snapshot(root, reason)
+    };
+
+    if let Err(e) = snapshot_result {
+        warn!(reason, root = %root.display(), "checkpoint snapshot failed (non-fatal): {e}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem tools
+// ---------------------------------------------------------------------------
 
 async fn tool_file_read(
     input: &serde_json::Value,


### PR DESCRIPTION
## Summary

Every `file_write` and `apply_patch` tool call now automatically snapshots the working directory into a shadow git repository before mutating files — enabling transparent undo/rollback.

## How it works

- Shadow repos stored at `~/.librefang/checkpoints/<16-hex>/` (hex = SHA-256 of working directory path)
- Completely isolated from user's git config via `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null`
- `snapshot()`: lazy-init shadow repo, `git add -A && git commit` (skips if no changes)
- `restore(commit_hash)`: validates hash (anti-injection), pre-rollback snapshot, then `git checkout <hash> -- .`
- `list_snapshots()`: newest 50 commits with timestamps

## Safety

- 50K file limit: skips `node_modules/`, `target/`, `.venv/` etc. before counting
- Commit hash validation: rejects empty, leading `-`, non-hex, out-of-range length
- Subprocess timeout via `std::thread::spawn` + `mpsc::recv_timeout`
- Snapshot failures only `warn!` — never block the file write

## Integration

- `tool_runner.rs`: `file_write` and `apply_patch` branches call `maybe_snapshot()` before execution
- `LibreFangKernel` owns `Arc<CheckpointManager>` and injects into deferred tool exec contexts

## Ported from

Hermes-Agent `tools/checkpoint_manager.py`

## Test plan
- [ ] CI passes
- [ ] Write a file via agent — verify snapshot created in `~/.librefang/checkpoints/`
- [ ] `list_snapshots()` returns the entry
- [ ] `restore(hash)` — verify file reverted to previous state
- [ ] Bad commit hash — verify `CheckpointError::InvalidCommitHash`