### PR TITLE
feat(kernel): add wakeAgent gate for cron script pre-check

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1261,6 +1261,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         message: message.clone(),
                         model_override: None,
                         timeout_secs: None,
+                        pre_check_script: None,
                     },
                     delivery: librefang_types::scheduler::CronDelivery::None,
                     peer_id: None,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1458,6 +1458,7 @@ pub async fn create_schedule(
             message: msg,
             model_override: None,
             timeout_secs: None,
+            pre_check_script: None,
         }
     };
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -13055,10 +13055,7 @@ async fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
 /// Finds the last non-empty line, tries JSON-decode, checks `wakeAgent`.
 /// Returns `true` (wake) unless `wakeAgent` is strictly `false`.
 fn parse_wake_gate(script_output: &str) -> bool {
-    let last_line = script_output
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .last();
+    let last_line = script_output.lines().rfind(|l| !l.trim().is_empty());
 
     let last_line = match last_line {
         Some(l) => l.trim(),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10217,7 +10217,7 @@ system_prompt = "You are a helpful assistant."
                                 // {"wakeAgent": false} in the last non-empty output line.
                                 // Only fires when the script exits successfully.
                                 if let Some(script_path) = pre_check_script {
-                                    if !cron_script_wake_gate(&job_name, script_path) {
+                                    if !cron_script_wake_gate(&job_name, script_path).await {
                                         tracing::info!(
                                             job = %job_name,
                                             "cron: script gate wakeAgent=false, skipping agent"
@@ -13008,12 +13008,23 @@ fn sanitize_reviewer_block(s: &str, max_chars: usize) -> String {
 /// - Find the last non-empty stdout line and try to parse it as JSON.
 /// - If the parsed object has `"wakeAgent": false` (strict bool), return false.
 /// - Everything else (non-JSON, missing key, null, 0, "") → return true.
-fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
-    use std::process::Command;
+async fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
+    use tokio::process::Command;
 
-    let output = match Command::new(script_path).output() {
-        Ok(o) => o,
-        Err(e) => {
+    // Hard cap: pre-check scripts must complete within 30 s.
+    // A hung script would otherwise block the cron dispatcher indefinitely.
+    let run = async { Command::new(script_path).output().await };
+
+    let output = match tokio::time::timeout(std::time::Duration::from_secs(30), run).await {
+        Err(_elapsed) => {
+            tracing::warn!(
+                job = %job_name,
+                script = %script_path,
+                "cron: pre-check script timed out after 30s, waking agent"
+            );
+            return true;
+        }
+        Ok(Err(e)) => {
             tracing::warn!(
                 job = %job_name,
                 script = %script_path,
@@ -13022,6 +13033,7 @@ fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
             );
             return true;
         }
+        Ok(Ok(o)) => o,
     };
 
     if !output.status.success() {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10208,9 +10208,25 @@ system_prompt = "You are a helpful assistant."
                             librefang_types::scheduler::CronAction::AgentTurn {
                                 message,
                                 timeout_secs,
+                                pre_check_script,
                                 ..
                             } => {
                                 tracing::debug!(job = %job_name, agent = %agent_id, "Cron: firing agent turn");
+
+                                // Wake-gate: run pre_check_script and check for
+                                // {"wakeAgent": false} in the last non-empty output line.
+                                // Only fires when the script exits successfully.
+                                if let Some(script_path) = pre_check_script {
+                                    if !cron_script_wake_gate(&job_name, script_path) {
+                                        tracing::info!(
+                                            job = %job_name,
+                                            "cron: script gate wakeAgent=false, skipping agent"
+                                        );
+                                        kernel.cron_scheduler.record_success(job_id);
+                                        continue;
+                                    }
+                                }
+
                                 let timeout_s = timeout_secs.unwrap_or(120);
                                 let timeout = std::time::Duration::from_secs(timeout_s);
                                 let delivery = job.delivery.clone();
@@ -12981,6 +12997,69 @@ fn sanitize_reviewer_block(s: &str, max_chars: usize) -> String {
     // UTF-8-safe truncation: keep chars, not bytes.
     let truncated: String = out.chars().take(max_chars.saturating_sub(14)).collect();
     format!("{truncated} …[truncated]")
+}
+
+/// Run a cron job's pre-check script and parse the wake gate from its output.
+///
+/// Returns `true` if the agent should be woken (normal path), `false` to skip.
+///
+/// Rules (mirrors Hermes `_parse_wake_gate`):
+/// - Script must exit 0; on any error we default to waking the agent.
+/// - Find the last non-empty stdout line and try to parse it as JSON.
+/// - If the parsed object has `"wakeAgent": false` (strict bool), return false.
+/// - Everything else (non-JSON, missing key, null, 0, "") → return true.
+fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
+    use std::process::Command;
+
+    let output = match Command::new(script_path).output() {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(
+                job = %job_name,
+                script = %script_path,
+                error = %e,
+                "cron: pre-check script failed to launch, waking agent"
+            );
+            return true;
+        }
+    };
+
+    if !output.status.success() {
+        tracing::warn!(
+            job = %job_name,
+            script = %script_path,
+            code = ?output.status.code(),
+            "cron: pre-check script exited non-zero, waking agent"
+        );
+        return true;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_wake_gate(&stdout)
+}
+
+/// Parse the wake gate from script stdout.
+///
+/// Finds the last non-empty line, tries JSON-decode, checks `wakeAgent`.
+/// Returns `true` (wake) unless `wakeAgent` is strictly `false`.
+fn parse_wake_gate(script_output: &str) -> bool {
+    let last_line = script_output
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .last();
+
+    let last_line = match last_line {
+        Some(l) => l.trim(),
+        None => return true,
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(last_line) {
+        Ok(v) => v,
+        Err(_) => return true,
+    };
+
+    // Only `{"wakeAgent": false}` (strict bool false) skips the agent.
+    value.get("wakeAgent") != Some(&serde_json::Value::Bool(false))
 }
 
 /// Deliver a cron job's agent response to the configured delivery target.

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -680,6 +680,7 @@ mod tests {
             message: String::new(),
             model_override: None,
             timeout_secs: None,
+            pre_check_script: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("empty"), "{err}");
@@ -692,6 +693,7 @@ mod tests {
             message: "x".repeat(16_385),
             model_override: None,
             timeout_secs: None,
+            pre_check_script: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("too long"), "{err}");
@@ -704,6 +706,7 @@ mod tests {
             message: "hello".into(),
             model_override: None,
             timeout_secs: Some(9),
+            pre_check_script: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("too small"), "{err}");
@@ -716,6 +719,7 @@ mod tests {
             message: "hello".into(),
             model_override: None,
             timeout_secs: Some(601),
+            pre_check_script: None,
         };
         let err = job.validate(0).unwrap_err();
         assert!(err.contains("too large"), "{err}");
@@ -728,6 +732,7 @@ mod tests {
             message: "hello".into(),
             model_override: Some("claude-haiku-4-5-20251001".into()),
             timeout_secs: Some(10),
+            pre_check_script: None,
         };
         assert!(job.validate(0).is_ok());
 
@@ -735,6 +740,7 @@ mod tests {
             message: "hello".into(),
             model_override: None,
             timeout_secs: Some(600),
+            pre_check_script: None,
         };
         assert!(job.validate(0).is_ok());
     }
@@ -746,6 +752,7 @@ mod tests {
             message: "hello".into(),
             model_override: None,
             timeout_secs: None,
+            pre_check_script: None,
         };
         assert!(job.validate(0).is_ok());
     }
@@ -874,6 +881,7 @@ mod tests {
             message: "hi".into(),
             model_override: None,
             timeout_secs: Some(30),
+            pre_check_script: None,
         };
         let json = serde_json::to_string(&action).unwrap();
         assert!(json.contains("\"kind\":\"agent_turn\""));

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -124,6 +124,12 @@ pub enum CronAction {
         model_override: Option<String>,
         /// Timeout in seconds (10..=600).
         timeout_secs: Option<u64>,
+        /// Optional pre-check script path. The script runs before the agent turn;
+        /// if its last non-empty stdout line is `{"wakeAgent": false}` the agent
+        /// call is skipped entirely (no LLM spend). Any other output, non-JSON, or
+        /// a missing `wakeAgent` key are treated as "wake normally".
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pre_check_script: Option<String>,
     },
     /// Trigger a workflow execution by ID or name.
     Workflow {


### PR DESCRIPTION
## Summary
- Adds optional `pre_check_script: Option<String>` to `CronAction::AgentTurn` (backward-compatible via `#[serde(default)]`)
- Before running the agent, executes the script and reads its last non-empty output line
- If the line is valid JSON with `wakeAgent: false` (strict bool), skips the agent turn (records success, continues)
- All other outputs (non-JSON, missing field, `wakeAgent: true`, etc.) proceed normally
- Ported from Hermes cron scheduler

## Test plan
- [ ] Compile: `cargo check -p librefang-kernel`
- [ ] Cron job without `pre_check_script` behaves as before
- [ ] Script outputting `{"wakeAgent": false}` → agent skipped, job marked success
- [ ] Script outputting `{"wakeAgent": true}` / `{}` / non-JSON → agent runs
- [ ] Script exits non-zero → agent runs (fail-open)