### PR TITLE
feat(ws,dashboard): per-tab session_id on WebSocket + URL-driven ChatPage (incremental on #2989)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -328,6 +328,13 @@ export interface SendAgentMessageOptions {
   thinking?: boolean;
   /** Whether to receive the model's reasoning trace. Defaults to true. */
   show_thinking?: boolean;
+  /**
+   * Optional explicit session id (issue #2959). When provided, this send
+   * targets the given session regardless of the agent's canonical session.
+   * Used by the chat UI when a specific session is selected in the URL so
+   * two browser tabs on the same agent don't race each other.
+   */
+  session_id?: string | null;
 }
 
 export interface ApiActionResponse {
@@ -978,6 +985,7 @@ export async function sendAgentMessage(
   const body: Record<string, unknown> = { message };
   if (options?.thinking !== undefined) body.thinking = options.thinking;
   if (options?.show_thinking !== undefined) body.show_thinking = options.show_thinking;
+  if (options?.session_id) body.session_id = options.session_id;
   return post<AgentMessageResponse>(
     `/api/agents/${encodeURIComponent(agentId)}/message`,
     body,

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -33,7 +33,6 @@ import {
   usePatchAgentConfig,
   useResolveApproval,
   useStopAgent,
-  useSwitchAgentSession,
 } from "../lib/mutations/agents";
 import "katex/dist/katex.min.css";
 
@@ -1762,7 +1761,9 @@ export function ChatPage() {
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const addToast = useUIStore((s) => s.addToast);
   const createSessionMutation = useCreateAgentSession();
-  const switchSessionMutation = useSwitchAgentSession();
+  // NOTE: switch_agent_session is no longer called from ChatPage — see issue
+  // #2959. Sessions are URL-driven per tab; other callers (CLI, cron) still
+  // use the endpoint for registry-canonical switching.
   const deleteSessionMutation = useDeleteAgentSession();
   const patchAgentConfigMutation = usePatchAgentConfig();
 
@@ -1878,12 +1879,17 @@ export function ChatPage() {
   );
   // Session state — bump version to force message reload after switch
   const [sessionVersion, setSessionVersion] = useState(0);
+  // URL-driven session selection (issue #2959). When a `sessionId` query
+  // param is present, it wins over the server's canonical active session so
+  // two browser tabs on the same agent can hold independent sessions.
+  const urlSessionId = search?.sessionId || null;
   const { messages, isLoading, sendMessage, stopMessage, clearHistory, wsConnected } = useChatMessages(
     selectedAgentId || null,
     agents,
     sessionVersion,
     () => void agentsQuery.refetch(),
     (message) => addToast(message, "error"),
+    urlSessionId,
   );
   // Track LLM text streaming (cleared on `typing:stop`) independently of
   // `isLoading`, which stays true through post-processing until the final
@@ -1934,29 +1940,51 @@ export function ChatPage() {
   const { pendingApprovals, removeApproval } = useApprovalPoller(selectedAgentId || null);
   const selectedAgent = agents.find(a => a.id === selectedAgentId);
 
-  // Per-agent session list
+  // Per-agent session list. `activeSessionId` is derived from the URL first
+  // (multi-tab safety, issue #2959); if absent, fall back to the server's
+  // canonical active session so initial navigation still highlights correctly.
   const sessionsQuery = useAgentSessions(selectedAgentId);
-  const activeSessionId = useMemo(() => {
+  const serverActiveSessionId = useMemo(() => {
     const active = sessionsQuery.data?.find((s: SessionListItem) => s.active);
     return active?.session_id;
   }, [sessionsQuery.data]);
+  const activeSessionId = urlSessionId ?? serverActiveSessionId;
 
+  // Sidebar clicks update the URL — no switch_agent_session POST. Each tab's
+  // URL carries its own sessionId, and the send path forwards it per-request.
   const handleSwitchSession = useCallback(async (sessionId: string) => {
     if (!selectedAgentId) return;
-    await switchSessionMutation.mutateAsync({ agentId: selectedAgentId, sessionId });
+    navigate({
+      to: "/chat",
+      search: { agentId: selectedAgentId, sessionId },
+      replace: false,
+    });
     setSessionVersion(v => v + 1);
-  }, [selectedAgentId, switchSessionMutation]);
+  }, [selectedAgentId, navigate]);
 
   const handleNewSession = useCallback(async () => {
     if (!selectedAgentId) return;
     const result = await createSessionMutation.mutateAsync({ agentId: selectedAgentId });
-    await switchSessionMutation.mutateAsync({ agentId: selectedAgentId, sessionId: result.session_id });
+    navigate({
+      to: "/chat",
+      search: { agentId: selectedAgentId, sessionId: result.session_id },
+      replace: false,
+    });
     setSessionVersion(v => v + 1);
-  }, [selectedAgentId, createSessionMutation, switchSessionMutation]);
+  }, [selectedAgentId, createSessionMutation, navigate]);
 
   const handleDeleteSession = useCallback(async (sessionId: string) => {
     await deleteSessionMutation.mutateAsync({ sessionId, agentId: selectedAgentId });
-  }, [deleteSessionMutation, selectedAgentId]);
+    // If the deleted session is the one pinned in the URL, drop the param
+    // so the next render falls back to server-active (if any).
+    if (urlSessionId && urlSessionId === sessionId) {
+      navigate({
+        to: "/chat",
+        search: { agentId: selectedAgentId },
+        replace: true,
+      });
+    }
+  }, [deleteSessionMutation, selectedAgentId, urlSessionId, navigate]);
 
   // If the current selection is no longer visible (e.g. hand agents toggled
   // off while a hand-spawned agent was selected), clear it so the auto-select

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -116,7 +116,7 @@ function makeMessageId(prefix: string): string {
 
 
 // WebSocket hook with auto-reconnect
-function useWebSocket(agentId: string | null) {
+function useWebSocket(agentId: string | null, sessionId: string | null = null) {
   const wsRef = useRef<WebSocket | null>(null);
   const [wsConnected, setWsConnected] = useState(false);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -130,7 +130,15 @@ function useWebSocket(agentId: string | null) {
       return;
     }
 
-    const url = buildAuthenticatedWebSocketUrl(`/api/agents/${encodeURIComponent(agentId)}/ws`);
+    // Issue #2959: per-connection session_id override. When the active
+    // session is set (usually from the `?sessionId=` URL), append it to the
+    // WS URL so every send on this socket targets that session regardless of
+    // the agent's registry-canonical session — enabling multi-tab isolation.
+    const base = `/api/agents/${encodeURIComponent(agentId)}/ws`;
+    const wsPath = sessionId
+      ? `${base}?session_id=${encodeURIComponent(sessionId)}`
+      : base;
+    const url = buildAuthenticatedWebSocketUrl(wsPath);
 
     function connect() {
       try {
@@ -183,7 +191,7 @@ function useWebSocket(agentId: string | null) {
         wsRef.current = null;
       }
     };
-  }, [agentId]);
+  }, [agentId, sessionId]);
 
   return { ws: wsRef, wsConnected, onDropRef };
 }
@@ -193,7 +201,7 @@ const sessionCache = new Map<string, ChatMessage[]>();
 
 // Chat message management - includes history loading and sending (with WS streaming)
 // sessionVersion: bump to force reload after session switch
-function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void) {
+function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void, sessionId: string | null = null) {
   const { t } = useTranslation();
   const stopAgentMutation = useStopAgent();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -250,7 +258,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
       if (!alive.has(id)) delete latestTurns[id];
     }
   }, [agents]);
-  const { ws, wsConnected, onDropRef } = useWebSocket(agentId);
+  const { ws, wsConnected, onDropRef } = useWebSocket(agentId, sessionId);
   const addSkillOutput = useUIStore((s) => s.addSkillOutput);
   const deepThinking = useUIStore((s) => s.deepThinking);
   const showThinkingProcess = useUIStore((s) => s.showThinkingProcess);
@@ -491,6 +499,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
         const response = await sendAgentMessage(sendAgentId, trimmed, {
           thinking: deepThinking,
           show_thinking: showThinkingProcess,
+          session_id: sessionId,
         });
         const fullContent = response.response || "";
         updateAgentMessages(sendAgentId, prev => prev.map(m =>

--- a/crates/librefang-api/dashboard/src/router.tsx
+++ b/crates/librefang-api/dashboard/src/router.tsx
@@ -138,9 +138,12 @@ const channelsRoute = createRoute({
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/chat",
-  validateSearch: (search: Record<string, unknown>) => ({
-    agentId: search.agentId as string | undefined
-  }),
+  validateSearch: (search: Record<string, unknown>): { agentId?: string; sessionId?: string } => {
+    const out: { agentId?: string; sessionId?: string } = {};
+    if (typeof search.agentId === "string") out.agentId = search.agentId;
+    if (typeof search.sessionId === "string") out.sessionId = search.sessionId;
+    return out;
+  },
   component: () => <L><ChatPage /></L>
 });
 

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -24,7 +24,7 @@ use librefang_channels::types::SenderContext;
 use librefang_runtime::kernel_handle::KernelHandle;
 use librefang_runtime::llm_driver::{StreamEvent, PHASE_RESPONSE_COMPLETE};
 use librefang_runtime::llm_errors;
-use librefang_types::agent::AgentId;
+use librefang_types::agent::{AgentId, SessionId};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
@@ -369,9 +369,40 @@ pub async fn agent_ws(
         return axum::http::StatusCode::NOT_FOUND.into_response();
     }
 
+    // Optional per-connection explicit session_id override (issue #2959).
+    // When present, every send on this socket targets the given session —
+    // two browser tabs on the same agent with different `?session_id=` values
+    // no longer race each other's sessions. We validate at upgrade time so
+    // the client sees a rejected handshake rather than a connected-then-dropped
+    // socket.
+    let explicit_session: Option<SessionId> = match ws_query_param(&uri, "session_id") {
+        None => None,
+        Some(raw) => match raw.parse::<SessionId>() {
+            Ok(sid) => match state.kernel.memory_substrate().get_session(sid) {
+                Ok(Some(s)) if s.agent_id == agent_id => Some(sid),
+                Ok(Some(_)) | Ok(None) => {
+                    warn!(
+                        agent_id = %agent_id,
+                        "WebSocket upgrade rejected: session_id invalid for agent"
+                    );
+                    return axum::http::StatusCode::BAD_REQUEST.into_response();
+                }
+                Err(e) => {
+                    warn!(error = %e, "WebSocket upgrade rejected: memory error resolving session");
+                    return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
+            },
+            Err(_) => {
+                return axum::http::StatusCode::BAD_REQUEST.into_response();
+            }
+        },
+    };
+
     let id_str = id.clone();
-    ws.on_upgrade(move |socket| handle_agent_ws(socket, state, agent_id, id_str, ip, guard))
-        .into_response()
+    ws.on_upgrade(move |socket| {
+        handle_agent_ws(socket, state, agent_id, id_str, ip, guard, explicit_session)
+    })
+    .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -389,6 +420,7 @@ async fn handle_agent_ws(
     id_str: String,
     client_ip: IpAddr,
     _guard: WsConnectionGuard,
+    explicit_session: Option<SessionId>,
 ) {
     info!(agent_id = %id_str, "WebSocket connected");
 
@@ -535,7 +567,16 @@ async fn handle_agent_ws(
                 }
                 msg_times.push(now);
 
-                handle_text_message(&sender, &state, agent_id, &text, &verbose, client_ip).await;
+                handle_text_message(
+                    &sender,
+                    &state,
+                    agent_id,
+                    &text,
+                    &verbose,
+                    client_ip,
+                    explicit_session,
+                )
+                .await;
             }
             Message::Close(_) => {
                 info!(agent_id = %id_str, "WebSocket closed by client");
@@ -567,6 +608,7 @@ async fn handle_text_message(
     text: &str,
     verbose: &Arc<AtomicU8>,
     client_ip: IpAddr,
+    explicit_session: Option<SessionId>,
 ) {
     // Parse the message
     let parsed: serde_json::Value = match serde_json::from_str(text) {
@@ -743,12 +785,13 @@ async fn handle_text_message(
             };
             match state
                 .kernel
-                .send_message_streaming_with_sender_context_routing_and_thinking(
+                .send_message_streaming_with_sender_context_routing_thinking_and_session(
                     agent_id,
                     &content,
                     Some(kernel_handle),
                     &sender_ctx,
                     thinking_override,
+                    explicit_session,
                 )
                 .await
             {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4729,13 +4729,18 @@ system_prompt = "You are a helpful assistant."
             allowed_tools,
             interrupt: Some(interrupt),
         };
+        // INVARIANT: forks must use the canonical session so the parent turn's
+        // prompt-cache prefix is reused. Do NOT pass a `session_id_override`
+        // here — it would win over the fork branch in
+        // `send_message_streaming_with_sender_and_opts`'s session resolver and
+        // break cache alignment (see issue #2959 for the override semantics).
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
             fork_prompt,
             None, // auto-wire self
             None, // no sender context — fork uses the canonical session
             None, // no thinking override
-            None, // forks always use canonical session
+            None, // forks MUST stay on canonical — see invariant above
             loop_opts,
         )
     }
@@ -4930,6 +4935,12 @@ system_prompt = "You are a helpful assistant."
                 // `SessionId::new()` here, producing a fresh empty session
                 // and breaking cache alignment. Force Persistent for forks
                 // regardless of manifest.
+                //
+                // NOTE: an explicit `session_id_override` (above) wins over
+                // this branch — if you ever plumb an override through a fork
+                // caller, prompt-cache alignment WILL break. The current
+                // `run_forked_agent_streaming` deliberately passes `None` to
+                // preserve this invariant.
                 _ if loop_opts.is_fork => entry.session_id,
                 _ => match entry.manifest.session_mode {
                     librefang_types::agent::SessionMode::Persistent => entry.session_id,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4624,6 +4624,35 @@ system_prompt = "You are a helpful assistant."
         .await
     }
 
+    /// Streaming entry point that combines a sender context with a per-request
+    /// `session_id_override` (multi-tab WebSocket UIs, issue #2959). The
+    /// override wins over channel-derived session resolution. When `None`,
+    /// behavior is identical to
+    /// [`Self::send_message_streaming_with_sender_context_routing_and_thinking`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn send_message_streaming_with_sender_context_routing_thinking_and_session(
+        self: &Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn KernelHandle>>,
+        sender: &SenderContext,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
+    )> {
+        self.send_message_streaming_resolved(
+            agent_id,
+            message,
+            kernel_handle,
+            Some(sender),
+            thinking_override,
+            session_id_override,
+        )
+        .await
+    }
+
     /// Send a message to an agent with streaming responses.
     ///
     /// Returns a receiver for incremental `StreamEvent`s and a `JoinHandle`

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -228,6 +228,13 @@ impl SessionId {
     }
 }
 
+impl std::str::FromStr for SessionId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        uuid::Uuid::parse_str(s).map(SessionId)
+    }
+}
+
 impl Default for SessionId {
     fn default() -> Self {
         Self::new()
@@ -1944,5 +1951,19 @@ model = "llama-3.3-70b-versatile"
         let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
         let sid = SessionId::for_channel(agent, "telegram");
         assert_eq!(sid.0.get_version_num(), 5, "SessionId must be UUID v5");
+    }
+
+    #[test]
+    fn session_id_from_str_parses_uuid() {
+        use std::str::FromStr;
+        let s = "550e8400-e29b-41d4-a716-446655440000";
+        let sid = SessionId::from_str(s).expect("valid uuid");
+        assert_eq!(sid.0.to_string(), s);
+    }
+
+    #[test]
+    fn session_id_from_str_rejects_garbage() {
+        use std::str::FromStr;
+        assert!(SessionId::from_str("not-a-uuid").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Closes #2959 (incremental on top of #2989).

#2989 already landed the kernel + HTTP body `session_id` override and the
per-session lock. This PR layers the remaining surfaces that were not
covered there:

- **WebSocket** `?session_id=<uuid>` per-connection override on
  `/api/agents/{id}/ws`. Validated at upgrade so the client sees a
  rejected handshake rather than a connected-then-dropped socket.
- **Dashboard** ChatPage drives the active session from the URL
  (`/chat?agentId=...&sessionId=...`). Sidebar clicks update the URL
  instead of calling `switch_agent_session`, so two browser tabs on the
  same agent now hold independent sessions without racing each other.
- **`sendAgentMessage`** in `api.ts` includes the `session_id` field in
  the body when set; `useChatMessages` / `useWebSocket` thread the
  active sessionId through.
- **Kernel helper** `send_message_streaming_with_sender_context_routing_thinking_and_session`:
  a 6-arg variant of the existing routing-with-sender-and-thinking
  streaming helper that also accepts `session_id_override`. Required by
  the WS path which already sets a `webui` SenderContext but now also
  needs the per-tab override. Existing 5-arg helper signature is
  unchanged.
- **`FromStr for SessionId`** so query strings (`?session_id=...`) parse
  cleanly into the typed id at the WS handshake.
- **Fork invariant docs.** Inline comments at both the fork branch in
  the session resolver and `run_forked_agent_streaming`'s call site
  warn that a future plumbing of `session_id_override` into a fork
  caller would win over the canonical-forcing branch and break
  prompt-cache alignment.

## Test Plan

Automated:
- [x] `cargo build --workspace --lib` clean.
- [x] `cargo clippy --workspace --lib -- -D warnings` clean.
- [x] `cargo test -p librefang-types --lib` — `FromStr for SessionId` parse + reject tests pass.
- [x] `cargo test -p librefang-api --lib` — 431/431 pass.
- [x] `cargo test -p librefang-kernel --lib` — 475 pass (1 pre-existing
  failure in `config::tests::test_load_config_defaults` unrelated to
  this branch; no `config.rs` changes here).
- [x] Dashboard `pnpm tsc --noEmit` clean.

WS handshake-level integration tests are deferred — the existing
`axum::serve()` test harness in `crates/librefang-api/tests/` does not
attach `ConnectInfo<SocketAddr>`, which the WS handler requires as an
extractor. Manual verification was performed against a live OpenRouter
daemon (`qwen/qwen3.6-plus`):

- [x] Unknown `session_id` (HTTP body) → `400 Session not found`
- [x] Foreign-agent `session_id` → `400 Session belongs to a different agent`
- [x] `ephemeral=true` + `session_id` → `400`
- [x] Send to S1 with override — response written to S1
- [x] Send to S2 with override — response written to S2
- [x] After both sends, S1 history isolated from S2 history (no
  cross-contamination)
- [x] Override sends do not mutate `entry.session_id` (verified by
  creating a third session S3, sending to S1 via override, S3 stayed
  empty)