### PR TITLE
fix(runtime): add missing checkpoint_manager arg to last skipped run_agent_loop call site

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -6345,6 +6345,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine


### PR DESCRIPTION
One call site at line 6326 was missed by PR #2928 because the script miscounted args (an inline comment contained a comma, causing an off-by-one). CI still fails with E0061.

Fix: insert `None, // checkpoint_manager` between `process_manager` and `user_content_blocks` at line 6326.