### PR TITLE
fix(runtime): retry LLM stream on transient errors and add SSL/TLS error patterns

### DIFF
--- a/crates/librefang-llm-driver/src/llm_errors.rs
+++ b/crates/librefang-llm-driver/src/llm_errors.rs
@@ -219,16 +219,19 @@ const TIMEOUT_PATTERNS: &[&str] = &[
 
 /// SSL/TLS transient error patterns — these indicate a mid-stream record-layer
 /// failure that is safe to retry (the server dropped the connection cleanly).
+///
+/// Note: `ssl handshake failure` is intentionally excluded — handshake failures
+/// are configuration errors (wrong cert, protocol mismatch) that will fail again
+/// on retry and are not transient network hiccups.
 const SSL_TRANSIENT_PATTERNS: &[&str] = &[
     "bad record mac",
+    "bad_record_mac",
     "ssl alert",
+    "ssl_alert",
     "tls alert",
-    "ssl handshake failure",
+    "tls_alert",
     "tlsv1 alert",
     "sslv3 alert",
-    "bad_record_mac",
-    "ssl_alert",
-    "tls_alert",
     "[ssl:",
 ];
 

--- a/crates/librefang-llm-driver/src/llm_errors.rs
+++ b/crates/librefang-llm-driver/src/llm_errors.rs
@@ -217,6 +217,21 @@ const TIMEOUT_PATTERNS: &[&str] = &[
     "fetch failed",
 ];
 
+/// SSL/TLS transient error patterns — these indicate a mid-stream record-layer
+/// failure that is safe to retry (the server dropped the connection cleanly).
+const SSL_TRANSIENT_PATTERNS: &[&str] = &[
+    "bad record mac",
+    "ssl alert",
+    "tls alert",
+    "ssl handshake failure",
+    "tlsv1 alert",
+    "sslv3 alert",
+    "bad_record_mac",
+    "ssl_alert",
+    "tls_alert",
+    "[ssl:",
+];
+
 // ---------------------------------------------------------------------------
 // Classification
 // ---------------------------------------------------------------------------
@@ -717,6 +732,7 @@ pub fn is_transient(message: &str) -> bool {
     matches_any(&lower, TIMEOUT_PATTERNS)
         || matches_any(&lower, OVERLOADED_PATTERNS)
         || matches_any(&lower, RATE_LIMIT_PATTERNS)
+        || matches_any(&lower, SSL_TRANSIENT_PATTERNS)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -3760,6 +3760,20 @@ async fn stream_with_retry(
                 )));
             }
             Err(e) => {
+                let err_str = e.to_string();
+                if llm_errors::is_transient(&err_str) && attempt < MAX_RETRIES {
+                    warn!(
+                        attempt,
+                        error = %err_str,
+                        "LLM stream died with transient error, retrying"
+                    );
+                    last_error = Some("Transient stream error".to_string());
+                    tokio::time::sleep(Duration::from_millis(
+                        BASE_RETRY_DELAY_MS * 2u64.pow(attempt),
+                    ))
+                    .await;
+                    continue;
+                }
                 let (is_billing, err) =
                     build_user_facing_llm_error(&e, "LLM stream error classified");
                 record_retry_failure(provider, cooldown, is_billing);


### PR DESCRIPTION
## Summary
- Adds `SSL_TRANSIENT_PATTERNS` (10 patterns: `bad record mac`, `ssl alert`, `tls alert`, `[ssl:`, etc.) to `llm_errors.rs`
- `is_transient()` now returns `true` for SSL/TLS mid-stream errors, so they are treated as retryable transport hiccups rather than hard failures
- `stream_with_retry` in `agent_loop.rs` now retries on any transient error (not just `RateLimited`/`Overloaded`) — exponential backoff up to `MAX_RETRIES`
- Before this fix: any SSL alert or connection drop mid-stream immediately surfaced as a hard error to the user; now it silently retries
- Ported from Hermes commits `ea67e4957` and `d74eaef5f`

## Design
SSL/TLS alerts are classified separately from server-disconnect patterns to avoid triggering context compression (which is reserved for actual context-overflow disconnects, not flaky TLS).

## Test plan
- [ ] Compile: `cargo check -p librefang-llm-driver -p librefang-runtime`
- [ ] Simulate a connection reset mid-stream, verify retry log appears and request succeeds on retry
- [ ] Verify `is_transient("bad record mac")` returns `true`
- [ ] Verify `is_transient("invalid api key")` still returns `false`