### PR TITLE
fix(kernel): read peer_id from job_json in cron_create

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -13465,7 +13465,7 @@ impl KernelHandle for LibreFangKernel {
             schedule,
             action,
             delivery,
-            peer_id: None,
+            peer_id: job_json["peer_id"].as_str().map(|s| s.to_string()),
             session_mode,
             enabled: true,
             created_at: chrono::Utc::now(),

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -1965,11 +1965,10 @@ async fn test_cron_create_preserves_peer_id() {
         "action": { "kind": "agent_turn", "message": "ping" },
     });
 
-    let job_id = kernel
+    kernel
         .cron_create(&agent_id, job_json)
         .await
         .expect("cron_create should succeed");
-    assert!(!job_id.is_empty());
 
     let jobs = kernel
         .cron_list(&agent_id)
@@ -1978,7 +1977,7 @@ async fn test_cron_create_preserves_peer_id() {
 
     let job = jobs
         .iter()
-        .find(|j| j["id"].as_str() == Some(&job_id))
+        .find(|j| j["name"].as_str() == Some("peer-id-regression"))
         .expect("created job should appear in list");
 
     assert_eq!(
@@ -1993,7 +1992,7 @@ async fn test_cron_create_preserves_peer_id() {
         "schedule": { "kind": "cron", "expr": "0 * * * *" },
         "action": { "kind": "agent_turn", "message": "ping" },
     });
-    let job_id2 = kernel
+    kernel
         .cron_create(&agent_id, job_no_peer)
         .await
         .expect("cron_create without peer_id should succeed");
@@ -2003,7 +2002,7 @@ async fn test_cron_create_preserves_peer_id() {
         .expect("cron_list should succeed");
     let job2 = jobs2
         .iter()
-        .find(|j| j["id"].as_str() == Some(&job_id2))
+        .find(|j| j["name"].as_str() == Some("no-peer-id"))
         .expect("second job should appear in list");
     assert!(
         job2["peer_id"].is_null(),

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -1961,8 +1961,8 @@ async fn test_cron_create_preserves_peer_id() {
     let job_json = serde_json::json!({
         "name": "peer-id-regression",
         "peer_id": "peer-abc-123",
-        "schedule": { "cron": "0 * * * *" },
-        "action": { "message": "ping" },
+        "schedule": { "kind": "cron", "expr": "0 * * * *" },
+        "action": { "kind": "agent_turn", "message": "ping" },
     });
 
     let job_id = kernel
@@ -1990,8 +1990,8 @@ async fn test_cron_create_preserves_peer_id() {
     // Also verify that a job created WITHOUT peer_id has peer_id = null.
     let job_no_peer = serde_json::json!({
         "name": "no-peer-id",
-        "schedule": { "cron": "0 * * * *" },
-        "action": { "message": "ping" },
+        "schedule": { "kind": "cron", "expr": "0 * * * *" },
+        "action": { "kind": "agent_turn", "message": "ping" },
     });
     let job_id2 = kernel
         .cron_create(&agent_id, job_no_peer)

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -1933,3 +1933,82 @@ fn test_skill_evolve_tools_default_available_to_restricted_agent() {
         );
     }
 }
+
+// Regression test for the fix that reads peer_id from job_json.
+// Before the fix, cron_create always set peer_id: None regardless of the
+// job payload, so OFP-triggered cron jobs lost the peer context entirely.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cron_create_preserves_peer_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    let agents = kernel.registry.list();
+    let assistant = agents
+        .iter()
+        .find(|a| a.name == "assistant")
+        .expect("assistant should exist");
+    let agent_id = assistant.id.to_string();
+
+    let job_json = serde_json::json!({
+        "name": "peer-id-regression",
+        "peer_id": "peer-abc-123",
+        "schedule": { "cron": "0 * * * *" },
+        "action": { "message": "ping" },
+    });
+
+    let job_id = kernel
+        .cron_create(&agent_id, job_json)
+        .await
+        .expect("cron_create should succeed");
+    assert!(!job_id.is_empty());
+
+    let jobs = kernel
+        .cron_list(&agent_id)
+        .await
+        .expect("cron_list should succeed");
+
+    let job = jobs
+        .iter()
+        .find(|j| j["id"].as_str() == Some(&job_id))
+        .expect("created job should appear in list");
+
+    assert_eq!(
+        job["peer_id"].as_str(),
+        Some("peer-abc-123"),
+        "peer_id must be preserved from job_json, not silently dropped"
+    );
+
+    // Also verify that a job created WITHOUT peer_id has peer_id = null.
+    let job_no_peer = serde_json::json!({
+        "name": "no-peer-id",
+        "schedule": { "cron": "0 * * * *" },
+        "action": { "message": "ping" },
+    });
+    let job_id2 = kernel
+        .cron_create(&agent_id, job_no_peer)
+        .await
+        .expect("cron_create without peer_id should succeed");
+    let jobs2 = kernel
+        .cron_list(&agent_id)
+        .await
+        .expect("cron_list should succeed");
+    let job2 = jobs2
+        .iter()
+        .find(|j| j["id"].as_str() == Some(&job_id2))
+        .expect("second job should appear in list");
+    assert!(
+        job2["peer_id"].is_null(),
+        "peer_id should be null when not provided"
+    );
+
+    kernel.shutdown();
+}


### PR DESCRIPTION
## Summary

- `cron_create` in `kernel/mod.rs` hard-coded `peer_id: None` when constructing `CronJob`, silently discarding the `peer_id` that `tool_runner.rs` (PR #2869) correctly injected into `job_json`
- Changed to `job_json["peer_id"].as_str().map(|s| s.to_string())` so cron jobs preserve the creator's peer identity
- Without this, cron jobs fire with empty `SenderContext`, making peer-scoped memory keys (`peer:{user_id}:TO-DO`) invisible

Cherry-picked from rodela-ai/librefang (original PR: #2964)

Fixes #2963
Ref: #2752, #2759, #2869