### PR TITLE
fix(kernel): fork inherits parent's SessionInterrupt for external cancel (#2939)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4361,15 +4361,22 @@ system_prompt = "You are a helpful assistant."
                 "run_forked_agent_streaming is only supported for LLM agents".to_string(),
             )));
         }
+        // Inherit the parent turn's interrupt when one exists so a caller
+        // invoking `stop_agent_run(agent_id)` on the parent also cancels
+        // tools that are in-flight inside this fork (#2939). Both handles
+        // wrap the same `Arc<AtomicBool>`, so `cancel()` on either one is
+        // observed by both. When no parent is running (e.g. auto_memorize
+        // fires from an idle agent), fall back to a fresh interrupt so the
+        // fork still has a cancellation primitive for its own tools.
+        let interrupt = self
+            .session_interrupts
+            .get(&agent_id)
+            .map(|entry| entry.value().clone())
+            .unwrap_or_default();
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: true,
             allowed_tools,
-            // TODO: fork should inherit parent's interrupt so cancelling the
-            // parent also cancels in-flight tools inside the fork.  For now,
-            // each fork gets an independent interrupt; the fork is short-lived
-            // (dream / auto_memorize) and driven by its own JoinHandle, so
-            // external cancellation via stop_agent_run is not wired for forks.
-            interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
+            interrupt: Some(interrupt),
         };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
@@ -5118,15 +5125,25 @@ system_prompt = "You are a helpful assistant."
 
                     // Task is finishing normally — remove the interrupt handle
                     // so the map doesn't grow without bound.
-                    kernel_clone.session_interrupts.remove(&agent_id);
-                    kernel_clone.running_tasks.remove(&agent_id);
+                    //
+                    // Forks share the parent's `SessionInterrupt` entry (see
+                    // `run_forked_agent_streaming`), so a fork must NOT remove
+                    // it on its own completion — that would orphan the parent
+                    // from `stop_agent_run` cancellation. Only the original
+                    // parent turn cleans up the map.
+                    if !loop_opts.is_fork {
+                        kernel_clone.session_interrupts.remove(&agent_id);
+                        kernel_clone.running_tasks.remove(&agent_id);
+                    }
                     Ok(result)
                 }
                 Err(e) => {
                     kernel_clone.supervisor.record_panic();
                     warn!(agent_id = %agent_id, error = %e, "Streaming agent loop failed");
-                    kernel_clone.session_interrupts.remove(&agent_id);
-                    kernel_clone.running_tasks.remove(&agent_id);
+                    if !loop_opts.is_fork {
+                        kernel_clone.session_interrupts.remove(&agent_id);
+                        kernel_clone.running_tasks.remove(&agent_id);
+                    }
                     Err(KernelError::LibreFang(e))
                 }
             }


### PR DESCRIPTION
Closes #2939.

## The problem

`run_forked_agent_streaming` allocated a fresh `SessionInterrupt` per fork:

```rust
interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
```

So `stop_agent_run(parent)` had no way to cancel tools running inside a fork turn — the parent's cancel signal never reached the fork's tool-polling futures. Dreams or `auto_memorize` spawned during a live parent turn kept executing even after the user stopped the parent.

## The fix

`SessionInterrupt` already wraps `Arc<AtomicBool>` and is `Clone` (verified by `interrupt::tests::clone_shares_flag`), so the fix is just handing the fork a clone of the parent's interrupt when one is registered:

```rust
let interrupt = self
    .session_interrupts
    .get(&agent_id)
    .map(|entry| entry.value().clone())
    .unwrap_or_default();
```

Both handles share the same atomic flag, so `cancel()` on either is observed by both. When no parent is running (e.g. `auto_memorize` firing from an idle agent), the `unwrap_or_default()` branch yields a fresh interrupt so the fork still has a cancellation primitive for its own tools — external cancellation via `agent_id` just isn't wired in that case, which matches the pre-existing contract.

## Necessary companion fix: don't orphan the parent's entry

Cleanup of `session_interrupts` on task exit is now gated on `!loop_opts.is_fork`:

```rust
if !loop_opts.is_fork {
    kernel_clone.session_interrupts.remove(&agent_id);
    kernel_clone.running_tasks.remove(&agent_id);
}
```

Forks share the parent's entry, so a fork completing must not remove it — otherwise a fork that finishes before its parent would orphan the parent from future `stop_agent_run` calls. Parent turns (the ones that originally inserted the entry) still clean up as before.

This was a latent ordering bug even without the interrupt-inheritance change: without the gate, any fork finishing before the parent would clear the parent's entry too. The new gate addresses both.

## Test coverage

The primitive behavior (`Clone` shares the underlying flag) is already covered by `interrupt::tests::clone_shares_flag` and `child_token_shares_flag`. A full kernel-level integration test for fork cancel would require spinning up the agent loop with a stub LLM driver and is out of scope here — the shared-flag property is what makes this correct, and the usage at the call site is a direct, auditable three-liner.

## Verification

- [x] `cargo test -p librefang-kernel --lib` — 472/472 pass
- [x] `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean