### PR TITLE
fix(gateway): recover Signal session when upsert delivers null payload

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -523,7 +523,11 @@ function normalizeBaseJid(jid) {
 }
 
 async function handleSessionRecovery(deviceJid, baseJid, msgId) {
-  if (!baseJid || !sock || typeof sock.assertSessions !== 'function') return;
+  if (!baseJid) return;
+  if (!sock || typeof sock.assertSessions !== 'function') {
+    console.debug(`[gateway][session-recovery] skipped for ${deviceJid}: socket not ready or assertSessions unavailable`);
+    return;
+  }
   const now = Date.now();
   const entry = sessionRecoveryMap.get(baseJid) || {
     attempts: 0,

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -500,6 +500,74 @@ function cleanupDecryptRetry(key) {
   decryptRetryMap.delete(key);
 }
 
+// ---------------------------------------------------------------------------
+// Signal session renegotiation tracking (upsert path)
+//
+// The existing messages.update stub-39 hook handles decryption failures that
+// Baileys surfaces via the update channel. A different class of failures —
+// libsignal throwing from session_cipher.js before any stub is emitted —
+// never reaches that hook. Those messages arrive in messages.upsert with
+// msg.message = null/undefined and are silently skipped. The fix is to
+// detect the null-content case in upsert and force a fresh Signal session
+// via assertSessions(..., true) so the peer re-keys on their next send.
+//   baseJid → { attempts, lastAttemptAt, lastMsgId, notified }
+const sessionRecoveryMap = new Map();
+const SESSION_RECOVERY_COOLDOWN_MS = 20_000;
+const SESSION_RECOVERY_MAX_ATTEMPTS = 3;
+const SESSION_RECOVERY_EXPIRE_MS = 30 * 60 * 1000; // 30 min
+
+function normalizeBaseJid(jid) {
+  if (!jid) return '';
+  // Strip device suffix "<id>:<device>@<server>" → "<id>@<server>"
+  return jid.replace(/:\d+@/, '@');
+}
+
+async function handleSessionRecovery(deviceJid, baseJid, msgId) {
+  if (!baseJid || !sock || typeof sock.assertSessions !== 'function') return;
+  const now = Date.now();
+  const entry = sessionRecoveryMap.get(baseJid) || {
+    attempts: 0,
+    lastAttemptAt: 0,
+    lastMsgId: null,
+    notified: false,
+  };
+  if (now - entry.lastAttemptAt < SESSION_RECOVERY_COOLDOWN_MS) return;
+  if (entry.attempts >= SESSION_RECOVERY_MAX_ATTEMPTS) {
+    if (!entry.notified && OWNER_JIDS && OWNER_JIDS.length > 0) {
+      entry.notified = true;
+      sessionRecoveryMap.set(baseJid, entry);
+      const peer = baseJid.replace(/@.*/, '');
+      const body = [
+        `⚠️ Unable to decrypt messages from ${peer}`,
+        `Tried ${entry.attempts} Signal session renegotiations — peer hasn't re-keyed.`,
+        `Last failed message id: ${entry.lastMsgId || 'unknown'}`,
+        `Hint: ask the contact to send a new message, or unlink/relink this device if it is you.`,
+      ].join('\n');
+      for (const ownerJid of OWNER_JIDS) {
+        try {
+          await sock.sendMessage(ownerJid, { text: body });
+        } catch (e) {
+          console.warn(`[gateway][session-recovery] notify ${ownerJid} failed: ${e?.message || e}`);
+        }
+      }
+      console.warn(`[gateway][session-recovery] exhausted, owner notified about ${baseJid}`);
+    }
+    return;
+  }
+  entry.attempts += 1;
+  entry.lastAttemptAt = now;
+  entry.lastMsgId = msgId || entry.lastMsgId;
+  sessionRecoveryMap.set(baseJid, entry);
+  console.warn(`[gateway][session-recovery] SessionError for ${deviceJid} (msgId=${msgId || 'n/a'}) — forcing renegotiation ${entry.attempts}/${SESSION_RECOVERY_MAX_ATTEMPTS}`);
+  try {
+    // Target the specific device so libsignal re-keys the exact chain that
+    // failed. A group/base JID would skip per-device handshake.
+    await sock.assertSessions([deviceJid], true);
+  } catch (e) {
+    console.warn(`[gateway][session-recovery] assertSessions(${deviceJid}) failed: ${e?.message || e}`);
+  }
+}
+
 // Single periodic cleanup for both stores
 setInterval(() => {
   const now = Date.now();
@@ -508,6 +576,9 @@ setInterval(() => {
   }
   for (const [key, entry] of decryptRetryMap) {
     if (now - entry.firstSeen > DECRYPT_RETRY_EXPIRE_MS) cleanupDecryptRetry(key);
+  }
+  for (const [key, entry] of sessionRecoveryMap) {
+    if (now - entry.lastAttemptAt > SESSION_RECOVERY_EXPIRE_MS) sessionRecoveryMap.delete(key);
   }
 }, 60_000).unref();
 
@@ -1296,13 +1367,16 @@ async function startConnection() {
       const sender = msg.key.remoteJid || '';
       const innerMsg = msg.message || {};
 
-      // Libsignal decrypt failure surfaces as `msg.message == null`. We
-      // intentionally do NOT mark the id as processed so that WA's
-      // retransmit of the same msgId can reach this branch again after
-      // the session recovers. Marking on first sight would strand the
-      // sender permanently behind a "duplicate message" skip.
+      // Signal session recovery: inbound message with null payload ⇒ libsignal
+      // rejected the ciphertext before stub 39 was emitted. Force a fresh
+      // session with the actual device (keep the device suffix when
+      // assertSessions is called — the session is per-device, not per-user).
       if (!msg.message && !msg.key.fromMe && sender) {
-        console.warn(`[gateway] Decrypt failed for ${msg.key.id} from ${sender} — leaving unmarked so WA can retransmit`);
+        const recoveryJid = msg.key.participant || sender;
+        const baseJid = normalizeBaseJid(recoveryJid);
+        handleSessionRecovery(recoveryJid, baseJid, msg.key.id).catch(err => {
+          console.warn(`[gateway][session-recovery] handler error: ${err?.message || err}`);
+        });
         continue;
       }
 
@@ -3015,4 +3089,8 @@ module.exports = {
   lidMapSet,
   db,
   LID_PERSIST_ENABLED,
+  normalizeBaseJid,
+  sessionRecoveryMap,
+  SESSION_RECOVERY_COOLDOWN_MS,
+  SESSION_RECOVERY_MAX_ATTEMPTS,
 };

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -40,6 +40,10 @@ const {
   lidMapSet,
   db,
   LID_PERSIST_ENABLED,
+  normalizeBaseJid,
+  sessionRecoveryMap,
+  SESSION_RECOVERY_COOLDOWN_MS,
+  SESSION_RECOVERY_MAX_ATTEMPTS,
 } = require('./index.js');
 
 // ---------------------------------------------------------------------------
@@ -983,6 +987,44 @@ describe('ID-02 cross-restart hydration', () => {
     } finally {
       db2.close();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signal session recovery — upsert-path SessionError
+// ---------------------------------------------------------------------------
+describe('normalizeBaseJid', () => {
+  it('strips device suffix :N from phone-number JID', () => {
+    assert.equal(normalizeBaseJid('393760105565:24@s.whatsapp.net'), '393760105565@s.whatsapp.net');
+  });
+
+  it('strips device suffix :N from LID JID', () => {
+    assert.equal(normalizeBaseJid('191856289808491:24@lid'), '191856289808491@lid');
+  });
+
+  it('leaves base JID unchanged when no device suffix', () => {
+    assert.equal(normalizeBaseJid('393760105565@s.whatsapp.net'), '393760105565@s.whatsapp.net');
+  });
+
+  it('handles empty/null input', () => {
+    assert.equal(normalizeBaseJid(''), '');
+    assert.equal(normalizeBaseJid(null), '');
+    assert.equal(normalizeBaseJid(undefined), '');
+  });
+
+  it('leaves group JID unchanged (no :N pattern)', () => {
+    assert.equal(normalizeBaseJid('120363123@g.us'), '120363123@g.us');
+  });
+});
+
+describe('sessionRecoveryMap constants', () => {
+  it('exposes cooldown and max-attempts thresholds', () => {
+    assert.ok(SESSION_RECOVERY_COOLDOWN_MS > 0);
+    assert.ok(SESSION_RECOVERY_MAX_ATTEMPTS >= 1);
+  });
+
+  it('map is a Map instance', () => {
+    assert.ok(sessionRecoveryMap instanceof Map);
   });
 });
 


### PR DESCRIPTION
## Summary

- When libsignal rejects an inbound ciphertext, Baileys delivers `messages.upsert` with `msg.message = null` but never emits `messageStubType === 39`
- The existing stub-39 retry hook therefore never fires; the upsert loop silently skips the message via the null-check branch
- Peers on fresh devices (new install, relinked WhatsApp, Signal session-chain break) stay permanently unreachable until the bot is restarted

**Fix**: Add a dedicated recovery path in `messages.upsert` — when an inbound message arrives with a missing payload, call `sock.assertSessions([deviceJid], true)` to force a fresh Signal handshake. Guardrails: 20s cooldown per base JID, cap at 3 attempts with owner notification on exhaustion, 30min expiry on recovery map entries.

Cherry-picked from f-liva/librefang (original PR: #2624)