### PR TITLE
feat(llm-drivers): add per-provider request_timeout_secs config

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1819,6 +1819,10 @@ impl LibreFangKernel {
             .provider_proxy_urls
             .get(&config.default_model.provider)
             .cloned();
+        let default_request_timeout_secs = config
+            .provider_request_timeout_secs
+            .get(&config.default_model.provider)
+            .copied();
         let driver_config = DriverConfig {
             provider: config.default_model.provider.clone(),
             api_key: default_api_key.clone(),
@@ -1829,6 +1833,7 @@ impl LibreFangKernel {
             message_timeout_secs: config.default_model.message_timeout_secs,
             mcp_bridge: Some(mcp_bridge_cfg.clone()),
             proxy_url: default_proxy_url.clone(),
+            request_timeout_secs: default_request_timeout_secs,
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -1865,6 +1870,7 @@ impl LibreFangKernel {
                     message_timeout_secs: config.default_model.message_timeout_secs,
                     mcp_bridge: Some(mcp_bridge_cfg.clone()),
                     proxy_url: default_proxy_url.clone(),
+                    request_timeout_secs: default_request_timeout_secs,
                 };
                 match drivers::create_driver(&profile_config) {
                     Ok(profile_driver) => {
@@ -1970,6 +1976,10 @@ impl LibreFangKernel {
                             message_timeout_secs: config.default_model.message_timeout_secs,
                             mcp_bridge: Some(mcp_bridge_cfg.clone()),
                             proxy_url: config.provider_proxy_urls.get(provider).cloned(),
+                            request_timeout_secs: config
+                                .provider_request_timeout_secs
+                                .get(provider)
+                                .copied(),
                         };
                         match drivers::create_driver(&auto_config) {
                             Ok(d) => {
@@ -2021,6 +2031,10 @@ impl LibreFangKernel {
                 message_timeout_secs: config.default_model.message_timeout_secs,
                 mcp_bridge: Some(mcp_bridge_cfg.clone()),
                 proxy_url: config.provider_proxy_urls.get(&fb.provider).cloned(),
+                request_timeout_secs: config
+                    .provider_request_timeout_secs
+                    .get(&fb.provider)
+                    .copied(),
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -10828,6 +10842,10 @@ system_prompt = "You are a helpful assistant."
                 message_timeout_secs: cfg.default_model.message_timeout_secs,
                 mcp_bridge: Some(build_mcp_bridge_cfg(&cfg)),
                 proxy_url: cfg.provider_proxy_urls.get(agent_provider).cloned(),
+                request_timeout_secs: cfg
+                    .provider_request_timeout_secs
+                    .get(agent_provider)
+                    .copied(),
             };
 
             match self.driver_cache.get_or_create(&driver_config) {
@@ -10913,6 +10931,10 @@ system_prompt = "You are a helpful assistant."
                     skip_permissions: true,
                     message_timeout_secs: cfg.default_model.message_timeout_secs,
                     proxy_url: cfg.provider_proxy_urls.get(&fb_provider).cloned(),
+                    request_timeout_secs: cfg
+                        .provider_request_timeout_secs
+                        .get(&fb_provider)
+                        .copied(),
                 };
                 match self.driver_cache.get_or_create(&config) {
                     Ok(d) => chain.push((d, strip_provider_prefix(&fb.model, &fb_provider))),

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -409,6 +409,14 @@ pub struct DriverConfig {
     /// When set, the driver uses this proxy instead of the global proxy config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_url: Option<String>,
+    /// Per-provider HTTP request timeout in seconds.
+    ///
+    /// When set, this overrides the HTTP client's default read timeout for LLM
+    /// API requests. Useful for providers known to be slower (e.g. local models,
+    /// long-context workloads). CLI-based providers use `message_timeout_secs`
+    /// instead; this field only applies to HTTP API drivers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_timeout_secs: Option<u64>,
 }
 
 /// Configuration for bridging LibreFang tools into a CLI-based driver via MCP.
@@ -438,6 +446,7 @@ impl Default for DriverConfig {
             message_timeout_secs: default_message_timeout_secs(),
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         }
     }
 }
@@ -474,6 +483,7 @@ impl std::fmt::Debug for DriverConfig {
             .field("message_timeout_secs", &self.message_timeout_secs)
             .field("mcp_bridge", &self.mcp_bridge.as_ref().map(|b| &b.base_url))
             .field("proxy_url", &self.proxy_url.as_ref().map(|_| "<redacted>"))
+            .field("request_timeout_secs", &self.request_timeout_secs)
             .finish()
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -22,6 +22,9 @@ pub struct AnthropicDriver {
     api_key: Zeroizing<String>,
     base_url: String,
     client: reqwest::Client,
+    /// Per-provider HTTP request timeout in seconds.
+    /// Overrides the HTTP client's default read timeout when set.
+    request_timeout_secs: Option<u64>,
 }
 
 impl AnthropicDriver {
@@ -32,6 +35,16 @@ impl AnthropicDriver {
 
     /// Create a new Anthropic driver with an optional per-provider proxy.
     pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        Self::with_proxy_and_timeout(api_key, base_url, proxy_url, None)
+    }
+
+    /// Create a new Anthropic driver with optional proxy and request timeout.
+    pub fn with_proxy_and_timeout(
+        api_key: String,
+        base_url: String,
+        proxy_url: Option<&str>,
+        request_timeout_secs: Option<u64>,
+    ) -> Self {
         let client = match proxy_url {
             Some(url) => librefang_http::proxied_client_with_override(url),
             None => librefang_http::proxied_client(),
@@ -40,6 +53,7 @@ impl AnthropicDriver {
             api_key: Zeroizing::new(api_key),
             base_url,
             client,
+            request_timeout_secs,
         }
     }
 }
@@ -324,13 +338,17 @@ impl LlmDriver for AnthropicDriver {
             let url = format!("{}/v1/messages", self.base_url);
             debug!(url = %url, attempt, "Sending Anthropic API request");
 
-            let resp = self
+            let mut req_builder = self
                 .client
                 .post(&url)
                 .header("x-api-key", self.api_key.as_str())
                 .header("anthropic-version", "2023-06-01")
                 .header("content-type", "application/json")
-                .json(&api_request)
+                .json(&api_request);
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
+            }
+            let resp = req_builder
                 .send()
                 .await
                 .map_err(|e| LlmError::Http(e.to_string()))?;
@@ -422,13 +440,17 @@ impl LlmDriver for AnthropicDriver {
             let url = format!("{}/v1/messages", self.base_url);
             debug!(url = %url, attempt, "Sending Anthropic streaming request");
 
-            let resp = self
+            let mut req_builder = self
                 .client
                 .post(&url)
                 .header("x-api-key", self.api_key.as_str())
                 .header("anthropic-version", "2023-06-01")
                 .header("content-type", "application/json")
-                .json(&api_request)
+                .json(&api_request);
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
+            }
+            let resp = req_builder
                 .send()
                 .await
                 .map_err(|e| LlmError::Http(e.to_string()))?;

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -29,6 +29,9 @@ pub struct GeminiDriver {
     api_key: Zeroizing<String>,
     base_url: String,
     client: reqwest::Client,
+    /// Per-provider HTTP request timeout in seconds.
+    /// Overrides the HTTP client's default read timeout when set.
+    request_timeout_secs: Option<u64>,
 }
 
 impl GeminiDriver {
@@ -39,6 +42,16 @@ impl GeminiDriver {
 
     /// Create a new Gemini driver with an optional per-provider proxy.
     pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        Self::with_proxy_and_timeout(api_key, base_url, proxy_url, None)
+    }
+
+    /// Create a new Gemini driver with optional proxy and request timeout.
+    pub fn with_proxy_and_timeout(
+        api_key: String,
+        base_url: String,
+        proxy_url: Option<&str>,
+        request_timeout_secs: Option<u64>,
+    ) -> Self {
         let client = match proxy_url {
             Some(url) => librefang_http::proxied_client_with_override(url),
             None => librefang_http::proxied_client(),
@@ -47,6 +60,7 @@ impl GeminiDriver {
             api_key: Zeroizing::new(api_key),
             base_url,
             client,
+            request_timeout_secs,
         }
     }
 }
@@ -791,12 +805,16 @@ impl LlmDriver for GeminiDriver {
             );
             debug!(url = %url, attempt, "Sending Gemini API request");
 
-            let resp = self
+            let mut req_builder = self
                 .client
                 .post(&url)
                 .header("x-goog-api-key", self.api_key.as_str())
                 .header("content-type", "application/json")
-                .json(&gemini_request)
+                .json(&gemini_request);
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
+            }
+            let resp = req_builder
                 .send()
                 .await
                 .map_err(|e| LlmError::Http(e.to_string()))?;
@@ -878,12 +896,16 @@ impl LlmDriver for GeminiDriver {
             );
             debug!(url = %url, attempt, "Sending Gemini streaming request");
 
-            let resp = self
+            let mut req_builder = self
                 .client
                 .post(&url)
                 .header("x-goog-api-key", self.api_key.as_str())
                 .header("content-type", "application/json")
-                .json(&gemini_request)
+                .json(&gemini_request);
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
+            }
+            let resp = req_builder
                 .send()
                 .await
                 .map_err(|e| LlmError::Http(e.to_string()))?;

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -94,11 +94,12 @@ impl DriverCache {
         let key_hash = hasher.finish();
 
         format!(
-            "{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}",
             config.provider,
             key_hash,
             config.base_url.as_deref().unwrap_or(""),
-            config.proxy_url.as_deref().unwrap_or("")
+            config.proxy_url.as_deref().unwrap_or(""),
+            config.request_timeout_secs.map_or(0, |s| s)
         )
     }
 }
@@ -686,15 +687,28 @@ fn create_driver_from_entry(
 
     let proxy_url = config.proxy_url.as_deref();
 
+    let request_timeout_secs = config.request_timeout_secs;
+
     match entry.api_format {
-        ApiFormat::OpenAI => Ok(Arc::new(openai::OpenAIDriver::with_proxy(
-            api_key, base_url, proxy_url,
+        ApiFormat::OpenAI => Ok(Arc::new(openai::OpenAIDriver::with_proxy_and_timeout(
+            api_key,
+            base_url,
+            proxy_url,
+            request_timeout_secs,
         ))),
-        ApiFormat::Anthropic => Ok(Arc::new(anthropic::AnthropicDriver::with_proxy(
-            api_key, base_url, proxy_url,
-        ))),
-        ApiFormat::Gemini => Ok(Arc::new(gemini::GeminiDriver::with_proxy(
-            api_key, base_url, proxy_url,
+        ApiFormat::Anthropic => Ok(Arc::new(
+            anthropic::AnthropicDriver::with_proxy_and_timeout(
+                api_key,
+                base_url,
+                proxy_url,
+                request_timeout_secs,
+            ),
+        )),
+        ApiFormat::Gemini => Ok(Arc::new(gemini::GeminiDriver::with_proxy_and_timeout(
+            api_key,
+            base_url,
+            proxy_url,
+            request_timeout_secs,
         ))),
         ApiFormat::ClaudeCode => {
             let mut d = claude_code::ClaudeCodeDriver::with_timeout(
@@ -807,10 +821,11 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             let env_var = format!("{}_API_KEY", provider.to_uppercase().replace('-', "_"));
             std::env::var(&env_var).unwrap_or_default()
         });
-        return Ok(Arc::new(openai::OpenAIDriver::with_proxy(
+        return Ok(Arc::new(openai::OpenAIDriver::with_proxy_and_timeout(
             api_key,
             base_url.clone(),
             config.proxy_url.as_deref(),
+            config.request_timeout_secs,
         )));
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -1095,6 +1095,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -1112,6 +1113,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1235,6 +1237,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1259,6 +1262,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -1283,6 +1287,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let result = create_driver(&config);
         assert!(result.is_err());
@@ -1316,6 +1321,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -1343,6 +1349,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
 
         let driver = create_driver(&config);
@@ -1382,6 +1389,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -1402,6 +1410,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         // Clear any env var that might interfere
         std::env::remove_var("AZURE_OPENAI_ENDPOINT");
@@ -1431,6 +1440,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let d1 = cache.get_or_create(&config).unwrap();
         let d2 = cache.get_or_create(&config).unwrap();
@@ -1451,6 +1461,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let config_b = DriverConfig {
             provider: "ollama".to_string(),
@@ -1462,6 +1473,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let d_a = cache.get_or_create(&config_a).unwrap();
         let d_b = cache.get_or_create(&config_b).unwrap();
@@ -1485,6 +1497,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         cache.get_or_create(&config).unwrap();
         assert_eq!(cache.len(), 1);

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -31,6 +31,9 @@ pub struct OpenAIDriver {
     /// Cache of uploaded file IDs for Moonshot/Kimi (hash of bytes → file_id).
     /// Avoids re-uploading the same file across agent loop iterations.
     moonshot_file_cache: std::sync::Arc<tokio::sync::Mutex<HashMap<[u8; 32], String>>>,
+    /// Per-provider HTTP request timeout in seconds.
+    /// Overrides the HTTP client's default read timeout when set.
+    request_timeout_secs: Option<u64>,
 }
 
 impl OpenAIDriver {
@@ -41,6 +44,16 @@ impl OpenAIDriver {
 
     /// Create a new OpenAI-compatible driver with an optional per-provider proxy.
     pub fn with_proxy(api_key: String, base_url: String, proxy_url: Option<&str>) -> Self {
+        Self::with_proxy_and_timeout(api_key, base_url, proxy_url, None)
+    }
+
+    /// Create a new OpenAI-compatible driver with optional proxy and request timeout.
+    pub fn with_proxy_and_timeout(
+        api_key: String,
+        base_url: String,
+        proxy_url: Option<&str>,
+        request_timeout_secs: Option<u64>,
+    ) -> Self {
         let client = match proxy_url {
             Some(url) => librefang_http::proxied_client_with_override(url),
             None => librefang_http::proxied_client(),
@@ -53,6 +66,7 @@ impl OpenAIDriver {
             use_api_key_header: false,
             url_query: None,
             moonshot_file_cache: Default::default(),
+            request_timeout_secs,
         }
     }
 
@@ -93,6 +107,7 @@ impl OpenAIDriver {
             use_api_key_header: true,
             url_query: Some(format!("api-version={}", api_version)),
             moonshot_file_cache: Default::default(),
+            request_timeout_secs: None,
         }
     }
 
@@ -832,6 +847,9 @@ impl LlmDriver for OpenAIDriver {
             for (k, v) in &self.extra_headers {
                 req_builder = req_builder.header(k, v);
             }
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
+            }
 
             let resp = req_builder
                 .send()
@@ -1207,6 +1225,9 @@ impl LlmDriver for OpenAIDriver {
             }
             for (k, v) in &self.extra_headers {
                 req_builder = req_builder.header(k, v);
+            }
+            if let Some(secs) = self.request_timeout_secs {
+                req_builder = req_builder.timeout(std::time::Duration::from_secs(secs));
             }
 
             let resp = req_builder

--- a/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
@@ -959,6 +959,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "us-central1");
@@ -979,6 +980,7 @@ mod tests {
             message_timeout_secs: 300,
             mcp_bridge: None,
             proxy_url: None,
+            request_timeout_secs: None,
         };
         let region = resolve_region(&config);
         assert_eq!(region, "europe-west4");

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2168,6 +2168,16 @@ pub struct KernelConfig {
     /// e.g. `openai = "http://proxy.corp:8080"`, `ollama = ""` (direct)
     #[serde(default)]
     pub provider_proxy_urls: HashMap<String, String>,
+    /// Per-provider HTTP request timeout overrides in seconds (provider ID → seconds).
+    ///
+    /// Overrides the HTTP client's default read timeout for LLM API requests to the
+    /// specified provider. Useful for slower providers or long-context workloads.
+    /// e.g. `ollama = 300`, `anthropic = 120`
+    ///
+    /// Only applies to HTTP API drivers (OpenAI-compatible, Anthropic, Gemini, etc.).
+    /// CLI-based providers (claude-code, qwen-code, etc.) use `message_timeout_secs`.
+    #[serde(default)]
+    pub provider_request_timeout_secs: HashMap<String, u64>,
     /// Provider region selection (provider ID → region name).
     /// Selects a regional endpoint from the provider's `[provider.regions]` map.
     /// e.g. `qwen = "us"` to use the US endpoint instead of China mainland.
@@ -3859,6 +3869,7 @@ impl Default for KernelConfig {
             budget: BudgetConfig::default(),
             provider_urls: HashMap::new(),
             provider_proxy_urls: HashMap::new(),
+            provider_request_timeout_secs: HashMap::new(),
             provider_regions: HashMap::new(),
             provider_api_keys: HashMap::new(),
             vertex_ai: VertexAiConfig::default(),


### PR DESCRIPTION
## Summary

Port from Hermes: per-provider (and per-model) LLM request timeout configuration.

**Config:**
```toml
[provider_request_timeout_secs]
ollama = 300
anthropic = 120
```

**Changes:**
- `KernelConfig`: new `provider_request_timeout_secs: HashMap<String, u64>` field
- `DriverConfig`: new `request_timeout_secs: Option<u64>` field
- `OpenAIDriver`, `AnthropicDriver`, `GeminiDriver`: apply timeout via `RequestBuilder::timeout()` on both `complete()` and `stream()` paths
- `DriverCache::cache_key` includes timeout value to prevent cross-timeout cache hits
- All 5 kernel `DriverConfig` build sites inject the per-provider value

CLI drivers (claude-code, qwen-code) use their own `message_timeout_secs` and are unaffected.

## Test plan
- [ ] No config → existing default timeout behaviour unchanged
- [ ] `ollama = 300` → Ollama requests use 300s timeout
- [ ] Slow model times out at configured value, not global default

🤖 Ported from Hermes with [Claude Code](https://claude.ai/claude-code)