### PR TITLE
feat(config): per-tool timeout overrides via [tool_timeouts]

### DIFF
--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -487,6 +487,18 @@ pub trait KernelHandle: Send + Sync {
         120
     }
 
+    /// Per-tool timeout override lookup.
+    ///
+    /// Resolution order:
+    /// 1. Exact match in `config.tool_timeouts`
+    /// 2. First glob match in `config.tool_timeouts`
+    /// 3. Global `config.tool_timeout_secs`
+    ///
+    /// The default impl delegates to `tool_timeout_secs()` (no per-tool config).
+    fn tool_timeout_secs_for(&self, _tool_name: &str) -> u64 {
+        self.tool_timeout_secs()
+    }
+
     /// Maximum inter-agent call depth (from config). Default: 5.
     fn max_agent_call_depth(&self) -> u32 {
         5

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -491,7 +491,7 @@ pub trait KernelHandle: Send + Sync {
     ///
     /// Resolution order:
     /// 1. Exact match in `config.tool_timeouts`
-    /// 2. First glob match in `config.tool_timeouts`
+    /// 2. Longest glob match in `config.tool_timeouts` (most specific wins)
     /// 3. Global `config.tool_timeout_secs`
     ///
     /// The default impl delegates to `tool_timeout_secs()` (no per-tool config).

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -14533,6 +14533,23 @@ impl KernelHandle for LibreFangKernel {
         cfg.tool_timeout_secs
     }
 
+    fn tool_timeout_secs_for(&self, tool_name: &str) -> u64 {
+        let cfg = self.config.load();
+        // 1. Exact match
+        if let Some(&t) = cfg.tool_timeouts.get(tool_name) {
+            return t;
+        }
+        // 2. First glob match (HashMap iteration order is unspecified, but
+        //    glob keys should not overlap in a well-formed config).
+        for (pattern, &timeout) in &cfg.tool_timeouts {
+            if librefang_types::capability::glob_matches(pattern, tool_name) {
+                return timeout;
+            }
+        }
+        // 3. Global fallback
+        cfg.tool_timeout_secs
+    }
+
     fn max_agent_call_depth(&self) -> u32 {
         let cfg = self.config.load();
         cfg.max_agent_call_depth

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -14539,12 +14539,16 @@ impl KernelHandle for LibreFangKernel {
         if let Some(&t) = cfg.tool_timeouts.get(tool_name) {
             return t;
         }
-        // 2. First glob match (HashMap iteration order is unspecified, but
-        //    glob keys should not overlap in a well-formed config).
-        for (pattern, &timeout) in &cfg.tool_timeouts {
-            if librefang_types::capability::glob_matches(pattern, tool_name) {
-                return timeout;
-            }
+        // 2. Best glob match — longest pattern wins (most specific first).
+        // HashMap iteration is unordered; picking the longest matching pattern
+        // gives deterministic resolution when multiple globs match.
+        let best = cfg
+            .tool_timeouts
+            .iter()
+            .filter(|(pattern, _)| librefang_types::capability::glob_matches(pattern, tool_name))
+            .max_by_key(|(pattern, _)| pattern.len());
+        if let Some((_, &timeout)) = best {
+            return timeout;
         }
         // 3. Global fallback
         cfg.tool_timeout_secs

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -745,10 +745,9 @@ async fn execute_single_tool_call(
     }
 
     let effective_exec_policy = ctx.manifest.exec_policy.as_ref();
-    let tool_timeout = ctx
-        .kernel
-        .as_ref()
-        .map_or(TOOL_TIMEOUT_SECS, |k| k.tool_timeout_secs());
+    let tool_timeout = ctx.kernel.as_ref().map_or(TOOL_TIMEOUT_SECS, |k| {
+        k.tool_timeout_secs_for(&tool_call.name)
+    });
     let trace_start = Instant::now();
     let trace_timestamp = chrono::Utc::now();
     let result = match tokio::time::timeout(

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -359,4 +359,40 @@ mod tests {
         assert!(glob_matches("mcp_*", "mcp_myserver_mytool"));
         assert!(!glob_matches("mcp_*", "file_read"));
     }
+
+    // Verifies the resolution strategy used in tool_timeout_secs_for:
+    // when multiple glob patterns match, longest pattern (most specific) wins.
+    #[test]
+    fn test_glob_tool_timeout_resolution_longest_wins() {
+        // "mcp_browser_*" (14 chars) must beat "mcp_*" (5 chars)
+        let patterns: &[(&str, u64)] = &[("mcp_*", 300), ("mcp_browser_*", 900)];
+        let tool = "mcp_browser_navigate";
+        let best = patterns
+            .iter()
+            .filter(|(p, _)| glob_matches(p, tool))
+            .max_by_key(|(p, _)| p.len());
+        assert_eq!(best.map(|(_, t)| *t), Some(900));
+    }
+
+    #[test]
+    fn test_glob_tool_timeout_resolution_star_loses_to_specific() {
+        let patterns: &[(&str, u64)] = &[("*", 60), ("shell_*", 300)];
+        let tool = "shell_exec";
+        let best = patterns
+            .iter()
+            .filter(|(p, _)| glob_matches(p, tool))
+            .max_by_key(|(p, _)| p.len());
+        assert_eq!(best.map(|(_, t)| *t), Some(300));
+    }
+
+    #[test]
+    fn test_glob_tool_timeout_resolution_no_match_returns_none() {
+        let patterns: &[(&str, u64)] = &[("mcp_*", 900), ("shell_*", 300)];
+        let tool = "file_read";
+        let best = patterns
+            .iter()
+            .filter(|(p, _)| glob_matches(p, tool))
+            .max_by_key(|(p, _)| p.len());
+        assert!(best.is_none());
+    }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2244,6 +2244,20 @@ pub struct KernelConfig {
     /// Increase for browser automation or long-running builds.
     #[serde(default = "default_tool_timeout_secs")]
     pub tool_timeout_secs: u64,
+    /// Per-tool timeout overrides. Exact key matches take priority over glob
+    /// patterns; among globs, iteration order is unspecified (TOML tables are
+    /// unordered). Falls back to `tool_timeout_secs` when no entry matches.
+    ///
+    /// Example:
+    /// ```toml
+    /// [tool_timeouts]
+    /// agent_send    = 600
+    /// agent_spawn   = 600
+    /// "mcp_browser_*" = 900
+    /// shell_exec    = 300
+    /// ```
+    #[serde(default)]
+    pub tool_timeouts: std::collections::HashMap<String, u64>,
     /// Maximum upload size in bytes (default: 10 MB).
     /// Enterprise deployments may need larger file uploads.
     #[serde(default = "default_max_upload_size_bytes")]
@@ -3834,6 +3848,7 @@ impl Default for KernelConfig {
             update_channel: UpdateChannel::default(),
             rate_limit: RateLimitConfig::default(),
             tool_timeout_secs: default_tool_timeout_secs(),
+            tool_timeouts: std::collections::HashMap::new(),
             max_upload_size_bytes: default_max_upload_size_bytes(),
             max_concurrent_bg_llm: default_max_concurrent_bg_llm(),
             max_agent_call_depth: default_max_agent_call_depth(),

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2245,8 +2245,8 @@ pub struct KernelConfig {
     #[serde(default = "default_tool_timeout_secs")]
     pub tool_timeout_secs: u64,
     /// Per-tool timeout overrides. Exact key matches take priority over glob
-    /// patterns; among globs, iteration order is unspecified (TOML tables are
-    /// unordered). Falls back to `tool_timeout_secs` when no entry matches.
+    /// patterns; among globs, the longest matching pattern wins (most specific
+    /// first). Falls back to `tool_timeout_secs` when no entry matches.
     ///
     /// Example:
     /// ```toml

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -89,6 +89,7 @@ impl KernelConfig {
             "registry",
             "rate_limit",
             "tool_timeout_secs",
+            "tool_timeouts",
             "max_upload_size_bytes",
             "max_concurrent_bg_llm",
             "max_agent_call_depth",


### PR DESCRIPTION
## Summary

- Adds `tool_timeouts: HashMap<String, u64>` to `KernelConfig`
- Adds `KernelHandle::tool_timeout_secs_for(tool_name)` to the trait; default impl delegates to existing `tool_timeout_secs()`
- Kernel implements full resolution; `agent_loop.rs` updated to use `tool_timeout_secs_for(&tool_call.name)` at the single timeout site
- Adds `"tool_timeouts"` to the config key allowlist (validation)

**Resolution order** for tool `T`:
1. Exact key match in `[tool_timeouts]`
2. First glob match via `glob_matches` (same function used for capability checks)
3. Global `tool_timeout_secs` fallback (no breaking change)

**Example config:**
```toml
tool_timeout_secs = 120       # unchanged global fallback

[tool_timeouts]
agent_send    = 600
agent_spawn   = 600
"mcp_browser_*" = 900
shell_exec    = 300
```

## Test plan

- [ ] Config with no `[tool_timeouts]` → all tools get `tool_timeout_secs`
- [ ] Exact key match (`agent_send = 600`) → `agent_send` gets 600s
- [ ] Glob match (`"mcp_browser_*" = 900`) → `mcp_browser_navigate` gets 900s
- [ ] Non-matching tool → falls back to global `tool_timeout_secs`
- [ ] Exact key beats glob when both would match

Closes #2941