### PR TITLE
feat(skills,runtime): skill config variable declaration and system prompt injection

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -112,6 +112,9 @@ struct CachedSkillMetadata {
     /// Total number of enabled skills represented in this summary.
     /// Used by the prompt builder for progressive disclosure (inline vs summary mode).
     skill_count: usize,
+    /// Pre-formatted skill config variable section for the system prompt.
+    /// Empty when no skills declare config variables or none have resolvable values.
+    skill_config_section: String,
     created_at: std::time::Instant,
 }
 
@@ -3654,6 +3657,7 @@ system_prompt = "You are a helpful assistant."
                 skill_summary: String::new(),
                 skill_count: 0,
                 skill_prompt_context: String::new(),
+                skill_config_section: String::new(),
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
                 } else {
@@ -4655,6 +4659,10 @@ system_prompt = "You are a helpful assistant."
                 skill_prompt_context: skill_meta
                     .as_ref()
                     .map(|s| s.skill_prompt_context.clone())
+                    .unwrap_or_default(),
+                skill_config_section: skill_meta
+                    .as_ref()
+                    .map(|s| s.skill_config_section.clone())
                     .unwrap_or_default(),
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
@@ -5981,6 +5989,10 @@ system_prompt = "You are a helpful assistant."
                 skill_prompt_context: skill_meta
                     .as_ref()
                     .map(|s| s.skill_prompt_context.clone())
+                    .unwrap_or_default(),
+                skill_config_section: skill_meta
+                    .as_ref()
+                    .map(|s| s.skill_config_section.clone())
                     .unwrap_or_default(),
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
@@ -11917,10 +11929,27 @@ system_prompt = "You are a helpful assistant."
 
         let skills = self.sorted_enabled_skills(skill_allowlist);
         let skill_count = skills.len();
+        let skill_config_section = {
+            let config_path = self.home_dir_boot.join("config.toml");
+            let config_toml: toml::Value = if config_path.exists() {
+                std::fs::read_to_string(&config_path)
+                    .ok()
+                    .and_then(|s| toml::from_str(&s).ok())
+                    .unwrap_or(toml::Value::Table(toml::map::Map::new()))
+            } else {
+                toml::Value::Table(toml::map::Map::new())
+            };
+            let declared = librefang_skills::config_injection::collect_config_vars(&skills);
+            let resolved =
+                librefang_skills::config_injection::resolve_config_vars(&declared, &config_toml);
+            librefang_skills::config_injection::format_config_section(&resolved)
+        };
+
         let metadata = CachedSkillMetadata {
             skill_summary: self.build_skill_summary_from_skills(&skills),
             skill_prompt_context: self.collect_prompt_context(skill_allowlist),
             skill_count,
+            skill_config_section,
             created_at: std::time::Instant::now(),
         };
 

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -124,6 +124,10 @@ pub struct PromptContext {
     pub skill_count: usize,
     /// Prompt context from prompt-only skills.
     pub skill_prompt_context: String,
+    /// Resolved skill config variable section (pre-formatted, from
+    /// `config_injection::format_config_section`).  Empty when no skills
+    /// declare config variables or when no values could be resolved.
+    pub skill_config_section: String,
     /// MCP server/tool summary text.
     pub mcp_summary: String,
     /// Agent workspace path.
@@ -212,11 +216,15 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
     sections.push(mem_section);
 
     // Section 5 — Skills (only if skills available)
-    if !ctx.skill_summary.is_empty() || !ctx.skill_prompt_context.is_empty() {
+    if !ctx.skill_summary.is_empty()
+        || !ctx.skill_prompt_context.is_empty()
+        || !ctx.skill_config_section.is_empty()
+    {
         sections.push(build_skills_section(
             &ctx.skill_summary,
             &ctx.skill_prompt_context,
             ctx.skill_count,
+            &ctx.skill_config_section,
         ));
     }
 
@@ -576,7 +584,12 @@ pub fn build_skill_section(
     out
 }
 
-fn build_skills_section(skill_summary: &str, prompt_context: &str, skill_count: usize) -> String {
+fn build_skills_section(
+    skill_summary: &str,
+    prompt_context: &str,
+    skill_count: usize,
+    config_section: &str,
+) -> String {
     let mut out = String::from("## Skills\n");
     if !skill_summary.is_empty() {
         out.push_str(&build_skill_section(
@@ -618,6 +631,13 @@ fn build_skills_section(skill_summary: &str, prompt_context: &str, skill_count: 
             );
         }
         out.push_str(&cap_str(prompt_context, SKILL_PROMPT_CONTEXT_TOTAL_CAP));
+    }
+    // Config variables section — appended after prompt context so skills'
+    // runtime instructions come first.  Injected only when at least one
+    // enabled skill declared a config variable with a resolvable value.
+    if !config_section.is_empty() {
+        out.push_str("\n\n");
+        out.push_str(config_section);
     }
     out
 }
@@ -1381,6 +1401,37 @@ mod tests {
             result.contains("skill_list"),
             "skill_list hint missing: {result}"
         );
+    }
+
+    #[test]
+    fn test_skill_config_section_injected() {
+        let mut ctx = basic_ctx();
+        ctx.skill_summary = "- wiki-helper: Wiki integration".to_string();
+        ctx.skill_config_section =
+            "## Skill Config Variables\nwiki.base_url = https://wiki.example.com".to_string();
+        let prompt = build_system_prompt(&ctx);
+        assert!(prompt.contains("## Skill Config Variables"));
+        assert!(prompt.contains("wiki.base_url = https://wiki.example.com"));
+    }
+
+    #[test]
+    fn test_skill_config_section_omitted_when_empty() {
+        let mut ctx = basic_ctx();
+        ctx.skill_summary = "- wiki-helper: Wiki integration".to_string();
+        // skill_config_section defaults to empty
+        let prompt = build_system_prompt(&ctx);
+        assert!(!prompt.contains("## Skill Config Variables"));
+    }
+
+    #[test]
+    fn test_skill_config_section_present_without_summary() {
+        // A skill with no summary but with config vars should still surface
+        // the config section (e.g. a prompt-only skill with config_vars).
+        let mut ctx = basic_ctx();
+        ctx.skill_config_section = "## Skill Config Variables\ndb.host = localhost".to_string();
+        let prompt = build_system_prompt(&ctx);
+        assert!(prompt.contains("## Skill Config Variables"));
+        assert!(prompt.contains("db.host = localhost"));
     }
 
     #[test]

--- a/crates/librefang-skills/src/config_injection.rs
+++ b/crates/librefang-skills/src/config_injection.rs
@@ -1,0 +1,491 @@
+//! Skill config variable declaration collection and resolution.
+//!
+//! Skills can declare global configuration values they depend on via
+//! `[[config_vars]]` in their `skill.toml`.  This module:
+//!
+//! 1. Collects all declarations from a set of enabled [`InstalledSkill`]s,
+//!    deduplicating by key (first declaration wins).
+//! 2. Resolves each declared key against a parsed `toml::Value` tree,
+//!    following the storage convention `skills.config.<key>` with dotted-path
+//!    traversal.
+//! 3. Formats the resolved values as a compact system-prompt section that
+//!    the prompt builder appends to the Skills block.
+//!
+//! # Storage convention
+//!
+//! Declared keys use a *logical* dotted path (e.g. `wiki.base_url`).  In
+//! `~/.librefang/config.toml` the value is stored under
+//! `skills.config.<logical-key>`, so:
+//!
+//! ```toml
+//! [skills.config.wiki]
+//! base_url = "https://wiki.corp.example.com"
+//! ```
+//!
+//! resolves the key `wiki.base_url` to `"https://wiki.corp.example.com"`.
+//!
+//! # Prompt injection format
+//!
+//! ```text
+//! ## Skill Config Variables
+//! wiki.base_url = https://wiki.corp.example.com
+//! db.host = localhost
+//! ```
+
+use crate::{InstalledSkill, SkillConfigVar};
+
+/// Storage prefix prepended to logical keys when looking up values in the
+/// config TOML tree.  A logical key `wiki.base_url` becomes the path
+/// `skills` → `config` → `wiki` → `base_url`.
+const SKILL_CONFIG_PREFIX: &str = "skills.config";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Collect all config variable declarations from a slice of enabled skills.
+///
+/// Disabled skills are skipped by the caller (only enabled skills are passed
+/// in). Duplicate keys — where two skills declare the same key — are
+/// deduplicated: the first declaration encountered wins, preserving the
+/// ordering of `skills`.
+pub fn collect_config_vars(skills: &[InstalledSkill]) -> Vec<SkillConfigVar> {
+    let mut seen = std::collections::HashSet::new();
+    let mut vars: Vec<SkillConfigVar> = Vec::new();
+
+    for skill in skills {
+        if !skill.enabled {
+            continue;
+        }
+        for var in &skill.manifest.config_vars {
+            let key = var.key.trim();
+            if key.is_empty() || var.description.trim().is_empty() {
+                // Incomplete declaration — skip silently (mirrors Python impl).
+                continue;
+            }
+            if seen.contains(key) {
+                continue;
+            }
+            seen.insert(key.to_string());
+            vars.push(SkillConfigVar {
+                key: key.to_string(),
+                description: var.description.clone(),
+                default: var.default.clone(),
+            });
+        }
+    }
+
+    vars
+}
+
+/// Resolve a slice of config variable declarations against the raw config TOML.
+///
+/// For each declared variable the function walks the path
+/// `skills.config.<logical-key>` inside `config_toml`.  If the path is
+/// absent or its leaf value is an empty string, the declared `default` is
+/// used instead.  Variables with neither a config value nor a default are
+/// omitted from the output (they would be empty strings in the prompt, which
+/// adds noise without information).
+///
+/// Returns `(logical_key, resolved_value)` pairs in declaration order.
+pub fn resolve_config_vars(
+    vars: &[SkillConfigVar],
+    config_toml: &toml::Value,
+) -> Vec<(String, String)> {
+    let mut resolved = Vec::with_capacity(vars.len());
+
+    for var in vars {
+        // Build the full storage path: SKILL_CONFIG_PREFIX + "." + logical key
+        let storage_path = format!("{}.{}", SKILL_CONFIG_PREFIX, var.key);
+        let value = resolve_dotpath(config_toml, &storage_path);
+
+        // Normalise to Option<String>; treat empty strings as absent.
+        let value_str: Option<String> = value.and_then(|v| {
+            let s = toml_value_to_string(v);
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        });
+
+        // Fall back to declared default, then skip if still nothing.
+        let final_value = match value_str.or_else(|| var.default.clone()) {
+            Some(v) if !v.trim().is_empty() => v,
+            _ => continue,
+        };
+
+        resolved.push((var.key.clone(), final_value));
+    }
+
+    resolved
+}
+
+/// Format resolved config variable pairs as a system-prompt section string.
+///
+/// Returns an empty string when `resolved` is empty so callers can cheaply
+/// skip injection with an `is_empty()` guard.
+///
+/// Format:
+/// ```text
+/// ## Skill Config Variables
+/// wiki.base_url = https://wiki.example.com
+/// db.host = localhost
+/// ```
+pub fn format_config_section(resolved: &[(String, String)]) -> String {
+    if resolved.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("## Skill Config Variables\n");
+    for (key, value) in resolved {
+        out.push_str(key);
+        out.push_str(" = ");
+        out.push_str(value);
+        out.push('\n');
+    }
+    // Trim the trailing newline so the caller controls spacing.
+    out.trim_end_matches('\n').to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Walk a nested `toml::Value` tree following a dotted key path.
+/// Returns `None` if any segment is missing or if the current node is not
+/// a table (i.e. we cannot descend further).
+fn resolve_dotpath<'a>(root: &'a toml::Value, dotted_key: &str) -> Option<&'a toml::Value> {
+    let mut current = root;
+    for part in dotted_key.split('.') {
+        match current {
+            toml::Value::Table(tbl) => match tbl.get(part) {
+                Some(next) => current = next,
+                None => return None,
+            },
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+/// Convert a `toml::Value` leaf to a display string.
+///
+/// Tables and arrays are rendered as compact TOML (fallback) — in practice
+/// skill config vars are expected to be scalars (strings, integers, booleans).
+fn toml_value_to_string(v: &toml::Value) -> String {
+    match v {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Integer(i) => i.to_string(),
+        toml::Value::Float(f) => f.to_string(),
+        toml::Value::Boolean(b) => b.to_string(),
+        toml::Value::Datetime(dt) => dt.to_string(),
+        // Arrays and tables are unlikely for scalar config vars; render as
+        // TOML for transparency rather than silently dropping them.
+        other => toml::to_string(other).unwrap_or_default(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        InstalledSkill, SkillConfigVar, SkillManifest, SkillMeta, SkillRequirements,
+        SkillRuntimeConfig, SkillTools,
+    };
+    use std::path::PathBuf;
+
+    fn make_skill(name: &str, config_vars: Vec<SkillConfigVar>) -> InstalledSkill {
+        InstalledSkill {
+            manifest: SkillManifest {
+                skill: SkillMeta {
+                    name: name.to_string(),
+                    version: "0.1.0".to_string(),
+                    description: String::new(),
+                    author: String::new(),
+                    license: String::new(),
+                    tags: vec![],
+                },
+                runtime: SkillRuntimeConfig::default(),
+                tools: SkillTools::default(),
+                requirements: SkillRequirements::default(),
+                prompt_context: None,
+                source: None,
+                config: std::collections::HashMap::new(),
+                config_vars,
+            },
+            path: PathBuf::from("/tmp/fake"),
+            enabled: true,
+        }
+    }
+
+    // --- collect_config_vars ---
+
+    #[test]
+    fn test_collect_empty() {
+        assert!(collect_config_vars(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_collect_single_skill() {
+        let skill = make_skill(
+            "wiki",
+            vec![SkillConfigVar {
+                key: "wiki.base_url".to_string(),
+                description: "Base URL of the wiki".to_string(),
+                default: Some("https://wiki.example.com".to_string()),
+            }],
+        );
+        let vars = collect_config_vars(&[skill]);
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].key, "wiki.base_url");
+    }
+
+    #[test]
+    fn test_collect_deduplicates_keys() {
+        let skill_a = make_skill(
+            "skill-a",
+            vec![SkillConfigVar {
+                key: "shared.endpoint".to_string(),
+                description: "Shared API endpoint (from A)".to_string(),
+                default: Some("https://a.example.com".to_string()),
+            }],
+        );
+        let skill_b = make_skill(
+            "skill-b",
+            vec![SkillConfigVar {
+                key: "shared.endpoint".to_string(),
+                description: "Shared API endpoint (from B)".to_string(),
+                default: Some("https://b.example.com".to_string()),
+            }],
+        );
+        let vars = collect_config_vars(&[skill_a, skill_b]);
+        // Only the first declaration survives.
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].description, "Shared API endpoint (from A)");
+    }
+
+    #[test]
+    fn test_collect_skips_disabled_skills() {
+        let mut skill = make_skill(
+            "disabled",
+            vec![SkillConfigVar {
+                key: "foo.bar".to_string(),
+                description: "some key".to_string(),
+                default: None,
+            }],
+        );
+        skill.enabled = false;
+        assert!(collect_config_vars(&[skill]).is_empty());
+    }
+
+    #[test]
+    fn test_collect_skips_incomplete_entries() {
+        let skill = make_skill(
+            "bad-skill",
+            vec![
+                // Missing key
+                SkillConfigVar {
+                    key: String::new(),
+                    description: "no key here".to_string(),
+                    default: None,
+                },
+                // Missing description
+                SkillConfigVar {
+                    key: "valid.key".to_string(),
+                    description: String::new(),
+                    default: None,
+                },
+                // Valid entry — should be kept
+                SkillConfigVar {
+                    key: "good.key".to_string(),
+                    description: "A good key".to_string(),
+                    default: None,
+                },
+            ],
+        );
+        let vars = collect_config_vars(&[skill]);
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].key, "good.key");
+    }
+
+    // --- resolve_config_vars ---
+
+    fn make_config(toml_str: &str) -> toml::Value {
+        toml::from_str(toml_str).expect("test TOML is valid")
+    }
+
+    #[test]
+    fn test_resolve_nested_key() {
+        let config = make_config(
+            r#"
+[skills.config.wiki]
+base_url = "https://wiki.corp.example.com"
+"#,
+        );
+        let vars = vec![SkillConfigVar {
+            key: "wiki.base_url".to_string(),
+            description: "Wiki URL".to_string(),
+            default: None,
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].0, "wiki.base_url");
+        assert_eq!(resolved[0].1, "https://wiki.corp.example.com");
+    }
+
+    #[test]
+    fn test_resolve_uses_default_when_absent() {
+        let config = make_config("[skills]\n");
+        let vars = vec![SkillConfigVar {
+            key: "wiki.base_url".to_string(),
+            description: "Wiki URL".to_string(),
+            default: Some("https://default.example.com".to_string()),
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].1, "https://default.example.com");
+    }
+
+    #[test]
+    fn test_resolve_omits_when_no_value_no_default() {
+        let config = make_config("[skills]\n");
+        let vars = vec![SkillConfigVar {
+            key: "missing.key".to_string(),
+            description: "Key with no default".to_string(),
+            default: None,
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_config_overrides_default() {
+        let config = make_config(
+            r#"
+[skills.config.db]
+host = "prod-db.corp.example.com"
+"#,
+        );
+        let vars = vec![SkillConfigVar {
+            key: "db.host".to_string(),
+            description: "Database host".to_string(),
+            default: Some("localhost".to_string()),
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert_eq!(resolved[0].1, "prod-db.corp.example.com");
+    }
+
+    #[test]
+    fn test_resolve_integer_value() {
+        let config = make_config(
+            r#"
+[skills.config.api]
+timeout = 30
+"#,
+        );
+        let vars = vec![SkillConfigVar {
+            key: "api.timeout".to_string(),
+            description: "API timeout in seconds".to_string(),
+            default: None,
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert_eq!(resolved[0].1, "30");
+    }
+
+    #[test]
+    fn test_resolve_empty_string_falls_back_to_default() {
+        let config = make_config(
+            r#"
+[skills.config.wiki]
+base_url = ""
+"#,
+        );
+        let vars = vec![SkillConfigVar {
+            key: "wiki.base_url".to_string(),
+            description: "Wiki URL".to_string(),
+            default: Some("https://fallback.example.com".to_string()),
+        }];
+        let resolved = resolve_config_vars(&vars, &config);
+        assert_eq!(resolved[0].1, "https://fallback.example.com");
+    }
+
+    // --- format_config_section ---
+
+    #[test]
+    fn test_format_empty() {
+        assert!(format_config_section(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_format_single_entry() {
+        let resolved = vec![(
+            "wiki.base_url".to_string(),
+            "https://wiki.example.com".to_string(),
+        )];
+        let section = format_config_section(&resolved);
+        assert!(section.contains("## Skill Config Variables"));
+        assert!(section.contains("wiki.base_url = https://wiki.example.com"));
+    }
+
+    #[test]
+    fn test_format_multiple_entries() {
+        let resolved = vec![
+            (
+                "wiki.base_url".to_string(),
+                "https://wiki.example.com".to_string(),
+            ),
+            ("db.host".to_string(), "localhost".to_string()),
+        ];
+        let section = format_config_section(&resolved);
+        assert!(section.contains("wiki.base_url = https://wiki.example.com"));
+        assert!(section.contains("db.host = localhost"));
+        // Should not end with a newline (caller controls spacing)
+        assert!(!section.ends_with('\n'));
+    }
+
+    // --- SkillManifest round-trip (config_vars field) ---
+
+    #[test]
+    fn test_manifest_parses_config_vars() {
+        let toml_str = r#"
+[skill]
+name = "wiki-helper"
+version = "0.1.0"
+description = "Wiki integration skill"
+
+[[config_vars]]
+key = "wiki.base_url"
+description = "Base URL of the internal wiki"
+default = "https://wiki.example.com"
+
+[[config_vars]]
+key = "wiki.api_key"
+description = "API key for wiki access"
+"#;
+        let manifest: crate::SkillManifest = toml::from_str(toml_str).unwrap();
+        assert_eq!(manifest.config_vars.len(), 2);
+        assert_eq!(manifest.config_vars[0].key, "wiki.base_url");
+        assert_eq!(
+            manifest.config_vars[0].default,
+            Some("https://wiki.example.com".to_string())
+        );
+        assert_eq!(manifest.config_vars[1].key, "wiki.api_key");
+        assert!(manifest.config_vars[1].default.is_none());
+    }
+
+    #[test]
+    fn test_manifest_without_config_vars_is_backward_compatible() {
+        let toml_str = r#"
+[skill]
+name = "plain-skill"
+version = "0.1.0"
+description = "No config vars declared"
+"#;
+        let manifest: crate::SkillManifest = toml::from_str(toml_str).unwrap();
+        assert!(manifest.config_vars.is_empty());
+    }
+}

--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -8,6 +8,7 @@
 //! - Remote skills from FangHub registry
 
 pub mod clawhub;
+pub mod config_injection;
 pub mod evolution;
 pub(crate) mod http_client;
 pub mod loader;
@@ -108,6 +109,35 @@ pub struct SkillRequirements {
     pub capabilities: Vec<String>,
 }
 
+/// Declaration of a config variable a skill depends on.
+///
+/// Skills can declare global configuration values they need under
+/// `[[config_vars]]` in their `skill.toml`:
+///
+/// ```toml
+/// [[config_vars]]
+/// key = "wiki.base_url"
+/// description = "Base URL of the internal wiki"
+/// default = "https://wiki.example.com"
+/// ```
+///
+/// The kernel collects all declarations from enabled skills, resolves
+/// each key against the user's `~/.librefang/config.toml` (dotted-path
+/// lookup under `skills.config.<key>`), and injects the resolved values
+/// into the LLM system prompt as a *Config variables* block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct SkillConfigVar {
+    /// Dotted-path key used to look up the value in config.toml, e.g.
+    /// `"wiki.base_url"`.  The storage path is
+    /// `skills.config.<key>`.
+    pub key: String,
+    /// Human-readable description of what this variable controls.
+    pub description: String,
+    /// Default value used when the config key is absent or empty.
+    pub default: Option<String>,
+}
+
 /// A skill manifest (parsed from skill.toml).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillManifest {
@@ -143,6 +173,11 @@ pub struct SkillManifest {
     /// ```
     #[serde(default)]
     pub config: HashMap<String, serde_json::Value>,
+    /// Config variable declarations — values the skill needs from the
+    /// global config to function correctly.  Resolved at prompt-build
+    /// time and injected into the system prompt.
+    #[serde(default)]
+    pub config_vars: Vec<SkillConfigVar>,
 }
 
 /// Skill metadata section.


### PR DESCRIPTION
## Summary

Skills can now declare required config variables in their `skill.toml` frontmatter. The runtime collects all declarations, resolves values from `~/.librefang/config.toml`, and injects them into the system prompt.

## How it works

**Skill declaration** (`skill.toml`):
```toml
[[config_vars]]
key = "wiki.base_url"
description = "Base URL of the internal wiki"
default = "https://wiki.example.com"
```

**User config** (`~/.librefang/config.toml`):
```toml
[skills.config.wiki]
base_url = "https://wiki.corp.example.com"
```

**System prompt injection**:
```
## Skill Config Variables
wiki.base_url = https://wiki.corp.example.com
```

## Changes

- `SkillManifest` gains `config_vars: Vec<SkillConfigVar>` (`#[serde(default)]` — fully backward compatible)
- New `config_injection.rs`: `collect_config_vars()`, `resolve_config_vars()` (dotted path traversal), `format_config_section()`
- `PromptContext` gains `skill_config_section: String`; injected after skill summary in Section 5
- Deduplication: if two skills declare the same key, first declaration wins

## Ported from

Hermes-Agent `agent/skill_utils.py` config variable extraction pattern

## Test plan
- [ ] CI passes
- [ ] Install skill with `config_vars` declaration — verify variables appear in system prompt
- [ ] Set value in `config.toml` — verify resolved value used over default
- [ ] Old skills without `config_vars` — verify no regression