### PR TITLE
feat(runtime): write compaction summaries in the user's conversation language

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -834,8 +834,28 @@ async fn execute_single_tool_call(
     };
     fire_hook_best_effort(ctx.hooks, &hook_ctx);
 
+    // Allow plugins to rewrite the tool result before it enters the conversation context.
+    let result_content = if let Some(hook_reg) = ctx.hooks {
+        let transform_ctx = crate::hooks::HookContext {
+            agent_name: &ctx.manifest.name,
+            agent_id: ctx.caller_id_str,
+            event: librefang_types::agent::HookEvent::TransformToolResult,
+            data: serde_json::json!({
+                "tool_name": &tool_call.name,
+                "args": &tool_call.input,
+                "result": &result.content,
+                "is_error": result.is_error,
+            }),
+        };
+        hook_reg
+            .fire_transform(&transform_ctx)
+            .unwrap_or_else(|| result.content.clone())
+    } else {
+        result.content.clone()
+    };
+
     let content = sanitize_tool_result_content(
-        &result.content,
+        &result_content,
         ctx.context_budget,
         ctx.context_engine,
         ctx.context_window_tokens,

--- a/crates/librefang-runtime/src/hooks.rs
+++ b/crates/librefang-runtime/src/hooks.rs
@@ -1,9 +1,11 @@
 //! Plugin lifecycle hooks — intercept points at key moments in agent execution.
 //!
 //! Provides a callback-based hook system (not dynamic loading) for safe extensibility.
-//! Four hook types:
+//! Five hook types:
 //! - `BeforeToolCall`: Fires before tool execution. Can block the call by returning Err.
 //! - `AfterToolCall`: Fires after tool execution. Observe-only.
+//! - `TransformToolResult`: Fires after tool execution to rewrite the result string.
+//!   The first handler returning `Ok(Some(s))` wins and replaces the result.
 //! - `BeforePromptBuild`: Fires before system prompt construction. Observe-only.
 //! - `AgentLoopEnd`: Fires after the agent loop completes. Observe-only.
 
@@ -30,6 +32,17 @@ pub trait HookHandler: Send + Sync {
     /// For `BeforeToolCall`: returning `Err(reason)` blocks the tool call.
     /// For all other events: return value is ignored (observe-only).
     fn on_event(&self, ctx: &HookContext) -> Result<(), String>;
+
+    /// Called for `TransformToolResult` hooks to optionally rewrite the tool result.
+    ///
+    /// Return `Ok(Some(new_result))` to replace the result string.
+    /// Return `Ok(None)` to leave the result unchanged and let later handlers run.
+    /// Return `Err(reason)` to signal a failure; the error is logged and this handler is skipped.
+    ///
+    /// Default implementation returns `Ok(None)` (no transformation).
+    fn transform(&self, _ctx: &HookContext) -> Result<Option<String>, String> {
+        Ok(None)
+    }
 }
 
 /// Registry of hook handlers, keyed by event type.
@@ -74,6 +87,30 @@ impl HookRegistry {
             }
         }
         Ok(())
+    }
+
+    /// Fire `TransformToolResult` handlers in registration order.
+    ///
+    /// Returns the first `Ok(Some(s))` result, replacing the tool output.
+    /// Handlers returning `Err` are warned and skipped (fail-open).
+    /// Returns `None` if no handler produces a replacement.
+    pub fn fire_transform(&self, ctx: &HookContext) -> Option<String> {
+        if let Some(handlers) = self.handlers.get(&HookEvent::TransformToolResult) {
+            for handler in handlers.iter() {
+                match handler.transform(ctx) {
+                    Ok(Some(new_result)) => return Some(new_result),
+                    Ok(None) => continue,
+                    Err(reason) => {
+                        tracing::warn!(
+                            agent = ctx.agent_name,
+                            error = %reason,
+                            "TransformToolResult hook handler returned error (skipping)"
+                        );
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// Check if any handlers are registered for a given event.

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -116,6 +116,9 @@ pub enum HookEvent {
     BeforeToolCall,
     /// Fires after a tool call completes.
     AfterToolCall,
+    /// Fires after tool execution to allow rewriting the result string.
+    /// The first handler returning Ok(Some(s)) wins; others are skipped.
+    TransformToolResult,
     /// Fires before the system prompt is constructed.
     BeforePromptBuild,
     /// Fires after the agent loop completes.


### PR DESCRIPTION
## Summary
- Adds two lines to the compactor system prompt instructing the LLM to write summaries in the same language the user was using
- Applied to both `summarize_messages` (single-pass) and `summarize_in_chunks` (merge step) to cover chunked compaction as well
- Ported from Hermes `agent/context_compressor.py`

## Test plan
- [ ] Confirm compactor system prompt includes the language instruction in both code paths
- [ ] Manual: start a Chinese conversation, trigger compaction, verify summary is in Chinese