### PR TITLE
release: v2026.4.23-beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.23] - 2026-04-23
+
+### Added
+
+- Auto-reset stuck in_progress tasks after TTL (closes #2923) (#2953) (@houko)
+- Named shared workspaces + identity file isolation (#2958) (@houko)
+- Add notify_owner tool + owner_notice output boundary (#2965) (@houko)
+- Moonshot/Kimi file upload support via /v1/files (#2966) (@houko)
+- Download channel files to disk for agent access (#2972) (@houko)
+- Session_key dispatch log + boot self-test for channel scoping (#2973) (@houko)
+
+### Fixed
+
+- Drop ellipsis-terminated preambles without tool_use as silent (#2617) (@f-liva)
+- Suppress NO_REPLY sentinel in streaming bridge, cron, and auto-reply (#2743) (@DaBlitzStein)
+- Make split_message HTML-tag-aware for Telegram (#2760) (@DaBlitzStein)
+- Auto-inject sender peer_id into cron jobs + delegation trust prompt (#2869) (@DaBlitzStein)
+- Route trigger-fired responses to agent's home channel (closes #2872) (#2952) (@houko)
+- Render real chat message timestamps on resume (closes #2934) (#2954) (@houko)
+- Apply assignee_match:self filter to task_posted triggers (closes #2924) (#2955) (@houko)
+- Inject bot identity into reply_precheck classifier (#2960) (@houko)
+- Sanitize bot_name in classify_reply_intent prompt; add unit tests (#2961) (@houko)
+- Tolerate tool_call_id collisions across turns in session_repair (#2962) (@houko)
+- Inject RELAY prompt only on explicit owner intent (#2967) (@houko)
+- Add missing timestamp field in session_repair Message structs (#2968) (@houko)
+- Fix all missing timestamp fields and incomplete test stubs (#2969) (@houko)
+- Read peer_id from job_json in cron_create (#2970) (@houko)
+- Recover Signal session when upsert delivers null payload (#2971) (@houko)
+
+
 ## [2026.4.22] - 2026-04-22
 
 _No notable changes._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "aes",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "chrono",
  "clap",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "axum",
  "clap",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "axum",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11019,7 +11019,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32223",
+  "version": "26.4.32234",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.22-beta3",
+  "version": "2026.4.23-beta4",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.22-beta3",
+  "version": "2026.4.23-beta4",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.22b3",
+    version="2026.4.23b4",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.22-beta3"
+version = "2026.4.23-beta4"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.4.23-beta4 -->
## Release v2026.4.23-beta4

### Added

- Auto-reset stuck in_progress tasks after TTL (closes #2923) (#2953) (@houko)
- Named shared workspaces + identity file isolation (#2958) (@houko)
- Add notify_owner tool + owner_notice output boundary (#2965) (@houko)
- Moonshot/Kimi file upload support via /v1/files (#2966) (@houko)
- Download channel files to disk for agent access (#2972) (@houko)
- Session_key dispatch log + boot self-test for channel scoping (#2973) (@houko)

### Fixed

- Drop ellipsis-terminated preambles without tool_use as silent (#2617) (@f-liva)
- Suppress NO_REPLY sentinel in streaming bridge, cron, and auto-reply (#2743) (@DaBlitzStein)
- Make split_message HTML-tag-aware for Telegram (#2760) (@DaBlitzStein)
- Auto-inject sender peer_id into cron jobs + delegation trust prompt (#2869) (@DaBlitzStein)
- Route trigger-fired responses to agent's home channel (closes #2872) (#2952) (@houko)
- Render real chat message timestamps on resume (closes #2934) (#2954) (@houko)
- Apply assignee_match:self filter to task_posted triggers (closes #2924) (#2955) (@houko)
- Inject bot identity into reply_precheck classifier (#2960) (@houko)
- Sanitize bot_name in classify_reply_intent prompt; add unit tests (#2961) (@houko)
- Tolerate tool_call_id collisions across turns in session_repair (#2962) (@houko)
- Inject RELAY prompt only on explicit owner intent (#2967) (@houko)
- Add missing timestamp field in session_repair Message structs (#2968) (@houko)
- Fix all missing timestamp fields and incomplete test stubs (#2969) (@houko)
- Read peer_id from job_json in cron_create (#2970) (@houko)
- Recover Signal session when upsert delivers null payload (#2971) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.22-beta3...v2026.4.23-beta4