### PR TITLE
feat(task-board): REST API for task_queue + max_retries TTL enforcement

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -160,11 +160,17 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         // Queue status
         .route("/queue/status", axum::routing::get(queue_status))
         // Task queue management
+        .route(
+            "/tasks",
+            axum::routing::get(task_queue_list_root),
+        )
         .route("/tasks/status", axum::routing::get(task_queue_status))
         .route("/tasks/list", axum::routing::get(task_queue_list))
         .route(
             "/tasks/{id}",
-            axum::routing::delete(task_queue_delete),
+            axum::routing::get(task_queue_get)
+                .patch(task_queue_patch)
+                .delete(task_queue_delete),
         )
         .route(
             "/tasks/{id}/retry",
@@ -4128,6 +4134,97 @@ pub async fn task_queue_retry(
                 "error": err_task_not_retryable
             })),
         ),
+        Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
+    }
+}
+
+/// GET /api/tasks — List tasks with optional ?status=, ?assigned_to=, ?limit= filters.
+///
+/// This is the primary RESTful list endpoint. The legacy /api/tasks/list endpoint
+/// remains for backwards compatibility.
+pub async fn task_queue_list_root(
+    State(state): State<Arc<AppState>>,
+    _lang: Option<axum::Extension<RequestLanguage>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let status_filter = params.get("status").map(|s| s.as_str());
+    match state.kernel.task_list(status_filter).await {
+        Ok(mut tasks) => {
+            // Filter by assigned_to if provided
+            if let Some(assignee) = params.get("assigned_to") {
+                tasks.retain(|t| t["assigned_to"].as_str().unwrap_or("") == assignee.as_str());
+            }
+            // Apply limit
+            if let Some(limit_str) = params.get("limit") {
+                if let Ok(limit) = limit_str.parse::<usize>() {
+                    tasks.truncate(limit);
+                }
+            }
+            let total = tasks.len();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"tasks": tasks, "total": total})),
+            )
+        }
+        Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
+    }
+}
+
+/// GET /api/tasks/{id} — Get a single task by ID including its result.
+pub async fn task_queue_get(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let err_not_found = {
+        let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+        t.t("api-error-task-not-found")
+    };
+    match state.kernel.task_get(&id).await {
+        Ok(Some(task)) => (StatusCode::OK, Json(task)),
+        Ok(None) => ApiErrorResponse::not_found(err_not_found).into_json_tuple(),
+        Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
+    }
+}
+
+/// PATCH /api/tasks/{id} — Update task status.
+///
+/// Body: `{"status": "pending"}` or `{"status": "cancelled"}`
+/// - `pending`: resets a failed/in_progress task so it can be re-claimed
+/// - `cancelled`: cancels a pending/in_progress task
+pub async fn task_queue_patch(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let err_not_found = {
+        let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+        t.t("api-error-task-not-found")
+    };
+    let new_status = match body["status"].as_str() {
+        Some(s @ ("pending" | "cancelled")) => s.to_string(),
+        Some(other) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("Invalid status '{other}': only 'pending' and 'cancelled' are allowed")
+                })),
+            );
+        }
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Missing 'status' field"})),
+            );
+        }
+    };
+    match state.kernel.task_update_status(&id, &new_status).await {
+        Ok(true) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"id": id, "status": new_status})),
+        ),
+        Ok(false) => ApiErrorResponse::not_found(err_not_found).into_json_tuple(),
         Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
     }
 }

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -96,6 +96,13 @@ pub trait KernelHandle: Send + Sync {
     /// Retry a task by resetting it to pending. Returns true if reset.
     async fn task_retry(&self, task_id: &str) -> Result<bool, String>;
 
+    /// Get a single task by ID including its result and retry_count.
+    async fn task_get(&self, task_id: &str) -> Result<Option<serde_json::Value>, String>;
+
+    /// Update a task's status to `pending` (reset) or `cancelled`.
+    /// Returns true if the task was found and updated.
+    async fn task_update_status(&self, task_id: &str, new_status: &str) -> Result<bool, String>;
+
     /// Publish a custom event that can trigger proactive agents.
     async fn publish_event(
         &self,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1027,11 +1027,12 @@ impl LibreFangKernel {
         handle.spawn(async move {
             loop {
                 // Read sweeper knobs live — hot reload takes effect on next tick.
-                let (interval_secs, ttl_secs) = {
+                let (interval_secs, ttl_secs, max_retries) = {
                     let cfg = kernel.config.load();
                     (
                         cfg.task_board.sweep_interval_secs.max(1),
                         cfg.task_board.claim_ttl_secs,
+                        cfg.task_board.max_retries,
                     )
                 };
 
@@ -1051,7 +1052,7 @@ impl LibreFangKernel {
                     continue;
                 }
 
-                match kernel.memory.task_reset_stuck(ttl_secs).await {
+                match kernel.memory.task_reset_stuck(ttl_secs, max_retries).await {
                     Ok(reset) if !reset.is_empty() => {
                         warn!(
                             count = reset.len(),
@@ -13361,6 +13362,24 @@ impl KernelHandle for LibreFangKernel {
             .task_retry(task_id)
             .await
             .map_err(|e| format!("Task retry failed: {e}"))
+    }
+
+    pub async fn task_get(&self, task_id: &str) -> Result<Option<serde_json::Value>, String> {
+        self.memory
+            .task_get(task_id)
+            .await
+            .map_err(|e| format!("Task get failed: {e}"))
+    }
+
+    pub async fn task_update_status(
+        &self,
+        task_id: &str,
+        new_status: &str,
+    ) -> Result<bool, String> {
+        self.memory
+            .task_update_status(task_id, new_status)
+            .await
+            .map_err(|e| format!("Task update status failed: {e}"))
     }
 
     async fn publish_event(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -13364,18 +13364,14 @@ impl KernelHandle for LibreFangKernel {
             .map_err(|e| format!("Task retry failed: {e}"))
     }
 
-    pub async fn task_get(&self, task_id: &str) -> Result<Option<serde_json::Value>, String> {
+    async fn task_get(&self, task_id: &str) -> Result<Option<serde_json::Value>, String> {
         self.memory
             .task_get(task_id)
             .await
             .map_err(|e| format!("Task get failed: {e}"))
     }
 
-    pub async fn task_update_status(
-        &self,
-        task_id: &str,
-        new_status: &str,
-    ) -> Result<bool, String> {
+    async fn task_update_status(&self, task_id: &str, new_status: &str) -> Result<bool, String> {
         self.memory
             .task_update_status(task_id, new_status)
             .await

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -1290,7 +1290,7 @@ async fn test_task_board_sweep_resets_stuck_in_progress_task() {
     tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
     let _ = past; // keep the variable (documents intent) even if unused
 
-    let reset = mem.task_reset_stuck(1).await.expect("sweep");
+    let reset = mem.task_reset_stuck(1, 0).await.expect("sweep");
     assert_eq!(reset, vec![task_id.clone()], "stuck task should be reset");
 
     let pending = mem.task_list(Some("pending")).await.expect("list");

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 20;
+const SCHEMA_VERSION: u32 = 21;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -89,6 +89,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 20 {
         migrate_v20(conn)?;
+    }
+
+    if current_version < 21 {
+        migrate_v21(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -664,6 +668,23 @@ fn migrate_v20(conn: &Connection) -> Result<(), rusqlite::Error> {
     )?;
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) VALUES (20, datetime('now'), 'Add claimed_at column to task_queue for stuck-task auto-reset')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 21: Add `retry_count` column to `task_queue` so the kernel sweep
+/// can enforce `max_retries` and mark exhausted tasks as `failed`.
+fn migrate_v21(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !column_exists(conn, "task_queue", "retry_count") {
+        conn.execute(
+            "ALTER TABLE task_queue ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (21, datetime('now'), 'Add retry_count column to task_queue for max_retries enforcement')",
         [],
     )?;
     Ok(())

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1322,7 +1322,7 @@ mod tests {
         }
 
         // With a 1 hour TTL, nothing should be reset (not stuck yet).
-        let reset = substrate.task_reset_stuck(3600).await.unwrap();
+        let reset = substrate.task_reset_stuck(3600, 0).await.unwrap();
         assert!(
             reset.is_empty(),
             "TTL larger than stall should not reset any task"
@@ -1331,7 +1331,7 @@ mod tests {
         assert_eq!(still_in_progress.len(), 1);
 
         // With a 60 s TTL, the stuck task should be flipped back to pending.
-        let reset = substrate.task_reset_stuck(60).await.unwrap();
+        let reset = substrate.task_reset_stuck(60, 0).await.unwrap();
         assert_eq!(reset, vec![task_id.clone()]);
 
         let pending = substrate.task_list(Some("pending")).await.unwrap();
@@ -1346,7 +1346,7 @@ mod tests {
         assert!(in_progress.is_empty());
 
         // Second sweep is a no-op — stuck task is already pending.
-        let reset_again = substrate.task_reset_stuck(60).await.unwrap();
+        let reset_again = substrate.task_reset_stuck(60, 0).await.unwrap();
         assert!(reset_again.is_empty());
     }
 

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -877,14 +877,18 @@ impl MemorySubstrate {
 
     /// Reset `in_progress` tasks whose worker stalled without calling
     /// `task_complete` — fixes issue #2923. A task is considered stuck when
-    /// `claimed_at` is older than `ttl_secs` seconds from now. Matching tasks
-    /// are flipped back to `pending` and their `assigned_to` / `claimed_at`
-    /// are cleared so that any worker can re-claim them.
+    /// `claimed_at` is older than `ttl_secs` seconds from now.
+    ///
+    /// When `max_retries > 0`: tasks that have already been reset that many
+    /// times are marked `failed` instead of pending, preventing infinite retry
+    /// loops. Pass `0` to disable the cap (current default behaviour).
     ///
     /// Returns the list of reset task IDs so the caller can log / emit events.
-    /// Rows still on the pre-migration schema (`claimed_at` NULL) are skipped
-    /// so long-running legacy tasks don't get nuked on first boot.
-    pub async fn task_reset_stuck(&self, ttl_secs: u64) -> LibreFangResult<Vec<String>> {
+    pub async fn task_reset_stuck(
+        &self,
+        ttl_secs: u64,
+        max_retries: u32,
+    ) -> LibreFangResult<Vec<String>> {
         let conn = Arc::clone(&self.conn);
 
         tokio::task::spawn_blocking(move || {
@@ -892,9 +896,6 @@ impl MemorySubstrate {
                 .lock()
                 .map_err(|e| LibreFangError::Internal(e.to_string()))?;
 
-            // Compute the cutoff timestamp in Rust (lexicographic RFC 3339 compare
-            // matches chronological order for UTC `Z`-suffixed strings written by
-            // `chrono::Utc::now().to_rfc3339()`).
             let cutoff = chrono::Utc::now()
                 - chrono::Duration::from_std(std::time::Duration::from_secs(ttl_secs))
                     .unwrap_or_else(|_| chrono::Duration::seconds(0));
@@ -902,36 +903,138 @@ impl MemorySubstrate {
 
             let mut stmt = db
                 .prepare(
-                    "SELECT id FROM task_queue \
+                    "SELECT id, COALESCE(retry_count, 0) FROM task_queue \
                      WHERE status = 'in_progress' \
                        AND claimed_at IS NOT NULL \
                        AND claimed_at < ?1",
                 )
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-            let stuck_ids: Vec<String> = stmt
-                .query_map(rusqlite::params![cutoff_str], |row| row.get::<_, String>(0))
+            let stuck: Vec<(String, u32)> = stmt
+                .query_map(rusqlite::params![cutoff_str], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+                })
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?
                 .filter_map(|r| r.ok())
                 .collect();
 
-            if stuck_ids.is_empty() {
+            if stuck.is_empty() {
                 return Ok(Vec::new());
             }
 
-            // Flip them all back to pending. Clear assigned_to so the original
-            // worker doesn't immediately re-claim, and clear claimed_at so the
-            // sweeper doesn't keep logging the same task on every tick.
-            for id in &stuck_ids {
-                db.execute(
-                    "UPDATE task_queue \
-                     SET status = 'pending', assigned_to = '', claimed_at = NULL \
-                     WHERE id = ?1 AND status = 'in_progress'",
-                    rusqlite::params![id],
+            let mut reset_ids = Vec::new();
+            for (id, retries) in &stuck {
+                let exhausted = max_retries > 0 && *retries >= max_retries;
+                if exhausted {
+                    db.execute(
+                        "UPDATE task_queue \
+                         SET status = 'failed', assigned_to = '', claimed_at = NULL, \
+                             retry_count = retry_count + 1 \
+                         WHERE id = ?1 AND status = 'in_progress'",
+                        rusqlite::params![id],
+                    )
+                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                } else {
+                    db.execute(
+                        "UPDATE task_queue \
+                         SET status = 'pending', assigned_to = '', claimed_at = NULL, \
+                             retry_count = retry_count + 1 \
+                         WHERE id = ?1 AND status = 'in_progress'",
+                        rusqlite::params![id],
+                    )
+                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                }
+                reset_ids.push(id.clone());
+            }
+            Ok(reset_ids)
+        })
+        .await
+        .map_err(|e| LibreFangError::Internal(e.to_string()))?
+    }
+
+    /// Get a single task by ID.
+    pub async fn task_get(&self, task_id: &str) -> LibreFangResult<Option<serde_json::Value>> {
+        let conn = Arc::clone(&self.conn);
+        let task_id = task_id.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let db = conn
+                .lock()
+                .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+            let mut stmt = db
+                .prepare(
+                    "SELECT id, title, description, status, assigned_to, created_by, \
+                     created_at, completed_at, result, claimed_at, \
+                     COALESCE(retry_count, 0) \
+                     FROM task_queue WHERE id = ?1",
                 )
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+            let mut rows = stmt
+                .query_map(rusqlite::params![task_id], |row| {
+                    Ok(serde_json::json!({
+                        "id":           row.get::<_, String>(0)?,
+                        "title":        row.get::<_, String>(1).unwrap_or_default(),
+                        "description":  row.get::<_, String>(2).unwrap_or_default(),
+                        "status":       row.get::<_, String>(3)?,
+                        "assigned_to":  row.get::<_, String>(4).unwrap_or_default(),
+                        "created_by":   row.get::<_, String>(5).unwrap_or_default(),
+                        "created_at":   row.get::<_, String>(6).unwrap_or_default(),
+                        "completed_at": row.get::<_, Option<String>>(7).unwrap_or(None),
+                        "result":       row.get::<_, Option<String>>(8).unwrap_or(None),
+                        "claimed_at":   row.get::<_, Option<String>>(9).unwrap_or(None),
+                        "retry_count":  row.get::<_, u32>(10).unwrap_or(0),
+                    }))
+                })
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+            match rows.next() {
+                Some(Ok(v)) => Ok(Some(v)),
+                Some(Err(e)) => Err(LibreFangError::Memory(e.to_string())),
+                None => Ok(None),
             }
-            Ok(stuck_ids)
+        })
+        .await
+        .map_err(|e| LibreFangError::Internal(e.to_string()))?
+    }
+
+    /// Update a task's status to `pending` (reset) or `cancelled`.
+    ///
+    /// Only `in_progress` / `pending` tasks can be reset to `pending`.
+    /// Any non-terminal task can be cancelled.
+    /// Returns `false` when the task was not found or the transition is invalid.
+    pub async fn task_update_status(
+        &self,
+        task_id: &str,
+        new_status: &str,
+    ) -> LibreFangResult<bool> {
+        let conn = Arc::clone(&self.conn);
+        let task_id = task_id.to_string();
+        let new_status = new_status.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let db = conn
+                .lock()
+                .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+            let rows = match new_status.as_str() {
+                "pending" => db.execute(
+                    "UPDATE task_queue \
+                     SET status = 'pending', claimed_at = NULL, assigned_to = '' \
+                     WHERE id = ?1 AND status IN ('in_progress', 'failed')",
+                    rusqlite::params![task_id],
+                ),
+                "cancelled" => db.execute(
+                    "UPDATE task_queue \
+                     SET status = 'cancelled' \
+                     WHERE id = ?1 AND status NOT IN ('completed', 'cancelled')",
+                    rusqlite::params![task_id],
+                ),
+                _ => {
+                    return Err(LibreFangError::InvalidInput(format!(
+                        "Invalid status '{new_status}': only 'pending' and 'cancelled' are allowed"
+                    )))
+                }
+            }
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+            Ok(rows > 0)
         })
         .await
         .map_err(|e| LibreFangError::Internal(e.to_string()))?

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1783,6 +1783,9 @@ pub struct TaskBoardConfig {
     pub claim_ttl_secs: u64,
     /// How often the sweeper scans for stuck tasks. Default: 30 s.
     pub sweep_interval_secs: u64,
+    /// Maximum number of auto-resets before a stuck task is marked `failed`.
+    /// Default: 0 = no limit (retry indefinitely).
+    pub max_retries: u32,
 }
 
 impl Default for TaskBoardConfig {
@@ -1790,6 +1793,7 @@ impl Default for TaskBoardConfig {
         Self {
             claim_ttl_secs: 600,
             sweep_interval_secs: 30,
+            max_retries: 0,
         }
     }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -94,6 +94,7 @@ impl KernelConfig {
             "max_agent_call_depth",
             "max_request_body_bytes",
             "terminal",
+            "task_board",
         ]
     }
 


### PR DESCRIPTION
## Summary

### Closes #2925 — REST API for task_queue

Three new endpoints complete the task CRUD surface:

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/tasks` | List with `?status=`, `?assigned_to=`, `?limit=` filters |
| `GET` | `/api/tasks/{id}` | Get single task including `result` and `retry_count` |
| `PATCH` | `/api/tasks/{id}` | Set status to `pending` (reset) or `cancelled` |

`DELETE /api/tasks/{id}` and `POST /api/tasks/{id}/retry` already existed and are unchanged.

### Closes #2926 — Claim TTL auto-reset with max_retries

Adds `max_retries` to `[task_board]` config (default `0` = unlimited retries, preserving current behavior):

```toml
[task_board]
claim_ttl_secs = 600   # existing
max_retries = 3        # new: mark failed after 3 auto-resets
```

Migration v21 adds `retry_count INTEGER NOT NULL DEFAULT 0` column. The sweeper increments it on every auto-reset; when `max_retries > 0` and `retry_count >= max_retries`, the task is marked `failed` instead of `pending`.

## Test plan
- [ ] `GET /api/tasks` returns task list; `?status=pending` filters correctly
- [ ] `GET /api/tasks/{id}` returns full task with `result` and `retry_count`
- [ ] `PATCH /api/tasks/{id}` with `{"status":"cancelled"}` cancels pending task
- [ ] `PATCH /api/tasks/{id}` with `{"status":"pending"}` resets failed task
- [ ] With `max_retries=2`, task stuck 3 times ends up `failed`
- [ ] With `max_retries=0`, task resets indefinitely (no change from before)