### PR TITLE
fix(gateway): inject RELAY prompt only on explicit owner intent

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -2137,9 +2137,16 @@ function ownerIntentsRelay(text) {
   if (!t) return false;
   if (t.startsWith('/relay') || t.startsWith('/reply')) return true;
   if (/(^|\s)@[\w.+-]+/.test(t)) return true;
-  return /\b(rispondi a|scrivi a|scrivigli|digli|dille|dica|saluta|manda a|inoltra|chiedi a|reply to|tell|write to|forward to|relay to)\b/.test(
-    t,
-  );
+  // Phrases that always imply a third-party recipient.
+  if (/\b(rispondi a|scrivi a|scrivigli|digli|dille|dica|saluta|manda a|inoltra|chiedi a|reply to|write to|relay to)\b/.test(t)) {
+    return true;
+  }
+  // `tell` and `forward to` have legitimate non-relay uses
+  // ("tell me a joke", "looking forward to meeting you"), so require them
+  // to name an addressee rather than matching the verb alone.
+  if (/\btell\s+(?!me\b|us\b|you\b)\w+/.test(t)) return true;
+  if (/\bforward\s+(?:it|this|that|the\s+\w+|a\s+\w+)\s+to\s+\w+/.test(t)) return true;
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -222,17 +222,30 @@ function dbUpdateLastSeen(jid, timestamp) {
 const CONFIG_PATH = process.env.LIBREFANG_CONFIG || path.join(os.homedir(), '.librefang', 'config.toml');
 
 function readWhatsAppConfig(configPath) {
-  const defaults = { default_agent: 'assistant', owner_numbers: [], conversation_ttl_hours: 24 };
+  const defaults = {
+    default_agent: 'assistant',
+    owner_numbers: [],
+    conversation_ttl_hours: 24,
+    // English-only by default keeps upstream deployments locale-neutral;
+    // set `[relay_intent].languages = ["en", "it", …]` in config.toml
+    // to enable extra language packs.
+    relay_intent_languages: ['en'],
+  };
   try {
     const content = fs.readFileSync(configPath, 'utf8');
     const parsed = toml.parse(content);
     const wa = parsed?.channels?.whatsapp || {};
+    const relay = parsed?.relay_intent || {};
     const cfg = {
       default_agent: wa.default_agent || defaults.default_agent,
       owner_numbers: Array.isArray(wa.owner_numbers) ? wa.owner_numbers : defaults.owner_numbers,
       conversation_ttl_hours: parseInt(wa.conversation_ttl_hours, 10) || defaults.conversation_ttl_hours,
+      relay_intent_languages:
+        Array.isArray(relay.languages) && relay.languages.length > 0
+          ? relay.languages
+          : defaults.relay_intent_languages,
     };
-    console.log(`[gateway] Read config from ${configPath}: default_agent="${cfg.default_agent}", owner_numbers=${JSON.stringify(cfg.owner_numbers)}, conversation_ttl_hours=${cfg.conversation_ttl_hours}`);
+    console.log(`[gateway] Read config from ${configPath}: default_agent="${cfg.default_agent}", owner_numbers=${JSON.stringify(cfg.owner_numbers)}, conversation_ttl_hours=${cfg.conversation_ttl_hours}, relay_intent_languages=${JSON.stringify(cfg.relay_intent_languages)}`);
     return cfg;
   } catch (err) {
     console.warn(`[gateway] Could not read ${configPath}: ${err.message} — using defaults/env vars`);
@@ -2132,21 +2145,19 @@ async function processMediaMessage(fullMsg, innerMsg, agentId) {
 // Only inject the relay instruction when the owner's message expresses an
 // explicit delegated-speech intent. Everything else is treated as owner
 // talking directly to the agent.
+// Regex compiled once at module load from the configured language
+// packs in `lib/intent_patterns.js`. Adding a locale is a file-level
+// change; adding the code to the config toggles it on.
+const RELAY_INTENT_RE = require('./lib/intent_patterns').compileIntentRegex(
+  tomlConfig.relay_intent_languages,
+);
+
 function ownerIntentsRelay(text) {
   const t = (text || '').trim().toLowerCase();
   if (!t) return false;
   if (t.startsWith('/relay') || t.startsWith('/reply')) return true;
   if (/(^|\s)@[\w.+-]+/.test(t)) return true;
-  // Phrases that always imply a third-party recipient.
-  if (/\b(rispondi a|scrivi a|scrivigli|digli|dille|dica|saluta|manda a|inoltra|chiedi a|reply to|write to|relay to)\b/.test(t)) {
-    return true;
-  }
-  // `tell` and `forward to` have legitimate non-relay uses
-  // ("tell me a joke", "looking forward to meeting you"), so require them
-  // to name an addressee rather than matching the verb alone.
-  if (/\btell\s+(?!me\b|us\b|you\b)\w+/.test(t)) return true;
-  if (/\bforward\s+(?:it|this|that|the\s+\w+|a\s+\w+)\s+to\s+\w+/.test(t)) return true;
-  return false;
+  return RELAY_INTENT_RE.test(t);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -1609,7 +1609,11 @@ async function startConnection() {
         } else if (isStranger) {
           const strangerContext = buildStrangerContext(pushName, phone, sender);
           messageToSend = strangerContext + messageText;
-        } else if (isOwner && activeConversations.size > 0) {
+        } else if (isOwner && activeConversations.size > 0 && ownerIntentsRelay(messageText)) {
+          // Only inject the relay system instruction when the owner's text
+          // expresses an explicit delegated-speech intent. A neutral greeting
+          // from the owner to the agent during an active stranger conversation
+          // must NOT be forced into relay mode.
           const context = buildConversationsContext();
           systemPrefix = buildRelaySystemInstruction();
           messageToSend = context + '\n\n[OWNER_MESSAGE]\n' + messageText;
@@ -2113,6 +2117,29 @@ async function processMediaMessage(fullMsg, innerMsg, agentId) {
     console.error(`[gateway] Media processing failed for ${filename}: ${err.message}`);
     return null; // Caller will fall back to text descriptor
   }
+}
+
+// ---------------------------------------------------------------------------
+// Detect whether an owner message expresses relay intent.
+//
+// Before this guard, `buildRelaySystemInstruction` was injected for every
+// owner turn whenever any stranger conversation was active — which forced
+// the model to interpret neutral owner-to-bot messages ("saludos", "hola",
+// "come stai?") as requests to relay a reply to the last stranger. Result
+// observed in production: owner writing "saludos" to the bot triggered a
+// RELAY_TO_STRANGER to an unrelated namesake contact.
+//
+// Only inject the relay instruction when the owner's message expresses an
+// explicit delegated-speech intent. Everything else is treated as owner
+// talking directly to the agent.
+function ownerIntentsRelay(text) {
+  const t = (text || '').trim().toLowerCase();
+  if (!t) return false;
+  if (t.startsWith('/relay') || t.startsWith('/reply')) return true;
+  if (/(^|\s)@[\w.+-]+/.test(t)) return true;
+  return /\b(rispondi a|scrivi a|scrivigli|digli|dille|dica|saluta|manda a|inoltra|chiedi a|reply to|tell|write to|forward to|relay to)\b/.test(
+    t,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -2986,6 +3013,7 @@ module.exports = {
   markdownToWhatsApp,
   extractNotifyOwner,
   extractRelayCommands,
+  ownerIntentsRelay,
   buildConversationsContext,
   isRateLimited,
   buildCorsHeaders,

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -17,6 +17,7 @@ const {
   markdownToWhatsApp,
   extractNotifyOwner,
   extractRelayCommands,
+  ownerIntentsRelay,
   buildConversationsContext,
   isRateLimited,
   buildCorsHeaders,
@@ -1157,5 +1158,57 @@ describe('createHoldbackAccumulator (OB-07 streaming hold-back)', () => {
     await acc.push('partial');
     assert.equal(acc.buffered, 'partial');
     assert.equal(acc.hasFlushed, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ownerIntentsRelay — guards the RELAY system-instruction injection so that
+// neutral owner-to-agent messages don't get forced into relay mode when a
+// stranger conversation happens to be active.
+// ---------------------------------------------------------------------------
+describe('ownerIntentsRelay', () => {
+  it('returns false for neutral greetings', () => {
+    assert.equal(ownerIntentsRelay('saludos'), false);
+    assert.equal(ownerIntentsRelay('hola'), false);
+    assert.equal(ownerIntentsRelay('ciao'), false);
+    assert.equal(ownerIntentsRelay('Buondì'), false);
+    assert.equal(ownerIntentsRelay('come stai?'), false);
+    assert.equal(ownerIntentsRelay(''), false);
+    assert.equal(ownerIntentsRelay('   '), false);
+  });
+
+  it('returns true for explicit /relay or /reply command', () => {
+    assert.equal(ownerIntentsRelay('/relay tell him I will be late'), true);
+    assert.equal(ownerIntentsRelay('/reply ok grazie'), true);
+  });
+
+  it('returns true for @mention', () => {
+    assert.equal(ownerIntentsRelay('@alice hi there'), true);
+    assert.equal(ownerIntentsRelay('please say @bob hi'), true);
+  });
+
+  it('returns true for Italian delegated-speech verbs', () => {
+    assert.equal(ownerIntentsRelay('rispondi a Federico che sto bene'), true);
+    assert.equal(ownerIntentsRelay('digli che arrivo'), true);
+    assert.equal(ownerIntentsRelay('saluta Caterina per me'), true);
+    assert.equal(ownerIntentsRelay('scrivi a Paolo'), true);
+    assert.equal(ownerIntentsRelay('chiedi a Mario il prezzo'), true);
+    assert.equal(ownerIntentsRelay('inoltra a tutti la comunicazione'), true);
+  });
+
+  it('returns true for English delegated-speech verbs', () => {
+    assert.equal(ownerIntentsRelay('reply to Bob that I agree'), true);
+    assert.equal(ownerIntentsRelay('tell Alice I am busy'), true);
+    assert.equal(ownerIntentsRelay('write to the team'), true);
+  });
+
+  it('is case-insensitive and whitespace-tolerant', () => {
+    assert.equal(ownerIntentsRelay('  RISPONDI A Mario ok'), true);
+    assert.equal(ownerIntentsRelay('DIGLI che sto arrivando'), true);
+  });
+
+  it('does not match partial words', () => {
+    assert.equal(ownerIntentsRelay('salutami la zia'), false);
+    assert.equal(ownerIntentsRelay('rispostaok'), false);
   });
 });

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -1187,13 +1187,30 @@ describe('ownerIntentsRelay', () => {
     assert.equal(ownerIntentsRelay('please say @bob hi'), true);
   });
 
-  it('returns true for Italian delegated-speech verbs', () => {
-    assert.equal(ownerIntentsRelay('rispondi a Federico che sto bene'), true);
-    assert.equal(ownerIntentsRelay('digli che arrivo'), true);
-    assert.equal(ownerIntentsRelay('saluta Caterina per me'), true);
-    assert.equal(ownerIntentsRelay('scrivi a Paolo'), true);
-    assert.equal(ownerIntentsRelay('chiedi a Mario il prezzo'), true);
-    assert.equal(ownerIntentsRelay('inoltra a tutti la comunicazione'), true);
+  it('Italian pack: recognises delegated-speech verbs, rejects owner→agent formal imperative', () => {
+    const { compileIntentRegex } = require('./lib/intent_patterns');
+    const re = compileIntentRegex(['it']);
+    // Positive — explicit recipient / verb-with-baked-in-object
+    assert.ok(re.test('rispondi a Federico che sto bene'));
+    assert.ok(re.test('digli che arrivo'));
+    assert.ok(re.test('saluta Caterina per me'));
+    assert.ok(re.test('scrivi a Paolo'));
+    assert.ok(re.test('chiedi a Mario il prezzo'));
+    assert.ok(re.test('inoltra a tutti la comunicazione'));
+    assert.ok(re.test('dica a Mario che sto bene'));
+    // Negative — owner addressing the bot, not a relay.
+    // Pre-fix regex matched bare `dica`, so "mi dica" triggered a false
+    // relay intent; the narrowed `dica\s+a\s+\w+` pattern blocks it.
+    assert.equal(re.test('mi dica'), false);
+    assert.equal(re.test('mi dica di più'), false);
+    assert.equal(re.test('Dica pure'), false);
+  });
+
+  it('multi-language union: both EN and IT patterns active simultaneously', () => {
+    const { compileIntentRegex } = require('./lib/intent_patterns');
+    const re = compileIntentRegex(['en', 'it']);
+    assert.ok(re.test('tell Alice I am busy'));
+    assert.ok(re.test('digli che arrivo'));
   });
 
   it('returns true for English delegated-speech verbs', () => {
@@ -1202,9 +1219,11 @@ describe('ownerIntentsRelay', () => {
     assert.equal(ownerIntentsRelay('write to the team'), true);
   });
 
-  it('is case-insensitive and whitespace-tolerant', () => {
-    assert.equal(ownerIntentsRelay('  RISPONDI A Mario ok'), true);
-    assert.equal(ownerIntentsRelay('DIGLI che sto arrivando'), true);
+  it('is case-insensitive (IT pack)', () => {
+    const { compileIntentRegex } = require('./lib/intent_patterns');
+    const re = compileIntentRegex(['it']);
+    assert.ok(re.test('  RISPONDI A Mario ok'.trim()));
+    assert.ok(re.test('DIGLI che sto arrivando'));
   });
 
   it('does not match partial words', () => {

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -1249,4 +1249,18 @@ describe('ownerIntentsRelay', () => {
     assert.equal(ownerIntentsRelay('forward this to Alice'), true);
     assert.equal(ownerIntentsRelay('forward the message to the team'), true);
   });
+
+  it('German pack: rejects "Sag mir" / "Sage uns" (owner→bot), accepts explicit recipient', () => {
+    const { compileIntentRegex } = require('./lib/intent_patterns');
+    const re = compileIntentRegex(['de']);
+    // Positive — explicit third-party recipient
+    assert.ok(re.test('Sag Klaus ich komme später'));
+    assert.ok(re.test('sage Anna bitte Bescheid'));
+    assert.ok(re.test('schreib an Petra'));
+    assert.ok(re.test('antworte an Marco'));
+    // Negative — self-directed (owner talking to the bot)
+    assert.equal(re.test('Sag mir was du denkst'), false);
+    assert.equal(re.test('sag mir bitte'), false);
+    assert.equal(re.test('sage uns die Wahrheit'), false);
+  });
 });

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -1211,4 +1211,23 @@ describe('ownerIntentsRelay', () => {
     assert.equal(ownerIntentsRelay('salutami la zia'), false);
     assert.equal(ownerIntentsRelay('rispostaok'), false);
   });
+
+  it('does not treat "tell me/us/you" as relay intent (owner → agent)', () => {
+    assert.equal(ownerIntentsRelay('tell me a joke'), false);
+    assert.equal(ownerIntentsRelay('can you tell me about this'), false);
+    assert.equal(ownerIntentsRelay('tell us the news'), false);
+    assert.equal(ownerIntentsRelay('tell you what'), false);
+  });
+
+  it('does not treat "looking forward to" as relay intent', () => {
+    assert.equal(ownerIntentsRelay('I look forward to meeting you'), false);
+    assert.equal(ownerIntentsRelay('looking forward to the call'), false);
+    assert.equal(ownerIntentsRelay('I am forward to hearing from you'), false);
+  });
+
+  it('still matches "forward <it|this|the X> to <recipient>"', () => {
+    assert.equal(ownerIntentsRelay('forward it to Bob'), true);
+    assert.equal(ownerIntentsRelay('forward this to Alice'), true);
+    assert.equal(ownerIntentsRelay('forward the message to the team'), true);
+  });
 });

--- a/packages/whatsapp-gateway/lib/intent_patterns.js
+++ b/packages/whatsapp-gateway/lib/intent_patterns.js
@@ -64,8 +64,10 @@ const DE_RELAY = [
   'frage\\s+\\w+',
   'sende\\s+an\\s+\\w+',
   'leite\\s+an\\s+\\w+\\s+weiter',
-  'sag\\s+\\w+',
-  'sage\\s+\\w+',
+  // Exclude "Sag mir" / "Sage uns" (owner→bot self-directed) — same
+  // negative-lookahead pattern used by the English "tell" entry.
+  'sag\\s+(?!mir\\b|uns\\b)\\w+',
+  'sage\\s+(?!mir\\b|uns\\b)\\w+',
   'grüße\\s+\\w+',
   'grusse\\s+\\w+',
 ];

--- a/packages/whatsapp-gateway/lib/intent_patterns.js
+++ b/packages/whatsapp-gateway/lib/intent_patterns.js
@@ -1,0 +1,143 @@
+// Pattern packs used by `ownerIntentsRelay()` to recognise when the
+// bot's owner is asking the bot to relay a message to a third
+// party ("write to Marta that..."), as opposed to talking to the
+// bot directly ("tell me a joke").
+//
+// Patterns are grouped by source language so adding a new locale is
+// a file-level change, not a regex-alternation edit. Every pattern
+// MUST require an explicit third-party object (preposition + name,
+// or a verb form that bakes the indirect object in) — otherwise bare
+// imperatives like `"mi dica"` (Italian "tell me", owner→bot) get
+// false-positive-matched as a relay intent and re-open the exact
+// class of incidents this guard exists to prevent.
+
+const EN_RELAY = [
+  // "reply to Marta", "write to the customer"
+  'reply\\s+to\\s+\\w+',
+  'write\\s+to\\s+\\w+',
+  'relay\\s+to\\s+\\w+',
+  // "tell <anyone-but-me/us/you> …" — keeps "tell me a joke" out while
+  // admitting "tell Alice I am busy", "tell him", "tell them".
+  'tell\\s+(?!me\\b|us\\b|you\\b)\\w+',
+  // "forward it/this/that/the X/a X to <recipient>" — narrow form so
+  // idioms like "look forward to" and "I am forward to hearing from"
+  // don't trigger a relay.
+  'forward\\s+(?:it|this|that|the\\s+\\w+|a\\s+\\w+)\\s+to\\s+\\w+',
+];
+
+// Spanish — every pattern requires explicit recipient so bare
+// imperatives like "dime" (tell-me) don't trigger relay mode.
+const ES_RELAY = [
+  'responde\\s+a\\s+\\w+',
+  'escribe\\s+a\\s+\\w+',
+  'pregunta\\s+a\\s+\\w+',
+  'envía\\s+a\\s+\\w+',
+  'envia\\s+a\\s+\\w+',
+  'reenvía\\s+a\\s+\\w+',
+  'reenvia\\s+a\\s+\\w+',
+  'salúdalo', 'saludalo',
+  'salúdala', 'saludala',
+  'dile\\s+a\\s+\\w+',
+  'dígale\\s+a\\s+\\w+',
+  'digale\\s+a\\s+\\w+',
+];
+
+// French
+const FR_RELAY = [
+  'réponds\\s+à\\s+\\w+',
+  'reponds\\s+à\\s+\\w+',
+  'écris\\s+à\\s+\\w+',
+  'ecris\\s+à\\s+\\w+',
+  'demande\\s+à\\s+\\w+',
+  'envoie\\s+à\\s+\\w+',
+  'transfère\\s+à\\s+\\w+',
+  'transfere\\s+à\\s+\\w+',
+  'dis\\s+à\\s+\\w+',
+  'dites\\s+à\\s+\\w+',
+  'salue\\s+\\w+',
+];
+
+// German
+const DE_RELAY = [
+  'antworte\\s+an\\s+\\w+',
+  'schreibe?\\s+an\\s+\\w+',
+  'frage\\s+\\w+',
+  'sende\\s+an\\s+\\w+',
+  'leite\\s+an\\s+\\w+\\s+weiter',
+  'sag\\s+\\w+',
+  'sage\\s+\\w+',
+  'grüße\\s+\\w+',
+  'grusse\\s+\\w+',
+];
+
+// Portuguese
+const PT_RELAY = [
+  'responde\\s+a(?:o|à)?\\s+\\w+',
+  'responda\\s+a(?:o|à)?\\s+\\w+',
+  'escreve\\s+a(?:o|à)?\\s+\\w+',
+  'escreva\\s+a(?:o|à)?\\s+\\w+',
+  'pergunta\\s+a(?:o|à)?\\s+\\w+',
+  'pergunte\\s+a(?:o|à)?\\s+\\w+',
+  'envia\\s+a(?:o|à)?\\s+\\w+',
+  'envie\\s+a(?:o|à)?\\s+\\w+',
+  'encaminhe\\s+a(?:o|à)?\\s+\\w+',
+  'encaminha\\s+a(?:o|à)?\\s+\\w+',
+  'diga\\s+a(?:o|à)?\\s+\\w+',
+  'cumprimenta\\s+\\w+',
+];
+
+const IT_RELAY = [
+  // "rispondi a Marta", "scrivi al cliente", "chiedi a Luca"
+  'rispondi\\s+a(?:l|lla|llo|lle|i|gli)?\\s+\\w+',
+  'scrivi\\s+a(?:l|lla|llo|lle|i|gli)?\\s+\\w+',
+  'chiedi\\s+a(?:l|lla|llo|lle|i|gli)?\\s+\\w+',
+  'manda\\s+a(?:l|lla|llo|lle|i|gli)?\\s+\\w+',
+  'inoltra\\s+a(?:l|lla|llo|lle|i|gli)?\\s+\\w+',
+  // Verb forms with a baked-in third-person indirect object:
+  // "digli" = "tell him", "dille" = "tell her", "scrivigli" = "write to him"
+  'digli',
+  'dille',
+  'scrivigli',
+  // "dica a Mario …" — requires the preposition so we don't match
+  // "mi dica" (owner addressing the bot in the formal register).
+  'dica\\s+a\\s+\\w+',
+  // "saluta <name>" — imperative + explicit recipient
+  'saluta\\s+\\w+',
+];
+
+/**
+ * Compile a union regex from the requested language packs.
+ *
+ * `languages` is a list of two-letter codes (`["en", "it"]`). Unknown
+ * codes are silently skipped so a config-side typo can't crash boot.
+ */
+function compileIntentRegex(languages = ['en']) {
+  const packs = {
+    en: EN_RELAY,
+    it: IT_RELAY,
+    es: ES_RELAY,
+    fr: FR_RELAY,
+    de: DE_RELAY,
+    pt: PT_RELAY,
+  };
+  const patterns = [];
+  for (const code of languages) {
+    const pack = packs[code.toLowerCase()];
+    if (pack) patterns.push(...pack);
+  }
+  if (patterns.length === 0) {
+    // Empty config → never match; safer than always-match.
+    return /(?!.*)/;
+  }
+  return new RegExp('\\b(?:' + patterns.join('|') + ')\\b', 'i');
+}
+
+module.exports = {
+  EN_RELAY,
+  IT_RELAY,
+  ES_RELAY,
+  FR_RELAY,
+  DE_RELAY,
+  PT_RELAY,
+  compileIntentRegex,
+};


### PR DESCRIPTION
## Summary

Fixes a production incident where neutral owner messages (e.g. "saludos", "hola") during an active stranger conversation triggered `RELAY_TO_STRANGER` to unrelated contacts.

- New `ownerIntentsRelay(text)` predicate: only returns true for explicit delegated-speech signals (`/relay`, `/reply`, `@mention`, or language-specific relay verbs)
- Relay-intent patterns extracted into `lib/intent_patterns.js` with per-language packs (EN, IT, ES, FR, DE, PT)
- `tell` narrowed to `tell\s+(?!me\b|us\b|you\b)\w+` to avoid false positives
- `forward` narrowed to `forward (it|this|that|the X) to <recipient>` to avoid "look forward to" false positives

Closes #2620

## Test plan

- [ ] `node --test packages/whatsapp-gateway/index.test.js` passes
- [ ] Neutral greetings do NOT trigger relay mode
- [ ] `/relay`, `/reply`, `@mention`, and known verb patterns DO trigger relay mode