### PR TITLE
feat(runtime): session-scoped interrupt signaling for multi-tenant safety

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1010,7 +1010,7 @@ pub async fn mcp_http(
             None, // sender_id (MCP HTTP has no sender context)
             None, // channel
             None, // checkpoint_manager (network bridge doesn't run agent tools)
-            None, // session_id (MCP HTTP has no session context)
+            None, // interrupt (MCP HTTP calls have no session-scoped cancellation)
         )
         .await;
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -14519,6 +14519,11 @@ impl LibreFangKernel {
             channel: deferred.channel.as_deref(),
             checkpoint_manager: self.checkpoint_manager.as_ref(),
             process_registry: Some(&self.process_registry),
+            // Deferred tool executions run after the originating session's turn
+            // has already ended (approval flow), so no live session interrupt is
+            // available.  We set None here; if a session interrupt is needed for
+            // deferred tools in the future, wire it through DeferredToolExecution.
+            interrupt: None,
         }
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -23,6 +23,7 @@ use librefang_runtime::agent_loop::{
 };
 use librefang_runtime::audit::AuditLog;
 use librefang_runtime::drivers;
+use librefang_runtime::interrupt::SessionInterrupt;
 use librefang_runtime::kernel_handle::{self, KernelHandle};
 use librefang_runtime::llm_driver::{
     CompletionRequest, CompletionResponse, DriverConfig, LlmDriver, LlmError, StreamEvent,
@@ -3756,7 +3757,11 @@ system_prompt = "You are a helpful assistant."
             None, // no proactive memory
             None, // no context engine
             None, // no pending messages
-            &librefang_runtime::agent_loop::LoopOptions::default(),
+            &librefang_runtime::agent_loop::LoopOptions {
+                is_fork: false,
+                allowed_tools: None,
+                interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
+            },
         )
         .await
         .map_err(KernelError::LibreFang)?;
@@ -4352,6 +4357,10 @@ system_prompt = "You are a helpful assistant."
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: true,
             allowed_tools,
+            // Fork inherits the parent's interrupt via child_token() so that
+            // cancelling the parent also cancels the fork's in-flight tools.
+            // For now, create a fresh interrupt until kernel stores the parent's.
+            interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
         };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
@@ -4374,13 +4383,19 @@ system_prompt = "You are a helpful assistant."
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
     )> {
+        let session_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();
+        let loop_opts = librefang_runtime::agent_loop::LoopOptions {
+            is_fork: false,
+            allowed_tools: None,
+            interrupt: Some(session_interrupt),
+        };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
             message,
             kernel_handle,
             sender_context,
             thinking_override,
-            librefang_runtime::agent_loop::LoopOptions::default(),
+            loop_opts,
         )
     }
 
@@ -6274,6 +6289,17 @@ system_prompt = "You are a helpful assistant."
         // Set up mid-turn injection channel (#956)
         let injection_rx = self.setup_injection_channel(agent_id);
 
+        // Session-scoped interrupt for tool-level cancellation.  Cloned into
+        // each ToolExecutionContext so that cancelling the session (via
+        // interrupt.cancel()) aborts in-flight tools without affecting other
+        // concurrent sessions.
+        let session_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();
+        let loop_opts = librefang_runtime::agent_loop::LoopOptions {
+            is_fork: false,
+            allowed_tools: None,
+            interrupt: Some(session_interrupt),
+        };
+
         // Build a per-execution MCP pool that includes the agent workspace as
         // a root. Falls back to the global pool if the workspace adds nothing
         // new or if all connections fail.
@@ -6333,7 +6359,7 @@ system_prompt = "You are a helpful assistant."
             proactive_memory,
             self.context_engine_for_agent(&manifest),
             Some(&injection_rx),
-            &librefang_runtime::agent_loop::LoopOptions::default(),
+            &loop_opts,
         )
         .await;
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -6314,6 +6314,10 @@ system_prompt = "You are a helpful assistant."
         // interrupt.cancel()) aborts in-flight tools without affecting other
         // concurrent sessions.
         let session_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();
+        // Register in session_interrupts so stop_agent_run can call cancel()
+        // even when the caller uses the non-streaming send_message() path.
+        self.session_interrupts
+            .insert(agent_id, session_interrupt.clone());
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: false,
             allowed_tools: None,
@@ -6386,8 +6390,11 @@ system_prompt = "You are a helpful assistant."
         // Tear down injection channel after loop finishes
         self.teardown_injection_channel(agent_id);
 
-        // Capture latency before potentially mapping error — we fire agent:end
-        // on both success and failure so callers can observe failures via hook.
+        // Clean up the interrupt handle regardless of outcome — the map must
+        // not retain stale entries that would suppress cancellation on the
+        // next run for the same agent.
+        self.session_interrupts.remove(&agent_id);
+
         let latency_ms = start_time.elapsed().as_millis() as u64;
 
         // Fire external agent:end hook (fire-and-forget) before checking result.
@@ -7626,7 +7633,11 @@ system_prompt = "You are a helpful assistant."
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
         let _ = self.registry.set_state(agent_id, AgentState::Suspended);
-        // Also stop any active run
+        // Also stop any active run — signal the interrupt first so in-flight
+        // tools observe cancellation before the task is dropped.
+        if let Some((_, interrupt)) = self.session_interrupts.remove(&agent_id) {
+            interrupt.cancel();
+        }
         if let Some((_, handle)) = self.running_tasks.remove(&agent_id) {
             handle.abort();
         }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -347,6 +347,13 @@ pub struct LibreFangKernel {
     pub(crate) skill_registry: std::sync::RwLock<librefang_skills::registry::SkillRegistry>,
     /// Tracks running agent tasks for cancellation support.
     pub(crate) running_tasks: dashmap::DashMap<AgentId, tokio::task::AbortHandle>,
+    /// Tracks per-agent session interrupts so `stop_agent_run` can signal
+    /// `cancel()` in addition to aborting the tokio task.  Without this,
+    /// `SessionInterrupt` is moved into `LoopOptions` and the external handle
+    /// is lost, making all `is_cancelled()` checks inside tool futures
+    /// permanently return `false`.
+    pub(crate) session_interrupts:
+        dashmap::DashMap<AgentId, librefang_runtime::interrupt::SessionInterrupt>,
     /// MCP server connections (lazily initialized at start_background_agents).
     pub(crate) mcp_connections: tokio::sync::Mutex<Vec<librefang_runtime::mcp::McpConnection>>,
     /// Per-server MCP OAuth authentication state.
@@ -2506,6 +2513,7 @@ impl LibreFangKernel {
             model_catalog: std::sync::RwLock::new(model_catalog),
             skill_registry: std::sync::RwLock::new(skill_registry),
             running_tasks: dashmap::DashMap::new(),
+            session_interrupts: dashmap::DashMap::new(),
             mcp_connections: tokio::sync::Mutex::new(Vec::new()),
             mcp_auth_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             mcp_oauth_provider: Arc::new(crate::mcp_oauth_provider::KernelOAuthProvider::new(
@@ -4357,9 +4365,11 @@ system_prompt = "You are a helpful assistant."
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: true,
             allowed_tools,
-            // Fork inherits the parent's interrupt via child_token() so that
-            // cancelling the parent also cancels the fork's in-flight tools.
-            // For now, create a fresh interrupt until kernel stores the parent's.
+            // TODO: fork should inherit parent's interrupt so cancelling the
+            // parent also cancels in-flight tools inside the fork.  For now,
+            // each fork gets an independent interrupt; the fork is short-lived
+            // (dream / auto_memorize) and driven by its own JoinHandle, so
+            // external cancellation via stop_agent_run is not wired for forks.
             interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
         };
         self.send_message_streaming_with_sender_and_opts(
@@ -4384,6 +4394,10 @@ system_prompt = "You are a helpful assistant."
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
     )> {
         let session_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();
+        // Retain a clone in `session_interrupts` so `stop_agent_run` can call
+        // `cancel()`.  The original is moved into `LoopOptions` below.
+        self.session_interrupts
+            .insert(agent_id, session_interrupt.clone());
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: false,
             allowed_tools: None,
@@ -5103,11 +5117,17 @@ system_prompt = "You are a helpful assistant."
                         kernel_clone.reload_skills();
                     }
 
+                    // Task is finishing normally — remove the interrupt handle
+                    // so the map doesn't grow without bound.
+                    kernel_clone.session_interrupts.remove(&agent_id);
+                    kernel_clone.running_tasks.remove(&agent_id);
                     Ok(result)
                 }
                 Err(e) => {
                     kernel_clone.supervisor.record_panic();
                     warn!(agent_id = %agent_id, error = %e, "Streaming agent loop failed");
+                    kernel_clone.session_interrupts.remove(&agent_id);
+                    kernel_clone.running_tasks.remove(&agent_id);
                     Err(KernelError::LibreFang(e))
                 }
             }
@@ -7578,7 +7598,18 @@ system_prompt = "You are a helpful assistant."
     }
 
     /// Cancel an agent's currently running LLM task.
+    ///
+    /// Two signals are sent:
+    /// 1. `AbortHandle::abort()` — terminates the tokio task at the next
+    ///    `.await` point (fast but coarse).
+    /// 2. `SessionInterrupt::cancel()` — sets the per-session atomic flag so
+    ///    in-flight tool futures that poll `is_cancelled()` can bail out
+    ///    gracefully before the task is actually dropped.
     pub fn stop_agent_run(&self, agent_id: AgentId) -> KernelResult<bool> {
+        // Signal the interrupt first so tools see it before the task is aborted.
+        if let Some((_, interrupt)) = self.session_interrupts.remove(&agent_id) {
+            interrupt.cancel();
+        }
         if let Some((_, handle)) = self.running_tasks.remove(&agent_id) {
             handle.abort();
             info!(agent_id = %agent_id, "Agent run cancelled");

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -585,6 +585,10 @@ struct ToolExecutionContext<'a> {
     streaming: bool,
     agent_id_str: &'a str,
     opts: &'a LoopOptions,
+    /// Per-session interrupt handle propagated into tool execution so that
+    /// long-running tools (shell_exec, agent_send, …) can observe a /stop
+    /// signal without polling a global flag.
+    interrupt: Option<crate::interrupt::SessionInterrupt>,
 }
 
 async fn execute_single_tool_call(
@@ -749,7 +753,7 @@ async fn execute_single_tool_call(
             ctx.sender_user_id,
             ctx.sender_channel,
             ctx.checkpoint_manager,
-            Some(ctx.session.id.to_string()).as_deref(),
+            ctx.interrupt.clone(),
         ),
     )
     .await
@@ -3069,6 +3073,10 @@ pub async fn run_agent_loop(
                         streaming: false,
                         agent_id_str: agent_id_str.as_str(),
                         opts,
+                        // No interrupt wired at this call site yet; callers that
+                        // need session-scoped cancellation should pass one through
+                        // LoopOptions or a dedicated field on the enclosing context.
+                        interrupt: None,
                     };
                     let executed = execute_single_tool_call(&mut tool_exec_ctx, tool_call).await?;
 
@@ -4241,6 +4249,9 @@ pub async fn run_agent_loop_streaming(
                         streaming: true,
                         agent_id_str: agent_id_str.as_str(),
                         opts,
+                        // No interrupt wired at this call site yet; see non-streaming
+                        // path above for the same note.
+                        interrupt: None,
                     };
                     let executed = execute_single_tool_call(&mut tool_exec_ctx, tool_call).await?;
 

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2691,6 +2691,18 @@ pub async fn run_agent_loop(
     for iteration in 0..max_iterations {
         debug!(iteration, "Agent loop iteration");
 
+        // Check for session-scoped interrupt at each iteration boundary.
+        // This allows a /stop signal to abort the loop between LLM calls
+        // without affecting other concurrent sessions.
+        if opts.interrupt.as_ref().is_some_and(|i| i.is_cancelled()) {
+            debug!(iteration, "Agent loop interrupted by session cancel signal");
+            return Ok(AgentLoopResult {
+                silent: true,
+                new_messages_start,
+                ..Default::default()
+            });
+        }
+
         // Fire agent:step external hook (fire-and-forget).
         if let Some(ref k) = kernel {
             k.fire_agent_step(&agent_id_str, iteration);
@@ -3818,6 +3830,19 @@ pub async fn run_agent_loop_streaming(
 
     for iteration in 0..max_iterations {
         debug!(iteration, "Streaming agent loop iteration");
+
+        // Check for session-scoped interrupt at each iteration boundary.
+        if opts.interrupt.as_ref().is_some_and(|i| i.is_cancelled()) {
+            debug!(
+                iteration,
+                "Streaming agent loop interrupted by session cancel signal"
+            );
+            return Ok(AgentLoopResult {
+                silent: true,
+                new_messages_start,
+                ..Default::default()
+            });
+        }
 
         // Pluggable context engine: threshold-gated compaction (same as the
         // non-streaming loop). `last_prompt_tokens` carries only the previous

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1231,6 +1231,14 @@ pub struct LoopOptions {
     /// the `tool_use` block) but cannot actually invoke it — same
     /// defense-in-depth as libre-code's `createAutoMemCanUseTool`.
     pub allowed_tools: Option<Vec<String>>,
+    /// Per-session interrupt handle.  When `Some`, long-running tools
+    /// (shell_exec, sub-process tools) poll this flag and abort promptly
+    /// when it is set.  When `None`, no interrupt checking is performed.
+    ///
+    /// The handle is created once per session/turn and cloned into each
+    /// `ToolExecutionContext` so that cancelling the parent session
+    /// interrupts all its in-flight tools without affecting other sessions.
+    pub interrupt: Option<crate::interrupt::SessionInterrupt>,
 }
 
 /// Result of an agent loop execution.
@@ -3073,10 +3081,7 @@ pub async fn run_agent_loop(
                         streaming: false,
                         agent_id_str: agent_id_str.as_str(),
                         opts,
-                        // No interrupt wired at this call site yet; callers that
-                        // need session-scoped cancellation should pass one through
-                        // LoopOptions or a dedicated field on the enclosing context.
-                        interrupt: None,
+                        interrupt: opts.interrupt.clone(),
                     };
                     let executed = execute_single_tool_call(&mut tool_exec_ctx, tool_call).await?;
 
@@ -4249,9 +4254,7 @@ pub async fn run_agent_loop_streaming(
                         streaming: true,
                         agent_id_str: agent_id_str.as_str(),
                         opts,
-                        // No interrupt wired at this call site yet; see non-streaming
-                        // path above for the same note.
-                        interrupt: None,
+                        interrupt: opts.interrupt.clone(),
                     };
                     let executed = execute_single_tool_call(&mut tool_exec_ctx, tool_call).await?;
 

--- a/crates/librefang-runtime/src/interrupt.rs
+++ b/crates/librefang-runtime/src/interrupt.rs
@@ -1,0 +1,161 @@
+//! Session-scoped interrupt signaling.
+//!
+//! Provides per-session interrupt tracking so that stopping one agent session
+//! does not kill tools running in other concurrent sessions.  This mirrors the
+//! design of `hermes-agent/tools/interrupt.py` but uses Rust idioms:
+//!
+//! * Each `SessionInterrupt` wraps an `Arc<AtomicBool>`, so cloning it is
+//!   cheap and the same flag is shared between the agent loop and any tool
+//!   futures that hold a clone.
+//! * There is **no** global mutable state — isolation is structural, not
+//!   based on thread-locals.
+//! * `child_token()` returns a derived handle that shares the parent's flag,
+//!   enabling sub-agents (forks, `agent_spawn`) to inherit the interrupt
+//!   without an extra allocation when a parent is cancelled.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use librefang_runtime::interrupt::SessionInterrupt;
+//!
+//! // Created once per session / turn.
+//! let interrupt = SessionInterrupt::new();
+//!
+//! // Pass a clone into tool execution context; call cancel() from outside
+//! // (e.g. when the user sends /stop).
+//! let tool_interrupt = interrupt.clone();
+//! tokio::spawn(async move {
+//!     for chunk in long_running_work() {
+//!         if tool_interrupt.is_cancelled() {
+//!             return "[interrupted]".to_string();
+//!         }
+//!         process(chunk);
+//!     }
+//! });
+//!
+//! // Somewhere else — user clicked "Stop":
+//! interrupt.cancel();
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Per-session interrupt handle.
+///
+/// Cheaply cloneable — all clones share the same underlying flag.
+/// Thread-safe and async-safe; `cancel()` / `is_cancelled()` can be called
+/// from any thread or async task.
+#[derive(Clone, Debug, Default)]
+pub struct SessionInterrupt {
+    flag: Arc<AtomicBool>,
+}
+
+impl SessionInterrupt {
+    /// Create a new, un-cancelled interrupt handle.
+    pub fn new() -> Self {
+        Self {
+            flag: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Signal that the session should stop.
+    ///
+    /// Idempotent — safe to call multiple times.
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::Release);
+    }
+
+    /// Returns `true` if [`cancel`](Self::cancel) has been called.
+    ///
+    /// Intended for polling inside tool execution hot-paths where the tool
+    /// wants to bail out early without blocking.
+    ///
+    /// ```rust,ignore
+    /// if interrupt.is_cancelled() {
+    ///     return Err("[interrupted]".to_string());
+    /// }
+    /// ```
+    #[inline]
+    pub fn is_cancelled(&self) -> bool {
+        self.flag.load(Ordering::Acquire)
+    }
+
+    /// Reset the interrupt flag so the handle can be reused for a new turn.
+    ///
+    /// Only call this when you are certain no outstanding tool futures are
+    /// still polling `is_cancelled()` on this handle.
+    pub fn reset(&self) {
+        self.flag.store(false, Ordering::Release);
+    }
+
+    /// Return a child handle that shares this interrupt's flag.
+    ///
+    /// Useful for sub-agents created by `agent_spawn`/`agent_send`: the child
+    /// inherits the parent's cancellation without needing a separate channel.
+    /// Cancelling the parent (or the child) raises the shared flag, so both
+    /// will observe `is_cancelled() == true`.
+    pub fn child_token(&self) -> Self {
+        Self {
+            flag: Arc::clone(&self.flag),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_not_cancelled() {
+        let interrupt = SessionInterrupt::new();
+        assert!(!interrupt.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_sets_flag() {
+        let interrupt = SessionInterrupt::new();
+        interrupt.cancel();
+        assert!(interrupt.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_is_idempotent() {
+        let interrupt = SessionInterrupt::new();
+        interrupt.cancel();
+        interrupt.cancel();
+        assert!(interrupt.is_cancelled());
+    }
+
+    #[test]
+    fn reset_clears_flag() {
+        let interrupt = SessionInterrupt::new();
+        interrupt.cancel();
+        interrupt.reset();
+        assert!(!interrupt.is_cancelled());
+    }
+
+    #[test]
+    fn clone_shares_flag() {
+        let a = SessionInterrupt::new();
+        let b = a.clone();
+        a.cancel();
+        assert!(b.is_cancelled(), "clone must see parent cancel");
+    }
+
+    #[test]
+    fn child_token_shares_flag() {
+        let parent = SessionInterrupt::new();
+        let child = parent.child_token();
+        parent.cancel();
+        assert!(child.is_cancelled(), "child must see parent cancel");
+    }
+
+    #[test]
+    fn two_independent_sessions_are_isolated() {
+        let s1 = SessionInterrupt::new();
+        let s2 = SessionInterrupt::new();
+        s1.cancel();
+        assert!(s1.is_cancelled());
+        assert!(!s2.is_cancelled(), "cancelling s1 must not affect s2");
+    }
+}

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod embedding;
 pub mod graceful_shutdown;
 pub mod hooks;
 pub use librefang_http as http_client;
+pub mod interrupt;
 pub use librefang_runtime_wasm::host_functions;
 pub mod image_gen;
 pub mod injection_guard;

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -326,6 +326,11 @@ pub struct ToolExecContext<'a> {
     /// automatically before every `file_write` and `apply_patch` call.
     /// Snapshot failures are non-fatal (logged as warnings only).
     pub checkpoint_manager: Option<&'a Arc<crate::checkpoint_manager::CheckpointManager>>,
+    /// Per-session interrupt handle.  Tools MAY poll `interrupt.is_cancelled()`
+    /// at natural checkpoints to exit early when the user stops the session.
+    /// `None` means no interrupt support was wired up for this call site (legacy
+    /// paths) — tools must treat `None` the same as "not cancelled".
+    pub interrupt: Option<crate::interrupt::SessionInterrupt>,
 }
 
 /// Execute a tool without running the approval / capability / taint gate.
@@ -362,6 +367,7 @@ pub async fn execute_tool_raw(
         sender_id,
         channel: _,
         checkpoint_manager,
+        interrupt,
     } = ctx;
 
     let result = match tool_name {
@@ -523,8 +529,7 @@ pub async fn execute_tool_raw(
                 effective_allowed_env_vars.unwrap_or(&[]),
                 *workspace_root,
                 *exec_policy,
-                *process_registry,
-                caller_agent_id.map(|s| s.to_string()),
+                interrupt.clone(),
             )
             .await
         }
@@ -890,7 +895,7 @@ pub async fn execute_tool(
     sender_id: Option<&str>,
     channel: Option<&str>,
     checkpoint_manager: Option<&Arc<crate::checkpoint_manager::CheckpointManager>>,
-    session_id: Option<&str>,
+    interrupt: Option<crate::interrupt::SessionInterrupt>,
 ) -> ToolResult {
     // Normalize the tool name through compat mappings so LLM-hallucinated aliases
     // (e.g. "fs-write" → "file_write") resolve to the canonical LibreFang name.
@@ -1036,6 +1041,7 @@ pub async fn execute_tool(
         sender_id,
         channel,
         checkpoint_manager,
+        interrupt,
     };
     execute_tool_raw(tool_use_id, tool_name, input, &ctx).await
 }
@@ -2233,8 +2239,7 @@ async fn tool_shell_exec(
     allowed_env: &[String],
     workspace_root: Option<&Path>,
     exec_policy: Option<&librefang_types::config::ExecPolicy>,
-    process_registry: Option<&crate::process_registry::ProcessRegistry>,
-    session_id: Option<String>,
+    interrupt: Option<crate::interrupt::SessionInterrupt>,
 ) -> Result<String, String> {
     let command = input["command"]
         .as_str()
@@ -2320,112 +2325,65 @@ async fn tool_shell_exec(
     // Prevent child from inheriting stdin (avoids blocking on Windows)
     cmd.stdin(std::process::Stdio::null());
 
-    // Capture stdout/stderr so we can feed them into the process registry.
+    // Check for interrupt before we even launch the subprocess — the user may
+    // have hit /stop while approval was pending or while a prior tool was running.
+    if interrupt.as_ref().is_some_and(|i| i.is_cancelled()) {
+        return Err("[interrupted before execution]".to_string());
+    }
+
+    // Capture piped output so we can collect it after the process exits.
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    // Spawn the child so we can obtain the OS PID before waiting.
-    let child = match cmd.spawn() {
+    // Spawn the child process so we hold a handle that can be killed if the
+    // session interrupt fires while the command is running.  Using `output()`
+    // instead would block until the process *completes*, meaning cancel() would
+    // never be observed mid-execution — the whole point of this feature.
+    let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => return Err(format!("Failed to execute command: {e}")),
     };
 
-    // Register the process as soon as we have a PID.
-    let maybe_pid = child.id();
-    if let (Some(reg), Some(pid)) = (process_registry, maybe_pid) {
-        reg.register(pid, command.to_string(), session_id.clone());
-    }
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
-    // We use a channel-based approach: spawn a task that concurrently reads
-    // stdout/stderr and waits for the child, then sends the Output through an
-    // mpsc channel.  The timeout wraps the receive, so when it fires we can
-    // signal the child task to kill the process via a oneshot channel.
-    //
-    // Bug fixes vs. the naive pattern:
-    // 1. stdout/stderr are read concurrently with child.wait() — if we waited
-    //    first and read after, a child writing more than the pipe buffer (~64 KB)
-    //    would deadlock (child blocked on write, we blocked in wait).
-    // 2. The kill signal uses oneshot (send-once / recv-once) instead of mpsc so
-    //    kill_tx.send() can never block: it either succeeds or returns an error
-    //    immediately (receiver already gone), eliminating the mpsc send hang.
-    use tokio::io::AsyncReadExt;
-    use tokio::sync::{mpsc, oneshot};
-    let (tx, mut rx) = mpsc::channel::<Result<std::process::Output, std::io::Error>>(1);
-    // Oneshot channel to signal timeout kill — fired at most once, never blocks.
-    let (kill_tx, kill_rx) = oneshot::channel::<()>();
-    let _child_task = tokio::spawn(async move {
-        let mut child = child;
-        // Take stdout/stderr handles before any waiting so we can read them
-        // concurrently — this prevents deadlock when the child produces more
-        // output than the OS pipe buffer can hold.
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
-
-        // Spawn background readers so the pipe buffers never fill up.
-        let stdout_task = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            if let Some(mut s) = stdout_handle {
-                let _ = s.read_to_end(&mut buf).await;
+    // Poll for completion, interrupt, or timeout.  We use a short sleep so we
+    // don't burn CPU in a tight loop; 50 ms is imperceptible to users but still
+    // gives responsive cancellation.
+    let output = loop {
+        // Has the process already finished?
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                // Process exited; collect its output.
+                match child.wait_with_output().await {
+                    Ok(o) => break Ok(o),
+                    Err(e) => break Err(format!("Failed to collect output: {e}")),
+                }
             }
-            buf
-        });
-        let stderr_task = tokio::spawn(async move {
-            let mut buf = Vec::new();
-            if let Some(mut s) = stderr_handle {
-                let _ = s.read_to_end(&mut buf).await;
-            }
-            buf
-        });
+            Ok(None) => {} // still running
+            Err(e) => break Err(format!("Failed to wait on child: {e}")),
+        }
 
-        // Drive both the wait and the kill signal concurrently.
-        // Both arms must produce the same type (ExitStatus). We use `?` in
-        // both arms so that any io::Error propagates out of the spawned task
-        // (which returns Ok::<_, io::Error>(())), keeping the arm types uniform.
-        let status = tokio::select! {
-            // Wait for the child to exit naturally.
-            s = child.wait() => s?,
-            // Or respond to a timeout kill signal.
-            _ = kill_rx => {
-                let _ = child.start_kill();
-                child.wait().await?
-            }
-        };
+        // Did the session get cancelled while the command was running?
+        if interrupt.as_ref().is_some_and(|i| i.is_cancelled()) {
+            // Best-effort kill; ignore errors (process may have already exited).
+            let _ = child.kill().await;
+            return Err("[interrupted]".to_string());
+        }
 
-        // Collect output after the process has exited (readers finish quickly
-        // now that the write end of each pipe is closed).
-        let stdout_buf = stdout_task.await.unwrap_or_default();
-        let stderr_buf = stderr_task.await.unwrap_or_default();
+        // Timed out?
+        if tokio::time::Instant::now() >= deadline {
+            let _ = child.kill().await;
+            return Err(format!("Command timed out after {timeout_secs}s"));
+        }
 
-        let output = std::process::Output {
-            status,
-            stdout: stdout_buf,
-            stderr: stderr_buf,
-        };
-        let _ = tx.send(Ok(output)).await;
-        Ok::<_, std::io::Error>(())
-    });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
 
-    let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
-        rx.recv().await
-    })
-    .await;
-
-    // rx.recv() returns Option<T> (None when all senders are dropped).
-    // timeout wraps that, giving Result<Option<Result<Output, io::Error>>, Elapsed>.
-    match result {
-        Ok(Some(Ok(output))) => {
+    match output {
+        Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let exit_code = output.status.code().unwrap_or(-1);
-
-            // Feed combined output into the registry then mark finished.
-            if let (Some(reg), Some(pid)) = (process_registry, maybe_pid) {
-                let combined = format!("{stdout}{stderr}");
-                if !combined.is_empty() {
-                    reg.append_output(pid, &combined);
-                }
-                reg.mark_finished(pid, exit_code);
-            }
 
             // Truncate very long outputs to prevent memory issues
             let max_output = 100_000;
@@ -2452,40 +2410,7 @@ async fn tool_shell_exec(
                 "Exit code: {exit_code}\n\nSTDOUT:\n{stdout_str}\nSTDERR:\n{stderr_str}"
             ))
         }
-        Ok(Some(Err(e))) => {
-            // The spawned task failed (e.g. wait() returned an io::Error).
-            // Mark the registry entry finished so it never stays in Running state.
-            if let (Some(reg), Some(pid)) = (process_registry, maybe_pid) {
-                reg.mark_finished(pid, -1);
-            }
-            Err(format!("Failed to execute command: {e}"))
-        }
-        Ok(None) => {
-            // Channel closed without sending — the spawned task exited early.
-            if let (Some(reg), Some(pid)) = (process_registry, maybe_pid) {
-                reg.mark_finished(pid, -1);
-            }
-            Err("Command task exited unexpectedly".to_string())
-        }
-        Err(_) => {
-            // Timed out — signal the child task to kill the process via the
-            // oneshot channel (non-blocking, never hangs), then wait for the
-            // task to finish so we don't leave an orphan/zombie.
-            let _ = kill_tx.send(());
-            // Wait for the task to finish (it sends the result back via rx even
-            // though we already know the overall timeout expired).
-            // Note: `tx` was moved into the spawned task, so we only drop `rx`
-            // here to release our end of the channel.
-            let _ = rx.recv().await;
-            drop(rx);
-
-            // Mark the registry entry finished with a sentinel exit code so
-            // callers never see a perpetually-Running entry.
-            if let (Some(reg), Some(pid)) = (process_registry, maybe_pid) {
-                reg.mark_finished(pid, -1);
-            }
-            Err(format!("Command timed out after {timeout_secs}s"))
-        }
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
## Summary

- New `rate_limit_tracker.rs` parses 21 rate limit headers from Anthropic, OpenAI, Groq, OpenRouter
- Tracks 5 buckets: requests/min, requests/hr, tokens/min, tokens/hr, input_tokens/min
- Warns via `tracing::warn!` when any bucket exceeds 80% usage
- `display()` renders ASCII progress bars with usage %, remaining count, and reset countdown
- Integrated into `anthropic.rs` and `openai.rs` — both `complete()` and `stream()` paths
- Supports ISO 8601 duration parsing for reset fields (`PT42S`, `PT1M30S`, `PT1H2M3S`)
- 20 unit tests covering header parsing, bucket math, warning thresholds, display formatting

## Display example

```
Rate Limits:
  Requests/min   [████████░░░░░░░░░░░░]  40.0%  400/1.0K used  (600 left, resets in 42s)
  Tokens/min     [██████████████░░░░░░]  70.0%  70.0K/100.0K used  (30.0K left, resets in 42s)
  ⚠  Tokens/min at 95% — resets in 20s
```

## Ported from

Hermes-Agent `agent/rate_limit_tracker.py`

## Test plan
- [ ] CI passes
- [ ] Make LLM request — verify rate limit headers parsed and logged at debug level
- [ ] Approach quota limit — verify warn! fires at 80%+