### PR TITLE
fix(kernel): per-request session_id override on message send

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4834,6 +4834,7 @@ mod tests {
             thinking: None,
             show_thinking: None,
             group_participants: None,
+            session_id: None,
         };
         assert!(request_sender_context(&req).is_none());
     }
@@ -4852,6 +4853,7 @@ mod tests {
             thinking: None,
             show_thinking: None,
             group_participants: None,
+            session_id: None,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert_eq!(sender.user_id, "u-123");
@@ -4874,6 +4876,7 @@ mod tests {
             thinking: None,
             show_thinking: None,
             group_participants: None,
+            session_id: None,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert!(sender.is_group);
@@ -4904,6 +4907,7 @@ mod tests {
             thinking: None,
             show_thinking: None,
             group_participants: Some(roster.clone()),
+            session_id: None,
         };
         let sender = request_sender_context(&req).expect("sender context");
         assert_eq!(sender.group_participants, roster);

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1282,6 +1282,8 @@ pub async fn send_message(
                 StatusCode::NOT_FOUND
             } else if format!("{e}").contains("quota") || format!("{e}").contains("Quota") {
                 StatusCode::TOO_MANY_REQUESTS
+            } else if format!("{e}").contains("belongs to a different agent") {
+                StatusCode::BAD_REQUEST
             } else {
                 StatusCode::INTERNAL_SERVER_ERROR
             };

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1184,6 +1184,20 @@ pub async fn send_message(
     let thinking_override = req.thinking;
     let show_thinking = req.show_thinking.unwrap_or(true);
 
+    // Parse optional explicit session_id override from the request body.
+    let session_id_override = match req.session_id.as_deref() {
+        None => None,
+        Some(s) => match s.parse::<uuid::Uuid>() {
+            Ok(id) => Some(librefang_types::agent::SessionId(id)),
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "invalid session_id: must be a UUID"})),
+                );
+            }
+        },
+    };
+
     let result = if is_ephemeral {
         // Ephemeral "side question" — use a temp session, no persistence
         state
@@ -1192,29 +1206,18 @@ pub async fn send_message(
             .await
     } else {
         let sender_context = request_sender_context(&req);
-        if let Some(sender) = sender_context.as_ref() {
-            state
-                .kernel
-                .send_message_with_sender_context_and_thinking(
-                    agent_id,
-                    &effective_message,
-                    sender,
-                    thinking_override,
-                )
-                .await
-        } else {
-            let kernel_handle: Arc<dyn KernelHandle> =
-                state.kernel.clone() as Arc<dyn KernelHandle>;
-            state
-                .kernel
-                .send_message_with_thinking_override(
-                    agent_id,
-                    &effective_message,
-                    Some(kernel_handle),
-                    thinking_override,
-                )
-                .await
-        }
+        let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+        state
+            .kernel
+            .send_message_with_session_override(
+                agent_id,
+                &effective_message,
+                Some(kernel_handle),
+                sender_context.as_ref(),
+                thinking_override,
+                session_id_override,
+            )
+            .await
     };
 
     match result {
@@ -1866,10 +1869,30 @@ pub async fn send_message_stream(
         }
     }
 
+    // Parse optional explicit session_id override from the request body.
+    let session_id_override = match req.session_id.as_deref() {
+        None => None,
+        Some(s) => match s.parse::<uuid::Uuid>() {
+            Ok(id) => Some(librefang_types::agent::SessionId(id)),
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "invalid session_id: must be a UUID"})),
+                )
+                    .into_response();
+            }
+        },
+    };
+
     let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
     let (rx, _handle) = match state
         .kernel
-        .send_message_streaming_with_routing(agent_id, &req.message, Some(kernel_handle))
+        .send_message_streaming_with_routing_and_session_override(
+            agent_id,
+            &req.message,
+            Some(kernel_handle),
+            session_id_override,
+        )
         .await
     {
         Ok(pair) => pair,

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -380,7 +380,25 @@ fn attach_probe_result(
     if !probe.discovered_models.is_empty() {
         entry["discovered_models"] = serde_json::json!(&probe.discovered_models);
         if let Ok(mut cat) = catalog.write() {
-            cat.merge_discovered_models(provider_id, &probe.discovered_models);
+            let info: Vec<_> = if probe.discovered_model_info.is_empty() {
+                probe
+                    .discovered_models
+                    .iter()
+                    .map(
+                        |name| librefang_runtime::provider_health::DiscoveredModelInfo {
+                            name: name.clone(),
+                            parameter_size: None,
+                            quantization_level: None,
+                            family: None,
+                            families: None,
+                            size: None,
+                        },
+                    )
+                    .collect()
+            } else {
+                probe.discovered_model_info.clone()
+            };
+            cat.merge_discovered_models(provider_id, &info);
         }
     }
     if !probe.discovered_model_info.is_empty() {
@@ -1398,7 +1416,25 @@ pub async fn set_provider_url(
     // Merge discovered models into catalog
     if !probe.discovered_models.is_empty() {
         if let Ok(mut catalog) = state.kernel.model_catalog_ref().write() {
-            catalog.merge_discovered_models(&name, &probe.discovered_models);
+            let info: Vec<_> = if probe.discovered_model_info.is_empty() {
+                probe
+                    .discovered_models
+                    .iter()
+                    .map(
+                        |n| librefang_runtime::provider_health::DiscoveredModelInfo {
+                            name: n.clone(),
+                            parameter_size: None,
+                            quantization_level: None,
+                            family: None,
+                            families: None,
+                            size: None,
+                        },
+                    )
+                    .collect()
+            } else {
+                probe.discovered_model_info.clone()
+            };
+            catalog.merge_discovered_models(&name, &info);
         }
     }
 

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -218,6 +218,16 @@ pub struct MessageRequest {
     /// `None` defaults to `true` when thinking content is available.
     #[serde(default)]
     pub show_thinking: Option<bool>,
+    /// Optional explicit session ID (UUID string) to use for this message.
+    ///
+    /// When set, overrides the default session resolution (channel-derived or
+    /// registry canonical). Enables multi-tab / multi-session UIs where the
+    /// caller tracks which session each conversation belongs to.
+    ///
+    /// Safety: the server rejects a `session_id` that belongs to a different
+    /// agent with 400 Bad Request.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Response from sending a message.

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -438,6 +438,10 @@ pub struct LibreFangKernel {
     /// session corruption when multiple messages arrive concurrently (e.g. rapid voice
     /// messages via Telegram). Different agents can still run in parallel.
     agent_msg_locks: dashmap::DashMap<AgentId, Arc<tokio::sync::Mutex<()>>>,
+    /// Per-session message locks — used instead of `agent_msg_locks` when a caller
+    /// supplies an explicit `session_id_override`. Allows concurrent messages to
+    /// different sessions of the same agent (multi-tab / multi-session UIs).
+    session_msg_locks: dashmap::DashMap<SessionId, Arc<tokio::sync::Mutex<()>>>,
     /// Per-agent mid-turn message injection senders (#956).
     /// When an agent loop is running, it holds the receiver; callers use the sender
     /// to inject messages between tool calls.
@@ -2661,6 +2665,7 @@ impl LibreFangKernel {
             default_model_override: std::sync::RwLock::new(None),
             tool_policy_override: std::sync::RwLock::new(None),
             agent_msg_locks: dashmap::DashMap::new(),
+            session_msg_locks: dashmap::DashMap::new(),
             injection_senders: dashmap::DashMap::new(),
             injection_receivers: dashmap::DashMap::new(),
             assistant_routes: dashmap::DashMap::new(),
@@ -3570,8 +3575,17 @@ system_prompt = "You are a helpful assistant."
             .get()
             .and_then(|w| w.upgrade())
             .map(|arc| arc as Arc<dyn KernelHandle>);
-        self.send_message_full(agent_id, message, handle, None, Some(sender), None, None)
-            .await
+        self.send_message_full(
+            agent_id,
+            message,
+            handle,
+            None,
+            Some(sender),
+            None,
+            None,
+            None,
+        )
+        .await
     }
 
     /// Send a message with both sender identity context and a per-call
@@ -3600,6 +3614,7 @@ system_prompt = "You are a helpful assistant."
             Some(sender),
             None,
             thinking_override,
+            None,
         )
         .await
     }
@@ -3625,6 +3640,7 @@ system_prompt = "You are a helpful assistant."
             Some(sender),
             None,
             None,
+            None,
         )
         .await
     }
@@ -3636,8 +3652,17 @@ system_prompt = "You are a helpful assistant."
         message: &str,
         kernel_handle: Option<Arc<dyn KernelHandle>>,
     ) -> KernelResult<AgentLoopResult> {
-        self.send_message_full(agent_id, message, kernel_handle, None, None, None, None)
-            .await
+        self.send_message_full(
+            agent_id,
+            message,
+            kernel_handle,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
     }
 
     /// Send a message with a per-call deep-thinking override.
@@ -3661,6 +3686,37 @@ system_prompt = "You are a helpful assistant."
             None,
             None,
             thinking_override,
+            None,
+        )
+        .await
+    }
+
+    /// Send a message with an explicit session ID override, optional sender context,
+    /// and optional deep-thinking override.
+    ///
+    /// Used by the HTTP `/message` endpoint when the caller supplies a `session_id`
+    /// in the request body (multi-tab / multi-session UIs). Resolution order:
+    /// explicit session_id > channel-derived > registry canonical.
+    ///
+    /// Returns 400 if `session_id_override` belongs to a different agent.
+    pub async fn send_message_with_session_override(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn KernelHandle>>,
+        sender_context: Option<&SenderContext>,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+    ) -> KernelResult<AgentLoopResult> {
+        self.send_message_full(
+            agent_id,
+            message,
+            kernel_handle,
+            None,
+            sender_context,
+            None,
+            thinking_override,
+            session_id_override,
         )
         .await
     }
@@ -3686,6 +3742,7 @@ system_prompt = "You are a helpful assistant."
             message,
             kernel_handle,
             content_blocks,
+            None,
             None,
             None,
             None,
@@ -3723,6 +3780,7 @@ system_prompt = "You are a helpful assistant."
             None,
             home_channel.as_ref(),
             session_mode_override,
+            None,
             None,
         )
         .await
@@ -4071,6 +4129,7 @@ system_prompt = "You are a helpful assistant."
         sender_context: Option<&SenderContext>,
         session_mode_override: Option<librefang_types::agent::SessionMode>,
         thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
     ) -> KernelResult<AgentLoopResult> {
         // Acquire a shared read lock on the config reload barrier.
         // This is non-blocking under normal operation (many readers proceed in
@@ -4082,15 +4141,22 @@ system_prompt = "You are a helpful assistant."
             .resolve_assistant_target(agent_id, message, sender_context)
             .await?;
 
-        // Acquire per-agent lock to serialize concurrent messages for the same agent.
-        // This prevents session corruption when multiple messages arrive in quick
-        // succession (e.g. rapid voice messages via Telegram). Messages for different
-        // agents are not blocked — each agent has its own independent lock.
-        let lock = self
-            .agent_msg_locks
-            .entry(agent_id)
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone();
+        // When the caller supplies an explicit session_id, scope the lock to that
+        // session so concurrent messages to *different* sessions of the same agent
+        // are not serialized against each other (multi-tab / multi-session UIs).
+        // Without an override, fall back to the per-agent lock to preserve the
+        // existing serialization guarantee for single-session agents.
+        let lock = if let Some(sid) = session_id_override {
+            self.session_msg_locks
+                .entry(sid)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        } else {
+            self.agent_msg_locks
+                .entry(agent_id)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
         let _guard = lock.lock().await;
 
         // Enforce quota on the effective target agent (after routing)
@@ -4128,6 +4194,7 @@ system_prompt = "You are a helpful assistant."
                     sender_context,
                     session_mode_override,
                     thinking_override,
+                    session_id_override,
                 )
                 .await
             }
@@ -4480,8 +4547,33 @@ system_prompt = "You are a helpful assistant."
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
     )> {
-        self.send_message_streaming_resolved(agent_id, message, kernel_handle, None, None)
+        self.send_message_streaming_resolved(agent_id, message, kernel_handle, None, None, None)
             .await
+    }
+
+    /// Streaming variant with an explicit session ID override.
+    ///
+    /// Used by the HTTP `/message/stream` endpoint when the caller supplies a
+    /// `session_id` in the request body (multi-tab / multi-session UIs).
+    pub async fn send_message_streaming_with_routing_and_session_override(
+        self: &Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn KernelHandle>>,
+        session_id_override: Option<SessionId>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
+    )> {
+        self.send_message_streaming_resolved(
+            agent_id,
+            message,
+            kernel_handle,
+            None,
+            None,
+            session_id_override,
+        )
+        .await
     }
 
     /// Sender-aware streaming entry point for channel bridges.
@@ -4495,8 +4587,15 @@ system_prompt = "You are a helpful assistant."
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
     )> {
-        self.send_message_streaming_resolved(agent_id, message, kernel_handle, Some(sender), None)
-            .await
+        self.send_message_streaming_resolved(
+            agent_id,
+            message,
+            kernel_handle,
+            Some(sender),
+            None,
+            None,
+        )
+        .await
     }
 
     /// Streaming entry point with per-call deep-thinking override.
@@ -4520,6 +4619,7 @@ system_prompt = "You are a helpful assistant."
             kernel_handle,
             Some(sender),
             thinking_override,
+            None,
         )
         .await
     }
@@ -4606,6 +4706,7 @@ system_prompt = "You are a helpful assistant."
             None, // auto-wire self
             None, // no sender context — fork uses the canonical session
             None, // no thinking override
+            None, // forks always use canonical session
             loop_opts,
         )
     }
@@ -4617,6 +4718,28 @@ system_prompt = "You are a helpful assistant."
         kernel_handle: Option<Arc<dyn KernelHandle>>,
         sender_context: Option<&SenderContext>,
         thinking_override: Option<bool>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
+    )> {
+        self.send_message_streaming_with_sender_and_session(
+            agent_id,
+            message,
+            kernel_handle,
+            sender_context,
+            thinking_override,
+            None,
+        )
+    }
+
+    fn send_message_streaming_with_sender_and_session(
+        self: &Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn KernelHandle>>,
+        sender_context: Option<&SenderContext>,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
     ) -> KernelResult<(
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
@@ -4637,6 +4760,7 @@ system_prompt = "You are a helpful assistant."
             kernel_handle,
             sender_context,
             thinking_override,
+            session_id_override,
             loop_opts,
         )
     }
@@ -4655,6 +4779,7 @@ system_prompt = "You are a helpful assistant."
         kernel_handle: Option<Arc<dyn KernelHandle>>,
         sender_context: Option<&SenderContext>,
         thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
         loop_opts: librefang_runtime::agent_loop::LoopOptions,
     ) -> KernelResult<(
         tokio::sync::mpsc::Receiver<StreamEvent>,
@@ -4741,35 +4866,47 @@ system_prompt = "You are a helpful assistant."
         }
 
         // LLM agent: true streaming via agent loop
-        // Derive session ID: channel-specific sessions are deterministic per
-        // (channel, chat_id). Including chat_id prevents context bleed between
-        // a group and a DM that share the same (agent, channel). For non-channel
-        // invocations, respect the agent's session_mode.
-        //
-        // `use_canonical_session` short-circuits the channel branch: the sender
-        // wants routing-cache scoping (per-channel assistant auto-router) but
-        // storage to land in `entry.session_id`. Used by the dashboard WS so
-        // webui chat shares history with agent_send / session management.
-        let effective_session_id = match sender_context {
-            Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-                let scope = match &ctx.chat_id {
-                    Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
-                    _ => ctx.channel.clone(),
-                };
-                SessionId::for_channel(agent_id, &scope)
+        // Session resolution order (highest priority first):
+        // 1. Explicit override from the HTTP caller (multi-tab / multi-session UIs).
+        //    Safety check: existing session must belong to this agent.
+        // 2. Channel-derived deterministic ID: `SessionId::for_channel(agent, scope)`.
+        // 3. Fork: always canonical to preserve prompt-cache alignment.
+        // 4. Session-mode fallback: Persistent = entry.session_id, New = fresh UUID.
+        let effective_session_id = if let Some(sid) = session_id_override {
+            if let Some(existing) = self
+                .memory
+                .get_session(sid)
+                .map_err(KernelError::LibreFang)?
+            {
+                if existing.agent_id != agent_id {
+                    return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                        format!("session {} belongs to a different agent", sid),
+                    )));
+                }
             }
-            // Fork calls always target the agent's canonical session —
-            // the whole point of fork mode is to share the parent turn's
-            // context (and therefore its prompt-cache prefix). An agent
-            // with `session_mode = "new"` would otherwise land on
-            // `SessionId::new()` here, producing a fresh empty session
-            // and breaking cache alignment. Force Persistent for forks
-            // regardless of manifest.
-            _ if loop_opts.is_fork => entry.session_id,
-            _ => match entry.manifest.session_mode {
-                librefang_types::agent::SessionMode::Persistent => entry.session_id,
-                librefang_types::agent::SessionMode::New => SessionId::new(),
-            },
+            sid
+        } else {
+            match sender_context {
+                Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
+                    let scope = match &ctx.chat_id {
+                        Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
+                        _ => ctx.channel.clone(),
+                    };
+                    SessionId::for_channel(agent_id, &scope)
+                }
+                // Fork calls always target the agent's canonical session —
+                // the whole point of fork mode is to share the parent turn's
+                // context (and therefore its prompt-cache prefix). An agent
+                // with `session_mode = "new"` would otherwise land on
+                // `SessionId::new()` here, producing a fresh empty session
+                // and breaking cache alignment. Force Persistent for forks
+                // regardless of manifest.
+                _ if loop_opts.is_fork => entry.session_id,
+                _ => match entry.manifest.session_mode {
+                    librefang_types::agent::SessionMode::Persistent => entry.session_id,
+                    librefang_types::agent::SessionMode::New => SessionId::new(),
+                },
+            }
         };
 
         let mut session = self
@@ -5684,6 +5821,7 @@ system_prompt = "You are a helpful assistant."
         kernel_handle: Option<Arc<dyn KernelHandle>>,
         sender_context: Option<&SenderContext>,
         thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
     ) -> KernelResult<(
         tokio::sync::mpsc::Receiver<StreamEvent>,
         tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
@@ -5691,12 +5829,13 @@ system_prompt = "You are a helpful assistant."
         let effective_id = self
             .resolve_assistant_target(agent_id, message, sender_context)
             .await?;
-        self.send_message_streaming_with_sender(
+        self.send_message_streaming_with_sender_and_session(
             effective_id,
             message,
             kernel_handle,
             sender_context,
             thinking_override,
+            session_id_override,
         )
     }
 
@@ -6022,6 +6161,7 @@ system_prompt = "You are a helpful assistant."
         sender_context: Option<&SenderContext>,
         session_mode_override: Option<librefang_types::agent::SessionMode>,
         thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
     ) -> KernelResult<AgentLoopResult> {
         let cfg = self.config.load_full();
         // Check metering quota before starting
@@ -6029,28 +6169,45 @@ system_prompt = "You are a helpful assistant."
             .check_quota(agent_id, &entry.manifest.resources)
             .map_err(KernelError::LibreFang)?;
 
-        // Derive session ID: channel-specific sessions are deterministic per
-        // (channel, chat_id). Including chat_id prevents context bleed between
-        // a group and a DM that share the same (agent, channel). For non-channel
-        // invocations (background ticks, triggers, agent_send), resolve the
-        // effective session mode: per-trigger override > agent manifest default.
+        // Derive session ID. Resolution order (highest priority first):
         //
-        // `use_canonical_session` short-circuits the channel branch so the
-        // dashboard WS (channel="webui") persists to `entry.session_id` while
-        // still scoping routing caches per-surface.
-        let effective_session_id = match sender_context {
-            Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-                let scope = match &ctx.chat_id {
-                    Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
-                    _ => ctx.channel.clone(),
-                };
-                SessionId::for_channel(agent_id, &scope)
+        // 1. Explicit override from the HTTP caller (multi-tab / multi-session UIs).
+        //    Safety check: if the session exists and belongs to a different agent,
+        //    reject with an error so sessions can never bleed across agents.
+        // 2. Channel-derived deterministic ID: `SessionId::for_channel(agent, scope)`
+        //    where scope = "<channel>:<chat_id>" (or just "<channel>"). Prevents
+        //    context bleed between group and DM on the same (agent, channel).
+        // 3. Session-mode fallback: per-trigger override > agent manifest default.
+        //    `use_canonical_session` forces Persistent so the dashboard WS always
+        //    persists to `entry.session_id`.
+        let effective_session_id = if let Some(sid) = session_id_override {
+            if let Some(existing) = self
+                .memory
+                .get_session(sid)
+                .map_err(KernelError::LibreFang)?
+            {
+                if existing.agent_id != agent_id {
+                    return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                        format!("session {} belongs to a different agent", sid),
+                    )));
+                }
             }
-            _ => {
-                let mode = session_mode_override.unwrap_or(entry.manifest.session_mode);
-                match mode {
-                    librefang_types::agent::SessionMode::Persistent => entry.session_id,
-                    librefang_types::agent::SessionMode::New => SessionId::new(),
+            sid
+        } else {
+            match sender_context {
+                Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
+                    let scope = match &ctx.chat_id {
+                        Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
+                        _ => ctx.channel.clone(),
+                    };
+                    SessionId::for_channel(agent_id, &scope)
+                }
+                _ => {
+                    let mode = session_mode_override.unwrap_or(entry.manifest.session_mode);
+                    match mode {
+                        librefang_types::agent::SessionMode::Persistent => entry.session_id,
+                        librefang_types::agent::SessionMode::New => SessionId::new(),
+                    }
                 }
             }
         };
@@ -10115,6 +10272,7 @@ system_prompt = "You are a helpful assistant."
                                         None,
                                         sender_ctx,
                                         mode_override,
+                                        None,
                                         None,
                                     ),
                                 )


### PR DESCRIPTION
## Summary

- Adds optional `session_id` field to `POST /api/agents/{id}/message` and `/message/stream` request bodies
- When supplied, the message is routed to the specified session (UUID) instead of the agent's default
- Enables multi-tab / multi-session UIs where the caller tracks which session each conversation belongs to

**Resolution order** (highest priority first):
1. Explicit `session_id` from the HTTP caller
2. Channel-derived deterministic ID (`SessionId::for_channel`)
3. Session-mode fallback (Persistent / New per agent manifest)

**Safety**: rejects a `session_id` belonging to a different agent with `400 Bad Request`

**Lock scoping**: per-session `session_msg_locks` DashMap used instead of per-agent lock when override is set, so concurrent messages to *different* sessions of the same agent no longer serialize against each other

## Test plan

- [ ] `POST /api/agents/{id}/message` with no `session_id` → behaves identically to before
- [ ] `POST /api/agents/{id}/message` with a valid `session_id` UUID → message lands in that session
- [ ] `POST /api/agents/{id}/message` with a `session_id` belonging to a different agent → `400 Bad Request`
- [ ] `POST /api/agents/{id}/message` with a malformed `session_id` (not a UUID) → `400 Bad Request`
- [ ] `POST /api/agents/{id}/message/stream` with `session_id` → same session routing
- [ ] Two concurrent requests with different `session_id` overrides → processed in parallel, no deadlock

Closes #2959