### PR TITLE
feat(channels): per-agent ChannelOverrides in AgentManifest

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1848,6 +1848,16 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         overrides
     }
 
+    async fn agent_channel_overrides(
+        &self,
+        agent_id: AgentId,
+    ) -> Option<librefang_types::config::ChannelOverrides> {
+        self.kernel
+            .agent_registry()
+            .get(agent_id)
+            .and_then(|entry| entry.manifest.channel_overrides.clone())
+    }
+
     async fn authorize_channel_user(
         &self,
         channel_type: &str,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -234,6 +234,13 @@ pub trait ChannelBridgeHandle: Send + Sync {
         None
     }
 
+    /// When an agent declares `[channel_overrides]` in its `agent.toml`,
+    /// those values take priority over the channel-level overrides.
+    /// Returns `None` if the agent has no per-agent overrides configured.
+    async fn agent_channel_overrides(&self, _agent_id: AgentId) -> Option<ChannelOverrides> {
+        None
+    }
+
     /// Lightweight LLM classification: should the bot reply to this group message?
     ///
     /// Returns `true` if the bot should reply, `false` to stay silent.
@@ -2155,13 +2162,24 @@ async fn dispatch_message(
         }
     }
 
-    // Fetch per-channel overrides (if configured)
-    let overrides = handle
+    // Resolve target agent early so per-agent overrides can take priority
+    let early_agent_id = resolve_or_fallback(message, handle, router).await;
+
+    // Fetch overrides: agent-level (from agent.toml) wins, channel-level is fallback.
+    let channel_overrides = handle
         .channel_overrides(
             ct_str,
             message.metadata.get("account_id").and_then(|v| v.as_str()),
         )
         .await;
+    let overrides = if let Some(aid) = early_agent_id {
+        handle
+            .agent_channel_overrides(aid)
+            .await
+            .or(channel_overrides)
+    } else {
+        channel_overrides
+    };
     let channel_default_format = default_output_format_for_channel(ct_str);
     let output_format = overrides
         .as_ref()
@@ -2871,7 +2889,7 @@ async fn dispatch_message(
         }
     }
 
-    let agent_id = match resolve_or_fallback(message, handle, router).await {
+    let agent_id = match early_agent_id {
         Some(id) => id,
         None => {
             send_response(

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -196,6 +196,7 @@ impl SetupWizard {
             auto_dream_min_sessions: None,
             show_progress: true,
             auto_evolve: true,
+            channel_overrides: None,
         };
 
         let skills_to_install: Vec<String> = intent

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -745,6 +745,11 @@ pub struct AgentManifest {
     /// the background LLM budget or concurrency semaphore after a turn.
     #[serde(default = "default_true")]
     pub auto_evolve: bool,
+    /// Per-agent channel behavior overrides (dm_policy, group_policy, etc.).
+    /// When set, these take priority over the channel-level `ChannelOverrides`
+    /// for this specific agent. Follows the same pattern as `exec_policy`.
+    #[serde(default)]
+    pub channel_overrides: Option<crate::config::ChannelOverrides>,
 }
 
 /// Access mode for a named workspace.
@@ -819,6 +824,7 @@ impl Default for AgentManifest {
             auto_dream_min_sessions: None,
             show_progress: true,
             auto_evolve: true,
+            channel_overrides: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `channel_overrides: Option<ChannelOverrides>` to `AgentManifest` so each agent can define its own `dm_policy`, `group_policy`, `group_trigger_patterns`, and `reply_precheck` — overriding the channel-level defaults from `config.toml`.
- Resolution order: **agent-level > channel-level > built-in defaults** (same pattern as `exec_policy`).
- `dispatch_message()` now resolves the target agent early via `resolve_or_fallback()` so agent overrides can be fetched before the DM/group gate runs.

## Motivation

Currently `ChannelOverrides` lives only at the channel level (`[channels.telegram]` in config.toml). When multiple agents share the same channel, they all inherit the same response policy. This makes it impossible for one agent to respond to all DMs while another ignores them, or for agents to have different group trigger patterns.

With this change, operators can set per-agent policies in `agent.toml`:

```toml
[channel_overrides]
dm_policy = "always"
group_policy = "trigger_only"
group_trigger_patterns = ["(?i)\\bmy-bot\\b"]
```

## Changes

| File | Change |
|------|--------|
| `crates/librefang-types/src/agent.rs` | Add `channel_overrides` field + Default |
| `crates/librefang-channels/src/bridge.rs` | Add `agent_channel_overrides` trait method; refactor `dispatch_message` to resolve agent before override lookup |
| `crates/librefang-api/src/channel_bridge.rs` | Implement `agent_channel_overrides` on kernel bridge |
| `crates/librefang-kernel/src/wizard.rs` | Add field to manifest construction |

## Test plan

- [x] `cargo check --workspace --lib` passes
- [x] `cargo test --workspace` passes (no regressions)
- [ ] Manual: configure `[channel_overrides]` in an agent.toml, verify agent-level policy takes priority over channel-level

Closes #3017