### PR TITLE
chore(drivers): remove deprecated providers ai21, aider, chutes, venice

### DIFF
--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -159,20 +159,6 @@ const PROVIDERS: &[ProviderInfo] = &[
         hint: "",
     },
     ProviderInfo {
-        name: "venice",
-        display: "Venice.ai",
-        env_var: "VENICE_API_KEY",
-        needs_key: true,
-        hint: "uncensored",
-    },
-    ProviderInfo {
-        name: "ai21",
-        display: "AI21",
-        env_var: "AI21_API_KEY",
-        needs_key: true,
-        hint: "",
-    },
-    ProviderInfo {
         name: "claude-code",
         display: "Claude Code",
         env_var: "",

--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -171,9 +171,9 @@ pub(super) fn infer_provider_from_model(model: &str) -> Option<String> {
         match prefix {
             "minimax" | "gemini" | "anthropic" | "openai" | "groq" | "deepseek" | "mistral"
             | "cohere" | "xai" | "ollama" | "together" | "fireworks" | "perplexity"
-            | "cerebras" | "sambanova" | "replicate" | "huggingface" | "ai21" | "codex"
-            | "claude-code" | "copilot" | "github-copilot" | "qwen" | "zhipu" | "zai"
-            | "moonshot" | "openrouter" | "volcengine" | "doubao" | "dashscope" => {
+            | "cerebras" | "sambanova" | "replicate" | "huggingface" | "codex" | "claude-code"
+            | "copilot" | "github-copilot" | "qwen" | "zhipu" | "zai" | "moonshot"
+            | "openrouter" | "volcengine" | "doubao" | "dashscope" => {
                 return Some(prefix.to_string());
             }
             // "z.ai" is a domain alias for the zai provider
@@ -217,8 +217,6 @@ pub(super) fn infer_provider_from_model(model: &str) -> Option<String> {
         Some("mistral".to_string())
     } else if lower.starts_with("command") || lower.starts_with("embed-") {
         Some("cohere".to_string())
-    } else if lower.starts_with("jamba") {
-        Some("ai21".to_string())
     } else if lower.starts_with("sonar") {
         Some("perplexity".to_string())
     } else if lower.starts_with("glm") {

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -2,10 +2,8 @@
 //!
 //! Contains drivers for Anthropic Claude, Google Gemini, OpenAI-compatible APIs, and more.
 //! Supports: Anthropic, Gemini, OpenAI, Groq, OpenRouter, DeepSeek, DeepInfra,
-//! Together, Mistral, Fireworks, Ollama, vLLM, Chutes.ai, Alibaba Coding Plan, and any
+//! Together, Mistral, Fireworks, Ollama, vLLM, Alibaba Coding Plan, and any
 //! OpenAI-compatible endpoint.
-
-pub mod aider;
 pub mod anthropic;
 pub mod chatgpt;
 pub mod claude_code;
@@ -123,8 +121,6 @@ pub enum ApiFormat {
     GeminiCli,
     /// Codex CLI subprocess.
     CodexCli,
-    /// Aider CLI subprocess.
-    Aider,
     /// ChatGPT with session token authentication.
     ChatGpt,
     /// GitHub Copilot with automatic token exchange.
@@ -330,16 +326,6 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         hidden: false,
     },
     ProviderEntry {
-        name: "ai21",
-        aliases: &[],
-        base_url: "https://api.ai21.com/studio/v1",
-        api_key_env: "AI21_API_KEY",
-        key_required: true,
-        api_format: ApiFormat::OpenAI,
-        alt_api_key_env: None,
-        hidden: false,
-    },
-    ProviderEntry {
         name: "cerebras",
         aliases: &[],
         base_url: "https://api.cerebras.ai/v1",
@@ -436,16 +422,6 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         api_key_env: "",
         key_required: false,
         api_format: ApiFormat::CodexCli,
-        alt_api_key_env: None,
-        hidden: false,
-    },
-    ProviderEntry {
-        name: "aider",
-        aliases: &[],
-        base_url: "",
-        api_key_env: "",
-        key_required: false,
-        api_format: ApiFormat::Aider,
         alt_api_key_env: None,
         hidden: false,
     },
@@ -564,26 +540,6 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         aliases: &[],
         base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
         api_key_env: "ALIBABA_CODING_PLAN_API_KEY",
-        key_required: true,
-        api_format: ApiFormat::OpenAI,
-        alt_api_key_env: None,
-        hidden: false,
-    },
-    ProviderEntry {
-        name: "chutes",
-        aliases: &[],
-        base_url: "https://llm.chutes.ai/v1",
-        api_key_env: "CHUTES_API_KEY",
-        key_required: true,
-        api_format: ApiFormat::OpenAI,
-        alt_api_key_env: None,
-        hidden: false,
-    },
-    ProviderEntry {
-        name: "venice",
-        aliases: &[],
-        base_url: "https://api.venice.ai/api/v1",
-        api_key_env: "VENICE_API_KEY",
         key_required: true,
         api_format: ApiFormat::OpenAI,
         alt_api_key_env: None,
@@ -733,10 +689,6 @@ fn create_driver_from_entry(
             config.base_url.clone(),
             config.skip_permissions,
         ))),
-        ApiFormat::Aider => Ok(Arc::new(aider::AiderDriver::new(
-            config.base_url.clone(),
-            config.skip_permissions,
-        ))),
         ApiFormat::ChatGpt => Ok(Arc::new(chatgpt::ChatGptDriver::with_proxy(
             api_key, base_url, proxy_url,
         ))),
@@ -793,13 +745,11 @@ fn create_driver_from_entry(
 /// - `lmstudio` — LM Studio (local)
 /// - `perplexity` — Perplexity AI (search-augmented)
 /// - `cohere` — Cohere (Command R)
-/// - `ai21` — AI21 Labs (Jamba)
 /// - `cerebras` — Cerebras (ultra-fast inference)
 /// - `sambanova` — SambaNova
 /// - `huggingface` — Hugging Face Inference API
 /// - `xai` — xAI (Grok)
 /// - `replicate` — Replicate
-/// - `chutes` — Chutes.ai (serverless open-source model inference)
 /// - `azure-openai` — Azure OpenAI Service (deployment-based URL, `api-key` header)
 /// - `vertex-ai` — Google Cloud Vertex AI (OAuth2 auth, enterprise Gemini)
 /// - `qwen` — Qwen / DashScope (use `provider_regions` for intl/us endpoints)
@@ -853,9 +803,9 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
         message: format!(
             "Unknown provider '{}'. Supported: anthropic, chatgpt, gemini, openai, groq, openrouter, \
              deepseek, deepinfra, together, mistral, fireworks, ollama, vllm, lmstudio, perplexity, \
-             cohere, ai21, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
-             chutes, venice, azure-openai, vertex-ai, nvidia-nim, codex, claude-code, qwen-code, \
-             gemini-cli, codex-cli, aider, qwen, minimax, zhipu. \
+             cohere, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
+             azure-openai, vertex-ai, nvidia-nim, codex, claude-code, qwen-code, \
+             gemini-cli, codex-cli, qwen, minimax, zhipu. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
             provider
         ),
@@ -944,7 +894,6 @@ pub fn cli_provider_available(name: &str) -> bool {
         "qwen-code" => qwen_code::qwen_code_available(),
         "gemini-cli" => gemini_cli::gemini_cli_available(),
         "codex-cli" => codex_cli::codex_cli_available(),
-        "aider" => aider::aider_available(),
         _ => false,
     }
 }
@@ -977,7 +926,7 @@ pub fn is_proxied_via_env(env_vars: &[&str], official_hosts: &[&str]) -> bool {
 pub fn is_cli_provider(name: &str) -> bool {
     matches!(
         name,
-        "claude-code" | "qwen-code" | "gemini-cli" | "codex-cli" | "aider"
+        "claude-code" | "qwen-code" | "gemini-cli" | "codex-cli"
     )
 }
 
@@ -1144,7 +1093,6 @@ mod tests {
         // New providers
         assert!(providers.contains(&"perplexity"));
         assert!(providers.contains(&"cohere"));
-        assert!(providers.contains(&"ai21"));
         assert!(providers.contains(&"cerebras"));
         assert!(providers.contains(&"sambanova"));
         assert!(providers.contains(&"huggingface"));
@@ -1163,16 +1111,14 @@ mod tests {
         assert!(providers.contains(&"volcengine"));
         assert!(providers.contains(&"alibaba-coding-plan"));
         assert!(providers.contains(&"deepinfra"));
-        assert!(providers.contains(&"chutes"));
         assert!(providers.contains(&"claude-code"));
         assert!(providers.contains(&"qwen-code"));
         assert!(providers.contains(&"gemini-cli"));
         assert!(providers.contains(&"codex-cli"));
-        assert!(providers.contains(&"aider"));
         assert!(providers.contains(&"azure-openai"));
         assert!(providers.contains(&"vertex-ai"));
         assert!(providers.contains(&"nvidia-nim"));
-        assert_eq!(providers.len(), 43);
+        assert_eq!(providers.len(), 39);
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -730,30 +730,9 @@ fn create_driver_from_entry(
 
 /// Create an LLM driver based on provider name and configuration.
 ///
-/// Supported providers:
-/// - `anthropic` — Anthropic Claude (Messages API)
-/// - `openai` — OpenAI GPT models
-/// - `groq` — Groq (ultra-fast inference)
-/// - `openrouter` — OpenRouter (multi-model gateway)
-/// - `deepseek` — DeepSeek
-/// - `deepinfra` — DeepInfra (OpenAI-compatible inference)
-/// - `together` — Together AI
-/// - `mistral` — Mistral AI
-/// - `fireworks` — Fireworks AI
-/// - `ollama` — Ollama (local)
-/// - `vllm` — vLLM (local)
-/// - `lmstudio` — LM Studio (local)
-/// - `perplexity` — Perplexity AI (search-augmented)
-/// - `cohere` — Cohere (Command R)
-/// - `cerebras` — Cerebras (ultra-fast inference)
-/// - `sambanova` — SambaNova
-/// - `huggingface` — Hugging Face Inference API
-/// - `xai` — xAI (Grok)
-/// - `replicate` — Replicate
-/// - `azure-openai` — Azure OpenAI Service (deployment-based URL, `api-key` header)
-/// - `vertex-ai` — Google Cloud Vertex AI (OAuth2 auth, enterprise Gemini)
-/// - `qwen` — Qwen / DashScope (use `provider_regions` for intl/us endpoints)
-/// - Any custom provider with `base_url` set uses OpenAI-compatible format
+/// See `PROVIDER_REGISTRY` for the full list of built-in providers and their aliases.
+/// Any provider not in the registry can also be used by setting `base_url` directly —
+/// it will be treated as an OpenAI-compatible endpoint.
 pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmError> {
     let provider = config.provider.as_str();
 
@@ -804,8 +783,8 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             "Unknown provider '{}'. Supported: anthropic, chatgpt, gemini, openai, groq, openrouter, \
              deepseek, deepinfra, together, mistral, fireworks, ollama, vllm, lmstudio, perplexity, \
              cohere, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
-             azure-openai, vertex-ai, nvidia-nim, codex, claude-code, qwen-code, gemini-cli, \
-             codex-cli, qwen, minimax, zhipu, zhipu_coding, zai, moonshot, kimi_coding, \
+             azure-openai, vertex-ai, nvidia-nim, claude-code, qwen-code, gemini-cli, codex-cli, \
+             qwen, minimax, zhipu, zhipu_coding, zai, moonshot, kimi_coding, \
              qianfan, volcengine, alibaba-coding-plan. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
             provider

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -804,8 +804,9 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             "Unknown provider '{}'. Supported: anthropic, chatgpt, gemini, openai, groq, openrouter, \
              deepseek, deepinfra, together, mistral, fireworks, ollama, vllm, lmstudio, perplexity, \
              cohere, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
-             azure-openai, vertex-ai, nvidia-nim, codex, claude-code, qwen-code, \
-             gemini-cli, codex-cli, qwen, minimax, zhipu. \
+             azure-openai, vertex-ai, nvidia-nim, codex, claude-code, qwen-code, gemini-cli, \
+             codex-cli, qwen, minimax, zhipu, zhipu_coding, zai, moonshot, kimi_coding, \
+             qianfan, volcengine, alibaba-coding-plan. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
             provider
         ),

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1162,7 +1162,7 @@ pub fn strip_provider_prefix(model: &str, provider: &str) -> String {
 fn needs_qualified_model_id(provider: &str) -> bool {
     matches!(
         provider,
-        "openrouter" | "together" | "fireworks" | "replicate" | "chutes" | "huggingface"
+        "openrouter" | "together" | "fireworks" | "replicate" | "huggingface"
     )
 }
 
@@ -8816,7 +8816,6 @@ mod tests {
         assert!(needs_qualified_model_id("together"));
         assert!(needs_qualified_model_id("fireworks"));
         assert!(needs_qualified_model_id("replicate"));
-        assert!(needs_qualified_model_id("chutes"));
         assert!(needs_qualified_model_id("huggingface"));
         assert!(!needs_qualified_model_id("openai"));
         assert!(!needs_qualified_model_id("anthropic"));

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -273,16 +273,11 @@ impl ModelCatalog {
             let has_cli_fallback = if suppressed {
                 false
             } else {
-                let aider_ok = || crate::drivers::cli_provider_available("aider");
                 match provider.id.as_str() {
-                    "anthropic" => {
-                        crate::drivers::cli_provider_available("claude-code") || aider_ok()
-                    }
-                    "gemini" => crate::drivers::cli_provider_available("gemini-cli") || aider_ok(),
-                    "openai" | "codex" => {
-                        crate::drivers::cli_provider_available("codex-cli") || aider_ok()
-                    }
-                    "qwen" => crate::drivers::cli_provider_available("qwen-code") || aider_ok(),
+                    "anthropic" => crate::drivers::cli_provider_available("claude-code"),
+                    "gemini" => crate::drivers::cli_provider_available("gemini-cli"),
+                    "openai" | "codex" => crate::drivers::cli_provider_available("codex-cli"),
+                    "qwen" => crate::drivers::cli_provider_available("qwen-code"),
                     _ => false,
                 }
             };
@@ -1377,7 +1372,6 @@ id = "acme"
         let catalog = test_catalog();
         assert!(catalog.get_provider("perplexity").is_some());
         assert!(catalog.get_provider("cohere").is_some());
-        assert!(catalog.get_provider("ai21").is_some());
         assert!(catalog.get_provider("cerebras").is_some());
         assert!(catalog.get_provider("sambanova").is_some());
         assert!(catalog.get_provider("huggingface").is_some());

--- a/web/public/registry.json
+++ b/web/public/registry.json
@@ -2319,20 +2319,6 @@
   ],
   "providers": [
     {
-      "id": "ai21",
-      "name": "ai21",
-      "description": "",
-      "category": "",
-      "icon": ""
-    },
-    {
-      "id": "aider",
-      "name": "aider",
-      "description": "",
-      "category": "",
-      "icon": ""
-    },
-    {
       "id": "aion-labs",
       "name": "aion-labs",
       "description": "",
@@ -2391,13 +2377,6 @@
     {
       "id": "chatgpt",
       "name": "chatgpt",
-      "description": "",
-      "category": "",
-      "icon": ""
-    },
-    {
-      "id": "chutes",
-      "name": "chutes",
       "description": "",
       "category": "",
       "icon": ""
@@ -2734,13 +2713,6 @@
     {
       "id": "upstage",
       "name": "upstage",
-      "description": "",
-      "category": "",
-      "icon": ""
-    },
-    {
-      "id": "venice",
-      "name": "venice",
       "description": "",
       "category": "",
       "icon": ""


### PR DESCRIPTION
## Summary

- Remove `ApiFormat::Aider` variant and delete `aider.rs` driver
- Remove `ProviderEntry` structs for `ai21`, `aider`, `chutes`, `venice` from `PROVIDER_REGISTRY`
- Clean up all call sites: `agent_loop.rs` (needs_qualified_model_id), `model_catalog.rs` (aider CLI fallback + test), `init_wizard.rs` (provider list), `manifest_helpers.rs` (model prefix inference), `web/public/registry.json`
- Fix `test_known_providers_list` count: 43 → 39

## Why

These four providers were removed from the registry (`librefang-registry`) because they don't meet inclusion criteria — no dedicated driver, no unique endpoint, just generic OpenAI-compatible wrappers. The source code still had dead ProviderEntry stubs and one full driver (`aider.rs`) that served no purpose.

## Test plan

- [ ] `cargo check --workspace --lib` passes with zero errors/warnings
- [ ] `cargo test -p librefang-llm-drivers` — `test_known_providers_list` passes with len=39
- [ ] `cargo test -p librefang-runtime` — `test_needs_qualified_model_id` passes without chutes