### PR TITLE
fix(providers): surface CLI logins as their own providers, not API-provider fallbacks

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1120,19 +1120,14 @@ pub async fn test_provider(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    let (env_var, base_url, key_required, auth_status) = {
+    let (env_var, base_url, key_required) = {
         let catalog = state
             .kernel
             .model_catalog_ref()
             .read()
             .unwrap_or_else(|e| e.into_inner());
         match catalog.get_provider(&name) {
-            Some(p) => (
-                p.api_key_env.clone(),
-                p.base_url.clone(),
-                p.key_required,
-                p.auth_status,
-            ),
+            Some(p) => (p.api_key_env.clone(), p.base_url.clone(), p.key_required),
             None => {
                 return ApiErrorResponse::not_found(format!("Unknown provider '{}'", name))
                     .into_json_tuple();
@@ -1167,45 +1162,6 @@ pub async fn test_provider(
                 StatusCode::OK,
                 Json(
                     serde_json::json!({"status":"error","provider":name,"error":"CLI not found in PATH"}),
-                ),
-            )
-        };
-    }
-
-    // API provider with CLI fallback but no API key — test the CLI instead.
-    if auth_status == librefang_types::model_catalog::AuthStatus::ConfiguredCli {
-        let cli_start = Instant::now();
-        // The CLI name may differ from the provider name (e.g. gemini → gemini-cli)
-        let cli_name = match name.as_str() {
-            "gemini" => "gemini-cli",
-            "anthropic" => "claude-code",
-            "openai" | "codex" => "codex-cli",
-            "qwen" => "qwen-code",
-            _ => name.as_str(),
-        };
-        let cli_ok = librefang_runtime::drivers::cli_provider_available(cli_name);
-        let cli_latency = cli_start.elapsed().as_millis();
-        state.provider_test_cache.insert(
-            name.clone(),
-            (
-                Instant::now(),
-                cli_latency,
-                chrono::Utc::now().to_rfc3339(),
-                cli_ok,
-            ),
-        );
-        return if cli_ok {
-            (
-                StatusCode::OK,
-                Json(
-                    serde_json::json!({"status":"ok","provider":name,"latency_ms":cli_latency,"note":format!("via {cli_name} CLI")}),
-                ),
-            )
-        } else {
-            (
-                StatusCode::OK,
-                Json(
-                    serde_json::json!({"status":"error","provider":name,"error":format!("{cli_name} CLI not found in PATH")}),
                 ),
             )
         };

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1162,22 +1162,29 @@ pub fn claude_code_available() -> bool {
     ClaudeCodeDriver::detect().is_some() || claude_credentials_exist()
 }
 
-/// Check if Claude Code appears to be installed by looking for known artifacts.
+/// Check if Claude Code credentials exist on disk.
 ///
-/// Checks multiple indicators across CLI versions and auth mechanisms:
+/// Only looks for actual credential files:
 /// - `~/.claude/.credentials.json` — older CLI versions (file-based auth)
 /// - `~/.claude/credentials.json`  — newer CLI versions (file-based auth)
-/// - `~/.claude/settings.json`     — present on all installs; newer versions use the
-///   system keychain instead of a credentials file, so the above files will not exist
+///
+/// `settings.json` is intentionally NOT checked. It is created on first launch
+/// as a preference file (theme, default model, etc.) whether or not the user
+/// ever authenticates, so treating it as a credential falsely marks Claude
+/// Code as "configured" for anyone who merely installed the CLI.
+///
+/// Keychain-based auth (newer versions) is already covered by the primary
+/// `detect()` path, which finds the `claude` binary on PATH or at common
+/// install locations (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`).
+/// The credentials-file fallback is only relevant for non-standard installs.
 fn claude_credentials_exist() -> bool {
-    if let Some(home) = home_dir() {
-        let claude_dir = home.join(".claude");
-        claude_dir.join(".credentials.json").exists()
-            || claude_dir.join("credentials.json").exists()
-            || claude_dir.join("settings.json").exists()
-    } else {
-        false
-    }
+    home_dir()
+        .map(|h| claude_credentials_in_dir(&h.join(".claude")))
+        .unwrap_or(false)
+}
+
+fn claude_credentials_in_dir(dir: &std::path::Path) -> bool {
+    dir.join(".credentials.json").exists() || dir.join("credentials.json").exists()
 }
 
 /// Cross-platform home directory.
@@ -1551,53 +1558,51 @@ mod tests {
         assert!(candidates.contains(&"/usr/local/bin/claude"));
     }
 
-    #[test]
-    fn test_claude_credentials_exist_checks_settings_json() {
-        use std::fs;
-
-        // Create a temp dir that looks like ~/.claude with only settings.json present
-        // (simulating keychain-based auth where no credentials file is written).
-        let tmp = std::env::temp_dir().join(format!(
-            "librefang-test-claude-dir-{}",
-            uuid::Uuid::new_v4()
+    fn make_claude_tmp_dir(label: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "librefang-test-claude-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
         ));
-        fs::create_dir_all(&tmp).unwrap();
-        let settings = tmp.join("settings.json");
-        fs::write(&settings, "{}").unwrap();
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
 
-        // Temporarily override HOME so home_dir() resolves to our temp parent.
-        // We test the helper directly since home_dir() reads HOME/USERPROFILE.
-        let _parent = tmp.parent().unwrap();
-        let _dir_name = tmp.file_name().unwrap().to_str().unwrap();
-
-        // Manually replicate the check logic against our temp path.
-        let has_credentials = tmp.join(".credentials.json").exists()
-            || tmp.join("credentials.json").exists()
-            || tmp.join("settings.json").exists();
-
+    #[test]
+    fn settings_json_alone_is_not_a_credential() {
+        // `settings.json` is created on first launch as a preference file
+        // (theme, default model) even when the user never signs in. It must
+        // not be treated as proof of authentication.
+        let dir = make_claude_tmp_dir("settings-only");
+        std::fs::write(dir.join("settings.json"), "{}").unwrap();
         assert!(
-            has_credentials,
-            "settings.json alone should be enough to signal Claude Code is installed"
+            !claude_credentials_in_dir(&dir),
+            "settings.json must not be treated as a Claude Code credential"
         );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
-        // Verify that without settings.json the check returns false.
-        fs::remove_file(&settings).unwrap();
-        let has_credentials_after = tmp.join(".credentials.json").exists()
-            || tmp.join("credentials.json").exists()
-            || tmp.join("settings.json").exists();
-        assert!(
-            !has_credentials_after,
-            "should return false when no credential artifacts exist"
-        );
+    #[test]
+    fn credentials_json_variants_are_recognised() {
+        for name in [".credentials.json", "credentials.json"] {
+            let dir = make_claude_tmp_dir(&format!("creds-{name}"));
+            std::fs::write(dir.join(name), "{}").unwrap();
+            assert!(
+                claude_credentials_in_dir(&dir),
+                "{name} should be recognised"
+            );
+            std::fs::remove_dir_all(&dir).unwrap();
+        }
+    }
 
-        // Verify that the old-style credentials.json still works.
-        fs::write(tmp.join("credentials.json"), "{}").unwrap();
-        let has_old_creds = tmp.join(".credentials.json").exists()
-            || tmp.join("credentials.json").exists()
-            || tmp.join("settings.json").exists();
-        assert!(has_old_creds, "credentials.json should still be recognised");
-
-        fs::remove_dir_all(&tmp).unwrap();
+    #[test]
+    fn claude_empty_dir_has_no_credentials() {
+        let dir = make_claude_tmp_dir("empty");
+        assert!(!claude_credentials_in_dir(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -237,13 +237,27 @@ pub fn gemini_cli_available() -> bool {
 }
 
 /// Check if Gemini CLI credentials exist.
+///
+/// Only looks for actual credential files. `settings.json` is intentionally
+/// excluded: it is a CLI preference file (theme, default model) that is
+/// created on first launch even when the user is not logged in, so treating
+/// it as proof of authentication marks Gemini as "configured" for anyone who
+/// merely installed the CLI.
 fn gemini_cli_credentials_exist() -> bool {
-    if let Some(home) = home_dir() {
-        let gemini_dir = home.join(".gemini");
-        gemini_dir.join("settings.json").exists() || gemini_dir.join(".credentials.json").exists()
-    } else {
-        false
-    }
+    home_dir()
+        .map(|h| credentials_in_dir(&h.join(".gemini")))
+        .unwrap_or(false)
+}
+
+/// Check a given directory for Gemini CLI credential files.
+///
+/// Recognised filenames:
+/// - `oauth_creds.json` — Google Gemini CLI's actual OAuth token file
+/// - `credentials.json` / `.credentials.json` — defensive fallbacks
+fn credentials_in_dir(dir: &std::path::Path) -> bool {
+    dir.join("oauth_creds.json").exists()
+        || dir.join("credentials.json").exists()
+        || dir.join(".credentials.json").exists()
 }
 
 /// Cross-platform home directory.
@@ -323,5 +337,58 @@ mod tests {
         assert!(SENSITIVE_ENV_EXACT.contains(&"ANTHROPIC_API_KEY"));
         assert!(SENSITIVE_ENV_EXACT.contains(&"GROQ_API_KEY"));
         assert!(SENSITIVE_ENV_EXACT.contains(&"DEEPSEEK_API_KEY"));
+    }
+
+    fn make_tmp_dir(label: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "librefang-test-gemini-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn settings_json_alone_is_not_a_credential() {
+        // `settings.json` is the CLI's preference file — it is created the
+        // first time `gemini` runs, even when the user never signs in.
+        // Treating it as a credential caused LibreFang to auto-mark Gemini
+        // as "configured" for anyone who had merely installed the CLI.
+        let dir = make_tmp_dir("settings-only");
+        std::fs::write(dir.join("settings.json"), "{}").unwrap();
+        assert!(
+            !credentials_in_dir(&dir),
+            "settings.json must not be treated as a Gemini credential"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn oauth_creds_json_is_recognised() {
+        let dir = make_tmp_dir("oauth-creds");
+        std::fs::write(dir.join("oauth_creds.json"), "{}").unwrap();
+        assert!(credentials_in_dir(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn credentials_json_variants_are_recognised() {
+        for name in ["credentials.json", ".credentials.json"] {
+            let dir = make_tmp_dir(&format!("creds-{name}"));
+            std::fs::write(dir.join(name), "{}").unwrap();
+            assert!(credentials_in_dir(&dir), "{name} should be recognised");
+            std::fs::remove_dir_all(&dir).unwrap();
+        }
+    }
+
+    #[test]
+    fn empty_dir_has_no_credentials() {
+        let dir = make_tmp_dir("empty");
+        assert!(!credentials_in_dir(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -619,20 +619,18 @@ fn create_driver_from_entry(
         .clone()
         .unwrap_or_else(|| entry.base_url.to_string());
 
-    // Resolve API key: explicit config > primary env var > alt env var
-    let mut api_key = config
+    // Resolve API key: explicit config > primary env var > alt env var.
+    //
+    // Intentionally does NOT fall back to the Codex CLI credential file for
+    // the `openai` provider. CLI logins are surfaced as their own provider
+    // (`codex-cli`) so the user sees exactly what they configured; running
+    // `provider = "openai"` requires an explicit `OPENAI_API_KEY`.
+    let api_key = config
         .api_key
         .clone()
         .or_else(|| std::env::var(entry.api_key_env).ok())
         .or_else(|| entry.alt_api_key_env.and_then(|v| std::env::var(v).ok()))
         .unwrap_or_default();
-
-    // Special: OpenAI also checks Codex credential
-    if api_key.is_empty() && entry.api_format == ApiFormat::OpenAI && entry.name == "openai" {
-        if let Some(codex_key) = read_codex_credential() {
-            api_key = codex_key;
-        }
-    }
 
     if entry.key_required && entry.api_format != ApiFormat::VertexAI && api_key.is_empty() {
         return Err(LlmError::MissingApiKey(format!(
@@ -910,8 +908,12 @@ pub fn is_cli_provider(name: &str) -> bool {
     )
 }
 
-/// Resolve the API key for a provider by checking all known sources:
-/// primary env var → alt env var → Codex credential file (for openai).
+/// Resolve the API key for a provider by checking the declared env vars.
+///
+/// Sources (in order): primary env var → alt env var (e.g. `GOOGLE_API_KEY`
+/// for Gemini). Does NOT read CLI credential files — CLI logins are exposed
+/// as their own provider entries (`claude-code` / `codex-cli` / `gemini-cli`
+/// / `qwen-code`) rather than silently substituting for an API provider.
 ///
 /// Returns `None` if no key is found through any source.
 pub fn resolve_provider_api_key(provider: &str) -> Option<String> {
@@ -927,59 +929,6 @@ pub fn resolve_provider_api_key(provider: &str) -> Option<String> {
                 .and_then(|v| std::env::var(v).ok())
                 .and_then(non_empty)
         })
-        .or_else(|| {
-            if entry.name == "openai" {
-                read_codex_credential()
-            } else {
-                None
-            }
-        })
-}
-
-/// Read an OpenAI API key from the Codex CLI credential file.
-///
-/// Checks `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.
-/// Returns `Some(api_key)` if the file exists and contains a valid, non-expired token.
-fn read_codex_credential() -> Option<String> {
-    let codex_home = std::env::var("CODEX_HOME")
-        .map(std::path::PathBuf::from)
-        .ok()
-        .or_else(|| {
-            #[cfg(target_os = "windows")]
-            {
-                std::env::var("USERPROFILE")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-        })?;
-
-    let auth_path = codex_home.join("auth.json");
-    let content = std::fs::read_to_string(&auth_path).ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    if let Some(expires_at) = parsed.get("expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-        if now >= expires_at {
-            return None;
-        }
-    }
-
-    parsed
-        .get("api_key")
-        .or_else(|| parsed.get("token"))
-        .or_else(|| parsed.get("tokens").and_then(|t| t.get("id_token")))
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
 }
 
 #[cfg(test)]

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -961,15 +961,20 @@ pub fn qwen_code_available() -> bool {
 }
 
 /// Check if Qwen credentials exist.
+///
+/// Qwen Code is a fork of Google's Gemini CLI, so its OAuth token file is
+/// named `oauth_creds.json`. The other names are defensive fallbacks.
 fn qwen_credentials_exist() -> bool {
-    if let Some(home) = home_dir() {
-        let qwen_dir = home.join(".qwen");
-        qwen_dir.join("credentials.json").exists()
-            || qwen_dir.join(".credentials.json").exists()
-            || qwen_dir.join("auth.json").exists()
-    } else {
-        false
-    }
+    home_dir()
+        .map(|h| qwen_credentials_in_dir(&h.join(".qwen")))
+        .unwrap_or(false)
+}
+
+fn qwen_credentials_in_dir(dir: &std::path::Path) -> bool {
+    dir.join("oauth_creds.json").exists()
+        || dir.join("credentials.json").exists()
+        || dir.join(".credentials.json").exists()
+        || dir.join("auth.json").exists()
 }
 
 /// Cross-platform home directory.
@@ -1506,5 +1511,44 @@ mod tests {
     fn test_which_nonexistent_binary() {
         // `which` for a non-existent binary should return None.
         assert!(QwenCodeDriver::which("__nonexistent_binary_12345__").is_none());
+    }
+
+    fn make_qwen_tmp_dir(label: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "librefang-test-qwen-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn oauth_creds_json_is_recognised_for_qwen() {
+        // Qwen Code forks Gemini CLI and writes the same OAuth file name.
+        let dir = make_qwen_tmp_dir("oauth-creds");
+        std::fs::write(dir.join("oauth_creds.json"), "{}").unwrap();
+        assert!(qwen_credentials_in_dir(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn qwen_credential_fallbacks_are_recognised() {
+        for name in ["credentials.json", ".credentials.json", "auth.json"] {
+            let dir = make_qwen_tmp_dir(&format!("creds-{name}"));
+            std::fs::write(dir.join(name), "{}").unwrap();
+            assert!(qwen_credentials_in_dir(&dir), "{name} should be recognised");
+            std::fs::remove_dir_all(&dir).unwrap();
+        }
+    }
+
+    #[test]
+    fn qwen_empty_dir_has_no_credentials() {
+        let dir = make_qwen_tmp_dir("empty");
+        assert!(!qwen_credentials_in_dir(&dir));
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -252,50 +252,39 @@ impl ModelCatalog {
             };
 
             // If the user explicitly removed this provider's key, skip
-            // fallback/CLI detection — only honour the primary env var.
+            // alias detection — only honour the primary env var.
             let suppressed = self.suppressed_providers.contains(&provider.id);
 
-            // Secondary: provider-specific fallback keys (still API-key-based auth)
-            let has_key_fallback = if suppressed {
+            // Secondary: recognised alias env var. Only officially documented
+            // aliases count (e.g. Google AI Studio docs both `GEMINI_API_KEY`
+            // and `GOOGLE_API_KEY` as equivalent). This is NOT a CLI-to-API
+            // mapping — both are explicit API keys the user set.
+            //
+            // LibreFang intentionally does NOT promote a CLI login (Claude
+            // Code, Codex, Gemini CLI, Qwen Code) to "configured" for the
+            // corresponding API provider. CLI auth and API-key auth are
+            // surfaced as separate providers so the user sees exactly what
+            // they configured — CLI logins show up under `claude-code` /
+            // `codex-cli` / `gemini-cli` / `qwen-code`, API keys under
+            // `anthropic` / `openai` / `gemini` / `qwen`.
+            let has_key_alias = if suppressed {
                 false
             } else {
-                match provider.id.as_str() {
-                    "gemini" => std::env::var("GOOGLE_API_KEY").is_ok_and(|v| !v.trim().is_empty()),
-                    "openai" | "codex" => {
-                        std::env::var("OPENAI_API_KEY").is_ok_and(|v| !v.trim().is_empty())
-                            || read_codex_credential().is_some()
-                    }
-                    _ => false,
-                }
-            };
-
-            // Tertiary: CLI tools that can serve as fallback for API providers
-            let has_cli_fallback = if suppressed {
-                false
-            } else {
-                match provider.id.as_str() {
-                    "anthropic" => crate::drivers::cli_provider_available("claude-code"),
-                    "gemini" => crate::drivers::cli_provider_available("gemini-cli"),
-                    "openai" | "codex" => crate::drivers::cli_provider_available("codex-cli"),
-                    "qwen" => crate::drivers::cli_provider_available("qwen-code"),
-                    _ => false,
-                }
+                provider.id == "gemini"
+                    && std::env::var("GOOGLE_API_KEY").is_ok_and(|v| !v.trim().is_empty())
             };
 
             provider.auth_status = if has_key {
                 AuthStatus::Configured
-            } else if has_key_fallback {
+            } else if has_key_alias {
                 AuthStatus::AutoDetected
-            } else if has_cli_fallback {
-                AuthStatus::ConfiguredCli
             } else {
                 AuthStatus::Missing
             };
             tracing::debug!(
                 provider = %provider.id,
                 has_key,
-                has_key_fallback,
-                has_cli_fallback,
+                has_key_alias,
                 auth_status = %provider.auth_status,
                 "detect_auth result"
             );
@@ -1041,55 +1030,6 @@ fn resolve_home_dir() -> std::path::PathBuf {
         })
 }
 
-/// Read an OpenAI API key from the Codex CLI credential file.
-///
-/// Checks `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.
-/// Returns `Some(api_key)` if the file exists and contains a valid, non-expired token.
-/// Only checks presence — the actual key value is used transiently, never stored.
-pub fn read_codex_credential() -> Option<String> {
-    let codex_home = std::env::var("CODEX_HOME")
-        .map(std::path::PathBuf::from)
-        .ok()
-        .or_else(|| {
-            #[cfg(target_os = "windows")]
-            {
-                std::env::var("USERPROFILE")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".codex"))
-            }
-        })?;
-
-    let auth_path = codex_home.join("auth.json");
-    let content = std::fs::read_to_string(&auth_path).ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    // Check expiry if present
-    if let Some(expires_at) = parsed.get("expires_at").and_then(|v| v.as_i64()) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-        if now >= expires_at {
-            return None; // Expired
-        }
-    }
-
-    parsed
-        .get("api_key")
-        .or_else(|| parsed.get("token"))
-        // Codex CLI OAuth stores the token nested at tokens.id_token
-        .or_else(|| parsed.get("tokens").and_then(|t| t.get("id_token")))
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1301,6 +1241,99 @@ id = "acme"
         assert_eq!(ollama.auth_status, AuthStatus::NotRequired);
         let vllm = catalog.get_provider("vllm").unwrap();
         assert_eq!(vllm.auth_status, AuthStatus::NotRequired);
+    }
+
+    /// Regression: a CLI login must NOT auto-configure the corresponding API
+    /// provider. `anthropic` / `openai` / `gemini` / `qwen` only light up
+    /// when the user sets their own API key. CLI logins surface via their
+    /// dedicated provider entries (`claude-code`, `codex-cli`, etc.).
+    ///
+    /// This test runs with no provider API-key env vars set, so every
+    /// API provider should report `Missing`. We only assert on the four
+    /// providers that previously borrowed CLI credentials — the others
+    /// are naturally Missing.
+    #[test]
+    fn detect_auth_does_not_promote_api_providers_from_cli_login() {
+        use std::sync::Mutex;
+        // env mutations are process-global; serialise this test with any
+        // other env-touching test that may run in the same binary.
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let preserved: Vec<(&str, Option<String>)> = [
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "QWEN_API_KEY",
+            "DASHSCOPE_API_KEY",
+        ]
+        .iter()
+        .map(|k| (*k, std::env::var(k).ok()))
+        .collect();
+        for (k, _) in &preserved {
+            // SAFETY: single-threaded section guarded by ENV_LOCK.
+            unsafe { std::env::remove_var(k) };
+        }
+
+        let mut catalog = test_catalog();
+        catalog.detect_auth();
+
+        for id in ["anthropic", "openai", "gemini", "qwen"] {
+            let p = catalog.get_provider(id).unwrap();
+            assert_eq!(
+                p.auth_status,
+                AuthStatus::Missing,
+                "{id} must be Missing when no API key is set, regardless of CLI login"
+            );
+        }
+
+        for (k, v) in preserved {
+            // SAFETY: single-threaded section guarded by ENV_LOCK.
+            unsafe {
+                if let Some(val) = v {
+                    std::env::set_var(k, val);
+                } else {
+                    std::env::remove_var(k);
+                }
+            }
+        }
+    }
+
+    /// `GOOGLE_API_KEY` remains a recognised alias for `GEMINI_API_KEY`
+    /// (officially documented by Google AI Studio as equivalent). Setting
+    /// it should promote Gemini to AutoDetected — this is a real API key
+    /// the user typed, not a CLI-credential borrow.
+    #[test]
+    fn google_api_key_alias_still_recognised_for_gemini() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prev_gemini = std::env::var("GEMINI_API_KEY").ok();
+        let prev_google = std::env::var("GOOGLE_API_KEY").ok();
+        unsafe {
+            std::env::remove_var("GEMINI_API_KEY");
+            std::env::set_var("GOOGLE_API_KEY", "test-alias-key");
+        }
+
+        let mut catalog = test_catalog();
+        catalog.detect_auth();
+        let gemini = catalog.get_provider("gemini").unwrap();
+        assert_eq!(gemini.auth_status, AuthStatus::AutoDetected);
+
+        unsafe {
+            if let Some(v) = prev_gemini {
+                std::env::set_var("GEMINI_API_KEY", v);
+            } else {
+                std::env::remove_var("GEMINI_API_KEY");
+            }
+            if let Some(v) = prev_google {
+                std::env::set_var("GOOGLE_API_KEY", v);
+            } else {
+                std::env::remove_var("GOOGLE_API_KEY");
+            }
+        }
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1243,6 +1243,14 @@ id = "acme"
         assert_eq!(vllm.auth_status, AuthStatus::NotRequired);
     }
 
+    /// Module-scope mutex for tests that mutate process env vars.
+    ///
+    /// `cargo test` runs tests in parallel by default, so any two tests
+    /// touching the same env var must share this lock — otherwise they race
+    /// on process-global state. Each test declaring its own `static` was the
+    /// earlier bug: two disjoint mutexes = no mutual exclusion.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Regression: a CLI login must NOT auto-configure the corresponding API
     /// provider. `anthropic` / `openai` / `gemini` / `qwen` only light up
     /// when the user sets their own API key. CLI logins surface via their
@@ -1254,10 +1262,6 @@ id = "acme"
     /// are naturally Missing.
     #[test]
     fn detect_auth_does_not_promote_api_providers_from_cli_login() {
-        use std::sync::Mutex;
-        // env mutations are process-global; serialise this test with any
-        // other env-touching test that may run in the same binary.
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let preserved: Vec<(&str, Option<String>)> = [
@@ -1306,12 +1310,11 @@ id = "acme"
     /// the user typed, not a CLI-credential borrow.
     #[test]
     fn google_api_key_alias_still_recognised_for_gemini() {
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let prev_gemini = std::env::var("GEMINI_API_KEY").ok();
         let prev_google = std::env::var("GOOGLE_API_KEY").ok();
+        // SAFETY: single-threaded section guarded by ENV_LOCK.
         unsafe {
             std::env::remove_var("GEMINI_API_KEY");
             std::env::set_var("GOOGLE_API_KEY", "test-alias-key");
@@ -1322,6 +1325,7 @@ id = "acme"
         let gemini = catalog.get_provider("gemini").unwrap();
         assert_eq!(gemini.auth_status, AuthStatus::AutoDetected);
 
+        // SAFETY: single-threaded section guarded by ENV_LOCK.
         unsafe {
             if let Some(v) = prev_gemini {
                 std::env::set_var("GEMINI_API_KEY", v);


### PR DESCRIPTION
## Summary

Two-commit fix for the provider-detection mess where CLI installs and CLI logins were being treated as API-provider credentials, causing false-positive detection and duplicate rows in the provider list.

### Commit 1 · `fix(llm-drivers): stop treating CLI config files as auth credentials`

**Bug**: `settings.json` / wrong credential filenames were matched as proof of authentication.

Reported trigger: fresh install, `GEMINI_API_KEY` / `GOOGLE_API_KEY` unset, vault empty — Gemini still showed as auto-detected because `~/.gemini/settings.json` (a preferences file created on first launch) was being checked.

- **gemini-cli**: was checking `settings.json` (preference file, always exists) and `.credentials.json` (wrong filename). Now checks `oauth_creds.json` (Google Gemini CLI's actual OAuth token) + `credentials.json` / `.credentials.json` fallbacks.
- **claude-code**: was checking `settings.json` with a comment claiming it covered keychain-auth users. `settings.json` is written before login, and the primary `detect()` path already probes the `claude` binary at PATH + `/opt/homebrew/bin` + `/usr/local/bin` + `/usr/bin`, so keychain users stay covered without the false-positive signal.
- **qwen-code**: Qwen Code forks Gemini CLI — added `oauth_creds.json` alongside existing fallbacks to match logged-in users that were previously missed.
- **codex-cli**: unchanged (already only checks `~/.codex/auth.json` + validates token expiry).

Each detector now delegates to a `*_credentials_in_dir(&Path)` helper so tests drive it against a tempdir without `HOME` manipulation.

### Commit 2 · `fix(providers): stop promoting CLI logins into API provider auth`

**Bug**: a CLI login silently promoted its corresponding API provider to Configured/AutoDetected:
- `claude-code` login → `anthropic` marked ConfiguredCli
- `codex-cli` login → `openai` marked AutoDetected (via `read_codex_credential()` extracting the token from `~/.codex/auth.json`)
- `gemini-cli` login → `gemini` marked ConfiguredCli
- `qwen-code` login → `qwen` marked ConfiguredCli

Dashboard then showed each credential twice (once under the CLI provider, once under the API provider), and `provider = "openai"` could run silently on a Codex-extracted token without `OPENAI_API_KEY` ever being set.

**New contract**: CLI login surfaces only as its own CLI provider entry; API provider lights up only when the user sets its own API key.

- `model_catalog.rs::detect_auth`: dropped `has_cli_fallback` and the `read_codex_credential()` clause from `has_key_fallback`. Renamed to `has_key_alias` — only Gemini's `GOOGLE_API_KEY` alias remains (Google AI Studio officially documents it as equivalent to `GEMINI_API_KEY`). Removed the now-unused `pub fn read_codex_credential()` helper.
- `drivers/mod.rs`: runtime driver factory and `resolve_provider_api_key()` no longer fall back to Codex auth.json when `OPENAI_API_KEY` is empty — runtime matches detection.
- `providers.rs::test_provider`: removed the dead `ConfiguredCli` branch; no API provider produces that status anymore.

`AuthStatus::ConfiguredCli` variant is retained (public enum) but unproduced; existing matches treat it as available so any stale serialised value round-trips harmlessly.

## Behavior change — release-note worthy

Agents previously configured with `provider = "openai"` and no `OPENAI_API_KEY` were silently running on a Codex CLI token. Those will now return `MissingApiKey`. Migration: either set `OPENAI_API_KEY`, or switch the agent to `provider = "codex-cli"` (uses the subprocess path).

## Test plan

- [x] `cargo test -p librefang-llm-drivers --lib` — 342 passed (10 new credential-detection tests)
- [x] `cargo test -p librefang-runtime --lib` — 2 new regression tests in `model_catalog::tests` pass
- [x] `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- [ ] Manual: with only `~/.gemini/settings.json`, confirm Gemini no longer appears as Configured in the provider list
- [ ] Manual: with only `~/.codex/auth.json`, confirm `openai` appears as Missing (but `codex-cli` still appears as Configured)
- [ ] Manual: with `OPENAI_API_KEY` set, confirm `openai` appears as Configured

## Follow-ups (not in this PR)

- `dashboard/src/pages/ProvidersPage.tsx` / `ChatPage.tsx` still branch on `"configured_cli"` — dead code now, safe to clean up.
- Naming: `claude_credentials_exist` / `qwen_credentials_exist` / `gemini_cli_credentials_exist` — three spellings for the same concept (pre-existing).