### PR TITLE
fix(runtime): pass None checkpoint_manager to run_agent_loop test call sites

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -6404,6 +6404,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -6462,6 +6463,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -6514,6 +6516,7 @@ mod tests {
             None,
             None,
             None,
+            None, // checkpoint_manager
             None,
             None,
             None,
@@ -6568,6 +6571,7 @@ mod tests {
             None,
             None,
             None,
+            None, // checkpoint_manager
             None,
             None,
             None,
@@ -6623,6 +6627,7 @@ mod tests {
             None,
             None,
             None,
+            None, // checkpoint_manager
             None,
             None,
             None,
@@ -6684,6 +6689,7 @@ mod tests {
             None,
             None,
             None,
+            None, // checkpoint_manager
             None,
             None,
             None,
@@ -6739,6 +6745,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -6872,6 +6879,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -6924,6 +6932,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -6984,6 +6993,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -7766,6 +7776,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -7838,6 +7849,7 @@ mod tests {
             None,
             None,
             None,
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -7906,6 +7918,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -8204,6 +8217,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -8261,6 +8275,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -8319,6 +8334,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine
@@ -8378,6 +8394,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine


### PR DESCRIPTION
## Summary

- `#2903` added `checkpoint_manager: Option<Arc<CheckpointManager>>` as a new parameter to both `run_agent_loop` and `run_agent_loop_streaming` (between `process_manager` and `user_content_blocks`), but did not update the test call sites
- All 11 `run_agent_loop` test call sites and 7 `run_agent_loop_streaming` test call sites in `agent_loop.rs` were missing the new argument (26/27 args instead of 27/28)
- This caused E0061 compilation errors and CI failures on main

## Changes

Added `None, // checkpoint_manager` to 18 call sites in `crates/librefang-runtime/src/agent_loop.rs`:

- `run_agent_loop` test calls (lines ~6326–8256): 10 sites fixed (1 was already updated)
- `run_agent_loop_streaming` test calls (lines ~6607–8374): 7 sites fixed

The production call sites in `crates/librefang-kernel/src/kernel/mod.rs` already pass `checkpoint_manager` correctly and were not modified.

## Test plan

- [ ] CI compilation passes (E0061 resolved)
- [ ] All existing tests pass unchanged