### PR TITLE
fix(runtime): add missing task_get and task_update_status to stub KernelHandle impls

### DIFF
--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -5896,6 +5896,18 @@ mod tests {
             Err("not used".to_string())
         }
 
+        async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+
+        async fn task_update_status(
+            &self,
+            _task_id: &str,
+            _new_status: &str,
+        ) -> Result<bool, String> {
+            Err("not used".to_string())
+        }
+
         async fn publish_event(
             &self,
             _event_type: &str,
@@ -7839,6 +7851,18 @@ mod tests {
         }
 
         async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
+            Err("not used".to_string())
+        }
+
+        async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+
+        async fn task_update_status(
+            &self,
+            _task_id: &str,
+            _new_status: &str,
+        ) -> Result<bool, String> {
             Err("not used".to_string())
         }
 


### PR DESCRIPTION
## Summary

- `KernelHandle` trait gained `task_get` and `task_update_status` in a recent commit, but the two test-only stub implementations in `tool_runner.rs` (`ApprovalKernel` and `SpawnCheckKernel`) were not updated, breaking `cargo test` on all platforms.
- Adds `Err("not used")` stubs to both impls to restore compilation.

## Test plan

- [x] `cargo test --lib -p librefang-runtime` passes (1176 tests)