### PR TITLE
fix(runtime): add missing timestamp field in session_repair Message structs

### DIFF
--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -407,6 +407,7 @@ fn enforce_adjacent_tool_result_pairs(messages: &mut Vec<Message>) -> usize {
                         role: Role::User,
                         content: MessageContent::Blocks(synthetic_blocks),
                         pinned: false,
+                        timestamp: None,
                     },
                 );
             }
@@ -416,6 +417,7 @@ fn enforce_adjacent_tool_result_pairs(messages: &mut Vec<Message>) -> usize {
                 role: Role::User,
                 content: MessageContent::Blocks(synthetic_blocks),
                 pinned: false,
+                timestamp: None,
             });
         }
 


### PR DESCRIPTION
## Summary

PR #2962 added new `Message { ... }` struct literals in `enforce_adjacent_tool_result_pairs` after the `timestamp: Option<DateTime<Utc>>` field was added to `Message` (PR #2954), but omitted the field in 2 places — breaking compilation on all platforms.

## Fix

Added `timestamp: None` to the 2 incomplete initializations at lines 406 and 415 of `session_repair.rs`.