### PR TITLE
fix(anthropic): guard max_tokens against zero to prevent HTTP 400

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -297,6 +297,18 @@ fn build_anthropic_request(request: &CompletionRequest) -> ApiRequest {
         request.max_tokens
     };
 
+    // Anthropic rejects max_tokens=0 with HTTP 400; fall back to a safe
+    // model ceiling so callers that forget to set max_tokens still work.
+    let effective_max_tokens = if effective_max_tokens == 0 {
+        warn!(
+            model = %request.model,
+            "max_tokens resolved to 0, using model ceiling fallback of 8192"
+        );
+        8192
+    } else {
+        effective_max_tokens
+    };
+
     ApiRequest {
         model: request.model.clone(),
         max_tokens: effective_max_tokens,

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -298,11 +298,11 @@ fn build_anthropic_request(request: &CompletionRequest) -> ApiRequest {
     };
 
     // Anthropic rejects max_tokens=0 with HTTP 400; fall back to a safe
-    // model ceiling so callers that forget to set max_tokens still work.
+    // minimum so callers that forget to set max_tokens still work.
     let effective_max_tokens = if effective_max_tokens == 0 {
         warn!(
             model = %request.model,
-            "max_tokens resolved to 0, using model ceiling fallback of 8192"
+            "max_tokens resolved to 0, falling back to safe minimum of 8192"
         );
         8192
     } else {


### PR DESCRIPTION
## Summary
- Adds a guard in `build_anthropic_request` after `effective_max_tokens` is resolved
- If `max_tokens` resolves to 0 (e.g. from a misconfigured default), falls back to 8192 instead of letting the API reject with HTTP 400
- 8192 is the most conservative safe floor — all current Anthropic models support ≥ 8192 output tokens
- Guard is placed after the thinking-budget adjustment so both thinking-on and thinking-off paths are covered
- Ported from Hermes commit `c9c618283` / openclaw#66664

## Test plan
- [ ] Compile: `cargo check -p librefang-llm-drivers`
- [ ] Set `max_tokens = 0` in config and verify fallback warning is logged, request succeeds