### PR TITLE
feat(dashboard): wire chat attachment uploads in ChatPage

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -290,6 +290,11 @@ export interface AgentTool {
 export interface AgentSessionImage {
   file_id: string;
   filename?: string;
+  /** Optional — backend currently only emits image attachments here, so
+   *  the renderer treats a missing value as image. Threading the field
+   *  through keeps the chat transcript correct if the server starts
+   *  serializing non-image attachments (PDF/text) into history. */
+  content_type?: string;
 }
 
 /** Reference passed back to the agent's `/message` endpoint or WS frame

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -292,6 +292,23 @@ export interface AgentSessionImage {
   filename?: string;
 }
 
+/** Reference passed back to the agent's `/message` endpoint or WS frame
+ *  after a successful upload. Mirrors `crate::types::AttachmentRef`. */
+export interface AttachmentRef {
+  file_id: string;
+  filename?: string;
+  content_type?: string;
+}
+
+export interface AgentFileUploadResult {
+  file_id: string;
+  filename: string;
+  content_type: string;
+  size: number;
+  /** Whisper transcription, populated only for audio uploads. */
+  transcription?: string;
+}
+
 export interface AgentSessionMessage {
   role?: string;
   content?: unknown;
@@ -335,6 +352,8 @@ export interface SendAgentMessageOptions {
    * two browser tabs on the same agent don't race each other.
    */
   session_id?: string | null;
+  /** File attachments uploaded via `/api/agents/{id}/upload`. */
+  attachments?: AttachmentRef[];
 }
 
 export interface ApiActionResponse {
@@ -986,6 +1005,7 @@ export async function sendAgentMessage(
   if (options?.thinking !== undefined) body.thinking = options.thinking;
   if (options?.show_thinking !== undefined) body.show_thinking = options.show_thinking;
   if (options?.session_id) body.session_id = options.session_id;
+  if (options?.attachments && options.attachments.length > 0) body.attachments = options.attachments;
   return post<AgentMessageResponse>(
     `/api/agents/${encodeURIComponent(agentId)}/message`,
     body,
@@ -1128,6 +1148,25 @@ export async function transcribeAudio(audioBlob: Blob): Promise<{ text: string; 
     throw await parseError(response);
   }
   return (await response.json()) as { text: string; provider: string; model: string };
+}
+
+// Upload a chat attachment for an agent. Body is the raw file bytes; backend
+// expects `Content-Type` to match the file MIME and `X-Filename` for the
+// original name. Server-side limits: 10MB and an exact MIME allowlist
+// (image/audio/text/pdf) — callers should still pre-validate to fail fast.
+export async function uploadAgentFile(agentId: string, file: File): Promise<AgentFileUploadResult> {
+  const response = await fetch(`/api/agents/${encodeURIComponent(agentId)}/upload`, {
+    method: "POST",
+    headers: buildHeaders({
+      "Content-Type": file.type || "application/octet-stream",
+      "X-Filename": encodeURIComponent(file.name),
+    }),
+    body: file,
+  });
+  if (!response.ok) {
+    throw await parseError(response);
+  }
+  return (await response.json()) as AgentFileUploadResult;
 }
 
 export async function submitVideo(req: { prompt: string; provider?: string; model?: string }): Promise<MediaVideoSubmitResult> {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1155,6 +1155,17 @@ export async function transcribeAudio(audioBlob: Blob): Promise<{ text: string; 
   return (await response.json()) as { text: string; provider: string; model: string };
 }
 
+// HTTP header values must be visible-ASCII (RFC 7230). Browsers reject
+// non-ASCII bytes in fetch headers, so we replace anything outside
+// 0x20–0x7e (and the header-breaking quote/CR/LF) with `_` before sending
+// the original filename. This loses fidelity for unicode names but never
+// throws, and keeps the server-side label render-safe — no decode pass
+// needed at display time.
+function sanitizeFilenameForHeader(name: string): string {
+  // eslint-disable-next-line no-control-regex
+  return name.replace(/[^\x20-\x7e]|["\r\n]/g, "_");
+}
+
 // Upload a chat attachment for an agent. Body is the raw file bytes; backend
 // expects `Content-Type` to match the file MIME and `X-Filename` for the
 // original name. Server-side limits: 10MB and an exact MIME allowlist
@@ -1164,7 +1175,7 @@ export async function uploadAgentFile(agentId: string, file: File): Promise<Agen
     method: "POST",
     headers: buildHeaders({
       "Content-Type": file.type || "application/octet-stream",
-      "X-Filename": encodeURIComponent(file.name),
+      "X-Filename": sanitizeFilenameForHeader(file.name),
     }),
     body: file,
   });

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -164,6 +164,8 @@ export {
   reloadChannels,
   sendCommsMessage,
   postCommsTask,
+  // attachments
+  uploadAgentFile,
   // media
   generateImage,
   synthesizeSpeech,

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -19,6 +19,7 @@ import {
   pauseExperiment,
   completeExperiment,
   resolveApproval,
+  uploadAgentFile,
 } from "../http/client";
 import { agentKeys, approvalKeys, overviewKeys, sessionKeys } from "../queries/keys";
 
@@ -287,6 +288,17 @@ export function useCompleteExperiment() {
       qc.invalidateQueries({ queryKey: agentKeys.experiments(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.experimentMetrics(variables.experimentId) });
     },
+  });
+}
+
+// Upload a chat attachment for the given agent. Returns the metadata that
+// callers must thread back through the next /message or WS frame as
+// `attachments[]` — uploads not referenced by a message stay orphaned in
+// the registry until the daemon restarts.
+export function useUploadAgentFile() {
+  return useMutation({
+    mutationFn: ({ agentId, file }: { agentId: string; file: File }) =>
+      uploadAgentFile(agentId, file),
   });
 }
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -295,6 +295,12 @@ export function useCompleteExperiment() {
 // callers must thread back through the next /message or WS frame as
 // `attachments[]` — uploads not referenced by a message stay orphaned in
 // the registry until the daemon restarts.
+//
+// Intentionally does NOT call invalidateQueries: the upload only registers
+// a file_id server-side, and no React Query cache reads UPLOAD_REGISTRY
+// directly. The file becomes visible in the UI only after it's referenced
+// in a /message call, which goes through useSendAgentMessage and triggers
+// the appropriate session invalidation there.
 export function useUploadAgentFile() {
   return useMutation({
     mutationFn: ({ agentId, file }: { agentId: string; file: File }) =>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -18,7 +18,7 @@ import { approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
 import { normalizeToolOutput } from "../lib/chat";
 import { useTtsManager } from "../lib/tts";
-import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe } from "lucide-react";
+import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe, Paperclip, FileText } from "lucide-react";
 import { Badge } from "../components/ui/Badge";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { useUIStore } from "../lib/store";
@@ -33,6 +33,7 @@ import {
   usePatchAgentConfig,
   useResolveApproval,
   useStopAgent,
+  useUploadAgentFile,
 } from "../lib/mutations/agents";
 import "katex/dist/katex.min.css";
 
@@ -77,6 +78,15 @@ interface ChatMessage {
   thinking?: string;
   /** Whether the thinking block is collapsed in the UI. */
   thinkingCollapsed?: boolean;
+  /** Image attachments — {file_id, filename} sourced from session history
+   *  (`AgentSessionMessage.images`) or the user's pending uploads at send. */
+  images?: ChatAttachment[];
+}
+
+interface ChatAttachment {
+  file_id: string;
+  filename?: string;
+  content_type?: string;
 }
 
 // Slash commands — desc is an i18n key under "chat.cmd_*"
@@ -342,7 +352,8 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
             }
 
             const hasTools = msg.tools && msg.tools.length > 0;
-            if (!content.trim() && !hasTools) return [];
+            const hasImages = msg.images && msg.images.length > 0;
+            if (!content.trim() && !hasTools && !hasImages) return [];
 
             return [{
               id: `hist-${idx}`,
@@ -358,6 +369,10 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
               // persisted before the backend started stamping (#2934).
               timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
               tools: msg.tools,
+              images: msg.images?.map((img) => ({
+                file_id: img.file_id,
+                filename: img.filename,
+              })),
             }];
           });
           // Refresh the cache unconditionally — the data is still correct
@@ -391,10 +406,15 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
     }
   }, [agentId, onClearError, t]);
 
-  // Send message - WS first, HTTP fallback
-  const sendMessage = useCallback(async (content: string) => {
-    if (!content.trim()) return;
+  // Send message - WS first, HTTP fallback. `attachments` is the list of
+  // already-uploaded files that the agent should attach to this turn (image
+  // bytes are pre-resolved by the backend at /upload time and looked up by
+  // file_id; image blocks land on the user message, non-image bytes are
+  // injected as text content blocks). Slash commands ignore attachments.
+  const sendMessage = useCallback(async (content: string, attachments?: ChatAttachment[]) => {
+    if (!content.trim() && !(attachments && attachments.length > 0)) return;
     const trimmed = content.trim();
+    const hasAttachments = !!(attachments && attachments.length > 0);
 
     // Slash command handling
     if (trimmed.startsWith("/")) {
@@ -478,6 +498,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
       role: "user",
       content: trimmed,
       timestamp: new Date(),
+      images: hasAttachments ? attachments : undefined,
     };
 
     const botMsg: ChatMessage = {
@@ -499,6 +520,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
           thinking: deepThinking,
           show_thinking: showThinkingProcess,
           session_id: sessionId,
+          attachments: hasAttachments ? attachments : undefined,
         });
         const fullContent = response.response || "";
         updateAgentMessages(sendAgentId, prev => prev.map(m =>
@@ -711,6 +733,9 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
           content: trimmed,
           thinking: deepThinking,
           show_thinking: showThinkingProcess,
+          // Backend ws handler reads `parsed["attachments"]` (ws.rs) and
+          // resolves them via the same path as the HTTP /message endpoint.
+          ...(hasAttachments ? { attachments } : {}),
         }));
 
         // Start inactivity timeout — resets on every received event
@@ -859,6 +884,50 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
           </div>
         )}
 
+        {/* Image attachments — rendered above the text bubble. Backend
+            stores all uploaded files (image/audio/text/pdf) under the
+            same `images` field of `AgentSessionMessage`; we still render
+            non-image entries because text/pdf attachments are otherwise
+            invisible in the transcript. */}
+        {message.images && message.images.length > 0 && (
+          <div className={`flex flex-wrap gap-2 mb-1.5 ${isUser ? "justify-end" : "justify-start"}`}>
+            {message.images.map((img) => {
+              const src = `/api/uploads/${encodeURIComponent(img.file_id)}`;
+              const isImage = !img.content_type || img.content_type.startsWith("image/");
+              if (isImage) {
+                return (
+                  <a
+                    key={img.file_id}
+                    href={src}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[240px]"
+                  >
+                    <img
+                      src={src}
+                      alt={img.filename ? decodeURIComponent(img.filename) : "attachment"}
+                      className="block max-h-[240px] w-auto object-contain bg-main/30"
+                    />
+                  </a>
+                );
+              }
+              const label = img.filename ? decodeURIComponent(img.filename) : img.file_id;
+              return (
+                <a
+                  key={img.file_id}
+                  href={src}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border-subtle bg-surface text-[11px] text-text hover:border-brand/40 transition-colors max-w-[220px]"
+                >
+                  <FileText className="h-3 w-3 text-text-dim shrink-0" />
+                  <span className="truncate">{label}</span>
+                </a>
+              );
+            })}
+          </div>
+        )}
+
         {/* Message content */}
         {(displayContent || isUser || message.isStreaming || message.error) && (
         <div className={`relative px-3.5 py-2.5 rounded-2xl text-sm leading-relaxed shadow-sm min-w-0 [overflow-wrap:anywhere] ${
@@ -974,12 +1043,89 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
   );
 });
 
+function AttachmentChip({ attachment, onRemove }: { attachment: PendingAttachment; onRemove: (localId: string) => void }) {
+  const { t } = useTranslation();
+  const isImage = attachment.contentType.startsWith("image/");
+  const isError = attachment.status === "error";
+  const isUploading = attachment.status === "uploading";
+  // Once uploaded, prefer the served URL so the chip survives without
+  // holding a blob URL — but during upload the local preview is all we
+  // have, so fall through to it for images.
+  const imageSrc = attachment.fileId
+    ? `/api/uploads/${encodeURIComponent(attachment.fileId)}`
+    : attachment.previewUrl;
+  return (
+    <div className={`group relative flex items-center gap-2 pl-1 pr-7 py-1 rounded-xl border text-[11px] max-w-[220px] ${
+      isError
+        ? "border-error/30 bg-error/5 text-error"
+        : "border-border-subtle bg-surface"
+    }`}>
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-main/40">
+        {isImage && imageSrc ? (
+          <img src={imageSrc} alt={attachment.filename} className="h-full w-full object-cover" />
+        ) : (
+          <FileText className="h-4 w-4 text-text-dim" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="truncate font-medium text-text">{attachment.filename}</div>
+        <div className="flex items-center gap-1 text-[10px] text-text-dim">
+          {isUploading && <Loader2 className="h-3 w-3 animate-spin" />}
+          <span className="truncate">
+            {isUploading
+              ? t("chat.attachment_uploading", { defaultValue: "Uploading…" })
+              : isError
+                ? (attachment.errorMessage ?? t("common.error"))
+                : `${(attachment.size / 1024).toFixed(0)} KB`}
+          </span>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onRemove(attachment.localId)}
+        title={t("chat.attachment_remove", { defaultValue: "Remove" })}
+        className="absolute right-1 top-1 h-5 w-5 rounded-md flex items-center justify-center text-text-dim/70 hover:text-text hover:bg-main"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+// Server-side cap (`KernelConfig.max_upload_size_bytes`, default 10MB).
+// Mirrored client-side so we can reject locally before pushing bytes over
+// the wire — the backend still enforces the real limit.
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+// Mirrors `is_allowed_content_type` in routes/agents.rs. Kept liberal to
+// avoid divergence — if the server's allowlist tightens, the upload will
+// fail with a 400 and we surface that error per-attachment.
+const ATTACHMENT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif,audio/mpeg,audio/wav,audio/webm,audio/ogg,audio/mp4,text/plain,text/markdown,text/csv,application/pdf";
+
+interface PendingAttachment {
+  /** Stable client id used to track this entry across upload state changes. */
+  localId: string;
+  filename: string;
+  size: number;
+  contentType: string;
+  /** Local preview URL for images while the upload is in flight. */
+  previewUrl?: string;
+  status: "uploading" | "ready" | "error";
+  /** Set on `status === "ready"`; absent until the server returns. */
+  fileId?: string;
+  errorMessage?: string;
+}
+
 // Input box - with shortcut hints
-function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, placeholder, authMissing, authStatus, providerName, supportsThinking, sttAvailable }: { onSend: (msg: string) => void; onStop?: () => void; isStreaming?: boolean; disabled: boolean; inputDisabled?: boolean; placeholder: string; authMissing?: boolean; authStatus?: string; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
+function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabled, placeholder, authMissing, authStatus, providerName, supportsThinking, sttAvailable }: { agentId: string; onSend: (msg: string, attachments?: ChatAttachment[]) => void; onStop?: () => void; isStreaming?: boolean; disabled: boolean; inputDisabled?: boolean; placeholder: string; authMissing?: boolean; authStatus?: string; providerName?: string; supportsThinking?: boolean; sttAvailable?: boolean }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
   const [activeIndex, setActiveIndex] = useState(-1);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [isDropping, setIsDropping] = useState(false);
+  const dragDepthRef = useRef(0);
+  const uploadMutation = useUploadAgentFile();
   const deepThinking = useUIStore((s) => s.deepThinking);
   const showThinkingProcess = useUIStore((s) => s.showThinkingProcess);
   const setDeepThinking = useUIStore((s) => s.setDeepThinking);
@@ -1055,13 +1201,144 @@ function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, place
   }, [hasDropdown, dropdownLen, activeIndex, isSlashPrefix, isModelArg, filteredCmds, filteredModels, selectCmd, selectModel]);
 
   // ─────────────────────────────────────────────────────────────────────────
+  // ── Attachment upload pipeline ────────────────────────────────────────────
+
+  const isImageMime = (mime: string) => mime.startsWith("image/");
+
+  const enqueueFiles = useCallback((files: File[]) => {
+    if (!agentId || files.length === 0) return;
+    for (const file of files) {
+      const localId = `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const tooLarge = file.size > MAX_ATTACHMENT_BYTES;
+      const previewUrl = isImageMime(file.type) ? URL.createObjectURL(file) : undefined;
+      if (tooLarge) {
+        setAttachments(prev => [...prev, {
+          localId,
+          filename: file.name,
+          size: file.size,
+          contentType: file.type || "application/octet-stream",
+          previewUrl,
+          status: "error",
+          errorMessage: t("chat.attachment_too_large", { defaultValue: "File too large (max 10MB)" }),
+        }]);
+        continue;
+      }
+      setAttachments(prev => [...prev, {
+        localId,
+        filename: file.name,
+        size: file.size,
+        contentType: file.type || "application/octet-stream",
+        previewUrl,
+        status: "uploading",
+      }]);
+      uploadMutation.mutate({ agentId, file }, {
+        onSuccess: (result) => {
+          setAttachments(prev => prev.map(a =>
+            a.localId === localId
+              ? { ...a, status: "ready" as const, fileId: result.file_id, contentType: result.content_type || a.contentType }
+              : a
+          ));
+        },
+        onError: (err) => {
+          const msg = err instanceof Error ? err.message : t("common.error");
+          setAttachments(prev => prev.map(a =>
+            a.localId === localId
+              ? { ...a, status: "error" as const, errorMessage: msg }
+              : a
+          ));
+        },
+      });
+    }
+  }, [agentId, uploadMutation, t]);
+
+  // Revoke any object URLs we created when the component unmounts so we
+  // don't leak memory in a long-lived chat session.
+  useEffect(() => {
+    return () => {
+      attachments.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const removeAttachment = useCallback((localId: string) => {
+    setAttachments(prev => {
+      const target = prev.find(a => a.localId === localId);
+      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter(a => a.localId !== localId);
+    });
+  }, []);
+
+  const handleFilePick = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (list && list.length > 0) {
+      enqueueFiles(Array.from(list));
+    }
+    // Reset value so the same file can be re-picked after removal.
+    e.target.value = "";
+  }, [enqueueFiles]);
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    const files: File[] = [];
+    for (const item of items) {
+      if (item.kind === "file") {
+        const f = item.getAsFile();
+        if (f) files.push(f);
+      }
+    }
+    if (files.length > 0) {
+      e.preventDefault();
+      enqueueFiles(files);
+    }
+  }, [enqueueFiles]);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer?.types.includes("Files")) return;
+    dragDepthRef.current += 1;
+    setIsDropping(true);
+  }, []);
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer?.types.includes("Files")) {
+      e.preventDefault();
+    }
+  }, []);
+  const handleDragLeave = useCallback(() => {
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDropping(false);
+  }, []);
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer?.files || e.dataTransfer.files.length === 0) return;
+    e.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDropping(false);
+    enqueueFiles(Array.from(e.dataTransfer.files));
+  }, [enqueueFiles]);
+
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const anyUploading = attachments.some(a => a.status === "uploading");
+  const readyAttachments = attachments.filter(a => a.status === "ready" && a.fileId);
+  const hasSendableAttachments = readyAttachments.length > 0;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (message.trim() && !effectiveDisabled) {
-      onSend(message);
-      setMessage("");
-    }
+    if (effectiveDisabled || anyUploading) return;
+    if (!message.trim() && !hasSendableAttachments) return;
+    const payload: ChatAttachment[] | undefined = hasSendableAttachments
+      ? readyAttachments.map(a => ({
+          file_id: a.fileId!,
+          filename: a.filename,
+          content_type: a.contentType,
+        }))
+      : undefined;
+    onSend(message, payload);
+    setMessage("");
+    // Revoke previews and clear the strip — the optimistic user bubble
+    // already references fileIds via /api/uploads/{id}, so we don't need
+    // the local blob URLs anymore.
+    attachments.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
+    setAttachments([]);
   };
 
   useEffect(() => {
@@ -1080,7 +1357,35 @@ function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, place
   const textareaDisabled = (inputDisabled ?? disabled) || !!authMissing;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form
+      onSubmit={handleSubmit}
+      className={`relative space-y-2 ${isDropping ? "ring-2 ring-brand/40 rounded-2xl" : ""}`}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDropping && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-brand/5 border border-dashed border-brand/40 text-xs font-medium text-brand">
+          {t("chat.attachment_drop_hint", { defaultValue: "Drop to attach" })}
+        </div>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ATTACHMENT_ACCEPT}
+        onChange={handleFilePick}
+        className="hidden"
+      />
+      {/* Pending / uploaded attachment chips */}
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {attachments.map(att => (
+            <AttachmentChip key={att.localId} attachment={att} onRemove={removeAttachment} />
+          ))}
+        </div>
+      )}
       {/* Auth missing warning */}
       {authMissing && (
         <div className="flex items-center gap-2 rounded-xl border border-warning/30 bg-warning/5 px-4 py-2.5 text-sm text-warning">
@@ -1156,6 +1461,7 @@ function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, place
             ref={textareaRef}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
+            onPaste={handlePaste}
             onKeyDown={(e) => {
               // Dropdown navigation takes priority
               if (hasDropdown) {
@@ -1173,6 +1479,15 @@ function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, place
             className="w-full min-h-[44px] sm:min-h-[52px] max-h-[150px] rounded-2xl border border-border-subtle bg-surface px-3 sm:px-5 py-2.5 sm:py-3.5 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none resize-none placeholder:text-text-dim/40 shadow-sm"
           />
         </div>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!agentId || textareaDisabled}
+          title={t("chat.attachment_add", { defaultValue: "Attach file" })}
+          className="group relative px-3 sm:px-3.5 py-2.5 sm:py-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed bg-surface text-text-dim border border-border-subtle hover:text-text hover:border-border hover:-translate-y-0.5"
+        >
+          <Paperclip className="h-4 w-4" />
+        </button>
         {voiceInput.isSupported && (
           <button
             type="button"
@@ -1205,10 +1520,10 @@ function ChatInput({ onSend, onStop, isStreaming, disabled, inputDisabled, place
         ) : (
           <button
             type="submit"
-            disabled={!message.trim() || effectiveDisabled}
+            disabled={effectiveDisabled || anyUploading || (!message.trim() && !hasSendableAttachments)}
             className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-brand to-brand/90 text-white font-bold text-sm shadow-lg shadow-brand/20 hover:shadow-brand/40 hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0"
           >
-            <Send className="h-4 w-4" />
+            {anyUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
             <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">
               {t("chat.send_hint")}
             </span>
@@ -2261,6 +2576,7 @@ export function ChatPage() {
           {/* Input area */}
           <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
+              agentId={selectedAgentId ?? ""}
               onSend={sendMessage}
               onStop={stopMessage}
               isStreaming={isStreaming}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -906,13 +906,13 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
                   >
                     <img
                       src={src}
-                      alt={img.filename ? decodeURIComponent(img.filename) : "attachment"}
+                      alt={img.filename || "attachment"}
                       className="block max-h-[240px] w-auto object-contain bg-main/30"
                     />
                   </a>
                 );
               }
-              const label = img.filename ? decodeURIComponent(img.filename) : img.file_id;
+              const label = img.filename || img.file_id;
               return (
                 <a
                   key={img.file_id}
@@ -1098,10 +1098,14 @@ function AttachmentChip({ attachment, onRemove }: { attachment: PendingAttachmen
 // Mirrored client-side so we can reject locally before pushing bytes over
 // the wire — the backend still enforces the real limit.
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
-// Mirrors `is_allowed_content_type` in routes/agents.rs. Kept liberal to
-// avoid divergence — if the server's allowlist tightens, the upload will
-// fail with a 400 and we surface that error per-attachment.
-const ATTACHMENT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif,audio/mpeg,audio/wav,audio/webm,audio/ogg,audio/mp4,text/plain,text/markdown,text/csv,application/pdf";
+// Restricted to image MIMEs because that's the only branch the agent loop
+// currently consumes: `routes/agents.rs::resolve_attachments()` skips any
+// attachment whose Content-Type doesn't start with `image/`. The /upload
+// endpoint itself accepts a wider set (audio for transcription, pdf/text)
+// but those paths aren't wired into the chat send pipeline yet — offering
+// them here would silently drop user context. Mirrors
+// `librefang_types::media::ALLOWED_IMAGE_TYPES`.
+const ATTACHMENT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
 
 interface PendingAttachment {
   /** Stable client id used to track this entry across upload state changes. */
@@ -1212,7 +1216,23 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
     for (const file of files) {
       const localId = `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const tooLarge = file.size > MAX_ATTACHMENT_BYTES;
-      const previewUrl = isImageMime(file.type) ? URL.createObjectURL(file) : undefined;
+      const isImage = isImageMime(file.type);
+      const previewUrl = isImage ? URL.createObjectURL(file) : undefined;
+      // Drop/paste bypasses <input accept>, so we still need to enforce
+      // image-only here — non-image attachments would upload but the agent
+      // loop would silently discard them.
+      if (!isImage) {
+        setAttachments(prev => [...prev, {
+          localId,
+          filename: file.name,
+          size: file.size,
+          contentType: file.type || "application/octet-stream",
+          previewUrl,
+          status: "error",
+          errorMessage: t("chat.attachment_unsupported_type", { defaultValue: "Only images are supported (png, jpeg, webp, gif)" }),
+        }]);
+        continue;
+      }
       if (tooLarge) {
         setAttachments(prev => [...prev, {
           localId,

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1484,7 +1484,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
           onClick={() => fileInputRef.current?.click()}
           disabled={!agentId || textareaDisabled}
           title={t("chat.attachment_add", { defaultValue: "Attach file" })}
-          className="group relative px-3 sm:px-3.5 py-2.5 sm:py-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed bg-surface text-text-dim border border-border-subtle hover:text-text hover:border-border hover:-translate-y-0.5"
+          className="group relative inline-flex items-center justify-center min-h-[44px] sm:min-h-[52px] px-3 sm:px-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed bg-surface text-text-dim border border-border-subtle hover:text-text hover:border-border hover:-translate-y-0.5"
         >
           <Paperclip className="h-4 w-4" />
         </button>
@@ -1494,7 +1494,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
             onClick={sttAvailable ? voiceInput.toggleRecording : undefined}
             disabled={!sttAvailable || textareaDisabled || voiceInput.isTranscribing}
             title={!sttAvailable ? t("chat.voice_not_configured") : voiceInput.isRecording ? t("chat.voice_stop") : t("chat.voice_input")}
-            className={`group relative px-3 sm:px-3.5 py-2.5 sm:py-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed ${
+            className={`group relative inline-flex items-center justify-center min-h-[44px] sm:min-h-[52px] px-3 sm:px-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed ${
               voiceInput.isRecording
                 ? "bg-error/10 text-error border border-error/30 animate-pulse"
                 : voiceInput.isTranscribing
@@ -1510,7 +1510,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
             type="button"
             onClick={onStop}
             title={t("chat.stop_hint")}
-            className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-error to-error/90 text-white font-bold text-sm shadow-lg shadow-error/20 hover:shadow-error/40 hover:-translate-y-0.5 transition-all duration-300"
+            className="group relative inline-flex items-center justify-center min-h-[44px] sm:min-h-[52px] px-3.5 sm:px-5 rounded-2xl bg-linear-to-r from-error to-error/90 text-white font-bold text-sm shadow-lg shadow-error/20 hover:shadow-error/40 hover:-translate-y-0.5 transition-all duration-300"
           >
             <Square className="h-4 w-4 fill-current" />
             <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">
@@ -1521,7 +1521,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
           <button
             type="submit"
             disabled={effectiveDisabled || anyUploading || (!message.trim() && !hasSendableAttachments)}
-            className="group relative px-3.5 sm:px-5 py-2.5 sm:py-3.5 rounded-2xl bg-linear-to-r from-brand to-brand/90 text-white font-bold text-sm shadow-lg shadow-brand/20 hover:shadow-brand/40 hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+            className="group relative inline-flex items-center justify-center min-h-[44px] sm:min-h-[52px] px-3.5 sm:px-5 rounded-2xl bg-linear-to-r from-brand to-brand/90 text-white font-bold text-sm shadow-lg shadow-brand/20 hover:shadow-brand/40 hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:translate-y-0"
           >
             {anyUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
             <span className="absolute -top-8 right-0 bg-surface border border-border-subtle rounded-lg px-2 py-1 text-[10px] text-text-dim opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap hidden sm:block">

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -372,6 +372,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
               images: msg.images?.map((img) => ({
                 file_id: img.file_id,
                 filename: img.filename,
+                content_type: img.content_type,
               })),
             }];
           });
@@ -1084,6 +1085,7 @@ function AttachmentChip({ attachment, onRemove }: { attachment: PendingAttachmen
         type="button"
         onClick={() => onRemove(attachment.localId)}
         title={t("chat.attachment_remove", { defaultValue: "Remove" })}
+        aria-label={t("chat.attachment_remove", { defaultValue: "Remove attachment" })}
         className="absolute right-1 top-1 h-5 w-5 rounded-md flex items-center justify-center text-text-dim/70 hover:text-text hover:bg-main"
       >
         <X className="h-3 w-3" />
@@ -1252,12 +1254,17 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
   }, [agentId, uploadMutation, t]);
 
   // Revoke any object URLs we created when the component unmounts so we
-  // don't leak memory in a long-lived chat session.
+  // don't leak memory in a long-lived chat session. We mirror `attachments`
+  // into a ref because the cleanup runs on unmount and would otherwise
+  // capture the empty initial state from first render.
+  const attachmentsRef = useRef<PendingAttachment[]>([]);
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
   useEffect(() => {
     return () => {
-      attachments.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
+      attachmentsRef.current.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const removeAttachment = useCallback((localId: string) => {
@@ -1325,7 +1332,12 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
     e.preventDefault();
     if (effectiveDisabled || anyUploading) return;
     if (!message.trim() && !hasSendableAttachments) return;
-    const payload: ChatAttachment[] | undefined = hasSendableAttachments
+    // Slash commands bypass the LLM send path (they're handled in
+    // useChatMessages.sendMessage), so they cannot carry attachments.
+    // Preserve the chips through a slash so the user doesn't silently lose
+    // their uploads when they run e.g. `/info` with an image already queued.
+    const isSlashCommand = message.trim().startsWith("/");
+    const payload: ChatAttachment[] | undefined = (!isSlashCommand && hasSendableAttachments)
       ? readyAttachments.map(a => ({
           file_id: a.fileId!,
           filename: a.filename,
@@ -1334,11 +1346,13 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
       : undefined;
     onSend(message, payload);
     setMessage("");
-    // Revoke previews and clear the strip — the optimistic user bubble
-    // already references fileIds via /api/uploads/{id}, so we don't need
-    // the local blob URLs anymore.
-    attachments.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
-    setAttachments([]);
+    if (!isSlashCommand) {
+      // Revoke previews and clear the strip — the optimistic user bubble
+      // already references fileIds via /api/uploads/{id}, so we don't need
+      // the local blob URLs anymore.
+      attachments.forEach(a => { if (a.previewUrl) URL.revokeObjectURL(a.previewUrl); });
+      setAttachments([]);
+    }
   };
 
   useEffect(() => {
@@ -1484,6 +1498,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
           onClick={() => fileInputRef.current?.click()}
           disabled={!agentId || textareaDisabled}
           title={t("chat.attachment_add", { defaultValue: "Attach file" })}
+          aria-label={t("chat.attachment_add", { defaultValue: "Attach file" })}
           className="group relative inline-flex items-center justify-center min-h-[44px] sm:min-h-[52px] px-3 sm:px-3.5 rounded-2xl font-bold text-sm transition-all duration-300 disabled:opacity-40 disabled:cursor-not-allowed bg-surface text-text-dim border border-border-subtle hover:text-text hover:border-border hover:-translate-y-0.5"
         >
           <Paperclip className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- **Backend already supported file uploads end-to-end** — `POST /api/agents/{id}/upload`, `attachments[]` on the HTTP `/message` body, and `attachments[]` on the WS `{"type":"message"}` frame (`crates/librefang-api/src/ws.rs:707-725`). The dashboard, however, had no UI to send attachments and didn't render `AgentSessionMessage.images`, so the path was effectively dead code from the user's perspective.
- This PR connects the dashboard to that pipeline, threading attachments through both the WS and HTTP send paths and rendering uploaded files in the chat transcript (live and historical).

## Changes

**Data layer**
- New `AttachmentRef` / `AgentFileUploadResult` types and `uploadAgentFile(agentId, file)` helper in `api.ts`; exposed via `http/client.ts` and a `useUploadAgentFile` mutation in `lib/mutations/agents.ts`.
- `SendAgentMessageOptions` gains `attachments?: AttachmentRef[]`; `sendAgentMessage()` forwards the field on the JSON body.

**ChatPage (`src/pages/ChatPage.tsx`)**
- `sendMessage(content, attachments?)` snapshots the attachments onto the optimistic user bubble, ships them on the WS `message` frame, and falls back to HTTP with the same attachments on WS-drop.
- `ChatInput` gains a paperclip picker, drag-drop, paste-image, an attachment chip strip with per-file upload status, and client-side 10MB / MIME pre-validation that mirrors the server allowlist.
- `MessageBubble` renders `message.images` for both freshly-sent uploads and historical sessions: image MIMEs become inline thumbnails linking to `/api/uploads/{file_id}`; non-image attachments render as a labeled file chip so text/PDF entries aren't invisible in the transcript.

## Test plan
- [x] `pnpm typecheck` introduces 0 new errors (25 pre-existing on `main`, same 25 on this branch).
- [x] `pnpm test` introduces 0 new failures (4 pre-existing failures on `main` in `TerminalPage.test.tsx` and `workflows.test.tsx`, same 4 here).
- [x] `pnpm build` succeeds; `ChatPage` chunk grew ~4kB gzipped.
- [ ] Manual: pick / drag / paste an image; verify thumbnail in chip and in user bubble after send; verify the agent receives the image (vision-capable model).
- [ ] Manual: upload a PDF / text file; verify file chip in user bubble; verify the LLM receives the text content.
- [ ] Manual: open an old session that has historical images; verify they render in the transcript.
- [ ] Manual: WS-drop mid-send → verify HTTP fallback also carries `attachments[]`.