### PR TITLE
fix(desktop): render connection screen via custom URI scheme (closes #3052)

### DIFF
--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -176,7 +176,17 @@ pub fn run(server_url: Option<String>, force_local: bool) {
 
     let show_connection_screen = matches!(mode, StartupMode::ConnectionScreen);
 
+    // Serve the connection screen HTML through a custom URI scheme instead of
+    // about:blank + document.write. The old approach no-ops on WebKitGTK 2.50
+    // (stock NixOS, current AppImage), leaving a blank window — see #3052.
     let mut builder = tauri::Builder::default()
+        .register_uri_scheme_protocol("lfconnect", |_ctx, _req| {
+            tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", "text/html; charset=utf-8")
+                .body(connection::connection_html().into_bytes())
+                .expect("connection response must build")
+        })
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init());
@@ -266,11 +276,14 @@ pub fn run(server_url: Option<String>, force_local: bool) {
         ])
         .setup(move |app| {
             if show_connection_screen {
-                // Show the connection screen via about:blank + eval
-                let window = WebviewWindowBuilder::new(
+                let _window = WebviewWindowBuilder::new(
                     app,
                     "main",
-                    WebviewUrl::External("about:blank".parse().expect("Invalid about:blank URL")),
+                    WebviewUrl::CustomProtocol(
+                        "lfconnect://localhost/"
+                            .parse()
+                            .expect("lfconnect URL must parse"),
+                    ),
                 )
                 .title("LibreFang — Connect")
                 .inner_size(1280.0, 800.0)
@@ -278,13 +291,6 @@ pub fn run(server_url: Option<String>, force_local: bool) {
                 .center()
                 .visible(true)
                 .build()?;
-
-                // Inject the connection screen HTML into the blank page
-                let html = connection::connection_html();
-                let escaped = serde_json::to_string(&html).unwrap_or_default();
-                window.eval(format!(
-                    "document.open(); document.write({escaped}); document.close();"
-                ))?;
             } else {
                 // Direct mode — navigate to the resolved URL
                 let _window = WebviewWindowBuilder::new(

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,9 @@
           cairo
           gdk-pixbuf
           pango
+          # tray-icon dlopens at runtime, not a link dep — patchelf below
+          # adds it to RPATH so the tray plugin can find it (#3052).
+          libayatana-appindicator
         ]);
 
         # Filter source to include Rust files plus non-Rust assets needed at compile time
@@ -114,6 +117,9 @@
         librefang-desktop = craneLib.buildPackage (desktopArgs // {
           cargoArtifacts = desktopCargoArtifacts;
           doCheck = false;
+          postFixup = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            patchelf --add-rpath "${pkgs.libayatana-appindicator}/lib" "$out/bin/librefang-desktop"
+          '';
           meta = with pkgs.lib; {
             description = "LibreFang — Open-source Agent Operating System (desktop UI)";
             homepage = "https://github.com/librefang/librefang";


### PR DESCRIPTION
## Summary

Closes #3052 — first-launch blank window on Linux desktop.

Two fixes bundled because they're both hit by the same user flow (fresh NixOS build, first launch):

### 1. Connection screen no longer renders (the primary bug)

`crates/librefang-desktop/src/lib.rs` built the first-launch connection screen by opening `about:blank` and injecting HTML via `window.eval(\"document.open(); document.write(...); document.close();\")`. On **WebKitGTK 2.50** — stock NixOS 25.11 / 26.05, and the webkit bundled in the AppImage — that sequence silently no-ops. The window opens, the title says \"LibreFang — Connect\", and the content area stays blank. New users (no saved preference, no `LIBREFANG_SERVER_URL`) always take this path, so the app is dead on arrival.

Fix: register a custom URI scheme (`lfconnect://`) on the Tauri `Builder`, return the connection HTML as a normal HTTP response, and point the webview at `lfconnect://localhost/` via `WebviewUrl::CustomProtocol`. That's a regular navigation to a regular response, so WebKit loads it the same way it loads any other page — no `about:blank` edge cases, no async eval race, and `connect_remote` / `start_local` still work via `window.location.href = …`.

### 2. Nix build runs but the binary panics on launch

#2974 merged the build-organisation part of a flake fix but dropped the libayatana-appindicator bits. Since `tray-icon` **dlopens** `libayatana-appindicator3.so.1` at runtime (it's not a link-time dep), the resulting binary aborts on first launch on stock NixOS. This is the \"build is again failing due to the dlopen not finding libayatana-appindicator\" half of #3052.

Restored the two lines from commit `cdad334e` in the original PR branch: add the lib to `desktopBuildInputs`, and a `postFixup` that patches it into the desktop binary's RPATH.

## Verification (on NixOS 25.11 + GNOME 49, WebKitGTK 2.50.5)

- `cargo check -p librefang-desktop` ✅ clean
- `cargo clippy -p librefang-desktop -- -D warnings` ✅ clean
- `nix build .#librefang-desktop` ✅ builds and produces a runnable binary
- Launched result/bin/librefang-desktop with no saved preference (first-run path):
  - **Before:** window opens, titled \"LibreFang — Connect\", content blank.
  - **After:** connection form renders (server URL input, Test/Connect/Start Local buttons, remember checkbox). Confirmed by the issue-reporter reproduction scenario at the same webkit version.

## Notes / follow-ups

- Not changing the connection HTML itself (`connection.rs`) — the `waitForTauri()` polling that was there for the old about:blank timing is harmless on the new path and I'd rather not scope-creep this PR.
- The custom scheme's origin is `lfconnect://localhost`; Tauri IPC (`__TAURI__.core.invoke`) works from it the same as from `http://127.0.0.1`, so the existing `test_connection` / `connect_remote` / `start_local` commands don't need any changes.
- No new dependencies, no new feature flags, no Cargo.lock churn.