### PR TITLE
feat(chat): /new creates a new session instead of resetting the current one

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -997,8 +997,12 @@ export async function resetAgentSession(agentId: string): Promise<ApiActionRespo
   return post<ApiActionResponse>(`/api/agents/${encodeURIComponent(agentId)}/reset`, {});
 }
 
-export async function loadAgentSession(agentId: string): Promise<AgentSessionResponse> {
-  return get<AgentSessionResponse>(`/api/agents/${encodeURIComponent(agentId)}/session`);
+export async function loadAgentSession(
+  agentId: string,
+  sessionId?: string | null,
+): Promise<AgentSessionResponse> {
+  const qs = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : "";
+  return get<AgentSessionResponse>(`/api/agents/${encodeURIComponent(agentId)}/session${qs}`);
 }
 
 export async function sendAgentMessage(

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1955,7 +1955,7 @@
     "cmd_clear": "Clear chat history",
     "cmd_agents": "List available agents",
     "cmd_info": "Show current agent info",
-    "cmd_new": "Reset session (clear history)",
+    "cmd_new": "Start a new session (new session id)",
     "cmd_compact": "Compress context to save space",
     "cmd_reset": "Reset session (clear history)",
     "cmd_reboot": "Reboot session (clear context)",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1904,7 +1904,7 @@
     "cmd_clear": "清除聊天记录",
     "cmd_agents": "列出可用 Agent",
     "cmd_info": "显示当前 Agent 信息",
-    "cmd_new": "重置会话（清除历史）",
+    "cmd_new": "新建会话（生成新会话 ID）",
     "cmd_compact": "压缩上下文以节省空间",
     "cmd_reset": "重置会话（清除历史）",
     "cmd_reboot": "重启会话（清除上下文）",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -15,7 +15,7 @@ import { usePendingApprovals } from "../lib/queries/approvals";
 import { useAgents, useAgentSessions } from "../lib/queries/agents";
 import { useSessionStream } from "../lib/queries/sessions";
 import { useActiveHandsWhen } from "../lib/queries/hands";
-import { approvalKeys } from "../lib/queries/keys";
+import { agentKeys, approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
 import { normalizeToolOutput } from "../lib/chat";
 import { useTtsManager } from "../lib/tts";
@@ -211,7 +211,7 @@ const sessionCache = new Map<string, ChatMessage[]>();
 
 // Chat message management - includes history loading and sending (with WS streaming)
 // sessionVersion: bump to force reload after session switch
-function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void, sessionId: string | null = null) {
+function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void, sessionId: string | null = null, onNewSession?: (sessionId: string) => void) {
   const { t } = useTranslation();
   const stopAgentMutation = useStopAgent();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -475,6 +475,11 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 // Refresh agent data so model/provider badge reflects the change
                 if (data.type === "command_result" && cmd === "model") {
                   onModelSwitch?.();
+                }
+                // /new created a fresh backend session; surface its id so the
+                // URL + sessions dropdown reflect the switch in a single step.
+                if (data.type === "command_result" && cmd === "new" && typeof data.session_id === "string" && data.session_id) {
+                  onNewSession?.(data.session_id);
                 }
               }
             } catch { /* ignore non-JSON */ }
@@ -2181,6 +2186,7 @@ function ApprovalCard({ approval, onResolved }: { approval: ApprovalItem; onReso
 export function ChatPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const search = useSearch({ from: "/chat" });
   const initialAgentId = search?.agentId || "";
   const [selectedAgentId, setSelectedAgentId] = useState(initialAgentId);
@@ -2310,6 +2316,17 @@ export function ChatPage() {
   // param is present, it wins over the server's canonical active session so
   // two browser tabs on the same agent can hold independent sessions.
   const urlSessionId = search?.sessionId || null;
+  const handleBackendNewSession = useCallback((newSessionId: string) => {
+    if (!selectedAgentId) return;
+    navigate({
+      to: "/chat",
+      search: { agentId: selectedAgentId, sessionId: newSessionId },
+      replace: false,
+    });
+    setSessionVersion(v => v + 1);
+    void queryClient.invalidateQueries({ queryKey: agentKeys.sessions(selectedAgentId) });
+  }, [selectedAgentId, navigate, queryClient]);
+
   const { messages, isLoading, sendMessage, stopMessage, clearHistory, wsConnected } = useChatMessages(
     selectedAgentId || null,
     agents,
@@ -2317,6 +2334,7 @@ export function ChatPage() {
     () => void agentsQuery.refetch(),
     (message) => addToast(message, "error"),
     urlSessionId,
+    handleBackendNewSession,
   );
   // Track LLM text streaming (cleared on `typing:stop`) independently of
   // `isLoading`, which stays true through post-processing until the final

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -387,7 +387,14 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
           }
         }
       })
-      .catch(() => { /* Session load failure — user will see empty chat */ })
+      .catch((error: unknown) => {
+        // Surface load failures to the user — most commonly a stale
+        // `?sessionId=` URL that no longer points at a session belonging to
+        // this agent (404 from the cross-agent guard) or a malformed UUID
+        // (400). Without this the chat just renders empty with no signal.
+        const message = error instanceof Error ? error.message : t("common.error");
+        onClearError?.(message);
+      })
       .finally(() => setAgentLoading(loadId, false));
   }, [agentId, sessionVersion]);
 

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -2449,10 +2449,17 @@ export function ChatPage() {
   useEffect(() => {
     if (!selectedAgentId) return;
     if (agentsQuery.data === undefined) return;
-    if (!agents.some(a => a.id === selectedAgentId)) {
-      setSelectedAgentId("");
+    if (agents.some(a => a.id === selectedAgentId)) return;
+    // Not in the current list — before clearing, try expanding the query
+    // to include hand-spawned agents. The URL may point at a hand agent
+    // while `showHandAgents` (a localStorage toggle) is off, which would
+    // otherwise dump the user back to the default agent on every refresh.
+    if (!showHandAgents) {
+      setShowHandAgents(true);
+      return;
     }
-  }, [agents, selectedAgentId, agentsQuery.data]);
+    setSelectedAgentId("");
+  }, [agents, selectedAgentId, agentsQuery.data, showHandAgents]);
 
   useEffect(() => {
     // Auto-select first running agent

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -335,7 +335,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
     setMessages([]);
     const loadId = agentId;
     setAgentLoading(loadId, true);
-    loadAgentSession(loadId)
+    loadAgentSession(loadId, sessionId)
       .then(session => {
         if (session.messages?.length) {
           const historical: ChatMessage[] = session.messages.flatMap((msg, idx) => {

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1519,6 +1519,16 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
     })
 }
 
+/// Query params for `GET /api/agents/{id}/session`.
+///
+/// Using a typed struct (rather than `HashMap<String,String>`) gives us
+/// automatic UUID validation: a malformed `session_id` is rejected by serde
+/// before the handler runs, returning a clean 400.
+#[derive(serde::Deserialize)]
+pub struct GetAgentSessionQuery {
+    pub session_id: Option<uuid::Uuid>,
+}
+
 /// GET /api/agents/:id/session — Get agent session (conversation history).
 #[utoipa::path(
     get,
@@ -1535,10 +1545,19 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
 pub async fn get_agent_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
-    Query(params): Query<HashMap<String, String>>,
+    query: Result<Query<GetAgentSessionQuery>, axum::extract::rejection::QueryRejection>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let Query(params) = match query {
+        Ok(q) => q,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid session_id"})),
+            );
+        }
+    };
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
@@ -1563,16 +1582,8 @@ pub async fn get_agent_session(
     // the canonical-active session for this request. The returned messages
     // must belong to that exact session; otherwise tabs pinned to different
     // sessions all render whichever session the kernel thinks is active.
-    let target_session_id = match params.get("session_id").map(|s| s.as_str()) {
-        Some(raw) => match raw.parse::<uuid::Uuid>() {
-            Ok(uuid) => librefang_types::agent::SessionId(uuid),
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({"error": "invalid session_id"})),
-                );
-            }
-        },
+    let target_session_id = match params.session_id {
+        Some(uuid) => librefang_types::agent::SessionId(uuid),
         None => entry.session_id,
     };
 
@@ -1750,16 +1761,34 @@ pub async fn get_agent_session(
                 })),
             )
         }
-        Ok(None) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "session_id": entry.session_id.0.to_string(),
-                "agent_id": agent_id.to_string(),
-                "message_count": 0,
-                "context_window_tokens": 0,
-                "messages": [],
-            })),
-        ),
+        Ok(None) => {
+            // The session row is not materialized in the memory substrate
+            // (e.g. agent just spawned, no messages yet). If the caller pinned
+            // an explicit session_id that does NOT match this agent's
+            // canonical-active id, refuse — otherwise the response would
+            // silently fall back to the agent's own canonical-empty session
+            // under the requested id, hiding the cross-agent guard. The
+            // canonical id is owned by this agent by construction (registry
+            // entry), so matching it is safe to treat as the no-query path.
+            if let Some(requested) = params.session_id {
+                if requested != entry.session_id.0 {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(serde_json::json!({"error": "session not found for this agent"})),
+                    );
+                }
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "session_id": entry.session_id.0.to_string(),
+                    "agent_id": agent_id.to_string(),
+                    "message_count": 0,
+                    "context_window_tokens": 0,
+                    "messages": [],
+                })),
+            )
+        }
         Err(e) => {
             tracing::warn!("Session load failed for agent {id}: {e}");
             (

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1524,7 +1524,10 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
     get,
     path = "/api/agents/{id}/session",
     tag = "agents",
-    params(("id" = String, Path, description = "Agent ID")),
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("session_id" = Option<String>, Query, description = "Optional session id to load instead of the canonical active session"),
+    ),
     responses(
         (status = 200, description = "Get agent conversation session history", body = serde_json::Value)
     )
@@ -1532,6 +1535,7 @@ fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
 pub async fn get_agent_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
@@ -1555,12 +1559,38 @@ pub async fn get_agent_session(
         }
     };
 
+    // Callers (e.g. the dashboard tab with `?sessionId=` pinned) can override
+    // the canonical-active session for this request. The returned messages
+    // must belong to that exact session; otherwise tabs pinned to different
+    // sessions all render whichever session the kernel thinks is active.
+    let target_session_id = match params.get("session_id").map(|s| s.as_str()) {
+        Some(raw) => match raw.parse::<uuid::Uuid>() {
+            Ok(uuid) => librefang_types::agent::SessionId(uuid),
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "invalid session_id"})),
+                );
+            }
+        },
+        None => entry.session_id,
+    };
+
     match state
         .kernel
         .memory_substrate()
-        .get_session(entry.session_id)
+        .get_session(target_session_id)
     {
         Ok(Some(session)) => {
+            // Reject cross-agent reads when the caller passed an explicit
+            // session_id — prevents leaking one agent's history via another's
+            // id.
+            if session.agent_id != agent_id {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "session not found for this agent"})),
+                );
+            }
             // Two-pass approach: ToolUse blocks live in Assistant messages while
             // ToolResult blocks arrive in subsequent User messages.  Pass 1
             // collects all tool_use entries keyed by id; pass 2 attaches results.

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -3032,7 +3032,8 @@ pub async fn pairing_notify(
 pub async fn list_commands(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let mut commands = vec![
         serde_json::json!({"cmd": "/help", "desc": "Show available commands"}),
-        serde_json::json!({"cmd": "/new", "desc": "Reset session (clear history)"}),
+        serde_json::json!({"cmd": "/new", "desc": "Start a new session (new session id)"}),
+        serde_json::json!({"cmd": "/reset", "desc": "Reset current session (clear history, same session id)"}),
         serde_json::json!({"cmd": "/reboot", "desc": "Hard reset session (full context clear, no summary)"}),
         serde_json::json!({"cmd": "/compact", "desc": "Trigger LLM session compaction"}),
         serde_json::json!({"cmd": "/model", "desc": "Show or switch model (/model [name])"}),
@@ -3080,7 +3081,11 @@ pub async fn get_command(
     // Built-in commands
     let builtins = [
         ("/help", "Show available commands"),
-        ("/new", "Reset session (clear history)"),
+        ("/new", "Start a new session (new session id)"),
+        (
+            "/reset",
+            "Reset current session (clear history, same session id)",
+        ),
         (
             "/reboot",
             "Hard reset session (full context clear, no summary)",

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1174,19 +1174,23 @@ async fn handle_command(
 ) -> serde_json::Value {
     match cmd {
         "new" => match state.kernel.create_agent_session(agent_id, None) {
-            Ok(info) => {
-                let sid = info
-                    .get("session_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string();
-                serde_json::json!({
+            Ok(info) => match info.get("session_id").and_then(|v| v.as_str()) {
+                Some(sid) if !sid.is_empty() => serde_json::json!({
                     "type": "command_result",
                     "command": "new",
                     "message": "New session created.",
                     "session_id": sid,
-                })
-            }
+                }),
+                // The kernel returned success but no session_id — treat as a
+                // hard failure rather than emitting an empty string the
+                // dashboard would silently swallow (frontend reads `sid`
+                // truthy and skips the navigate, leaving the URL stale on the
+                // old session). Surface explicitly so the user sees the bug.
+                _ => serde_json::json!({
+                    "type": "error",
+                    "content": "New session failed: kernel returned no session_id",
+                }),
+            },
             Err(e) => {
                 serde_json::json!({"type": "error", "content": format!("New session failed: {e}")})
             }

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1173,9 +1173,27 @@ async fn handle_command(
     verbose: &Arc<AtomicU8>,
 ) -> serde_json::Value {
     match cmd {
-        "new" | "reset" => match state.kernel.reset_session(agent_id) {
+        "new" => match state.kernel.create_agent_session(agent_id, None) {
+            Ok(info) => {
+                let sid = info
+                    .get("session_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                serde_json::json!({
+                    "type": "command_result",
+                    "command": "new",
+                    "message": "New session created.",
+                    "session_id": sid,
+                })
+            }
+            Err(e) => {
+                serde_json::json!({"type": "error", "content": format!("New session failed: {e}")})
+            }
+        },
+        "reset" => match state.kernel.reset_session(agent_id) {
             Ok(()) => {
-                serde_json::json!({"type": "command_result", "command": cmd, "message": "Session reset. Chat history cleared."})
+                serde_json::json!({"type": "command_result", "command": "reset", "message": "Session reset. Chat history cleared."})
             }
             Err(e) => serde_json::json!({"type": "error", "content": format!("Reset failed: {e}")}),
         },

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -702,6 +702,121 @@ async fn test_agent_session_empty() {
     assert_eq!(body["messages"].as_array().unwrap().len(), 0);
 }
 
+/// Regression test for the cross-agent session-read guard added in PR #3071.
+///
+/// `GET /api/agents/{A}/session?session_id={B's session}` MUST NOT return
+/// agent B's history under agent A's id — otherwise one agent id can read
+/// another agent's conversation by guessing a session UUID.
+///
+/// Also verifies the malformed-uuid case returns 400 (typed query param
+/// validation) and that passing the agent's own session_id round-trips.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_agent_session_rejects_cross_agent_session_id() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Spawn agent A.
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body_a: serde_json::Value = resp.json().await.unwrap();
+    let agent_a = body_a["agent_id"].as_str().unwrap().to_string();
+
+    // Spawn agent B (distinct name so the manifest validates).
+    const TEST_MANIFEST_B: &str = r#"
+name = "test-agent-b"
+version = "0.1.0"
+description = "Integration test agent B"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent. Reply concisely."
+
+[capabilities]
+tools = ["file_read"]
+memory_read = ["*"]
+memory_write = ["self.*"]
+"#;
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST_B}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body_b: serde_json::Value = resp.json().await.unwrap();
+    let agent_b = body_b["agent_id"].as_str().unwrap().to_string();
+
+    // Discover B's session id (canonical-active).
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session",
+            server.base_url, agent_b
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let b_session: serde_json::Value = resp.json().await.unwrap();
+    let b_session_id = b_session["session_id"].as_str().unwrap().to_string();
+
+    // Cross-agent read: A's id with B's session_id → 404 (the guard).
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session?session_id={}",
+            server.base_url, agent_a, b_session_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "cross-agent session read must be rejected"
+    );
+
+    // Malformed UUID → 400 (typed serde validation).
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session?session_id=not-a-uuid",
+            server.base_url, agent_a
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Same-agent round-trip: A's id with A's own session_id → 200.
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session",
+            server.base_url, agent_a
+        ))
+        .send()
+        .await
+        .unwrap();
+    let a_session: serde_json::Value = resp.json().await.unwrap();
+    let a_session_id = a_session["session_id"].as_str().unwrap().to_string();
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session?session_id={}",
+            server.base_url, agent_a, a_session_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["session_id"].as_str().unwrap(), a_session_id);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_agent_session_trajectory_export_empty() {
     let server = start_test_server().await;

--- a/openapi.json
+++ b/openapi.json
@@ -1250,6 +1250,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "description": "Optional session id to load instead of the canonical active session",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -364,8 +364,8 @@ func (r *AgentsResource) SetModel(id string, data map[string]interface{}) (inter
 	return r.client.request("PUT", fmt.Sprintf("/api/agents/%s/model", id), data, nil)
 }
 
-func (r *AgentsResource) GetAgentSession(id string) (interface{}, error) {
-	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/session", id), nil, nil)
+func (r *AgentsResource) GetAgentSession(id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/session", id), nil, query)
 }
 
 func (r *AgentsResource) CompactSession(id string) (interface{}, error) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -232,8 +232,8 @@ class AgentsResource {
     return this._c._request("PUT", `/api/agents/${id}/model`, data, undefined);
   }
 
-  async getAgentSession(id) {
-    return this._c._request("GET", `/api/agents/${id}/session`);
+  async getAgentSession(id, query) {
+    return this._c._request("GET", `/api/agents/${id}/session`, undefined, query);
   }
 
   async compactSession(id) {

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -216,8 +216,8 @@ class _AgentsResource(_Resource):
     def set_model(self, id: str, **data):
         return self._c._request("PUT", f"/api/agents/{id}/model", data)
 
-    def get_agent_session(self, id: str):
-        return self._c._request("GET", f"/api/agents/{id}/session")
+    def get_agent_session(self, id: str, session_id: Any = None):
+        return self._c._request("GET", f"/api/agents/{id}/session", None, query={"session_id": session_id})
 
     def compact_session(self, id: str):
         return self._c._request("POST", f"/api/agents/{id}/session/compact")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -340,8 +340,8 @@ impl AgentsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/model", id), Some(data), &[]).await
     }
 
-    pub async fn get_agent_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/session", id), None, &[]).await
+    pub async fn get_agent_session(&self, id: &str, session_id: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/session", id), None, &[("session_id", session_id)]).await
     }
 
     pub async fn compact_session(&self, id: &str) -> Result<Value> {


### PR DESCRIPTION
## Summary

Splits `/new` (fresh session, new UUID, navigate) from `/reset` (wipe in place, same UUID). Also adds two related fixes for URL-pinned sessions discovered while testing.

## Behaviour changes

1. **`/new` creates a new session** instead of clearing in place. Channels/scripts that relied on the old behaviour should switch to `/reset`.
2. **`GET /api/agents/{id}/session` now accepts `?session_id=<uuid>`** to load a specific session. Cross-agent reads return 404; malformed UUIDs 400.
3. **Landing on a hand-agent URL flips `showHandAgents` to `"1"`** in localStorage so the picker keeps showing hand agents on refresh.

## Changes

- `ws.rs` — split `new`/`reset`; `/new` now surfaces an explicit error if the kernel returns no `session_id` instead of swallowing it.
- `routes/agents.rs` — typed `GetAgentSessionQuery { session_id: Option<Uuid> }`; cross-agent guard now also fires in the `Ok(None)` branch (an explicit `session_id` that doesn't match this agent's canonical id 404s rather than falling back to the canonical empty session).
- `ChatPage.tsx` — `useChatMessages` honors the URL-pinned `sessionId`; auto-flips `showHandAgents` for hand-agent URLs; surfaces session-load errors via the existing `onClearError` toast channel.
- `zh.json` — `cmd_new` now reads "新建会话（生成新会话 ID）".
- SDKs (`go`, `js`, `python`, `rust`): `get_agent_session` gains an optional `session_id` query param. Helper functions in all four SDKs already drop `None`/`undefined`/empty values, so default callers are unaffected.

## Tests

- `cargo test -p librefang-api`: 42 passed (includes new `test_get_agent_session_rejects_cross_agent_session_id` covering the cross-agent 404 + malformed-UUID 400 + same-agent round-trip).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test --workspace`: 1 pre-existing failure (`librefang-kernel::config::tests::test_load_config_defaults`) — host-env dependent (asserts default `log_level == "info"` but reads from `~/.librefang/config.toml`), identical on `upstream/main` unmodified.

## Test plan

- [x] `/new` flips URL `?sessionId` to a fresh UUID, dropdown shows the new row, history empty.
- [x] `/reset` still clears history in the current session (same `session_id`).
- [x] Cross-agent `GET /api/agents/{A}/session?session_id=<B's session>` → 404.
- [x] Malformed `?session_id=foo` → 400.
- [x] Refresh on `?agentId=<hand-agent>` no longer dumps to default assistant.