### PR TITLE
fix(mcp): include stdio server arg paths in MCP roots capability

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10917,7 +10917,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
-            roots: self.mcp_roots_for_server(server_config),
+            roots: self.mcp_roots_for_server(&server_config),
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -11185,7 +11185,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
-            roots: self.mcp_roots_for_server(server_config),
+            roots: self.mcp_roots_for_server(&server_config),
         };
 
         match McpConnection::connect(mcp_config).await {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -678,6 +678,31 @@ impl LibreFangKernel {
         &self.home_dir_boot
     }
 
+    /// Build the roots list for a specific MCP server config.
+    ///
+    /// Starts with the default roots (workspaces directory) and, for stdio
+    /// servers, appends any absolute-path arguments the user configured.
+    /// This ensures that filesystem-aware MCP servers (e.g.
+    /// `@modelcontextprotocol/server-filesystem`) receive the directories
+    /// explicitly passed in their args — such as `/mnt/obsidian` — rather
+    /// than being silently restricted to the agent workspace.
+    fn mcp_roots_for_server(
+        &self,
+        server_config: &librefang_types::config::McpServerConfigEntry,
+    ) -> Vec<String> {
+        use librefang_types::config::McpTransportEntry;
+        let mut roots = self.default_mcp_roots();
+        if let Some(McpTransportEntry::Stdio { args, .. }) = &server_config.transport {
+            for arg in args {
+                let p = std::path::Path::new(arg.as_str());
+                if p.is_absolute() && !roots.contains(arg) {
+                    roots.push(arg.clone());
+                }
+            }
+        }
+        roots
+    }
+
     /// Build the default list of root directories to advertise to MCP servers
     /// via the MCP Roots capability.
     ///
@@ -789,6 +814,14 @@ impl LibreFangKernel {
                 },
             };
 
+            // Merge agent workspace into server-specific roots.
+            let mut server_roots = self.mcp_roots_for_server(server_config);
+            for r in &roots {
+                if !server_roots.contains(r) {
+                    server_roots.push(r.clone());
+                }
+            }
+
             let mcp_config = McpServerConfig {
                 name: server_config.name.clone(),
                 transport,
@@ -798,7 +831,7 @@ impl LibreFangKernel {
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
-                roots: roots.clone(),
+                roots: server_roots,
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -10736,7 +10769,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
-                roots: self.default_mcp_roots(),
+                roots: self.mcp_roots_for_server(server_config),
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -10884,7 +10917,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
-            roots: self.default_mcp_roots(),
+            roots: self.mcp_roots_for_server(server_config),
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -11007,7 +11040,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
-                roots: self.default_mcp_roots(),
+                roots: self.mcp_roots_for_server(server_config),
             };
 
             self.mcp_health.register(&server_config.name);
@@ -11152,7 +11185,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
-            roots: self.default_mcp_roots(),
+            roots: self.mcp_roots_for_server(server_config),
         };
 
         match McpConnection::connect(mcp_config).await {


### PR DESCRIPTION
Fixes #2949.

## Problem

Users who configure a stdio MCP server with explicit directory arguments — e.g.:

```toml
[[mcp_servers]]
name = "filesystem"
[mcp_servers.transport]
command = "npx"
args = ["-y", "@modelcontextprotocol/server-filesystem", "/mnt/obsidian"]
type = "stdio"
```

get this error at runtime:

```
Access denied - path outside allowed directories:
/mnt/obsidian/CS/logs not in /home/assistent/.librefang/workspaces
```

## Root cause

`build_agent_mcp_pool()` (and the global pool) built the MCP Roots capability list from `default_mcp_roots()` only — which contains the workspaces directory and the agent workspace. The user-configured paths in the server's `args` were never included.

Filesystem-aware MCP servers honour the Roots capability and refuse to access anything outside those roots, so `/mnt/obsidian` was unreachable despite being explicitly configured.

## Fix

Add `mcp_roots_for_server()` helper: starts from `default_mcp_roots()` and appends any absolute-path arguments found in the stdio server's `args`. Use it at all 5 `McpServerConfig` construction sites (per-agent pool + global pool + reconnect paths).

Non-stdio transports and stdio servers with no absolute-path args are unaffected.