### PR TITLE
feat(llm-drivers): add Novita AI as OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@
 # Fireworks AI
 # FIREWORKS_API_KEY=...
 
+# Novita AI (multi-model gateway, OpenAI-compatible)
+# NOVITA_API_KEY=...
+
 # ─── Local LLM Providers (no API key needed) ─────────────────────────
 
 # Ollama (default: http://localhost:11434)

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -575,6 +575,16 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         alt_api_key_env: None,
         hidden: false,
     },
+    ProviderEntry {
+        name: "novita",
+        aliases: &["novita-ai"],
+        base_url: "https://api.novita.ai/openai/v1",
+        api_key_env: "NOVITA_API_KEY",
+        key_required: true,
+        api_format: ApiFormat::OpenAI,
+        alt_api_key_env: None,
+        hidden: false,
+    },
 ];
 
 // ── Registry Lookup ──────────────────────────────────────────────
@@ -781,7 +791,7 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             "Unknown provider '{}'. Supported: anthropic, chatgpt, gemini, openai, groq, openrouter, \
              deepseek, deepinfra, together, mistral, fireworks, ollama, vllm, lmstudio, perplexity, \
              cohere, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
-             azure-openai, vertex-ai, nvidia-nim, claude-code, qwen-code, gemini-cli, codex-cli, \
+             azure-openai, vertex-ai, nvidia-nim, novita, claude-code, qwen-code, gemini-cli, codex-cli, \
              qwen, minimax, zhipu, zhipu_coding, zai, moonshot, kimi_coding, \
              qianfan, volcengine, alibaba-coding-plan. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
@@ -1065,7 +1075,8 @@ mod tests {
         assert!(providers.contains(&"azure-openai"));
         assert!(providers.contains(&"vertex-ai"));
         assert!(providers.contains(&"nvidia-nim"));
-        assert_eq!(providers.len(), 39);
+        assert!(providers.contains(&"novita"));
+        assert_eq!(providers.len(), 40);
     }
 
     #[test]
@@ -1111,6 +1122,22 @@ mod tests {
         let d = provider_defaults("huggingface").unwrap();
         assert_eq!(d.base_url, "https://api-inference.huggingface.co/v1");
         assert_eq!(d.api_key_env, "HF_API_KEY");
+        assert!(d.key_required);
+    }
+
+    #[test]
+    fn test_provider_defaults_novita() {
+        let d = provider_defaults("novita").unwrap();
+        assert_eq!(d.base_url, "https://api.novita.ai/openai/v1");
+        assert_eq!(d.api_key_env, "NOVITA_API_KEY");
+        assert!(d.key_required);
+    }
+
+    #[test]
+    fn test_provider_defaults_novita_ai_alias() {
+        let d = provider_defaults("novita-ai").unwrap();
+        assert_eq!(d.base_url, "https://api.novita.ai/openai/v1");
+        assert_eq!(d.api_key_env, "NOVITA_API_KEY");
         assert!(d.key_required);
     }
 


### PR DESCRIPTION
## Summary
- Register Novita AI in `PROVIDER_REGISTRY` (`librefang-llm-drivers`) at `https://api.novita.ai/openai/v1`, env `NOVITA_API_KEY`, alias `novita-ai`. Uses the OpenAI API format.
- Update `known_providers()` count (39 → 40), unknown-provider error hint, and `.env.example`.
- Add registry-lookup unit tests covering canonical name and alias.

Auto-detection is automatic via the existing registry-driven `detect_available_provider()` (Phase 2 falls through to the full `PROVIDER_REGISTRY`) — no separate `PRIORITY` entry is needed.

Ported from openfang `365bec8` and `4714efb`, adapted to LibreFang's registry architecture (which is cleaner than the upstream `match` arms).

Companion registry PR (model catalog so Novita's models surface in the dashboard picker without `/api/models/custom`): librefang/librefang-registry#72

## Test plan
- [x] `cargo check -p librefang-llm-drivers --tests` — green
- [x] `cargo test -p librefang-llm-drivers --lib drivers::tests` — 30 passed (incl. `test_provider_defaults_novita`, `test_provider_defaults_novita_ai_alias`)
- [x] `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- [ ] Manual: configure `NOVITA_API_KEY` + `provider = "novita"` and send a chat through `/api/agents/{id}/message`