### PR TITLE
fix(telemetry): create HTTP trace spans at INFO so OTel exporter sees them

### DIFF
--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{DefaultMakeSpan, TraceLayer};
 use tracing::info;
 
 /// Daemon info written to `~/.librefang/daemon.json` so the CLI can find us.
@@ -965,7 +965,15 @@ pub async fn build_router(
         .layer(axum::middleware::from_fn(middleware::security_headers))
         .layer(axum::middleware::from_fn(middleware::request_logging))
         .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
+        // INFO-level request spans so they're created even when the console
+        // log level is INFO. Required for the OpenTelemetry layer to pick
+        // them up and ship to the OTLP collector — at DEBUG (the default for
+        // `new_for_http`) spans never exist at INFO and the OTel exporter
+        // sees nothing.
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+        )
         .layer(cors);
 
     // Split body-limit application: apply the global limit to the main app,


### PR DESCRIPTION
## Summary

Follow-up to #3062. After that PR brought up the OTel collector and wired LibreFang's config to export traces, manual probes via `:4317` / `:4318` worked end-to-end but **LibreFang's own HTTP requests produced no spans** in the collector.

Verified: daemon logs `OpenTelemetry OTLP tracing initialized` on boot; `/api/health` and `/api/agents` were hit multiple times; collector stdout (debug exporter) showed zero `service.name=librefang` traces even after the batch-flush window.

## Root cause

`crates/librefang-api/src/server.rs:968`:

```rust
.layer(TraceLayer::new_for_http())
```

`tower_http`'s default `MakeSpan` uses **DEBUG** level. The daemon runs with an INFO subscriber filter, so DEBUG spans are never created. `tracing-opentelemetry` forwards existing spans; if none exist, the OTel exporter has nothing to ship.

## Fix

One-liner — configure the `MakeSpan` at INFO so HTTP request spans are always created:

```rust
.layer(
    TraceLayer::new_for_http()
        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
)
```

## Test plan

- [x] `cargo check -p librefang-api`
- [ ] Manual: after rebuild, `curl http://localhost:4545/api/health` → wait 5-10s for batch flush → `docker logs librefang-otel-collector` shows a `request` span with `service.name=librefang` and HTTP method/path attributes

## Scope

Intentionally narrow — span-level instrumentation (tower_http → OTel). Does not touch:
- Sampling rate (already configurable via `[telemetry] sample_rate`)
- Span names or attributes (tower_http defaults are fine for now)
- Custom `#[tracing::instrument]` on handlers (can be added incrementally)