### PR TITLE
feat(auto-detect): treat CLI logins as first-class default providers

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2805,9 +2805,17 @@ fn detect_best_provider() -> (String, String, String) {
                 Some(first) => first.to_uppercase().to_string() + c.as_str(),
             }
         };
+        // CLI-backed providers return an empty env_var (auth via OAuth token
+        // or keychain, not an env variable). Display a readable placeholder
+        // so the i18n message doesn't end with an empty parenthetical.
+        let auth_display = if env_var.is_empty() {
+            "CLI login"
+        } else {
+            env_var
+        };
         ui::success(&i18n::t_args(
             "detected-provider",
-            &[("display", &display_name), ("env_var", env_var)],
+            &[("display", &display_name), ("env_var", auth_display)],
         ));
         return (
             provider.to_string(),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1760,11 +1760,16 @@ impl LibreFangKernel {
                 } else {
                     model_hint.to_string()
                 };
+                let auth_source = if env_var.is_empty() {
+                    "CLI login"
+                } else {
+                    env_var
+                };
                 info!(
                     provider = %provider,
                     model = %model,
-                    env_var = %env_var,
-                    "Auto-detected default provider from environment"
+                    auth_source = %auth_source,
+                    "Auto-detected default provider"
                 );
                 config.default_model.provider = provider.to_string();
                 config.default_model.model = model;
@@ -1984,11 +1989,16 @@ impl LibreFangKernel {
                         };
                         match drivers::create_driver(&auto_config) {
                             Ok(d) => {
+                                let auth_source = if env_var.is_empty() {
+                                    "CLI login"
+                                } else {
+                                    env_var
+                                };
                                 info!(
                                     provider = %provider,
                                     model = %model,
-                                    "Auto-detected provider from {} — using as default",
-                                    env_var
+                                    auth_source = %auth_source,
+                                    "Auto-detected provider — using as default"
                                 );
                                 driver_chain.push(d);
                                 // Update the running config so agents get the right model

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -850,6 +850,24 @@ pub fn detect_available_provider() -> Option<(&'static str, &'static str, &'stat
         }
     }
 
+    // Phase 3: CLI-backed providers. No env var is involved — a CLI login
+    // is detected via binary-on-PATH or on-disk credential files. These are
+    // tried only after all API-key providers so that a user with both an
+    // API key and a CLI login gets the direct-API path (cheaper, faster).
+    //
+    // An empty `api_key_env` in the returned tuple signals to the caller
+    // that no env var lookup is needed; the CLI driver manages its own
+    // authentication (OAuth token, keychain, or subprocess login).
+    //
+    // Order matches typical install prevalence — claude-code first, then
+    // codex-cli, then Google's Gemini CLI, then Qwen's fork.
+    const CLI_PRIORITY: &[&str] = &["claude-code", "codex-cli", "gemini-cli", "qwen-code"];
+    for &name in CLI_PRIORITY {
+        if cli_provider_available(name) {
+            return Some((name, "", ""));
+        }
+    }
+
     None
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3059. That PR stopped silently promoting CLI logins into API-provider auth status — users with only a CLI login (e.g. `~/.codex/auth.json` signed in, no `OPENAI_API_KEY`) now correctly see `openai` as Missing.

But the daemon's auto-detect fallback in `detect_available_provider()` only scanned API-key env vars, and CLI providers were skipped by the `!p.key_required` guard. Result: those users now hit

```
WARN Primary LLM driver init failed — trying auto-detect provider=openai error=Missing API key
WARN No LLM drivers available — agents will return errors until a provider is configured
```

There was no way for auto-detect to recover.

## Changes

- **`drivers/mod.rs::detect_available_provider`** — add Phase 3 that scans CLI-backed providers (`claude-code`, `codex-cli`, `gemini-cli`, `qwen-code`) after all API-key providers. Returns an empty `api_key_env` in the tuple to signal "no env lookup needed — driver handles its own auth". API-key providers still win when both are available so users with an API key get the direct-API path.
- **`kernel/mod.rs`** (two call sites) and **`cli/main.rs`** — render an empty env_var as `"CLI login"` in log messages / user-facing strings so operators can tell at a glance that the daemon chose a CLI subprocess. Avoids trailing `()` / `from  —` artefacts in the log.

## Behavior after this PR

| Host state | Before #3059 | After #3059 only | After this PR |
|---|---|---|---|
| `OPENAI_API_KEY` set | openai (direct API) | openai (direct API) | openai (direct API) |
| Only `~/.codex/auth.json` | openai (via Codex token — **wrong**) | No driver — error | **codex-cli (subprocess)** |
| Only `~/.claude/.credentials.json` | anthropic (ConfiguredCli) | No driver — error | **claude-code (subprocess)** |
| Only `~/.gemini/oauth_creds.json` | gemini (ConfiguredCli) | No driver — error | **gemini-cli (subprocess)** |
| Nothing | Interactive wizard | No driver — error | No driver — error (unchanged) |

## Test plan

- [x] `cargo test -p librefang-llm-drivers -p librefang-kernel -p librefang-cli --lib` — no regressions
- [ ] Manual: on a machine with only `~/.codex/auth.json`, start the daemon and confirm logs show `Auto-detected default provider provider=codex-cli auth_source="CLI login"` instead of `No LLM drivers available`
- [ ] Manual: on a machine with both `OPENAI_API_KEY` and `~/.codex/auth.json`, confirm openai is chosen (direct API path preferred)

## Not in this PR

- Dashboard dead branches on `"configured_cli"` status (follow-up noted in #3059).