### PR TITLE
fix(cron): honor session_mode=new with per-fire isolated sessions

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -9,7 +9,7 @@
 
 use chrono::{Duration, Utc};
 use dashmap::DashMap;
-use librefang_types::agent::AgentId;
+use librefang_types::agent::{AgentId, SessionId, SessionMode};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::scheduler::{CronJob, CronJobId, CronSchedule};
 use serde::{Deserialize, Serialize};
@@ -558,14 +558,108 @@ pub fn compute_next_run_after(
 }
 
 // ---------------------------------------------------------------------------
+// Per-fire session derivation
+// ---------------------------------------------------------------------------
+
+/// Compute `(session_mode_override, session_id_override)` for a cron fire.
+///
+/// `session_mode = Some(New)` means each fire must land on its own isolated
+/// session: the channel-derived branch in `send_message_full` would otherwise
+/// always route cron back to the persistent `(agent, "cron")` session
+/// because the synthetic `SenderContext{channel:"cron"}` wins over a
+/// session-mode override (see CLAUDE.md note on cron + session_mode). We
+/// bypass that by handing `send_message_full` an explicit
+/// `session_id_override` derived from the job id and fire timestamp via
+/// [`SessionId::for_cron_run`], so the override path takes priority over
+/// the channel branch.
+///
+/// `Persistent` (or `None` — historical default) returns `(None, None)`,
+/// preserving the long-standing `(agent, "cron")` shared-session behaviour.
+pub fn cron_fire_session_override(
+    agent_id: AgentId,
+    job_session_mode: Option<SessionMode>,
+    job_id: CronJobId,
+    fire_time: chrono::DateTime<chrono::Utc>,
+) -> (Option<SessionMode>, Option<SessionId>) {
+    if job_session_mode != Some(SessionMode::New) {
+        return (None, None);
+    }
+    let run_key = format!(
+        "{}:{}",
+        job_id.0,
+        fire_time.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
+    );
+    (
+        Some(SessionMode::New),
+        Some(SessionId::for_cron_run(agent_id, &run_key)),
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, Timelike};
+    use chrono::{Duration, TimeZone, Timelike};
     use librefang_types::scheduler::{CronAction, CronDelivery};
+
+    #[test]
+    fn fire_session_override_persistent_returns_none() {
+        let agent = AgentId::new();
+        let job_id = CronJobId::new();
+        let now = chrono::Utc::now();
+        // Default (no per-job override) — historical persistent cron session.
+        let (mode, sid) = cron_fire_session_override(agent, None, job_id, now);
+        assert!(mode.is_none());
+        assert!(sid.is_none());
+        // Explicit Persistent same.
+        let (mode, sid) =
+            cron_fire_session_override(agent, Some(SessionMode::Persistent), job_id, now);
+        assert!(mode.is_none());
+        assert!(sid.is_none());
+    }
+
+    #[test]
+    fn fire_session_override_new_yields_isolated_id() {
+        let agent = AgentId::new();
+        let job_id = CronJobId::new();
+        let now = chrono::Utc::now();
+        let (mode, sid) = cron_fire_session_override(agent, Some(SessionMode::New), job_id, now);
+        assert_eq!(mode, Some(SessionMode::New));
+        let sid = sid.expect("New must produce a session id override");
+        // And it must NOT collide with the persistent (agent, "cron") session.
+        assert_ne!(sid, SessionId::for_channel(agent, "cron"));
+    }
+
+    #[test]
+    fn fire_session_override_new_distinguishes_two_fires() {
+        let agent = AgentId::new();
+        let job_id = CronJobId::new();
+        // Two distinct timestamps representing two fires.
+        let t1 = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let t2 = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 5, 0).unwrap();
+        let (_, sid_a) = cron_fire_session_override(agent, Some(SessionMode::New), job_id, t1);
+        let (_, sid_b) = cron_fire_session_override(agent, Some(SessionMode::New), job_id, t2);
+        assert_ne!(
+            sid_a, sid_b,
+            "two fires of the same New-mode job must yield distinct session ids"
+        );
+    }
+
+    #[test]
+    fn fire_session_override_new_is_deterministic_per_fire() {
+        // Reproducibility: same (agent, job_id, fire_time) must always derive
+        // the same session id — useful for log correlation when a fire's
+        // session id is referenced after the fact.
+        let agent = AgentId::new();
+        let job_id = CronJobId::new();
+        let t = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let (_, sid_a) = cron_fire_session_override(agent, Some(SessionMode::New), job_id, t);
+        let (_, sid_b) = cron_fire_session_override(agent, Some(SessionMode::New), job_id, t);
+        assert_eq!(sid_a, sid_b);
+    }
 
     /// Build a minimal valid `CronJob` with an `Every` schedule.
     fn make_job(agent_id: AgentId) -> CronJob {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10347,46 +10347,45 @@ system_prompt = "You are a helpful assistant."
                                 let kh: std::sync::Arc<
                                     dyn librefang_runtime::kernel_handle::KernelHandle,
                                 > = kernel.clone();
-                                // Cron jobs use a synthetic SenderContext so they
-                                // get their own isolated session (channel="cron").
+                                // Cron jobs synthesize their SenderContext locally
+                                // so memory/peer lookups still see channel="cron".
                                 //
-                                // Exception: when `session_mode = "new"` the job
-                                // requested per-fire isolation. In that case we
-                                // skip the fixed channel session and instead pass
-                                // a `session_mode_override` of `New` so each fire
-                                // receives its own fresh SessionId.
+                                // Session resolution by `job.session_mode`:
+                                //   * None / Some(Persistent) — all fires share
+                                //     the agent's `(agent, channel="cron")`
+                                //     persistent session (historical default).
+                                //   * Some(New) — each fire receives a fresh
+                                //     deterministic session via
+                                //     `SessionId::for_cron_run(agent, run_key)`.
+                                //     We pass it as `session_id_override` (rather
+                                //     than relying on `session_mode_override`
+                                //     alone) because the channel-derived branch
+                                //     in `send_message_full` would otherwise
+                                //     win over the mode override and route
+                                //     every fire back to the persistent
+                                //     `(agent, "cron")` session — see
+                                //     CLAUDE.md note on cron + session_mode.
                                 let wants_new_session = job.session_mode
                                     == Some(librefang_types::agent::SessionMode::New);
-                                let (sender_ctx_owned, mode_override) = if wants_new_session {
-                                    let cron_sender = SenderContext {
-                                        channel: "cron".to_string(),
-                                        user_id: job.peer_id.clone().unwrap_or_default(),
-                                        display_name: "cron".to_string(),
-                                        is_group: false,
-                                        was_mentioned: false,
-                                        thread_id: None,
-                                        account_id: None,
-                                        is_internal_cron: true,
-                                        ..Default::default()
-                                    };
-                                    (
-                                        Some(cron_sender),
-                                        Some(librefang_types::agent::SessionMode::New),
-                                    )
-                                } else {
-                                    let cron_sender = SenderContext {
-                                        channel: "cron".to_string(),
-                                        user_id: job.peer_id.clone().unwrap_or_default(),
-                                        display_name: "cron".to_string(),
-                                        is_group: false,
-                                        was_mentioned: false,
-                                        thread_id: None,
-                                        account_id: None,
-                                        is_internal_cron: true,
-                                        ..Default::default()
-                                    };
-                                    (Some(cron_sender), None)
+                                let cron_sender = SenderContext {
+                                    channel: "cron".to_string(),
+                                    user_id: job.peer_id.clone().unwrap_or_default(),
+                                    display_name: "cron".to_string(),
+                                    is_group: false,
+                                    was_mentioned: false,
+                                    thread_id: None,
+                                    account_id: None,
+                                    is_internal_cron: true,
+                                    ..Default::default()
                                 };
+                                let sender_ctx_owned = Some(cron_sender);
+                                let (mode_override, fire_session_override) =
+                                    crate::cron::cron_fire_session_override(
+                                        agent_id,
+                                        job.session_mode,
+                                        job.id,
+                                        chrono::Utc::now(),
+                                    );
                                 let sender_ctx = sender_ctx_owned.as_ref();
 
                                 // Prune the persistent cron session before firing
@@ -10440,7 +10439,7 @@ system_prompt = "You are a helpful assistant."
                                         sender_ctx,
                                         mode_override,
                                         None,
-                                        None,
+                                        fire_session_override,
                                     ),
                                 )
                                 .await

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -220,6 +220,13 @@ const CHANNEL_SESSION_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
     0xa3, 0x4e, 0x7c, 0x01, 0x8f, 0x2b, 0x4d, 0x6a, 0x91, 0x5c, 0xd7, 0x3e, 0xf4, 0x0a, 0xb8, 0x52,
 ]);
 
+/// Distinct UUID v5 namespace for per-fire cron session IDs. Disjoint from
+/// `CHANNEL_SESSION_NAMESPACE` so a `for_cron_run` id can never collide with
+/// a `for_channel` id even if input strings happen to coincide.
+const CRON_RUN_SESSION_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x7e, 0x91, 0x2c, 0x4f, 0xb5, 0xa3, 0x48, 0xd1, 0xa0, 0x6c, 0xe2, 0x83, 0x1f, 0x57, 0xc4, 0x09,
+]);
+
 impl SessionId {
     /// Create a new random SessionId.
     pub fn new() -> Self {
@@ -234,6 +241,26 @@ impl SessionId {
         let name = format!("{}:{}", agent_id.0, channel.to_lowercase());
         Self(uuid::Uuid::new_v5(
             &CHANNEL_SESSION_NAMESPACE,
+            name.as_bytes(),
+        ))
+    }
+
+    /// Derive a per-fire cron session id keyed by `(agent, run_key)`.
+    ///
+    /// Used when a cron job is configured with `session_mode = "new"` and
+    /// each fire must land on its own isolated session — prior fires must
+    /// not leak context into the current run, and the agent's persistent
+    /// `(agent, "cron")` session must stay untouched.
+    ///
+    /// `run_key` should uniquely identify the fire (typical choice:
+    /// `"<job_uuid>:<rfc3339_timestamp>"`). Lower-cased before hashing so
+    /// a caller's case quirks don't fan id space. Determinism (vs.
+    /// `SessionId::new()`) makes a fire's session id reproducible from logs
+    /// for debugging.
+    pub fn for_cron_run(agent_id: AgentId, run_key: &str) -> Self {
+        let name = format!("{}:{}", agent_id.0, run_key.to_lowercase());
+        Self(uuid::Uuid::new_v5(
+            &CRON_RUN_SESSION_NAMESPACE,
             name.as_bytes(),
         ))
     }
@@ -1989,5 +2016,35 @@ model = "llama-3.3-70b-versatile"
     fn session_id_from_str_rejects_garbage() {
         use std::str::FromStr;
         assert!(SessionId::from_str("not-a-uuid").is_err());
+    }
+
+    #[test]
+    fn for_cron_run_deterministic() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let a = SessionId::for_cron_run(agent, "job-uuid:2026-04-25T10:00:00Z");
+        let b = SessionId::for_cron_run(agent, "job-uuid:2026-04-25T10:00:00Z");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn for_cron_run_distinguishes_fires() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let fire_a = SessionId::for_cron_run(agent, "job-uuid:2026-04-25T10:00:00Z");
+        let fire_b = SessionId::for_cron_run(agent, "job-uuid:2026-04-25T10:05:00Z");
+        assert_ne!(
+            fire_a, fire_b,
+            "different fires must yield different sessions"
+        );
+    }
+
+    #[test]
+    fn for_cron_run_distinct_from_for_channel_cron() {
+        // Same input string, different namespaces → different UUIDs. Prevents
+        // a per-fire cron session from ever colliding with the persistent
+        // (agent, channel="cron") session.
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let persistent = SessionId::for_channel(agent, "cron");
+        let isolated = SessionId::for_cron_run(agent, "cron");
+        assert_ne!(persistent, isolated);
     }
 }


### PR DESCRIPTION
## Summary

- CLAUDE.md flagged this as a known-but-unfixed bug: every cron fire for an agent shares one \`(agent, channel=\"cron\")\` session because the cron dispatcher synthesizes \`SenderContext{channel:\"cron\"}\` that always wins over the session_mode override in \`send_message_full\`'s resolution logic. A job declared with \`session_mode=new\` was still routing every fire through the same persistent cron session, leaking context across runs and defeating the very intent of opting into \`new\`.
- Fix: the cron dispatcher now also passes \`session_id_override = Some(SessionId::for_cron_run(agent, \"<job>:<rfc3339>\"))\` when \`session_mode == Some(New)\`. \`session_id_override\` has top priority in the resolver, so it correctly bypasses the channel branch without needing to rewrite the resolution order (which is intentionally biased toward channel-stickiness for chat sessions). Persistent and the historical default (\`None\`) are unaffected.
- Bonus: extracted the override computation into a pure helper \`cron::cron_fire_session_override\` so it can be unit-tested without spinning up the cron loop.

## Why a separate namespace?

\`SessionId::for_cron_run\` uses a distinct UUID v5 namespace (disjoint from \`CHANNEL_SESSION_NAMESPACE\`) so a per-fire id can never collide with a \`for_channel\` id even if input strings happen to coincide. Determinism (vs \`SessionId::new()\`) makes a fire's session id reproducible from logs for debugging.

## Validation

- 3 \`SessionId::for_cron_run\` unit tests (determinism, fire distinction, disjointness from \`for_channel\")
- 4 \`cron_fire_session_override\` unit tests (None / Persistent / New paths, two-fire distinction, single-fire determinism)
- \`cargo build --workspace --lib\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- Pre-existing codex/model_catalog test failures on \`origin/main\` are unrelated (verified by reproducing them on \`main\` with no changes).

## Test plan

- [x] cargo build --workspace --lib
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test (helpers + types unit tests)
- [ ] Manual smoke against a long-running cron job with \`session_mode=new\` (deferred — requires an active deployment to observe two fires; left to follow-up if needed)