### PR TITLE
fix(ci): use pnpm for dashboard Docker build

### DIFF
--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,9 @@ FROM node:20-alpine AS dashboard-builder
 WORKDIR /build
 COPY crates/librefang-api/dashboard ./dashboard
 WORKDIR /build/dashboard
-RUN npm install && npm run build
+RUN corepack enable \
+    && pnpm install --frozen-lockfile --config.strict-dep-builds=false \
+    && pnpm run build
 
 # Stage 2: Build Rust binary
 FROM rust:1-slim-bookworm AS builder


### PR DESCRIPTION
## Summary
- switch the Docker dashboard build stage from `npm install` to `pnpm install --frozen-lockfile --config.strict-dep-builds=false`
- declare the dashboard package manager in `crates/librefang-api/dashboard/package.json`
- keep the Docker release path aligned with the passing dashboard CI workflow

## Root Cause
The release Docker jobs were building the dashboard in `deploy/Dockerfile` with `npm install`, which triggered a fresh npm peer-dependency resolution. That now fails on the dashboard dependency graph (`@xterm/xterm@6` with `@xterm/addon-search@0.15.0`). The repository already has a working pnpm lockfile and the dashboard workflow installs with pnpm, so the Docker path had drifted from the supported install path.

## Impact
This restores the `Docker / linux/amd64` and `Docker / linux/arm64` release jobs so they can build and publish the image again.

## Validation
- `cd crates/librefang-api/dashboard && corepack enable && pnpm --version && pnpm install --frozen-lockfile --config.strict-dep-builds=false && pnpm run build`

## Notes
I could not run a full `docker build` locally in this environment because the Docker daemon was unavailable.