### PR TITLE
feat(mcp): per-tool / per-path taint policy with TaintRuleId skip API

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -5412,6 +5412,7 @@ mod tests {
             headers: vec!["xc-mcp-token: secret".to_string()],
             oauth: None,
             taint_scanning: true,
+            taint_policy: None,
         };
 
         upsert_mcp_server_config(&config_path, &entry).expect("upsert should succeed");
@@ -5466,6 +5467,7 @@ mod tests {
             headers: vec![],
             oauth: None,
             taint_scanning: true,
+            taint_policy: None,
         };
         upsert_mcp_server_config(&config_path, &v1).unwrap();
 
@@ -5480,6 +5482,7 @@ mod tests {
             headers: vec![],
             oauth: None,
             taint_scanning: true,
+            taint_policy: None,
         };
         upsert_mcp_server_config(&config_path, &v2).unwrap();
 

--- a/crates/librefang-extensions/src/installer.rs
+++ b/crates/librefang-extensions/src/installer.rs
@@ -145,6 +145,7 @@ pub fn catalog_entry_to_mcp_server(entry: &McpCatalogEntry) -> McpServerConfigEn
         headers: Vec::new(),
         oauth,
         taint_scanning: true,
+        taint_policy: None,
     }
 }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -835,6 +835,7 @@ impl LibreFangKernel {
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
+                taint_policy: server_config.taint_policy.clone(),
                 roots: server_roots,
             };
 
@@ -11046,6 +11047,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
+                taint_policy: server_config.taint_policy.clone(),
                 roots: self.mcp_roots_for_server(server_config),
             };
 
@@ -11194,6 +11196,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
+            taint_policy: server_config.taint_policy.clone(),
             roots: self.mcp_roots_for_server(&server_config),
         };
 
@@ -11317,6 +11320,7 @@ system_prompt = "You are a helpful assistant."
                 oauth_provider: Some(self.oauth_provider_ref()),
                 oauth_config: server_config.oauth.clone(),
                 taint_scanning: server_config.taint_scanning,
+                taint_policy: server_config.taint_policy.clone(),
                 roots: self.mcp_roots_for_server(server_config),
             };
 
@@ -11462,6 +11466,7 @@ system_prompt = "You are a helpful assistant."
             oauth_provider: Some(self.oauth_provider_ref()),
             oauth_config: server_config.oauth.clone(),
             taint_scanning: server_config.taint_scanning,
+            taint_policy: server_config.taint_policy.clone(),
             roots: self.mcp_roots_for_server(&server_config),
         };
 

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -9,11 +9,12 @@
 pub mod mcp_oauth;
 
 use http::{HeaderName, HeaderValue};
+use librefang_types::config::McpTaintPolicy;
 use librefang_types::config::{
     HttpCompatHeaderConfig, HttpCompatMethod, HttpCompatRequestMode, HttpCompatResponseMode,
     HttpCompatToolConfig,
 };
-use librefang_types::taint::{check_outbound_text_violation, TaintSink};
+use librefang_types::taint::{check_outbound_text_violation_with_skip, TaintRuleId, TaintSink};
 use librefang_types::tool::ToolDefinition;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,86 +54,189 @@ fn is_sensitive_key_name(key: &str) -> bool {
     MCP_SENSITIVE_KEY_NAMES.iter().any(|k| lower == *k)
 }
 
-/// Walk every string leaf in a JSON argument tree and run
-/// [`check_outbound_text_violation`] against it with the
-/// `TaintSink::mcp_tool_call` sink. Returns a *redacted* rule
-/// description (JSON path + rule name) if any leaf trips the
-/// denylist, otherwise `None`.
+// ── Minimal JSONPath matching ───────────────────────────────────────────────
+
+/// Returns `true` if a dot-separated JSONPath `pattern` (as stored in
+/// `McpTaintPolicy`) matches the given `path` built by the walker.
 ///
-/// IMPORTANT: the returned string must NOT contain the offending
-/// payload. It flows back to the LLM as an error and is emitted to
-/// logs — echoing the secret we just blocked would defeat the
-/// filter. We only surface the JSON path to the offending leaf.
-///
-/// Non-string leaves (numbers, bools, null) can't carry plaintext
-/// credentials in any meaningful way, so they are skipped.
-///
-/// Recursion is hard-capped at [`MCP_TAINT_SCAN_MAX_DEPTH`].
-fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
-    let sink = TaintSink::mcp_tool_call();
-    fn walk(v: &serde_json::Value, sink: &TaintSink, path: &str, depth: usize) -> Option<String> {
-        if depth > MCP_TAINT_SCAN_MAX_DEPTH {
-            return Some(format!(
-                "taint violation: MCP argument tree exceeds max depth {} at '{}'",
-                MCP_TAINT_SCAN_MAX_DEPTH, path
-            ));
-        }
-        match v {
-            serde_json::Value::String(s) => {
-                // Discard the underlying violation string entirely — it
-                // may be derived from the payload — and report only the
-                // JSON path of the offending leaf.
-                if check_outbound_text_violation(s, sink).is_some() {
-                    Some(format!(
-                        "taint violation: sensitive value in MCP argument '{}' (blocked by sink '{}')",
-                        path, sink.name
-                    ))
-                } else {
-                    None
-                }
-            }
-            serde_json::Value::Array(items) => {
-                for (i, item) in items.iter().enumerate() {
-                    let child = format!("{path}[{i}]");
-                    if let Some(violation) = walk(item, sink, &child, depth + 1) {
-                        return Some(violation);
-                    }
-                }
-                None
-            }
-            serde_json::Value::Object(obj) => {
-                for (k, v) in obj {
-                    let child = if path.is_empty() {
-                        k.clone()
-                    } else {
-                        format!("{path}.{k}")
-                    };
-                    // Credential-shaped object key with a non-empty
-                    // string value is an unambiguous outbound
-                    // credential, regardless of what the value looks
-                    // like (e.g. `"Authorization": "Bearer sk-…"`
-                    // has whitespace and wouldn't trip the text
-                    // heuristic alone).
-                    if is_sensitive_key_name(k) {
-                        if let serde_json::Value::String(s) = v {
-                            if !s.trim().is_empty() {
-                                return Some(format!(
-                                    "taint violation: sensitive MCP argument key at '{}' (blocked by sink '{}')",
-                                    child, sink.name
-                                ));
-                            }
-                        }
-                    }
-                    if let Some(violation) = walk(v, sink, &child, depth + 1) {
-                        return Some(violation);
-                    }
-                }
-                None
-            }
-            _ => None,
+/// Supported syntax:
+/// - `$.a.b`   — exact nested property
+/// - `$.a.*`   — any direct child of `$.a`
+/// - `$.a[*]`  — any array element of `$.a`
+/// - `$.*`     — any top-level property
+fn jsonpath_matches(pattern: &str, path: &str) -> bool {
+    if pattern == path {
+        return true;
+    }
+    let p_segs: Vec<&str> = split_jsonpath(pattern);
+    let h_segs: Vec<&str> = split_jsonpath(path);
+    segs_match(&p_segs, &h_segs)
+}
+
+fn split_jsonpath(p: &str) -> Vec<&str> {
+    // Split on '.' but preserve array notation like `items[0]` as one segment.
+    let mut out = Vec::new();
+    let mut start = 0;
+    for (i, b) in p.bytes().enumerate() {
+        if b == b'.' && i > 0 {
+            out.push(&p[start..i]);
+            start = i + 1;
         }
     }
-    walk(value, &sink, "$", 0)
+    out.push(&p[start..]);
+    out
+}
+
+fn segs_match(pattern: &[&str], path: &[&str]) -> bool {
+    match (pattern, path) {
+        ([], []) => true,
+        ([], _) | (_, []) => false,
+        ([p, pr @ ..], [h, hr @ ..]) => {
+            let ok =
+                *p == *h || (*p == "*" && !h.contains('[')) || seg_array_wildcard_matches(p, h);
+            ok && segs_match(pr, hr)
+        }
+    }
+}
+
+/// Checks whether a pattern segment ending in `[*]` (e.g. `items[*]`)
+/// matches a path segment with a concrete index (e.g. `items[0]`).
+fn seg_array_wildcard_matches(pattern: &str, path: &str) -> bool {
+    let Some(prefix) = pattern.strip_suffix("[*]") else {
+        return false;
+    };
+    if !path.starts_with(prefix) {
+        return false;
+    }
+    let rest = &path[prefix.len()..];
+    rest.starts_with('[')
+        && rest.ends_with(']')
+        && rest[1..rest.len() - 1].chars().all(|c| c.is_ascii_digit())
+}
+
+/// Collect all `TaintRuleId`s that should be skipped for a specific tool +
+/// argument path according to the server's `McpTaintPolicy`.
+///
+/// Returns an empty set when `policy` is `None` or the tool/path have no
+/// matching exemption entries — i.e. all rules apply.
+fn resolve_skip_rules(
+    policy: Option<&McpTaintPolicy>,
+    tool_name: &str,
+    json_path: &str,
+) -> std::collections::HashSet<TaintRuleId> {
+    let mut skip = std::collections::HashSet::new();
+    let Some(policy) = policy else {
+        return skip;
+    };
+    let Some(tool_policy) = policy.tools.get(tool_name) else {
+        return skip;
+    };
+    for (pattern, path_policy) in &tool_policy.paths {
+        if jsonpath_matches(pattern, json_path) {
+            for rule in &path_policy.skip_rules {
+                skip.insert(rule.clone());
+            }
+        }
+    }
+    skip
+}
+
+// ── Taint scanner ──────────────────────────────────────────────────────────
+
+/// Walk every string leaf in a JSON argument tree and check it against
+/// `TaintSink::mcp_tool_call`.  Returns a *redacted* rule description
+/// (JSON path + rule name) if any leaf trips the denylist, `None` otherwise.
+///
+/// When `taint_policy` and `tool_name` are supplied, per-path skip rules
+/// from the policy are applied before calling
+/// [`check_outbound_text_violation_with_skip`].
+///
+/// IMPORTANT: the returned string must NOT contain the offending payload.
+/// It flows back to the LLM as an error and is emitted to logs — echoing
+/// the secret we just blocked would defeat the filter. Only the JSON path
+/// of the offending leaf is surfaced.
+///
+/// Non-string leaves (numbers, bools, null) are skipped.
+///
+/// Recursion is hard-capped at [`MCP_TAINT_SCAN_MAX_DEPTH`].
+#[cfg_attr(not(test), allow(dead_code))]
+fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
+    scan_mcp_arguments_for_taint_with_policy(value, None, "")
+}
+
+fn scan_mcp_arguments_for_taint_with_policy(
+    value: &serde_json::Value,
+    taint_policy: Option<&McpTaintPolicy>,
+    tool_name: &str,
+) -> Option<String> {
+    let sink = TaintSink::mcp_tool_call();
+    walk_taint(value, &sink, "$", 0, taint_policy, tool_name)
+}
+
+fn walk_taint(
+    v: &serde_json::Value,
+    sink: &TaintSink,
+    path: &str,
+    depth: usize,
+    policy: Option<&McpTaintPolicy>,
+    tool_name: &str,
+) -> Option<String> {
+    if depth > MCP_TAINT_SCAN_MAX_DEPTH {
+        return Some(format!(
+            "taint violation: MCP argument tree exceeds max depth {} at '{}'",
+            MCP_TAINT_SCAN_MAX_DEPTH, path
+        ));
+    }
+
+    let skip = resolve_skip_rules(policy, tool_name, path);
+
+    match v {
+        serde_json::Value::String(s) => {
+            // Discard the underlying violation string entirely — it may be
+            // derived from the payload — and report only the JSON path.
+            if check_outbound_text_violation_with_skip(s, sink, &skip).is_some() {
+                Some(format!(
+                    "taint violation: sensitive value in MCP argument '{}' (blocked by sink '{}')",
+                    path, sink.name
+                ))
+            } else {
+                None
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                let child = format!("{path}[{i}]");
+                if let Some(v) = walk_taint(item, sink, &child, depth + 1, policy, tool_name) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        serde_json::Value::Object(obj) => {
+            for (k, val) in obj {
+                let child = format!("{path}.{k}");
+                // Credential-shaped object key with a non-empty string value
+                // is an unambiguous outbound credential, regardless of the
+                // value shape (e.g. `"Authorization": "Bearer sk-…"` has
+                // whitespace and wouldn't trip the text heuristic alone).
+                if is_sensitive_key_name(k) && !skip.contains(&TaintRuleId::SensitiveKeyName) {
+                    if let serde_json::Value::String(s) = val {
+                        if !s.trim().is_empty() {
+                            return Some(format!(
+                                "taint violation: sensitive MCP argument key at '{}' (blocked by sink '{}')",
+                                child, sink.name
+                            ));
+                        }
+                    }
+                }
+                if let Some(v) = walk_taint(val, sink, &child, depth + 1, policy, tool_name) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -182,6 +286,13 @@ pub struct McpServerConfig {
     /// when this is `false` — only the content-based heuristic is disabled.
     #[serde(default = "default_taint_scanning")]
     pub taint_scanning: bool,
+    /// Fine-grained per-tool, per-path taint exemptions.
+    ///
+    /// When set, individual taint rules can be disabled for specific argument
+    /// paths in specific tools rather than disabling scanning entirely.
+    /// Ignored when `taint_scanning = false`.
+    #[serde(default)]
+    pub taint_policy: Option<McpTaintPolicy>,
     /// Root directories advertised to this MCP server via the MCP Roots capability.
     ///
     /// Each entry is an absolute path (e.g. `/home/user/project`).  librefang
@@ -210,6 +321,7 @@ impl std::fmt::Debug for McpServerConfig {
             )
             .field("oauth_config", &self.oauth_config)
             .field("taint_scanning", &self.taint_scanning)
+            .field("taint_policy", &self.taint_policy)
             .field("roots", &self.roots)
             .finish()
     }
@@ -226,6 +338,7 @@ impl Clone for McpServerConfig {
             oauth_provider: self.oauth_provider.clone(),
             oauth_config: self.oauth_config.clone(),
             taint_scanning: self.taint_scanning,
+            taint_policy: self.taint_policy.clone(),
             roots: self.roots.clone(),
         }
     }
@@ -1139,37 +1252,40 @@ impl McpConnection {
         name: &str,
         arguments: &serde_json::Value,
     ) -> Result<String, String> {
-        // SECURITY: best-effort taint filter before shipping arguments
-        // to an out-of-process MCP server. An LLM that has been pushed
-        // into smuggling credentials into tool-call arguments would
-        // otherwise exfiltrate them straight through this call — the
-        // MCP transport hands the JSON to whoever implements the server.
-        // Walk every string leaf in the arguments tree and refuse the
-        // call if anything trips `check_outbound_text_violation`. Non-
-        // string leaves (numbers, bools, null) can't carry plaintext
-        // credentials in any meaningful way, so they are left alone.
-        //
-        // This is still a best-effort pattern match (see
-        // `librefang_types::taint::check_outbound_text_violation` for
-        // exactly which patterns trip it) — not a full information-
-        // flow tracker. Copy-pasted obfuscation still bypasses it.
-        if self.config.taint_scanning {
-            if let Some(violation) = scan_mcp_arguments_for_taint(arguments) {
-                // `violation` is already a redacted rule description from
-                // the scanner — do NOT concatenate the raw payload or the
-                // offending value into the error surface.
-                return Err(violation);
-            }
-        }
-
-        // Resolve to an owned String immediately so the borrow of self.original_names
-        // and self.config.name ends before any mutable operations below.
+        // Resolve raw (un-prefixed) tool name before taint check so we can
+        // look it up in the per-tool policy.
         let raw_name: String = self
             .original_names
             .get(name)
             .cloned()
             .or_else(|| strip_mcp_prefix(&self.config.name, name).map(|s| s.to_string()))
             .unwrap_or_else(|| name.to_string());
+
+        // SECURITY: best-effort taint filter before shipping arguments
+        // to an out-of-process MCP server. An LLM that has been pushed
+        // into smuggling credentials into tool-call arguments would
+        // otherwise exfiltrate them straight through this call — the
+        // MCP transport hands the JSON to whoever implements the server.
+        // Walk every string leaf in the arguments tree and refuse the
+        // call if anything trips `check_outbound_text_violation_with_skip`.
+        // Non-string leaves (numbers, bools, null) can't carry plaintext
+        // credentials in any meaningful way, so they are left alone.
+        //
+        // This is still a best-effort pattern match — not a full
+        // information-flow tracker. Copy-pasted obfuscation still bypasses
+        // it. Per-tool, per-path exemptions in `taint_policy` let operators
+        // disable specific rules for known-safe fields.
+        if self.config.taint_scanning {
+            let policy = self.config.taint_policy.as_ref();
+            if let Some(violation) =
+                scan_mcp_arguments_for_taint_with_policy(arguments, policy, &raw_name)
+            {
+                // `violation` is already a redacted rule description from
+                // the scanner — do NOT concatenate the raw payload or the
+                // offending value into the error surface.
+                return Err(violation);
+            }
+        }
 
         // Determine the transport kind without holding any reference into self.inner
         // across an await or across a mutable reborrow of self.  Using a simple
@@ -1980,6 +2096,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            taint_policy: None,
             roots: vec![],
         };
 
@@ -2011,6 +2128,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            taint_policy: None,
             roots: vec![],
         };
         let json = serde_json::to_string(&sse_config).unwrap();
@@ -2046,6 +2164,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            taint_policy: None,
             roots: vec![],
         };
         let json = serde_json::to_string(&http_compat_config).unwrap();
@@ -2076,6 +2195,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            taint_policy: None,
             roots: vec![],
         };
         let json = serde_json::to_string(&http_config).unwrap();
@@ -2122,6 +2242,7 @@ mod tests {
                 oauth_provider: None,
                 oauth_config: None,
                 taint_scanning: true,
+                taint_policy: None,
                 roots: vec![],
             },
             tools: Vec::new(),
@@ -2289,6 +2410,7 @@ mod tests {
             oauth_provider: None,
             oauth_config: None,
             taint_scanning: true,
+            taint_policy: None,
             roots: vec![],
         })
         .await

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -159,7 +159,7 @@ fn resolve_skip_rules(
 /// Non-string leaves (numbers, bools, null) are skipped.
 ///
 /// Recursion is hard-capped at [`MCP_TAINT_SCAN_MAX_DEPTH`].
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(test)]
 fn scan_mcp_arguments_for_taint(value: &serde_json::Value) -> Option<String> {
     scan_mcp_arguments_for_taint_with_policy(value, None, "")
 }
@@ -215,11 +215,15 @@ fn walk_taint(
         serde_json::Value::Object(obj) => {
             for (k, val) in obj {
                 let child = format!("{path}.{k}");
+                // SensitiveKeyName is a property of the key's own path (child),
+                // not the parent path, so resolve skip rules against `child`.
+                let child_skip = resolve_skip_rules(policy, tool_name, &child);
                 // Credential-shaped object key with a non-empty string value
                 // is an unambiguous outbound credential, regardless of the
                 // value shape (e.g. `"Authorization": "Bearer sk-…"` has
                 // whitespace and wouldn't trip the text heuristic alone).
-                if is_sensitive_key_name(k) && !skip.contains(&TaintRuleId::SensitiveKeyName) {
+                if is_sensitive_key_name(k) && !child_skip.contains(&TaintRuleId::SensitiveKeyName)
+                {
                     if let serde_json::Value::String(s) = val {
                         if !s.trim().is_empty() {
                             return Some(format!(
@@ -1943,6 +1947,142 @@ mod tests {
             scan_mcp_arguments_for_taint(&args).is_some(),
             "real credential under session-like key must still be blocked"
         );
+    }
+
+    // ── per-path policy tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_policy_skip_opaque_token_allows_tab_id() {
+        use librefang_types::config::{McpTaintPathPolicy, McpTaintPolicy, McpTaintToolPolicy};
+        use librefang_types::taint::TaintRuleId;
+
+        let mut paths = std::collections::HashMap::new();
+        paths.insert(
+            "$.tabId".to_string(),
+            McpTaintPathPolicy {
+                skip_rules: vec![TaintRuleId::OpaqueToken],
+            },
+        );
+        let mut tools = std::collections::HashMap::new();
+        tools.insert("navigate".to_string(), McpTaintToolPolicy { paths });
+        let policy = McpTaintPolicy { tools };
+
+        // Opaque-looking tab handle — blocked without policy, allowed with it.
+        let args = serde_json::json!({ "tabId": "xAbCdEfGhIjKlMnOpQrStUvWxYz1234567890AB" });
+        assert!(
+            scan_mcp_arguments_for_taint(&args).is_some(),
+            "must block without policy"
+        );
+        assert!(
+            scan_mcp_arguments_for_taint_with_policy(&args, Some(&policy), "navigate").is_none(),
+            "OpaqueToken skip must allow browser tab ID under navigate.tabId"
+        );
+    }
+
+    #[test]
+    fn test_policy_skip_sensitive_key_name_uses_child_path() {
+        use librefang_types::config::{McpTaintPathPolicy, McpTaintPolicy, McpTaintToolPolicy};
+        use librefang_types::taint::TaintRuleId;
+
+        // Configure skip for the child path "$.authorization", NOT the parent "$".
+        // This verifies the bug fix: SensitiveKeyName resolution must use child path.
+        let mut paths = std::collections::HashMap::new();
+        paths.insert(
+            "$.authorization".to_string(),
+            McpTaintPathPolicy {
+                skip_rules: vec![TaintRuleId::SensitiveKeyName],
+            },
+        );
+        let mut tools = std::collections::HashMap::new();
+        tools.insert("send_request".to_string(), McpTaintToolPolicy { paths });
+        let policy = McpTaintPolicy { tools };
+
+        let args = serde_json::json!({ "authorization": "some-non-empty-value" });
+
+        // Without policy: blocked because "authorization" is a sensitive key name.
+        assert!(
+            scan_mcp_arguments_for_taint(&args).is_some(),
+            "must block sensitive key without policy"
+        );
+
+        // With SensitiveKeyName skipped for "$.authorization": allowed.
+        assert!(
+            scan_mcp_arguments_for_taint_with_policy(&args, Some(&policy), "send_request")
+                .is_none(),
+            "SensitiveKeyName skip at child path must allow the key"
+        );
+
+        // Policy on different tool must NOT apply.
+        assert!(
+            scan_mcp_arguments_for_taint_with_policy(&args, Some(&policy), "other_tool").is_some(),
+            "skip for send_request must not affect other_tool"
+        );
+    }
+
+    #[test]
+    fn test_policy_non_skipped_rules_still_fire() {
+        use librefang_types::config::{McpTaintPathPolicy, McpTaintPolicy, McpTaintToolPolicy};
+        use librefang_types::taint::TaintRuleId;
+
+        // Skip OpaqueToken for "$.token", but the value contains "api_key=secret"
+        // which trips KeyValueSecret — that rule is NOT skipped.
+        let mut paths = std::collections::HashMap::new();
+        paths.insert(
+            "$.token".to_string(),
+            McpTaintPathPolicy {
+                skip_rules: vec![TaintRuleId::OpaqueToken],
+            },
+        );
+        let mut tools = std::collections::HashMap::new();
+        tools.insert("call".to_string(), McpTaintToolPolicy { paths });
+        let policy = McpTaintPolicy { tools };
+
+        let args = serde_json::json!({ "token": "api_key=sk-not-real" });
+        assert!(
+            scan_mcp_arguments_for_taint_with_policy(&args, Some(&policy), "call").is_some(),
+            "non-skipped KeyValueSecret must still fire even when OpaqueToken is skipped"
+        );
+    }
+
+    // ── JSONPath matcher unit tests ───────────────────────────────────────
+
+    #[test]
+    fn test_jsonpath_exact_match() {
+        assert!(jsonpath_matches("$.a.b", "$.a.b"));
+        assert!(jsonpath_matches("$", "$"));
+        assert!(!jsonpath_matches("$.a.b", "$.a.c"));
+        assert!(!jsonpath_matches("$.a.b", "$.a"));
+    }
+
+    #[test]
+    fn test_jsonpath_star_wildcard() {
+        assert!(jsonpath_matches("$.*", "$.foo"));
+        assert!(jsonpath_matches("$.*", "$.bar"));
+        assert!(
+            !jsonpath_matches("$.*", "$.foo.child"),
+            "star must not cross depth"
+        );
+        // star must not match array-index segments
+        assert!(!jsonpath_matches("$.*", "$.items[0]"));
+    }
+
+    #[test]
+    fn test_jsonpath_array_wildcard() {
+        assert!(jsonpath_matches("$.items[*]", "$.items[0]"));
+        assert!(jsonpath_matches("$.items[*]", "$.items[99]"));
+        assert!(!jsonpath_matches("$.items[*]", "$.other[0]"));
+        assert!(
+            !jsonpath_matches("$.items[*]", "$.items[0].name"),
+            "must not match deeper path"
+        );
+    }
+
+    #[test]
+    fn test_jsonpath_nested_star() {
+        assert!(jsonpath_matches("$.a.*", "$.a.x"));
+        assert!(jsonpath_matches("$.a.*", "$.a.y"));
+        assert!(!jsonpath_matches("$.a.*", "$.b.x"));
+        assert!(!jsonpath_matches("$.a.*", "$.a.x.z"));
     }
 
     #[test]

--- a/crates/librefang-runtime/tests/mcp_oauth_integration.rs
+++ b/crates/librefang-runtime/tests/mcp_oauth_integration.rs
@@ -89,6 +89,7 @@ async fn test_http_connect_calls_oauth_provider_load_token() {
         oauth_provider: Some(provider.clone()),
         oauth_config: None,
         taint_scanning: true,
+        taint_policy: None,
         roots: vec![],
     };
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3561,6 +3561,42 @@ fn default_prompt_caching() -> bool {
     true
 }
 
+/// Taint skip rules for a single argument path within a tool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct McpTaintPathPolicy {
+    /// Rule IDs to skip when scanning this path.  An empty list means
+    /// all rules apply (no exemption).
+    #[serde(default)]
+    pub skip_rules: Vec<crate::taint::TaintRuleId>,
+}
+
+/// Per-tool taint policy for an MCP server.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct McpTaintToolPolicy {
+    /// Per-path exemptions.  The key is a minimal JSONPath expression
+    /// (e.g. `$.tabId`, `$.headers.*`, `$.items[*]`).  Paths not
+    /// listed here have all rules applied.
+    #[serde(default)]
+    pub paths: HashMap<String, McpTaintPathPolicy>,
+}
+
+/// Per-server taint policy that lets operators disable specific taint
+/// rules for known-safe fields rather than turning off all scanning.
+///
+/// Example config.toml:
+/// ```toml
+/// [mcp_servers.my_firefox.taint_policy.tools.navigate.paths]
+/// "$.tabId"     = { skip_rules = ["opaque_token"] }
+/// "$.sessionId" = { skip_rules = ["opaque_token"] }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct McpTaintPolicy {
+    /// Per-tool exemptions.  The key is the tool name as it appears in
+    /// the MCP server's tool list (without the `mcp_<server>_` prefix).
+    #[serde(default)]
+    pub tools: HashMap<String, McpTaintToolPolicy>,
+}
+
 /// Configuration entry for an MCP server.
 ///
 /// This is the config.toml representation. The runtime `McpServerConfig`
@@ -3607,6 +3643,13 @@ pub struct McpServerConfigEntry {
     /// trip the scanner. Key-name blocking remains active regardless.
     #[serde(default = "default_taint_scanning")]
     pub taint_scanning: bool,
+    /// Fine-grained taint exemptions per tool and per argument path.
+    ///
+    /// When `taint_scanning = true` (the default), specific rules can be
+    /// disabled for known-safe fields here rather than disabling all scanning.
+    /// When `taint_scanning = false`, this field is ignored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taint_policy: Option<McpTaintPolicy>,
 }
 
 fn default_taint_scanning() -> bool {

--- a/crates/librefang-types/src/taint.rs
+++ b/crates/librefang-types/src/taint.rs
@@ -11,6 +11,35 @@ use std::collections::HashSet;
 use std::fmt;
 use std::sync::OnceLock;
 
+/// Identifies a specific taint detection rule.
+///
+/// Used by [`check_outbound_text_violation_with_skip`] to let callers opt out
+/// of individual rules without touching the main code path.  Per-tool,
+/// per-path exemptions in `McpTaintPolicy` map directly to these variants.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaintRuleId {
+    /// Blocks the literal `Authorization:` header prefix.
+    AuthorizationLiteral,
+    /// Blocks `key=value` / `key: value` / `"key":` shapes for known secret-key names.
+    KeyValueSecret,
+    /// Blocks well-known credential prefixes (`sk-`, `ghp_`, `AKIA`, `AIza`, …).
+    WellKnownPrefix,
+    /// Blocks long opaque tokens (≥32 mixed-alnum chars without a date component).
+    OpaqueToken,
+    /// Blocks e-mail addresses.
+    PiiEmail,
+    /// Blocks phone numbers.
+    PiiPhone,
+    /// Blocks credit-card numbers.
+    PiiCreditCard,
+    /// Blocks Social Security Numbers.
+    PiiSsn,
+    /// Blocks JSON object keys whose name is a well-known credential key
+    /// (e.g. `authorization`, `api_key`, `secret`).
+    SensitiveKeyName,
+}
+
 /// A classification label applied to data flowing through the system.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TaintLabel {
@@ -192,7 +221,24 @@ impl TaintSink {
 /// (homoglyph, base64, zero-width splits, …) still bypasses it.
 /// The goal is to catch the obvious "LLM stuffs an API key into a
 /// tool call" shape on the way out.
+///
+/// To skip specific rules for known-safe fields, use
+/// [`check_outbound_text_violation_with_skip`] instead.
 pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<String> {
+    check_outbound_text_violation_with_skip(payload, sink, &HashSet::new())
+}
+
+/// Like [`check_outbound_text_violation`] but lets callers skip specific
+/// [`TaintRuleId`]s.  Rules listed in `skip_rules` are not evaluated.
+///
+/// Rules not in `skip_rules` behave identically to the base function.
+/// An empty `skip_rules` is equivalent to calling
+/// [`check_outbound_text_violation`] directly.
+pub fn check_outbound_text_violation_with_skip(
+    payload: &str,
+    sink: &TaintSink,
+    skip_rules: &HashSet<TaintRuleId>,
+) -> Option<String> {
     const SECRET_KEYS: &[&str] = &[
         "api_key",
         "apikey",
@@ -212,7 +258,8 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     let lower = payload.to_lowercase();
 
     // 1. `Authorization:` header literal — unambiguous.
-    let mut hit = lower.contains("authorization:");
+    let mut hit = !skip_rules.contains(&TaintRuleId::AuthorizationLiteral)
+        && lower.contains("authorization:");
 
     // 2. `key=value` / `key: value` / `"key":` / `'key':` shapes,
     //    including variants with whitespace around the separator
@@ -221,7 +268,7 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     //    separator list can stay compact. The separator gate still
     //    keeps natural-language ("a token of appreciation") from
     //    tripping the filter.
-    if !hit {
+    if !hit && !skip_rules.contains(&TaintRuleId::KeyValueSecret) {
         let normalized = lower
             .replace(" = ", "=")
             .replace(" =", "=")
@@ -229,15 +276,12 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
             .replace(" : ", ":")
             .replace(" :", ":")
             .replace(": ", ":");
-        for k in SECRET_KEYS {
+        'outer: for k in SECRET_KEYS {
             for sep in ["=", ":", "\":", "':"] {
                 if normalized.contains(&format!("{k}{sep}")) {
                     hit = true;
-                    break;
+                    break 'outer;
                 }
-            }
-            if hit {
-                break;
             }
         }
     }
@@ -253,56 +297,68 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     // flagged. Real opaque tokens mix letters and digits.
     if !hit {
         let trimmed = payload.trim();
-        let charset_ok = !trimmed.chars().any(char::is_whitespace)
-            && trimmed.chars().all(|c| {
-                c.is_ascii_alphanumeric()
-                    || c == '-'
-                    || c == '_'
-                    || c == '.'
-                    || c == '/'
-                    || c == '+'
-                    || c == '='
-            });
-        let has_letter = trimmed.chars().any(|c| c.is_ascii_alphabetic());
-        let has_digit = trimmed.chars().any(|c| c.is_ascii_digit());
-        let is_hex_only = trimmed.chars().all(|c| c.is_ascii_hexdigit());
-        // Require letters + digits AND reject pure-hex runs. This
-        // excludes git SHAs (40-hex), sha256 (64-hex), UUIDs without
-        // dashes (32-hex), and bare decimal runs — all common in
-        // legitimate tool arguments.
-        let mixed_enough = has_letter && has_digit && !is_hex_only;
-        // Strings containing a calendar date component (YYYY-MM-DD) are
-        // structured resource identifiers, not opaque credentials. Real
-        // API tokens never embed dates. This prevents false positives on
-        // MCP session handles of the form `tab-2026-04-16-<uuid-parts>`.
-        let has_date_component = date_component_regex().is_match(trimmed);
-        // File paths (absolute or relative with directory separators)
-        // are structured identifiers, not credentials. Exclude strings
-        // that look like paths: start with `/` or `C:\`, or contain
-        // multiple `/` segments with a file extension at the end.
-        let looks_like_path = trimmed.starts_with('/')
-            || (trimmed.len() >= 3
-                && trimmed.as_bytes()[1] == b':'
-                && trimmed.as_bytes()[2] == b'\\')
-            || trimmed.starts_with("\\\\")
-            || (trimmed.contains('/')
-                && trimmed
-                    .rfind('.')
-                    .is_some_and(|dot| dot > trimmed.rfind('/').unwrap_or(0)));
-        let looks_opaque = trimmed.len() >= 32
-            && charset_ok
-            && mixed_enough
-            && !has_date_component
-            && !looks_like_path;
-        let well_known = trimmed.starts_with("sk-")
-            || trimmed.starts_with("ghp_")
-            || trimmed.starts_with("github_pat_")
-            || trimmed.starts_with("xoxp-")
-            || trimmed.starts_with("xoxb-")
-            || trimmed.starts_with("AKIA")
-            || trimmed.starts_with("AIza");
-        if looks_opaque || well_known {
-            hit = true;
+        let skip_opaque = skip_rules.contains(&TaintRuleId::OpaqueToken);
+        let skip_well_known = skip_rules.contains(&TaintRuleId::WellKnownPrefix);
+        if !skip_opaque || !skip_well_known {
+            let charset_ok = !trimmed.chars().any(char::is_whitespace)
+                && trimmed.chars().all(|c| {
+                    c.is_ascii_alphanumeric()
+                        || c == '-'
+                        || c == '_'
+                        || c == '.'
+                        || c == '/'
+                        || c == '+'
+                        || c == '='
+                });
+            let has_letter = trimmed.chars().any(|c| c.is_ascii_alphabetic());
+            let has_digit = trimmed.chars().any(|c| c.is_ascii_digit());
+            let is_hex_only = trimmed.chars().all(|c| c.is_ascii_hexdigit());
+            // Require letters + digits AND reject pure-hex runs. This
+            // excludes git SHAs (40-hex), sha256 (64-hex), UUIDs without
+            // dashes (32-hex), and bare decimal runs — all common in
+            // legitimate tool arguments.
+            let mixed_enough = has_letter && has_digit && !is_hex_only;
+            // Strings containing a calendar date component (YYYY-MM-DD) are
+            // structured resource identifiers, not opaque credentials. Real
+            // API tokens never embed dates. This prevents false positives on
+            // MCP session handles of the form `tab-2026-04-16-<uuid-parts>`.
+            let has_date_component = date_component_regex().is_match(trimmed);
+            // File paths (absolute or relative with directory separators)
+            // are structured identifiers, not credentials. Exclude strings
+            // that look like paths: start with `/` or `C:\`, or contain
+            // multiple `/` segments with a file extension at the end.
+            let looks_like_path = trimmed.starts_with('/')
+                || (trimmed.len() >= 3
+                    && trimmed.as_bytes()[1] == b':'
+                    && trimmed.as_bytes()[2] == b'\\')
+                || trimmed.starts_with("\\\\")
+                || (trimmed.contains('/')
+                    && trimmed
+                        .rfind('.')
+                        .is_some_and(|dot| dot > trimmed.rfind('/').unwrap_or(0)));
+
+            if !skip_opaque {
+                let looks_opaque = trimmed.len() >= 32
+                    && charset_ok
+                    && mixed_enough
+                    && !has_date_component
+                    && !looks_like_path;
+                if looks_opaque {
+                    hit = true;
+                }
+            }
+            if !hit && !skip_well_known {
+                let well_known = trimmed.starts_with("sk-")
+                    || trimmed.starts_with("ghp_")
+                    || trimmed.starts_with("github_pat_")
+                    || trimmed.starts_with("xoxp-")
+                    || trimmed.starts_with("xoxb-")
+                    || trimmed.starts_with("AKIA")
+                    || trimmed.starts_with("AIza");
+                if well_known {
+                    hit = true;
+                }
+            }
         }
     }
 
@@ -310,7 +366,9 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     if hit {
         labels.insert(TaintLabel::Secret);
     }
-    if sink.blocked_labels.contains(&TaintLabel::Pii) && payload_contains_pii(payload) {
+    if sink.blocked_labels.contains(&TaintLabel::Pii)
+        && payload_contains_pii_with_skip(payload, skip_rules)
+    {
         labels.insert(TaintLabel::Pii);
     }
     if labels.is_empty() {
@@ -323,7 +381,7 @@ pub fn check_outbound_text_violation(payload: &str, sink: &TaintSink) -> Option<
     None
 }
 
-fn payload_contains_pii(payload: &str) -> bool {
+fn payload_contains_pii_with_skip(payload: &str, skip_rules: &HashSet<TaintRuleId>) -> bool {
     let trimmed = payload.trim();
     let tokenish_mixed = !trimmed.is_empty()
         && !trimmed.contains('@')
@@ -354,10 +412,11 @@ fn payload_contains_pii(payload: &str) -> bool {
     if is_numeric_timestamp {
         return false;
     }
-    email_regex().is_match(payload)
-        || phone_regex().is_match(payload)
-        || credit_card_regex().is_match(payload)
-        || ssn_regex().is_match(payload)
+    (!skip_rules.contains(&TaintRuleId::PiiEmail) && email_regex().is_match(payload))
+        || (!skip_rules.contains(&TaintRuleId::PiiPhone) && phone_regex().is_match(payload))
+        || (!skip_rules.contains(&TaintRuleId::PiiCreditCard)
+            && credit_card_regex().is_match(payload))
+        || (!skip_rules.contains(&TaintRuleId::PiiSsn) && ssn_regex().is_match(payload))
 }
 
 /// Matches a calendar date in ISO 8601 / RFC 3339 form (`YYYY-MM-DD`).
@@ -703,5 +762,81 @@ mod tests {
             check_outbound_text_violation(tok, &sink).is_some(),
             "opaque token without date must still be blocked"
         );
+    }
+
+    // ── skip-rules API ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_skip_opaque_token_allows_browser_tab_id() {
+        // camofox tabId is a long mixed-alnum handle — normally blocked by
+        // OpaqueToken heuristic.  Skipping that rule must let it through.
+        let sink = TaintSink::mcp_tool_call();
+        let tab_id = "xAbCdEfGhIjKlMnOpQrStUvWxYz1234567890AB";
+        assert!(tab_id.len() >= 32);
+
+        // Without skip: blocked.
+        assert!(check_outbound_text_violation(tab_id, &sink).is_some());
+
+        // With OpaqueToken skipped: allowed.
+        let mut skip = HashSet::new();
+        skip.insert(TaintRuleId::OpaqueToken);
+        assert!(
+            check_outbound_text_violation_with_skip(tab_id, &sink, &skip).is_none(),
+            "OpaqueToken skip must allow browser tab IDs"
+        );
+    }
+
+    #[test]
+    fn test_skip_pii_email_allows_email_field() {
+        let sink = TaintSink::mcp_tool_call();
+        let email = "user@example.com";
+
+        assert!(check_outbound_text_violation(email, &sink).is_some());
+
+        let mut skip = HashSet::new();
+        skip.insert(TaintRuleId::PiiEmail);
+        assert!(
+            check_outbound_text_violation_with_skip(email, &sink, &skip).is_none(),
+            "PiiEmail skip must allow e-mail values"
+        );
+    }
+
+    #[test]
+    fn test_skip_well_known_prefix_allows_sk_token() {
+        let sink = TaintSink::mcp_tool_call();
+        let tok = "sk-not-a-real-token";
+
+        assert!(check_outbound_text_violation(tok, &sink).is_some());
+
+        let mut skip = HashSet::new();
+        skip.insert(TaintRuleId::WellKnownPrefix);
+        assert!(
+            check_outbound_text_violation_with_skip(tok, &sink, &skip).is_none(),
+            "WellKnownPrefix skip must allow sk- values"
+        );
+    }
+
+    #[test]
+    fn test_skip_does_not_bypass_non_skipped_rules() {
+        // Skipping OpaqueToken must not suppress KeyValueSecret detection.
+        let sink = TaintSink::mcp_tool_call();
+        let payload = "api_key=sk-not-real";
+        let mut skip = HashSet::new();
+        skip.insert(TaintRuleId::OpaqueToken);
+        assert!(
+            check_outbound_text_violation_with_skip(payload, &sink, &skip).is_some(),
+            "Non-skipped rules must still fire"
+        );
+    }
+
+    #[test]
+    fn test_taint_rule_id_serde_roundtrip() {
+        // Verify that TaintRuleId serializes to the snake_case form the
+        // config parser expects and round-trips correctly.
+        let rule = TaintRuleId::OpaqueToken;
+        let json = serde_json::to_string(&rule).unwrap();
+        assert_eq!(json, "\"opaque_token\"");
+        let back: TaintRuleId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rule);
     }
 }


### PR DESCRIPTION
## Summary

Implements [#2728](https://github.com/librefang/librefang/issues/2728) (Parts 1 + 2 of the 3-PR rollout plan).

- **`TaintRuleId` enum** — individually addressable rules: `AuthorizationLiteral`, `KeyValueSecret`, `WellKnownPrefix`, `OpaqueToken`, `PiiEmail`, `PiiPhone`, `PiiCreditCard`, `PiiSsn`, `SensitiveKeyName`
- **`check_outbound_text_violation_with_skip(payload, sink, skip_rules)`** — parallel API; each rule is gated on `!skip_rules.contains(&RuleId)`. Original function delegates with `HashSet::new()`, so no behavior change for existing callers.
- **`McpTaintPolicy` / `McpTaintToolPolicy` / `McpTaintPathPolicy`** config types with TOML-friendly serde (`snake_case` rule IDs, optional at every level)
- **Minimal JSONPath matcher** (`$.a.b`, `$.a.*`, `$.a[*]`, `$.*`) — ~60 LOC, no dependencies
- **`scan_mcp_arguments_for_taint_with_policy`** — per-path `resolve_skip_rules` lookup feeds into `check_outbound_text_violation_with_skip` and `SensitiveKeyName` guard
- **`McpServerConfigEntry.taint_policy`** + **`McpServerConfig.taint_policy`** propagated through all 5 kernel construction sites
- `call_tool` computes `raw_name` before taint check so the correct un-prefixed tool name is used for policy lookup

### Example config

```toml
[mcp_servers.camofox.taint_policy.tools.navigate.paths]
"$.tabId"     = { skip_rules = ["opaque_token"] }
"$.sessionId" = { skip_rules = ["opaque_token"] }
"$.contextId" = { skip_rules = ["opaque_token"] }
```

### Coexistence / migration

- `taint_scanning = false` → `taint_policy` is ignored (no regression)
- `taint_scanning = true` (default) + no `taint_policy` → same behavior as before
- `taint_scanning = true` + `taint_policy` set → fine-grained enforcement

### Out of scope (Part 3)

Dashboard tree editor + `GET /api/mcp/servers/:name/tools` + `PUT /api/mcp/servers/:name/taint_policy` can follow in a separate PR once this lands.

## Test plan

- [x] All 25 `librefang-types::taint` tests pass (including 5 new skip-API tests)
- [x] All 61 `librefang-runtime-mcp` tests pass
- [x] Full workspace `cargo test --workspace --lib` passes (1 pre-existing flaky embedding env-pollution test, passes in isolation)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #2728