### PR TITLE
feat(browser): attach to remote CDP endpoint instead of spawning Chromium

### DIFF
--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -355,33 +355,36 @@ impl BrowserSession {
     /// Attach to an existing browser via a remote CDP endpoint.
     ///
     /// `endpoint` may be:
-    /// - `ws://host:port/devtools/browser/<id>` — connect directly
-    /// - `ws://host:port` — discover a page via `/json/list`
-    /// - `http://host:port` — discover the browser WS via `/json/version`,
-    ///   then find a page via `/json/list`
+    /// - `ws://host:port/devtools/browser/<id>` — create a new tab via `Target.createTarget`
+    /// - `ws://host:port/devtools/page/<id>` — use the given page directly
+    /// - `ws://host:port` — discover browser WS via `/json/version`, then create a new tab
+    /// - `http://host:port` — discover browser WS via `/json/version`, then create a new tab
     ///
-    /// A new blank tab is created so each agent session gets its own isolated
-    /// browsing context. The browser process is never killed on drop.
+    /// A new blank tab is created (except for explicit page URLs) so each agent
+    /// session gets its own isolated browsing context. The browser process is
+    /// never killed on drop.
     async fn attach(endpoint: &str) -> Result<Self, String> {
         info!(endpoint, "Attaching to remote CDP endpoint");
 
         // Resolve the page WebSocket URL from the given endpoint.
         let page_ws = if endpoint.starts_with("ws://") || endpoint.starts_with("wss://") {
-            // Already a WS URL — try it directly first; if it looks like a
-            // browser-level URL (no `/devtools/page/`) try /json/list instead.
-            if endpoint.contains("/devtools/page/") || endpoint.contains("/devtools/browser/") {
-                // Fully qualified page or browser WS — use it as-is, but we
-                // still need a page target. Open a new tab via Target.createTarget.
+            if endpoint.contains("/devtools/page/") {
+                // Already a specific page WS URL — use it directly.
+                endpoint.to_string()
+            } else if endpoint.contains("/devtools/browser/") {
+                // Browser-level WS — create a new isolated tab.
                 Self::attach_via_browser_ws(endpoint).await?
             } else {
-                // Bare ws://host:port — derive HTTP base and use /json/list.
+                // Bare ws://host:port — discover browser WS via /json/version
+                // then create a new tab so each agent gets its own context.
                 let http_base = endpoint
                     .replacen("wss://", "https://", 1)
                     .replacen("ws://", "http://", 1)
                     .trim_end_matches('/')
                     .to_string();
-                let list_url = format!("{http_base}/json/list");
-                Self::find_page_ws(&list_url).await?
+                let version_url = format!("{http_base}/json/version");
+                let browser_ws = Self::fetch_browser_ws(&version_url).await?;
+                Self::attach_via_browser_ws(&browser_ws).await?
             }
         } else {
             // http:// or https:// — discover browser WS via /json/version first.

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -225,7 +225,9 @@ impl Drop for CdpConnection {
 
 /// A live browser session: one Chromium process + one CDP connection per agent.
 struct BrowserSession {
-    process: tokio::process::Child,
+    /// Local Chromium child process. `None` when in attach mode (externally
+    /// managed browser) — we never kill a browser we didn't start.
+    process: Option<tokio::process::Child>,
     cdp: CdpConnection,
     #[allow(dead_code)]
     last_active: Instant,
@@ -344,10 +346,107 @@ impl BrowserSession {
         let _ = cdp.send("Runtime.enable", serde_json::json!({})).await;
 
         Ok(Self {
-            process: child,
+            process: Some(child),
             cdp,
             last_active: Instant::now(),
         })
+    }
+
+    /// Attach to an existing browser via a remote CDP endpoint.
+    ///
+    /// `endpoint` may be:
+    /// - `ws://host:port/devtools/browser/<id>` — connect directly
+    /// - `ws://host:port` — discover a page via `/json/list`
+    /// - `http://host:port` — discover the browser WS via `/json/version`,
+    ///   then find a page via `/json/list`
+    ///
+    /// A new blank tab is created so each agent session gets its own isolated
+    /// browsing context. The browser process is never killed on drop.
+    async fn attach(endpoint: &str) -> Result<Self, String> {
+        info!(endpoint, "Attaching to remote CDP endpoint");
+
+        // Resolve the page WebSocket URL from the given endpoint.
+        let page_ws = if endpoint.starts_with("ws://") || endpoint.starts_with("wss://") {
+            // Already a WS URL — try it directly first; if it looks like a
+            // browser-level URL (no `/devtools/page/`) try /json/list instead.
+            if endpoint.contains("/devtools/page/") || endpoint.contains("/devtools/browser/") {
+                // Fully qualified page or browser WS — use it as-is, but we
+                // still need a page target. Open a new tab via Target.createTarget.
+                Self::attach_via_browser_ws(endpoint).await?
+            } else {
+                // Bare ws://host:port — derive HTTP base and use /json/list.
+                let http_base = endpoint
+                    .replacen("wss://", "https://", 1)
+                    .replacen("ws://", "http://", 1)
+                    .trim_end_matches('/')
+                    .to_string();
+                let list_url = format!("{http_base}/json/list");
+                Self::find_page_ws(&list_url).await?
+            }
+        } else {
+            // http:// or https:// — discover browser WS via /json/version first.
+            let base = endpoint.trim_end_matches('/');
+            let version_url = format!("{base}/json/version");
+            let browser_ws = Self::fetch_browser_ws(&version_url).await?;
+            Self::attach_via_browser_ws(&browser_ws).await?
+        };
+
+        debug!(page_ws = %page_ws, "Connecting to remote page");
+        let cdp = CdpConnection::connect(&page_ws).await?;
+
+        let _ = cdp.send("Page.enable", serde_json::json!({})).await;
+        let _ = cdp.send("Runtime.enable", serde_json::json!({})).await;
+
+        Ok(Self {
+            process: None, // externally managed — never kill
+            cdp,
+            last_active: Instant::now(),
+        })
+    }
+
+    /// Fetch `/json/version` and return the `webSocketDebuggerUrl`.
+    async fn fetch_browser_ws(version_url: &str) -> Result<String, String> {
+        let resp = crate::http_client::new_client()
+            .get(version_url)
+            .send()
+            .await
+            .map_err(|e| format!("Cannot reach CDP endpoint {version_url}: {e}"))?;
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Invalid JSON from {version_url}: {e}"))?;
+        json["webSocketDebuggerUrl"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                format!("No webSocketDebuggerUrl in response from {version_url}. Is CDP enabled?")
+            })
+    }
+
+    /// Open a new blank tab via `Target.createTarget` on the browser WS,
+    /// then return its page WS URL.
+    async fn attach_via_browser_ws(browser_ws: &str) -> Result<String, String> {
+        let browser_cdp = CdpConnection::connect(browser_ws)
+            .await
+            .map_err(|e| format!("Cannot connect to browser WS {browser_ws}: {e}"))?;
+
+        let result = browser_cdp
+            .send(
+                "Target.createTarget",
+                serde_json::json!({"url": "about:blank"}),
+            )
+            .await
+            .map_err(|e| format!("Target.createTarget failed: {e}"))?;
+
+        let target_id = result["result"]["targetId"]
+            .as_str()
+            .ok_or("No targetId in Target.createTarget response")?
+            .to_string();
+
+        // Derive the page WS URL from the browser WS by replacing
+        // `/devtools/browser/<id>` with `/devtools/page/<targetId>`.
+        let base = browser_ws.split("/devtools/").next().unwrap_or(browser_ws);
+        Ok(format!("{base}/devtools/page/{target_id}"))
     }
 
     /// Read stderr until we find "DevTools listening on ws://...".
@@ -685,7 +784,12 @@ impl BrowserSession {
 
 impl Drop for BrowserSession {
     fn drop(&mut self) {
-        let _ = self.process.start_kill();
+        // Only kill the browser if we spawned it. In attach mode the browser
+        // lifecycle belongs to the operator; we just close our tab (done via
+        // BrowserCommand::Close before drop in normal flows).
+        if let Some(ref mut child) = self.process {
+            let _ = child.start_kill();
+        }
     }
 }
 
@@ -880,10 +984,19 @@ impl BrowserManager {
             ));
         }
 
-        let session = BrowserSession::launch(&self.config).await?;
+        let session = if let Some(ref endpoint) = self.config.cdp_endpoint {
+            BrowserSession::attach(endpoint).await?
+        } else {
+            BrowserSession::launch(&self.config).await?
+        };
         let arc = Arc::new(Mutex::new(session));
         self.sessions.insert(agent_id.to_string(), Arc::clone(&arc));
-        info!(agent_id, "Browser session created (native CDP)");
+        let mode = if self.config.cdp_endpoint.is_some() {
+            "attached"
+        } else {
+            "launched"
+        };
+        info!(agent_id, mode, "Browser session created (native CDP)");
         Ok(arc)
     }
 }

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -357,34 +357,32 @@ impl BrowserSession {
     /// `endpoint` may be:
     /// - `ws://host:port/devtools/browser/<id>` — create a new tab via `Target.createTarget`
     /// - `ws://host:port/devtools/page/<id>` — use the given page directly
-    /// - `ws://host:port` — discover browser WS via `/json/version`, then create a new tab
-    /// - `http://host:port` — discover browser WS via `/json/version`, then create a new tab
+    /// - `ws://host:port` — discover a page via `/json/list`
+    /// - `http://host:port` — discover the browser WS via `/json/version`,
+    ///   then create a new tab via `Target.createTarget`
     ///
-    /// A new blank tab is created (except for explicit page URLs) so each agent
-    /// session gets its own isolated browsing context. The browser process is
-    /// never killed on drop.
+    /// A new blank tab is created so each agent session gets its own isolated
+    /// browsing context. The browser process is never killed on drop.
     async fn attach(endpoint: &str) -> Result<Self, String> {
         info!(endpoint, "Attaching to remote CDP endpoint");
 
         // Resolve the page WebSocket URL from the given endpoint.
         let page_ws = if endpoint.starts_with("ws://") || endpoint.starts_with("wss://") {
             if endpoint.contains("/devtools/page/") {
-                // Already a specific page WS URL — use it directly.
+                // Specific page WS URL — use it directly.
                 endpoint.to_string()
             } else if endpoint.contains("/devtools/browser/") {
                 // Browser-level WS — create a new isolated tab.
                 Self::attach_via_browser_ws(endpoint).await?
             } else {
-                // Bare ws://host:port — discover browser WS via /json/version
-                // then create a new tab so each agent gets its own context.
+                // Bare ws://host:port — derive HTTP base and use /json/list.
                 let http_base = endpoint
                     .replacen("wss://", "https://", 1)
                     .replacen("ws://", "http://", 1)
                     .trim_end_matches('/')
                     .to_string();
-                let version_url = format!("{http_base}/json/version");
-                let browser_ws = Self::fetch_browser_ws(&version_url).await?;
-                Self::attach_via_browser_ws(&browser_ws).await?
+                let list_url = format!("{http_base}/json/list");
+                Self::find_page_ws(&list_url).await?
             }
         } else {
             // http:// or https:// — discover browser WS via /json/version first.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -531,6 +531,21 @@ pub struct BrowserConfig {
     pub max_sessions: usize,
     /// Path to Chromium/Chrome binary. Auto-detected if None.
     pub chromium_path: Option<String>,
+    /// Remote CDP endpoint URL. When set, librefang attaches to an
+    /// already-running browser instead of spawning a local Chromium process.
+    ///
+    /// Accepts either a WebSocket URL (`ws://host:9222`) or an HTTP URL
+    /// (`http://host:9222`) from which the browser WebSocket URL is discovered
+    /// via `/json/version`.
+    ///
+    /// **Security**: CDP provides full browser control and is unauthenticated.
+    /// Never expose this port on a public interface. Use SSH tunnels, WireGuard,
+    /// or a loopback-only port on a trusted host.
+    ///
+    /// When set, `headless`, `viewport_*`, and the local chromium discovery
+    /// path are ignored — browser lifecycle is the operator's responsibility.
+    #[serde(default)]
+    pub cdp_endpoint: Option<String>,
 }
 
 impl Default for BrowserConfig {
@@ -544,6 +559,7 @@ impl Default for BrowserConfig {
             idle_timeout_secs: 300,
             max_sessions: 5,
             chromium_path: None,
+            cdp_endpoint: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `cdp_endpoint: Option<String>` to `BrowserConfig` (`[browser]` section in config.toml)
- Adds `BrowserSession::attach(endpoint)` — connects to an already-running browser via CDP
- `BrowserManager::get_or_create` picks `attach` vs `launch` based on whether `cdp_endpoint` is set
- `BrowserSession.process` is now `Option<Child>`: `None` in attach mode, so `Drop` never kills the external browser

**Endpoint formats accepted:**
| Format | Behavior |
|--------|----------|
| `ws://host:port` | Discovers page via `/json/list` |
| `ws://host:port/devtools/browser/<id>` | Opens new tab via `Target.createTarget` |
| `http://host:port` | Discovers browser WS via `/json/version`, then opens new tab |

**Isolation**: each agent still gets its own tab (`Target.createTarget` or existing blank page). No cross-agent tab leakage.

**Security**: docs note CDP is unauthenticated — never expose on a public interface. SSH tunnel, WireGuard, or loopback-only recommended.

## Config example

```toml
[browser]
cdp_endpoint = "ws://browser-host:9222"
# headless, viewport_*, chromium_path are ignored in attach mode
```

## Test plan

- [ ] No `cdp_endpoint` set → existing `launch` path unchanged
- [ ] `cdp_endpoint = "http://localhost:9222"` → attaches to local headless chromium (`chromium --remote-debugging-port=9222`)
- [ ] `cdp_endpoint = "ws://..."` WS URL → attaches correctly
- [ ] Each agent gets a distinct tab (run two agents, verify separate page WS URLs)
- [ ] Session close removes the tab but does NOT kill the browser process

Closes #2938