### PR TITLE
feat(kernel): configurable cron session size limit

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10063,6 +10063,47 @@ system_prompt = "You are a helpful assistant."
                                     (Some(cron_sender), None)
                                 };
                                 let sender_ctx = sender_ctx_owned.as_ref();
+
+                                // Prune the persistent cron session before firing
+                                // if the user has configured a size cap.
+                                if !wants_new_session {
+                                    let cfg_snap = kernel.config.load();
+                                    let max_tokens = cfg_snap.cron_session_max_tokens;
+                                    let max_messages = cfg_snap.cron_session_max_messages;
+                                    drop(cfg_snap);
+                                    if max_tokens.is_some() || max_messages.is_some() {
+                                        let cron_sid = SessionId::for_channel(agent_id, "cron");
+                                        if let Ok(Some(mut session)) =
+                                            kernel.memory.get_session(cron_sid)
+                                        {
+                                            // Prune by message count first.
+                                            if let Some(max_msgs) = max_messages {
+                                                while session.messages.len() > max_msgs {
+                                                    session.messages.remove(0);
+                                                }
+                                            }
+                                            // Prune by token count.
+                                            if let Some(max_tok) = max_tokens {
+                                                use librefang_runtime::compactor::estimate_token_count;
+                                                loop {
+                                                    let est = estimate_token_count(
+                                                        &session.messages,
+                                                        None,
+                                                        None,
+                                                    );
+                                                    if est <= max_tok as usize
+                                                        || session.messages.is_empty()
+                                                    {
+                                                        break;
+                                                    }
+                                                    session.messages.remove(0);
+                                                }
+                                            }
+                                            let _ = kernel.memory.save_session(&session);
+                                        }
+                                    }
+                                }
+
                                 match tokio::time::timeout(
                                     timeout,
                                     kernel.send_message_full(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10078,8 +10078,9 @@ system_prompt = "You are a helpful assistant."
                                         {
                                             // Prune by message count first.
                                             if let Some(max_msgs) = max_messages {
-                                                while session.messages.len() > max_msgs {
-                                                    session.messages.remove(0);
+                                                if session.messages.len() > max_msgs {
+                                                    let excess = session.messages.len() - max_msgs;
+                                                    session.messages.drain(0..excess);
                                                 }
                                             }
                                             // Prune by token count.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2102,6 +2102,21 @@ pub struct KernelConfig {
     /// Cron scheduler max total jobs across all agents. Default: 500.
     #[serde(default = "default_max_cron_jobs")]
     pub max_cron_jobs: usize,
+    /// Maximum estimated token count for the cron session before automatic
+    /// pruning. Oldest messages are removed from the front of the session
+    /// until the estimated count falls below this threshold.
+    ///
+    /// `None` (default) disables pruning and preserves existing behaviour.
+    /// Set to e.g. `100000` for a rolling 100k-token window.
+    #[serde(default)]
+    pub cron_session_max_tokens: Option<u64>,
+    /// Maximum number of messages retained in a cron session. When the
+    /// session exceeds this count the oldest messages are pruned before
+    /// each cron fire. Applied in addition to `cron_session_max_tokens`.
+    ///
+    /// `None` (default) disables message-count pruning.
+    #[serde(default)]
+    pub cron_session_max_messages: Option<usize>,
     /// Config include files — loaded and deep-merged before the root config.
     /// Paths are relative to the root config file's directory.
     /// Security: absolute paths and `..` components are rejected.
@@ -3824,6 +3839,8 @@ impl Default for KernelConfig {
             approval: crate::approval::ApprovalPolicy::default(),
             notification: crate::approval::NotificationConfig::default(),
             max_cron_jobs: default_max_cron_jobs(),
+            cron_session_max_tokens: None,
+            cron_session_max_messages: None,
             include: Vec::new(),
             exec_policy: ExecPolicy::default(),
             bindings: Vec::new(),

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -90,6 +90,8 @@ impl KernelConfig {
             "rate_limit",
             "tool_timeout_secs",
             "tool_timeouts",
+            "cron_session_max_tokens",
+            "cron_session_max_messages",
             "max_upload_size_bytes",
             "max_concurrent_bg_llm",
             "max_agent_call_depth",


### PR DESCRIPTION
## Summary
- Adds `cron_session_max_tokens` and `cron_session_max_messages` to `KernelConfig` (both `Option`, default `None` = no limit)
- Before each persistent cron session fires, prunes the oldest messages from the front until the session is within both limits
- Pruning is skipped when `session_mode = "new"` (those fires always get a fresh session)
- Uses the existing `estimate_token_count` from `librefang_runtime::compactor`

## Config example
```toml
[kernel]
cron_session_max_tokens = 50000
cron_session_max_messages = 100
```

## Test plan
- [ ] Cron job with no limits set behaves identically to before
- [ ] With `cron_session_max_messages = 5`, confirm session has ≤5 messages after 10 fires
- [ ] With `cron_session_max_tokens = 1000`, confirm session is pruned to fit
- [ ] `session_mode = "new"` agents are unaffected (prune block is skipped)

Closes #2650