### PR TITLE
fix(runtime/types): Gemini array-items default + first-message-must-be-user

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -264,6 +264,10 @@ fn safe_trim_messages(
 
     // Re-validate after trim.
     *messages = crate::session_repair::validate_and_repair(messages);
+    // Ensure history starts with a user turn: trimming may have left an
+    // assistant turn at position 0, which strict providers (e.g. Gemini)
+    // reject with INVALID_ARGUMENT on function-call turns.
+    *messages = crate::session_repair::ensure_starts_with_user(std::mem::take(messages));
 
     // Post-trim safety: ensure at least a user message survives so the LLM
     // request body is never empty.
@@ -3009,6 +3013,8 @@ pub async fn run_agent_loop(
             if !compression_events.is_empty() {
                 messages = compressed;
                 messages = crate::session_repair::validate_and_repair(&messages);
+                // Ensure history starts with a user turn after soft compression.
+                messages = crate::session_repair::ensure_starts_with_user(messages);
                 // Keep session.messages in sync with the compressed LLM working copy
                 // so subsequent turns don't re-read the uncompressed history.
                 session.messages = messages.clone();
@@ -3032,6 +3038,8 @@ pub async fn run_agent_loop(
                     }
                     if recovery != RecoveryStage::None {
                         messages = crate::session_repair::validate_and_repair(&messages);
+                        // Ensure history starts with a user turn after overflow recovery.
+                        messages = crate::session_repair::ensure_starts_with_user(messages);
                     }
                 }
             } else {
@@ -3046,6 +3054,8 @@ pub async fn run_agent_loop(
                 }
                 if recovery != RecoveryStage::None {
                     messages = crate::session_repair::validate_and_repair(&messages);
+                    // Ensure history starts with a user turn after overflow recovery.
+                    messages = crate::session_repair::ensure_starts_with_user(messages);
                 }
             }
             apply_context_guard(&mut messages, &context_budget, available_tools);
@@ -4313,6 +4323,8 @@ pub async fn run_agent_loop_streaming(
             if !compression_events.is_empty() {
                 messages = compressed;
                 messages = crate::session_repair::validate_and_repair(&messages);
+                // Ensure history starts with a user turn after soft compression.
+                messages = crate::session_repair::ensure_starts_with_user(messages);
                 // Keep session.messages in sync with the compressed LLM working copy
                 // so subsequent turns don't re-read the uncompressed history.
                 session.messages = messages.clone();
@@ -4333,6 +4345,8 @@ pub async fn run_agent_loop_streaming(
                     );
                     if r != RecoveryStage::None {
                         messages = crate::session_repair::validate_and_repair(&messages);
+                        // Ensure history starts with a user turn after overflow recovery.
+                        messages = crate::session_repair::ensure_starts_with_user(messages);
                     }
                     r
                 } else {
@@ -4349,6 +4363,8 @@ pub async fn run_agent_loop_streaming(
                 );
                 if recovery != RecoveryStage::None {
                     messages = crate::session_repair::validate_and_repair(&messages);
+                    // Ensure history starts with a user turn after overflow recovery.
+                    messages = crate::session_repair::ensure_starts_with_user(messages);
                 }
                 apply_context_guard(&mut messages, &context_budget, available_tools);
                 recovery

--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -223,6 +223,33 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
     (merged, stats)
 }
 
+/// Ensure the message history starts with a user turn.
+///
+/// After context trimming the drain boundary may land on an assistant turn,
+/// leaving it at position 0. Providers (especially Gemini) require the first
+/// message to be from the user. This function drops leading assistant messages
+/// and re-validates to clean up newly-orphaned ToolResults.
+///
+/// The loop handles the edge case where the first user turn consisted entirely
+/// of ToolResult blocks that became orphaned (dropped by `validate_and_repair`),
+/// which would re-expose another leading assistant turn.
+pub fn ensure_starts_with_user(mut messages: Vec<Message>) -> Vec<Message> {
+    loop {
+        match messages.iter().position(|m| m.role == Role::User) {
+            Some(0) | None => break,
+            Some(i) => {
+                warn!(
+                    dropped = i,
+                    "Dropping leading assistant turn(s) to ensure history starts with user"
+                );
+                messages.drain(..i);
+                messages = validate_and_repair(&messages);
+            }
+        }
+    }
+    messages
+}
+
 /// Phase 2a: Rescue ToolResult blocks from assistant-role messages.
 ///
 /// After a crash, ToolResult blocks may end up inside an assistant-role message
@@ -2503,5 +2530,62 @@ mod tests {
             has_synthetic_result_for(after_assistant, "call_1"),
             "user message after assistant must contain synthetic ToolResult for call_1"
         );
+    }
+
+    #[test]
+    fn ensure_starts_with_user_drops_leading_assistant() {
+        // Trim left an assistant turn at position 0 — Gemini rejects this.
+        let messages = vec![
+            Message::assistant("orphaned reply"),
+            Message::user("first user turn"),
+            Message::assistant("response"),
+        ];
+        let result = ensure_starts_with_user(messages);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].role, Role::User);
+        assert_eq!(result[1].role, Role::Assistant);
+    }
+
+    #[test]
+    fn ensure_starts_with_user_no_op_when_already_user() {
+        let messages = vec![Message::user("hi"), Message::assistant("hello")];
+        let result = ensure_starts_with_user(messages.clone());
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].role, Role::User);
+    }
+
+    #[test]
+    fn ensure_starts_with_user_handles_no_user_at_all() {
+        // No user turns anywhere — function returns input unchanged
+        // (the caller's post-trim safety path will synthesize a user turn).
+        let messages = vec![Message::assistant("orphan")];
+        let result = ensure_starts_with_user(messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].role, Role::Assistant);
+    }
+
+    #[test]
+    fn ensure_starts_with_user_recovers_after_orphan_tool_result() {
+        // First user turn consists solely of an orphaned ToolResult that
+        // validate_and_repair will drop, re-exposing another assistant turn.
+        // The loop must keep dropping until a real user turn surfaces.
+        let messages = vec![
+            Message::assistant("first orphan"),
+            Message {
+                role: Role::User,
+                content: MessageContent::Blocks(vec![tool_result_block("missing", "x")]),
+                pinned: false,
+                timestamp: None,
+            },
+            Message::assistant("second orphan"),
+            Message::user("real user turn"),
+            Message::assistant("real reply"),
+        ];
+        let result = ensure_starts_with_user(messages);
+        assert_eq!(result[0].role, Role::User);
+        match &result[0].content {
+            MessageContent::Text(t) => assert_eq!(t, "real user turn"),
+            other => panic!("expected text user turn, got {other:?}"),
+        }
     }
 }

--- a/crates/librefang-types/src/tool.rs
+++ b/crates/librefang-types/src/tool.rs
@@ -344,6 +344,15 @@ fn normalize_schema_recursive(schema: &serde_json::Value) -> serde_json::Value {
         result.insert(key.clone(), value.clone());
     }
 
+    // Gemini requires `items` for every array-typed parameter.
+    // JSON Schema allows arrays without `items`, but the Gemini API rejects
+    // such schemas with INVALID_ARGUMENT. Inject a default string items schema
+    // so MCP tools (and any other source) don't break Gemini requests.
+    if result.get("type").and_then(|t| t.as_str()) == Some("array") && !result.contains_key("items")
+    {
+        result.insert("items".to_string(), serde_json::json!({"type": "string"}));
+    }
+
     serde_json::Value::Object(result)
 }
 
@@ -833,6 +842,38 @@ mod tests {
         let result = normalize_schema_for_provider(&schema, "gemini");
         let payload_prop = &result["properties"]["payload"];
         assert!(payload_prop.get("anyOf").is_none());
+    }
+
+    #[test]
+    fn test_normalize_injects_items_for_array_without_items() {
+        // MCP tools often send array params without `items` — Gemini rejects these.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "fields": { "type": "array", "description": "List of fields" },
+                "filters": { "type": "array" }
+            }
+        });
+        let result = normalize_schema_for_provider(&schema, "gemini");
+        // Both array properties must have `items` injected
+        assert_eq!(result["properties"]["fields"]["items"]["type"], "string");
+        assert_eq!(result["properties"]["filters"]["items"]["type"], "string");
+    }
+
+    #[test]
+    fn test_normalize_preserves_existing_items() {
+        // If `items` already exists, it must not be overwritten
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": { "type": "integer" }
+                }
+            }
+        });
+        let result = normalize_schema_for_provider(&schema, "gemini");
+        assert_eq!(result["properties"]["ids"]["items"]["type"], "integer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two stability fixes for Gemini, which has stricter request validation than other providers:

1. **Inject default `items` schema for array parameters** — `normalize_schema_recursive` in `librefang-types` now fills in `{"type": "string"}` for any `type: array` that is missing `items`. MCP tools occasionally publish array params without items; without this Gemini returns INVALID_ARGUMENT.
2. **Ensure message history starts with a user turn** — `session_repair::ensure_starts_with_user` drains leading assistant turns (and orphan tool results) until either the first turn is a user, or the history is empty. Wired in after every `validate_and_repair` call in `agent_loop` (sync + streaming, soft + hard compaction, plus `safe_trim_messages`). Without this, context-trim that drops the first user can leave an assistant in slot 0 and Gemini rejects with INVALID_ARGUMENT.

Ported from openfang `3b21494` and `3c221dc`.

## Test plan
- [x] 2 new tool-schema tests covering the array-without-items injection
- [x] 4 new session_repair tests covering core/no-op/no-user/orphan-tool-result
- [x] grep'd LibreFang main — neither fix exists; agent_loop call sites all missing
- [ ] Manual: run an agent with a long history under Gemini, force a hard compaction, confirm the next request goes through

## Notes
- Upstream's `gemini.rs` driver-layer `i==0` defensive check was *not* ported — LibreFang's gemini driver doesn't have an equivalent `sanitize_gemini_turns` hook, and the `session_repair` fix already covers this above the driver layer.
