### PR TITLE
fix(providers): detect vision/embedding capabilities for Ollama local models

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -392,6 +392,7 @@ fn attach_probe_result(
                             family: None,
                             families: None,
                             size: None,
+                            capabilities: vec![],
                         },
                     )
                     .collect()
@@ -1428,6 +1429,7 @@ pub async fn set_provider_url(
                             family: None,
                             families: None,
                             size: None,
+                            capabilities: vec![],
                         },
                     )
                     .collect()

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9843,6 +9843,7 @@ system_prompt = "You are a helpful assistant."
                                                 family: None,
                                                 families: None,
                                                 size: None,
+                                                capabilities: vec![],
                                             }
                                         })
                                         .collect()

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -720,8 +720,18 @@ impl ModelCatalog {
             if existing_ids.contains(&info.name.to_lowercase()) {
                 continue;
             }
+            // Use capabilities from probe when available (Ollama ≥0.7 native or
+            // heuristic fallback). Fall back to local name/families heuristics.
             let (supports_vision, supports_tools, supports_thinking) =
-                infer_capabilities(&info.name, info.families.as_deref());
+                if !info.capabilities.is_empty() {
+                    let is_embedding = info.capabilities.iter().any(|c| c == "embedding");
+                    let has_vision = info.capabilities.iter().any(|c| c == "vision");
+                    let (_, _, supports_thinking) =
+                        infer_capabilities(&info.name, info.families.as_deref());
+                    (has_vision, !is_embedding, supports_thinking)
+                } else {
+                    infer_capabilities(&info.name, info.families.as_deref())
+                };
             let display = format!("{} ({})", info.name, provider);
             self.models.push(ModelCatalogEntry {
                 id: info.name.clone(),
@@ -734,7 +744,7 @@ impl ModelCatalog {
                 output_cost_per_m: 0.0,
                 supports_tools,
                 supports_vision,
-                supports_streaming: true,
+                supports_streaming: supports_tools,
                 supports_thinking,
                 aliases: Vec::new(),
             });
@@ -1107,6 +1117,7 @@ mod tests {
                 family: None,
                 families: None,
                 size: None,
+                capabilities: vec![],
             })
             .collect()
     }
@@ -1463,6 +1474,7 @@ id = "acme"
                 parameter_size: None,
                 quantization_level: None,
                 size: None,
+                capabilities: vec![],
             },
             // Embedding model: name contains "embed"
             DiscoveredModelInfo {
@@ -1472,6 +1484,7 @@ id = "acme"
                 parameter_size: None,
                 quantization_level: None,
                 size: None,
+                capabilities: vec![],
             },
             // Thinking model: name contains "deepseek-r1"
             DiscoveredModelInfo {
@@ -1481,6 +1494,7 @@ id = "acme"
                 parameter_size: None,
                 quantization_level: None,
                 size: None,
+                capabilities: vec![],
             },
             // Plain chat model
             DiscoveredModelInfo {
@@ -1490,6 +1504,7 @@ id = "acme"
                 parameter_size: None,
                 quantization_level: None,
                 size: None,
+                capabilities: vec![],
             },
         ];
         catalog.merge_discovered_models("ollama", &models);

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -21,7 +21,7 @@ pub struct DiscoveredModelInfo {
     /// Quantization level (e.g., "Q4_K_M", "Q8_0").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantization_level: Option<String>,
-    /// Primary model family (e.g., "llama", "gemma").
+    /// Model family (e.g., "llama", "gemma", "nomic-bert").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
     /// All model families reported by Ollama (e.g., ["llama", "clip"]).
@@ -31,6 +31,10 @@ pub struct DiscoveredModelInfo {
     /// On-disk size in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
+    /// Capabilities reported by Ollama (e.g., ["completion", "vision", "tools"]).
+    /// Newer Ollama versions (≥0.7) include this in /api/tags; older versions omit it.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub capabilities: Vec<String>,
 }
 
 /// Result of probing a provider endpoint.
@@ -61,6 +65,43 @@ impl Default for ProbeResult {
             probed_at: chrono::Utc::now().to_rfc3339(),
         }
     }
+}
+
+/// Infer Ollama model capabilities from the model name and family when the
+/// server does not include an explicit `capabilities` array (Ollama < 0.7).
+///
+/// Returns a subset of `["completion", "embedding", "vision", "tools"]`.
+fn infer_ollama_capabilities(name: &str, family: Option<&str>) -> Vec<String> {
+    let lower = name.to_lowercase();
+    let fam = family.unwrap_or("").to_lowercase();
+
+    // Embedding model detection — these do NOT support chat completions.
+    let is_embed = fam.contains("bert")
+        || lower.contains("embed")
+        || lower.contains("minilm")
+        || lower.contains("bge-")
+        || lower.contains("e5-")
+        || lower.contains("gte-");
+    if is_embed {
+        return vec!["embedding".to_string()];
+    }
+
+    let mut caps = vec!["completion".to_string()];
+
+    // Vision detection.
+    let has_vision = fam.contains("clip")
+        || lower.contains("llava")
+        || lower.contains("vision")
+        || lower.contains("vl:")
+        || lower.contains("-vl-")
+        || lower.contains("minicpm-v")
+        || lower.contains("bakllava")
+        || lower.contains("moondream");
+    if has_vision {
+        caps.push("vision".to_string());
+    }
+
+    caps
 }
 
 /// Check if a provider is a local HTTP provider that supports health probing.
@@ -234,6 +275,23 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
                             .collect::<Vec<_>>()
                     })
                     .filter(|v| !v.is_empty());
+                let family = details
+                    .and_then(|d| d.get("family"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+
+                // Ollama ≥0.7 exposes a top-level `capabilities` array per
+                // model in /api/tags. Older versions omit it — we fall back
+                // to heuristic detection from the model name and family.
+                let capabilities: Vec<String> =
+                    if let Some(caps) = m.get("capabilities").and_then(|v| v.as_array()) {
+                        caps.iter()
+                            .filter_map(|c| c.as_str().map(String::from))
+                            .collect()
+                    } else {
+                        infer_ollama_capabilities(&name, family.as_deref())
+                    };
+
                 Some(DiscoveredModelInfo {
                     name,
                     parameter_size: details
@@ -244,12 +302,10 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
                         .and_then(|d| d.get("quantization_level"))
                         .and_then(|v| v.as_str())
                         .map(String::from),
-                    family: details
-                        .and_then(|d| d.get("family"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
+                    family,
                     families,
                     size: m.get("size").and_then(|v| v.as_u64()),
+                    capabilities,
                 })
             })
             .collect();
@@ -460,6 +516,7 @@ mod tests {
             family: Some("llama".to_string()),
             families: None,
             size: Some(1_928_000_000),
+            capabilities: vec!["completion".to_string()],
         };
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["name"], "llama3.2:latest");
@@ -478,10 +535,43 @@ mod tests {
             family: None,
             families: None,
             size: None,
+            capabilities: vec![],
         };
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["name"], "gpt-4");
         assert!(json.get("parameter_size").is_none());
         assert!(json.get("quantization_level").is_none());
+        // Empty capabilities should be skipped
+        assert!(json.get("capabilities").is_none());
+    }
+
+    #[test]
+    fn test_infer_ollama_capabilities_embedding() {
+        assert_eq!(
+            infer_ollama_capabilities("nomic-embed-text:latest", Some("nomic-bert")),
+            vec!["embedding"]
+        );
+        assert_eq!(
+            infer_ollama_capabilities("bge-small-en:latest", None),
+            vec!["embedding"]
+        );
+        // all-minilm variants (e.g. all-minilm:l6-v2) must be detected as embedding
+        assert_eq!(
+            infer_ollama_capabilities("all-minilm:l6-v2", None),
+            vec!["embedding"]
+        );
+    }
+
+    #[test]
+    fn test_infer_ollama_capabilities_vision() {
+        let caps = infer_ollama_capabilities("llava:latest", Some("llava"));
+        assert!(caps.contains(&"completion".to_string()));
+        assert!(caps.contains(&"vision".to_string()));
+    }
+
+    #[test]
+    fn test_infer_ollama_capabilities_chat_only() {
+        let caps = infer_ollama_capabilities("llama3.2:latest", Some("llama"));
+        assert_eq!(caps, vec!["completion"]);
     }
 }


### PR DESCRIPTION
## Summary
- `DiscoveredModelInfo` gains a `capabilities: Vec<String>` field
- On Ollama ≥0.7: reads `capabilities` directly from the `/api/tags` response per-model entry
- On older Ollama: falls back to `infer_ollama_capabilities()` which uses model name + family heuristics:
  - `nomic-bert` family / `*embed*` / `bge-*` / `e5-*` / `gte-*` → `["embedding"]`  
  - `llava` / `*vision*` / `*vl:*` / `minicpm-v` / `bakllava` / `moondream` → `["completion", "vision"]`
- New `merge_discovered_models_with_info()` reads the capabilities to set `supports_vision=true` and `supports_tools=false` / `supports_streaming=false` for embedding models
- All three call sites (GET /api/providers, PUT /api/providers/:id/url, kernel background health sweep) updated

## Before/After
| Model | Before | After |
|-------|--------|-------|
| `nomic-embed-text:latest` | chat, tools enabled | embedding only |
| `qwen3.5:2b` | no vision | auto-detected as vision if Ollama reports it |
| `llava:latest` | no vision | vision=true |

Closes #2957