### PR TITLE
fix(llm-drivers): Copilot streaming empty tool calls + Claude assistant strip

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1733,6 +1733,11 @@ impl LlmDriver for OpenAIDriver {
             }
 
             let stop_reason = match finish_reason.as_deref() {
+                // If the upstream said "tool_calls" but we filtered them all
+                // out (e.g. Copilot proxy dropped function-name chunks),
+                // downgrade to EndTurn so the agent loop doesn't stage an
+                // empty tool-use turn that nothing can execute.
+                Some("tool_calls") if tool_calls.is_empty() => StopReason::EndTurn,
                 Some("stop") => StopReason::EndTurn,
                 Some("tool_calls") => StopReason::ToolUse,
                 Some("length") => StopReason::MaxTokens,

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1657,6 +1657,19 @@ impl LlmDriver for OpenAIDriver {
             }
 
             for (id, name, arguments) in &tool_accum {
+                // Skip malformed tool calls (empty ID or name can happen if
+                // streaming chunks arrive out of order or are dropped by proxy,
+                // e.g. the GitHub Copilot proxy occasionally drops the function
+                // name chunk). Replaying these to the API yields
+                // "tool call must have a tool call ID and function name" errors.
+                if id.is_empty() || name.is_empty() {
+                    warn!(
+                        tool_id = %id,
+                        tool_name = %name,
+                        "Skipping tool call with empty ID or name from streaming response"
+                    );
+                    continue;
+                }
                 let input: serde_json::Value = match parse_tool_args(arguments) {
                     Ok(v) => ensure_object(v),
                     Err(e) => {

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -508,7 +508,7 @@ struct OaiPromptTokensDetails {
 fn strip_trailing_empty_assistant(messages: &mut Vec<OaiMessage>, model: &str) {
     let is_claude = model.contains("claude");
 
-    while messages.last().map_or(false, |m| {
+    while messages.last().is_some_and(|m| {
         m.role == "assistant"
             && m.tool_calls.is_none()
             && if is_claude {

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -500,6 +500,33 @@ struct OaiPromptTokensDetails {
     cached_tokens: u64,
 }
 
+/// Strip trailing assistant messages that would trigger "prefill not supported"
+/// errors on the Copilot proxy for Claude models.
+/// Only strips assistant messages that have no tool_calls (tool call messages
+/// are part of the protocol and must stay). Checks the model name to only
+/// apply for Claude models which enforce this restriction.
+fn strip_trailing_empty_assistant(messages: &mut Vec<OaiMessage>, model: &str) {
+    let is_claude = model.contains("claude");
+
+    while messages.last().map_or(false, |m| {
+        m.role == "assistant"
+            && m.tool_calls.is_none()
+            && if is_claude {
+                // Claude via Copilot: strip any trailing assistant without tool_calls
+                true
+            } else {
+                // Other models: only strip truly empty messages
+                match &m.content {
+                    None => true,
+                    Some(OaiMessageContent::Text(t)) => t.trim().is_empty(),
+                    _ => false,
+                }
+            }
+    }) {
+        messages.pop();
+    }
+}
+
 impl OpenAIDriver {
     /// Build the `OaiRequest` from a `CompletionRequest`.
     ///
@@ -725,6 +752,8 @@ impl OpenAIDriver {
                 },
             })
             .collect();
+
+        strip_trailing_empty_assistant(&mut oai_messages, &request.model);
 
         // Guard: an empty message list would produce an unparseable API response
         // (typically "EOF while parsing a value at line 1 column 0").
@@ -2604,5 +2633,97 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed.get("extra_body").is_none());
+    }
+
+    fn make_msg(role: &str, content: Option<&str>, has_tool_calls: bool) -> OaiMessage {
+        OaiMessage {
+            role: role.to_string(),
+            content: content.map(|c| OaiMessageContent::Text(c.to_string())),
+            tool_calls: if has_tool_calls {
+                Some(vec![OaiToolCall {
+                    id: "call_1".to_string(),
+                    call_type: "function".to_string(),
+                    function: OaiFunction {
+                        name: "test".to_string(),
+                        arguments: "{}".to_string(),
+                    },
+                }])
+            } else {
+                None
+            },
+            tool_call_id: None,
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn test_strip_trailing_empty_assistant_non_claude_keeps_non_empty() {
+        // For non-Claude models, a trailing assistant with non-empty text must be kept
+        // (otherwise the agent loop would never terminate).
+        let mut msgs = vec![
+            make_msg("user", Some("hi"), false),
+            make_msg("assistant", Some("hello there"), false),
+        ];
+        strip_trailing_empty_assistant(&mut msgs, "gpt-4o");
+        assert_eq!(
+            msgs.len(),
+            2,
+            "non-empty assistant should survive for non-Claude"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_empty_assistant_non_claude_strips_empty() {
+        let mut msgs = vec![
+            make_msg("user", Some("hi"), false),
+            make_msg("assistant", Some("   "), false),
+            make_msg("assistant", None, false),
+        ];
+        strip_trailing_empty_assistant(&mut msgs, "gpt-4o");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
+    fn test_strip_trailing_empty_assistant_claude_strips_non_empty() {
+        // Claude via Copilot: strip any trailing assistant without tool_calls,
+        // even if it has non-empty text — Anthropic rejects assistant prefill.
+        let mut msgs = vec![
+            make_msg("user", Some("hi"), false),
+            make_msg("assistant", Some("partial response"), false),
+        ];
+        strip_trailing_empty_assistant(&mut msgs, "claude-3-5-sonnet");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
+    fn test_strip_trailing_empty_assistant_keeps_tool_calls() {
+        // Assistant messages with tool_calls are protocol-essential and must stay
+        // for both Claude and non-Claude models.
+        let mut claude_msgs = vec![
+            make_msg("user", Some("hi"), false),
+            make_msg("assistant", None, true),
+        ];
+        strip_trailing_empty_assistant(&mut claude_msgs, "claude-3-5-sonnet");
+        assert_eq!(claude_msgs.len(), 2);
+
+        let mut gpt_msgs = vec![
+            make_msg("user", Some("hi"), false),
+            make_msg("assistant", None, true),
+        ];
+        strip_trailing_empty_assistant(&mut gpt_msgs, "gpt-4o");
+        assert_eq!(gpt_msgs.len(), 2);
+    }
+
+    #[test]
+    fn test_strip_trailing_empty_assistant_claude_keeps_user_last() {
+        let mut msgs = vec![
+            make_msg("assistant", Some("earlier"), false),
+            make_msg("user", Some("now"), false),
+        ];
+        strip_trailing_empty_assistant(&mut msgs, "claude-3-opus");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs.last().unwrap().role, "user");
     }
 }


### PR DESCRIPTION
## Summary
Two fixes to the OpenAI driver (used by github-copilot proxy):

1. **Skip streaming tool-calls with empty id or name** — Copilot streaming occasionally delivers a function-call delta with an empty `id` or `name`, which then poisons the next API request. We log a warn and drop those entries.
2. **Model-aware trailing-assistant strip** — Claude (via Copilot proxy) does not support assistant prefill; if the message history ends with an assistant turn that has no tool_calls, we strip it. For non-Claude models we only strip empty content (preserving the previous behaviour).

The strip is wired through the single `build_request` entry-point in LibreFang (one call site instead of upstream's two).

Ported from openfang `abeaaf5` and `64b1ec5`.

## Test plan
- [x] 5 new unit tests in `drivers/openai.rs` covering claude/non-claude × empty/non-empty/with-tool_calls
- [x] grep'd LibreFang main — neither fix exists upstream; no overlap
- [ ] Manual: run a Telegram/Matrix channel agent against `provider = "github-copilot"` + a Claude model, send a message that triggers a tool call, verify the conversation continues without the upstream "assistant prefill not supported" error
