### PR TITLE
feat(api): SSE attach endpoint for multi-client session co-watching

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -55,6 +55,7 @@ use crate::types;
         routes::update_agent,
         routes::send_message,
         routes::send_message_stream,
+        routes::attach_session_stream,
         routes::get_agent_session,
         routes::list_agent_sessions,
         routes::create_agent_session,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -53,6 +53,10 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::post(send_message_stream),
         )
         .route(
+            "/agents/{id}/sessions/{session_id}/stream",
+            axum::routing::get(attach_session_stream),
+        )
+        .route(
             "/agents/{id}/session",
             axum::routing::get(get_agent_session),
         )
@@ -2167,6 +2171,177 @@ pub async fn send_message_stream(
     });
 
     Sse::new(sse_stream).into_response()
+}
+
+/// GET /api/agents/{id}/sessions/{session_id}/stream — attach to a session's
+/// in-flight stream events (SSE).
+///
+/// Any client can subscribe to the events emitted by an active turn on this
+/// session: the originating client (CLI, Tauri desktop, web) plus any number
+/// of additional clients. Late attachers begin receiving events from the
+/// moment they subscribe — partial-turn snapshots are not replayed.
+///
+/// Returns 404 if the session does not exist or belongs to a different agent.
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/sessions/{session_id}/stream",
+    tag = "agents",
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("session_id" = String, Path, description = "Session ID to attach to"),
+    ),
+    responses(
+        (status = 200, description = "Server-sent events stream of session events"),
+        (status = 400, description = "Invalid agent or session ID"),
+        (status = 404, description = "Agent or session not found")
+    )
+)]
+pub async fn attach_session_stream(
+    State(state): State<Arc<AppState>>,
+    Path((id, session_id_str)): Path<(String, String)>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> axum::response::Response {
+    use axum::response::sse::{Event, Sse};
+    use futures::stream;
+    use librefang_runtime::llm_driver::StreamEvent;
+    use tokio::sync::broadcast::error::RecvError;
+
+    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+
+    let agent_id: AgentId = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+            )
+                .into_response();
+        }
+    };
+
+    let session_id = match session_id_str.parse::<uuid::Uuid>() {
+        Ok(uuid) => librefang_types::agent::SessionId(uuid),
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": t.t("api-error-session-invalid-id")})),
+            )
+                .into_response();
+        }
+    };
+
+    let agent_entry = match state.kernel.agent_registry().get(agent_id) {
+        Some(e) => e,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+            )
+                .into_response();
+        }
+    };
+
+    // Validate the session belongs to this agent. Two acceptable shapes:
+    //   1. The session has been persisted (one or more turns ran) and its
+    //      `agent_id` matches the path agent.
+    //   2. The session has not been persisted yet (fresh agent, no turn yet)
+    //      but the id matches the agent's canonical `session_id` from the
+    //      registry. Sessions are written lazily on first turn, so requiring
+    //      a memory row would forbid attach-before-first-turn.
+    // Anything else is rejected — a caller cannot attach to an arbitrary
+    // session UUID without first proving the agent–session binding.
+    let session_lookup = state.kernel.memory_substrate().get_session(session_id);
+    let session_valid = match &session_lookup {
+        Ok(Some(s)) => s.agent_id == agent_id,
+        Ok(None) => agent_entry.session_id == session_id,
+        Err(_) => false,
+    };
+    if !session_valid {
+        if let Err(e) = session_lookup {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+                ),
+            )
+                .into_response();
+        }
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "session not found for this agent"
+            })),
+        )
+            .into_response();
+    }
+
+    let receiver = state.kernel.session_stream_hub().subscribe(session_id);
+
+    // Bridge broadcast::Receiver into an SSE stream. Skip Lagged events with
+    // a debug log (intentionally lossy semantics — see SessionStreamHub
+    // docs) and end the stream when the channel closes.
+    let sse_stream = stream::unfold(
+        (receiver, StreamDedup::new()),
+        |(mut rx, mut dedup)| async move {
+            loop {
+                let event = match rx.recv().await {
+                    Ok(ev) => ev,
+                    Err(RecvError::Lagged(n)) => {
+                        tracing::debug!(skipped = n, "session attach stream lagged, skipping");
+                        continue;
+                    }
+                    Err(RecvError::Closed) => return None,
+                };
+                let sse_event: Result<Event, std::convert::Infallible> = Ok(match event {
+                    StreamEvent::TextDelta { text } => {
+                        if dedup.is_duplicate(&text) {
+                            continue;
+                        }
+                        dedup.record_sent(&text);
+                        Event::default()
+                            .event("chunk")
+                            .json_data(serde_json::json!({"content": text, "done": false}))
+                            .unwrap_or_else(|_| Event::default().data("error"))
+                    }
+                    StreamEvent::ToolUseStart { name, .. } => Event::default()
+                        .event("tool_use")
+                        .json_data(serde_json::json!({"tool": name}))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::ToolUseEnd { name, input, .. } => Event::default()
+                        .event("tool_result")
+                        .json_data(serde_json::json!({"tool": name, "input": input}))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::ContentComplete { usage, .. } => Event::default()
+                        .event("done")
+                        .json_data(serde_json::json!({
+                            "done": true,
+                            "usage": {
+                                "input_tokens": usage.input_tokens,
+                                "output_tokens": usage.output_tokens,
+                            }
+                        }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::PhaseChange { phase, detail } => Event::default()
+                        .event("phase")
+                        .json_data(serde_json::json!({
+                            "phase": phase,
+                            "detail": detail,
+                        }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::OwnerNotice { text } => Event::default()
+                        .event("owner_notice")
+                        .json_data(serde_json::json!({ "text": text }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    _ => Event::default().comment("skip"),
+                });
+                return Some((sse_event, (rx, dedup)));
+            }
+        },
+    );
+
+    Sse::new(sse_stream)
+        .keep_alive(axum::response::sse::KeepAlive::default())
+        .into_response()
 }
 
 #[utoipa::path(

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1084,6 +1084,11 @@ pub async fn run_daemon(
     // `task_board.sweep_interval_secs` (default 30s).
     kernel.clone().spawn_task_board_sweep_task();
 
+    // Session stream hub idle GC — drops broadcast entries with no live
+    // receivers so the per-session sender map does not grow unbounded under
+    // churn (multi-client SSE attach, PR #3078).
+    kernel.clone().spawn_session_stream_hub_gc_task();
+
     // Config file hot-reload watcher (polls every 30 seconds).
     // Spawned after `build_router` so it can access `AppState` for bridge reload.
     {

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -141,6 +141,10 @@ async fn start_test_server_with_provider(
             axum::routing::get(routes::export_session_trajectory),
         )
         .route(
+            "/api/agents/{id}/sessions/{session_id}/stream",
+            axum::routing::get(routes::attach_session_stream),
+        )
+        .route(
             "/api/agents/{id}/metrics",
             axum::routing::get(routes::agent_metrics),
         )
@@ -1529,6 +1533,10 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
             axum::routing::get(routes::export_session_trajectory),
         )
         .route(
+            "/api/agents/{id}/sessions/{session_id}/stream",
+            axum::routing::get(routes::attach_session_stream),
+        )
+        .route(
             "/api/agents/{id}/metrics",
             axum::routing::get(routes::agent_metrics),
         )
@@ -2062,5 +2070,118 @@ async fn test_mcp_http_enforces_agent_tool_allowlist() {
     assert!(
         content.contains("Permission denied") || content.contains("capability"),
         "denial must mention permission/capability; got: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-client session attach (GET /api/agents/{id}/sessions/{sid}/stream)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_session_stream_404_for_unknown_agent() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    let bogus_agent = uuid::Uuid::new_v4();
+    let bogus_session = uuid::Uuid::new_v4();
+
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/sessions/{}/stream",
+            server.base_url, bogus_agent, bogus_session
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_attach_session_stream_fans_out_to_multiple_clients() {
+    use futures::StreamExt as _;
+    use librefang_runtime::llm_driver::StreamEvent;
+    use std::time::Duration;
+
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Spawn an agent (ollama, no LLM call needed).
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({ "manifest_toml": TEST_MANIFEST }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let agent_id_str = body["agent_id"].as_str().unwrap().to_string();
+    let agent_id: librefang_types::agent::AgentId = agent_id_str.parse().unwrap();
+
+    // Pull the agent's canonical session id from the registry — the attach
+    // route validates the session belongs to the agent.
+    let session_id = server
+        .state
+        .kernel
+        .agent_registry()
+        .get(agent_id)
+        .unwrap()
+        .session_id;
+
+    let url = format!(
+        "{}/api/agents/{}/sessions/{}/stream",
+        server.base_url, agent_id_str, session_id
+    );
+
+    // Helper that opens an SSE attach connection and reads until it sees a
+    // complete SSE frame (one `\n\n` boundary) or the timeout elapses. Returns
+    // the bytes accumulated so the test can assert on the published payload.
+    async fn read_first_frame(client: reqwest::Client, url: String) -> String {
+        let resp = client.get(url).send().await.unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        let mut buf: Vec<u8> = Vec::new();
+        let mut stream = resp.bytes_stream();
+        let _ = tokio::time::timeout(Duration::from_secs(2), async {
+            while let Some(Ok(chunk)) = stream.next().await {
+                buf.extend_from_slice(&chunk);
+                if buf.windows(2).any(|w| w == b"\n\n") {
+                    return;
+                }
+            }
+        })
+        .await;
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    let attacher_a = tokio::spawn(read_first_frame(client.clone(), url.clone()));
+    let attacher_b = tokio::spawn(read_first_frame(client.clone(), url.clone()));
+
+    // Wait briefly so both attachers have completed `subscribe()` inside the
+    // handler before we publish — broadcast is fire-and-forget for events
+    // that arrive with zero subscribers.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let hub = server.state.kernel.session_stream_hub();
+    let sender = hub.sender(session_id);
+    let receiver_count = sender
+        .send(StreamEvent::TextDelta {
+            text: "hello-multiattach".to_string(),
+        })
+        .expect("at least one receiver should be attached");
+    assert!(
+        receiver_count >= 2,
+        "expected both attachers to be subscribed before publish; got {receiver_count}"
+    );
+
+    let body_a = attacher_a.await.unwrap();
+    let body_b = attacher_b.await.unwrap();
+
+    assert!(
+        body_a.contains("hello-multiattach"),
+        "client A body should contain published event: {body_a}"
+    );
+    assert!(
+        body_b.contains("hello-multiattach"),
+        "client B body should contain published event: {body_b}"
     );
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2156,13 +2156,27 @@ async fn test_attach_session_stream_fans_out_to_multiple_clients() {
     let attacher_a = tokio::spawn(read_first_frame(client.clone(), url.clone()));
     let attacher_b = tokio::spawn(read_first_frame(client.clone(), url.clone()));
 
-    // Wait briefly so both attachers have completed `subscribe()` inside the
-    // handler before we publish — broadcast is fire-and-forget for events
-    // that arrive with zero subscribers.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
+    // Wait until both attachers have completed `subscribe()` inside the
+    // handler before publishing — broadcast is fire-and-forget for events
+    // that arrive with zero subscribers, so a sleep-based wait would be
+    // racy on slow CI. Poll receiver_count until it reaches 2.
     let hub = server.state.kernel.session_stream_hub();
     let sender = hub.sender(session_id);
+    let waited = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if sender.receiver_count() >= 2 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        waited.is_ok(),
+        "both attachers should subscribe within 5s; receiver_count={}",
+        sender.receiver_count()
+    );
+
     let receiver_count = sender
         .send(StreamEvent::TextDelta {
             text: "hello-multiattach".to_string(),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -307,6 +307,8 @@ pub struct LibreFangKernel {
     pub(crate) event_bus: EventBus,
     /// Session lifecycle event bus (push-based pub/sub for session-scoped events).
     pub(crate) session_lifecycle_bus: Arc<crate::session_lifecycle::SessionLifecycleBus>,
+    /// Per-session stream-event hub for multi-client SSE attach.
+    pub(crate) session_stream_hub: Arc<crate::session_stream_hub::SessionStreamHub>,
     /// Agent scheduler.
     pub(crate) scheduler: AgentScheduler,
     /// Memory substrate.
@@ -1635,6 +1637,15 @@ impl LibreFangKernel {
 }
 
 impl LibreFangKernel {
+    /// Per-session stream-event hub (multi-client SSE attach).
+    ///
+    /// API handlers use this to subscribe attaching clients to a session's
+    /// in-flight `StreamEvent` flow. Returns the shared `Arc` so subscribers
+    /// outlive any individual turn.
+    pub fn session_stream_hub(&self) -> Arc<crate::session_stream_hub::SessionStreamHub> {
+        Arc::clone(&self.session_stream_hub)
+    }
+
     /// Boot the kernel with configuration from the given path.
     pub fn boot(config_path: Option<&Path>) -> KernelResult<Self> {
         let config = load_config(config_path);
@@ -2643,6 +2654,7 @@ impl LibreFangKernel {
             session_lifecycle_bus: Arc::new(crate::session_lifecycle::SessionLifecycleBus::new(
                 256,
             )),
+            session_stream_hub: Arc::new(crate::session_stream_hub::SessionStreamHub::new()),
             scheduler: AgentScheduler::new(),
             memory: memory.clone(),
             proactive_memory: OnceLock::new(),
@@ -4961,7 +4973,12 @@ system_prompt = "You are a helpful assistant."
 
         // Non-LLM modules: execute non-streaming and emit results as stream events
         if is_wasm || is_python {
-            let (tx, rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+            // Fan out to the session hub so attached clients see the
+            // synthesized text delta + complete event for non-LLM agents too.
+            let (tx, rx) = crate::session_stream_hub::install_stream_fanout(
+                &self.session_stream_hub,
+                entry.session_id,
+            );
             let kernel_clone = Arc::clone(self);
             let message_owned = message.to_string();
             let entry_clone = entry.clone();
@@ -5128,7 +5145,10 @@ system_prompt = "You are a helpful assistant."
                 .filter(|w| *w > 0)
         });
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+        let (tx, rx) = crate::session_stream_hub::install_stream_fanout(
+            &self.session_stream_hub,
+            effective_session_id,
+        );
         let mut manifest = entry.manifest.clone();
 
         // Inject model_supports_tools for auto web search augmentation

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -479,6 +479,8 @@ pub struct LibreFangKernel {
     approval_sweep_started: AtomicBool,
     /// Idempotency guard for the task-board stuck-task sweeper (issue #2923).
     task_board_sweep_started: AtomicBool,
+    /// Idempotency guard for the session-stream-hub idle GC task.
+    session_stream_hub_gc_started: AtomicBool,
     /// Config reload barrier — write-locked during `apply_hot_actions_inner` to prevent
     /// concurrent readers from seeing a half-updated configuration (e.g. new provider
     /// URLs but old default model). Read-locked in message hot paths so multiple
@@ -1114,6 +1116,54 @@ impl LibreFangKernel {
                 .task_board_sweep_started
                 .store(false, Ordering::Release);
             tracing::debug!("Task board sweep task stopped");
+        });
+    }
+
+    /// Spawn the session-stream-hub idle GC loop.
+    ///
+    /// `SessionStreamHub` lazily creates a broadcast sender per session on
+    /// first publish or first attach. Without periodic pruning, the senders
+    /// map grows unbounded under churn (many short-lived sessions, many
+    /// reconnects). This task calls `gc_idle()` every 60s to drop entries
+    /// with zero live receivers.
+    ///
+    /// Idempotent: re-calling while already running is a no-op.
+    pub fn spawn_session_stream_hub_gc_task(self: Arc<Self>) {
+        let handle = tokio::runtime::Handle::current();
+        if self
+            .session_stream_hub_gc_started
+            .swap(true, Ordering::AcqRel)
+        {
+            debug!("Session stream hub GC task already running");
+            return;
+        }
+
+        let kernel = Arc::clone(&self);
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+
+        handle.spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            // Skip the immediate first tick — nothing to GC at boot.
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let pruned = kernel.session_stream_hub.gc_idle();
+                        if pruned > 0 {
+                            tracing::debug!(pruned, "Session stream hub GC pruned idle sessions");
+                        }
+                    }
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+            kernel
+                .session_stream_hub_gc_started
+                .store(false, Ordering::Release);
+            tracing::debug!("Session stream hub GC task stopped");
         });
     }
 
@@ -2737,6 +2787,7 @@ impl LibreFangKernel {
             budget_config: std::sync::RwLock::new(initial_budget),
             approval_sweep_started: AtomicBool::new(false),
             task_board_sweep_started: AtomicBool::new(false),
+            session_stream_hub_gc_started: AtomicBool::new(false),
             shutdown_tx: tokio::sync::watch::channel(false).0,
             checkpoint_manager: {
                 let cp_dir = checkpoint_base_dir

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -27,6 +27,7 @@ pub use librefang_kernel_router as router;
 pub mod scheduler;
 pub mod session_lifecycle;
 pub mod session_policy;
+pub mod session_stream_hub;
 pub mod supervisor;
 pub mod trajectory;
 pub mod triggers;

--- a/crates/librefang-kernel/src/session_stream_hub.rs
+++ b/crates/librefang-kernel/src/session_stream_hub.rs
@@ -1,0 +1,238 @@
+//! Session-scoped fan-out for in-turn `StreamEvent`s.
+//!
+//! The kernel's streaming entry point (`send_message_streaming_*`) creates a
+//! per-turn `mpsc::channel<StreamEvent>` between the agent loop (producer) and
+//! the HTTP/SSE handler that originally triggered the turn (consumer). That
+//! single-consumer channel is fine for the originating client, but it makes
+//! it impossible for any *other* client to observe the same turn — the
+//! desktop app cannot watch a conversation the CLI just kicked off, and a
+//! reconnecting browser tab cannot resume mid-turn.
+//!
+//! `SessionStreamHub` is a side-channel keyed by `SessionId`: a
+//! `tokio::sync::broadcast` sender per active session. The kernel installs a
+//! short forwarder task that drains the producer mpsc, fans each event out to
+//! both the original caller and the broadcast channel, so any number of late
+//! attachers can `subscribe()` and start receiving events from the moment
+//! they connect.
+//!
+//! Hub entries are created lazily on first send and pruned when no senders
+//! and no live receivers remain (`gc_idle`). Lossiness is intentional: a slow
+//! attacher lags rather than backpressuring the producer.
+
+use dashmap::DashMap;
+use librefang_llm_driver::StreamEvent;
+use librefang_types::agent::SessionId;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Buffer size for per-session broadcast channels.
+///
+/// Sized to absorb a few seconds of fast token streaming (Anthropic ~50 tok/s,
+/// Groq ~500 tok/s) without lag for typical attachers. Slow attachers that
+/// fall behind will see `RecvError::Lagged` and may resync from the next
+/// event — broadcast is intentionally lossy here.
+const SESSION_BROADCAST_CAPACITY: usize = 1024;
+
+/// Session-scoped event hub for multi-client SSE attach.
+#[derive(Debug)]
+pub struct SessionStreamHub {
+    senders: DashMap<SessionId, broadcast::Sender<StreamEvent>>,
+}
+
+impl SessionStreamHub {
+    pub fn new() -> Self {
+        Self {
+            senders: DashMap::new(),
+        }
+    }
+
+    /// Get (or create) the broadcast sender for a session.
+    ///
+    /// Always returns a sender — entries are created on first publish so that
+    /// late attachers can also call `subscribe(session_id)` before any turn
+    /// has run for that session and still receive future events.
+    pub fn sender(&self, session_id: SessionId) -> broadcast::Sender<StreamEvent> {
+        if let Some(existing) = self.senders.get(&session_id) {
+            return existing.clone();
+        }
+        let entry = self
+            .senders
+            .entry(session_id)
+            .or_insert_with(|| broadcast::channel(SESSION_BROADCAST_CAPACITY).0);
+        entry.clone()
+    }
+
+    /// Subscribe to events for a session. Creates an empty channel on demand
+    /// so attach calls before any producer has published still succeed.
+    pub fn subscribe(&self, session_id: SessionId) -> broadcast::Receiver<StreamEvent> {
+        self.sender(session_id).subscribe()
+    }
+
+    /// Drop entries with no active receivers — bounded memory under churn
+    /// (lots of one-shot sessions). Cheap to call periodically; safe to skip.
+    pub fn gc_idle(&self) -> usize {
+        let stale: Vec<SessionId> = self
+            .senders
+            .iter()
+            .filter(|e| e.value().receiver_count() == 0)
+            .map(|e| *e.key())
+            .collect();
+        let count = stale.len();
+        for id in stale {
+            // Re-check under the entry lock: a subscriber may have appeared
+            // between the snapshot above and this remove. DashMap's
+            // remove_if covers that race.
+            self.senders.remove_if(&id, |_, v| v.receiver_count() == 0);
+        }
+        count
+    }
+
+    /// Active session count (entries currently retained).
+    pub fn active_session_count(&self) -> usize {
+        self.senders.len()
+    }
+}
+
+impl Default for SessionStreamHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wire a producer mpsc through the hub: every event is broadcast to all
+/// session subscribers AND forwarded to the original caller.
+///
+/// Returns the producer sender (hand this to the agent loop) and the caller
+/// receiver (hand this back to the original HTTP/SSE handler). Spawns one
+/// short-lived forwarder task that exits when the producer side is dropped.
+///
+/// Backpressure semantics:
+/// - producer → forwarder mpsc(64): same as today, backpressures the loop.
+/// - forwarder → caller mpsc(64): same bound; if caller closes its receiver,
+///   send returns Err and the forwarder skips it (turn keeps running).
+/// - forwarder → broadcast: best-effort, drops on no-subscribers (Err) or on
+///   slow subscribers (handled inside broadcast). Never blocks the forwarder.
+pub fn install_stream_fanout(
+    hub: &Arc<SessionStreamHub>,
+    session_id: SessionId,
+) -> (
+    tokio::sync::mpsc::Sender<StreamEvent>,
+    tokio::sync::mpsc::Receiver<StreamEvent>,
+) {
+    let (producer_tx, mut producer_rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+    let (caller_tx, caller_rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+    let broadcast_tx = hub.sender(session_id);
+
+    tokio::spawn(async move {
+        while let Some(event) = producer_rx.recv().await {
+            // Best-effort fan-out to attached clients. `broadcast::send`
+            // returns Err only when there are zero receivers — fine, just
+            // means nobody is attached right now.
+            let _ = broadcast_tx.send(event.clone());
+            // Forward to the originating caller. If the caller dropped its
+            // receiver we keep draining the producer so the agent loop is
+            // never backpressured by an absent listener.
+            let _ = caller_tx.send(event).await;
+        }
+    });
+
+    (producer_tx, caller_rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use librefang_types::agent::AgentId;
+    use librefang_types::message::{StopReason, TokenUsage};
+
+    fn fresh_session() -> SessionId {
+        SessionId::for_channel(AgentId::new(), "test")
+    }
+
+    fn delta(t: &str) -> StreamEvent {
+        StreamEvent::TextDelta {
+            text: t.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn fanout_forwards_to_both_caller_and_subscriber() {
+        let hub = Arc::new(SessionStreamHub::new());
+        let session = fresh_session();
+        let (producer_tx, mut caller_rx) = install_stream_fanout(&hub, session);
+        let mut subscriber = hub.subscribe(session);
+
+        producer_tx.send(delta("hi")).await.unwrap();
+        producer_tx.send(delta("there")).await.unwrap();
+        drop(producer_tx);
+
+        // Caller side gets both events in order.
+        let a = caller_rx.recv().await.unwrap();
+        let b = caller_rx.recv().await.unwrap();
+        assert!(matches!(a, StreamEvent::TextDelta { text } if text == "hi"));
+        assert!(matches!(b, StreamEvent::TextDelta { text } if text == "there"));
+        assert!(
+            caller_rx.recv().await.is_none(),
+            "caller stream should close"
+        );
+
+        // Subscriber receives the same sequence.
+        let s1 = subscriber.recv().await.unwrap();
+        let s2 = subscriber.recv().await.unwrap();
+        assert!(matches!(s1, StreamEvent::TextDelta { text } if text == "hi"));
+        assert!(matches!(s2, StreamEvent::TextDelta { text } if text == "there"));
+    }
+
+    #[tokio::test]
+    async fn caller_drop_does_not_stall_broadcast() {
+        let hub = Arc::new(SessionStreamHub::new());
+        let session = fresh_session();
+        let (producer_tx, caller_rx) = install_stream_fanout(&hub, session);
+        let mut subscriber = hub.subscribe(session);
+
+        // Originating caller hangs up immediately.
+        drop(caller_rx);
+
+        // Producer can still send — forwarder must keep draining and broadcasting.
+        producer_tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        let received = subscriber.recv().await.unwrap();
+        assert!(matches!(received, StreamEvent::ContentComplete { .. }));
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_each_get_full_stream() {
+        let hub = Arc::new(SessionStreamHub::new());
+        let session = fresh_session();
+        // Subscribe before any producer exists — empty channel preallocated.
+        let mut a = hub.subscribe(session);
+        let mut b = hub.subscribe(session);
+        let (producer_tx, mut caller_rx) = install_stream_fanout(&hub, session);
+
+        producer_tx.send(delta("x")).await.unwrap();
+        drop(producer_tx);
+
+        for sub in [&mut a, &mut b] {
+            let ev = sub.recv().await.unwrap();
+            assert!(matches!(ev, StreamEvent::TextDelta { text } if text == "x"));
+        }
+        let _ = caller_rx.recv().await;
+    }
+
+    #[tokio::test]
+    async fn gc_idle_drops_unsubscribed_sessions() {
+        let hub = Arc::new(SessionStreamHub::new());
+        let session = fresh_session();
+        // Touch the session so an entry exists.
+        let _ = hub.sender(session);
+        assert_eq!(hub.active_session_count(), 1);
+        let pruned = hub.gc_idle();
+        assert_eq!(pruned, 1);
+        assert_eq!(hub.active_session_count(), 0);
+    }
+}

--- a/crates/librefang-kernel/src/session_stream_hub.rs
+++ b/crates/librefang-kernel/src/session_stream_hub.rs
@@ -10,14 +10,15 @@
 //!
 //! `SessionStreamHub` is a side-channel keyed by `SessionId`: a
 //! `tokio::sync::broadcast` sender per active session. The kernel installs a
-//! short forwarder task that drains the producer mpsc, fans each event out to
-//! both the original caller and the broadcast channel, so any number of late
-//! attachers can `subscribe()` and start receiving events from the moment
-//! they connect.
+//! short forwarder task that drains the producer mpsc, fans each event out
+//! to both the original caller (via a non-blocking `try_send`) and the
+//! broadcast channel. Any number of late attachers can `subscribe()` and
+//! start receiving events from the moment they connect.
 //!
-//! Hub entries are created lazily on first send and pruned when no senders
-//! and no live receivers remain (`gc_idle`). Lossiness is intentional: a slow
-//! attacher lags rather than backpressuring the producer.
+//! Hub entries are created lazily on first publish or first subscribe and
+//! pruned when no live receivers remain (`gc_idle`). Lossiness is intentional:
+//! a slow attacher (including the originating caller) lags rather than
+//! backpressuring the producer or starving other attachers.
 
 use dashmap::DashMap;
 use librefang_llm_driver::StreamEvent;
@@ -100,18 +101,23 @@ impl Default for SessionStreamHub {
 }
 
 /// Wire a producer mpsc through the hub: every event is broadcast to all
-/// session subscribers AND forwarded to the original caller.
+/// session subscribers AND queued non-blocking to the originating caller.
 ///
 /// Returns the producer sender (hand this to the agent loop) and the caller
 /// receiver (hand this back to the original HTTP/SSE handler). Spawns one
-/// short-lived forwarder task that exits when the producer side is dropped.
+/// short-lived forwarder task that exits when the producer side is dropped,
+/// which in turn drops the caller sender so the SSE handler's stream ends
+/// naturally.
 ///
 /// Backpressure semantics:
-/// - producer → forwarder mpsc(64): same as today, backpressures the loop.
-/// - forwarder → caller mpsc(64): same bound; if caller closes its receiver,
-///   send returns Err and the forwarder skips it (turn keeps running).
-/// - forwarder → broadcast: best-effort, drops on no-subscribers (Err) or on
-///   slow subscribers (handled inside broadcast). Never blocks the forwarder.
+/// - producer → forwarder mpsc(64): same as before; backpressures the agent
+///   loop only if the forwarder itself stalls (it never does).
+/// - forwarder → caller mpsc(SESSION_BROADCAST_CAPACITY): try_send only —
+///   a slow CLI/desktop falls behind by at worst the buffer size before
+///   drops begin. Crucially, the forwarder never awaits on the caller, so
+///   one slow client cannot choke broadcast subscribers or the agent loop.
+/// - forwarder → broadcast: synchronous, never blocks. Broadcast handles
+///   slow attachers internally with `Lagged`.
 pub fn install_stream_fanout(
     hub: &Arc<SessionStreamHub>,
     session_id: SessionId,
@@ -119,8 +125,11 @@ pub fn install_stream_fanout(
     tokio::sync::mpsc::Sender<StreamEvent>,
     tokio::sync::mpsc::Receiver<StreamEvent>,
 ) {
+    use tokio::sync::mpsc::error::TrySendError;
+
     let (producer_tx, mut producer_rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
-    let (caller_tx, caller_rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
+    let (caller_tx, caller_rx) =
+        tokio::sync::mpsc::channel::<StreamEvent>(SESSION_BROADCAST_CAPACITY);
     let broadcast_tx = hub.sender(session_id);
 
     tokio::spawn(async move {
@@ -129,10 +138,18 @@ pub fn install_stream_fanout(
             // returns Err only when there are zero receivers — fine, just
             // means nobody is attached right now.
             let _ = broadcast_tx.send(event.clone());
-            // Forward to the originating caller. If the caller dropped its
-            // receiver we keep draining the producer so the agent loop is
-            // never backpressured by an absent listener.
-            let _ = caller_tx.send(event).await;
+            // Non-blocking forward to the originating caller. If the caller
+            // dropped its receiver or fell behind by the full buffer, drop
+            // the event rather than awaiting — keeps the forwarder loop and
+            // hence the agent loop unblocked.
+            match caller_tx.try_send(event) {
+                Ok(()) | Err(TrySendError::Closed(_)) => {}
+                Err(TrySendError::Full(_)) => {
+                    tracing::debug!(
+                        "originating caller queue full; dropping event from originating client (broadcast subscribers unaffected)"
+                    );
+                }
+            }
         }
     });
 

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -264,6 +264,44 @@ impl SessionId {
             name.as_bytes(),
         ))
     }
+
+    /// Derive a session ID from a structured (channel, account, conversation) key.
+    ///
+    /// Backward compatible with `for_channel`: when `account` is empty, the
+    /// resulting id is identical to `for_channel(agent, channel)` if
+    /// `conversation` is also empty, or to `for_channel(agent, format!("{channel}:{conversation}"))`
+    /// when only `conversation` is set. This preserves existing session ids for
+    /// channels that never carried an account dimension.
+    ///
+    /// When `account` is non-empty, a `v2:` byte prefix is mixed in so the
+    /// hash space is disjoint from the legacy format — avoids collisions even
+    /// if a real channel/account ever lines up textually with a legacy scope.
+    pub fn from_route_key(
+        agent_id: AgentId,
+        channel: &str,
+        account: &str,
+        conversation: &str,
+    ) -> Self {
+        if account.is_empty() {
+            let scope = if conversation.is_empty() {
+                channel.to_string()
+            } else {
+                format!("{channel}:{conversation}")
+            };
+            return Self::for_channel(agent_id, &scope);
+        }
+        let name = format!(
+            "v2:{}:{}:{}:{}",
+            agent_id.0,
+            channel.to_lowercase(),
+            account.to_lowercase(),
+            conversation.to_lowercase()
+        );
+        Self(uuid::Uuid::new_v5(
+            &CHANNEL_SESSION_NAMESPACE,
+            name.as_bytes(),
+        ))
+    }
 }
 
 impl std::str::FromStr for SessionId {
@@ -2046,5 +2084,55 @@ model = "llama-3.3-70b-versatile"
         let persistent = SessionId::for_channel(agent, "cron");
         let isolated = SessionId::for_cron_run(agent, "cron");
         assert_ne!(persistent, isolated);
+    }
+
+    #[test]
+    fn from_route_key_empty_account_matches_for_channel() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        // Plain channel, no conversation: must equal for_channel(agent, channel).
+        assert_eq!(
+            SessionId::from_route_key(agent, "telegram", "", ""),
+            SessionId::for_channel(agent, "telegram"),
+        );
+        // Channel + conversation, empty account: must equal for_channel(agent, "channel:conv")
+        // — preserves legacy `format!("{channel}:{chat_id}")` scope.
+        assert_eq!(
+            SessionId::from_route_key(agent, "telegram", "", "12345"),
+            SessionId::for_channel(agent, "telegram:12345"),
+        );
+    }
+
+    #[test]
+    fn from_route_key_separates_accounts() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let alice = SessionId::from_route_key(agent, "telegram", "alice", "12345");
+        let bob = SessionId::from_route_key(agent, "telegram", "bob", "12345");
+        assert_ne!(
+            alice, bob,
+            "Different accounts on same channel+conversation must yield different sessions"
+        );
+        // And neither should collide with the legacy account-less id.
+        let legacy = SessionId::from_route_key(agent, "telegram", "", "12345");
+        assert_ne!(alice, legacy);
+        assert_ne!(bob, legacy);
+    }
+
+    #[test]
+    fn from_route_key_normalizes_case() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let mixed = SessionId::from_route_key(agent, "Telegram", "Alice", "ABC");
+        let lower = SessionId::from_route_key(agent, "telegram", "alice", "abc");
+        assert_eq!(
+            mixed, lower,
+            "channel/account/conversation must be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn from_route_key_deterministic() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let a = SessionId::from_route_key(agent, "matrix", "alice@example.org", "!room:server");
+        let b = SessionId::from_route_key(agent, "matrix", "alice@example.org", "!room:server");
+        assert_eq!(a, b);
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1537,6 +1537,47 @@
         }
       }
     },
+    "/api/agents/{id}/sessions/{session_id}/stream": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /api/agents/{id}/sessions/{session_id}/stream — attach to a session's\nin-flight stream events (SSE).",
+        "description": "Any client can subscribe to the events emitted by an active turn on this\nsession: the originating client (CLI, Tauri desktop, web) plus any number\nof additional clients. Late attachers begin receiving events from the\nmoment they subscribe — partial-turn snapshots are not replayed.\n\nReturns 404 if the session does not exist or belongs to a different agent.",
+        "operationId": "attach_session_stream",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID to attach to",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-sent events stream of session events"
+          },
+          "400": {
+            "description": "Invalid agent or session ID"
+          },
+          "404": {
+            "description": "Agent or session not found"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/sessions/{session_id}/switch": {
       "post": {
         "tags": [

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -396,6 +396,10 @@ func (r *AgentsResource) ExportSession(id string, session_id string) (interface{
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/sessions/%s/export", id, session_id), nil, nil)
 }
 
+func (r *AgentsResource) AttachSessionStream(id string, session_id string) <-chan map[string]interface{} {
+	return r.client.stream("GET", fmt.Sprintf("/api/agents/%s/sessions/%s/stream", id, session_id), nil, nil)
+}
+
 func (r *AgentsResource) SwitchAgentSession(id string, session_id string) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/sessions/%s/switch", id, session_id), nil, nil)
 }

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -264,6 +264,10 @@ class AgentsResource {
     return this._c._request("GET", `/api/agents/${id}/sessions/${session_id}/export`);
   }
 
+  async *attachSessionStream(id, session_id) {
+    yield* this._c._stream("GET", `/api/agents/${id}/sessions/${session_id}/stream`);
+  }
+
   async switchAgentSession(id, session_id) {
     return this._c._request("POST", `/api/agents/${id}/sessions/${session_id}/switch`);
   }

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -240,6 +240,9 @@ class _AgentsResource(_Resource):
     def export_session(self, id: str, session_id: str):
         return self._c._request("GET", f"/api/agents/{id}/sessions/{session_id}/export")
 
+    def attach_session_stream(self, id: str, session_id: str) -> Generator[Dict, None, None]:
+        return self._c._stream("GET", f"/api/agents/{id}/sessions/{session_id}/stream")
+
     def switch_agent_session(self, id: str, session_id: str):
         return self._c._request("POST", f"/api/agents/{id}/sessions/{session_id}/switch")
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -372,6 +372,10 @@ impl AgentsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/export", id, session_id), None, &[]).await
     }
 
+    pub fn attach_session_stream(&self, id: &str, session_id: &str) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
+        do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/sessions/{}/stream", id, session_id), reqwest::Method::GET, None, Vec::new())
+    }
+
     pub async fn switch_agent_session(&self, id: &str, session_id: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/switch", id, session_id), None, &[]).await
     }


### PR DESCRIPTION
## Summary

- Five client surfaces (CLI / Tauri desktop on Win/Linux/macOS / web) all talked to the daemon over HTTP+SSE, but \`POST /agents/{id}/message/stream\` is single-consumer mpsc — only the originating client could watch a turn. Starting a conversation in the CLI made it invisible to the desktop or any other browser tab.
- Add a per-session **\`SessionStreamHub\`** (\`tokio::sync::broadcast\` per \`SessionId\`) plus a side-channel forwarder that tees every produced \`StreamEvent\` to both the original caller and any number of additional subscribers.
- Expose attach via **\`GET /api/agents/{id}/sessions/{session_id}/stream\`** — late attachers begin receiving events from the moment they connect. Lossy by design: a slow attacher lags rather than backpressuring the agent loop.
- Bonus: \`SessionId::from_route_key(agent, channel, account, conversation)\` for multi-account routing. Backward-compatible — when \`account\` is empty the hash falls through to \`for_channel\`'s existing UUID v5 input bytes, so no existing session id changes. New \`v2:\` prefix is mixed in only when account is non-empty, keeping hash spaces disjoint.

## Why

Inspired by openclaw's persistent-bindings pattern. The right takeaway from their ACP design wasn't \"do a custom protocol\" — librefang's HTTP+SSE is fine — it was \"sessions need to be persistent state with multi-attach, not per-request mpsc.\"

## Validation

- 4 \`SessionId::from_route_key\` unit tests (back-compat with \`for_channel\`, account separation, case-normalization, determinism)
- 4 \`SessionStreamHub\` unit tests (fan-out, caller-drop resilience, multi-subscriber, gc)
- 2 reqwest integration tests in \`api_integration_test.rs\`:
  - 404 path for unknown agent/session
  - Two clients attached to the same session both receive a published \`TextDelta\`
- \`cargo build --workspace --lib\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- \`cargo test --workspace\` — all related tests green; 3 pre-existing \`model_catalog\` test failures (\`test_codex_aliases\`, \`test_codex_models_under_openai\`, \`detect_auth_does_not_promote_api_providers_from_cli_login\`) reproduce on \`origin/main\` and are unrelated to this PR
- Live integration smoke against \`./target/debug/librefang start\`:
  - bogus agent → 404
  - bogus session → 404
  - valid attach → 200 OK + \`content-type: text/event-stream\`

## Security note

The route 404s unless the session is either persisted with a matching \`agent_id\` or matches the agent's canonical \`session_id\` from the registry. Without this, anyone could subscribe to any session UUID — broadcast hubs are keyed by SessionId alone, so the route is the only authorization gate.

## Test plan

- [x] cargo build --workspace --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace (related tests; pre-existing codex failures unrelated)
- [x] reqwest integration test exercises full HTTP+SSE handler via real listener
- [x] Live curl smoke against debug binary