### PR TITLE
feat(media): generic OpenAI-compat driver for user-defined image providers

### DIFF
--- a/crates/librefang-runtime/src/media/mod.rs
+++ b/crates/librefang-runtime/src/media/mod.rs
@@ -309,9 +309,22 @@ fn create_media_driver(
         "minimax" => Ok(Arc::new(minimax::MiniMaxMediaDriver::new(base_url))),
         "openai" => Ok(Arc::new(openai::OpenAIMediaDriver::new(base_url))),
         "google_tts" => Ok(Arc::new(google_tts::GoogleTtsMediaDriver::new(base_url))),
-        other => Err(MediaError::InvalidRequest(format!(
-            "Unknown media provider: '{other}'. Available: openai, gemini, elevenlabs, minimax, google_tts"
-        ))),
+        other => {
+            // For user-defined providers with a configured base_url, use the
+            // generic OpenAI-compatible driver. The API key is read from the
+            // {PROVIDER_UPPER}_API_KEY environment variable.
+            if let Some(url) = base_url {
+                Ok(Arc::new(openai::GenericOpenAICompatMediaDriver::new(
+                    other, url,
+                )))
+            } else {
+                Err(MediaError::InvalidRequest(format!(
+                    "Unknown media provider '{other}' and no base_url configured. \
+                     Set provider_urls.{other} in config.toml to use this provider \
+                     with the OpenAI-compatible API."
+                )))
+            }
+        }
     }
 }
 

--- a/crates/librefang-runtime/src/media/openai.rs
+++ b/crates/librefang-runtime/src/media/openai.rs
@@ -248,6 +248,147 @@ impl MediaDriver for OpenAIMediaDriver {
     }
 }
 
+/// Generic OpenAI-compatible media driver for user-defined providers.
+///
+/// Users configure a custom provider via `provider_urls` in `config.toml`:
+/// ```toml
+/// [provider_urls]
+/// volcengine = "https://open.volcengineapi.com/v1"
+/// ```
+/// and set the corresponding API key env var:
+/// ```sh
+/// VOLCENGINE_API_KEY=sk-...
+/// ```
+/// The driver advertises `ImageGeneration` capability and delegates to the
+/// OpenAI-compatible `/images/generations` endpoint.
+pub struct GenericOpenAICompatMediaDriver {
+    provider: String,
+    base_url: String,
+    api_key_env: String,
+}
+
+impl GenericOpenAICompatMediaDriver {
+    pub fn new(provider: &str, base_url: &str) -> Self {
+        let api_key_env = format!("{}_API_KEY", provider.to_uppercase().replace('-', "_"));
+        Self {
+            provider: provider.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key_env,
+        }
+    }
+
+    fn api_key(&self) -> Result<String, MediaError> {
+        std::env::var(&self.api_key_env).map_err(|_| {
+            MediaError::MissingKey(format!(
+                "{} not set. Set this environment variable to use the {} provider for media generation.",
+                self.api_key_env, self.provider
+            ))
+        })
+    }
+}
+
+#[async_trait]
+impl MediaDriver for GenericOpenAICompatMediaDriver {
+    fn capabilities(&self) -> Vec<MediaCapability> {
+        vec![MediaCapability::ImageGeneration]
+    }
+
+    fn is_configured(&self) -> bool {
+        self.api_key().is_ok()
+    }
+
+    fn provider_name(&self) -> &str {
+        &self.provider
+    }
+
+    async fn generate_image(
+        &self,
+        request: &MediaImageRequest,
+    ) -> Result<MediaImageResult, MediaError> {
+        request.validate().map_err(MediaError::InvalidRequest)?;
+
+        let api_key = self.api_key()?;
+        let model = request.model.as_deref().unwrap_or("default");
+
+        let size = if let (Some(w), Some(h)) = (request.width, request.height) {
+            format!("{w}x{h}")
+        } else {
+            "1024x1024".to_string()
+        };
+
+        let mut body = serde_json::json!({
+            "model": model,
+            "prompt": request.prompt,
+            "n": request.count,
+            "size": size,
+            "response_format": "b64_json",
+        });
+        if let Some(ref q) = request.quality {
+            body["quality"] = serde_json::json!(q);
+        }
+
+        let url = format!("{}/images/generations", self.base_url);
+        let client = crate::http_client::proxied_client();
+        let response = client
+            .post(&url)
+            .bearer_auth(&api_key)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(120))
+            .send()
+            .await
+            .map_err(|e| MediaError::Http(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let err = response.text().await.unwrap_or_default();
+            let truncated = crate::str_utils::safe_truncate_str(&err, 500);
+            return Err(MediaError::Api {
+                status,
+                message: truncated.to_string(),
+            });
+        }
+
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| MediaError::Http(format!("Failed to parse response: {e}")))?;
+
+        let mut images = Vec::new();
+        let mut revised_prompt = None;
+        if let Some(data) = json.get("data").and_then(|d| d.as_array()) {
+            for item in data {
+                let b64 = item
+                    .get("b64_json")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let url_str = item.get("url").and_then(|v| v.as_str()).map(str::to_string);
+                if revised_prompt.is_none() {
+                    revised_prompt = item
+                        .get("revised_prompt")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                }
+                images.push(GeneratedImage {
+                    data_base64: b64,
+                    url: url_str,
+                });
+            }
+        }
+
+        if images.is_empty() {
+            return Err(MediaError::Other("No images returned by provider".into()));
+        }
+
+        Ok(MediaImageResult {
+            images,
+            model: model.to_string(),
+            provider: self.provider.clone(),
+            revised_prompt,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +415,15 @@ mod tests {
     fn test_driver_custom_base_url() {
         let driver = OpenAIMediaDriver::new(Some("https://custom.api.com/v1/"));
         assert_eq!(driver.base_url, "https://custom.api.com/v1");
+    }
+
+    #[test]
+    fn test_generic_driver_key_lookup() {
+        // Key env var for a custom provider is {PROVIDER_UPPER}_API_KEY
+        let driver =
+            GenericOpenAICompatMediaDriver::new("volcengine", "https://api.example.com/v1");
+        // Without the env var set, is_configured() returns false
+        assert!(!driver.is_configured());
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/media/openai.rs
+++ b/crates/librefang-runtime/src/media/openai.rs
@@ -308,7 +308,12 @@ impl MediaDriver for GenericOpenAICompatMediaDriver {
         request.validate().map_err(MediaError::InvalidRequest)?;
 
         let api_key = self.api_key()?;
-        let model = request.model.as_deref().unwrap_or("default");
+        let model = request.model.as_deref().ok_or_else(|| {
+            MediaError::InvalidRequest(format!(
+                "'model' is required for the {} provider — specify the model name in your request",
+                self.provider
+            ))
+        })?;
 
         let size = if let (Some(w), Some(h)) = (request.width, request.height) {
             format!("{w}x{h}")


### PR DESCRIPTION
## Summary

Adds `GenericOpenAICompatMediaDriver` as a fallback for provider names not in the builtin list (`openai`, `gemini`, `elevenlabs`, `minimax`, `google_tts`).

Previously: any custom provider with a configured URL hit "Unknown media provider" error.
Now: custom providers with `provider_urls` in config automatically get an OpenAI-compatible image generation driver.

## Usage

```toml
# config.toml
[provider_urls]
volcengine = "https://open.volcengineapi.com/v1"
tongyi = "https://dashscope.aliyuncs.com/compatible-mode/v1"
```

```sh
# environment variables
VOLCENGINE_API_KEY=sk-...
TONGYI_API_KEY=sk-...
```

The API key env var name is `{PROVIDER_UPPER}_API_KEY` (dashes converted to underscores).

## What it does

- Uses `POST /images/generations` (OpenAI-compatible endpoint)
- Supports `ImageGeneration` capability
- `is_configured()` checks whether the corresponding env var is set
- Auto-detected by `detect_for_capability(MediaCapability::ImageGeneration)` when configured

## Out of scope

- TTS/video for custom providers (can be added per-provider later)
- Per-provider model defaults (users can specify `model` in requests)

Closes #2667