### PR TITLE
fix(ci): resolve clippy ptr-arg error and cross-platform test failures

### DIFF
--- a/crates/librefang-api/src/terminal_tmux.rs
+++ b/crates/librefang-api/src/terminal_tmux.rs
@@ -352,18 +352,22 @@ pub fn validate_window_id(id: &str) -> bool {
 ///
 /// The `|` character is forbidden because it is used as the field separator
 /// in our `list-windows -F` format string; allowing it would corrupt parsing.
-/// Control characters (including newlines and null bytes) are rejected because
-/// they cannot appear in tmux window names meaningfully.
-///
-/// Since window names are passed via `Command::arg` (not a shell), there is no
-/// shell-injection risk — we only need to guard against chars that break our
-/// own tmux output parsing.
+/// Control characters and shell-special characters are rejected.  The list
+/// covers characters that could be misused if the name ever reaches a shell
+/// context (logging, display, scripting) or that break our own tmux output
+/// parsing (e.g. `|` is the field delimiter).
 pub fn validate_window_name(name: &str) -> bool {
+    const FORBIDDEN: &[char] = &[
+        ';', '&', '|', '`', '$', '(', ')', '{', '}', '<', '>', '/', '\\', '"', '\'', '#', '!', '@',
+        '=', '+', '~',
+    ];
     let len = name.chars().count();
     if len == 0 || len > 64 {
         return false;
     }
-    !name.chars().any(|c| c.is_control() || c == '|')
+    !name
+        .chars()
+        .any(|c| c.is_control() || FORBIDDEN.contains(&c))
 }
 
 // ── internal parser ───────────────────────────────────────────────────────────

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -404,8 +404,9 @@ impl CheckpointManager {
 
     /// Validate a commit hash to prevent git argument injection.
     ///
-    /// Accepts 4–64 lowercase or uppercase hex characters.  Values starting
-    /// with `-` would be misinterpreted as git flags.
+    /// Accepts 4–40 lowercase or uppercase hex characters (SHA-1 abbreviated
+    /// through full-length).  Values starting with `-` would be misinterpreted
+    /// as git flags.
     fn validate_commit_hash(hash: &str) -> Result<(), CheckpointError> {
         if hash.is_empty() {
             return Err(CheckpointError::InvalidHash("empty hash".to_string()));
@@ -416,9 +417,9 @@ impl CheckpointManager {
             )));
         }
         let len = hash.len();
-        if !(4..=64).contains(&len) {
+        if !(4..=40).contains(&len) {
             return Err(CheckpointError::InvalidHash(format!(
-                "hash length {len} not in 4–64 range"
+                "hash length {len} not in 4–40 range"
             )));
         }
         if !hash.chars().all(|c| c.is_ascii_hexdigit()) {

--- a/crates/librefang-runtime/src/tool_budget.rs
+++ b/crates/librefang-runtime/src/tool_budget.rs
@@ -132,7 +132,7 @@ impl ToolBudgetEnforcer {
     /// Already-persisted results (those whose content starts with the
     /// [`PERSISTED_MARKER`]) are counted toward the total but are never
     /// re-persisted.
-    pub fn enforce_turn_budget(&self, results: &mut Vec<ToolResultEntry>) {
+    pub fn enforce_turn_budget(&self, results: &mut [ToolResultEntry]) {
         let total: usize = results.iter().map(|r| r.content.len()).sum();
         if total <= self.per_turn_budget {
             return;
@@ -287,11 +287,15 @@ mod tests {
 
     #[test]
     fn layer2_fallback_on_bad_path() {
-        // Use an unwriteable path to force the fallback.
+        // Use a path whose parent is a regular file (not a directory) so that
+        // create_dir_all always fails, cross-platform.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("i_am_a_regular_file");
+        fs::write(&file_path, b"").unwrap();
         let enforcer = ToolBudgetEnforcer {
             per_result_threshold: 10,
             per_turn_budget: 1000,
-            temp_dir: PathBuf::from("/proc/no-such-dir-librefang-test"),
+            temp_dir: file_path.join("subdir"), // can't create inside a file
         };
         let content = "z".repeat(100);
         let result = enforcer.maybe_persist_result(&content, "bad-id");


### PR DESCRIPTION
## Summary

Four CI failures on main after merging PR #2903 (checkpoint manager):

- **Clippy `ptr_arg`**: `enforce_turn_budget(&mut Vec<_>)` → `&mut [_]` in `tool_budget.rs`
- **`layer2_fallback_on_bad_path` test**: Used `/proc/no-such-dir` which is writeable on macOS/Windows CI runners; replaced with a file-subpath that reliably fails cross-platform
- **`invalid_commit_hashes_are_rejected` test**: `validate_commit_hash` accepted 64-char hashes (4–64 range) but test documented the 64-char case as "too long"; narrowed range to 4–40 (SHA-1 only)
- **`window_name_rejects_*` tests**: `validate_window_name` only blocked control chars and `|`, but security-focused tests expected `;`, `$`, `` ` ``, etc. to be rejected; added `FORBIDDEN` char set

## Test plan
- [ ] All four test functions pass: `layer2_fallback_on_bad_path`, `invalid_commit_hashes_are_rejected`, `window_name_rejects_shell_injection_in_create`, `window_name_rejects_all_special_chars`
- [ ] Clippy passes with `-D warnings`
- [ ] `valid_window_names` still passes (spaces, dashes, underscores, unicode allowed)
- [ ] `valid_commit_hashes_are_accepted` still passes (4–40 char hashes)