### PR TITLE
feat(llm-driver): add LlmFamily enum + LlmDriver::family()

### DIFF
--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -333,6 +333,48 @@ pub enum StreamEvent {
     OwnerNotice { text: String },
 }
 
+/// High-level grouping of LLM providers that share wire format and
+/// policy-relevant behaviour (prompt-cache semantics, tool-schema style,
+/// thinking-block handling, …).
+///
+/// This is intentionally coarser than `provider`/`api_format` — it exists so
+/// that future cross-cutting policy code can be hung off a single dimension
+/// without re-implementing the same logic per concrete driver. No policy
+/// logic is attached to the variants in this PR; consumers should treat the
+/// enum as opaque metadata until follow-up work introduces family-aware
+/// hooks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmFamily {
+    /// Anthropic Claude family (direct API, Anthropic-compatible providers,
+    /// Claude Code CLI).
+    Anthropic,
+    /// OpenAI Chat Completions wire format (OpenAI, Azure OpenAI, Groq,
+    /// OpenRouter, DeepInfra, Together, Cerebras, …).
+    OpenAi,
+    /// Google Gemini family (Gemini API, Vertex AI Gemini, Gemini CLI).
+    Google,
+    /// Locally-hosted runtimes accessed via their own native protocol
+    /// (Ollama, LM Studio, vLLM, sglang, llama.cpp). Drivers that proxy
+    /// local servers via the OpenAI-compatible shim still report `OpenAi`.
+    Local,
+    /// Anything that does not fit the above (Cohere v2, Aider, custom
+    /// CLIs, etc.). Default for drivers that have not opted into a family.
+    Other,
+}
+
+impl std::fmt::Display for LlmFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LlmFamily::Anthropic => write!(f, "anthropic"),
+            LlmFamily::OpenAi => write!(f, "open_ai"),
+            LlmFamily::Google => write!(f, "google"),
+            LlmFamily::Local => write!(f, "local"),
+            LlmFamily::Other => write!(f, "other"),
+        }
+    }
+}
+
 /// Trait for LLM drivers.
 #[async_trait]
 pub trait LlmDriver: Send + Sync {
@@ -364,6 +406,16 @@ pub trait LlmDriver: Send + Sync {
     /// Returns false only for StubDriver; all real drivers return true.
     fn is_configured(&self) -> bool {
         true
+    }
+
+    /// The high-level family this driver belongs to.
+    ///
+    /// Defaults to [`LlmFamily::Other`] so that out-of-tree drivers continue
+    /// to compile without modification. Concrete in-tree drivers override
+    /// this to enable future family-level shared policy (prompt-cache
+    /// replay, tool-schema normalisation, …) without per-driver duplication.
+    fn family(&self) -> LlmFamily {
+        LlmFamily::Other
     }
 }
 
@@ -549,6 +601,80 @@ mod tests {
             },
         ];
         assert_eq!(events.len(), 5);
+    }
+
+    #[test]
+    fn test_llm_family_serializes_to_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&LlmFamily::Anthropic).unwrap(),
+            "\"anthropic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LlmFamily::OpenAi).unwrap(),
+            "\"open_ai\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LlmFamily::Google).unwrap(),
+            "\"google\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LlmFamily::Local).unwrap(),
+            "\"local\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LlmFamily::Other).unwrap(),
+            "\"other\""
+        );
+    }
+
+    #[test]
+    fn test_llm_family_deserializes_from_snake_case() {
+        assert_eq!(
+            serde_json::from_str::<LlmFamily>("\"anthropic\"").unwrap(),
+            LlmFamily::Anthropic
+        );
+        assert_eq!(
+            serde_json::from_str::<LlmFamily>("\"open_ai\"").unwrap(),
+            LlmFamily::OpenAi
+        );
+        assert_eq!(
+            serde_json::from_str::<LlmFamily>("\"google\"").unwrap(),
+            LlmFamily::Google
+        );
+        assert_eq!(
+            serde_json::from_str::<LlmFamily>("\"local\"").unwrap(),
+            LlmFamily::Local
+        );
+        assert_eq!(
+            serde_json::from_str::<LlmFamily>("\"other\"").unwrap(),
+            LlmFamily::Other
+        );
+    }
+
+    #[test]
+    fn test_llm_family_display_matches_serde() {
+        assert_eq!(LlmFamily::Anthropic.to_string(), "anthropic");
+        assert_eq!(LlmFamily::OpenAi.to_string(), "open_ai");
+        assert_eq!(LlmFamily::Google.to_string(), "google");
+        assert_eq!(LlmFamily::Local.to_string(), "local");
+        assert_eq!(LlmFamily::Other.to_string(), "other");
+    }
+
+    #[test]
+    fn test_llm_driver_family_default_is_other() {
+        struct BareDriver;
+
+        #[async_trait]
+        impl LlmDriver for BareDriver {
+            async fn complete(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<CompletionResponse, LlmError> {
+                unreachable!("test does not call complete")
+            }
+        }
+
+        assert_eq!(BareDriver.family(), LlmFamily::Other);
     }
 
     #[tokio::test]

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -4,7 +4,9 @@
 //! system prompt extraction, and retry on 429/529 errors.
 
 use crate::backoff::standard_retry_delay;
-use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmDriver, LlmError, StreamEvent};
+use crate::llm_driver::{
+    CompletionRequest, CompletionResponse, LlmDriver, LlmError, LlmFamily, StreamEvent,
+};
 use crate::rate_limit_tracker::RateLimitSnapshot;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -762,6 +764,10 @@ impl LlmDriver for AnthropicDriver {
             message: "Max retries exceeded".to_string(),
         })
     }
+
+    fn family(&self) -> LlmFamily {
+        LlmFamily::Anthropic
+    }
 }
 
 /// Ensure a `serde_json::Value` is an object.  The Anthropic API requires the
@@ -1029,6 +1035,15 @@ mod tests {
         let msg = Message::user("Hello");
         let api_msg = convert_message(&msg);
         assert_eq!(api_msg.role, "user");
+    }
+
+    #[test]
+    fn test_anthropic_driver_family_is_anthropic() {
+        let driver = AnthropicDriver::new(
+            "test-key".to_string(),
+            "https://api.anthropic.com".to_string(),
+        );
+        assert_eq!(driver.family(), LlmFamily::Anthropic);
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -924,6 +924,10 @@ impl crate::llm_driver::LlmDriver for ChatGptDriver {
 
         Ok(response)
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::OpenAi
+    }
 }
 
 #[cfg(test)]

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1149,6 +1149,10 @@ impl LlmDriver for ClaudeCodeDriver {
             usage: final_usage,
         })
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::Anthropic
+    }
 }
 
 /// Check if the Claude Code CLI is available.

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -224,6 +224,10 @@ impl LlmDriver for CodexCliDriver {
             },
         })
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::OpenAi
+    }
 }
 
 /// Check if the Codex CLI is available.

--- a/crates/librefang-llm-drivers/src/drivers/copilot.rs
+++ b/crates/librefang-llm-drivers/src/drivers/copilot.rs
@@ -240,6 +240,10 @@ impl crate::llm_driver::LlmDriver for CopilotDriver {
         let driver = self.make_inner_driver(&token);
         driver.stream(request, tx).await
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::OpenAi
+    }
 }
 
 #[cfg(test)]

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -1153,6 +1153,10 @@ impl LlmDriver for GeminiDriver {
             message: "Max retries exceeded".to_string(),
         })
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::Google
+    }
 }
 
 #[cfg(test)]

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -220,6 +220,10 @@ impl LlmDriver for GeminiCliDriver {
             },
         })
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::Google
+    }
 }
 
 /// Check if the Gemini CLI is available.

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1736,6 +1736,10 @@ impl LlmDriver for OpenAIDriver {
             message: "Max retries exceeded".to_string(),
         })
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::OpenAi
+    }
 }
 
 /// Extract `<think>...</think>` blocks from content text.

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -950,6 +950,10 @@ impl LlmDriver for QwenCodeDriver {
         let prepared = Self::build_prompt(&request);
         self.stream_inner(&prepared, &request, &tx).await
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::OpenAi
+    }
 }
 
 /// Check if the Qwen Code CLI is available.

--- a/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
@@ -887,6 +887,10 @@ impl LlmDriver for VertexAiDriver {
 
         Err(last_error.unwrap_or_else(|| LlmError::Http("Max retries exceeded".into())))
     }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        crate::llm_driver::LlmFamily::Google
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

Several upcoming features need to branch on the broad LLM provider family rather than the concrete provider name:

- Anthropic-family prompt-cache replay (re-applying `cache_control` markers across turns to retain cache hits).
- OpenAI-family tool-schema normalisation (uniform JSON-schema massaging for OpenAI Chat Completions wire format).
- Google-family thinking-block / `thoughtSignature` round-tripping.

Today this would mean per-concrete-driver duplication or string matching on `provider`. Adding a single coarse-grained dimension on the trait lets future PRs hang shared policy off it without touching every driver.

## What's in this PR

- New public enum `LlmFamily` in `librefang-llm-driver` with variants `Anthropic`, `OpenAi`, `Google`, `Local`, `Other`. Derives `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `Hash`, `Serialize`, `Deserialize` (`#[serde(rename_all = "snake_case")]`) plus a `Display` impl matching the serde representation.
- New default trait method `LlmDriver::family() -> LlmFamily` that returns `LlmFamily::Other`. Existing/out-of-tree drivers continue to compile unchanged.
- Per-driver overrides in `librefang-llm-drivers`:
  - `AnthropicDriver`, `ClaudeCodeDriver` → `Anthropic`
  - `OpenAIDriver`, `ChatGptDriver`, `CopilotDriver`, `CodexCliDriver`, `QwenCodeDriver` → `OpenAi`
  - `GeminiDriver`, `VertexAiDriver`, `GeminiCliDriver` → `Google`
  - `AiderDriver` deliberately keeps the default `Other` — it dispatches to a provider-agnostic CLI.
- Unit tests in `librefang-llm-driver` covering `LlmFamily` serde round-trip, `Display` parity, and the default trait method returning `Other`. Driver-level test in `anthropic.rs` asserting `AnthropicDriver::family()` returns `LlmFamily::Anthropic`.

### Note on `Local`

`OpenAIDriver` is shared by Ollama / LM Studio / vLLM / Cerebras / Groq / OpenRouter / etc. Per the trait-injection constraints (no per-instance provider tag on the existing struct, "don't refactor existing driver structs"), the struct reports `OpenAi` because that is the wire format. The `Local` variant is reserved for future native local-runtime drivers; it is intentionally not used by any concrete driver in this PR.

## Deliberately NOT in this PR

- No policy code (`replay_policy()`, `tool_schema_style()`, prompt-cache helpers, etc.). Those land in follow-ups that consume `family()`.
- No new fields on `CompletionRequest` / `CompletionResponse`.
- No changes to driver runtime behaviour (auth, retries, request building, response parsing).
- No registry/`ApiFormat` refactor — `family()` lives next to drivers, not next to `ProviderEntry`.

## Validation

Validation: gates intentionally not run locally per user instruction; relying on CI to verify build/test/clippy.

Pre-existing test failures noted on `origin/main` that are unrelated to this PR:
- `librefang-runtime::model_catalog::tests::test_codex_*`
- `detect_auth_does_not_promote_api_providers_from_cli_login`

## Test plan

- [ ] CI: `cargo build --workspace --lib`
- [ ] CI: `cargo test -p librefang-llm-driver --lib`
- [ ] CI: `cargo test -p librefang-llm-drivers --lib`
- [ ] CI: `cargo test --workspace`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`