### PR TITLE
fix(dashboard/queries): restore audit polling to 30s, drop expensive verify refetchInterval

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
@@ -66,8 +66,8 @@ export const auditRecentQueryOptions = (limit: number) =>
   queryOptions({
     queryKey: auditKeys.recent(limit),
     queryFn: () => listAuditRecent(limit),
-    staleTime: 120_000,
-    refetchInterval: 120_000,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
   });
 
 export function useAuditRecent(limit: number, options: QueryOverrides = {}) {
@@ -78,8 +78,8 @@ export const auditVerifyQueryOptions = () =>
   queryOptions({
     queryKey: auditKeys.verify(),
     queryFn: verifyAuditChain,
-    staleTime: 120_000,
-    refetchInterval: 120_000,
+    staleTime: 60_000,
+    // No refetchInterval — chain verification is expensive; fetch on mount/focus only.
   });
 
 export function useAuditVerify(options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
@@ -4,7 +4,7 @@ import { telemetryKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 5_000;
-const REFRESH_MS = 10_000; // intentionally aggressive: live metrics dashboard
+const REFRESH_MS = 10_000; // live metrics: 10 s refetch (stale at 5 s to catch tab-switch refreshes)
 
 export const telemetryQueryOptions = () =>
   queryOptions({


### PR DESCRIPTION
## Follow-up to #2981

Three small corrections caught in review of the QueryOverrides refactor.

### Changes

**`runtime.ts` — `auditRecentQueryOptions`**
Restore `staleTime`/`refetchInterval` from 120 s back to 30 s.
120 s is too slow for an audit log page where users expect near-realtime visibility.

**`runtime.ts` — `auditVerifyQueryOptions`**
Remove the newly added `refetchInterval: 120_000`. Chain verification rewrites the full audit log on every call — it should only run on mount/focus, not on a background timer. Restored `staleTime` to 60 s (original value).

**`telemetry.ts`**
Fix misleading comment: `"intentionally aggressive"` implied the 5 s original was kept, but the refetch interval is actually 10 s. New comment accurately describes the stale/refetch split.

## Test plan
- [ ] Audit log page refreshes every ~30 s
- [ ] Audit chain verify does not fire on a 120 s timer in network tab
- [ ] Telemetry metrics still poll every 10 s