### PR TITLE
fix(observability): drop ingester/compactor from Tempo config

### DIFF
--- a/deploy/tempo/tempo.yaml
+++ b/deploy/tempo/tempo.yaml
@@ -1,9 +1,15 @@
 # Grafana Tempo config for LibreFang's local dev stack.
 #
-# Single-binary mode with local filesystem storage. Receives traces from the
-# OpenTelemetry collector over OTLP/gRPC on port 4317 (inside the Docker
-# network — not exposed to the host; the host's 4317 is the collector).
-# Exposes a query API on 3200 that Grafana's Tempo datasource uses.
+# Minimal single-binary mode with local filesystem storage. Receives
+# traces from the OpenTelemetry collector over OTLP/gRPC on port 4317
+# (inside the Docker network — not exposed to the host; the host's 4317
+# is the collector). Exposes a query API on 3200 that Grafana's Tempo
+# datasource uses.
+#
+# Ingester flush cadence and compactor retention use built-in defaults.
+# To customize, add `ingester:` / `compactor:` sections — their nested
+# fields are strict, so check the Tempo docs for the exact schema your
+# image version accepts.
 
 server:
   http_listen_port: 3200
@@ -15,17 +21,10 @@ distributor:
         grpc:
           endpoint: 0.0.0.0:4317
 
-ingester:
-  max_block_duration: 5m
-
-compactor:
-  compaction:
-    block_retention: 24h   # keep local dev traces for a day; bump if needed
-
 storage:
   trace:
     backend: local
-    local:
-      path: /var/tempo/traces
     wal:
       path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
## Summary

Tiny fix caught when running the stack from #3064 end-to-end. The Tempo
`latest` image refuses to start with:

```
failed parsing config: /etc/tempo/tempo.yaml: yaml: unmarshal errors:
  line 18: field ingester not found in type app.Config
  line 21: field compactor not found in type app.Config
```

`librefang-tempo` restart-loops; `:3200` never comes up; Grafana's Tempo
datasource shows "No data" because there's no Tempo to query.

The `ingester:` / `compactor:` sections I added were nice-to-haves
(block flush cadence + 24h retention). Their built-in defaults are fine
for a local dev stack. A comment points at the Tempo docs for anyone
who wants to re-add them with the correct schema for their image
version.

## Test plan

- [x] `docker restart librefang-tempo` with the new config — container
      stays `Up`, `curl http://localhost:3200/api/search ...` returns
      valid JSON instead of connection-refused.
- [x] End-to-end: agent message → collector → Tempo → Grafana Explore →
      trace visible (confirmed locally after #3065 also merges).