### PR TITLE
fix(channels): add plaintext fallback when editMessageText HTML is rejected

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -1130,7 +1130,24 @@ impl TelegramAdapter {
         if !resp.status().is_success() {
             let status = resp.status();
             let body_text = resp.text().await.unwrap_or_default();
-            if !body_text.contains("message is not modified") {
+            if body_text.contains("message is not modified") {
+                // no-op
+            } else if status == reqwest::StatusCode::BAD_REQUEST
+                && body_text.contains("can't parse entities")
+            {
+                warn!("Telegram editMessageText (interactive) HTML rejected, retrying as plain text: {body_text}");
+                let plain_body = serde_json::json!({
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "text": text,
+                    "reply_markup": { "inline_keyboard": keyboard },
+                });
+                let retry = self.client.post(&url).json(&plain_body).send().await?;
+                if !retry.status().is_success() {
+                    let retry_text = retry.text().await.unwrap_or_default();
+                    warn!("Telegram editMessageText (interactive) plain fallback also failed: {retry_text}");
+                }
+            } else {
                 warn!("Telegram editMessageText (interactive) failed ({status}): {body_text}");
             }
         }
@@ -1291,7 +1308,27 @@ impl TelegramAdapter {
             let body_text = resp.text().await.unwrap_or_default();
             // Telegram returns 400 "message is not modified" when text hasn't changed —
             // this is expected and harmless.
-            if !body_text.contains("message is not modified") {
+            if body_text.contains("message is not modified") {
+                // no-op
+            } else if status == reqwest::StatusCode::BAD_REQUEST
+                && body_text.contains("can't parse entities")
+            {
+                // HTML tag mismatch — retry without parse_mode so the user sees
+                // the response as plain text rather than losing it entirely.
+                warn!(
+                    "Telegram editMessageText HTML rejected, retrying as plain text: {body_text}"
+                );
+                let plain_body = serde_json::json!({
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "text": text,
+                });
+                let retry = self.client.post(&url).json(&plain_body).send().await?;
+                if !retry.status().is_success() {
+                    let retry_text = retry.text().await.unwrap_or_default();
+                    warn!("Telegram editMessageText plain fallback also failed: {retry_text}");
+                }
+            } else {
                 warn!("Telegram editMessageText failed ({status}): {body_text}");
             }
         }


### PR DESCRIPTION
## Problem

When an LLM response contains malformed or unclosed HTML tags, Telegram rejects `editMessageText` with HTTP 400 `"can't parse entities"`. The edit silently fails, leaving the streaming placeholder message stale — the user never sees the response.

This affects both `api_edit_message` (used during streaming) and `api_edit_interactive_message` (used for approval/button messages).

## Fix

`sendMessage` already handles this case: on a 400 "can't parse entities" response it retries without `parse_mode`, sending plain text so the user at least sees the content.

This PR applies the same pattern to `api_edit_message` and `api_edit_interactive_message`:

- **`api_edit_message`**: on 400 + "can't parse entities", retry the edit without `parse_mode: HTML`
- **`api_edit_interactive_message`**: same, but preserve `reply_markup` in the retry so inline keyboard buttons are not discarded

The "message is not modified" branch is also refactored from a negated condition to an explicit no-op branch for clarity, consistent with the `sendMessage` implementation.

## Changes

Single file changed: `crates/librefang-channels/src/telegram.rs`

- `api_edit_interactive_message`: replace `if !body_text.contains("message is not modified")` with a three-branch match: no-op / HTML-fallback / warn
- `api_edit_message`: same refactor + HTML-fallback branch

## Testing

- `cargo build -p librefang-channels --lib` passes with zero errors
- Pattern is identical to the existing `sendMessage` fallback (line ~450) which has been in production