### PR TITLE
fix(providers): reprobe local providers every 60s + refresh on test

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1167,6 +1167,53 @@ pub async fn test_provider(
         };
     }
 
+    // ── Local providers (Ollama / vLLM / LM Studio / lemonade) ──
+    // Delegate to the kernel's shared probe helper so the on-demand test
+    // updates `auth_status` in the catalog (NotRequired on success,
+    // LocalOffline on failure). Before this, the endpoint only refreshed an
+    // in-memory cache — users could start Ollama after LibreFang booted and
+    // the dashboard would stay stuck on `local_offline` forever.
+    if librefang_runtime::provider_health::is_local_provider(&name) {
+        let result = librefang_kernel::kernel::probe_and_update_local_provider(
+            &state.kernel,
+            &name,
+            &base_url,
+            false, // user-triggered test — don't escalate to warn!
+        )
+        .await;
+        let latency = result.latency_ms as u128;
+        state.provider_test_cache.insert(
+            name.clone(),
+            (
+                Instant::now(),
+                latency,
+                chrono::Utc::now().to_rfc3339(),
+                result.reachable,
+            ),
+        );
+        return if result.reachable {
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "ok",
+                    "provider": name,
+                    "latency_ms": latency,
+                    "discovered_models": result.discovered_models.len(),
+                })),
+            )
+        } else {
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "error",
+                    "provider": name,
+                    "latency_ms": latency,
+                    "error": result.error.unwrap_or_else(|| "unreachable".to_string()),
+                })),
+            )
+        };
+    }
+
     // API providers with no base_url configured cannot be tested.
     if base_url.is_empty() {
         return ApiErrorResponse::bad_request("Provider base URL not configured").into_json_tuple();

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -13523,6 +13523,13 @@
       },
       "description": "Link understanding configuration."
     },
+    "local_probe_interval_secs": {
+      "default": 60,
+      "description": "Interval in seconds between reachability probes of local providers (Ollama, vLLM, LM Studio, lemonade).\n\nLower values make the dashboard react faster to `brew services start/stop ollama` at the cost of extra HTTP calls to `/api/tags`. 60 s is the default — it keeps the UI responsive without noticeably loading a local Ollama daemon. Dev machines flipping Ollama on/off frequently can drop to 10; long-lived production boxes can raise to 300+ since the state rarely changes.\n\nZero or values below the probe timeout (2 s) are treated as 60.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
     "log_dir": {
       "default": null,
       "description": "Custom log directory. When set, log files are written here instead of the default `~/.librefang/` directory.",

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9965,15 +9965,24 @@ system_prompt = "You are a helpful assistant."
             } else {
                 60
             };
+            let mut shutdown_rx = self.supervisor.subscribe();
             tokio::spawn(async move {
                 let mut interval =
                     tokio::time::interval(std::time::Duration::from_secs(probe_interval_secs));
+                // Race the tick against the shutdown watch so daemon
+                // shutdown breaks immediately instead of blocking up to
+                // `probe_interval_secs` (60s by default) on the next tick.
                 loop {
-                    interval.tick().await;
-                    if kernel.supervisor.is_shutting_down() {
-                        break;
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            probe_all_local_providers_once(&kernel, &relevant_providers).await;
+                        }
+                        _ = shutdown_rx.changed() => {
+                            if *shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
                     }
-                    probe_all_local_providers_once(&kernel, &relevant_providers).await;
                 }
             });
         }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9956,11 +9956,18 @@ system_prompt = "You are a helpful assistant."
                             .map(|fb| fb.provider.to_lowercase()),
                     )
                     .collect();
+            // Probe interval comes from `[providers] local_probe_interval_secs`
+            // (default 60). Values below the 2s probe timeout are nonsensical
+            // — clamp to the default so a mis-configured TOML doesn't
+            // stampede the local daemon.
+            let probe_interval_secs = if cfg.local_probe_interval_secs >= 2 {
+                cfg.local_probe_interval_secs
+            } else {
+                60
+            };
             tokio::spawn(async move {
-                const LOCAL_PROBE_INTERVAL_SECS: u64 = 60;
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(
-                    LOCAL_PROBE_INTERVAL_SECS,
-                ));
+                let mut interval =
+                    tokio::time::interval(std::time::Duration::from_secs(probe_interval_secs));
                 loop {
                     interval.tick().await;
                     if kernel.supervisor.is_shutting_down() {
@@ -15724,6 +15731,12 @@ pub async fn probe_and_update_local_provider(
 
 /// Probe every local provider once and update the catalog. Called from the
 /// periodic loop in `start_background_agents`.
+///
+/// Probes run concurrently via `join_all`. The total wall time of one cycle
+/// is bounded by the slowest probe (≤ 2 s per provider — see
+/// `PROBE_TIMEOUT_SECS` in `provider_health`) instead of the sum across
+/// providers, which matters when a local server is hung rather than simply
+/// offline.
 async fn probe_all_local_providers_once(
     kernel: &Arc<LibreFangKernel>,
     relevant_providers: &std::collections::HashSet<String>,
@@ -15743,10 +15756,15 @@ async fn probe_all_local_providers_once(
             .map(|p| (p.id.clone(), p.base_url.clone()))
             .collect()
     };
-    for (provider_id, base_url) in &local_providers {
+    let tasks = local_providers.into_iter().map(|(provider_id, base_url)| {
+        let kernel = Arc::clone(kernel);
         let is_relevant = relevant_providers.contains(&provider_id.to_lowercase());
-        let _ = probe_and_update_local_provider(kernel, provider_id, base_url, is_relevant).await;
-    }
+        async move {
+            let _ = probe_and_update_local_provider(&kernel, &provider_id, &base_url, is_relevant)
+                .await;
+        }
+    });
+    futures::future::join_all(tasks).await;
 }
 
 // --- OFP Wire Protocol integration ---

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9933,6 +9933,12 @@ system_prompt = "You are a helpful assistant."
 
         // Probe local providers for reachability and model discovery.
         //
+        // Runs once immediately on boot, then every `LOCAL_PROBE_INTERVAL_SECS`
+        // so the catalog tracks local servers that start / stop after boot
+        // (common: user installs Ollama while LibreFang is running, or `brew
+        // services stop ollama`). Without periodic reprobing a one-shot
+        // failure at startup sticks in the catalog forever.
+        //
         // The set of providers the user actually relies on (default + fallback
         // chain) gets a `warn!` when offline — those are real misconfigurations
         // or stopped services. Every other local provider in the built-in
@@ -9951,89 +9957,16 @@ system_prompt = "You are a helpful assistant."
                     )
                     .collect();
             tokio::spawn(async move {
-                let local_providers: Vec<(String, String)> = {
-                    let catalog = kernel
-                        .model_catalog
-                        .read()
-                        .unwrap_or_else(|e| e.into_inner());
-                    catalog
-                        .list_providers()
-                        .iter()
-                        .filter(|p| {
-                            librefang_runtime::provider_health::is_local_provider(&p.id)
-                                && !p.base_url.is_empty()
-                        })
-                        .map(|p| (p.id.clone(), p.base_url.clone()))
-                        .collect()
-                };
-
-                for (provider_id, base_url) in &local_providers {
-                    let result =
-                        librefang_runtime::provider_health::probe_provider(provider_id, base_url)
-                            .await;
-                    if result.reachable {
-                        info!(
-                            provider = %provider_id,
-                            models = result.discovered_models.len(),
-                            latency_ms = result.latency_ms,
-                            "Local provider online"
-                        );
-                        if let Ok(mut catalog) = kernel.model_catalog.write() {
-                            catalog.set_provider_auth_status(
-                                provider_id,
-                                librefang_types::model_catalog::AuthStatus::NotRequired,
-                            );
-                            if !result.discovered_models.is_empty() {
-                                // Use enriched metadata when available (Ollama populates
-                                // discovered_model_info; other providers leave it empty).
-                                let info: Vec<_> = if result.discovered_model_info.is_empty() {
-                                    result
-                                        .discovered_models
-                                        .iter()
-                                        .map(|name| {
-                                            librefang_runtime::provider_health::DiscoveredModelInfo {
-                                                name: name.clone(),
-                                                parameter_size: None,
-                                                quantization_level: None,
-                                                family: None,
-                                                families: None,
-                                                size: None,
-                                                capabilities: vec![],
-                                            }
-                                        })
-                                        .collect()
-                                } else {
-                                    result.discovered_model_info.clone()
-                                };
-                                catalog.merge_discovered_models(provider_id, &info);
-                            }
-                        }
-                    } else {
-                        let err = result.error.as_deref().unwrap_or("unknown");
-                        if relevant_providers.contains(&provider_id.to_lowercase()) {
-                            warn!(
-                                provider = %provider_id,
-                                error = err,
-                                "Configured local provider offline"
-                            );
-                        } else {
-                            debug!(
-                                provider = %provider_id,
-                                error = err,
-                                "Local provider offline (not configured as default/fallback)"
-                            );
-                        }
-                        // Mark unreachable local providers as LocalOffline (not Missing).
-                        // Using Missing would cause detect_auth() to reset the status back
-                        // to NotRequired on the next unrelated auth check, making offline
-                        // providers reappear in the model switcher.
-                        if let Ok(mut catalog) = kernel.model_catalog.write() {
-                            catalog.set_provider_auth_status(
-                                provider_id,
-                                librefang_types::model_catalog::AuthStatus::LocalOffline,
-                            );
-                        }
+                const LOCAL_PROBE_INTERVAL_SECS: u64 = 60;
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+                    LOCAL_PROBE_INTERVAL_SECS,
+                ));
+                loop {
+                    interval.tick().await;
+                    if kernel.supervisor.is_shutting_down() {
+                        break;
                     }
+                    probe_all_local_providers_once(&kernel, &relevant_providers).await;
                 }
             });
         }
@@ -15698,6 +15631,121 @@ impl LibreFangKernel {
             );
             false
         }
+    }
+}
+
+// --- Local-provider probe helpers ---
+//
+// Shared between the periodic background probe (see `start_background_agents`)
+// and the on-demand refresh path in `/api/providers/{id}/test`. Authoritative
+// for the `auth_status` of local providers (Ollama / vLLM / LM Studio /
+// lemonade) — no other code writes `NotRequired` or `LocalOffline` to them.
+
+/// Probe a single local provider and update its catalog entry.
+///
+/// Returns the probe result so callers (e.g. the test endpoint) can surface
+/// latency / error detail in their response.
+///
+/// `log_offline_as_warn = true` for providers in the default-or-fallback set
+/// (a real misconfiguration), `false` for incidentally-defined local
+/// providers (not configured — expected to be offline).
+pub async fn probe_and_update_local_provider(
+    kernel: &Arc<LibreFangKernel>,
+    provider_id: &str,
+    base_url: &str,
+    log_offline_as_warn: bool,
+) -> librefang_runtime::provider_health::ProbeResult {
+    let result = librefang_runtime::provider_health::probe_provider(provider_id, base_url).await;
+    if result.reachable {
+        info!(
+            provider = %provider_id,
+            models = result.discovered_models.len(),
+            latency_ms = result.latency_ms,
+            "Local provider online"
+        );
+        if let Ok(mut catalog) = kernel.model_catalog.write() {
+            catalog.set_provider_auth_status(
+                provider_id,
+                librefang_types::model_catalog::AuthStatus::NotRequired,
+            );
+            if !result.discovered_models.is_empty() {
+                // Use enriched metadata when available (Ollama populates
+                // discovered_model_info; other providers leave it empty).
+                let info: Vec<_> = if result.discovered_model_info.is_empty() {
+                    result
+                        .discovered_models
+                        .iter()
+                        .map(
+                            |name| librefang_runtime::provider_health::DiscoveredModelInfo {
+                                name: name.clone(),
+                                parameter_size: None,
+                                quantization_level: None,
+                                family: None,
+                                families: None,
+                                size: None,
+                                capabilities: vec![],
+                            },
+                        )
+                        .collect()
+                } else {
+                    result.discovered_model_info.clone()
+                };
+                catalog.merge_discovered_models(provider_id, &info);
+            }
+        }
+    } else {
+        let err = result.error.as_deref().unwrap_or("unknown");
+        if log_offline_as_warn {
+            warn!(
+                provider = %provider_id,
+                error = err,
+                "Configured local provider offline"
+            );
+        } else {
+            debug!(
+                provider = %provider_id,
+                error = err,
+                "Local provider offline (not configured as default/fallback)"
+            );
+        }
+        // Mark unreachable local providers as LocalOffline (not Missing).
+        // Using Missing would cause detect_auth() to reset the status back
+        // to NotRequired on the next unrelated auth check, making offline
+        // providers reappear in the model switcher.
+        if let Ok(mut catalog) = kernel.model_catalog.write() {
+            catalog.set_provider_auth_status(
+                provider_id,
+                librefang_types::model_catalog::AuthStatus::LocalOffline,
+            );
+        }
+    }
+    result
+}
+
+/// Probe every local provider once and update the catalog. Called from the
+/// periodic loop in `start_background_agents`.
+async fn probe_all_local_providers_once(
+    kernel: &Arc<LibreFangKernel>,
+    relevant_providers: &std::collections::HashSet<String>,
+) {
+    let local_providers: Vec<(String, String)> = {
+        let catalog = kernel
+            .model_catalog
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        catalog
+            .list_providers()
+            .iter()
+            .filter(|p| {
+                librefang_runtime::provider_health::is_local_provider(&p.id)
+                    && !p.base_url.is_empty()
+            })
+            .map(|p| (p.id.clone(), p.base_url.clone()))
+            .collect()
+    };
+    for (provider_id, base_url) in &local_providers {
+        let is_relevant = relevant_providers.contains(&provider_id.to_lowercase());
+        let _ = probe_and_update_local_provider(kernel, provider_id, base_url, is_relevant).await;
     }
 }
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2223,6 +2223,19 @@ pub struct KernelConfig {
     /// If not set, the convention `{PROVIDER_UPPER}_API_KEY` is used automatically.
     #[serde(default)]
     pub provider_api_keys: HashMap<String, String>,
+    /// Interval in seconds between reachability probes of local providers
+    /// (Ollama, vLLM, LM Studio, lemonade).
+    ///
+    /// Lower values make the dashboard react faster to `brew services
+    /// start/stop ollama` at the cost of extra HTTP calls to `/api/tags`.
+    /// 60 s is the default — it keeps the UI responsive without noticeably
+    /// loading a local Ollama daemon. Dev machines flipping Ollama on/off
+    /// frequently can drop to 10; long-lived production boxes can raise to
+    /// 300+ since the state rarely changes.
+    ///
+    /// Zero or values below the probe timeout (2 s) are treated as 60.
+    #[serde(default = "default_local_probe_interval_secs")]
+    pub local_probe_interval_secs: u64,
     /// Vertex AI provider configuration.
     #[serde(default)]
     pub vertex_ai: VertexAiConfig,
@@ -3958,6 +3971,7 @@ impl Default for KernelConfig {
             provider_request_timeout_secs: HashMap::new(),
             provider_regions: HashMap::new(),
             provider_api_keys: HashMap::new(),
+            local_probe_interval_secs: default_local_probe_interval_secs(),
             vertex_ai: VertexAiConfig::default(),
             azure_openai: AzureOpenAiConfig::default(),
             oauth: OAuthConfig::default(),
@@ -4711,6 +4725,10 @@ pub struct WhatsAppConfig {
 
 fn default_conversation_ttl_hours() -> u32 {
     24
+}
+
+fn default_local_probe_interval_secs() -> u64 {
+    60
 }
 
 impl Default for WhatsAppConfig {


### PR DESCRIPTION
## Summary

Reported symptom: install Ollama while LibreFang is already running, `/api/providers/ollama` stays stuck at `auth_status = local_offline` forever. The dashboard filters out every Ollama model (`LocalOffline` is excluded from `AuthStatus::is_available`), and the only workaround was restarting the daemon.

Two design gaps fuelled it:

1. The startup probe was fire-and-forget — a single `tokio::spawn` with a for-loop over local providers, no interval. After that first pass, nothing re-checked Ollama / vLLM / LM Studio / lemonade. Starting a local server post-boot left the state wrong until a daemon restart.
2. `POST /api/providers/{id}/test` for local providers only populated an in-memory test cache. It never called `set_provider_auth_status`, so even the dashboard's manual "Test" button couldn't flip the status.

## Changes

- **`kernel/mod.rs`** — extracted the per-provider probe update into:
  - `pub async fn probe_and_update_local_provider(kernel, id, url, log_as_warn) -> ProbeResult` — authoritative writer of `NotRequired` / `LocalOffline` for local providers; callable from both the loop and the API layer.
  - `async fn probe_all_local_providers_once(kernel, relevant_providers)` — iterates and delegates. Probes inside one cycle run **concurrently via `futures::future::join_all`**, so cycle wall time is bounded by the slowest probe (≤ 2 s, see `PROBE_TIMEOUT_SECS`) instead of the sum.

  The boot task now runs inside a `tokio::time::interval` every `local_probe_interval_secs` (**default 60 s**, configurable). The wait races against the supervisor's shutdown watch via `tokio::select!` so daemon shutdown breaks immediately instead of blocking up to one full interval. `interval.tick()` fires immediately on first call, so startup semantics are preserved.

- **`librefang-types/config/types.rs`** — new `KernelConfig.local_probe_interval_secs: u64` (default 60) under `[providers]`. Values below the 2 s probe timeout are clamped to 60 to prevent a mis-configured TOML from stampeding the local daemon.

- **`routes/providers.rs::test_provider`** — for `is_local_provider` names, delegate to `probe_and_update_local_provider` instead of running a separate HTTP probe. The endpoint now returns latency + discovered model count AND updates `auth_status`, keeping the catalog and the test cache in sync.

- **`tests/fixtures/kernel_config_schema.golden.json`** — regenerated for the new config field.

## Behaviour after this PR

| Scenario | Before | After |
|---|---|---|
| Ollama up at boot | detected | detected |
| Ollama started after boot | **stuck LocalOffline until daemon restart** | **picked up within `local_probe_interval_secs` (60 s default), or instantly via `/test`** |
| Ollama stopped mid-run | stuck NotRequired, calls fail | marked LocalOffline within one interval |
| Dashboard "Test Connection" button for Ollama | updates a cache only — status unchanged | updates status atomically |
| Daemon shutdown while probe loop idle | up to 60 s lag waiting for next tick | breaks immediately on shutdown signal |

## Test plan

- [x] `cargo check -p librefang-api -p librefang-kernel --lib` — green
- [x] `cargo clippy -p librefang-kernel --lib -- -D warnings` — green
- [ ] Manual: `brew services stop ollama` → wait 60 s → `/api/providers/ollama` shows `local_offline`; `brew services start ollama` → wait 60 s → shows `not_required`, gemma/llama models appear in Dashboard model switcher.
- [ ] Manual: click "Test" button in Dashboard while Ollama is up — response shows `status: ok`, and the provider state refreshes immediately instead of waiting for the next tick.
- [ ] Manual: set `local_probe_interval_secs = 10` in config, restart daemon, confirm probes fire every 10 s in logs.

## Out of scope (follow-up ideas)

- Dashboard: add an explicit "Refresh local providers" button wired to the test endpoint.