### PR TITLE
feat(gateway): session_key dispatch log + boot self-test for channel scoping

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -19,6 +19,7 @@ const {
   resolvePeerId,
   deriveOwnerJids,
 } = require('./lib/identity');
+const { buildSessionKey, channelTypeForChat } = require('./lib/session-key');
 
 // ---------------------------------------------------------------------------
 // Persisted LID cache (ID-02, Phase 4 §B)
@@ -41,6 +42,25 @@ const LID_PERSIST_ENABLED = process.env.LIBREFANG_LID_PERSIST !== 'off';
 // librefang. Flag `LIBREFANG_ECHO_TRACKER=off` disables end-to-end (no-op).
 const ECHO_TRACKER_ENABLED = process.env.LIBREFANG_ECHO_TRACKER !== 'off';
 const echoTracker = new EchoTracker(100);
+
+// Phase 3 §B (EB-02) — gate the `forward_dispatch` structured log.
+// Default ON ('verbose'); set LIBREFANG_DISPATCH_LOG to any other value
+// (e.g. 'off') to silence the diagnostic line without redeploy.
+const DISPATCH_LOG_VERBOSE = (process.env.LIBREFANG_DISPATCH_LOG || 'verbose') === 'verbose';
+
+// Phase 3 §B — CS-01 regression guard. Runs once at boot (and is exported
+// for unit tests). Two distinct chatJids must yield two distinct
+// channel_type strings; otherwise the gateway-to-kernel per-conversation
+// isolation contract is broken and we refuse to boot.
+function runDispatchSelfTest(channelTypeFn) {
+  const fn = channelTypeFn || channelTypeForChat;
+  const a = fn('111@s.whatsapp.net');
+  const b = fn('222@s.whatsapp.net');
+  if (a === b || !a.startsWith('whatsapp:') || !b.startsWith('whatsapp:')) {
+    return { ok: false, reason: `channel_type regression: a=${a} b=${b}` };
+  }
+  return { ok: true };
+}
 
 // ---------------------------------------------------------------------------
 // SQLite Message Store (better-sqlite3)
@@ -2343,7 +2363,24 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
   // Per-conversation session isolation: include chat JID in channel_type
   // so the kernel creates separate sessions for each WhatsApp conversation.
   // CS-01: chatJid has already been validated non-empty at function entry.
-  const channelType = `whatsapp:${chatJid}`;
+  // Phase 3 §B — centralized in channelTypeForChat for single-sourcing.
+  const channelType = channelTypeForChat(chatJid);
+
+  // Phase 3 §B (EB-02) — single structured log per dispatch; allows
+  // reconstructing (agent, peer, chat) tuple from logs alone. Retry recursion
+  // re-enters this function, which is the desired diagnostic behavior.
+  if (DISPATCH_LOG_VERBOSE) {
+    console.log(JSON.stringify({
+      event: 'forward_dispatch',
+      session_key: buildSessionKey(cachedAgentId, phone, chatJid),
+      channel_type: channelType,
+      phone,
+      push_name: pushName,
+      is_group: !!isGroup,
+      was_mentioned: !!wasMentioned,
+    }));
+  }
+
   const payload = {
     message: fullMessage,
     channel_type: channelType,
@@ -2486,7 +2523,22 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
   const fullMessage = systemPrefix ? systemPrefix + text : text;
 
   // CS-01: chatJid has already been validated non-empty at function entry.
-  const channelType = `whatsapp:${chatJid}`;
+  // Phase 3 §B — centralized in channelTypeForChat for single-sourcing.
+  const channelType = channelTypeForChat(chatJid);
+
+  // Phase 3 §B (EB-02) — streaming-path dispatch log parity.
+  if (DISPATCH_LOG_VERBOSE) {
+    console.log(JSON.stringify({
+      event: 'forward_dispatch',
+      session_key: buildSessionKey(cachedAgentId, phone, chatJid),
+      channel_type: channelType,
+      phone,
+      push_name: pushName,
+      is_group: !!isGroup,
+      was_mentioned: !!wasMentioned,
+    }));
+  }
+
   const payload = {
     message: fullMessage,
     channel_type: channelType,
@@ -3102,6 +3154,19 @@ const server = http.createServer(async (req, res) => {
 });
 
 if (require.main === module) {
+// Phase 3 §B — CS-01 regression guard. Fail fast if the chatJid-to-
+// channel_type contract has silently degraded (e.g. future refactor
+// collapses both chats to bare `whatsapp`). Runs before we accept any
+// socket traffic.
+{
+  const _selfTest = runDispatchSelfTest();
+  if (!_selfTest.ok) {
+    console.error('[gateway] FATAL dispatch_self_test failed:', _selfTest.reason);
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ event: 'dispatch_self_test', ok: true }));
+}
+
 server.listen(PORT, '127.0.0.1', async () => {
   console.log(`[gateway] WhatsApp Web gateway listening on http://127.0.0.1:${PORT}`);
   console.log(`[gateway] LibreFang URL: ${LIBREFANG_URL}`);
@@ -3213,4 +3278,7 @@ module.exports = {
   sessionRecoveryMap,
   SESSION_RECOVERY_COOLDOWN_MS,
   SESSION_RECOVERY_MAX_ATTEMPTS,
+  runDispatchSelfTest,
+  channelTypeForChat,
+  buildSessionKey,
 };

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -45,6 +45,8 @@ const {
   sessionRecoveryMap,
   SESSION_RECOVERY_COOLDOWN_MS,
   SESSION_RECOVERY_MAX_ATTEMPTS,
+  runDispatchSelfTest,
+  channelTypeForChat,
 } = require('./index.js');
 
 // ---------------------------------------------------------------------------
@@ -736,6 +738,135 @@ describe('echo tracker wiring (Phase 3 §A)', () => {
     const trackCount = (src.match(/echoTracker\.track\(/g) || []).length;
     assert.equal(trackCount, 7,
       `expected 7 echoTracker.track() calls (one per outbound text site), got ${trackCount}`);
+    });
+});
+
+// Phase 3 §B (EB-02): forward_dispatch structured log + boot self-test
+// ---------------------------------------------------------------------------
+describe('EB-02 forward_dispatch log + dispatch_self_test', () => {
+  let mockServer;
+  const LISTEN_PORT = MOCK_LIBREFANG_PORT; // reuse
+
+  // Capture console.log lines containing forward_dispatch; preserve original.
+  const originalLog = console.log;
+  let captured = [];
+  function startCapture() {
+    captured = [];
+    console.log = (...args) => {
+      const line = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+      captured.push(line);
+      // also forward to original so node --test output stays readable
+      originalLog(...args);
+    };
+  }
+  function stopCapture() {
+    console.log = originalLog;
+  }
+
+  before(async () => {
+    // Reuse the mock server from CS-01 suite spec: it's torn down after that
+    // suite. Spin up a local instance for this block.
+    mockServer = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        if (req.url === '/api/agents' && req.method === 'GET') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify([{ id: 'test-agent-id', name: 'TestAgent' }]));
+          return;
+        }
+        if (req.url && req.url.startsWith('/api/agents/') && req.url.endsWith('/message')) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ response: 'mock reply' }));
+          return;
+        }
+        if (req.url && req.url.startsWith('/api/agents/') && req.url.endsWith('/message/stream')) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          res.write('data: {"type":"text","content":"hi"}\n\n');
+          res.write('data: {"type":"done","response":"hi"}\n\n');
+          res.end();
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+    });
+    await new Promise((resolve) => mockServer.listen(LISTEN_PORT, '127.0.0.1', resolve));
+  });
+
+  after(async () => {
+    if (mockServer) await new Promise((r) => mockServer.close(r));
+  });
+
+  it('Test 1: forwardToLibreFang emits exactly one forward_dispatch JSON line per call', async () => {
+    startCapture();
+    try {
+      delete process.env.LIBREFANG_DISPATCH_LOG; // default ON
+      await forwardToLibreFang('hi', '', '+39123', 'Alice', false, [], {
+        isGroup: false, wasMentioned: false, chatJid: '39123@s.whatsapp.net',
+      });
+    } finally {
+      stopCapture();
+    }
+    const dispatchLines = captured.filter((l) => l.includes('"event":"forward_dispatch"'));
+    assert.equal(dispatchLines.length, 1, `expected exactly 1 forward_dispatch, got ${dispatchLines.length}`);
+    const parsed = JSON.parse(dispatchLines[0]);
+    assert.equal(parsed.event, 'forward_dispatch');
+    assert.equal(typeof parsed.session_key, 'string');
+    assert.match(parsed.session_key, /:\+39123:39123@s\.whatsapp\.net$/);
+    assert.equal(parsed.phone, '+39123');
+    assert.equal(parsed.push_name, 'Alice');
+    assert.equal(parsed.is_group, false);
+    assert.equal(parsed.was_mentioned, false);
+    assert.equal(parsed.channel_type, 'whatsapp:39123@s.whatsapp.net');
+  });
+
+  it('Test 2: forwardToLibreFangStreaming emits exactly one forward_dispatch per call', async () => {
+    startCapture();
+    try {
+      delete process.env.LIBREFANG_DISPATCH_LOG;
+      await forwardToLibreFangStreaming(
+        'hi', '', '+39456', 'Bob', false, [], () => {},
+        '456@g.us', { isGroup: true, wasMentioned: true }
+      ).catch(() => {}); // streaming may fall back on mock SSE oddities; log still emits pre-POST
+    } finally {
+      stopCapture();
+    }
+    const dispatchLines = captured.filter((l) => l.includes('"event":"forward_dispatch"'));
+    assert.ok(dispatchLines.length >= 1, `expected >=1 forward_dispatch (streaming may recurse on fallback), got ${dispatchLines.length}`);
+    const parsed = JSON.parse(dispatchLines[0]);
+    assert.equal(parsed.is_group, true);
+    assert.equal(parsed.was_mentioned, true);
+    assert.match(parsed.session_key, /:\+39456:456@g\.us$/);
+  });
+
+  it('Test 3: LIBREFANG_DISPATCH_LOG=off silences forward_dispatch but HTTP still fires', async () => {
+    // The flag is read at module load time. Simulate "off" by monkey-patching
+    // the exported constant via require cache? Simpler: assert that when the
+    // flag is set BEFORE a fresh require we'd get no log. Since we can't
+    // re-require the monolith safely mid-suite (SQLite locks), verify the
+    // source-level invariant: the emission is guarded by a DISPATCH_LOG_VERBOSE
+    // const derived from env, and no unguarded emission exists.
+    const srcFs = require('node:fs');
+    const src = srcFs.readFileSync(__dirname + '/index.js', 'utf8');
+    // Exactly 2 emission sites (one per forward function), each guarded.
+    const matches = src.match(/DISPATCH_LOG_VERBOSE[\s\S]{0,200}forward_dispatch/g) || [];
+    assert.equal(matches.length, 2, `expected exactly 2 guarded forward_dispatch emissions, got ${matches.length}`);
+    // And the flag itself is parsed from env with default 'verbose'.
+    assert.match(src, /LIBREFANG_DISPATCH_LOG[\s\S]{0,80}verbose/);
+  });
+
+  it('Test 4: runDispatchSelfTest returns ok for distinct chatJids and flags regression', () => {
+    const r = runDispatchSelfTest();
+    assert.equal(r.ok, true, `self-test should pass on a healthy helper; got ${JSON.stringify(r)}`);
+    // Simulate regression by passing a degraded function — the exported
+    // helper accepts an optional override to keep the real one pure.
+    const degraded = () => 'whatsapp'; // always returns same thing
+    const r2 = runDispatchSelfTest(degraded);
+    assert.equal(r2.ok, false);
+    assert.match(r2.reason, /channel_type regression/);
+    // Sanity: channelTypeForChat itself is exported and behaves.
+    assert.notEqual(channelTypeForChat('a@s.whatsapp.net'), channelTypeForChat('b@s.whatsapp.net'));
   });
 });
 

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -849,10 +849,15 @@ describe('EB-02 forward_dispatch log + dispatch_self_test', () => {
     // const derived from env, and no unguarded emission exists.
     const srcFs = require('node:fs');
     const src = srcFs.readFileSync(__dirname + '/index.js', 'utf8');
-    // Exactly 2 emission sites (one per forward function), each guarded.
-    const matches = src.match(/DISPATCH_LOG_VERBOSE[\s\S]{0,200}forward_dispatch/g) || [];
-    assert.equal(matches.length, 2, `expected exactly 2 guarded forward_dispatch emissions, got ${matches.length}`);
-    // And the flag itself is parsed from env with default 'verbose'.
+    // Exactly 2 `if (DISPATCH_LOG_VERBOSE)` guard blocks must exist — one per
+    // forward function. Count the guard itself (not a span to the emission),
+    // so this stays green if the body of the if-block is reformatted.
+    const guardCount = (src.match(/if\s*\(DISPATCH_LOG_VERBOSE\)/g) || []).length;
+    assert.equal(guardCount, 2, `expected exactly 2 if(DISPATCH_LOG_VERBOSE) guards, got ${guardCount}`);
+    // And there must be exactly 2 forward_dispatch emission sites total.
+    const emitCount = (src.match(/"event"\s*:\s*'forward_dispatch'/g) || []).length;
+    assert.equal(emitCount, 2, `expected exactly 2 forward_dispatch emission sites, got ${emitCount}`);
+    // The flag is parsed from env with default 'verbose'.
     assert.match(src, /LIBREFANG_DISPATCH_LOG[\s\S]{0,80}verbose/);
   });
 

--- a/packages/whatsapp-gateway/lib/session-key.js
+++ b/packages/whatsapp-gateway/lib/session-key.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Phase 3 §B — Gateway-side sessionKey diagnostics.
+// `buildSessionKey` returns a composite log-friendly string per Q5:
+//   <agent>:<peer>:<chatJid>
+// Used only for `forward_dispatch` log lines — the kernel already derives its
+// own SessionId from channel_type (Phase 1 CS-01). Any missing part falls
+// back to "unknown" so partial-context forwards (catchup, tests) stay
+// greppable instead of producing an `undefined:null:` soup.
+function buildSessionKey(agent, peer, chatJid) {
+  return `${agent || 'unknown'}:${peer || 'unknown'}:${chatJid || 'unknown'}`;
+}
+
+// Centralizes the previously inline `whatsapp:<chatJid>` synthesis
+// (forwardToLibreFang L1873 / forwardToLibreFangStreaming L2007). Empty
+// chatJid collapses to bare `whatsapp`; callers that enforce CS-01 reject
+// empty chatJids before reaching this helper, so the bare form is only
+// observable from the boot-time self-test.
+function channelTypeForChat(chatJid) {
+  return chatJid ? `whatsapp:${chatJid}` : 'whatsapp';
+}
+
+module.exports = { buildSessionKey, channelTypeForChat };

--- a/packages/whatsapp-gateway/test/session-key.test.js
+++ b/packages/whatsapp-gateway/test/session-key.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+
+const { buildSessionKey, channelTypeForChat } = require('../lib/session-key');
+
+describe('buildSessionKey', () => {
+  it('Test 1: returns composite <agent>:<peer>:<chatJid> string', () => {
+    assert.equal(
+      buildSessionKey('agent-uuid', '+391234', '391234@s.whatsapp.net'),
+      'agent-uuid:+391234:391234@s.whatsapp.net'
+    );
+  });
+
+  it('Test 2: falls back to "unknown" for missing parts (robust against partial context)', () => {
+    assert.equal(buildSessionKey(undefined, null, ''), 'unknown:unknown:unknown');
+    assert.equal(buildSessionKey('a', null, 'c'), 'a:unknown:c');
+  });
+
+  it('Test 3: distinct chatJids produce distinct session keys', () => {
+    const a = 'agent';
+    const p = '+39123';
+    const keyGroupA = buildSessionKey(a, p, '111-aaa@g.us');
+    const keyGroupB = buildSessionKey(a, p, '222-bbb@g.us');
+    assert.notEqual(keyGroupA, keyGroupB);
+  });
+});
+
+describe('channelTypeForChat', () => {
+  it('Test 4: returns "whatsapp:<jid>" for a non-empty chatJid', () => {
+    assert.equal(
+      channelTypeForChat('391234@s.whatsapp.net'),
+      'whatsapp:391234@s.whatsapp.net'
+    );
+  });
+
+  it('Test 5: returns bare "whatsapp" for empty/undefined chatJid', () => {
+    assert.equal(channelTypeForChat(''), 'whatsapp');
+    assert.equal(channelTypeForChat(undefined), 'whatsapp');
+    assert.equal(channelTypeForChat(null), 'whatsapp');
+  });
+
+  it('Test 6: CS-01 invariant — distinct chatJids yield distinct channel_type strings', () => {
+    const a = channelTypeForChat('111@s.whatsapp.net');
+    const b = channelTypeForChat('222@s.whatsapp.net');
+    assert.notEqual(a, b);
+    assert.ok(a.startsWith('whatsapp:'));
+    assert.ok(b.startsWith('whatsapp:'));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/whatsapp-gateway/lib/session-key.js` with pure `buildSessionKey` + `channelTypeForChat` helpers to single-source the `whatsapp:<chatJid>` synthesis (previously inlined at two sites in `index.js`)
- Emits one structured JSON `forward_dispatch` log line per `forwardToLibreFang` / `forwardToLibreFangStreaming` call containing `session_key`, `channel_type`, `phone`, `push_name`, `is_group`, `was_mentioned`; gated by `LIBREFANG_DISPATCH_LOG` (default `'verbose'`)
- `runDispatchSelfTest()` asserts at boot that two distinct `chatJid` values yield distinct `channel_type` strings; exits hard on regression

Zero Rust changes, zero new JS deps.

Cherry-picked from f-liva/librefang (original PR: #2499)