### PR TITLE
fix(llm-drivers): tolerate trailing chars in tool call arguments

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -623,10 +623,8 @@ impl LlmDriver for AnthropicDriver {
                                 input_json,
                             }) = blocks.get(block_idx)
                             {
-                                let input: serde_json::Value = match serde_json::from_str::<
-                                    serde_json::Value,
-                                >(
-                                    input_json
+                                let input: serde_json::Value = match super::openai::parse_tool_args(
+                                    input_json,
                                 ) {
                                     Ok(v) => ensure_object(v),
                                     Err(e) => {
@@ -690,7 +688,7 @@ impl LlmDriver for AnthropicDriver {
                         input_json,
                     } => {
                         let input: serde_json::Value =
-                            match serde_json::from_str::<serde_json::Value>(&input_json) {
+                            match super::openai::parse_tool_args(&input_json) {
                                 Ok(v) => ensure_object(v),
                                 Err(e) => {
                                     tracing::warn!(

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -876,19 +876,18 @@ impl LlmDriver for OpenAIDriver {
 
             if let Some(calls) = choice.message.tool_calls {
                 for call in calls {
-                    let input: serde_json::Value =
-                        match serde_json::from_str::<serde_json::Value>(&call.function.arguments) {
-                            Ok(v) => ensure_object(v),
-                            Err(e) => {
-                                tracing::warn!(
-                                    tool = %call.function.name,
-                                    raw_args_len = call.function.arguments.len(),
-                                    error = %e,
-                                    "Malformed tool call arguments from LLM"
-                                );
-                                malformed_tool_input(&e, call.function.arguments.len())
-                            }
-                        };
+                    let input: serde_json::Value = match parse_tool_args(&call.function.arguments) {
+                        Ok(v) => ensure_object(v),
+                        Err(e) => {
+                            tracing::warn!(
+                                tool = %call.function.name,
+                                raw_args_len = call.function.arguments.len(),
+                                error = %e,
+                                "Malformed tool call arguments from LLM"
+                            );
+                            malformed_tool_input(&e, call.function.arguments.len())
+                        }
+                    };
                     content.push(ContentBlock::ToolUse {
                         id: call.id.clone(),
                         name: call.function.name.clone(),
@@ -1438,19 +1437,18 @@ impl LlmDriver for OpenAIDriver {
             }
 
             for (id, name, arguments) in &tool_accum {
-                let input: serde_json::Value =
-                    match serde_json::from_str::<serde_json::Value>(arguments) {
-                        Ok(v) => ensure_object(v),
-                        Err(e) => {
-                            tracing::warn!(
-                                tool = %name,
-                                raw_args_len = arguments.len(),
-                                error = %e,
-                                "Malformed tool call arguments from LLM stream"
-                            );
-                            malformed_tool_input(&e, arguments.len())
-                        }
-                    };
+                let input: serde_json::Value = match parse_tool_args(arguments) {
+                    Ok(v) => ensure_object(v),
+                    Err(e) => {
+                        tracing::warn!(
+                            tool = %name,
+                            raw_args_len = arguments.len(),
+                            error = %e,
+                            "Malformed tool call arguments from LLM stream"
+                        );
+                        malformed_tool_input(&e, arguments.len())
+                    }
+                };
                 content.push(ContentBlock::ToolUse {
                     id: id.clone(),
                     name: name.clone(),
@@ -1662,7 +1660,7 @@ fn parse_groq_failed_tool_call(body: &str) -> Option<CompletionResponse> {
         };
 
         // Parse args as JSON Value
-        let args_value: serde_json::Value = match serde_json::from_str::<serde_json::Value>(args) {
+        let args_value: serde_json::Value = match parse_tool_args(args) {
             Ok(v) => ensure_object(v),
             Err(e) => {
                 tracing::warn!(
@@ -1747,6 +1745,69 @@ fn ensure_object(v: serde_json::Value) -> serde_json::Value {
             serde_json::json!({"raw_input": other})
         }
     }
+}
+
+/// Parse tool call arguments tolerantly: if strict parsing fails due to trailing
+/// characters (common with thinking models via Ollama that append reasoning
+/// tokens after the JSON arguments), extract just the first complete JSON value.
+pub(crate) fn parse_tool_args(arguments: &str) -> Result<serde_json::Value, serde_json::Error> {
+    match serde_json::from_str::<serde_json::Value>(arguments) {
+        Ok(v) => Ok(v),
+        Err(strict_err) => {
+            // "trailing characters" means valid JSON followed by extra data (common
+            // with thinking models that append reasoning tokens after the JSON).
+            // Find the end of the first top-level JSON object and parse just that.
+            if let Some(end) = find_json_object_end(arguments) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&arguments[..end]) {
+                    tracing::debug!(
+                        total_len = arguments.len(),
+                        json_len = end,
+                        trailing = arguments.len() - end,
+                        "Recovered tool args by trimming trailing characters"
+                    );
+                    return Ok(v);
+                }
+            }
+            Err(strict_err)
+        }
+    }
+}
+
+/// Find the byte offset where the first top-level JSON object ends (closing `}`).
+/// Tracks brace depth and skips string literals.
+fn find_json_object_end(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escape = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if b == b'\\' && in_string {
+            escape = true;
+            continue;
+        }
+        if b == b'"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Marker key embedded in tool input when the LLM's streamed JSON was truncated.


### PR DESCRIPTION
## Summary

- Thinking models (Qwen 3.5, DeepSeek-R1) served via Ollama append reasoning tokens after the valid JSON in streamed `tool_call` argument deltas
- `serde_json::from_str` rejects the entire payload with "trailing characters", killing otherwise valid tool calls
- Adds `parse_tool_args()` with a brace-depth JSON boundary finder that extracts the first complete JSON object when strict parsing fails
- Applied to all three parse sites: non-streaming (openai.rs), streaming accumulator (openai.rs), and Anthropic driver (anthropic.rs)

Resubmission of #2976 — scoped to only the LLM driver files, no unrelated changes.

Closes #2975

## Test plan

- [ ] `cargo build --workspace --lib` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [ ] Manual: send tool-using prompt via Ollama with Qwen 3.5 — tool call succeeds instead of "trailing characters" error