### PR TITLE
feat(web-search): add SearXNG self-hosted search provider

### DIFF
--- a/crates/librefang-api/tests/config_schema_golden.rs
+++ b/crates/librefang-api/tests/config_schema_golden.rs
@@ -101,10 +101,13 @@ fn kernel_config_schema_matches_golden_fixture() {
     if canon(&actual) != canon(&expected) {
         let actual_lines = actual.lines().count();
         let expected_lines = expected.lines().count();
-        // Print the full actual schema between machine-parseable markers so
-        // the new fixture can be lifted out of the CI log when running
-        // `cargo test --ignored regenerate_golden` is impractical (e.g. on
-        // sandboxed dev environments). Removed once the fixture is updated.
+        // Print the full actual schema base64-encoded between markers so the
+        // new fixture can be lifted out of the CI log. GitHub Actions secret
+        // masking rewrites `Authorization: <token>` into `Authorization: ***`,
+        // which corrupts raw JSON; base64 sidesteps that. Removed once the
+        // fixture is updated.
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(actual.as_bytes());
         panic!(
             "KernelConfig schema drifted from golden fixture.\n\
              actual: {actual_lines} lines / {} bytes\n\
@@ -115,9 +118,9 @@ fn kernel_config_schema_matches_golden_fixture() {
              \tcargo test -p librefang-api --test config_schema_golden \\\n\
              \t\t-- --ignored regenerate_golden --nocapture\n\
              \n\
-             ===BEGIN_ACTUAL_SCHEMA===\n\
-             {actual}\n\
-             ===END_ACTUAL_SCHEMA===\n",
+             ===BEGIN_ACTUAL_SCHEMA_B64===\n\
+             {b64}\n\
+             ===END_ACTUAL_SCHEMA_B64===\n",
             actual.len(),
             expected.len(),
         );

--- a/crates/librefang-api/tests/config_schema_golden.rs
+++ b/crates/librefang-api/tests/config_schema_golden.rs
@@ -101,13 +101,6 @@ fn kernel_config_schema_matches_golden_fixture() {
     if canon(&actual) != canon(&expected) {
         let actual_lines = actual.lines().count();
         let expected_lines = expected.lines().count();
-        // Print the full actual schema base64-encoded between markers so the
-        // new fixture can be lifted out of the CI log. GitHub Actions secret
-        // masking rewrites `Authorization: <token>` into `Authorization: ***`,
-        // which corrupts raw JSON; base64 sidesteps that. Removed once the
-        // fixture is updated.
-        use base64::Engine as _;
-        let b64 = base64::engine::general_purpose::STANDARD.encode(actual.as_bytes());
         panic!(
             "KernelConfig schema drifted from golden fixture.\n\
              actual: {actual_lines} lines / {} bytes\n\
@@ -116,13 +109,9 @@ fn kernel_config_schema_matches_golden_fixture() {
              Review the schema diff. If the change is intentional, regenerate:\n\
              \n\
              \tcargo test -p librefang-api --test config_schema_golden \\\n\
-             \t\t-- --ignored regenerate_golden --nocapture\n\
-             \n\
-             ===BEGIN_ACTUAL_SCHEMA_B64===\n\
-             {b64}\n\
-             ===END_ACTUAL_SCHEMA_B64===\n",
+             \t\t-- --ignored regenerate_golden --nocapture\n",
             actual.len(),
-            expected.len(),
+            expected.len()
         );
     }
 }

--- a/crates/librefang-api/tests/config_schema_golden.rs
+++ b/crates/librefang-api/tests/config_schema_golden.rs
@@ -101,6 +101,10 @@ fn kernel_config_schema_matches_golden_fixture() {
     if canon(&actual) != canon(&expected) {
         let actual_lines = actual.lines().count();
         let expected_lines = expected.lines().count();
+        // Print the full actual schema between machine-parseable markers so
+        // the new fixture can be lifted out of the CI log when running
+        // `cargo test --ignored regenerate_golden` is impractical (e.g. on
+        // sandboxed dev environments). Removed once the fixture is updated.
         panic!(
             "KernelConfig schema drifted from golden fixture.\n\
              actual: {actual_lines} lines / {} bytes\n\
@@ -109,9 +113,13 @@ fn kernel_config_schema_matches_golden_fixture() {
              Review the schema diff. If the change is intentional, regenerate:\n\
              \n\
              \tcargo test -p librefang-api --test config_schema_golden \\\n\
-             \t\t-- --ignored regenerate_golden --nocapture\n",
+             \t\t-- --ignored regenerate_golden --nocapture\n\
+             \n\
+             ===BEGIN_ACTUAL_SCHEMA===\n\
+             {actual}\n\
+             ===END_ACTUAL_SCHEMA===\n",
             actual.len(),
-            expected.len()
+            expected.len(),
         );
     }
 }

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -10408,13 +10408,31 @@
           "type": "string"
         },
         {
-          "description": "Auto-select based on available API keys (Tavily → Brave → Jina → Perplexity → DuckDuckGo).",
+          "description": "SearXNG self-hosted search (no API key needed).",
+          "enum": [
+            "searxng"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Auto-select based on available API keys (Tavily → Brave → Jina → Perplexity → Searxng → DuckDuckGo).",
           "enum": [
             "auto"
           ],
           "type": "string"
         }
       ]
+    },
+    "SearxngSearchConfig": {
+      "description": "SearXNG self-hosted search configuration.\n\nRequires only a `url`; SearXNG public instances reject `limit` and the LLM-facing `max_results` is taken from the per-call `tool_args` (the runtime truncates client-side after fetching).",
+      "properties": {
+        "url": {
+          "default": "",
+          "description": "Base URL of the SearXNG instance (e.g., \"https://search.example.com\"). Empty means the provider is disabled.",
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "SecondFactor": {
       "description": "Second-factor verification scope.\n\nControls where TOTP verification is enforced: - `Totp` = approvals only (backward-compatible default when TOTP is enabled) - `Login` = dashboard login only - `Both` = approvals + dashboard login",
@@ -12423,6 +12441,17 @@
           "default": "auto",
           "description": "Which search provider to use."
         },
+        "searxng": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SearxngSearchConfig"
+            }
+          ],
+          "default": {
+            "url": ""
+          },
+          "description": "SearXNG self-hosted search configuration."
+        },
         "tavily": {
           "allOf": [
             {
@@ -14219,6 +14248,9 @@
           "model": "sonar"
         },
         "search_provider": "auto",
+        "searxng": {
+          "url": ""
+        },
         "tavily": {
           "api_key_env": "TAVILY_API_KEY",
           "include_answer": true,

--- a/crates/librefang-runtime/src/web_search.rs
+++ b/crates/librefang-runtime/src/web_search.rs
@@ -79,6 +79,7 @@ impl WebSearchEngine {
             SearchProvider::Jina => self.search_jina(query, max_results).await,
             SearchProvider::Perplexity => self.search_perplexity(query).await,
             SearchProvider::DuckDuckGo => self.search_duckduckgo(query, max_results).await,
+            SearchProvider::Searxng => self.search_searxng(query, max_results, None, 1).await,
             SearchProvider::Auto => self.search_auto(query, max_results).await,
         };
 
@@ -91,7 +92,7 @@ impl WebSearchEngine {
     }
 
     /// Auto-select provider based on available API keys.
-    /// Priority: Tavily → Brave → Jina → Perplexity → DuckDuckGo
+    /// Priority: Tavily → Brave → Jina → Perplexity → Searxng → DuckDuckGo
     async fn search_auto(&self, query: &str, max_results: usize) -> Result<String, String> {
         // Tavily first (AI-agent-native)
         if resolve_api_key(&self.config.tavily.api_key_env).is_some() {
@@ -133,13 +134,22 @@ impl WebSearchEngine {
             }
         }
 
+        // Searxng fifth (self-hosted, requires only a URL — no API key)
+        if !self.config.searxng.url.is_empty() {
+            debug!("Auto: trying Searxng");
+            match self.search_searxng(query, max_results, None, 1).await {
+                Ok(result) => return Ok(result),
+                Err(e) => warn!("Searxng failed, falling back: {e}"),
+            }
+        }
+
         // DuckDuckGo as zero-config fallback — but it often gets captcha-blocked,
         // so treat it as best-effort and surface the last upstream error if it also
         // fails, giving the user a more actionable message.
         debug!("Auto: falling back to DuckDuckGo");
         match self.search_duckduckgo(query, max_results).await {
             Ok(result) if !result.trim().is_empty() => Ok(result),
-            Ok(_) => Err("All search providers failed; DuckDuckGo returned empty results (likely captcha-blocked). Configure a Brave, Tavily, Jina, or Perplexity API key for reliable search.".to_string()),
+            Ok(_) => Err("All search providers failed; DuckDuckGo returned empty results (likely captcha-blocked). Configure a Brave, Tavily, Jina, Perplexity, or SearXNG provider for reliable search.".to_string()),
             Err(e) => Err(format!("All search providers exhausted. Last error (DuckDuckGo): {e}")),
         }
     }
@@ -489,6 +499,145 @@ impl WebSearchEngine {
 
         Ok(output)
     }
+
+    /// Search via a self-hosted SearXNG instance.
+    ///
+    /// SearXNG public instances reject the upstream `limit` query param, so we
+    /// fetch a full page and truncate client-side. `category` defaults to
+    /// "general" and is validated against the instance's `/config` endpoint
+    /// (mismatches return an error so the LLM can pick a valid category on
+    /// retry). `page` is 1-based and forwarded as the `pageno` SearXNG param.
+    async fn search_searxng(
+        &self,
+        query: &str,
+        max_results: usize,
+        category: Option<&str>,
+        page: u32,
+    ) -> Result<String, String> {
+        if self.config.searxng.url.is_empty() {
+            return Err("SearXNG URL is not configured".to_string());
+        }
+
+        let category = category.unwrap_or("general");
+
+        // Validate category against the instance — fail fast with the available
+        // list so the agent can correct itself; treat connectivity errors as
+        // non-fatal (validation is best-effort, the search request itself will
+        // surface the real failure).
+        match self.list_searxng_categories().await {
+            Ok(cats) => {
+                if !cats.iter().any(|c| c == category) {
+                    return Err(format!(
+                        "Invalid SearXNG category '{}'. Available: {}",
+                        category,
+                        cats.join(", ")
+                    ));
+                }
+            }
+            Err(e) => warn!("Could not validate SearXNG category: {e}"),
+        }
+
+        debug!(query, category, page, "Searching via SearXNG");
+
+        let page_str = page.to_string();
+        let resp = self
+            .client
+            .get(format!(
+                "{}/search",
+                self.config.searxng.url.trim_end_matches('/')
+            ))
+            .query(&[
+                ("q", query),
+                ("format", "json"),
+                ("categories", category),
+                ("pageno", page_str.as_str()),
+            ])
+            .header("User-Agent", "Mozilla/5.0 (compatible; LibreFangAgent/0.1)")
+            .send()
+            .await
+            .map_err(|e| format!("SearXNG request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            return Err(format!("SearXNG API returned {}", resp.status()));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct SearxngResponse {
+            results: Vec<SearxngResult>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct SearxngResult {
+            url: String,
+            title: String,
+            content: Option<String>,
+            #[serde(alias = "pubdate")]
+            published_date: Option<String>,
+        }
+
+        let data: SearxngResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("SearXNG JSON parse failed: {e}"))?;
+
+        if data.results.is_empty() {
+            return Err(format!("No results found for '{query}' (SearXNG)."));
+        }
+
+        let mut output = format!("Search results for '{query}' (SearXNG):\n\n");
+        for (i, r) in data.results.iter().take(max_results).enumerate() {
+            let content = r.content.as_deref().unwrap_or("");
+            output.push_str(&format!("{}. {}\n   URL: {}\n", i + 1, r.title, r.url));
+            if !content.is_empty() {
+                output.push_str(&format!("   {content}\n"));
+            }
+            if let Some(date) = &r.published_date {
+                output.push_str(&format!("   Published: {date}\n"));
+            }
+            output.push('\n');
+        }
+
+        Ok(wrap_external_content("searxng-search", &output))
+    }
+
+    /// List available search categories from the configured SearXNG instance.
+    ///
+    /// Fetches the `/config` endpoint and returns the categories the instance
+    /// supports (e.g. "general", "images", "news", "videos"). Used both by
+    /// `search_searxng` for category validation and as a discovery hook for
+    /// agents that want to know what's available before issuing a query.
+    pub async fn list_searxng_categories(&self) -> Result<Vec<String>, String> {
+        if self.config.searxng.url.is_empty() {
+            return Err("SearXNG URL is not configured".to_string());
+        }
+
+        #[derive(serde::Deserialize)]
+        struct SearxngConfig {
+            categories: Vec<String>,
+        }
+
+        let resp = self
+            .client
+            .get(format!(
+                "{}/config",
+                self.config.searxng.url.trim_end_matches('/')
+            ))
+            .header("User-Agent", "Mozilla/5.0 (compatible; LibreFangAgent/0.1)")
+            .send()
+            .await
+            .map_err(|e| format!("SearXNG config request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            return Err(format!("SearXNG config API returned {}", resp.status()));
+        }
+
+        let data: SearxngConfig = resp
+            .json()
+            .await
+            .map_err(|e| format!("SearXNG config JSON parse failed: {e}"))?;
+
+        Ok(data.categories)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -810,5 +959,88 @@ mod tests {
         assert_eq!(config.web.jina.max_results, 3);
         // Perplexity should keep its default
         assert_eq!(config.web.perplexity.api_key_env, "PERPLEXITY_API_KEY");
+    }
+
+    // ── SearXNG provider tests ───────────────────────────────
+
+    #[test]
+    fn test_searxng_config_default_url_empty() {
+        let config = librefang_types::config::SearxngSearchConfig::default();
+        assert!(
+            config.url.is_empty(),
+            "SearXNG defaults to disabled (empty URL) so users opt in explicitly"
+        );
+    }
+
+    #[test]
+    fn test_searxng_search_provider_serde_json() {
+        let provider = librefang_types::config::SearchProvider::Searxng;
+        let json = serde_json::to_string(&provider).unwrap();
+        assert_eq!(json, "\"searxng\"");
+        let back: librefang_types::config::SearchProvider = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, librefang_types::config::SearchProvider::Searxng);
+    }
+
+    #[test]
+    fn test_searxng_config_toml_full_roundtrip() {
+        let toml_str = r#"
+            [web]
+            search_provider = "searxng"
+            [web.searxng]
+            url = "https://search.example.com"
+        "#;
+        let config: librefang_types::config::KernelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.web.search_provider,
+            librefang_types::config::SearchProvider::Searxng
+        );
+        assert_eq!(config.web.searxng.url, "https://search.example.com");
+    }
+
+    #[test]
+    fn test_searxng_config_toml_partial_uses_defaults() {
+        let toml_str = r#"
+            [web]
+            search_provider = "searxng"
+        "#;
+        let config: librefang_types::config::KernelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.web.search_provider,
+            librefang_types::config::SearchProvider::Searxng
+        );
+        assert!(config.web.searxng.url.is_empty());
+    }
+
+    #[test]
+    fn test_web_config_default_includes_searxng() {
+        let config = librefang_types::config::WebConfig::default();
+        assert!(config.searxng.url.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_searxng_unconfigured_url_errors() {
+        let config = librefang_types::config::WebConfig::default();
+        let cache = std::sync::Arc::new(crate::web_cache::WebCache::new(std::time::Duration::ZERO));
+        let engine = WebSearchEngine::new(config, cache, Vec::new());
+        let err = engine
+            .search_searxng("test", 5, None, 1)
+            .await
+            .expect_err("empty SearXNG URL must fail");
+        assert!(
+            err.contains("SearXNG URL is not configured"),
+            "expected configuration error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_searxng_categories_unconfigured_url_errors() {
+        let config = librefang_types::config::WebConfig::default();
+        let cache = std::sync::Arc::new(crate::web_cache::WebCache::new(std::time::Duration::ZERO));
+        let engine = WebSearchEngine::new(config, cache, Vec::new());
+        let err = engine
+            .list_searxng_categories()
+            .await
+            .expect_err("empty SearXNG URL must fail");
+        assert!(err.contains("SearXNG URL is not configured"));
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -342,7 +342,10 @@ pub enum SearchProvider {
     Jina,
     /// DuckDuckGo HTML (no API key needed).
     DuckDuckGo,
-    /// Auto-select based on available API keys (Tavily → Brave → Jina → Perplexity → DuckDuckGo).
+    /// SearXNG self-hosted search (no API key needed).
+    Searxng,
+    /// Auto-select based on available API keys
+    /// (Tavily → Brave → Jina → Perplexity → Searxng → DuckDuckGo).
     #[default]
     Auto,
 }
@@ -367,6 +370,8 @@ pub struct WebConfig {
     pub perplexity: PerplexitySearchConfig,
     /// Jina Search configuration.
     pub jina: JinaSearchConfig,
+    /// SearXNG self-hosted search configuration.
+    pub searxng: SearxngSearchConfig,
     /// Web fetch configuration.
     pub fetch: WebFetchConfig,
 }
@@ -385,6 +390,7 @@ impl Default for WebConfig {
             tavily: TavilySearchConfig::default(),
             perplexity: PerplexitySearchConfig::default(),
             jina: JinaSearchConfig::default(),
+            searxng: SearxngSearchConfig::default(),
             fetch: WebFetchConfig::default(),
         }
     }
@@ -491,6 +497,19 @@ impl Default for JinaSearchConfig {
             no_cache: false,
         }
     }
+}
+
+/// SearXNG self-hosted search configuration.
+///
+/// Requires only a `url`; SearXNG public instances reject `limit` and the
+/// LLM-facing `max_results` is taken from the per-call `tool_args` (the
+/// runtime truncates client-side after fetching).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct SearxngSearchConfig {
+    /// Base URL of the SearXNG instance (e.g., "https://search.example.com").
+    /// Empty means the provider is disabled.
+    pub url: String,
 }
 
 /// Web fetch configuration.

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -609,6 +609,13 @@ impl KernelConfig {
                     ));
                 }
             }
+            SearchProvider::Searxng => {
+                if self.web.searxng.url.is_empty() {
+                    warnings.push(
+                        "Searxng search selected but searxng.url is not configured".to_string(),
+                    );
+                }
+            }
             SearchProvider::DuckDuckGo | SearchProvider::Auto => {}
         }
 


### PR DESCRIPTION
## Summary
- Adds `SearchProvider::Searxng` + `WebConfig.searxng` (url-only). Defaults disabled (empty URL → opt-in).
- Implements `search_searxng` with: `/search?format=json`, dynamic category validation against `/config`, `pageno` pagination, client-side truncation (SearXNG instances reject `limit`), and an output filtered to `title/url/content/published_date` only (no engine/score noise leaking to the LLM).
- Adds Searxng to the Auto cascade (between Perplexity and DuckDuckGo) — only kicks in when `searxng.url` is non-empty, preserving existing fallback order byte-for-byte for users without a SearXNG configured.
- Adds `list_searxng_categories` as a discovery hook (also used internally for category validation).

Skipped openfang `46eac44` (\"searxng search specialist skill\") because LibreFang doesn't carry bundled skills the same way.

Squashed from openfang commits: `656e273`, `ce3344a`, `d75a56a`, `79ca1cd`, `50c51dd`, `9cf37ea` — final-state porting (pagination + dynamic categories + noise filter + client-side truncate).

## Test plan
- [x] `cargo check -p librefang-runtime -p librefang-types --tests` — green
- [x] `cargo test -p librefang-runtime --lib web_search` — 23 passed (incl. 7 new `test_searxng_*`/`test_search_searxng_unconfigured_url_errors`/`test_list_searxng_categories_unconfigured_url_errors`)
- [x] `cargo clippy -p librefang-runtime -p librefang-types --all-targets -- -D warnings` — clean
- [ ] Manual: spin up `docker run searxng/searxng`, set `web.searxng.url`, search via tool — verify category validation rejects bogus categories with the available list
- [ ] Manual: confirm Auto cascade still picks Tavily/Brave/Jina/Perplexity first when their keys are set (regression check)
