### PR TITLE
refactor(dashboard/queries): add QueryOverrides support, use withOverrides consistently

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -69,6 +69,8 @@ export {
   // models
   listModels,
   getModelOverrides,
+  // providers
+  listProviders,
   // network / peers / a2a
   getNetworkStatus,
   listPeers,
@@ -110,6 +112,21 @@ export {
   listTerminalWindows,
   // auto-dream
   getAutoDreamStatus,
+  // overview
+  loadDashboardSnapshot,
+  getVersionInfo,
+  // runtime
+  getStatus,
+  getQueueStatus,
+  getHealthDetail,
+  getSecurityStatus,
+  listBackups,
+  getTaskQueueStatus,
+  listTaskQueue,
+  listCronJobs,
+  // audit
+  listAuditRecent,
+  verifyAuditChain,
 } from "../../api";
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -9,6 +9,7 @@ import {
   getExperimentMetrics,
 } from "../http/client";
 import { agentKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
@@ -60,81 +61,33 @@ export const agentQueries = {
     }),
 };
 
-type UseAgentOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
 export function useAgents(
   opts: { includeHands?: boolean } = {},
-  options: UseAgentOptions = {},
+  options: QueryOverrides = {},
 ) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.list(opts),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+  return useQuery(withOverrides(agentQueries.list(opts), options));
 }
 
-export function useAgentDetail(agentId: string, options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.detail(agentId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useAgentDetail(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.detail(agentId), options));
 }
 
-export function useAgentSessions(agentId: string, options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.sessions(agentId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useAgentSessions(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.sessions(agentId), options));
 }
 
-export function useAgentTemplates(options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.templates(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useAgentTemplates(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.templates(), options));
 }
 
-export function usePromptVersions(agentId: string, options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.promptVersions(agentId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function usePromptVersions(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.promptVersions(agentId), options));
 }
 
-export function useExperiments(agentId: string, options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.experiments(agentId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useExperiments(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.experiments(agentId), options));
 }
 
-export function useExperimentMetrics(experimentId: string, options: UseAgentOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...agentQueries.experimentMetrics(experimentId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useExperimentMetrics(experimentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.experimentMetrics(experimentId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -26,6 +26,7 @@ export const agentQueries = {
       queryKey: agentKeys.detail(agentId),
       queryFn: () => getAgentDetail(agentId),
       enabled: !!agentId,
+      staleTime: 30_000,
     }),
   sessions: (agentId: string) =>
     queryOptions({
@@ -59,30 +60,81 @@ export const agentQueries = {
     }),
 };
 
-export function useAgents(opts: { includeHands?: boolean } = {}) {
-  return useQuery(agentQueries.list(opts));
+type UseAgentOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function useAgents(
+  opts: { includeHands?: boolean } = {},
+  options: UseAgentOptions = {},
+) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.list(opts),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useAgentDetail(agentId: string) {
-  return useQuery(agentQueries.detail(agentId));
+export function useAgentDetail(agentId: string, options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.detail(agentId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useAgentSessions(agentId: string) {
-  return useQuery(agentQueries.sessions(agentId));
+export function useAgentSessions(agentId: string, options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.sessions(agentId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useAgentTemplates(options: { enabled?: boolean } = {}) {
-  return useQuery({ ...agentQueries.templates(), enabled: options.enabled });
+export function useAgentTemplates(options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.templates(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function usePromptVersions(agentId: string) {
-  return useQuery(agentQueries.promptVersions(agentId));
+export function usePromptVersions(agentId: string, options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.promptVersions(agentId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useExperiments(agentId: string) {
-  return useQuery(agentQueries.experiments(agentId));
+export function useExperiments(agentId: string, options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.experiments(agentId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useExperimentMetrics(experimentId: string) {
-  return useQuery(agentQueries.experimentMetrics(experimentId));
+export function useExperimentMetrics(experimentId: string, options: UseAgentOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...agentQueries.experimentMetrics(experimentId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
@@ -9,8 +9,14 @@ import {
 } from "../http/client";
 import { usageKeys, budgetKeys } from "./keys";
 
+type UseAnalyticsOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
 const REFRESH_MS = 30_000;
-const STALE_MS = 30_000;
+const STALE_MS = 20_000;
 
 export const usageQueries = {
   summary: () =>
@@ -53,33 +59,69 @@ export const usageQueries = {
 export const budgetQueries = {
   status: () =>
     queryOptions({
-      queryKey: budgetKeys.all,
+      queryKey: budgetKeys.status(),
       queryFn: getBudgetStatus,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
     }),
 };
 
-export function useUsageSummary() {
-  return useQuery(usageQueries.summary());
+export function useUsageSummary(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...usageQueries.summary(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useUsageByAgent() {
-  return useQuery(usageQueries.byAgent());
+export function useUsageByAgent(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...usageQueries.byAgent(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useUsageByModel() {
-  return useQuery(usageQueries.byModel());
+export function useUsageByModel(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...usageQueries.byModel(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useUsageDaily() {
-  return useQuery(usageQueries.daily());
+export function useUsageDaily(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...usageQueries.daily(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useModelPerformance() {
-  return useQuery(usageQueries.modelPerformance());
+export function useModelPerformance(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...usageQueries.modelPerformance(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useBudgetStatus() {
-  return useQuery(budgetQueries.status());
+export function useBudgetStatus(options: UseAnalyticsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...budgetQueries.status(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
@@ -8,12 +8,7 @@ import {
   getBudgetStatus,
 } from "../http/client";
 import { usageKeys, budgetKeys } from "./keys";
-
-type UseAnalyticsOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
+import { withOverrides, type QueryOverrides } from "./options";
 
 const REFRESH_MS = 30_000;
 const STALE_MS = 20_000;
@@ -66,62 +61,26 @@ export const budgetQueries = {
     }),
 };
 
-export function useUsageSummary(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...usageQueries.summary(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useUsageSummary(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(usageQueries.summary(), options));
 }
 
-export function useUsageByAgent(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...usageQueries.byAgent(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useUsageByAgent(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(usageQueries.byAgent(), options));
 }
 
-export function useUsageByModel(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...usageQueries.byModel(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useUsageByModel(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(usageQueries.byModel(), options));
 }
 
-export function useUsageDaily(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...usageQueries.daily(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useUsageDaily(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(usageQueries.daily(), options));
 }
 
-export function useModelPerformance(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...usageQueries.modelPerformance(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useModelPerformance(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(usageQueries.modelPerformance(), options));
 }
 
-export function useBudgetStatus(options: UseAnalyticsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...budgetQueries.status(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useBudgetStatus(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(budgetQueries.status(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
@@ -58,8 +58,8 @@ export const approvalQueries = {
     }),
 };
 
-export function useApprovals(options: { enabled?: boolean } = {}) {
-  return useQuery({ ...approvalQueries.list(), enabled: options.enabled });
+export function useApprovals(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(approvalQueries.list(), options));
 }
 
 export function useApprovalCount(options: QueryOverrides = {}) {
@@ -83,13 +83,9 @@ export function useApprovalAudit(
     agent_id?: string;
     tool_name?: string;
   } = {},
-  options: { enabled?: boolean; staleTime?: number } = {},
+  options: QueryOverrides = {},
 ) {
-  return useQuery({
-    ...approvalQueries.audit(params),
-    enabled: options.enabled,
-    staleTime: options.staleTime,
-  });
+  return useQuery(withOverrides(approvalQueries.audit(params), options));
 }
 
 export function useTotpStatus() {

--- a/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
@@ -7,6 +7,7 @@ import {
   totpStatus,
 } from "../../api";
 import { approvalKeys, totpKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_APPROVALS = 10_000;
 const REFETCH_APPROVALS = 15_000;
@@ -61,21 +62,17 @@ export function useApprovals(options: { enabled?: boolean } = {}) {
   return useQuery({ ...approvalQueries.list(), enabled: options.enabled });
 }
 
-export function useApprovalCount(options: { refetchInterval?: number } = {}) {
-  return useQuery({
-    ...approvalQueries.count(),
-    refetchInterval: options.refetchInterval,
-  });
+export function useApprovalCount(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(approvalQueries.count(), options));
 }
 
 export function usePendingApprovals(
   agentId?: string,
-  options: { enabled?: boolean; refetchInterval?: number } = {},
+  options: QueryOverrides = {},
 ) {
   return useQuery({
-    ...approvalQueries.pending(agentId),
+    ...withOverrides(approvalQueries.pending(agentId), options),
     enabled: options.enabled ?? Boolean(agentId),
-    refetchInterval: options.refetchInterval,
   });
 }
 

--- a/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
@@ -12,7 +12,7 @@ const STALE_APPROVALS = 10_000;
 const REFETCH_APPROVALS = 15_000;
 const STALE_COUNT = 10_000;
 const REFETCH_COUNT = 15_000;
-const STALE_PENDING = 5_000;
+const STALE_PENDING = 3_000;
 const REFETCH_PENDING = 5_000;
 const STALE_TOTP = 60_000;
 
@@ -47,6 +47,7 @@ export const approvalQueries = {
     queryOptions({
       queryKey: approvalKeys.audit(params),
       queryFn: () => queryApprovalAudit(params),
+      staleTime: 30_000,
     }),
   totpStatus: () =>
     queryOptions({
@@ -63,7 +64,7 @@ export function useApprovals(options: { enabled?: boolean } = {}) {
 export function useApprovalCount(options: { refetchInterval?: number } = {}) {
   return useQuery({
     ...approvalQueries.count(),
-    refetchInterval: options.refetchInterval ?? REFETCH_COUNT,
+    refetchInterval: options.refetchInterval,
   });
 }
 
@@ -74,17 +75,24 @@ export function usePendingApprovals(
   return useQuery({
     ...approvalQueries.pending(agentId),
     enabled: options.enabled ?? Boolean(agentId),
-    ...(options.refetchInterval != null ? { refetchInterval: options.refetchInterval } : {}),
+    refetchInterval: options.refetchInterval,
   });
 }
 
-export function useApprovalAudit(params: {
-  limit?: number;
-  offset?: number;
-  agent_id?: string;
-  tool_name?: string;
-} = {}) {
-  return useQuery(approvalQueries.audit(params));
+export function useApprovalAudit(
+  params: {
+    limit?: number;
+    offset?: number;
+    agent_id?: string;
+    tool_name?: string;
+  } = {},
+  options: { enabled?: boolean; staleTime?: number } = {},
+) {
+  return useQuery({
+    ...approvalQueries.audit(params),
+    enabled: options.enabled,
+    staleTime: options.staleTime,
+  });
 }
 
 export function useTotpStatus() {

--- a/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { getAutoDreamStatus } from "../http/client";
 import { autoDreamKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 // Polling at 15s matches the cron scheduler cadence — short enough that a
 // dream fired via the manual trigger becomes visible quickly, long enough
@@ -18,18 +19,6 @@ export const autoDreamQueries = {
     }),
 };
 
-type UseAutoDreamStatusOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
-export function useAutoDreamStatus(options: UseAutoDreamStatusOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...autoDreamQueries.status(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useAutoDreamStatus(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(autoDreamQueries.status(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
@@ -18,6 +18,18 @@ export const autoDreamQueries = {
     }),
 };
 
-export function useAutoDreamStatus() {
-  return useQuery(autoDreamQueries.status());
+type UseAutoDreamStatusOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function useAutoDreamStatus(options: UseAutoDreamStatusOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...autoDreamQueries.status(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels.ts
@@ -29,29 +29,43 @@ export const commsQueries = {
       staleTime: STALE_MS,
       refetchInterval: TOPOLOGY_REFRESH_MS,
     }),
-  events: (limit = 200, refetchInterval = REFRESH_MS) =>
+  events: (limit = 200) =>
     queryOptions({
       queryKey: commsKeys.events(limit),
       queryFn: () => listCommsEvents(limit),
       staleTime: EVENTS_STALE_MS,
-      refetchInterval,
     }),
 };
 
-export function useChannels() {
-  return useQuery(channelQueries.list());
+type UseChannelsOptions = { enabled?: boolean; staleTime?: number; refetchInterval?: number | false };
+
+export function useChannels(options: UseChannelsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...channelQueries.list(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useCommsTopology() {
-  return useQuery(commsQueries.topology());
+export function useCommsTopology(options: UseChannelsOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...commsQueries.topology(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
 export function useCommsEvents(
   limit = 200,
-  options: { enabled?: boolean; refetchInterval?: number } = {},
+  options: { enabled?: boolean; refetchInterval?: number | false } = {},
 ) {
   return useQuery({
-    ...commsQueries.events(limit, options.refetchInterval),
+    ...commsQueries.events(limit),
     enabled: options.enabled,
+    refetchInterval: options.refetchInterval ?? REFRESH_MS,
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels.ts
@@ -5,6 +5,7 @@ import {
   listCommsEvents,
 } from "../http/client";
 import { channelKeys, commsKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
@@ -37,26 +38,12 @@ export const commsQueries = {
     }),
 };
 
-type UseChannelsOptions = { enabled?: boolean; staleTime?: number; refetchInterval?: number | false };
-
-export function useChannels(options: UseChannelsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...channelQueries.list(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useChannels(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(channelQueries.list(), options));
 }
 
-export function useCommsTopology(options: UseChannelsOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...commsQueries.topology(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useCommsTopology(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(commsQueries.topology(), options));
 }
 
 export function useCommsEvents(

--- a/crates/librefang-api/dashboard/src/lib/queries/config.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.ts
@@ -7,49 +7,62 @@ import {
 } from "../http/client";
 import { configKeys, registryKeys } from "./keys";
 
+const STALE_MS = 60_000;
+const SCHEMA_STALE_MS = 300_000;
+const RAW_STALE_MS = 5_000;
+
 export const configQueries = {
   full: () =>
     queryOptions({
       queryKey: configKeys.full(),
       queryFn: getFullConfig,
-      staleTime: 60_000,
+      staleTime: STALE_MS,
     }),
   schema: () =>
     queryOptions({
       queryKey: configKeys.schema(),
       queryFn: getConfigSchema,
-      staleTime: 300_000,
+      staleTime: SCHEMA_STALE_MS,
     }),
   registrySchema: (contentType: string) =>
     queryOptions({
       queryKey: registryKeys.schema(contentType),
       queryFn: () => fetchRegistrySchema(contentType),
       enabled: !!contentType,
-      staleTime: 300_000,
+      staleTime: SCHEMA_STALE_MS,
       retry: 1,
+    }),
+  rawToml: (enabled: boolean) =>
+    queryOptions({
+      queryKey: configKeys.rawToml(),
+      queryFn: getRawConfigToml,
+      enabled,
+      staleTime: RAW_STALE_MS,
     }),
 };
 
-export function useFullConfig() {
-  return useQuery(configQueries.full());
+type UseConfigOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function useFullConfig(options: UseConfigOptions = {}) {
+  return useQuery({ ...configQueries.full(), ...options });
 }
 
-export function useConfigSchema() {
-  return useQuery(configQueries.schema());
+export function useConfigSchema(options: UseConfigOptions = {}) {
+  return useQuery({ ...configQueries.schema(), ...options });
 }
 
-export function useRegistrySchema(contentType: string) {
-  return useQuery(configQueries.registrySchema(contentType));
+export function useRegistrySchema(contentType: string, options: UseConfigOptions = {}) {
+  // Empty contentType disables query (enabled gate in configQueries)
+  return useQuery({ ...configQueries.registrySchema(contentType), ...options });
 }
 
 // Raw config.toml as text. Disabled by default — caller passes
 // `enabled: true` only when the viewer modal is open. Short staleTime
 // so re-opening shortly after a save reflects the change.
 export function useRawConfigToml(enabled: boolean) {
-  return useQuery({
-    queryKey: configKeys.rawToml(),
-    queryFn: getRawConfigToml,
-    enabled,
-    staleTime: 5_000,
-  });
+  return useQuery(configQueries.rawToml(enabled));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/config.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.ts
@@ -6,6 +6,7 @@ import {
   getRawConfigToml,
 } from "../http/client";
 import { configKeys, registryKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 60_000;
 const SCHEMA_STALE_MS = 300_000;
@@ -41,23 +42,19 @@ export const configQueries = {
     }),
 };
 
-type UseConfigOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
-export function useFullConfig(options: UseConfigOptions = {}) {
-  return useQuery({ ...configQueries.full(), ...options });
+
+export function useFullConfig(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(configQueries.full(), options));
 }
 
-export function useConfigSchema(options: UseConfigOptions = {}) {
-  return useQuery({ ...configQueries.schema(), ...options });
+export function useConfigSchema(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(configQueries.schema(), options));
 }
 
-export function useRegistrySchema(contentType: string, options: UseConfigOptions = {}) {
+export function useRegistrySchema(contentType: string, options: QueryOverrides = {}) {
   // Empty contentType disables query (enabled gate in configQueries)
-  return useQuery({ ...configQueries.registrySchema(contentType), ...options });
+  return useQuery(withOverrides(configQueries.registrySchema(contentType), options));
 }
 
 // Raw config.toml as text. Disabled by default — caller passes

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.ts
@@ -1,15 +1,10 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listGoals, listGoalTemplates } from "../http/client";
 import { goalKeys } from "./keys";
+import { withOverrides, QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const TEMPLATE_STALE_MS = 300_000;
-
-type UseGoalOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 export const goalQueries = {
   list: () =>
@@ -17,6 +12,7 @@ export const goalQueries = {
       queryKey: goalKeys.lists(),
       queryFn: listGoals,
       staleTime: STALE_MS,
+      refetchInterval: STALE_MS,
     }),
   templates: () =>
     queryOptions({
@@ -26,22 +22,10 @@ export const goalQueries = {
     }),
 };
 
-export function useGoals(options: UseGoalOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...goalQueries.list(),
-    enabled,
-    staleTime,
-    refetchInterval: refetchInterval ?? STALE_MS,
-  });
+export function useGoals(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(goalQueries.list(), options));
 }
 
-export function useGoalTemplates(options: UseGoalOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...goalQueries.templates(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useGoalTemplates(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(goalQueries.templates(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.ts
@@ -2,17 +2,21 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listGoals, listGoalTemplates } from "../http/client";
 import { goalKeys } from "./keys";
 
-const REFRESH_MS = 30_000;
 const STALE_MS = 30_000;
 const TEMPLATE_STALE_MS = 300_000;
+
+type UseGoalOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
 
 export const goalQueries = {
   list: () =>
     queryOptions({
-      queryKey: goalKeys.list(),
+      queryKey: goalKeys.lists(),
       queryFn: listGoals,
       staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
     }),
   templates: () =>
     queryOptions({
@@ -22,10 +26,22 @@ export const goalQueries = {
     }),
 };
 
-export function useGoals() {
-  return useQuery(goalQueries.list());
+export function useGoals(options: UseGoalOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...goalQueries.list(),
+    enabled,
+    staleTime,
+    refetchInterval: refetchInterval ?? STALE_MS,
+  });
 }
 
-export function useGoalTemplates() {
-  return useQuery(goalQueries.templates());
+export function useGoalTemplates(options: UseGoalOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...goalQueries.templates(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands.ts
@@ -35,12 +35,14 @@ export const handQueries = {
       queryKey: handKeys.detail(handId),
       queryFn: () => getHandDetail(handId),
       enabled: !!handId,
+      staleTime: STALE_MS,
     }),
   settings: (handId: string) =>
     queryOptions({
       queryKey: handKeys.settings(handId),
       queryFn: () => getHandSettings(handId),
       enabled: !!handId,
+      staleTime: STALE_MS,
     }),
   stats: (instanceId: string) =>
     queryOptions({
@@ -75,12 +77,21 @@ export const handQueries = {
       queryKey: handKeys.session(instanceId),
       queryFn: () => getHandSession(instanceId),
       enabled: !!instanceId,
+      staleTime: STALE_MS,
     }),
   instanceStatus: (instanceId: string) =>
     queryOptions({
       queryKey: handKeys.instanceStatus(instanceId),
       queryFn: () => getHandInstanceStatus(instanceId),
       enabled: !!instanceId,
+      staleTime: STALE_MS,
+    }),
+  manifest: (handId: string, enabled = false) =>
+    queryOptions({
+      queryKey: handKeys.manifest(handId),
+      queryFn: () => getHandManifestToml(handId),
+      enabled: enabled && !!handId,
+      staleTime: 60_000,
     }),
 };
 
@@ -127,10 +138,5 @@ export function useHandInstanceStatus(instanceId: string) {
 // `enabled: true` only when the viewer modal opens, so we don't fetch
 // every hand's TOML eagerly.
 export function useHandManifestToml(handId: string, enabled: boolean) {
-  return useQuery({
-    queryKey: handKeys.manifest(handId),
-    queryFn: () => getHandManifestToml(handId),
-    enabled: enabled && !!handId,
-    staleTime: 60_000,
-  });
+  return useQuery(handQueries.manifest(handId, enabled));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -182,6 +182,13 @@ describe("query key factories", () => {
       ]);
     });
 
+    it("searchOrList is nested under lists", () => {
+      const searchKey = memoryKeys.searchOrList("test");
+      expect(searchKey).toEqual(["memory", "list", "searchOrList", "test"]);
+      const listsPrefix = memoryKeys.lists();
+      expect(searchKey.slice(0, listsPrefix.length)).toEqual(listsPrefix);
+    });
+
     it("stats is per agent or global", () => {
       expect(memoryKeys.statsAll()).toEqual(["memory", "stats"]);
       expect(memoryKeys.stats()).toEqual(["memory", "stats", undefined]);

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -194,6 +194,7 @@ export const memoryKeys = {
     limit?: number;
     category?: string;
   } = {}) => [...memoryKeys.lists(), filters] as const,
+  searchOrList: (search: string) => [...memoryKeys.lists(), "searchOrList", search] as const,
   statsAll: () => [...memoryKeys.all, "stats"] as const,
   stats: (agentId?: string) =>
     [...memoryKeys.statsAll(), agentId] as const,
@@ -212,12 +213,12 @@ export const usageKeys = {
 
 export const budgetKeys = {
   all: ["budget"] as const,
+  status: () => [...budgetKeys.all, "status"] as const,
 };
 
 export const goalKeys = {
   all: ["goals"] as const,
   lists: () => [...goalKeys.all, "list"] as const,
-  list: () => [...goalKeys.lists()] as const,
   templates: () => [...goalKeys.all, "templates"] as const,
 };
 
@@ -229,7 +230,6 @@ export const networkKeys = {
 export const peerKeys = {
   all: ["peers"] as const,
   lists: () => [...peerKeys.all, "list"] as const,
-  list: () => [...peerKeys.lists()] as const,
   details: () => [...peerKeys.all, "detail"] as const,
   detail: (id: string) => [...peerKeys.details(), id] as const,
 };

--- a/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
@@ -9,6 +9,12 @@ import {
 } from "../http/client";
 import { mcpKeys } from "./keys";
 
+type UseMcpOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
 const SERVERS_STALE_MS = 30_000;
 const SERVERS_REFRESH_MS = 30_000;
 const CATALOG_STALE_MS = 300_000;
@@ -29,7 +35,7 @@ export const mcpQueries = {
       staleTime: SERVERS_STALE_MS,
       enabled: Boolean(id),
     }),
-  catalog: (opts: { enabled?: boolean } = {}) =>
+  catalog: (opts: UseMcpOptions = {}) =>
     queryOptions({
       queryKey: mcpKeys.catalog(),
       queryFn: listMcpCatalog,
@@ -49,39 +55,71 @@ export const mcpQueries = {
       queryFn: getMcpHealth,
       staleTime: HEALTH_STALE_MS,
     }),
-  authStatus: (id: string, opts: { enabled?: boolean } = {}) =>
+  authStatus: (id: string, opts: UseMcpOptions = {}) =>
     queryOptions({
       queryKey: mcpKeys.authStatus(id),
       queryFn: () => getMcpAuthStatus(id),
       // Auth polling needs a fresh read on each fetchQuery call.
-      staleTime: 0,
+      staleTime: 2_000,
       enabled: opts.enabled ?? Boolean(id),
     }),
 };
 
-export function useMcpServers() {
-  return useQuery(mcpQueries.servers());
+export function useMcpServers(options: UseMcpOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...mcpQueries.servers(),
+    enabled,
+    staleTime: staleTime ?? SERVERS_STALE_MS,
+    refetchInterval: refetchInterval ?? SERVERS_REFRESH_MS,
+  });
 }
 
-export function useMcpServer(id: string) {
-  return useQuery(mcpQueries.server(id));
+export function useMcpServer(id: string, options: UseMcpOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...mcpQueries.server(id),
+    enabled: enabled ?? Boolean(id),
+    staleTime: staleTime ?? SERVERS_STALE_MS,
+    refetchInterval,
+  });
 }
 
-export function useMcpCatalog(opts: { enabled?: boolean } = {}) {
-  return useQuery(mcpQueries.catalog(opts));
+export function useMcpCatalog(options: UseMcpOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...mcpQueries.catalog(options),
+    enabled,
+    staleTime: staleTime ?? CATALOG_STALE_MS,
+    refetchInterval,
+  });
 }
 
-export function useMcpCatalogEntry(id: string) {
-  return useQuery(mcpQueries.catalogEntry(id));
+export function useMcpCatalogEntry(id: string, options: UseMcpOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...mcpQueries.catalogEntry(id),
+    enabled: enabled ?? Boolean(id),
+    staleTime: staleTime ?? CATALOG_STALE_MS,
+    refetchInterval,
+  });
 }
 
-export function useMcpHealth() {
-  return useQuery(mcpQueries.health());
+export function useMcpHealth(options: UseMcpOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...mcpQueries.health(),
+    enabled,
+    staleTime: staleTime ?? HEALTH_STALE_MS,
+    refetchInterval,
+  });
 }
 
-export function useMcpAuthStatus(id: string, options: { enabled?: boolean } = {}) {
+export function useMcpAuthStatus(id: string, options: UseMcpOptions = {}) {
+  const { staleTime, refetchInterval } = options;
   return useQuery({
     ...mcpQueries.authStatus(id, options),
-    enabled: options.enabled ?? Boolean(id),
+    staleTime: staleTime ?? 2_000,
+    refetchInterval,
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
@@ -8,12 +8,7 @@ import {
   getMcpAuthStatus,
 } from "../http/client";
 import { mcpKeys } from "./keys";
-
-type UseMcpOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
+import { QueryOverrides, withOverrides } from "./options";
 
 const SERVERS_STALE_MS = 30_000;
 const SERVERS_REFRESH_MS = 30_000;
@@ -35,7 +30,7 @@ export const mcpQueries = {
       staleTime: SERVERS_STALE_MS,
       enabled: Boolean(id),
     }),
-  catalog: (opts: UseMcpOptions = {}) =>
+  catalog: (opts: QueryOverrides = {}) =>
     queryOptions({
       queryKey: mcpKeys.catalog(),
       queryFn: listMcpCatalog,
@@ -55,71 +50,36 @@ export const mcpQueries = {
       queryFn: getMcpHealth,
       staleTime: HEALTH_STALE_MS,
     }),
-  authStatus: (id: string, opts: UseMcpOptions = {}) =>
+  authStatus: (id: string, opts: QueryOverrides = {}) =>
     queryOptions({
       queryKey: mcpKeys.authStatus(id),
       queryFn: () => getMcpAuthStatus(id),
-      // Auth polling needs a fresh read on each fetchQuery call.
+      // 2s staleTime balances OAuth polling freshness with request deduplication during rapid refetch cycles.
       staleTime: 2_000,
       enabled: opts.enabled ?? Boolean(id),
     }),
 };
 
-export function useMcpServers(options: UseMcpOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.servers(),
-    enabled,
-    staleTime: staleTime ?? SERVERS_STALE_MS,
-    refetchInterval: refetchInterval ?? SERVERS_REFRESH_MS,
-  });
+export function useMcpServers(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.servers(), options));
 }
 
-export function useMcpServer(id: string, options: UseMcpOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.server(id),
-    enabled: enabled ?? Boolean(id),
-    staleTime: staleTime ?? SERVERS_STALE_MS,
-    refetchInterval,
-  });
+export function useMcpServer(id: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.server(id), options));
 }
 
-export function useMcpCatalog(options: UseMcpOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.catalog(options),
-    enabled,
-    staleTime: staleTime ?? CATALOG_STALE_MS,
-    refetchInterval,
-  });
+export function useMcpCatalog(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.catalog(), options));
 }
 
-export function useMcpCatalogEntry(id: string, options: UseMcpOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.catalogEntry(id),
-    enabled: enabled ?? Boolean(id),
-    staleTime: staleTime ?? CATALOG_STALE_MS,
-    refetchInterval,
-  });
+export function useMcpCatalogEntry(id: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.catalogEntry(id), options));
 }
 
-export function useMcpHealth(options: UseMcpOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.health(),
-    enabled,
-    staleTime: staleTime ?? HEALTH_STALE_MS,
-    refetchInterval,
-  });
+export function useMcpHealth(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.health(), options));
 }
 
-export function useMcpAuthStatus(id: string, options: UseMcpOptions = {}) {
-  const { staleTime, refetchInterval } = options;
-  return useQuery({
-    ...mcpQueries.authStatus(id, options),
-    staleTime: staleTime ?? 2_000,
-    refetchInterval,
-  });
+export function useMcpAuthStatus(id: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mcpQueries.authStatus(id), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/media.ts
@@ -1,4 +1,4 @@
-import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
   listMediaProviders,
   pollVideo,
@@ -43,6 +43,13 @@ function shouldPollVideoTask(status?: MediaVideoStatus) {
   return status.status !== "completed" && status.status !== "failed" && !status.error;
 }
 
-export function useVideoTask(taskId: string, options: QueryOverrides = {}) {
-  return useQuery(withOverrides(mediaQueries.videoTask(taskId), options));
+export function useVideoTask(params: VideoTaskParams | null, options: QueryOverrides = {}) {
+  return useQuery({
+    ...withOverrides(mediaQueries.videoTask(params ?? { taskId: "", provider: "" }), options),
+    enabled: Boolean(params) && options.enabled !== false,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      return shouldPollVideoTask(data) ? VIDEO_TASK_REFETCH_MS : false;
+    },
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/media.ts
@@ -9,7 +9,7 @@ import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 60_000;
 const REFRESH_MS = 60_000;
-const VIDEO_TASK_STALE_MS = 1_000;
+const VIDEO_TASK_STALE_MS = 5_000;
 const VIDEO_TASK_REFETCH_MS = 5_000;
 
 type VideoTaskParams = {
@@ -43,33 +43,6 @@ function shouldPollVideoTask(status?: MediaVideoStatus) {
   return status.status !== "completed" && status.status !== "failed" && !status.error;
 }
 
-export function useVideoTask(
-  params: VideoTaskParams | null,
-  options: QueryOverrides = {},
-) {
-  const base = params
-    ? mediaQueries.videoTask(params)
-    : {
-        queryKey: mediaKeys.videoTaskDisabled(),
-        queryFn: skipToken,
-        staleTime: VIDEO_TASK_STALE_MS,
-        gcTime: 0,
-      } as const;
-
-  const isEnabled =
-    (options.enabled ?? true) && !!params?.taskId && !!params?.provider;
-
-  return useQuery({
-    ...base,
-    enabled: isEnabled,
-    staleTime: options.staleTime ?? VIDEO_TASK_STALE_MS,
-    refetchInterval: (query) => {
-      const resolvedInterval = options.refetchInterval ?? VIDEO_TASK_REFETCH_MS;
-      if (resolvedInterval === false) return false;
-      return shouldPollVideoTask(query.state.data as MediaVideoStatus | undefined)
-        ? resolvedInterval
-        : false;
-    },
-    refetchIntervalInBackground: true,
-  });
+export function useVideoTask(taskId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(mediaQueries.videoTask(taskId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/media.ts
@@ -47,6 +47,7 @@ export function useVideoTask(params: VideoTaskParams | null, options: QueryOverr
   return useQuery({
     ...withOverrides(mediaQueries.videoTask(params ?? { taskId: "", provider: "" }), options),
     enabled: Boolean(params) && options.enabled !== false,
+    refetchIntervalInBackground: true,
     refetchInterval: (query) => {
       const data = query.state.data;
       return shouldPollVideoTask(data) ? VIDEO_TASK_REFETCH_MS : false;

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.ts
@@ -20,12 +20,7 @@ type UseMemoryHealthOptions = {
 };
 
 export const memoryQueries = {
-  list: (params?: { agentId?: string; offset?: number; limit?: number; category?: string }) =>
-    queryOptions({
-      queryKey: memoryKeys.list(params),
-      queryFn: () => listMemories(params),
-      staleTime: STALE_MS,
-    }),
+
   stats: (agentId?: string) =>
     queryOptions({
       queryKey: memoryKeys.stats(agentId),
@@ -41,13 +36,11 @@ export const memoryQueries = {
     }),
 };
 
-export function useMemories(params?: { agentId?: string; offset?: number; limit?: number; category?: string }) {
-  return useQuery(memoryQueries.list(params));
-}
+
 
 export const memorySearchOrListQueryOptions = (search: string) =>
   queryOptions<{ memories: MemoryItem[]; total: number }>({
-    queryKey: [...memoryKeys.lists(), "searchOrList", search] as const,
+    queryKey: memoryKeys.searchOrList(search),
     queryFn: async () => {
       if (search.trim()) {
         const items = await searchMemories({ query: search.trim(), limit: 50 });

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.ts
@@ -8,16 +8,11 @@ import {
 } from "../http/client";
 import { healthDetailQueryOptions } from "./runtime";
 import { memoryKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const REFRESH_MS = 30_000;
 const STALE_MS = 30_000;
 const CONFIG_STALE_MS = 300_000;
-
-type UseMemoryHealthOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 export const memoryQueries = {
 
@@ -78,13 +73,9 @@ export function useMemoryConfig() {
  * narrows the returned data so consumers of this hook don't re-render on
  * unrelated health field changes.
  */
-export function useMemoryHealth(options: UseMemoryHealthOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
+export function useMemoryHealth(options: QueryOverrides = {}) {
   return useQuery({
-    ...healthDetailQueryOptions(),
-    enabled,
-    staleTime,
-    refetchInterval,
+    ...withOverrides(healthDetailQueryOptions(), options),
     select: (data): boolean => data.memory?.embedding_available ?? false,
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/models.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/models.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listModels, getModelOverrides } from "../http/client";
 import { modelKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 60_000;
@@ -22,16 +23,17 @@ export const modelQueries = {
       queryKey: modelKeys.overrides(modelKey),
       queryFn: () => getModelOverrides(modelKey),
       enabled: !!modelKey,
+      staleTime: 60_000,
     }),
 };
 
 export function useModels(
   filters: { provider?: string; tier?: string; available?: boolean } = {},
-  options: { enabled?: boolean; staleTime?: number; refetchInterval?: number | false } = {},
+  options: QueryOverrides = {},
 ) {
-  return useQuery({ ...modelQueries.list(filters), ...options });
+  return useQuery(withOverrides(modelQueries.list(filters), options));
 }
 
-export function useModelOverrides(modelKey: string) {
-  return useQuery(modelQueries.overrides(modelKey));
+export function useModelOverrides(modelKey: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(modelQueries.overrides(modelKey), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/network.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/network.ts
@@ -5,6 +5,7 @@ import {
   listA2AAgents,
 } from "../http/client";
 import { networkKeys, peerKeys, a2aKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const REFRESH_MS = 15_000;
 const STALE_MS = 30_000;
@@ -33,14 +34,14 @@ export const networkQueries = {
     }),
 };
 
-export function useNetworkStatus() {
-  return useQuery(networkQueries.status());
+export function useNetworkStatus(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(networkQueries.status(), options));
 }
 
-export function usePeers() {
-  return useQuery(networkQueries.peers());
+export function usePeers(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(networkQueries.peers(), options));
 }
 
-export function useA2AAgents() {
-  return useQuery(networkQueries.a2aAgents());
+export function useA2AAgents(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(networkQueries.a2aAgents(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/overview.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/overview.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { loadDashboardSnapshot, getVersionInfo } from "../../api";
+import { loadDashboardSnapshot, getVersionInfo } from "../http/client";
 import { overviewKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 export const dashboardSnapshotQueryOptions = () =>
   queryOptions({
@@ -15,12 +16,13 @@ export const versionInfoQueryOptions = () =>
     queryKey: overviewKeys.version(),
     queryFn: getVersionInfo,
     staleTime: Infinity,
+    gcTime: Infinity,
   });
 
-export function useDashboardSnapshot() {
-  return useQuery(dashboardSnapshotQueryOptions());
+export function useDashboardSnapshot(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(dashboardSnapshotQueryOptions(), options));
 }
 
-export function useVersionInfo() {
-  return useQuery(versionInfoQueryOptions());
+export function useVersionInfo(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(versionInfoQueryOptions(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/plugins.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/plugins.ts
@@ -1,8 +1,9 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listPlugins, listPluginRegistries } from "../http/client";
 import { pluginKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
-const STALE_MS = 30_000;
+const STALE_MS = 60_000;
 
 export const pluginQueries = {
   list: () =>
@@ -17,13 +18,14 @@ export const pluginQueries = {
       queryKey: pluginKeys.registries(),
       queryFn: listPluginRegistries,
       staleTime: 300_000,
+      refetchInterval: 300_000,
     }),
 };
 
-export function usePlugins() {
-  return useQuery(pluginQueries.list());
+export function usePlugins(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(pluginQueries.list(), options));
 }
 
-export function usePluginRegistries(enabled?: boolean) {
-  return useQuery({ ...pluginQueries.registries(), enabled });
+export function usePluginRegistries(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(pluginQueries.registries(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/providers.ts
@@ -1,5 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { listProviders } from "../../api";
+import { listProviders } from "../http/client";
 import { providerKeys } from "./keys";
 
 export { useSystemStatus as useProviderStatus } from "./runtime";

--- a/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/queries-enabled-guards.test.tsx
@@ -106,7 +106,7 @@ describe("useApprovals", () => {
 
 describe("usePluginRegistries", () => {
   it("should not fetch when enabled is false", async () => {
-    const { result } = renderHook(() => usePluginRegistries(false), {
+    const { result } = renderHook(() => usePluginRegistries({ enabled: false }), {
       wrapper: createQueryClientWrapper().wrapper,
     });
 
@@ -119,7 +119,7 @@ describe("usePluginRegistries", () => {
   it("should fetch by default when enabled is undefined", async () => {
     mockListPluginRegistries.mockResolvedValue({ registries: [] });
 
-    renderHook(() => usePluginRegistries(undefined), {
+    renderHook(() => usePluginRegistries(), {
       wrapper: createQueryClientWrapper().wrapper,
     });
 
@@ -133,7 +133,7 @@ describe("usePluginRegistries", () => {
     const mockData = { registries: [{ id: "npm", url: "https://registry.npmjs.org" }] };
     mockListPluginRegistries.mockResolvedValue(mockData);
 
-    const { result } = renderHook(() => usePluginRegistries(true), {
+    const { result } = renderHook(() => usePluginRegistries({ enabled: true }), {
       wrapper: createQueryClientWrapper().wrapper,
     });
 
@@ -149,7 +149,7 @@ describe("usePluginRegistries", () => {
 
     const { queryClient, wrapper } = createQueryClientWrapper();
 
-    renderHook(() => usePluginRegistries(true), { wrapper });
+    renderHook(() => usePluginRegistries({ enabled: true }), { wrapper });
 
     await waitFor(() => {
       expect(queryClient.getQueryData(pluginKeys.registries())).toEqual(mockData);

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
@@ -10,11 +10,9 @@ import {
   getTaskQueueStatus,
   listTaskQueue,
   listCronJobs,
-} from "../../api";
+} from "../http/client";
 import { runtimeKeys, auditKeys, cronKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
-
-export { useDashboardSnapshot, useVersionInfo } from "./overview";
 
 export const systemStatusQueryOptions = () =>
   queryOptions({
@@ -56,7 +54,7 @@ export const securityStatusQueryOptions = () =>
   queryOptions({
     queryKey: runtimeKeys.security(),
     queryFn: getSecurityStatus,
-    staleTime: 60_000,
+    staleTime: 120_000,
     refetchInterval: 120_000,
   });
 
@@ -68,8 +66,8 @@ export const auditRecentQueryOptions = (limit: number) =>
   queryOptions({
     queryKey: auditKeys.recent(limit),
     queryFn: () => listAuditRecent(limit),
-    staleTime: 30_000,
-    refetchInterval: 30_000,
+    staleTime: 120_000,
+    refetchInterval: 120_000,
   });
 
 export function useAuditRecent(limit: number, options: QueryOverrides = {}) {
@@ -80,7 +78,7 @@ export const auditVerifyQueryOptions = () =>
   queryOptions({
     queryKey: auditKeys.verify(),
     queryFn: verifyAuditChain,
-    staleTime: 60_000,
+    staleTime: 120_000,
     refetchInterval: 120_000,
   });
 
@@ -124,12 +122,15 @@ export function useTaskQueue(status?: string) {
   return useQuery(taskQueueQueryOptions(status));
 }
 
-export function useCronJobs(agentId?: string) {
-  return useQuery({
+export const cronJobsQueryOptions = (agentId?: string) =>
+  queryOptions({
     queryKey: cronKeys.jobs(agentId),
     queryFn: () => listCronJobs(agentId),
     enabled: !!agentId,
     staleTime: 30_000,
     refetchInterval: 30_000,
   });
+
+export function useCronJobs(agentId?: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(cronJobsQueryOptions(agentId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
@@ -3,7 +3,6 @@ import { listSchedules, listTriggers } from "../http/client";
 import { scheduleKeys, triggerKeys } from "./keys";
 
 const STALE_MS = 30_000;
-const REFRESH_MS = 30_000;
 
 export const scheduleQueries = {
   list: () =>
@@ -11,20 +10,39 @@ export const scheduleQueries = {
       queryKey: scheduleKeys.lists(),
       queryFn: listSchedules,
       staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
+      refetchInterval: STALE_MS,
     }),
   triggers: () =>
     queryOptions({
       queryKey: triggerKeys.lists(),
       queryFn: listTriggers,
       staleTime: STALE_MS,
+      refetchInterval: STALE_MS,
     }),
 };
 
-export function useSchedules() {
-  return useQuery(scheduleQueries.list());
+type UseSchedulesOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function useSchedules(options: UseSchedulesOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...scheduleQueries.list(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useTriggers() {
-  return useQuery(scheduleQueries.triggers());
+export function useTriggers(options: UseSchedulesOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...scheduleQueries.triggers(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listSchedules, listTriggers } from "../http/client";
 import { scheduleKeys, triggerKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 
@@ -21,28 +22,10 @@ export const scheduleQueries = {
     }),
 };
 
-type UseSchedulesOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
-export function useSchedules(options: UseSchedulesOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...scheduleQueries.list(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useSchedules(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(scheduleQueries.list(), options));
 }
 
-export function useTriggers(options: UseSchedulesOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...scheduleQueries.triggers(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useTriggers(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(scheduleQueries.triggers(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
@@ -1,8 +1,8 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { listSessions, getSessionDetails } from "../http/client";
 import { sessionKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
-const REFRESH_MS = 30_000;
 const STALE_MS = 30_000;
 
 export const sessionQueries = {
@@ -11,7 +11,7 @@ export const sessionQueries = {
       queryKey: sessionKeys.lists(),
       queryFn: listSessions,
       staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
+      refetchInterval: STALE_MS,
     }),
   detail: (sessionId: string) =>
     queryOptions({
@@ -21,10 +21,10 @@ export const sessionQueries = {
     }),
 };
 
-export function useSessions() {
-  return useQuery(sessionQueries.list());
+export function useSessions(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(sessionQueries.list(), options));
 }
 
-export function useSessionDetails(sessionId: string) {
-  return useQuery(sessionQueries.detail(sessionId));
+export function useSessionDetails(sessionId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(sessionQueries.detail(sessionId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/skills.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills.ts
@@ -15,16 +15,11 @@ import {
   fanghubListSkills,
 } from "../http/client";
 import { skillKeys, clawhubKeys, clawhubCnKeys, skillhubKeys, fanghubKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
 const BROWSE_STALE_MS = 60_000;
-
-type UseSkillOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 export const skillQueries = {
   list: () =>
@@ -115,106 +110,46 @@ export const skillQueries = {
     }),
 };
 
-export function useSkills(options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.list(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useSkills(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.list(), options));
 }
 
-export function useSkillDetail(name: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.detail(name),
-    enabled: enabled ?? Boolean(name),
-    staleTime: staleTime ?? STALE_MS,
-    refetchInterval: refetchInterval ?? false,
-  });
+export function useSkillDetail(name: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.detail(name), options));
 }
 
 export function useSupportingFile(
   name: string,
   path: string,
-  options: UseSkillOptions = {},
+  options: QueryOverrides = {},
 ) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.supportingFile(name, path),
-    enabled: enabled ?? (Boolean(name) && Boolean(path)),
-    staleTime: staleTime ?? STALE_MS,
-    refetchInterval: refetchInterval ?? false,
-  });
+  return useQuery(withOverrides(skillQueries.supportingFile(name, path), options));
 }
 
-export function useClawHubBrowse(sort?: string, limit?: number, cursor?: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.clawhubBrowse(sort, limit, cursor),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useClawHubBrowse(sort?: string, limit?: number, cursor?: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.clawhubBrowse(sort, limit, cursor), options));
 }
 
-export function useClawHubSearch(query: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.clawhubSearch(query),
-    enabled: enabled ?? !!query,
-    staleTime,
-    refetchInterval,
-  });
+export function useClawHubSearch(query: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.clawhubSearch(query), options));
 }
 
-export function useClawHubSkill(slug: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.clawhubSkill(slug),
-    enabled: enabled ?? !!slug,
-    staleTime,
-    refetchInterval,
-  });
+export function useClawHubSkill(slug: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.clawhubSkill(slug), options));
 }
 
-export function useSkillHubBrowse(sort?: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.skillhubBrowse(sort),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useSkillHubBrowse(sort?: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.skillhubBrowse(sort), options));
 }
 
-export function useSkillHubSearch(query: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.skillhubSearch(query),
-    enabled: enabled ?? !!query,
-    staleTime,
-    refetchInterval,
-  });
+export function useSkillHubSearch(query: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.skillhubSearch(query), options));
 }
 
-export function useSkillHubSkill(slug: string, options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.skillhubSkill(slug),
-    enabled: enabled ?? !!slug,
-    staleTime,
-    refetchInterval,
-  });
+export function useSkillHubSkill(slug: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.skillhubSkill(slug), options));
 }
 
-export function useFangHubSkills(options: UseSkillOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...skillQueries.fanghubList(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useFangHubSkills(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(skillQueries.fanghubList(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/skills.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills.ts
@@ -66,6 +66,7 @@ export const skillQueries = {
       queryKey: clawhubKeys.detail(slug),
       queryFn: () => clawhubGetSkill(slug),
       enabled: !!slug,
+      staleTime: BROWSE_STALE_MS,
     }),
   clawhubCnBrowse: (sort?: string, limit?: number, cursor?: string) =>
     queryOptions({
@@ -104,6 +105,7 @@ export const skillQueries = {
       queryKey: skillhubKeys.detail(slug),
       queryFn: () => skillhubGetSkill(slug),
       enabled: !!slug,
+      staleTime: BROWSE_STALE_MS,
     }),
   fanghubList: () =>
     queryOptions({
@@ -113,8 +115,14 @@ export const skillQueries = {
     }),
 };
 
-export function useSkills() {
-  return useQuery(skillQueries.list());
+export function useSkills(options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.list(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
 export function useSkillDetail(name: string, options: UseSkillOptions = {}) {
@@ -141,30 +149,72 @@ export function useSupportingFile(
   });
 }
 
-export function useClawHubBrowse(sort?: string, limit?: number, cursor?: string) {
-  return useQuery(skillQueries.clawhubBrowse(sort, limit, cursor));
+export function useClawHubBrowse(sort?: string, limit?: number, cursor?: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.clawhubBrowse(sort, limit, cursor),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useClawHubSearch(query: string) {
-  return useQuery(skillQueries.clawhubSearch(query));
+export function useClawHubSearch(query: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.clawhubSearch(query),
+    enabled: enabled ?? !!query,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useClawHubSkill(slug: string) {
-  return useQuery(skillQueries.clawhubSkill(slug));
+export function useClawHubSkill(slug: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.clawhubSkill(slug),
+    enabled: enabled ?? !!slug,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useSkillHubBrowse(sort?: string) {
-  return useQuery(skillQueries.skillhubBrowse(sort));
+export function useSkillHubBrowse(sort?: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.skillhubBrowse(sort),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useSkillHubSearch(query: string) {
-  return useQuery(skillQueries.skillhubSearch(query));
+export function useSkillHubSearch(query: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.skillhubSearch(query),
+    enabled: enabled ?? !!query,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useSkillHubSkill(slug: string) {
-  return useQuery(skillQueries.skillhubSkill(slug));
+export function useSkillHubSkill(slug: string, options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.skillhubSkill(slug),
+    enabled: enabled ?? !!slug,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useFangHubSkills() {
-  return useQuery(skillQueries.fanghubList());
+export function useFangHubSkills(options: UseSkillOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...skillQueries.fanghubList(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
@@ -4,7 +4,7 @@ import { telemetryKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 5_000;
-const REFRESH_MS = 5_000;
+const REFRESH_MS = 10_000; // intentionally aggressive: live metrics dashboard
 
 export const telemetryQueryOptions = () =>
   queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
@@ -1,14 +1,9 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { getTerminalHealth, listTerminalWindows } from "../http/client";
 import { terminalKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 const REFRESH_MS = 10_000;
-
-type UseTerminalQueryOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
 
 export const terminalQueries = {
   health: () =>
@@ -21,26 +16,15 @@ export const terminalQueries = {
     queryOptions({
       queryKey: terminalKeys.windows(),
       queryFn: listTerminalWindows,
+      staleTime: REFRESH_MS,
       refetchInterval: REFRESH_MS,
     }),
 };
 
-export function useTerminalHealth(options: UseTerminalQueryOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...terminalQueries.health(),
-    enabled,
-    ...(staleTime !== undefined ? { staleTime } : {}),
-    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
-  });
+export function useTerminalHealth(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(terminalQueries.health(), options));
 }
 
-export function useTerminalWindows(options: UseTerminalQueryOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...terminalQueries.windows(),
-    enabled,
-    ...(staleTime !== undefined ? { staleTime } : {}),
-    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
-  });
+export function useTerminalWindows(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(terminalQueries.windows(), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
@@ -6,6 +6,7 @@ import {
   listWorkflowTemplates,
 } from "../http/client";
 import { workflowKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
 
 /** Stale/refetch timing constants.
  *  STALE_MS / REFRESH_MS — workflow list: 30 s stale, 30 s poll.
@@ -51,48 +52,18 @@ export const workflowQueries = {
     }),
 };
 
-export type UseWorkflowOptions = {
-  enabled?: boolean;
-  staleTime?: number;
-  refetchInterval?: number | false;
-};
-
-export function useWorkflows(options: UseWorkflowOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...workflowQueries.list(),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useWorkflows(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(workflowQueries.list(), options));
 }
 
-export function useWorkflowRuns(workflowId: string, options: UseWorkflowOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...workflowQueries.runs(workflowId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useWorkflowRuns(workflowId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(workflowQueries.runs(workflowId), options));
 }
 
-export function useWorkflowRunDetail(runId: string, options: UseWorkflowOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...workflowQueries.runDetail(runId),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useWorkflowRunDetail(runId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(workflowQueries.runDetail(runId), options));
 }
 
-export function useWorkflowTemplates(q?: string, category?: string, options: UseWorkflowOptions = {}) {
-  const { enabled, staleTime, refetchInterval } = options;
-  return useQuery({
-    ...workflowQueries.templates(q, category),
-    enabled,
-    staleTime,
-    refetchInterval,
-  });
+export function useWorkflowTemplates(q?: string, category?: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(workflowQueries.templates(q, category), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
@@ -7,10 +7,17 @@ import {
 } from "../http/client";
 import { workflowKeys } from "./keys";
 
+/** Stale/refetch timing constants.
+ *  STALE_MS / REFRESH_MS — workflow list: 30 s stale, 30 s poll.
+ *  RUN_STALE_MS / RUN_REFETCH_MS — run list: 10 s stale (fast-changing), 30 s poll.
+ *  RUN_DETAIL_STALE_MS — single run detail: 30 s stale, no background poll (fetch-on-focus only).
+ *  TEMPLATE_STALE_MS — templates change rarely: 5 min stale, no poll.
+ */
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
 const RUN_STALE_MS = 10_000;
 const RUN_REFETCH_MS = 30_000;
+const RUN_DETAIL_STALE_MS = 30_000;
 const TEMPLATE_STALE_MS = 300_000;
 
 export const workflowQueries = {
@@ -34,6 +41,7 @@ export const workflowQueries = {
       queryKey: workflowKeys.runDetail(runId),
       queryFn: () => getWorkflowRun(runId),
       enabled: !!runId,
+      staleTime: RUN_DETAIL_STALE_MS,
     }),
   templates: (q?: string, category?: string) =>
     queryOptions({
@@ -43,18 +51,48 @@ export const workflowQueries = {
     }),
 };
 
-export function useWorkflows() {
-  return useQuery(workflowQueries.list());
+export type UseWorkflowOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number | false;
+};
+
+export function useWorkflows(options: UseWorkflowOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...workflowQueries.list(),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useWorkflowRuns(workflowId: string) {
-  return useQuery(workflowQueries.runs(workflowId));
+export function useWorkflowRuns(workflowId: string, options: UseWorkflowOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...workflowQueries.runs(workflowId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useWorkflowRunDetail(runId: string) {
-  return useQuery(workflowQueries.runDetail(runId));
+export function useWorkflowRunDetail(runId: string, options: UseWorkflowOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...workflowQueries.runDetail(runId),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }
 
-export function useWorkflowTemplates(q?: string, category?: string) {
-  return useQuery(workflowQueries.templates(q, category));
+export function useWorkflowTemplates(q?: string, category?: string, options: UseWorkflowOptions = {}) {
+  const { enabled, staleTime, refetchInterval } = options;
+  return useQuery({
+    ...workflowQueries.templates(q, category),
+    enabled,
+    staleTime,
+    refetchInterval,
+  });
 }

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -33,7 +33,7 @@ import { filterVisible } from "../lib/hiddenModels";
 import { Search, Users, MessageCircle, X, Cpu, Wrench, Shield, Plus, Loader2, Pause, Play, Clock, Brain, Zap, FlaskConical, GitBranch, Trash2, Check, BarChart3, Copy, RotateCcw, Pencil } from "lucide-react";
 import { truncateId } from "../lib/string";
 import { getStatusVariant } from "../lib/status";
-import { useDashboardSnapshot } from "../lib/queries/runtime";
+import { useDashboardSnapshot } from "../lib/queries/overview";
 import { useProviders } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
 import { AgentManifestForm } from "../components/AgentManifestForm";

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -62,7 +62,7 @@ export function PluginsPage() {
   const [scaffoldRuntime, setScaffoldRuntime] = useState("python");
 
   const pluginsQuery = usePlugins();
-  const registriesQuery = usePluginRegistries(tab === "registry");
+  const registriesQuery = usePluginRegistries({ enabled: tab === "registry" });
 
   const addToast = useUIStore((s) => s.addToast);
   const installMutation = useInstallPlugin();

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -17,8 +17,6 @@ import {
   AlertTriangle, Clock, Brain, Database, Lock, Eye,
 } from "lucide-react";
 import {
-  useDashboardSnapshot,
-  useVersionInfo,
   useQueueStatus,
   useHealthDetail,
   useSecurityStatus,
@@ -28,6 +26,7 @@ import {
   useTaskQueueStatus,
   useTaskQueue,
 } from "../lib/queries/runtime";
+import { useDashboardSnapshot, useVersionInfo } from "../lib/queries/overview";
 import {
   useShutdownServer,
   useCreateBackup,


### PR DESCRIPTION
## Type

- [x] Refactor / Performance

## Summary

Standardizes query hook patterns across all 24 dashboard query files. Every hook now accepts optional QueryOverrides for enabled/staleTime/refetchInterval overrides, using the shared withOverrides helper to preserve factory defaults.

## Changes

- Added options: QueryOverrides = {} parameter to 60+ query hooks
- Replaced manual destructuring/spread with withOverrides() helper
- Fixed staleTime/refetchInterval mismatches (stale < refetch)
- Extracted inline queries to queryOptions factories (hands, config, runtime)
- Removed dead code (useMemories, redundant key factories)
- Fixed import paths (../../api → ../http/client)
- Restored dynamic polling logic in useVideoTask
- Added missing staleTime to detail/settings/session queries
- Added gcTime: Infinity to version info query

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
