### PR TITLE
fix(docker): pre-create logs dir in entrypoint (defense for #3058)

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -8,16 +8,22 @@ CONFIG="$DATA_DIR/config.toml"
 
 mkdir -p "$DATA_DIR"
 
+if [ "$(stat -c '%U' "$DATA_DIR" 2>/dev/null)" != "node" ]; then
+  chown -R node:node "$DATA_DIR"
+fi
+
 # Pre-create the logs directory so `librefang start --foreground` can open
 # its daily log file on a fresh container. The CLI also creates this dir
 # itself (see setup_foreground_tee), but we do it here too as defense in
 # depth — a missing logs dir previously caused the daemon to panic with
 # exit 101 silently (GH #3058).
-mkdir -p "$DATA_DIR/logs"
-
-if [ "$(stat -c '%U' "$DATA_DIR" 2>/dev/null)" != "node" ]; then
-  chown -R node:node "$DATA_DIR"
-fi
+#
+# Create as the node user so that on reused volumes (where $DATA_DIR is
+# already owned by node and the chown -R above is skipped) the new dir
+# isn't left as root:root 0755 — that would block `gosu node librefang`
+# from writing daemon-*.log and reproduce the same failure under a
+# different error code.
+gosu node mkdir -p "$DATA_DIR/logs"
 
 # First boot only. Subsequent boots skip init: the kernel re-syncs the
 # registry on its own at startup (see librefang-kernel/src/kernel.rs ~2054),

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -8,6 +8,13 @@ CONFIG="$DATA_DIR/config.toml"
 
 mkdir -p "$DATA_DIR"
 
+# Pre-create the logs directory so `librefang start --foreground` can open
+# its daily log file on a fresh container. The CLI also creates this dir
+# itself (see setup_foreground_tee), but we do it here too as defense in
+# depth — a missing logs dir previously caused the daemon to panic with
+# exit 101 silently (GH #3058).
+mkdir -p "$DATA_DIR/logs"
+
 if [ "$(stat -c '%U' "$DATA_DIR" 2>/dev/null)" != "node" ]; then
   chown -R node:node "$DATA_DIR"
 fi


### PR DESCRIPTION
## Summary

- Pre-creates `$LIBREFANG_HOME/logs/` in `deploy/docker-entrypoint.sh` before starting the daemon.
- Defense-in-depth only — the real fix for #3058 already landed at the CLI layer in 5ed09183 (#3057).

## Context

GH #3058 reports the `v2026.4.24-beta5` Docker image exiting 101 right after "Starting daemon…". Root cause:

1. Container sets `LIBREFANG_HOME=/data` and runs `librefang start --foreground`.
2. Pre-#3057 `setup_foreground_tee` dup2'd stdout/stderr to a pipe **before** trying to open the daily log file at `/data/logs/daemon-<date>.log`.
3. `/data/logs/` doesn't exist on a fresh container, so the open panics (Rust exit code 101). The panic message is written into the pipe, but the reader thread hasn't been spawned yet — so Docker just shows `Exited (101)` with no explanation.

#3057 fixes the ordering (create_dir_all + open log **before** dup2) at the CLI layer. That fix landed after the beta5 tag, so the published image is still broken until a new release is cut.

This PR adds a belt-and-suspenders `mkdir -p "$DATA_DIR/logs"` in the entrypoint so:

- Any future regression that reintroduces the "open log before creating dir" failure mode won't be able to silently crash the container.
- Combined with #3057, the next release image is doubly protected.

Does **not** retroactively fix the beta5 image — users on beta5 need to wait for the next release (or rebuild from `main`).

## Test plan

- [x] `sh -n deploy/docker-entrypoint.sh` — syntax valid
- [ ] Manual: build image from this branch, `docker run` fresh, confirm `/data/logs/` exists and daemon starts
- [ ] Manual: verify existing behavior (config init, PORT override, api_listen rewrite) unchanged

Closes #3058 once released.