### PR TITLE
fix(cli): create log dir + open log before stdout redirect

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3139,6 +3139,36 @@ impl Drop for ForegroundTeeGuard {
 /// spawn a background thread that copies to both terminal and log file.
 #[cfg(unix)]
 fn setup_foreground_tee(log_path: &std::path::Path) -> ForegroundTeeGuard {
+    // Ensure the parent directory exists (e.g. `~/.librefang/logs/`) before we
+    // try to open the log file. Fresh installations and test environments may
+    // not have this directory yet.
+    if let Some(parent) = log_path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            // Report the failure on the real stderr (not yet redirected), then
+            // exit instead of limping forward into the silent-hang regime the
+            // old ordering produced.
+            eprintln!("Failed to create log directory {}: {e}", parent.display());
+            std::process::exit(1);
+        }
+    }
+
+    // Open the log file BEFORE redirecting stdout/stderr. If the open panics
+    // (permissions, read-only fs, parent still missing, …) the panic message
+    // reaches the real stderr the user is watching. Previously we opened the
+    // file AFTER `dup2`, so a failure wrote its panic message into a pipe
+    // whose reader hadn't been spawned yet — the message was trapped in the
+    // pipe buffer and the process appeared to hang at "Starting daemon…".
+    let log_file = std::sync::Mutex::new(
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_path)
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to open daemon log file {}: {e}", log_path.display());
+                std::process::exit(1);
+            }),
+    );
+
     // Create pipe for stdout+stderr (we'll write to it, background thread reads)
     let mut fds = [0i32, 0i32];
     unsafe {
@@ -3151,21 +3181,14 @@ fn setup_foreground_tee(log_path: &std::path::Path) -> ForegroundTeeGuard {
     let stdout_copy = unsafe { libc::dup(libc::STDOUT_FILENO) };
     let stderr_copy = unsafe { libc::dup(libc::STDERR_FILENO) };
 
-    // Redirect stdout and stderr to the pipe
+    // Redirect stdout and stderr to the pipe. From here on any write to the
+    // standard streams goes through the pipe and must be drained by the
+    // read thread below — do not fail between this point and `thread::spawn`.
     unsafe {
         libc::dup2(pipe_write, libc::STDOUT_FILENO);
         libc::dup2(pipe_write, libc::STDERR_FILENO);
         libc::close(pipe_write);
     }
-
-    // Create log file (append mode)
-    let log_file = std::sync::Mutex::new(
-        std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(log_path)
-            .expect("daemon log file"),
-    );
 
     // Spawn background thread that reads from pipe and writes to both terminal and log
     std::thread::spawn(move || {


### PR DESCRIPTION
## Symptom

`librefang start --foreground` (and therefore `just dev` / `cargo xtask dev`) appears to hang indefinitely at `Starting daemon...` on any machine that doesn't yet have `~/.librefang/logs/`. The process is silently dead — no error, no stderr, `ps` shows nothing.

## Reproduction

```bash
rm -rf ~/.librefang/logs
target/debug/librefang start --foreground
# prints banner + "Starting daemon..." and hangs forever
```

After this PR: daemon either starts normally (directory auto-created) or exits with a visible `Failed to create log directory …` / `Failed to open daemon log file …` line on stderr.

## Root cause

Two issues stacked in `setup_foreground_tee` at `crates/librefang-cli/src/main.rs:3141`:

1. **The log directory is never created.** `OpenOptions::new().create(true).append(true).open(log_path)` creates the *file* but not the parent directory. On a fresh install, `~/.librefang/logs/` doesn't exist and the open fails with `NotFound`.

2. **The failure mode is invisible.** The function redirected stdout/stderr to a pipe via `libc::dup2` **before** attempting to open the log file, and spawned the read thread that drains the pipe **after** the open. When `.expect("daemon log file")` panicked, the panic message was written to stderr → which was now the pipe → which had no reader yet. The message sat in the kernel pipe buffer, the process exited, and the user saw nothing beyond the last line printed before the redirect.

Net effect: any failure between the `dup2` and the `thread::spawn` became an invisible silent-hang.

## Fix

- `fs::create_dir_all(log_path.parent())` before the open, so the fresh-install case resolves automatically. Prints a real `eprintln!` + `exit(1)` on failure (directory truly uncreatable — permissions, read-only fs).
- Move the log-file open **before** the `dup2` redirect. Any open error now panics with stdout/stderr still attached to the real terminal, so the user sees the actual problem instead of a hang.
- Keep the existing `{pipe → dup2 → spawn read thread}` ordering *after* the successful open, with a comment making the ordering invariant explicit.

## Test plan

- [x] `cargo check --bin librefang` — clean
- [x] `cargo fmt --check` — clean
- [ ] Live: `rm -rf ~/.librefang/logs && target/debug/librefang start --foreground` — daemon boots normally, log dir auto-created
- [ ] Live: make log dir read-only, repeat — daemon exits with visible `Failed to open daemon log file` error (not a hang)

Note: `just dev` hit this today on a fresh workspace because the `~/.librefang/logs/` dir is only populated after the first successful foreground run elsewhere. The workaround was `mkdir -p ~/.librefang/logs` — this PR removes the need.