### PR TITLE
fix(ci): repair main branch build + tests

### DIFF
--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -1374,9 +1374,13 @@ mod tests {
 
     #[test]
     fn window_name_rejects_shell_injection_in_create() {
-        assert!(!crate::terminal_tmux::validate_window_name("a;rm -rf /"));
-        assert!(!crate::terminal_tmux::validate_window_name("$(evil)"));
-        assert!(!crate::terminal_tmux::validate_window_name("`cmd`"));
+        // window names are passed via `Command::arg` (not a shell), so
+        // validate_window_name only rejects control chars and the pipe character
+        // used as the list-windows format separator. Shell metacharacters like
+        // `;`, `$()`, and backticks are allowed — they pose no injection risk
+        // when passed as a direct argument.
+        assert!(!crate::terminal_tmux::validate_window_name("a|b"));
+        assert!(!crate::terminal_tmux::validate_window_name("foo\0bar"));
     }
 
     #[test]
@@ -1393,10 +1397,10 @@ mod tests {
 
     #[test]
     fn window_name_rejects_all_special_chars() {
-        for bad in &[
-            "a;b", "a&b", "a|b", "a`b", "a$b", "a(b)", "a{b}", "a<b>", "a>b", "a/b", "a\\b",
-            "a\"b", "a'b", "a#b", "a!b", "a@b", "a=b", "a+b", "a~b",
-        ] {
+        // validate_window_name only rejects the pipe separator and control chars.
+        // Other punctuation is intentionally allowed (see 5d271afa which broadened
+        // the allowlist to support Unicode, CJK, emoji, and common punctuation).
+        for bad in &["a|b", "foo\0bar", "foo\x1fbar"] {
             assert!(
                 !crate::terminal_tmux::validate_window_name(bad),
                 "should reject: {bad:?}"

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -6345,6 +6345,7 @@ mod tests {
             None, // hooks
             None, // context_window_tokens
             None, // process_manager
+            None, // checkpoint_manager
             None, // user_content_blocks
             None, // proactive_memory
             None, // context_engine

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -642,7 +642,7 @@ mod tests {
         assert!(CheckpointManager::validate_commit_hash("").is_err());
         // Too long (65 chars)
         assert!(CheckpointManager::validate_commit_hash(
-            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2a1b2c3d4e5f6a1b2c3d4e5f6"
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2a1b2c3d4e5f6a1b2c3d4e5f6f"
         )
         .is_err());
     }

--- a/crates/librefang-runtime/src/tool_budget.rs
+++ b/crates/librefang-runtime/src/tool_budget.rs
@@ -132,7 +132,7 @@ impl ToolBudgetEnforcer {
     /// Already-persisted results (those whose content starts with the
     /// [`PERSISTED_MARKER`]) are counted toward the total but are never
     /// re-persisted.
-    pub fn enforce_turn_budget(&self, results: &mut Vec<ToolResultEntry>) {
+    pub fn enforce_turn_budget(&self, results: &mut [ToolResultEntry]) {
         let total: usize = results.iter().map(|r| r.content.len()).sum();
         if total <= self.per_turn_budget {
             return;
@@ -286,8 +286,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn layer2_fallback_on_bad_path() {
-        // Use an unwriteable path to force the fallback.
+        // Use an unwriteable path to force the fallback. `/proc` on Linux is a
+        // read-only virtual filesystem; macOS has no `/proc` so `create_dir_all`
+        // fails at the filesystem root. Either way, the write must fail so the
+        // fallback path in `maybe_persist_result` runs.
+        //
+        // Skipped on Windows because `/proc/...` gets resolved to
+        // `C:\proc\...`, which is writeable under a standard user account.
         let enforcer = ToolBudgetEnforcer {
             per_result_threshold: 10,
             per_turn_budget: 1000,


### PR DESCRIPTION
## Summary

`main` is currently red across Quality + Test / {Ubuntu, macOS, Windows}. This PR fixes every failure I can reproduce locally.

### Compile failure (runtime tests)

`test_empty_response_after_tool_use_returns_fallback` in `agent_loop.rs:6326` was missed by #2928 — it still passes 26 args to the 27-arg `run_agent_loop`. Added `None, // checkpoint_manager`.

### Clippy failure (Quality job)

`enforce_turn_budget` in `tool_budget.rs:135` was reverted from `&mut [ToolResultEntry]` back to `&mut Vec<_>` by #2921, re-introducing the `clippy::ptr_arg` error that #2902 had fixed. Reverted to slice.

### Test failures

- `routes::terminal::tests::window_name_rejects_shell_injection_in_create` and `window_name_rejects_all_special_chars` (Ubuntu / macOS / Windows): the tests expected `validate_window_name` to reject shell metacharacters, but #2863 intentionally broadened the allowlist to permit Unicode/punctuation since names are passed via `Command::arg` (no shell). The test-side fix from #2902 was also reverted by #2921. Re-applied.
- `checkpoint_manager::tests::invalid_commit_hashes_are_rejected` (Ubuntu / macOS / Windows): the "too long (65 chars)" literal was only 64 hex chars — which is the inclusive upper bound of `validate_commit_hash` and therefore valid. Added one more hex char so the literal is actually 65.
- `tool_budget::tests::layer2_fallback_on_bad_path` (Windows only): the test uses `/proc/no-such-dir-librefang-test` as an "unwriteable" path, but on Windows this resolves to `C:\proc\...` which is writeable, so the fallback branch never runs. Gated the test behind `#[cfg(unix)]`.

## Test plan

- [x] `cargo clippy -p librefang-runtime -p librefang-api --all-targets -- -D warnings` — clean.
- [x] `cargo test -p librefang-runtime --lib checkpoint_manager::` — 7/7 pass.
- [x] `cargo test -p librefang-runtime --lib tool_budget::` — 8/8 pass on macOS (layer2_fallback_on_bad_path exercised).
- [x] `cargo test -p librefang-api --lib routes::terminal::tests::` — 30/30 pass.
- [ ] Verify green in CI (Windows + Ubuntu + macOS).