### PR TITLE
fix(flake.nix): Add missing files to src to fix librefang-cli build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,11 @@
             ./crates/librefang-desktop/icons
             ./crates/librefang-desktop/gen
             ./packages/whatsapp-gateway
+            ./deploy/docker-compose.observability.yml
+            ./deploy/grafana
+            ./deploy/otel-collector
+            ./deploy/prometheus
+            ./deploy/tempo
           ];
         };
 


### PR DESCRIPTION
## Type

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [ ] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [x ] Other

## Summary

The PR adds missing files from the deploy directory to the `src` in `flake.nix` to fix build failure. Fixes issue [https://github.com/librefang/librefang/issues/3072](https://github.com/librefang/librefang/issues/3072).

## Changes

Changed `flake.nix` file:
```
src = pkgs.lib.fileset.toSource {
          root = ./.;
          fileset = pkgs.lib.fileset.unions [
            (craneLib.fileset.commonCargoSources ./.)
             ...
             ./crates/librefang-desktop/icons
             ./crates/librefang-desktop/gen
             ./packages/whatsapp-gateway
+            ./deploy/docker-compose.observability.yml
+            ./deploy/grafana
+            ./deploy/otel-collector
+            ./deploy/prometheus
+            ./deploy/tempo
           ];
         };
```

## Attribution

Does not apply.

## Testing

With the modification the build on NixOS succeeds. Other checks do not apply.

## Security

Does not apply.