### PR TITLE
feat(webhook): add deliver_only mode for zero-LLM push notifications

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3120,7 +3120,8 @@ pub async fn start_channel_bridge_with_config(
                     wh_config.listen_port,
                     wh_config.callback_url.clone(),
                 )
-                .with_account_id(wh_config.account_id.clone()),
+                .with_account_id(wh_config.account_id.clone())
+                .with_deliver_only(wh_config.deliver_only, wh_config.deliver.clone()),
             );
             adapters.push((
                 adapter,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2073,6 +2073,47 @@ async fn dispatch_message(
 ) {
     let ct_str = channel_type_str(&message.channel);
 
+    // --- Webhook direct delivery (deliver_only mode) ---
+    // If the incoming message was tagged by a deliver_only webhook route,
+    // forward the content straight to the configured delivery channel and
+    // return early — no LLM or agent is involved.
+    if message
+        .metadata
+        .get("__deliver_only__")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let target = message
+            .metadata
+            .get("__deliver_target__")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let text = match &message.content {
+            ChannelContent::Text(t) => t.as_str(),
+            _ => "",
+        };
+        let route = message
+            .metadata
+            .get("account_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(ct_str);
+        info!(
+            route = route,
+            target = target,
+            "webhook: direct delivery for route {}, skipping agent",
+            route
+        );
+        if !target.is_empty() && !text.is_empty() {
+            if let Err(e) = handle
+                .send_channel_push(target, &message.sender.platform_id, text, None)
+                .await
+            {
+                warn!(target = target, error = %e, "webhook direct delivery failed");
+            }
+        }
+        return;
+    }
+
     // --- Input sanitization (prompt injection detection) ---
     if !sanitizer.is_off() {
         let text_to_check: Option<&str> = match &message.content {

--- a/crates/librefang-channels/src/webhook.rs
+++ b/crates/librefang-channels/src/webhook.rs
@@ -58,6 +58,12 @@ pub struct WebhookAdapter {
     client: reqwest::Client,
     /// Optional account identifier for multi-bot routing.
     account_id: Option<String>,
+    /// When true, incoming messages are forwarded directly to `deliver_target`
+    /// without invoking an agent or LLM.
+    deliver_only: bool,
+    /// Target channel name for direct delivery (e.g. "telegram"). Used only
+    /// when `deliver_only` is true.
+    deliver_target: Option<String>,
 }
 
 impl WebhookAdapter {
@@ -73,11 +79,25 @@ impl WebhookAdapter {
             callback_url,
             client: crate::http_client::new_client(),
             account_id: None,
+            deliver_only: false,
+            deliver_target: None,
         }
     }
+
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
+        self
+    }
+
+    /// Enable direct-delivery mode. Returns self for builder chaining.
+    ///
+    /// When enabled, incoming messages are tagged with `__deliver_only__` and
+    /// `__deliver_target__` metadata so the bridge can forward them directly to
+    /// the specified channel without invoking an agent or LLM.
+    pub fn with_deliver_only(mut self, deliver_only: bool, deliver_target: Option<String>) -> Self {
+        self.deliver_only = deliver_only;
+        self.deliver_target = deliver_target;
         self
     }
 
@@ -183,6 +203,8 @@ impl ChannelAdapter for WebhookAdapter {
         let tx = Arc::new(tx);
         let secret = Arc::new(self.secret.clone());
         let account_id = Arc::new(self.account_id.clone());
+        let deliver_only = self.deliver_only;
+        let deliver_target = Arc::new(self.deliver_target.clone());
 
         let app = axum::Router::new().route(
             "/webhook",
@@ -190,10 +212,12 @@ impl ChannelAdapter for WebhookAdapter {
                 let tx = Arc::clone(&tx);
                 let secret = Arc::clone(&secret);
                 let account_id = Arc::clone(&account_id);
+                let deliver_target = Arc::clone(&deliver_target);
                 move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let tx = Arc::clone(&tx);
                     let secret = Arc::clone(&secret);
                     let account_id = Arc::clone(&account_id);
+                    let deliver_target = Arc::clone(&deliver_target);
                     async move {
                         let signature = headers
                             .get("X-Webhook-Signature")
@@ -261,6 +285,18 @@ impl ChannelAdapter for WebhookAdapter {
                             if let Some(ref aid) = *account_id {
                                 msg.metadata
                                     .insert("account_id".to_string(), serde_json::json!(aid));
+                            }
+                            if deliver_only {
+                                msg.metadata.insert(
+                                    "__deliver_only__".to_string(),
+                                    serde_json::json!(true),
+                                );
+                                if let Some(ref target) = *deliver_target {
+                                    msg.metadata.insert(
+                                        "__deliver_target__".to_string(),
+                                        serde_json::json!(target),
+                                    );
+                                }
                             }
                             if tx.send(msg).await.is_err() {
                                 // Bridge receiver closed — the message is lost

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -6072,6 +6072,15 @@ pub struct WebhookConfig {
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
+    /// When true, incoming POST bodies are forwarded directly to the delivery
+    /// target channel without invoking the LLM or any agent. Requires
+    /// `deliver` to be set to a valid channel name (not "log").
+    #[serde(default)]
+    pub deliver_only: bool,
+    /// Target channel name for direct delivery (e.g. "telegram", "discord").
+    /// Required when `deliver_only` is true.
+    #[serde(default)]
+    pub deliver: Option<String>,
 }
 
 impl Default for WebhookConfig {
@@ -6083,6 +6092,8 @@ impl Default for WebhookConfig {
             account_id: None,
             default_agent: None,
             overrides: ChannelOverrides::default(),
+            deliver_only: false,
+            deliver: None,
         }
     }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -535,6 +535,21 @@ impl KernelConfig {
                     wh.secret_env
                 ));
             }
+            if wh.deliver_only {
+                match wh.deliver.as_deref() {
+                    None => warnings.push(format!(
+                        "Webhook (port {}) has deliver_only = true but no deliver channel is configured — \
+                         set deliver = \"<channel>\" (e.g. \"telegram\")",
+                        wh.listen_port
+                    )),
+                    Some("log") => warnings.push(format!(
+                        "Webhook (port {}) has deliver_only = true but deliver = \"log\" is not a valid \
+                         delivery channel — use a real channel name (e.g. \"telegram\")",
+                        wh.listen_port
+                    )),
+                    Some(_) => {}
+                }
+            }
         }
         for li in self.channels.linkedin.iter() {
             if std::env::var(&li.access_token_env)


### PR DESCRIPTION
## Summary
- Adds `deliver_only: bool` and `deliver: Option<String>` to `WebhookConfig` (serde default false)
- When `deliver_only = true`, incoming webhook payloads bypass the entire LLM pipeline (sanitizer, rate-limiter, agent lookup) and are forwarded directly to the target channel via `send_channel_push`
- Target is specified by `deliver` config field; startup emits a warning if `deliver_only = true` but no valid target is set
- Delivery mode is signaled via message metadata (`__deliver_only__`, `__deliver_target__`) to avoid changing any trait signatures — consistent with how `account_id` is propagated
- Ported from Hermes webhook channel implementation

## Test plan
- [ ] Compile: `cargo check -p librefang-channels`
- [ ] `deliver_only = false` (default): webhook behaves as before, goes through full LLM pipeline
- [ ] `deliver_only = true, deliver = "slack"`: webhook payload forwarded directly to Slack channel, no LLM call
- [ ] `deliver_only = true, deliver = "log"` or missing: startup warning emitted