### PR TITLE
fix(telemetry): move env_filter to fmt layer so OTel sees INFO spans

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1618,6 +1618,7 @@ enum ServiceCommands {
 fn init_tracing_stderr(log_level: &str) {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
 
     // One-shot CLI commands (status, stop, doctor, …) load config.toml as a
     // side effect. librefang_kernel::config emits INFO on every load and WARN
@@ -1660,22 +1661,32 @@ fn init_tracing_stderr(log_level: &str) {
     // the WARN/ERROR text, not the timestamp or the fully-qualified target.
     // One-shot CLI runs are transient — stderr is the only sink; the daemon
     // has its own file appender under `logs/daemon.log`.
+    //
+    // `.with_filter(env_filter)` applies the user-visible log filter to the
+    // fmt layer ONLY. A registry-level filter would also suppress span
+    // CREATION, which would starve the OTel exporter layer attached below
+    // (`librefang_kernel`/`librefang_runtime` downgraded to WARN means all
+    // INFO-level `#[instrument]` spans are filtered out before OTel ever
+    // sees them). Per-layer filtering keeps stderr terse while OTel
+    // receives the full span tree.
     let fmt_layer = tracing_subscriber::fmt::layer()
         .without_time()
         .with_target(false)
-        .compact();
+        .compact()
+        .with_filter(env_filter);
 
     // Register a no-op reload slot so `init_otel_tracing` can swap a real
     // OTel layer in later without needing to claim the global dispatcher.
     // The slot is stacked **first** (directly on Registry) so its boxed
     // `Layer<Registry>` trait object matches the innermost subscriber type.
+    // No filter is attached to this layer on purpose — see comment above.
     #[cfg(feature = "telemetry")]
     let registry =
         tracing_subscriber::registry().with(librefang_api::telemetry::install_otel_reload_layer());
     #[cfg(not(feature = "telemetry"))]
     let registry = tracing_subscriber::registry();
 
-    registry.with(env_filter).with(fmt_layer).init();
+    registry.with(fmt_layer).init();
 }
 
 /// Get the LibreFang home directory, respecting LIBREFANG_HOME env var.


### PR DESCRIPTION
## Summary

Completes the span-emission path for #3064. After that PR's Tempo backend + `#[instrument]` annotations merged and the daemon was rebuilt, Tempo only showed `request` spans from tower-http. None of the new `execute_llm_agent`, `call_with_retry`, `execute_single_tool_call`, or even the pre-existing `run_agent_loop` spans appeared, even when no rate-limit / retry artefacts could explain it.

Verified the code was compiled in — the binary contains all the new span name strings, attribute keys (`llm.provider`, `agent.id`, `tool.name`, etc.), and module paths. The missing spans were being dropped at span *creation* time, not export time.

## Root cause

`init_tracing_stderr` applies `env_filter` at the **registry level**:

```rust
let env_filter = EnvFilter::try_from_default_env()
    .unwrap_or_else(|_| EnvFilter::new(log_level))
    .add_directive("librefang_kernel=warn".parse().unwrap())
    .add_directive("librefang_runtime=warn".parse().unwrap());
// …
registry.with(env_filter).with(fmt_layer).init();
```

The `librefang_kernel=warn` / `librefang_runtime=warn` directives were added to keep one-shot CLI output terse. But in `tracing-subscriber`, a registry-level filter decides at span *creation* whether a span exists at all. Every INFO-level `#[instrument]` on a function in those two crates is rejected before the OTel reload layer ever sees it. OTel has nothing to export.

## Fix

Move the filter to the fmt layer:

```rust
let fmt_layer = fmt::layer()
    .without_time()
    .with_target(false)
    .compact()
    .with_filter(env_filter);   // ← per-layer, not registry

registry.with(fmt_layer).init(); // registry has no filter
```

Per-layer filtering means only the fmt layer respects this filter; the OTel layer (attached above without its own filter) now receives the full span tree. Stderr stays exactly as terse as before.

Required importing `tracing_subscriber::Layer` for the `.with_filter` method.

## Test plan

- [ ] Manual after rebuild: restart daemon, send any agent message (or any POST `/api/agents/{id}/message`). In Tempo Explore → search `{resource.service.name="librefang"}` → click any message trace → span tree should show `request → execute_llm_agent → run_agent_loop → call_with_retry` with the expected attributes (`agent.name`, `llm.provider`, `llm.model`, etc.).
- [x] `strings target/debug/librefang | grep -E 'execute_llm_agent|call_with_retry'` — confirms instrumentation was already compiled, so this PR is purely a filter-layering fix, not new code.

## No stderr regression

The existing muted-level directives for `librefang_kernel` / `librefang_runtime` still apply to stderr output — operators see the same terse CLI experience. The only difference is that OTel (and any future layer attached above this filter) receives the full unfiltered span tree.