### PR TITLE
fix(runtime,channels): fix all missing timestamp fields and incomplete test stubs

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5208,6 +5208,18 @@ mod tests {
 
         #[async_trait::async_trait]
         impl ChannelBridgeHandle for CapturingHandle {
+            async fn send_message(&self, _: AgentId, _: &str) -> Result<String, String> {
+                Err("not used in test".into())
+            }
+            async fn find_agent_by_name(&self, _: &str) -> Result<Option<AgentId>, String> {
+                Err("not used in test".into())
+            }
+            async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+                Err("not used in test".into())
+            }
+            async fn spawn_agent_by_name(&self, _: &str) -> Result<AgentId, String> {
+                Err("not used in test".into())
+            }
             async fn classify_reply_intent(
                 &self,
                 _message_text: &str,
@@ -5224,7 +5236,20 @@ mod tests {
         async fn default_impl_returns_true_with_bot_name() {
             struct AlwaysTrue;
             #[async_trait::async_trait]
-            impl ChannelBridgeHandle for AlwaysTrue {}
+            impl ChannelBridgeHandle for AlwaysTrue {
+                async fn send_message(&self, _: AgentId, _: &str) -> Result<String, String> {
+                    Err("not used in test".into())
+                }
+                async fn find_agent_by_name(&self, _: &str) -> Result<Option<AgentId>, String> {
+                    Err("not used in test".into())
+                }
+                async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+                    Err("not used in test".into())
+                }
+                async fn spawn_agent_by_name(&self, _: &str) -> Result<AgentId, String> {
+                    Err("not used in test".into())
+                }
+            }
 
             let h = AlwaysTrue;
             assert!(

--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -2241,11 +2241,13 @@ mod tests {
                     provider_metadata: None,
                 }]),
                 pinned: false,
+                timestamp: None,
             },
             Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![tool_result_a]),
                 pinned: false,
+                timestamp: None,
             },
             Message {
                 role: Role::Assistant,
@@ -2256,11 +2258,13 @@ mod tests {
                     provider_metadata: None,
                 }]),
                 pinned: false,
+                timestamp: None,
             },
             Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![tool_result_b]),
                 pinned: false,
+                timestamp: None,
             },
         ];
 
@@ -2284,11 +2288,13 @@ mod tests {
                 role: Role::User,
                 content: MessageContent::Text("hello ".to_string()),
                 pinned: false,
+                timestamp: None,
             },
             Message {
                 role: Role::User,
                 content: MessageContent::Text("world".to_string()),
                 pinned: false,
+                timestamp: None,
             },
         ];
         let (repaired, stats) = validate_and_repair_with_stats(&messages);
@@ -2337,12 +2343,14 @@ mod tests {
                 role: Role::Assistant,
                 content: MessageContent::Blocks(vec![tool_use_block("memory_store:6")]),
                 pinned: false,
+                timestamp: None,
             },
             // msg 1: user answers with the real ToolResult — already adjacent
             Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![tool_result_block("memory_store:6", "first")]),
                 pinned: false,
+                timestamp: None,
             },
             // msg 2: assistant sends plain text
             Message::assistant("ack"),
@@ -2353,6 +2361,7 @@ mod tests {
                 role: Role::Assistant,
                 content: MessageContent::Blocks(vec![tool_use_block("memory_store:6")]),
                 pinned: false,
+                timestamp: None,
             },
             // msg 5: user plain text — no ToolResult present (orphan trigger)
             Message::user("no result yet"),
@@ -2470,6 +2479,7 @@ mod tests {
                 role: Role::Assistant,
                 content: MessageContent::Blocks(vec![tool_use_block("call_1")]),
                 pinned: false,
+                timestamp: None,
             },
             Message::user("plain text, no tool result"),
         ];


### PR DESCRIPTION
## Summary

Continues the fix started in #2968 — `--lib` clippy passed but `--all-targets` (what CI uses) exposed more errors:

- 10 more `Message { }` struct literals in `session_repair.rs` test code missing `timestamp: None` (all from the `f3cd31b7` / #2962 commit)
- `CapturingHandle` and `AlwaysTrue` test mocks in `bridge.rs` missing the 4 required `ChannelBridgeHandle` methods (`send_message`, `find_agent_by_name`, `list_agents`, `spawn_agent_by_name`)