### PR TITLE
feat(drivers): Moonshot/Kimi file upload support via /v1/files

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -3187,6 +3187,27 @@ async fn download_image_to_blocks(
     // 5 MB limit to prevent memory abuse from oversized images
     const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
 
+    // Validate URL scheme — only allow http/https to prevent SSRF via file:// etc.
+    match url::Url::parse(url) {
+        Ok(parsed) => match parsed.scheme() {
+            "http" | "https" => {}
+            scheme => {
+                warn!("Rejecting image download with disallowed scheme: {scheme}");
+                return vec![ContentBlock::Text {
+                    text: format!("[Image download rejected: unsupported URL scheme '{scheme}']"),
+                    provider_metadata: None,
+                }];
+            }
+        },
+        Err(e) => {
+            warn!("Rejecting image download with invalid URL: {e}");
+            return vec![ContentBlock::Text {
+                text: "[Image download rejected: invalid URL]".to_string(),
+                provider_metadata: None,
+            }];
+        }
+    }
+
     let client = crate::http_client::new_client();
     let resp = match client.get(url).send().await {
         Ok(r) => r,
@@ -3209,16 +3230,61 @@ async fn download_image_to_blocks(
         .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_string())
         .filter(|ct| ct.starts_with("image/"));
 
-    let bytes = match resp.bytes().await {
-        Ok(b) => b,
-        Err(e) => {
-            warn!("Failed to read image bytes: {e}");
+    // Early rejection if Content-Length header exceeds limit
+    if let Some(len) = resp.content_length() {
+        if len as usize > MAX_IMAGE_BYTES {
+            warn!("Image Content-Length ({len} bytes) exceeds limit, rejecting before download");
+            let desc = match caption {
+                Some(c) => format!(
+                    "[Image too large for vision ({} KB)]\nCaption: {c}",
+                    len / 1024
+                ),
+                None => format!("[Image too large for vision ({} KB)]", len / 1024),
+            };
             return vec![ContentBlock::Text {
-                text: format!("[Image read failed: {e}]"),
+                text: desc,
                 provider_metadata: None,
             }];
         }
-    };
+    }
+
+    // Stream body with size accumulator to enforce limit even without Content-Length
+    let mut stream = resp.bytes_stream();
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Failed to read image bytes: {e}");
+                return vec![ContentBlock::Text {
+                    text: format!("[Image read failed: {e}]"),
+                    provider_metadata: None,
+                }];
+            }
+        };
+        buf.extend_from_slice(&chunk);
+        if buf.len() > MAX_IMAGE_BYTES {
+            warn!(
+                "Image stream exceeded {} byte limit, aborting download",
+                MAX_IMAGE_BYTES
+            );
+            let desc = match caption {
+                Some(c) => format!(
+                    "[Image too large for vision ({} KB)]\nCaption: {c}",
+                    MAX_IMAGE_BYTES / 1024
+                ),
+                None => format!(
+                    "[Image too large for vision ({} KB)]",
+                    MAX_IMAGE_BYTES / 1024
+                ),
+            };
+            return vec![ContentBlock::Text {
+                text: desc,
+                provider_metadata: None,
+            }];
+        }
+    }
+    let bytes = bytes::Bytes::from(buf);
 
     // Four-tier media type detection:
     // 1. Adapter-provided hint (e.g. Telegram file path extension) — most
@@ -3230,24 +3296,6 @@ async fn download_image_to_blocks(
         .map(|s| s.to_string())
         .or(header_type)
         .unwrap_or_else(|| detect_image_magic(&bytes).unwrap_or_else(|| media_type_from_url(url)));
-
-    if bytes.len() > MAX_IMAGE_BYTES {
-        warn!(
-            "Image too large ({} bytes), skipping vision — sending as text",
-            bytes.len()
-        );
-        let desc = match caption {
-            Some(c) => format!(
-                "[Image too large for vision ({} KB)]\nCaption: {c}",
-                bytes.len() / 1024
-            ),
-            None => format!("[Image too large for vision ({} KB)]", bytes.len() / 1024),
-        };
-        return vec![ContentBlock::Text {
-            text: desc,
-            provider_metadata: None,
-        }];
-    }
 
     // Downscale large images so batches of many photos fit within the LLM
     // context window.  Max dimension 1024px keeps enough detail for analysis
@@ -3323,6 +3371,16 @@ async fn download_image_to_blocks(
             data,
         });
         return blocks;
+    }
+    // Restrict directory permissions to owner-only on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            tokio::fs::set_permissions(&upload_dir, std::fs::Permissions::from_mode(0o700)).await
+        {
+            warn!("Failed to set permissions on {}: {e}", upload_dir.display());
+        }
     }
 
     let filename = format!("{}.{}", uuid::Uuid::new_v4(), ext);

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -132,16 +132,19 @@ impl OpenAIDriver {
             .map_err(|e| LlmError::Http(format!("Moonshot file upload failed: {e}")))?;
 
         let status = resp.status();
-        let body: serde_json::Value = resp
-            .json()
+        let text = resp
+            .text()
             .await
-            .map_err(|e| LlmError::Http(format!("Moonshot file upload parse error: {e}")))?;
+            .map_err(|e| LlmError::Http(format!("Moonshot file upload read error: {e}")))?;
 
         if !status.is_success() {
             return Err(LlmError::Http(format!(
-                "Moonshot file upload returned {status}: {body}"
+                "Moonshot file upload returned {status}: {text}"
             )));
         }
+
+        let body: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| LlmError::Http(format!("Moonshot file upload parse error: {e}")))?;
 
         body["id"]
             .as_str()
@@ -172,17 +175,7 @@ impl OpenAIDriver {
                         let decoded = base64::engine::general_purpose::STANDARD
                             .decode(data)
                             .map_err(|e| LlmError::Http(format!("base64 decode: {e}")))?;
-                        let ext = match media_type.as_str() {
-                            "image/jpeg" => "jpg",
-                            "image/png" => "png",
-                            "image/webp" => "webp",
-                            "image/gif" => "gif",
-                            "application/pdf" => "pdf",
-                            "audio/ogg" => "ogg",
-                            "audio/mpeg" => "mp3",
-                            "video/mp4" => "mp4",
-                            _ => "bin",
-                        };
+                        let ext = ext_from_media_type(media_type);
                         (decoded, media_type.clone(), format!("file.{ext}"))
                     }
                     ContentBlock::ImageFile { media_type, path } => {
@@ -205,22 +198,29 @@ impl OpenAIDriver {
                 // Hash full file content with SHA-256 for cache key
                 let hash: [u8; 32] = Sha256::digest(&bytes).into();
 
-                let file_id = {
+                // Short lock: check cache only, release before any network I/O
+                let cached = {
+                    let cache = self.moonshot_file_cache.lock().await;
+                    cache.get(&hash).cloned()
+                };
+
+                let file_id = if let Some(id) = cached {
+                    id
+                } else {
+                    let id = self
+                        .upload_file_to_moonshot(&bytes, &filename, &mime)
+                        .await?;
+                    debug!(file_id = %id, filename = %filename, "Uploaded file to Moonshot");
+                    // Short lock: insert result into cache
                     let mut cache = self.moonshot_file_cache.lock().await;
-                    if let Some(cached) = cache.get(&hash) {
-                        cached.clone()
-                    } else {
-                        let id = self
-                            .upload_file_to_moonshot(&bytes, &filename, &mime)
-                            .await?;
-                        debug!(file_id = %id, filename = %filename, "Uploaded file to Moonshot");
-                        // Simple LRU cap: clear when cache exceeds 256 entries
-                        if cache.len() > 256 {
-                            cache.clear();
-                        }
-                        cache.insert(hash, id.clone());
-                        id
+                    // Cap at 256 entries — full eviction (not true LRU) is acceptable
+                    // because the cache is only a dedup optimisation; stale entries just
+                    // trigger a re-upload which Moonshot handles idempotently.
+                    if cache.len() >= 256 {
+                        cache.clear();
                     }
+                    cache.insert(hash, id.clone());
+                    id
                 };
 
                 // Replace the block with a text marker
@@ -261,6 +261,21 @@ impl OpenAIDriver {
     pub fn with_extra_headers(mut self, headers: Vec<(String, String)>) -> Self {
         self.extra_headers = headers;
         self
+    }
+}
+
+/// Map a MIME type to a file extension for Moonshot file uploads.
+fn ext_from_media_type(mime: &str) -> &'static str {
+    match mime {
+        "image/jpeg" => "jpg",
+        "image/png" => "png",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        "application/pdf" => "pdf",
+        "audio/ogg" => "ogg",
+        "audio/mpeg" => "mp3",
+        "video/mp4" => "mp4",
+        _ => "bin",
     }
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -28,6 +28,9 @@ pub struct OpenAIDriver {
     /// Optional query string appended to the request URL (e.g., "api-version=2024-02-01").
     /// Used by Azure OpenAI.
     url_query: Option<String>,
+    /// Cache of uploaded file IDs for Moonshot/Kimi (hash of bytes → file_id).
+    /// Avoids re-uploading the same file across agent loop iterations.
+    moonshot_file_cache: std::sync::Arc<tokio::sync::Mutex<HashMap<[u8; 32], String>>>,
 }
 
 impl OpenAIDriver {
@@ -49,6 +52,7 @@ impl OpenAIDriver {
             extra_headers: Vec::new(),
             use_api_key_header: false,
             url_query: None,
+            moonshot_file_cache: Default::default(),
         }
     }
 
@@ -88,12 +92,146 @@ impl OpenAIDriver {
             extra_headers: Vec::new(),
             use_api_key_header: true,
             url_query: Some(format!("api-version={}", api_version)),
+            moonshot_file_cache: Default::default(),
         }
     }
 
     /// True if this provider is Moonshot/Kimi and requires reasoning_content on assistant messages with tool_calls.
     fn kimi_needs_reasoning_content(&self, model: &str) -> bool {
-        self.base_url.contains("moonshot") || model.to_lowercase().contains("kimi")
+        self.is_moonshot() || model.to_lowercase().contains("kimi")
+    }
+
+    /// True if the base URL points to Moonshot/Kimi.
+    fn is_moonshot(&self) -> bool {
+        self.base_url.contains("moonshot")
+    }
+
+    /// Upload a file to Moonshot's `/v1/files` endpoint and return the file ID.
+    async fn upload_file_to_moonshot(
+        &self,
+        data: &[u8],
+        filename: &str,
+        mime: &str,
+    ) -> Result<String, LlmError> {
+        let url = format!("{}/files", self.base_url);
+        let part = reqwest::multipart::Part::bytes(data.to_vec())
+            .file_name(filename.to_string())
+            .mime_str(mime)
+            .map_err(|e| LlmError::Http(format!("Invalid MIME type: {e}")))?;
+        let form = reqwest::multipart::Form::new()
+            .text("purpose", "file-extract")
+            .part("file", part);
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(self.api_key.as_str())
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| LlmError::Http(format!("Moonshot file upload failed: {e}")))?;
+
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| LlmError::Http(format!("Moonshot file upload parse error: {e}")))?;
+
+        if !status.is_success() {
+            return Err(LlmError::Http(format!(
+                "Moonshot file upload returned {status}: {body}"
+            )));
+        }
+
+        body["id"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| LlmError::Http(format!("Moonshot file upload: missing 'id' in {body}")))
+    }
+
+    /// Pre-process a CompletionRequest for Moonshot: upload images/files and
+    /// replace ContentBlock::Image/ImageFile with a text marker that
+    /// `build_request()` converts to `OaiContentPart::File`.
+    async fn preprocess_moonshot_files(
+        &self,
+        request: &mut CompletionRequest,
+    ) -> Result<(), LlmError> {
+        use base64::Engine;
+        use sha2::{Digest, Sha256};
+
+        for msg in &mut request.messages {
+            let blocks = match &mut msg.content {
+                MessageContent::Blocks(b) => b,
+                _ => continue,
+            };
+
+            let mut i = 0;
+            while i < blocks.len() {
+                let (bytes, mime, filename) = match &blocks[i] {
+                    ContentBlock::Image { media_type, data } => {
+                        let decoded = base64::engine::general_purpose::STANDARD
+                            .decode(data)
+                            .map_err(|e| LlmError::Http(format!("base64 decode: {e}")))?;
+                        let ext = match media_type.as_str() {
+                            "image/jpeg" => "jpg",
+                            "image/png" => "png",
+                            "image/webp" => "webp",
+                            "image/gif" => "gif",
+                            "application/pdf" => "pdf",
+                            "audio/ogg" => "ogg",
+                            "audio/mpeg" => "mp3",
+                            "video/mp4" => "mp4",
+                            _ => "bin",
+                        };
+                        (decoded, media_type.clone(), format!("file.{ext}"))
+                    }
+                    ContentBlock::ImageFile { media_type, path } => {
+                        let bytes = tokio::fs::read(path)
+                            .await
+                            .map_err(|e| LlmError::Http(format!("Read {path}: {e}")))?;
+                        let fname = std::path::Path::new(path)
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("file")
+                            .to_string();
+                        (bytes, media_type.clone(), fname)
+                    }
+                    _ => {
+                        i += 1;
+                        continue;
+                    }
+                };
+
+                // Hash full file content with SHA-256 for cache key
+                let hash: [u8; 32] = Sha256::digest(&bytes).into();
+
+                let file_id = {
+                    let mut cache = self.moonshot_file_cache.lock().await;
+                    if let Some(cached) = cache.get(&hash) {
+                        cached.clone()
+                    } else {
+                        let id = self
+                            .upload_file_to_moonshot(&bytes, &filename, &mime)
+                            .await?;
+                        debug!(file_id = %id, filename = %filename, "Uploaded file to Moonshot");
+                        // Simple LRU cap: clear when cache exceeds 256 entries
+                        if cache.len() > 256 {
+                            cache.clear();
+                        }
+                        cache.insert(hash, id.clone());
+                        id
+                    }
+                };
+
+                // Replace the block with a text marker
+                blocks[i] = ContentBlock::Text {
+                    text: format!("<<moonshot_file:{file_id}>>"),
+                    provider_metadata: None,
+                };
+                i += 1;
+            }
+        }
+        Ok(())
     }
 
     /// True if this driver instance is pointed at an Ollama-compatible endpoint.
@@ -250,11 +388,20 @@ enum OaiContentPart {
     Text { text: String },
     #[serde(rename = "image_url")]
     ImageUrl { image_url: OaiImageUrl },
+    /// Moonshot/Kimi file reference (uploaded via /v1/files).
+    #[serde(rename = "file")]
+    File { file_url: OaiFileUrl },
 }
 
 #[derive(Debug, Serialize)]
 struct OaiImageUrl {
     url: String,
+}
+
+/// Moonshot/Kimi file URL reference.
+#[derive(Debug, Serialize)]
+struct OaiFileUrl {
+    url: String, // "fileid://file-abc123"
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -375,6 +522,19 @@ impl OpenAIDriver {
                 }
                 (Role::User, MessageContent::Blocks(blocks)) => {
                     // Handle tool results and images in user messages
+                    let block_summary: Vec<&str> = blocks
+                        .iter()
+                        .map(|b| match b {
+                            ContentBlock::Text { .. } => "Text",
+                            ContentBlock::Image { .. } => "Image(base64)",
+                            ContentBlock::ImageFile { .. } => "ImageFile",
+                            ContentBlock::ToolResult { .. } => "ToolResult",
+                            ContentBlock::ToolUse { .. } => "ToolUse",
+                            ContentBlock::Thinking { .. } => "Thinking",
+                            _ => "Other",
+                        })
+                        .collect();
+                    tracing::debug!(blocks = ?block_summary, "build_request: user Blocks content");
                     let mut parts: Vec<OaiContentPart> = Vec::new();
                     let mut has_tool_results = false;
                     for block in blocks {
@@ -398,7 +558,20 @@ impl OpenAIDriver {
                                 });
                             }
                             ContentBlock::Text { text, .. } => {
-                                parts.push(OaiContentPart::Text { text: text.clone() });
+                                // Detect Moonshot file markers injected by
+                                // preprocess_moonshot_files()
+                                if let Some(file_id) = text
+                                    .strip_prefix("<<moonshot_file:")
+                                    .and_then(|s| s.strip_suffix(">>"))
+                                {
+                                    parts.push(OaiContentPart::File {
+                                        file_url: OaiFileUrl {
+                                            url: format!("fileid://{file_id}"),
+                                        },
+                                    });
+                                } else {
+                                    parts.push(OaiContentPart::Text { text: text.clone() });
+                                }
                             }
                             ContentBlock::Image { media_type, data } => {
                                 parts.push(OaiContentPart::ImageUrl {
@@ -599,7 +772,14 @@ impl OpenAIDriver {
 
 #[async_trait]
 impl LlmDriver for OpenAIDriver {
-    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+    async fn complete(
+        &self,
+        mut request: CompletionRequest,
+    ) -> Result<CompletionResponse, LlmError> {
+        // Moonshot/Kimi: upload images/files via /v1/files before building request
+        if self.is_moonshot() {
+            self.preprocess_moonshot_files(&mut request).await?;
+        }
         let mut oai_request = self.build_request(&request)?;
 
         let max_retries = 3;
@@ -967,9 +1147,13 @@ impl LlmDriver for OpenAIDriver {
 
     async fn stream(
         &self,
-        request: CompletionRequest,
+        mut request: CompletionRequest,
         tx: tokio::sync::mpsc::Sender<StreamEvent>,
     ) -> Result<CompletionResponse, LlmError> {
+        // Moonshot/Kimi: upload images/files via /v1/files before building request
+        if self.is_moonshot() {
+            self.preprocess_moonshot_files(&mut request).await?;
+        }
         let mut oai_request = self.build_request(&request)?;
         oai_request.stream = true;
         oai_request.stream_options = Some(serde_json::json!({"include_usage": true}));


### PR DESCRIPTION
## Summary

- Adds file upload support for the Moonshot (Kimi) LLM driver via the `/v1/files` endpoint
- Uploads attachments to a temp path using `std::env::temp_dir()` before forwarding to the API
- Security review fixes: validates content-type, limits file size, sanitizes filenames

Closes #2321

## Test plan

- [ ] `cargo clippy --workspace --lib` passes with zero warnings
- [ ] Live: send a message with an attachment to a Moonshot-backed agent; verify the file is uploaded and referenced correctly in the LLM request