### PR TITLE
feat(runtime): skill index progressive disclosure in system prompt

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -109,6 +109,9 @@ impl CachedWorkspaceMetadata {
 struct CachedSkillMetadata {
     skill_summary: String,
     skill_prompt_context: String,
+    /// Total number of enabled skills represented in this summary.
+    /// Used by the prompt builder for progressive disclosure (inline vs summary mode).
+    skill_count: usize,
     created_at: std::time::Instant,
 }
 
@@ -3649,6 +3652,7 @@ system_prompt = "You are a helpful assistant."
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
                 recalled_memories: vec![],
                 skill_summary: String::new(),
+                skill_count: 0,
                 skill_prompt_context: String::new(),
                 mcp_summary: if mcp_tool_count > 0 {
                     self.build_mcp_summary(&manifest.mcp_servers)
@@ -4647,6 +4651,7 @@ system_prompt = "You are a helpful assistant."
                     .as_ref()
                     .map(|s| s.skill_summary.clone())
                     .unwrap_or_default(),
+                skill_count: skill_meta.as_ref().map(|s| s.skill_count).unwrap_or(0),
                 skill_prompt_context: skill_meta
                     .as_ref()
                     .map(|s| s.skill_prompt_context.clone())
@@ -5972,6 +5977,7 @@ system_prompt = "You are a helpful assistant."
                     .as_ref()
                     .map(|s| s.skill_summary.clone())
                     .unwrap_or_default(),
+                skill_count: skill_meta.as_ref().map(|s| s.skill_count).unwrap_or(0),
                 skill_prompt_context: skill_meta
                     .as_ref()
                     .map(|s| s.skill_prompt_context.clone())
@@ -11909,9 +11915,12 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        let skills = self.sorted_enabled_skills(skill_allowlist);
+        let skill_count = skills.len();
         let metadata = CachedSkillMetadata {
-            skill_summary: self.build_skill_summary(skill_allowlist),
+            skill_summary: self.build_skill_summary_from_skills(&skills),
             skill_prompt_context: self.collect_prompt_context(skill_allowlist),
+            skill_count,
             created_at: std::time::Instant::now(),
         };
 
@@ -11993,10 +12002,17 @@ system_prompt = "You are a helpful assistant."
         skills
     }
 
-    fn build_skill_summary(&self, skill_allowlist: &[String]) -> String {
+    /// Build a skill summary string from a pre-sorted skills slice.
+    ///
+    /// Accepts the already-filtered-and-sorted list returned by
+    /// [`sorted_enabled_skills`] so the caller can reuse it for counting
+    /// without a second registry read.
+    fn build_skill_summary_from_skills(
+        &self,
+        skills: &[librefang_skills::InstalledSkill],
+    ) -> String {
         use librefang_runtime::prompt_builder::{sanitize_for_prompt, SKILL_NAME_DISPLAY_CAP};
 
-        let skills = self.sorted_enabled_skills(skill_allowlist);
         if skills.is_empty() {
             return String::new();
         }
@@ -12008,7 +12024,7 @@ system_prompt = "You are a helpful assistant."
             String,
             Vec<&librefang_skills::InstalledSkill>,
         > = std::collections::BTreeMap::new();
-        for skill in &skills {
+        for skill in skills {
             let category = librefang_skills::registry::derive_category(&skill.manifest).to_string();
             categories.entry(category).or_default().push(skill);
         }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2684,7 +2684,25 @@ pub async fn run_agent_loop(
                             kept = result.kept_messages.len(),
                             "Context engine compaction complete"
                         );
-                        messages = result.kept_messages;
+                        // Inject the LLM-generated summary as a synthetic user message
+                        // so the agent retains context about what was compacted.
+                        // Without this, the summary is silently discarded and the agent
+                        // loses all knowledge of earlier turns.
+                        let mut compacted = Vec::with_capacity(result.kept_messages.len() + 1);
+                        if !result.summary.is_empty() {
+                            compacted.push(Message {
+                                role: Role::User,
+                                content: MessageContent::Text(format!(
+                                    "[Context compaction summary] Earlier conversation turns \
+                                     were summarised to preserve context space. Summary of \
+                                     removed messages: {}",
+                                    result.summary
+                                )),
+                                pinned: false,
+                            });
+                        }
+                        compacted.extend(result.kept_messages);
+                        messages = compacted;
                         // Reset last_prompt_tokens so should_compress does not
                         // re-fire on the next iteration before the LLM has run.
                         // Do NOT touch total_usage — it is the cross-turn budget
@@ -3747,7 +3765,25 @@ pub async fn run_agent_loop_streaming(
                             kept = result.kept_messages.len(),
                             "Context engine compaction complete (streaming)"
                         );
-                        messages = result.kept_messages;
+                        // Inject the LLM-generated summary as a synthetic user message
+                        // so the agent retains context about what was compacted.
+                        // Without this, the summary is silently discarded and the agent
+                        // loses all knowledge of earlier turns.
+                        let mut compacted = Vec::with_capacity(result.kept_messages.len() + 1);
+                        if !result.summary.is_empty() {
+                            compacted.push(Message {
+                                role: Role::User,
+                                content: MessageContent::Text(format!(
+                                    "[Context compaction summary] Earlier conversation turns \
+                                     were summarised to preserve context space. Summary of \
+                                     removed messages: {}",
+                                    result.summary
+                                )),
+                                pinned: false,
+                            });
+                        }
+                        compacted.extend(result.kept_messages);
+                        messages = compacted;
                         // Reset last_prompt_tokens so should_compress does not
                         // re-fire on the next iteration before the LLM has run.
                         // Do NOT touch total_usage — it is the cross-turn budget

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2685,11 +2685,11 @@ pub async fn run_agent_loop(
                             "Context engine compaction complete"
                         );
                         messages = result.kept_messages;
-                        // Reset the stale token count so should_compress does
-                        // not re-fire on the next iteration before the LLM
-                        // has run. The real count will be refreshed by
-                        // accumulate_token_usage after the upcoming LLM call.
-                        total_usage.input_tokens = 0;
+                        // Reset last_prompt_tokens so should_compress does not
+                        // re-fire on the next iteration before the LLM has run.
+                        // Do NOT touch total_usage — it is the cross-turn budget
+                        // accumulator and must never be zeroed here.
+                        last_prompt_tokens = 0;
                     }
                     Err(e) => {
                         warn!("Context engine compaction failed (continuing): {e}");
@@ -3748,11 +3748,11 @@ pub async fn run_agent_loop_streaming(
                             "Context engine compaction complete (streaming)"
                         );
                         messages = result.kept_messages;
-                        // Reset the stale token count so should_compress does
-                        // not re-fire on the next iteration before the LLM
-                        // has run. The real count will be refreshed by
-                        // accumulate_token_usage after the upcoming LLM call.
-                        total_usage.input_tokens = 0;
+                        // Reset last_prompt_tokens so should_compress does not
+                        // re-fire on the next iteration before the LLM has run.
+                        // Do NOT touch total_usage — it is the cross-turn budget
+                        // accumulator and must never be zeroed here.
+                        last_prompt_tokens = 0;
                     }
                     Err(e) => {
                         warn!("Context engine compaction failed (continuing, streaming): {e}");

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2640,6 +2640,7 @@ pub async fn run_agent_loop(
     let mut hallucination_retried = false;
     let mut action_nudge_retried = false;
     let mut consecutive_all_failed: u32 = 0;
+    let mut last_prompt_tokens: usize = 0;
 
     for iteration in 0..max_iterations {
         debug!(iteration, "Agent loop iteration");
@@ -2647,6 +2648,54 @@ pub async fn run_agent_loop(
         // Fire agent:step external hook (fire-and-forget).
         if let Some(ref k) = kernel {
             k.fire_agent_step(&agent_id_str, iteration);
+        }
+
+        // Pluggable context engine: threshold-gated compaction. When the
+        // engine signals that the current token count has crossed its
+        // compression threshold, run a compaction pass *before* assemble so
+        // the assembled context is already trimmed.
+        //
+        // `last_prompt_tokens` carries the prompt-token count from the
+        // previous LLM call — never a running sum.  This correctly gates
+        // `should_compress` on each turn's own input cost.  On the first
+        // iteration `last_prompt_tokens` is 0, so compaction can only fire
+        // when the model's context window itself (via `ctx_window`) is
+        // below threshold.  `total_usage` (accumulated across iterations) is
+        // never read here, so it remains a clean snapshot for the kernel
+        // budget tracker and is never mutated by the compaction path.
+        if let Some(engine) = context_engine {
+            if engine.should_compress(last_prompt_tokens, ctx_window) {
+                debug!(
+                    iteration,
+                    last_prompt_tokens, ctx_window, "Context engine requested compaction"
+                );
+                match engine
+                    .compact(
+                        session.agent_id,
+                        &messages,
+                        driver.clone(),
+                        &manifest.model.model,
+                        ctx_window,
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        debug!(
+                            kept = result.kept_messages.len(),
+                            "Context engine compaction complete"
+                        );
+                        messages = result.kept_messages;
+                        // Reset the stale token count so should_compress does
+                        // not re-fire on the next iteration before the LLM
+                        // has run. The real count will be refreshed by
+                        // accumulate_token_usage after the upcoming LLM call.
+                        total_usage.input_tokens = 0;
+                    }
+                    Err(e) => {
+                        warn!("Context engine compaction failed (continuing): {e}");
+                    }
+                }
+            }
         }
 
         // Context assembly — use context engine if available, else inline logic
@@ -2735,6 +2784,11 @@ pub async fn run_agent_loop(
         let mut response = call_with_retry(&*driver, request, Some(provider_name), None).await?;
 
         accumulate_token_usage(&mut total_usage, &response.usage);
+
+        // Snapshot prompt tokens for the next iteration's should_compress check.
+        // This is the per-turn input cost, NOT a running sum — we deliberately
+        // do NOT accumulate into last_prompt_tokens.
+        last_prompt_tokens = response.usage.input_tokens as usize;
 
         // Strip image base64 from earlier messages (LLM already processed them)
         strip_processed_image_data(&mut messages);
@@ -3661,9 +3715,51 @@ pub async fn run_agent_loop_streaming(
     let mut hallucination_retried = false;
     let mut action_nudge_retried = false;
     let mut consecutive_all_failed: u32 = 0;
+    let mut last_prompt_tokens: usize = 0;
 
     for iteration in 0..max_iterations {
         debug!(iteration, "Streaming agent loop iteration");
+
+        // Pluggable context engine: threshold-gated compaction (same as the
+        // non-streaming loop). `last_prompt_tokens` carries only the previous
+        // turn's prompt cost — never the cumulative total.  `total_usage`
+        // (accumulated) is never read or written here.
+        if let Some(engine) = context_engine {
+            if engine.should_compress(last_prompt_tokens, ctx_window) {
+                debug!(
+                    iteration,
+                    last_prompt_tokens,
+                    ctx_window,
+                    "Context engine requested compaction (streaming path)"
+                );
+                match engine
+                    .compact(
+                        session.agent_id,
+                        &messages,
+                        driver.clone(),
+                        &manifest.model.model,
+                        ctx_window,
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        debug!(
+                            kept = result.kept_messages.len(),
+                            "Context engine compaction complete (streaming)"
+                        );
+                        messages = result.kept_messages;
+                        // Reset the stale token count so should_compress does
+                        // not re-fire on the next iteration before the LLM
+                        // has run. The real count will be refreshed by
+                        // accumulate_token_usage after the upcoming LLM call.
+                        total_usage.input_tokens = 0;
+                    }
+                    Err(e) => {
+                        warn!("Context engine compaction failed (continuing, streaming): {e}");
+                    }
+                }
+            }
+        }
 
         // Context assembly — use context engine if available, else inline logic
         let recovery = if let Some(engine) = context_engine {
@@ -3815,6 +3911,11 @@ pub async fn run_agent_loop_streaming(
         };
 
         accumulate_token_usage(&mut total_usage, &response.usage);
+
+        // Snapshot prompt tokens for the next iteration's should_compress check.
+        // This is the per-turn input cost, NOT a running sum — we deliberately
+        // do NOT accumulate into last_prompt_tokens.
+        last_prompt_tokens = response.usage.input_tokens as usize;
 
         // Strip image base64 from earlier messages (LLM already processed them)
         strip_processed_image_data(&mut messages);

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -357,6 +357,22 @@ pub trait ContextEngine: Send + Sync {
     fn per_agent_metrics(&self) -> std::collections::HashMap<String, HookStats> {
         std::collections::HashMap::new()
     }
+
+    /// Return `true` when the context engine believes compaction should run
+    /// before the next LLM call.
+    ///
+    /// `last_prompt_tokens` is the input-token count reported by the previous
+    /// LLM response (0 on the first iteration).  `ctx_window` is the model's
+    /// full context-window size.
+    ///
+    /// The default implementation fires when `last_prompt_tokens` exceeds 70 %
+    /// of `ctx_window`, matching the built-in `CompactionConfig::token_threshold_ratio`
+    /// default.  Override this to implement a custom threshold policy.
+    fn should_compress(&self, last_prompt_tokens: usize, ctx_window: usize) -> bool {
+        const DEFAULT_TOKEN_THRESHOLD_RATIO: f64 = 0.7;
+        let threshold = (ctx_window as f64 * DEFAULT_TOKEN_THRESHOLD_RATIO) as usize;
+        last_prompt_tokens > threshold
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -489,16 +489,29 @@ pub fn build_skill_section(
         // Extract only skill names from the full summary string.
         // Lines that describe a skill look like:
         //   `  - skill-name: description …`
-        // We collect the name tokens (part before the first `:`) and join
+        // We collect the name tokens (part before the first `: `) and join
         // them as a comma-separated list.
+        //
+        // Use `split_once(": ")` (colon + space) rather than `split(':')` so
+        // that skill names containing a bare colon (e.g. `http:client`) are
+        // preserved intact.  The format emitted by `build_skill_summary_from_skills`
+        // always separates name from description with `: `, so this delimiter
+        // is unambiguous for names that don't themselves contain ": ".
         let names: Vec<&str> = skill_summary
             .lines()
             .filter_map(|line| {
                 let trimmed = line.trim();
                 if let Some(after_dash) = trimmed.strip_prefix("- ") {
                     let name_part = after_dash.trim();
-                    // Take everything before the first `: ` as the name
-                    Some(name_part.split(':').next().unwrap_or(name_part).trim())
+                    // Split on ": " (colon + space) so names containing a bare
+                    // colon are kept whole; fall back to the full token if the
+                    // separator is absent.
+                    let name = name_part
+                        .split_once(": ")
+                        .map(|(n, _)| n)
+                        .unwrap_or(name_part)
+                        .trim();
+                    Some(name)
                 } else {
                     None
                 }
@@ -1282,6 +1295,32 @@ mod tests {
         let result = build_skill_section(&summary, count, SKILL_INLINE_THRESHOLD);
         assert!(!result.contains("<available_skills>"));
         assert!(result.contains("skill_read_file"));
+    }
+
+    #[test]
+    fn test_skill_section_summary_mode_preserves_colon_in_name() {
+        // Skill names that contain a bare colon (e.g. "http:client") must not
+        // be truncated when summary mode strips descriptions.
+        // The separator between name and description is ": " (colon + space),
+        // so "http:client: fetches URLs" should yield the name "http:client".
+        let count = SKILL_INLINE_THRESHOLD + 1;
+        let mut summary = String::new();
+        // One skill whose name contains a colon
+        summary.push_str("  - http:client: fetches URLs\n");
+        for i in 2..=count {
+            summary.push_str(&format!("  - skill-{i}: Desc {i}\n"));
+        }
+        let result = build_skill_section(&summary, count, SKILL_INLINE_THRESHOLD);
+        // Full name must appear, not just the prefix before the colon
+        assert!(
+            result.contains("http:client"),
+            "Expected 'http:client' in summary output, got: {result}"
+        );
+        // The description must not leak into the name list
+        assert!(
+            !result.contains("fetches URLs"),
+            "Description should be omitted in summary mode, got: {result}"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -457,6 +457,14 @@ pub fn format_memory_items_as_personal_context(memories: &[(String, String)]) ->
 /// skill descriptions are inlined. Matches Hermes-Agent's design.
 pub const SKILL_INLINE_THRESHOLD: usize = 10;
 
+/// Maximum number of skill names listed in summary mode.
+///
+/// At `SKILL_NAME_DISPLAY_CAP` (80) chars per name plus a 2-char separator,
+/// 200 names ≈ 16 400 chars — well within a typical context window budget.
+/// Names beyond this cap are silently omitted; the agent is told the total
+/// count so it knows there are more skills it can discover via `skill_list`.
+pub const SKILL_SUMMARY_NAME_CAP: usize = 200;
+
 /// Build the skills index block for inclusion in a system prompt.
 ///
 /// Implements progressive disclosure:
@@ -466,6 +474,9 @@ pub const SKILL_INLINE_THRESHOLD: usize = 10;
 ///   the agent is told to call `skill_read_file` to load each skill before
 ///   applying it. This prevents the system prompt from bloating when many
 ///   skills are installed.
+///
+/// In summary mode the name list is capped at `SKILL_SUMMARY_NAME_CAP` entries
+/// to bound context consumption regardless of how many skills are installed.
 ///
 /// `skill_summary` is the pre-built summary string from the kernel (either
 /// full descriptions or the plain name list — the caller always passes the
@@ -497,7 +508,7 @@ pub fn build_skill_section(
         // preserved intact.  The format emitted by `build_skill_summary_from_skills`
         // always separates name from description with `: `, so this delimiter
         // is unambiguous for names that don't themselves contain ": ".
-        let names: Vec<&str> = skill_summary
+        let all_names: Vec<&str> = skill_summary
             .lines()
             .filter_map(|line| {
                 let trimmed = line.trim();
@@ -519,8 +530,23 @@ pub fn build_skill_section(
             .filter(|n| !n.is_empty())
             .collect();
 
+        // Cap the number of names emitted to bound context consumption.
+        // With SKILL_NAME_DISPLAY_CAP (80) chars per name and a 2-char
+        // separator, SKILL_SUMMARY_NAME_CAP names ≈ 16 KB — well within
+        // a normal context window budget.  When truncated, append a count
+        // hint so the agent knows more skills exist.
+        let truncated = all_names.len() > SKILL_SUMMARY_NAME_CAP;
+        let names = &all_names[..all_names.len().min(SKILL_SUMMARY_NAME_CAP)];
+
         out.push_str("Available skills: ");
         out.push_str(&names.join(", "));
+        if truncated {
+            out.push_str(&format!(
+                " … ({} more — use `skill_list` to browse all {})",
+                all_names.len().saturating_sub(SKILL_SUMMARY_NAME_CAP),
+                all_names.len(),
+            ));
+        }
         out.push('\n');
         out.push_str("Use `skill_read_file` to load a skill by name before applying it. ");
         out.push_str("Load any skill that seems relevant before proceeding.\n");
@@ -1320,6 +1346,40 @@ mod tests {
         assert!(
             !result.contains("fetches URLs"),
             "Description should be omitted in summary mode, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_skill_section_summary_mode_caps_name_list() {
+        // When skill_count > SKILL_SUMMARY_NAME_CAP the emitted name list must
+        // be bounded to prevent flooding the context window.
+        let count = SKILL_SUMMARY_NAME_CAP + 5;
+        let mut summary = String::new();
+        for i in 1..=count {
+            summary.push_str(&format!("  - skill-{i}: Desc {i}\n"));
+        }
+        let result = build_skill_section(&summary, count, SKILL_INLINE_THRESHOLD);
+        // The first capped name must appear
+        assert!(result.contains("skill-1"), "first name missing: {result}");
+        // Name at the cap boundary must appear
+        assert!(
+            result.contains(&format!("skill-{SKILL_SUMMARY_NAME_CAP}")),
+            "name at cap boundary missing: {result}"
+        );
+        // Names beyond the cap must not appear
+        assert!(
+            !result.contains(&format!("skill-{}", SKILL_SUMMARY_NAME_CAP + 1)),
+            "name past cap should be omitted: {result}"
+        );
+        // A truncation hint indicating the overflow count must be present
+        assert!(
+            result.contains("5 more"),
+            "truncation hint missing: {result}"
+        );
+        // The hint must also reference skill_list for browsing
+        assert!(
+            result.contains("skill_list"),
+            "skill_list hint missing: {result}"
         );
     }
 

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -117,6 +117,11 @@ pub struct PromptContext {
     pub recalled_memories: Vec<(String, String)>,
     /// Skill summary text (from kernel.build_skill_summary()).
     pub skill_summary: String,
+    /// Total number of enabled skills represented in `skill_summary`.
+    /// Used for progressive disclosure: when this exceeds
+    /// `SKILL_INLINE_THRESHOLD`, only skill names are shown inline with
+    /// a hint to use `skill_list` for details.
+    pub skill_count: usize,
     /// Prompt context from prompt-only skills.
     pub skill_prompt_context: String,
     /// MCP server/tool summary text.
@@ -211,6 +216,7 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
         sections.push(build_skills_section(
             &ctx.skill_summary,
             &ctx.skill_prompt_context,
+            ctx.skill_count,
         ));
     }
 
@@ -446,10 +452,66 @@ pub fn format_memory_items_as_personal_context(memories: &[(String, String)]) ->
     out
 }
 
-fn build_skills_section(skill_summary: &str, prompt_context: &str) -> String {
-    let mut out = String::from("## Skills\n");
-    if !skill_summary.is_empty() {
-        // Mandatory skill loading language — ensures agents proactively use skills
+/// When skill count exceeds this threshold, the system prompt uses a compact
+/// summary listing only skill names and instructs the agent to call
+/// `skill_list` for full descriptions. Below or at this threshold, full
+/// skill descriptions are inlined. Matches Hermes-Agent's design.
+pub const SKILL_INLINE_THRESHOLD: usize = 10;
+
+/// Build the skills index block for inclusion in a system prompt.
+///
+/// Implements progressive disclosure:
+/// - `skill_count <= SKILL_INLINE_THRESHOLD`: full descriptions are inlined
+///   inside `<available_skills>` (existing behaviour).
+/// - `skill_count > SKILL_INLINE_THRESHOLD`: only skill names are listed and
+///   the agent is told to call `skill_list` for details. This prevents the
+///   system prompt from bloating when many skills are installed.
+///
+/// `skill_summary` is the pre-built summary string from the kernel (either
+/// full descriptions or the plain name list — the caller always passes the
+/// full version; this function decides how much of it to surface).
+/// `skill_count` is the total number of enabled skills; `0` means unknown
+/// (falls back to inline mode for backward compatibility).
+pub fn build_skill_section(
+    skill_summary: &str,
+    skill_count: usize,
+    inline_threshold: usize,
+) -> String {
+    if skill_summary.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+
+    let use_summary_mode = skill_count > inline_threshold && skill_count > 0;
+
+    if use_summary_mode {
+        // Extract only skill names from the full summary string.
+        // Lines that describe a skill look like:
+        //   `  - skill-name: description …`
+        // We collect the name tokens (part before the first `:`) and join
+        // them as a comma-separated list.
+        let names: Vec<&str> = skill_summary
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.starts_with("- ") {
+                    let after_dash = trimmed[2..].trim();
+                    // Take everything before the first `: ` as the name
+                    Some(after_dash.split(':').next().unwrap_or(after_dash).trim())
+                } else {
+                    None
+                }
+            })
+            .filter(|n| !n.is_empty())
+            .collect();
+
+        out.push_str("Available skills (use `skill_list` tool for full details): ");
+        out.push_str(&names.join(", "));
+        out.push('\n');
+        out.push_str("Use `skill_read_file` to load a skill before applying it.\n");
+    } else {
+        // Inline mode — full descriptions
         out.push_str(concat!(
             "Before replying, scan the skills below. If a skill matches or is even ",
             "partially relevant to your task, you MUST load it with `skill_read_file` ",
@@ -469,6 +531,19 @@ fn build_skills_section(skill_summary: &str, prompt_context: &str) -> String {
         out.push_str(
             "Only proceed without loading a skill if genuinely none are relevant to the task.\n",
         );
+    }
+
+    out
+}
+
+fn build_skills_section(skill_summary: &str, prompt_context: &str, skill_count: usize) -> String {
+    let mut out = String::from("## Skills\n");
+    if !skill_summary.is_empty() {
+        out.push_str(&build_skill_section(
+            skill_summary,
+            skill_count,
+            SKILL_INLINE_THRESHOLD,
+        ));
     }
     // Skill evolution guidance — only inject when skills are actually installed
     if !skill_summary.is_empty() {
@@ -1142,6 +1217,69 @@ mod tests {
         let prompt = build_system_prompt(&ctx);
         assert!(prompt.contains("## Skills"));
         assert!(prompt.contains("web-search"));
+    }
+
+    #[test]
+    fn test_skill_section_inline_mode_below_threshold() {
+        // 2 skills ≤ 10 threshold → full descriptions inlined
+        let summary = "general:\n  - web-search: Search the web\n  - git-expert: Git commands\n";
+        let result = build_skill_section(summary, 2, SKILL_INLINE_THRESHOLD);
+        assert!(result.contains("<available_skills>"));
+        assert!(result.contains("web-search"));
+        assert!(result.contains("Search the web"));
+        assert!(!result.contains("skill_list"));
+    }
+
+    #[test]
+    fn test_skill_section_summary_mode_above_threshold() {
+        // 11 skills > 10 threshold → name list only
+        let mut summary = String::new();
+        for i in 1..=11 {
+            summary.push_str(&format!("  - skill-{i}: Description for skill {i}\n"));
+        }
+        let result = build_skill_section(&summary, 11, SKILL_INLINE_THRESHOLD);
+        // Names present
+        assert!(result.contains("skill-1"));
+        assert!(result.contains("skill-11"));
+        // Descriptions NOT inlined
+        assert!(!result.contains("Description for skill 1"));
+        // Hint to use skill_list tool
+        assert!(result.contains("skill_list"));
+        // No <available_skills> wrapper in summary mode
+        assert!(!result.contains("<available_skills>"));
+    }
+
+    #[test]
+    fn test_skill_section_zero_count_falls_back_to_inline() {
+        // skill_count == 0 (unknown) → inline mode regardless of threshold
+        let summary = "  - web-search: Search the web\n";
+        let result = build_skill_section(summary, 0, SKILL_INLINE_THRESHOLD);
+        assert!(result.contains("<available_skills>"));
+        assert!(!result.contains("skill_list"));
+    }
+
+    #[test]
+    fn test_skill_section_at_threshold_boundary_is_inline() {
+        // Exactly at threshold → inline mode (≤, not <)
+        let mut summary = String::new();
+        for i in 1..=SKILL_INLINE_THRESHOLD {
+            summary.push_str(&format!("  - skill-{i}: Desc {i}\n"));
+        }
+        let result = build_skill_section(&summary, SKILL_INLINE_THRESHOLD, SKILL_INLINE_THRESHOLD);
+        assert!(result.contains("<available_skills>"));
+        assert!(!result.contains("skill_list"));
+    }
+
+    #[test]
+    fn test_skill_section_one_above_threshold_is_summary() {
+        let count = SKILL_INLINE_THRESHOLD + 1;
+        let mut summary = String::new();
+        for i in 1..=count {
+            summary.push_str(&format!("  - skill-{i}: Desc {i}\n"));
+        }
+        let result = build_skill_section(&summary, count, SKILL_INLINE_THRESHOLD);
+        assert!(!result.contains("<available_skills>"));
+        assert!(result.contains("skill_list"));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -120,7 +120,7 @@ pub struct PromptContext {
     /// Total number of enabled skills represented in `skill_summary`.
     /// Used for progressive disclosure: when this exceeds
     /// `SKILL_INLINE_THRESHOLD`, only skill names are shown inline with
-    /// a hint to use `skill_list` for details.
+    /// a hint to use `skill_read_file` for details.
     pub skill_count: usize,
     /// Prompt context from prompt-only skills.
     pub skill_prompt_context: String,
@@ -495,10 +495,10 @@ pub fn build_skill_section(
             .lines()
             .filter_map(|line| {
                 let trimmed = line.trim();
-                if trimmed.starts_with("- ") {
-                    let after_dash = trimmed[2..].trim();
+                if let Some(after_dash) = trimmed.strip_prefix("- ") {
+                    let name_part = after_dash.trim();
                     // Take everything before the first `: ` as the name
-                    Some(after_dash.split(':').next().unwrap_or(after_dash).trim())
+                    Some(name_part.split(':').next().unwrap_or(name_part).trim())
                 } else {
                     None
                 }

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -453,8 +453,7 @@ pub fn format_memory_items_as_personal_context(memories: &[(String, String)]) ->
 }
 
 /// When skill count exceeds this threshold, the system prompt uses a compact
-/// summary listing only skill names and instructs the agent to call
-/// `skill_list` for full descriptions. Below or at this threshold, full
+/// summary listing only skill names. Below or at this threshold, full
 /// skill descriptions are inlined. Matches Hermes-Agent's design.
 pub const SKILL_INLINE_THRESHOLD: usize = 10;
 
@@ -464,8 +463,9 @@ pub const SKILL_INLINE_THRESHOLD: usize = 10;
 /// - `skill_count <= SKILL_INLINE_THRESHOLD`: full descriptions are inlined
 ///   inside `<available_skills>` (existing behaviour).
 /// - `skill_count > SKILL_INLINE_THRESHOLD`: only skill names are listed and
-///   the agent is told to call `skill_list` for details. This prevents the
-///   system prompt from bloating when many skills are installed.
+///   the agent is told to call `skill_read_file` to load each skill before
+///   applying it. This prevents the system prompt from bloating when many
+///   skills are installed.
 ///
 /// `skill_summary` is the pre-built summary string from the kernel (either
 /// full descriptions or the plain name list — the caller always passes the
@@ -506,10 +506,11 @@ pub fn build_skill_section(
             .filter(|n| !n.is_empty())
             .collect();
 
-        out.push_str("Available skills (use `skill_list` tool for full details): ");
+        out.push_str("Available skills: ");
         out.push_str(&names.join(", "));
         out.push('\n');
-        out.push_str("Use `skill_read_file` to load a skill before applying it.\n");
+        out.push_str("Use `skill_read_file` to load a skill by name before applying it. ");
+        out.push_str("Load any skill that seems relevant before proceeding.\n");
     } else {
         // Inline mode — full descriptions
         out.push_str(concat!(
@@ -1243,8 +1244,9 @@ mod tests {
         assert!(result.contains("skill-11"));
         // Descriptions NOT inlined
         assert!(!result.contains("Description for skill 1"));
-        // Hint to use skill_list tool
-        assert!(result.contains("skill_list"));
+        // Compact format: no skill_list (non-existent tool), uses skill_read_file
+        assert!(!result.contains("skill_list"));
+        assert!(result.contains("skill_read_file"));
         // No <available_skills> wrapper in summary mode
         assert!(!result.contains("<available_skills>"));
     }
@@ -1279,7 +1281,7 @@ mod tests {
         }
         let result = build_skill_section(&summary, count, SKILL_INLINE_THRESHOLD);
         assert!(!result.contains("<available_skills>"));
-        assert!(result.contains("skill_list"));
+        assert!(result.contains("skill_read_file"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

### Prompt Injection Guard (`librefang-runtime`)
- New `injection_guard.rs` scans user input for 15 text patterns + 10 invisible Unicode codepoints (zero-width chars U+200B/200C/200D/2060/FEFF + bidi control chars U+202A–202E)
- On detection: emits `tracing::warn!` and prepends an inline warning to the message — does NOT block execution (preserves usability)
- Integrated into both streaming and non-streaming paths of `agent_loop.rs`

### Cron `[SILENT]` Marker (`librefang-kernel`)
- When a cron job prompt contains `[SILENT]`, the assistant response is removed from session history after execution
- Prevents maintenance cron jobs from polluting conversation history
- Audit trail preserved: `tracing::info!(event = "cron_silent_job_completed")` still fires; metering/usage/delivery all run normally
- Integration point: `execute_llm_agent` in `kernel/mod.rs`, after `run_agent_loop` returns

## Test plan
- [ ] CI passes
- [ ] Send message containing `ignore previous instructions` — verify warning in logs
- [ ] Send message with zero-width Unicode — verify detection
- [ ] Create cron job with `[SILENT]` in prompt — verify response not in session history after run