### PR TITLE
fix(hands): detect macOS Chrome .app bundle for browser hand

### DIFF
--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -1042,7 +1042,13 @@ fn check_requirement(req: &HandRequirement) -> bool {
                     || which_binary("chrome")
                     || std::env::var("CHROME_PATH")
                         .map(|v| !v.is_empty())
-                        .unwrap_or(false);
+                        .unwrap_or(false)
+                    || std::path::Path::new(
+                        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                    )
+                    .exists()
+                    || std::path::Path::new("/Applications/Chromium.app/Contents/MacOS/Chromium")
+                        .exists();
             }
             false
         }


### PR DESCRIPTION
## Summary

- On macOS, Chrome is installed as an `.app` bundle (`/Applications/Google Chrome.app`) and is not on `PATH`
- The existing `which_binary()` checks all fail, causing the browser hand to always report `degraded` even when Chrome is installed
- Added explicit path checks for `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` and `/Applications/Chromium.app/Contents/MacOS/Chromium`

## Test plan

- [ ] Start daemon on macOS with Chrome installed — browser hand should no longer show `WARN Hand has unsatisfied requirements (degraded)`
- [ ] Verify `CHROME_PATH` env var override still works
- [ ] Verify Linux behavior unchanged (paths don't exist, falls through to existing checks)