### PR TITLE
fix(observability): bundle compose stack in-binary, add OTLP collector

### DIFF
--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1174,11 +1174,13 @@ pub async fn run_daemon(
     info!("WebChat UI available at http://{addr}/",);
     info!("WebSocket endpoint: ws://{addr}/api/agents/{{id}}/ws",);
 
-    // Auto-start observability stack (Prometheus + Grafana) if Docker is available
+    // Auto-start observability stack (OTLP collector + Prometheus + Grafana) if Docker is available
     let observability_started = if kernel.config_ref().telemetry.enabled {
-        match start_observability_stack() {
+        match start_observability_stack(kernel.home_dir()) {
             Ok(ObservabilityStartup::Started) => {
-                info!("Observability stack started (Prometheus :9090, Grafana :3000)");
+                info!(
+                    "Observability stack started (OTLP :4317/:4318, Prometheus :9090, Grafana :3000)"
+                );
                 true
             }
             Ok(ObservabilityStartup::DockerUnavailable) => {
@@ -1187,7 +1189,7 @@ pub async fn run_daemon(
             }
             Ok(ObservabilityStartup::ComposeFailed { stderr }) => {
                 tracing::warn!(
-                    "Observability stack failed to start (likely a port conflict on 9090/3000 or an existing stack): {}",
+                    "Observability stack failed to start (likely a port conflict on 4317/9090/3000 or an existing stack): {}",
                     stderr.trim()
                 );
                 false
@@ -1339,7 +1341,7 @@ pub async fn run_daemon(
 
     // Stop observability stack
     if observability_started {
-        if let Err(e) = stop_observability_stack() {
+        if let Err(e) = stop_observability_stack(state.kernel.home_dir()) {
             tracing::warn!("Failed to stop observability stack: {e}");
         } else {
             info!("Observability stack stopped");
@@ -1386,8 +1388,73 @@ enum ObservabilityStartup {
     ComposeFailed { stderr: String },
 }
 
+/// Observability assets embedded at compile time. Written to
+/// `<home>/observability/` on boot so Docker Desktop (macOS) can bind-mount
+/// them from a path that is always in its File Sharing list (`~`). Avoids
+/// the `operation not permitted` failure we hit when the daemon runs from
+/// an external disk (`/Volumes/...`) that the user has not added manually.
+const OBSERVABILITY_ASSETS: &[(&str, &str)] = &[
+    (
+        "docker-compose.observability.yml",
+        include_str!("../../../deploy/docker-compose.observability.yml"),
+    ),
+    (
+        "prometheus/prometheus.yml",
+        include_str!("../../../deploy/prometheus/prometheus.yml"),
+    ),
+    (
+        "otel-collector/config.yaml",
+        include_str!("../../../deploy/otel-collector/config.yaml"),
+    ),
+    (
+        "grafana/provisioning/datasources/prometheus.yml",
+        include_str!("../../../deploy/grafana/provisioning/datasources/prometheus.yml"),
+    ),
+    (
+        "grafana/provisioning/dashboards/dashboard.yml",
+        include_str!("../../../deploy/grafana/provisioning/dashboards/dashboard.yml"),
+    ),
+    (
+        "grafana/dashboards/librefang.json",
+        include_str!("../../../deploy/grafana/dashboards/librefang.json"),
+    ),
+    (
+        "grafana/dashboards/librefang-llm.json",
+        include_str!("../../../deploy/grafana/dashboards/librefang-llm.json"),
+    ),
+    (
+        "grafana/dashboards/librefang-http.json",
+        include_str!("../../../deploy/grafana/dashboards/librefang-http.json"),
+    ),
+    (
+        "grafana/dashboards/librefang-cost.json",
+        include_str!("../../../deploy/grafana/dashboards/librefang-cost.json"),
+    ),
+    (
+        "grafana/dashboards/ollama.json",
+        include_str!("../../../deploy/grafana/dashboards/ollama.json"),
+    ),
+];
+
+/// Stage all embedded observability assets under `<home>/observability/`,
+/// overwriting on every call so upgrades ship new configs without
+/// manual intervention. Returns the staged compose file path.
+fn stage_observability_assets(home_dir: &Path) -> std::io::Result<std::path::PathBuf> {
+    let root = home_dir.join("observability");
+    for (rel, contents) in OBSERVABILITY_ASSETS {
+        let target = root.join(rel);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&target, contents)?;
+    }
+    Ok(root.join("docker-compose.observability.yml"))
+}
+
 /// Check if Docker is available and start the observability stack.
-fn start_observability_stack() -> Result<ObservabilityStartup, Box<dyn std::error::Error>> {
+fn start_observability_stack(
+    home_dir: &Path,
+) -> Result<ObservabilityStartup, Box<dyn std::error::Error>> {
     // Check if docker CLI exists and daemon is reachable
     let docker_check = std::process::Command::new("docker")
         .arg("version")
@@ -1400,8 +1467,8 @@ fn start_observability_stack() -> Result<ObservabilityStartup, Box<dyn std::erro
         _ => return Ok(ObservabilityStartup::DockerUnavailable),
     }
 
-    // Find the compose file relative to the executable or well-known paths
-    let compose_file = find_compose_file()?;
+    let compose_file = stage_observability_assets(home_dir)
+        .map_err(|e| format!("failed to stage observability assets: {e}"))?;
 
     let output = std::process::Command::new("docker")
         .args(["compose", "-f"])
@@ -1419,9 +1486,14 @@ fn start_observability_stack() -> Result<ObservabilityStartup, Box<dyn std::erro
     }
 }
 
-/// Stop the observability stack.
-fn stop_observability_stack() -> Result<(), Box<dyn std::error::Error>> {
-    let compose_file = find_compose_file()?;
+/// Stop the observability stack using the staged compose file.
+fn stop_observability_stack(home_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let compose_file = home_dir
+        .join("observability")
+        .join("docker-compose.observability.yml");
+    if !compose_file.exists() {
+        return Ok(());
+    }
 
     std::process::Command::new("docker")
         .args(["compose", "-f"])
@@ -1433,30 +1505,6 @@ fn stop_observability_stack() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| format!("docker compose down failed: {e}"))?;
 
     Ok(())
-}
-
-/// Locate the observability docker-compose file.
-fn find_compose_file() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
-    // Try relative to current exe
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            // Binary might be in target/release or target/debug
-            for ancestor in dir.ancestors().take(4) {
-                let candidate = ancestor.join("deploy/docker-compose.observability.yml");
-                if candidate.exists() {
-                    return Ok(candidate);
-                }
-            }
-        }
-    }
-
-    // Try current working directory
-    let cwd_candidate = std::path::PathBuf::from("deploy/docker-compose.observability.yml");
-    if cwd_candidate.exists() {
-        return Ok(cwd_candidate);
-    }
-
-    Err("Could not find deploy/docker-compose.observability.yml".into())
 }
 
 /// SECURITY: Restrict file permissions to owner-only (0600) on Unix.

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -1,6 +1,20 @@
 name: librefang
 
 services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: librefang-otel-collector
+    ports:
+      - "4317:4317"   # OTLP gRPC receiver (LibreFang's otlp_endpoint)
+      - "4318:4318"   # OTLP HTTP receiver
+      - "8889:8889"   # Prometheus scrape endpoint (OTLP metrics → Prometheus)
+    volumes:
+      - ./otel-collector/config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   prometheus:
     image: prom/prometheus:latest
     container_name: librefang-prometheus
@@ -11,6 +25,8 @@ services:
       - prometheus-data:/prometheus
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    depends_on:
+      - otel-collector
     restart: unless-stopped
 
   grafana:

--- a/deploy/otel-collector/config.yaml
+++ b/deploy/otel-collector/config.yaml
@@ -1,0 +1,35 @@
+# OpenTelemetry Collector config for LibreFang's local dev stack.
+#
+# Receives OTLP traces + metrics from LibreFang on 4317 (gRPC) / 4318 (HTTP)
+# and exposes a Prometheus scrape endpoint on 8889 for Prometheus to pick up
+# OTLP-delivered metrics. Traces are written to the collector's stdout via
+# the debug exporter — replace with a real backend (Tempo, Jaeger, …) when
+# you need trace search.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: normal
+  prometheus:
+    endpoint: 0.0.0.0:8889
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -16,3 +16,11 @@ scrape_configs:
       - targets: ["host.docker.internal:9102"]
         labels:
           instance: "ollama-local"
+
+  # OTLP metrics routed through the collector (LibreFang → OTLP :4317 → collector → :8889).
+  - job_name: "otel-collector"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["otel-collector:8889"]
+        labels:
+          instance: "otel-collector"


### PR DESCRIPTION
## Summary

Two root-cause fixes for the auto-started observability stack. Tested trigger: `~/.librefang/logs/daemon-2026-04-27.log` showed both ports silently broken even though `[telemetry] enabled = true`.

### 1. macOS external-disk mount failure (Prometheus restart-looping, port 9090 dead)

The auto-started stack bind-mounts config files from the binary's `deploy/` dir:

```yaml
- ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
```

On macOS, Docker Desktop's File Sharing only exposes `/Users` (and a few system paths) by default. When the daemon runs from an external disk (`/Volumes/Lexar/...`) — a very common dev setup — the bind mount silently fails with `operation not permitted` and Prometheus exits 2 in a restart loop. The manual workaround (add the path to File Sharing) is brittle: every new machine / new external disk needs it.

**Fix**: `include_str!` every compose asset into the binary and stage them under `<home>/observability/` on boot. `<home>` is always under `/Users/...` on macOS, which Docker Desktop always shares. Overwrites on every boot so upgrades propagate without manual intervention. `find_compose_file()` and its fallback chain (exe-relative → cwd) are gone.

### 2. Missing OTLP collector (port 4317 always dead)

`[telemetry] otlp_endpoint = "http://localhost:4317"` was the default, but nothing in the stack listened on 4317. Traces went to the void.

**Fix**: added `otel-collector` to the compose stack:
- OTLP gRPC on **4317**, HTTP on **4318** (matches the config default)
- Prometheus scrape endpoint on **8889** for OTLP-delivered metrics
- Debug exporter writes traces to stdout (replace with Tempo/Jaeger later — out of scope)
- Prometheus has a new scrape job for the collector

## Files

| Status | Path |
|---|---|
| new | `deploy/otel-collector/config.yaml` |
| modified | `deploy/docker-compose.observability.yml` |
| modified | `deploy/prometheus/prometheus.yml` |
| modified | `crates/librefang-api/src/server.rs` |

## Test plan

- [x] `cargo build -p librefang-api` — compiles (all assets embed via `include_str!`)
- [ ] Manual — fresh machine, run daemon from `/Volumes/...`:
  - Start daemon; confirm log says `Observability stack started (OTLP :4317/:4318, Prometheus :9090, Grafana :3000)`
  - `curl -sI http://localhost:9090/` → 302
  - `curl -sI http://localhost:3000/` → 302
  - `docker logs librefang-prometheus` — no `operation not permitted`
  - Stack files land in `~/.librefang/observability/`
- [ ] Manual — stop daemon; confirm `docker ps` shows no `librefang-*` containers
- [ ] Manual — send an OTLP metric via `otel-cli` / LibreFang's own tracer to `localhost:4317`, confirm it shows up in Prometheus `/graph` under `otel-collector` target

## Behavior change

- **Staged assets at `~/.librefang/observability/`** are considered LibreFang-managed: edits are overwritten on the next daemon boot. Users who need to customize should patch the bundled source and rebuild.
- **Port 4317** was effectively unused before and is now opened. If the user already runs a collector on 4317, the compose up will fail with a port conflict — `ComposeFailed` log already covers that case.