### PR TITLE
fix(nix): scope CLI build to librefang-cli only (fixes #2937)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,13 @@
         librefang-cli = craneLib.buildPackage (cliArgs // {
           cargoArtifacts = cliCargoArtifacts;
           doCheck = false; # Tests require network/runtime setup.
+          meta = with pkgs.lib; {
+            description = "LibreFang — Open-source Agent Operating System (CLI / daemon)";
+            homepage = "https://github.com/librefang/librefang";
+            license = licenses.mit;
+            platforms = platforms.unix;
+            mainProgram = "librefang";
+          };
         });
 
         # Desktop build scope — adds the GTK / webview deps on Linux.
@@ -92,6 +99,13 @@
         librefang-desktop = craneLib.buildPackage (desktopArgs // {
           cargoArtifacts = desktopCargoArtifacts;
           doCheck = false;
+          meta = with pkgs.lib; {
+            description = "LibreFang — Open-source Agent Operating System (desktop UI)";
+            homepage = "https://github.com/librefang/librefang";
+            license = licenses.mit;
+            platforms = platforms.linux ++ platforms.darwin;
+            mainProgram = "librefang-desktop";
+          };
         });
 
         # Full-workspace args for checks (clippy runs across the whole tree
@@ -122,8 +136,12 @@
           inherit librefang-cli librefang-desktop;
         };
 
-        apps.default = flake-utils.lib.mkApp {
+        apps.default = (flake-utils.lib.mkApp {
           drv = librefang-cli;
+        }) // {
+          # Propagate the package's meta so `nix flake check` doesn't warn
+          # about the app lacking metadata.
+          meta = librefang-cli.meta;
         };
 
         devShells.default = craneLib.devShell {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        # Common build inputs needed by native dependencies
+        # Common build inputs needed by every workspace crate.
         nativeBuildInputs = with pkgs; [
           pkg-config
           rustToolchain
@@ -38,6 +38,22 @@
           pkgs.libiconv
         ];
 
+        # `librefang-desktop` pulls in Tauri / wry, which require the GTK
+        # webview stack at link time. Split these out so the CLI build (the
+        # common case) doesn't pay for the heavy native graphics deps just to
+        # produce a server binary — this is what breaks `nix build
+        # .#librefang-cli` on stock NixOS today (#2937).
+        desktopBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux (with pkgs; [
+          glib
+          gtk3
+          libsoup_3
+          webkitgtk_4_1
+          atkmm
+          cairo
+          gdk-pixbuf
+          pango
+        ]);
+
         # Filter source to only include Rust-relevant files
         src = craneLib.cleanCargoSource ./.;
 
@@ -47,23 +63,51 @@
           strictDeps = true;
         };
 
-        # Build workspace dependencies first (for caching)
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        # Build the full workspace
-        librefang = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-          # The default package is the CLI binary
+        # CLI build scope — do NOT compile the desktop crate's native
+        # dependencies just to produce the CLI binary. Scoping the
+        # deps-only build to `--package librefang-cli` keeps
+        # `nix build .#librefang-cli` green on machines that don't have
+        # the GTK / webview stack installed.
+        cliArgs = commonArgs // {
+          pname = "librefang-cli";
           cargoExtraArgs = "--package librefang-cli";
-          doCheck = false; # Tests require network/runtime setup
+        };
+
+        cliCargoArtifacts = craneLib.buildDepsOnly cliArgs;
+
+        librefang-cli = craneLib.buildPackage (cliArgs // {
+          cargoArtifacts = cliCargoArtifacts;
+          doCheck = false; # Tests require network/runtime setup.
         });
+
+        # Desktop build scope — adds the GTK / webview deps on Linux.
+        desktopArgs = commonArgs // {
+          pname = "librefang-desktop";
+          cargoExtraArgs = "--package librefang-desktop";
+          buildInputs = buildInputs ++ desktopBuildInputs;
+        };
+
+        desktopCargoArtifacts = craneLib.buildDepsOnly desktopArgs;
+
+        librefang-desktop = craneLib.buildPackage (desktopArgs // {
+          cargoArtifacts = desktopCargoArtifacts;
+          doCheck = false;
+        });
+
+        # Full-workspace args for checks (clippy runs across the whole tree
+        # including librefang-desktop, so it needs the GTK inputs too).
+        workspaceArgs = commonArgs // {
+          buildInputs = buildInputs ++ desktopBuildInputs;
+        };
+
+        workspaceCargoArtifacts = craneLib.buildDepsOnly workspaceArgs;
       in
       {
         checks = {
-          inherit librefang;
+          inherit librefang-cli;
 
-          librefang-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
+          librefang-clippy = craneLib.cargoClippy (workspaceArgs // {
+            cargoArtifacts = workspaceCargoArtifacts;
             cargoClippyExtraArgs = "--workspace --all-targets -- -D warnings";
           });
 
@@ -74,12 +118,12 @@
         };
 
         packages = {
-          default = librefang;
-          librefang-cli = librefang;
+          default = librefang-cli;
+          inherit librefang-cli librefang-desktop;
         };
 
         apps.default = flake-utils.lib.mkApp {
-          drv = librefang;
+          drv = librefang-cli;
         };
 
         devShells.default = craneLib.devShell {
@@ -97,9 +141,9 @@
             git
             nodejs
             python3
-          ];
+          ] ++ desktopBuildInputs;
 
-          inputsFrom = [ librefang ];
+          inputsFrom = [ librefang-cli ];
 
           shellHook = ''
             echo "LibreFang development environment loaded"


### PR DESCRIPTION
Closes #2937.

## Problem

\`nix build .#librefang-cli\` fails on stock NixOS because the deps-only build runs across the whole workspace — pulling in \`librefang-desktop\`'s Tauri / wry / GTK transitive dependencies. Those crates use \`pkg-config\` to link against \`glib-2.0\`, \`gobject-2.0\`, \`gtk-3\`, \`webkitgtk\`, etc., which aren't declared in the flake's \`buildInputs\`:

\`\`\`
The system library \`gobject-2.0\` required by crate \`gobject-sys\` was not found.
...
error: failed to run custom build command for \`glib-sys v0.18.1\`
\`\`\`

## Root cause

\`librefang-cli\` has **no compile-time dependency** on \`librefang-desktop\` (verified: only \`crates/librefang-desktop/Cargo.toml\` references \`wry\` / \`tauri\` / \`gtk\`, and nothing in the workspace depends on \`librefang-desktop\`). But the flake's \`buildDepsOnly\` was scoped to the whole workspace, so it pulled in GTK-related deps anyway.

## Fix

- **Scope the CLI deps-only build to \`--package librefang-cli\`** — the primary fix. Makes \`nix build .#librefang-cli\` green on stock NixOS.
- **Split GTK stack into \`desktopBuildInputs\`** (gated on \`stdenv.isLinux\`) and reuse it for:
  - \`packages.librefang-desktop\` — new target for users who want the desktop binary
  - \`checks.librefang-clippy\` — full-workspace clippy still runs across the whole tree, so it needs GTK too
  - \`devShells.default\` — dev shell includes GTK on Linux so contributors can build everything
- **Add \`meta\` to both packages and propagate to \`apps.default\`** — silences 4 \`flake check\` warnings (\`apps.*.default lacks attribute 'meta'\`). License pulled from the repo's MIT LICENSE file.

## Resulting flake outputs

\`\`\`
packages
├── default             → librefang-cli
├── librefang-cli       → CLI / daemon (no GTK)
└── librefang-desktop   → desktop UI (Linux + Darwin; GTK on Linux)

checks
├── librefang-cli       → CLI build
├── librefang-clippy    → full-workspace clippy
└── librefang-fmt       → rustfmt
\`\`\`

## Verification

- [x] \`nix flake check --no-build --all-systems\` — all 4 systems (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin) evaluate cleanly
- [x] No more \`apps.<system>.default lacks attribute 'meta'\` warnings
- [ ] Actual \`nix build .#librefang-cli\` on NixOS (can't test locally; @FrantaNautilus please verify)