### PR TITLE
fix(channels): sanitize bot_name in classify_reply_intent prompt; add unit tests

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1645,8 +1645,9 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         };
         let sanitized = sanitize(message_text, 500);
         let safe_sender = sanitize(sender_name, 64);
+        let safe_bot_name = bot_name.map(|n| sanitize(n, 64));
 
-        let bot_identity_section = match bot_name {
+        let bot_identity_section = match safe_bot_name.as_deref() {
             Some(name) if !name.is_empty() => format!(
                 "Bot identity: The bot's name is \"{name}\". \
                  A message that addresses the bot by name (e.g. \"{name}, do X\" or \

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5185,4 +5185,79 @@ mod tests {
             assert!(ctx.group_participants.is_empty());
         }
     }
+
+    mod classify_reply_intent_tests {
+        use super::super::*;
+        use std::sync::{Arc, Mutex};
+
+        struct CapturingHandle {
+            captured_bot_name: Arc<Mutex<Option<Option<String>>>>,
+        }
+
+        impl CapturingHandle {
+            fn new() -> (Self, Arc<Mutex<Option<Option<String>>>>) {
+                let slot = Arc::new(Mutex::new(None));
+                (
+                    Self {
+                        captured_bot_name: Arc::clone(&slot),
+                    },
+                    slot,
+                )
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl ChannelBridgeHandle for CapturingHandle {
+            async fn classify_reply_intent(
+                &self,
+                _message_text: &str,
+                _sender_name: &str,
+                _model: Option<&str>,
+                bot_name: Option<&str>,
+            ) -> bool {
+                *self.captured_bot_name.lock().unwrap() = Some(bot_name.map(|s| s.to_string()));
+                true
+            }
+        }
+
+        #[tokio::test]
+        async fn default_impl_returns_true_with_bot_name() {
+            struct AlwaysTrue;
+            #[async_trait::async_trait]
+            impl ChannelBridgeHandle for AlwaysTrue {}
+
+            let h = AlwaysTrue;
+            assert!(
+                h.classify_reply_intent("hello", "user", None, Some("rodelo"))
+                    .await
+            );
+            assert!(h.classify_reply_intent("hello", "user", None, None).await);
+        }
+
+        #[tokio::test]
+        async fn bot_name_is_forwarded_to_implementation() {
+            let (handle, slot) = CapturingHandle::new();
+            handle
+                .classify_reply_intent("rodelo qué hora es?", "Alice", None, Some("rodelo"))
+                .await;
+            assert_eq!(
+                *slot.lock().unwrap(),
+                Some(Some("rodelo".to_string())),
+                "bot_name must be forwarded to the classify_reply_intent implementation"
+            );
+        }
+
+        #[tokio::test]
+        async fn none_bot_name_is_forwarded() {
+            let (handle, slot) = CapturingHandle::new();
+            handle
+                .classify_reply_intent("hey there", "Bob", None, None)
+                .await;
+            assert_eq!(
+                *slot.lock().unwrap(),
+                Some(None),
+                "None bot_name must be forwarded as None"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Follow-up to #2960

### Changes

**`channel_bridge.rs`** — apply the existing `sanitize()` closure to `bot_name` before embedding it in the LLM classifier prompt. `message_text` and `sender_name` were already sanitized; `bot_name` was not, creating an inconsistency. Although the name is admin-configured (not attacker-controlled), defense-in-depth applies the same treatment for consistency.

**`bridge.rs`** — three unit tests for `classify_reply_intent`:
- Default trait impl returns `true` regardless of `bot_name` value
- Concrete impl receives `Some("rodelo")` when passed
- Concrete impl receives `None` when not passed

## Test plan
- [x] Unit tests added and passing