### PR TITLE
fix(desktop): fix connection screen IPC on Windows + add uninstall button

### DIFF
--- a/crates/librefang-desktop/src/commands.rs
+++ b/crates/librefang-desktop/src/commands.rs
@@ -196,3 +196,97 @@ pub fn open_logs_dir() -> Result<(), String> {
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create logs dir: {e}"))?;
     open::that(&dir).map_err(|e| format!("Failed to open directory: {e}"))
 }
+
+/// Launch the platform uninstaller and exit the app.
+///
+/// - **Windows**: reads `UninstallString` from the NSIS registry key and runs it.
+/// - **macOS**: moves the `.app` bundle to Trash via `osascript` + Finder.
+/// - **Linux/AppImage**: deletes the AppImage binary directly.
+/// - **Linux/system package**: returns a hint to run the distro uninstall command.
+#[tauri::command]
+pub async fn uninstall_app(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        // `reg query` is a built-in Windows tool — no extra deps required.
+        let output = std::process::Command::new("reg")
+            .args([
+                "query",
+                "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+                "/f",
+                "LibreFang",
+                "/s",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to query registry: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("UninstallString") {
+                // reg output columns are space-separated: Name    REG_SZ    Value
+                if let Some(value) = trimmed.splitn(3, "    ").nth(2) {
+                    let cmd = value.trim().to_string();
+                    std::process::Command::new("cmd")
+                        .args(["/C", &cmd])
+                        .spawn()
+                        .map_err(|e| format!("Failed to launch uninstaller: {e}"))?;
+                    app.exit(0);
+                    return Ok(());
+                }
+            }
+        }
+        Err("Uninstaller not found in registry. The app may have been installed without the NSIS installer.".to_string())
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // Walk up from the executable to find the enclosing .app bundle.
+        let exe = std::env::current_exe().map_err(|e| format!("Cannot locate executable: {e}"))?;
+        let bundle = exe
+            .ancestors()
+            .find(|p| p.extension().and_then(|e| e.to_str()) == Some("app"))
+            .map(|p| p.to_path_buf())
+            .ok_or_else(|| {
+                "App bundle (.app) not found — was LibreFang installed from a .dmg?".to_string()
+            })?;
+
+        let path = bundle.to_string_lossy().replace('"', "\\\"");
+        std::process::Command::new("osascript")
+            .args([
+                "-e",
+                &format!(r#"tell application "Finder" to move POSIX file "{path}" to trash"#),
+            ])
+            .spawn()
+            .map_err(|e| format!("Failed to move app to Trash: {e}"))?;
+        app.exit(0);
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let exe = std::env::current_exe().map_err(|e| format!("Cannot locate executable: {e}"))?;
+        let exe_str = exe.to_string_lossy();
+
+        // AppImage: the executable IS the package — just remove it.
+        if exe_str.ends_with(".AppImage") || std::env::var("APPIMAGE").is_ok() {
+            let target = std::env::var("APPIMAGE")
+                .map(std::path::PathBuf::from)
+                .unwrap_or(exe.clone());
+            std::fs::remove_file(&target).map_err(|e| format!("Failed to remove AppImage: {e}"))?;
+            app.exit(0);
+            return Ok(());
+        }
+
+        // System package: we can't elevate from inside the app, so surface the command.
+        let hint = if std::path::Path::new("/usr/bin/apt").exists() {
+            "sudo apt remove librefang"
+        } else if std::path::Path::new("/usr/bin/dnf").exists() {
+            "sudo dnf remove librefang"
+        } else if std::path::Path::new("/usr/bin/pacman").exists() {
+            "sudo pacman -R librefang"
+        } else {
+            "use your distro's package manager to remove librefang"
+        };
+        Err(format!("To uninstall, run in a terminal: {hint}"))
+    }
+}

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -363,6 +363,23 @@ pub fn connection_html() -> String {
     color: #a1a1aa;
     cursor: pointer;
   }
+  .btn-reset {
+    width: 100%;
+    padding: 8px 16px;
+    font-size: 12px;
+    font-weight: 500;
+    background: transparent;
+    color: #52525b;
+    border: 1px dashed #3f3f46;
+    border-radius: 8px;
+    cursor: pointer;
+    margin-top: 12px;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .btn-reset:hover:not(:disabled) {
+    color: #ef4444;
+    border-color: #ef4444;
+  }
   .status {
     margin-top: 16px;
     min-height: 20px;
@@ -399,11 +416,36 @@ pub fn connection_html() -> String {
     <label for="remember">Remember this choice</label>
   </div>
 
+  <button class="btn-reset" id="btn-reset" onclick="uninstallApp()">Uninstall LibreFang</button>
+
   <div class="status" id="status"></div>
 </div>
 
 <script>
-  const { invoke } = window.__TAURI__.core;
+  // Wait for Tauri v2 IPC to finish initializing before calling invoke.
+  // On about:blank pages, window.__TAURI__ is injected asynchronously by
+  // WebView2, so top-level access hits TDZ; lazy + polling avoids both.
+  function waitForTauri() {
+    return new Promise(function(resolve, reject) {
+      var deadline = Date.now() + 8000;
+      function check() {
+        if (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke) {
+          resolve();
+        } else if (Date.now() > deadline) {
+          reject(new Error('Tauri IPC unavailable — try restarting the app.'));
+        } else {
+          setTimeout(check, 50);
+        }
+      }
+      check();
+    });
+  }
+
+  function tauriInvoke(cmd, args) {
+    return waitForTauri().then(function() {
+      return window.__TAURI__.core.invoke(cmd, args);
+    });
+  }
 
   function setStatus(msg, cls) {
     const el = document.getElementById('status');
@@ -424,7 +466,7 @@ pub fn connection_html() -> String {
     setStatus('Testing connection...', 'info');
     setAllDisabled(true);
     try {
-      const result = await invoke('test_connection', { url });
+      await tauriInvoke('test_connection', { url });
       setStatus('Connected! Server is healthy.', 'success');
     } catch (e) {
       setStatus(String(e), 'error');
@@ -440,7 +482,7 @@ pub fn connection_html() -> String {
     setStatus('Connecting...', 'info');
     setAllDisabled(true);
     try {
-      await invoke('connect_remote', { url, remember });
+      await tauriInvoke('connect_remote', { url, remember });
     } catch (e) {
       setStatus(String(e), 'error');
       setAllDisabled(false);
@@ -452,10 +494,22 @@ pub fn connection_html() -> String {
     setStatus('Starting local server...', 'info');
     setAllDisabled(true);
     try {
-      await invoke('start_local', { remember });
+      await tauriInvoke('start_local', { remember });
     } catch (e) {
       setStatus(String(e), 'error');
       setAllDisabled(false);
+    }
+  }
+
+  async function uninstallApp() {
+    if (!confirm('Uninstall LibreFang? This will remove the application.')) return;
+    document.getElementById('btn-reset').disabled = true;
+    setStatus('Launching uninstaller...', 'info');
+    try {
+      await tauriInvoke('uninstall_app');
+    } catch (e) {
+      setStatus(String(e), 'error');
+      document.getElementById('btn-reset').disabled = false;
     }
   }
 </script>

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -259,6 +259,7 @@ pub fn run(server_url: Option<String>, force_local: bool) {
             commands::install_update,
             commands::open_config_dir,
             commands::open_logs_dir,
+            commands::uninstall_app,
             connection::test_connection,
             connection::connect_remote,
             connection::start_local,

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -5,6 +5,7 @@
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {
+    "withGlobalTauri": true,
     "windows": [],
     "security": {
       "csp": "default-src 'self' http://127.0.0.1:* ws://127.0.0.1:* https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob: http://127.0.0.1:*; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' blob: http://127.0.0.1:*; frame-src 'self' blob: http://127.0.0.1:*; object-src 'none'; base-uri 'self'; form-action 'self'"


### PR DESCRIPTION
## Summary

- **TDZ crash on Windows**: The connection screen is injected via `about:blank` + `document.write()`. The top-level `const { invoke } = window.__TAURI__.core` triggered a Temporal Dead Zone error on WebView2 because Tauri v2 initializes its IPC asynchronously. Fixed by moving the access into a lazy `tauriInvoke()` wrapper.
- **Test Connection / Connect buttons silently broken**: `withGlobalTauri` defaults to `false` in Tauri v2, so `window.__TAURI__.core` is never populated. Fixed by enabling `withGlobalTauri: true` in `tauri.conf.json`, plus a `waitForTauri()` polling guard (8 s timeout) to handle any remaining async-init races.
- **Uninstall button**: Added an "Uninstall LibreFang" button to the connection screen with per-platform handling:
  - **Windows** — reads `UninstallString` from the NSIS registry key via `reg query` and runs it
  - **macOS** — walks up to the `.app` bundle and moves it to Trash via `osascript` + Finder
  - **Linux / AppImage** — detects the `APPIMAGE` env var and deletes the binary directly
  - **Linux / system package** — returns the appropriate package manager uninstall command as a hint

## Changed files

- `crates/librefang-desktop/tauri.conf.json` — enable `withGlobalTauri: true`
- `crates/librefang-desktop/src/connection.rs` — lazy IPC wrapper, `waitForTauri` polling, uninstall button HTML/JS
- `crates/librefang-desktop/src/commands.rs` — `uninstall_app` Tauri command (all three platforms)
- `crates/librefang-desktop/src/lib.rs` — register `uninstall_app` in the invoke handler

## Test plan

- [ ] Windows: connection screen loads; Test Connection and Connect work with a custom URL
- [ ] Windows: Start Local Server no longer crashes with a TDZ / ReferenceError
- [ ] Windows: Uninstall button shows a confirm dialog then launches the NSIS uninstaller
- [ ] macOS: Uninstall button moves the `.app` bundle to Trash
- [ ] Linux AppImage: Uninstall button removes the AppImage binary