### PR TITLE
feat(observability): Grafana Tempo + business-level span instrumentation

### DIFF
--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1187,7 +1187,7 @@ pub async fn run_daemon(
         match start_observability_stack(kernel.home_dir()) {
             Ok(ObservabilityStartup::Started) => {
                 info!(
-                    "Observability stack started (OTLP :4317/:4318, Prometheus :9090, Grafana :3000)"
+                    "Observability stack started (OTLP :4317/:4318, Tempo :3200, Prometheus :9090, Grafana :3000)"
                 );
                 true
             }
@@ -1197,7 +1197,7 @@ pub async fn run_daemon(
             }
             Ok(ObservabilityStartup::ComposeFailed { stderr }) => {
                 tracing::warn!(
-                    "Observability stack failed to start (likely a port conflict on 4317/9090/3000 or an existing stack): {}",
+                    "Observability stack failed to start (likely a port conflict on 3000/3200/4317/9090 or an existing stack): {}",
                     stderr.trim()
                 );
                 false
@@ -1415,8 +1415,16 @@ const OBSERVABILITY_ASSETS: &[(&str, &str)] = &[
         include_str!("../../../deploy/otel-collector/config.yaml"),
     ),
     (
+        "tempo/tempo.yaml",
+        include_str!("../../../deploy/tempo/tempo.yaml"),
+    ),
+    (
         "grafana/provisioning/datasources/prometheus.yml",
         include_str!("../../../deploy/grafana/provisioning/datasources/prometheus.yml"),
+    ),
+    (
+        "grafana/provisioning/datasources/tempo.yml",
+        include_str!("../../../deploy/grafana/provisioning/datasources/tempo.yml"),
     ),
     (
         "grafana/provisioning/dashboards/dashboard.yml",

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 /// Build the MCP bridge config that lets CLI-based drivers (Claude Code)
 /// reach back into the daemon's own `/mcp` endpoint. Uses loopback when the
@@ -6289,6 +6289,15 @@ system_prompt = "You are a helpful assistant."
 
     /// Execute the default LLM-based agent loop.
     #[allow(clippy::too_many_arguments)]
+    #[instrument(
+        skip_all,
+        fields(
+            agent.id = %agent_id,
+            agent.name = %entry.manifest.name,
+            message.len = message.len(),
+            channel = sender_context.map(|c| c.channel.as_str()).unwrap_or("direct"),
+        ),
+    )]
     async fn execute_llm_agent(
         &self,
         entry: &AgentEntry,

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -671,6 +671,13 @@ struct ToolExecutionContext<'a> {
         Option<&'a Arc<tokio::sync::RwLock<crate::dangerous_command::DangerousCommandChecker>>>,
 }
 
+#[instrument(
+    skip_all,
+    fields(
+        tool.name = %tool_call.name,
+        tool.id = %tool_call.id,
+    ),
+)]
 async fn execute_single_tool_call(
     ctx: &mut ToolExecutionContext<'_>,
     tool_call: &ToolCall,
@@ -3717,6 +3724,15 @@ fn build_user_facing_llm_error(
     (classified.is_billing, LibreFangError::LlmDriver(user_msg))
 }
 
+#[instrument(
+    skip_all,
+    fields(
+        llm.provider = provider.unwrap_or("unknown"),
+        llm.model = %request.model,
+        llm.messages = request.messages.len(),
+        llm.tools = request.tools.len(),
+    ),
+)]
 async fn call_with_retry(
     driver: &dyn LlmDriver,
     request: CompletionRequest,

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -13,6 +13,23 @@ services:
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    depends_on:
+      - tempo
+    restart: unless-stopped
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: librefang-tempo
+    # 3200 (HTTP query API) is exposed so Grafana's Tempo datasource can
+    # reach it through the Docker network. Tempo's OTLP receiver on 4317
+    # is NOT exposed to the host — the host's 4317 is the OTel collector;
+    # the collector forwards traces to tempo:4317 internally.
+    ports:
+      - "3200:3200"
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
     restart: unless-stopped
 
   prometheus:
@@ -43,8 +60,10 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+      - tempo
     restart: unless-stopped
 
 volumes:
   prometheus-data:
+  tempo-data:
   grafana-data:

--- a/deploy/grafana/provisioning/datasources/tempo.yml
+++ b/deploy/grafana/provisioning/datasources/tempo.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: librefang-tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      # Link trace spans back to Prometheus metrics via the configured
+      # service name / operation labels. Grafana auto-fills these when
+      # both datasources are present.
+      tracesToMetrics:
+        datasourceUid: librefang-prometheus
+      nodeGraph:
+        enabled: true

--- a/deploy/otel-collector/config.yaml
+++ b/deploy/otel-collector/config.yaml
@@ -1,10 +1,8 @@
 # OpenTelemetry Collector config for LibreFang's local dev stack.
 #
-# Receives OTLP traces + metrics from LibreFang on 4317 (gRPC) / 4318 (HTTP)
-# and exposes a Prometheus scrape endpoint on 8889 for Prometheus to pick up
-# OTLP-delivered metrics. Traces are written to the collector's stdout via
-# the debug exporter — replace with a real backend (Tempo, Jaeger, …) when
-# you need trace search.
+# Receives OTLP traces + metrics from LibreFang on 4317 (gRPC) / 4318 (HTTP).
+# - Traces fan out to Tempo (for Grafana search) AND stdout (debug visibility).
+# - Metrics are exposed on the Prometheus scrape endpoint :8889.
 
 receivers:
   otlp:
@@ -22,13 +20,20 @@ exporters:
     verbosity: normal
   prometheus:
     endpoint: 0.0.0.0:8889
+  # Forward traces to Tempo over OTLP/gRPC (inside the compose network).
+  # `tls.insecure` because Tempo's OTLP receiver is plaintext on the
+  # internal network — traces never leave the docker bridge.
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug]
+      exporters: [debug, otlp/tempo]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/deploy/tempo/tempo.yaml
+++ b/deploy/tempo/tempo.yaml
@@ -1,0 +1,31 @@
+# Grafana Tempo config for LibreFang's local dev stack.
+#
+# Single-binary mode with local filesystem storage. Receives traces from the
+# OpenTelemetry collector over OTLP/gRPC on port 4317 (inside the Docker
+# network — not exposed to the host; the host's 4317 is the collector).
+# Exposes a query API on 3200 that Grafana's Tempo datasource uses.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h   # keep local dev traces for a day; bump if needed
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
## Summary

Two complementary commits that bring the observability stack from "HTTP requests are visible" to "LibreFang's actual work is visible and searchable in Grafana".

### 1. `feat(observability): add Grafana Tempo for trace search`

Follow-up to #3062 / #3063. Traces were only going to the collector's stdout (debug exporter) — to find a trace by ID or walk a call tree you had to `docker logs librefang-otel-collector | grep`.

- `deploy/tempo/tempo.yaml` — single-binary Tempo, local filesystem storage, OTLP/gRPC receiver on internal `:4317`, query API on `:3200`. 24h retention.
- `deploy/docker-compose.observability.yml` — new `tempo` service with a persistent volume. `grafana` / `otel-collector` depend on it.
- `deploy/otel-collector/config.yaml` — added `otlp/tempo` exporter; the trace pipeline now fans out to `[debug, otlp/tempo]` so stdout visibility is preserved.
- `deploy/grafana/provisioning/datasources/tempo.yml` — Tempo datasource auto-provisioned with `tracesToMetrics` + `nodeGraph.enabled` for one-click jumps.
- `server.rs::OBSERVABILITY_ASSETS` — embed the new config files so `~/.librefang/observability/` is complete after staging.

Only port `3200` is newly exposed (Tempo query). Tempo's OTLP receiver stays internal — host `:4317` is still the collector.

### 2. `feat(telemetry): instrument agent loop, LLM calls, and tool execution`

Without this, Tempo only has tower-http's generic `request` span. "200ms on `/api/agents/<id>/message`" is visible; **which** agent, **which** LLM, **which** tools — invisible.

Three strategic `#[instrument]` annotations:

| Function | File | Span attributes |
|---|---|---|
| `Kernel::execute_llm_agent` | `kernel/mod.rs` | `agent.id`, `agent.name`, `message.len`, `channel` |
| `call_with_retry` | `agent_loop.rs` | `llm.provider`, `llm.model`, `llm.messages`, `llm.tools` |
| `execute_single_tool_call` | `agent_loop.rs` | `tool.name`, `tool.id` |

All use `skip_all` — no message bodies, tool inputs, or LLM payloads enter trace exports. Only metadata.

Resulting trace shape per chat message:

```
request GET /api/agents/.../message
└── execute_llm_agent (agent.name=chief, channel=direct)
    └── run_agent_loop (already instrumented)
        ├── call_with_retry (llm.provider=openai, llm.model=gpt-4.1)
        ├── execute_single_tool_call (tool.name=memory_recall)
        └── call_with_retry (llm.provider=openai, llm.model=gpt-4.1)
```

## Test plan

- [x] `cargo check -p librefang-api --lib` — Tempo embed compiles
- [x] `cargo check -p librefang-kernel -p librefang-runtime --lib` — instrument macros compile
- [ ] Manual after merge + rebuild:
  - Restart daemon; confirm log says `Observability stack started (OTLP :4317/:4318, Tempo :3200, Prometheus :9090, Grafana :3000)`
  - Hit `/api/health` / send an agent message
  - Grafana → Explore → Tempo → search by `service.name=librefang` → see the new span names
  - Any LLM call shows `llm.provider` / `llm.model` on the span inspector
  - Any tool call shows `tool.name` / `tool.id`

## Not in this PR

Logs → Loki, Prometheus exemplars, subprocess-CLI trace propagation, tail-based sampling. Can be separate PRs; this one focuses on "make Tempo useful for real LibreFang work".