### PR TITLE
fix(llm-drivers): infer Ollama model capabilities from families metadata

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9638,10 +9638,27 @@ system_prompt = "You are a helpful assistant."
                                 librefang_types::model_catalog::AuthStatus::NotRequired,
                             );
                             if !result.discovered_models.is_empty() {
-                                catalog.merge_discovered_models(
-                                    provider_id,
-                                    &result.discovered_models,
-                                );
+                                // Use enriched metadata when available (Ollama populates
+                                // discovered_model_info; other providers leave it empty).
+                                let info: Vec<_> = if result.discovered_model_info.is_empty() {
+                                    result
+                                        .discovered_models
+                                        .iter()
+                                        .map(|name| {
+                                            librefang_runtime::provider_health::DiscoveredModelInfo {
+                                                name: name.clone(),
+                                                parameter_size: None,
+                                                quantization_level: None,
+                                                family: None,
+                                                families: None,
+                                                size: None,
+                                            }
+                                        })
+                                        .collect()
+                                } else {
+                                    result.discovered_model_info.clone()
+                                };
+                                catalog.merge_discovered_models(provider_id, &info);
                             }
                         }
                     } else {

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -22,6 +22,37 @@ pub struct ModelCatalog {
     overrides: HashMap<String, ModelOverrides>,
 }
 
+/// Infer (supports_vision, supports_tools, supports_thinking) from a model's
+/// name and the `families` array returned by Ollama's `/api/tags`.
+///
+/// Rules:
+/// - `families` contains "clip"  → vision model (LLaVA, BakLLaVA, Moondream, …)
+/// - name contains "embed"       → embedding model; tools/thinking N/A
+/// - name contains known thinking-model patterns → supports_thinking
+fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, bool) {
+    let lower = name.to_lowercase();
+
+    // Embedding models are not chat models — tools and thinking don't apply.
+    let is_embed = lower.contains("embed") || lower.contains("embedding");
+    if is_embed {
+        return (false, false, false);
+    }
+
+    let supports_vision = families
+        .map(|fs| fs.iter().any(|f| f.to_lowercase() == "clip"))
+        .unwrap_or(false);
+
+    // Heuristic for known thinking/reasoning model families.
+    let supports_thinking = lower.contains("qwq")
+        || lower.contains("deepseek-r1")
+        || lower.contains("/r1")
+        || lower.contains(":r1")
+        || lower.contains("qwen3")
+        || lower.contains("marco-o1");
+
+    (supports_vision, true, supports_thinking)
+}
+
 impl ModelCatalog {
     /// Create a new catalog by loading providers from `home_dir/providers/`
     /// and aliases from `home_dir/aliases.toml`.
@@ -663,9 +694,15 @@ impl ModelCatalog {
 
     /// Merge dynamically discovered models from a local provider.
     ///
-    /// Adds models not already in the catalog with `Local` tier and zero cost.
+    /// Accepts enriched metadata from Ollama's `/api/tags` response to infer
+    /// capabilities (vision via the "clip" family, embeddings, thinking models).
+    /// Falls back to conservative defaults when metadata is absent.
     /// Also updates the provider's `model_count`.
-    pub fn merge_discovered_models(&mut self, provider: &str, model_ids: &[String]) {
+    pub fn merge_discovered_models(
+        &mut self,
+        provider: &str,
+        model_info: &[crate::provider_health::DiscoveredModelInfo],
+    ) {
         let existing_ids: std::collections::HashSet<String> = self
             .models
             .iter()
@@ -674,14 +711,15 @@ impl ModelCatalog {
             .collect();
 
         let mut added = 0usize;
-        for id in model_ids {
-            if existing_ids.contains(&id.to_lowercase()) {
+        for info in model_info {
+            if existing_ids.contains(&info.name.to_lowercase()) {
                 continue;
             }
-            // Generate a human-friendly display name
-            let display = format!("{} ({})", id, provider);
+            let (supports_vision, supports_tools, supports_thinking) =
+                infer_capabilities(&info.name, info.families.as_deref());
+            let display = format!("{} ({})", info.name, provider);
             self.models.push(ModelCatalogEntry {
-                id: id.clone(),
+                id: info.name.clone(),
                 display_name: display,
                 provider: provider.to_string(),
                 tier: ModelTier::Local,
@@ -689,10 +727,10 @@ impl ModelCatalog {
                 max_output_tokens: 16_384,
                 input_cost_per_m: 0.0,
                 output_cost_per_m: 0.0,
-                supports_tools: true,
-                supports_vision: false,
+                supports_tools,
+                supports_vision,
                 supports_streaming: true,
-                supports_thinking: false,
+                supports_thinking,
                 aliases: Vec::new(),
             });
             added += 1;
@@ -1045,12 +1083,27 @@ pub fn read_codex_credential() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider_health::DiscoveredModelInfo;
 
-    /// Build a catalog for tests.
-    ///
     fn test_catalog() -> ModelCatalog {
         let home = crate::registry_sync::resolve_home_dir_for_tests();
         ModelCatalog::new(&home)
+    }
+
+    /// Convert plain name strings to minimal `DiscoveredModelInfo` for tests
+    /// that don't need to exercise capability inference.
+    fn names_to_info(names: &[&str]) -> Vec<DiscoveredModelInfo> {
+        names
+            .iter()
+            .map(|n| DiscoveredModelInfo {
+                name: n.to_string(),
+                parameter_size: None,
+                quantization_level: None,
+                family: None,
+                families: None,
+                size: None,
+            })
+            .collect()
     }
 
     #[test]
@@ -1355,10 +1408,8 @@ id = "acme"
     fn test_merge_adds_new_models() {
         let mut catalog = test_catalog();
         let before = catalog.models_by_provider("ollama").len();
-        catalog.merge_discovered_models(
-            "ollama",
-            &["codestral:latest".to_string(), "qwen2:7b".to_string()],
-        );
+        catalog
+            .merge_discovered_models("ollama", &names_to_info(&["codestral:latest", "qwen2:7b"]));
         let after = catalog.models_by_provider("ollama").len();
         assert_eq!(after, before + 2);
         // Verify the new models are Local tier with zero cost
@@ -1380,7 +1431,7 @@ id = "acme"
             .id
             .clone();
         let before = catalog.list_models().len();
-        catalog.merge_discovered_models("ollama", &[existing_id]);
+        catalog.merge_discovered_models("ollama", &names_to_info(&[existing_id.as_str()]));
         let after = catalog.list_models().len();
         assert_eq!(after, before); // no new model added
     }
@@ -1389,9 +1440,78 @@ id = "acme"
     fn test_merge_updates_model_count() {
         let mut catalog = test_catalog();
         let before_count = catalog.get_provider("ollama").unwrap().model_count;
-        catalog.merge_discovered_models("ollama", &["new-model:latest".to_string()]);
+        catalog.merge_discovered_models("ollama", &names_to_info(&["new-model:latest"]));
         let after_count = catalog.get_provider("ollama").unwrap().model_count;
         assert_eq!(after_count, before_count + 1);
+    }
+
+    #[test]
+    fn test_merge_infers_capabilities_from_ollama_metadata() {
+        let mut catalog = test_catalog();
+
+        let models = vec![
+            // Vision model: families includes "clip"
+            DiscoveredModelInfo {
+                name: "llava:latest".to_string(),
+                families: Some(vec!["llama".to_string(), "clip".to_string()]),
+                family: Some("llama".to_string()),
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+            },
+            // Embedding model: name contains "embed"
+            DiscoveredModelInfo {
+                name: "nomic-embed-text:latest".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+            },
+            // Thinking model: name contains "deepseek-r1"
+            DiscoveredModelInfo {
+                name: "deepseek-r1:8b".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+            },
+            // Plain chat model
+            DiscoveredModelInfo {
+                name: "llama3.2:latest".to_string(),
+                families: Some(vec!["llama".to_string()]),
+                family: Some("llama".to_string()),
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+            },
+        ];
+        catalog.merge_discovered_models("ollama", &models);
+
+        let llava = catalog.find_model("llava:latest").unwrap();
+        assert!(
+            llava.supports_vision,
+            "llava should have vision via clip family"
+        );
+        assert!(llava.supports_tools);
+
+        let embed = catalog.find_model("nomic-embed-text:latest").unwrap();
+        assert!(!embed.supports_vision);
+        assert!(
+            !embed.supports_tools,
+            "embedding model should not have tools"
+        );
+        assert!(!embed.supports_thinking);
+
+        let r1 = catalog.find_model("deepseek-r1:8b").unwrap();
+        assert!(r1.supports_thinking, "deepseek-r1 should have thinking");
+        assert!(!r1.supports_vision);
+
+        let llama = catalog.find_model("llama3.2:latest").unwrap();
+        assert!(!llama.supports_vision);
+        assert!(llama.supports_tools);
+        assert!(!llama.supports_thinking);
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -32,7 +32,10 @@ pub struct ModelCatalog {
 fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, bool) {
     let lower = name.to_lowercase();
 
-    // Embedding models are not chat models — tools and thinking don't apply.
+    // Embedding check runs first and short-circuits the rest.
+    // A vision-encoder used for embeddings (e.g. a hypothetical "clip-embed")
+    // is still not a chat vision model, so the families check is intentionally
+    // skipped for embedding models.
     let is_embed = lower.contains("embed") || lower.contains("embedding");
     if is_embed {
         return (false, false, false);
@@ -42,7 +45,9 @@ fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, b
         .map(|fs| fs.iter().any(|f| f.to_lowercase() == "clip"))
         .unwrap_or(false);
 
-    // Heuristic for known thinking/reasoning model families.
+    // Name-based heuristics for thinking/reasoning models.
+    // Note: `qwen3` matches all Qwen3 variants, including non-thinking ones —
+    // Ollama does not distinguish thinking vs standard mode in `families`.
     let supports_thinking = lower.contains("qwq")
         || lower.contains("deepseek-r1")
         || lower.contains("/r1")
@@ -2354,6 +2359,96 @@ supports_streaming = true
                 model.id
             );
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for infer_capabilities
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod infer_capabilities_tests {
+    use super::infer_capabilities;
+
+    fn families(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn embedding_model_has_no_capabilities() {
+        assert_eq!(
+            infer_capabilities("nomic-embed-text:latest", None),
+            (false, false, false)
+        );
+        assert_eq!(
+            infer_capabilities("bge-embedding:latest", None),
+            (false, false, false)
+        );
+        // embedding check wins even when families contains "clip"
+        assert_eq!(
+            infer_capabilities("clip-embed:latest", Some(&families(&["clip"]))),
+            (false, false, false)
+        );
+    }
+
+    #[test]
+    fn vision_model_detected_via_clip_family() {
+        assert_eq!(
+            infer_capabilities("llava:latest", Some(&families(&["llama", "clip"]))),
+            (true, true, false)
+        );
+        assert_eq!(
+            infer_capabilities("moondream:latest", Some(&families(&["clip"]))),
+            (true, true, false)
+        );
+        // clip family match is case-insensitive
+        assert_eq!(
+            infer_capabilities("llava:7b", Some(&families(&["CLIP"]))),
+            (true, true, false)
+        );
+    }
+
+    #[test]
+    fn plain_chat_model_gets_tools_only() {
+        assert_eq!(
+            infer_capabilities("llama3.2:latest", Some(&families(&["llama"]))),
+            (false, true, false)
+        );
+        assert_eq!(infer_capabilities("mistral:7b", None), (false, true, false));
+    }
+
+    #[test]
+    fn thinking_models_detected_by_name() {
+        assert_eq!(
+            infer_capabilities("deepseek-r1:8b", None),
+            (false, true, true)
+        );
+        assert_eq!(infer_capabilities("qwq:32b", None), (false, true, true));
+        assert_eq!(infer_capabilities("qwen3:8b", None), (false, true, true));
+        assert_eq!(
+            infer_capabilities("marco-o1:latest", None),
+            (false, true, true)
+        );
+        // :r1 tag variant
+        assert_eq!(
+            infer_capabilities("some-model:r1", None),
+            (false, true, true)
+        );
+        // /r1 path variant
+        assert_eq!(
+            infer_capabilities("vendor/r1:latest", None),
+            (false, true, true)
+        );
+    }
+
+    #[test]
+    fn vision_and_thinking_can_combine() {
+        // hypothetical future model that is both vision + thinking
+        let fs = families(&["llama", "clip"]);
+        let (vision, tools, thinking) = infer_capabilities("deepseek-r1-vision:latest", Some(&fs));
+        assert!(vision);
+        assert!(tools);
+        assert!(thinking);
     }
 }
 

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -21,9 +21,13 @@ pub struct DiscoveredModelInfo {
     /// Quantization level (e.g., "Q4_K_M", "Q8_0").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantization_level: Option<String>,
-    /// Model family (e.g., "llama", "gemma").
+    /// Primary model family (e.g., "llama", "gemma").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
+    /// All model families reported by Ollama (e.g., ["llama", "clip"]).
+    /// "clip" indicates a vision-capable model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub families: Option<Vec<String>>,
     /// On-disk size in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
@@ -221,6 +225,15 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
             .filter_map(|m| {
                 let name = m.get("name").and_then(|n| n.as_str())?.to_string();
                 let details = m.get("details");
+                let families = details
+                    .and_then(|d| d.get("families"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|f| f.as_str().map(String::from))
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|v| !v.is_empty());
                 Some(DiscoveredModelInfo {
                     name,
                     parameter_size: details
@@ -235,6 +248,7 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
                         .and_then(|d| d.get("family"))
                         .and_then(|v| v.as_str())
                         .map(String::from),
+                    families,
                     size: m.get("size").and_then(|v| v.as_u64()),
                 })
             })

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -458,6 +458,7 @@ mod tests {
             parameter_size: Some("3.2B".to_string()),
             quantization_level: Some("Q4_K_M".to_string()),
             family: Some("llama".to_string()),
+            families: None,
             size: Some(1_928_000_000),
         };
         let json = serde_json::to_value(&info).unwrap();
@@ -475,6 +476,7 @@ mod tests {
             parameter_size: None,
             quantization_level: None,
             family: None,
+            families: None,
             size: None,
         };
         let json = serde_json::to_value(&info).unwrap();


### PR DESCRIPTION
Fixes #2957.

## Problem

All Ollama-discovered models got hardcoded capabilities:
- `supports_vision = false` — even for LLaVA, BakLLaVA, Moondream
- `supports_tools = true` — even for embedding models like `nomic-embed-text`
- `supports_thinking = false` — even for DeepSeek-R1, QwQ, Qwen3

## Root cause

`merge_discovered_models()` only accepted `&[String]` model IDs with no metadata, so it had no choice but to apply the same defaults to everything. The enriched `DiscoveredModelInfo` (already populated from Ollama's `/api/tags`) was never passed through.

## Fix

1. **Add `families` field to `DiscoveredModelInfo`** — extracted from `details.families` in Ollama's `/api/tags` response (e.g. `["llama", "clip"]`)

2. **Change `merge_discovered_models` signature** to accept `&[DiscoveredModelInfo]` instead of `&[String]`

3. **Add `infer_capabilities()` helper** with these rules:
   - `families` contains `"clip"` → `supports_vision = true` (LLaVA, BakLLaVA, Moondream, …)
   - name contains `"embed"` → embedding model; `supports_tools = false`, `supports_thinking = false`
   - name matches `deepseek-r1`, `qwq`, `qwen3`, `marco-o1` patterns → `supports_thinking = true`
   - everything else → `supports_tools = true`, `supports_vision = false`, `supports_thinking = false`

4. **Kernel call site** builds `DiscoveredModelInfo` stubs for non-Ollama providers that don't populate `discovered_model_info`, so behaviour is unchanged for vLLM/LM Studio.

## Test

Added `test_merge_infers_capabilities_from_ollama_metadata` covering llava (vision), nomic-embed-text (embedding), deepseek-r1 (thinking), and a plain llama model.