### PR TITLE
release: v2026.4.22-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.22] - 2026-04-22
+
+### Added
+
+- Search, font size, tab drag reorder, copy/paste hint (#2864) (@houko)
+- Add ClawHub CN mirror support with source dropdown switcher (#2865) (@houko)
+- Show-all-commands in TUI scrollable view, add 1-9 number shortcuts (#2876) (@houko)
+- Ctrl+L clear, tab overflow arrows, cursor inactive style, auto-dismiss reconnect toast (#2879) (@houko)
+- Three-layer tool result budget enforcement (#2881) (@houko)
+- Chat input history, channels inline actions, memory delete confirmation (#2888) (@houko)
+- Checkpoint manager with shadow git repos for transparent file snapshots (#2903) (@houko)
+- Event hook system with wildcard matching and fire-and-forget execution (#2904) (@houko)
+- Session auto-reset with idle/daily policies (#2905) (@houko)
+- UTF-16 aware message truncation for Telegram and Discord (#2906) (@houko)
+- Background process registry with rolling output buffer (#2907) (@houko)
+- Skill config variable declaration and system prompt injection (#2908) (@houko)
+- Session-scoped approval resolution and per-session batch approve (#2909) (@houko)
+- Rate limit header tracking with ASCII progress display (#2910) (@houko)
+- Jittered exponential backoff for retry decorrelation (#2911) (@houko)
+- Pluggable ContextEngine trait with SummaryContextEngine and NullContextEngine (#2912) (@houko)
+- MemoryProvider plugin trait with error isolation (#2913) (@houko)
+- Multi-credential pool with fill-first/round-robin/least-used strategies (#2914) (@houko)
+- Session-scoped interrupt signaling for multi-tenant safety (#2915) (@houko)
+- Dangerous command detection with approval mode (#2916) (@houko)
+- Prompt injection guard + cron [SILENT] marker (#2917) (@houko)
+- Context compression with iterative refinement (#2918) (@houko)
+- Skill index progressive disclosure in system prompt (#2919) (@houko)
+- FailoverReason classification and provider fallback chain (#2920) (@houko)
+- Schedule a hand from its detail page (closes #2691) (#2946) (@houko)
+
+### Fixed
+
+- Suppress NO_REPLY sentinel in streaming text bridge (#2855) (@houko)
+- Fix height overflow, invalid resize errors, and polish UI (#2861) (@houko)
+- Fix terminal height collapse and tmux duplicate session race (#2862) (@houko)
+- Allow Unicode (CJK, emoji, accented) in window names (#2863) (@houko)
+- Remove non-existent addon-search CSS import (#2870) (@houko)
+- Fix help popover not showing due to overflow-x-auto clipping (#2871) (@houko)
+- Dashboard snapshot exposes uptime_seconds + memory_used_mb (#2877) (@houko)
+- Dashboard snapshot also exposes api_listen / home_dir / log_level (#2882) (@houko)
+- Audit badge width + verify chain button always clickable (#2892) (@houko)
+- Audit card readability + visible verify-chain feedback (#2897) (@houko)
+- Populate Hostname row via authenticated endpoints (#2899) (@houko)
+- Trust agent_send delegation results over untrusted data prompt (#2900) (@houko)
+- Use slice instead of vec in enforce_turn_budget + update terminal tests (#2902) (@houko)
+- Use sort_by_key instead of sort_by in enforce_turn_budget (#2921) (@houko)
+- Use sort_by_key; chore: upgrade actions/github-script to v9 (#2922) (@houko)
+- Pass None checkpoint_manager to run_agent_loop test call sites (#2928) (@houko)
+- Reduce memory footprint for 256 MB fly.io deployment (#2929) (@houko)
+- Add missing checkpoint_manager arg to last skipped run_agent_loop call site (#2930) (@houko)
+- Repair main branch build + tests (#2932) (@houko)
+- Launcher clippy + workflow selective-build on bin-only crates (#2933) (@houko)
+- Tighten page regressions (#2936) (@leszek3737)
+- Address bugs found in merged PRs #2904-#2913 (#2940) (@houko)
+- Repair main build — struct fields, call sites, warnings (#2942) (@houko)
+- Repair main — truncator entity regression + clippy 1.95 lint (#2943) (@houko)
+- Scope CLI build to librefang-cli only (fixes #2937) (#2944) (@houko)
+- Fork inherits parent's SessionInterrupt for external cancel (#2939) (#2945) (@houko)
+
+### Changed
+
+- Optimize TerminalPage, SettingsPage, SkillsPage, PluginsPage, and ProvidersPage (#2843) (@leszek3737)
+- Clean up SkillsPage (#2858) (@houko)
+- Unify two separate checkouts of the upstream repo (#2859) (@houko)
+- Apply RC-safe perf and correctness fixes across lib utils (#2935) (@leszek3737)
+
+### Performance
+
+- Optimize rendering and runtime query behavior (#2856) (@leszek3737)
+
+### Documentation
+
+- Document 19 hermes-agent ported features (#2927) (@houko)
+
+
 ## [2026.4.21] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "chrono",
  "clap",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "axum",
  "clap",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11019,7 +11019,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32211",
+  "version": "26.4.32222",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.21-beta1",
+  "version": "2026.4.22-beta2",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.21-beta1",
+  "version": "2026.4.22-beta2",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.21b1",
+    version="2026.4.22b2",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.21-beta1"
+version = "2026.4.22-beta2"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.22-beta2 -->
## Release v2026.4.22-beta2

### Added

- Search, font size, tab drag reorder, copy/paste hint (#2864) (@houko)
- Add ClawHub CN mirror support with source dropdown switcher (#2865) (@houko)
- Show-all-commands in TUI scrollable view, add 1-9 number shortcuts (#2876) (@houko)
- Ctrl+L clear, tab overflow arrows, cursor inactive style, auto-dismiss reconnect toast (#2879) (@houko)
- Three-layer tool result budget enforcement (#2881) (@houko)
- Chat input history, channels inline actions, memory delete confirmation (#2888) (@houko)
- Checkpoint manager with shadow git repos for transparent file snapshots (#2903) (@houko)
- Event hook system with wildcard matching and fire-and-forget execution (#2904) (@houko)
- Session auto-reset with idle/daily policies (#2905) (@houko)
- UTF-16 aware message truncation for Telegram and Discord (#2906) (@houko)
- Background process registry with rolling output buffer (#2907) (@houko)
- Skill config variable declaration and system prompt injection (#2908) (@houko)
- Session-scoped approval resolution and per-session batch approve (#2909) (@houko)
- Rate limit header tracking with ASCII progress display (#2910) (@houko)
- Jittered exponential backoff for retry decorrelation (#2911) (@houko)
- Pluggable ContextEngine trait with SummaryContextEngine and NullContextEngine (#2912) (@houko)
- MemoryProvider plugin trait with error isolation (#2913) (@houko)
- Multi-credential pool with fill-first/round-robin/least-used strategies (#2914) (@houko)
- Session-scoped interrupt signaling for multi-tenant safety (#2915) (@houko)
- Dangerous command detection with approval mode (#2916) (@houko)
- Prompt injection guard + cron [SILENT] marker (#2917) (@houko)
- Context compression with iterative refinement (#2918) (@houko)
- Skill index progressive disclosure in system prompt (#2919) (@houko)
- FailoverReason classification and provider fallback chain (#2920) (@houko)
- Schedule a hand from its detail page (closes #2691) (#2946) (@houko)

### Fixed

- Suppress NO_REPLY sentinel in streaming text bridge (#2855) (@houko)
- Fix height overflow, invalid resize errors, and polish UI (#2861) (@houko)
- Fix terminal height collapse and tmux duplicate session race (#2862) (@houko)
- Allow Unicode (CJK, emoji, accented) in window names (#2863) (@houko)
- Remove non-existent addon-search CSS import (#2870) (@houko)
- Fix help popover not showing due to overflow-x-auto clipping (#2871) (@houko)
- Dashboard snapshot exposes uptime_seconds + memory_used_mb (#2877) (@houko)
- Dashboard snapshot also exposes api_listen / home_dir / log_level (#2882) (@houko)
- Audit badge width + verify chain button always clickable (#2892) (@houko)
- Audit card readability + visible verify-chain feedback (#2897) (@houko)
- Populate Hostname row via authenticated endpoints (#2899) (@houko)
- Trust agent_send delegation results over untrusted data prompt (#2900) (@houko)
- Use slice instead of vec in enforce_turn_budget + update terminal tests (#2902) (@houko)
- Use sort_by_key instead of sort_by in enforce_turn_budget (#2921) (@houko)
- Use sort_by_key; chore: upgrade actions/github-script to v9 (#2922) (@houko)
- Pass None checkpoint_manager to run_agent_loop test call sites (#2928) (@houko)
- Reduce memory footprint for 256 MB fly.io deployment (#2929) (@houko)
- Add missing checkpoint_manager arg to last skipped run_agent_loop call site (#2930) (@houko)
- Repair main branch build + tests (#2932) (@houko)
- Launcher clippy + workflow selective-build on bin-only crates (#2933) (@houko)
- Tighten page regressions (#2936) (@leszek3737)
- Address bugs found in merged PRs #2904-#2913 (#2940) (@houko)
- Repair main build — struct fields, call sites, warnings (#2942) (@houko)
- Repair main — truncator entity regression + clippy 1.95 lint (#2943) (@houko)
- Scope CLI build to librefang-cli only (fixes #2937) (#2944) (@houko)
- Fork inherits parent's SessionInterrupt for external cancel (#2939) (#2945) (@houko)

### Changed

- Optimize TerminalPage, SettingsPage, SkillsPage, PluginsPage, and ProvidersPage (#2843) (@leszek3737)
- Clean up SkillsPage (#2858) (@houko)
- Unify two separate checkouts of the upstream repo (#2859) (@houko)
- Apply RC-safe perf and correctness fixes across lib utils (#2935) (@leszek3737)

### Performance

- Optimize rendering and runtime query behavior (#2856) (@leszek3737)

### Documentation

- Document 19 hermes-agent ported features (#2927) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.21-beta1...v2026.4.22-beta2