### PR TITLE
feat(dashboard): SSE attach hook for multi-client session co-watching

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSessionStream } from "./sessions";
+
+// Minimal in-test EventSource fake. Native EventSource exists in jsdom only
+// as a no-op stub; we drive our own so we can deterministically assert
+// open / message / error transitions.
+class FakeEventSource implements Partial<EventSource> {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  readyState: number = 0; // CONNECTING
+  closed = false;
+  private listeners = new Map<string, Set<EventListener>>();
+
+  constructor(url: string, init?: EventSourceInit) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, fn: EventListener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(fn);
+  }
+  removeEventListener(type: string, fn: EventListener) {
+    this.listeners.get(type)?.delete(fn);
+  }
+  close() {
+    this.closed = true;
+    this.readyState = 2;
+  }
+  // Test helpers
+  emitOpen() {
+    this.readyState = 1;
+    for (const fn of this.listeners.get("open") ?? []) fn(new Event("open"));
+  }
+  emit(type: string, data: string) {
+    const ev = new MessageEvent(type, { data });
+    for (const fn of this.listeners.get(type) ?? []) fn(ev);
+  }
+  emitError(closed: boolean) {
+    if (closed) this.readyState = 2;
+    for (const fn of this.listeners.get("error") ?? []) fn(new Event("error"));
+  }
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSessionStream", () => {
+  it("does nothing when ids are missing", () => {
+    const { result } = renderHook(() =>
+      useSessionStream(null, null, {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(result.current.isAttached).toBe(false);
+    expect(result.current.events).toEqual([]);
+    expect(result.current.lastError).toBeNull();
+  });
+
+  it("opens a stream when both ids are present and parses events", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const es = FakeEventSource.instances[0];
+    expect(es.url).toBe("/api/agents/agent-1/sessions/sess-1/stream");
+
+    act(() => es.emitOpen());
+    expect(result.current.isAttached).toBe(true);
+
+    act(() => es.emit("chunk", JSON.stringify({ content: "hi" })));
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0].type).toBe("chunk");
+    expect(result.current.events[0].data).toEqual({ content: "hi" });
+
+    act(() => es.emit("tool_use", JSON.stringify({ tool: "fs_read", input: { path: "/tmp" } })));
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[1].type).toBe("tool_use");
+  });
+
+  it("auto-detaches on `done` and surfaces the event", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    act(() => es.emitOpen());
+    expect(result.current.isAttached).toBe(true);
+
+    act(() => es.emit("done", "{}"));
+    expect(result.current.isAttached).toBe(false);
+    expect(result.current.events.at(-1)?.type).toBe("done");
+  });
+
+  it("treats error-before-any-data as a silent no-op (404 / not-deployed)", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    // Connection closed without a single event arriving — looks exactly
+    // like a 404 from the not-yet-deployed route.
+    act(() => es.emitError(true));
+    expect(result.current.isAttached).toBe(false);
+    expect(result.current.lastError).toBeNull();
+    expect(result.current.events).toHaveLength(0);
+  });
+
+  it("surfaces mid-stream disconnects via lastError", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    act(() => es.emitOpen());
+    act(() => es.emit("chunk", JSON.stringify({ content: "partial" })));
+    act(() => es.emitError(true));
+    expect(result.current.lastError).toBe("session stream disconnected");
+    expect(result.current.isAttached).toBe(false);
+  });
+
+  it("closes the stream on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    expect(es.closed).toBe(false);
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+
+  it("closes and reconnects when sessionId changes", () => {
+    const { rerender } = renderHook(
+      ({ s }: { s: string }) =>
+        useSessionStream("agent-1", s, {
+          eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        }),
+      { initialProps: { s: "sess-1" } },
+    );
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const first = FakeEventSource.instances[0];
+
+    rerender({ s: "sess-2" });
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1].url).toContain("sess-2");
+  });
+
+  it("falls back to raw content when payload is non-JSON", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    act(() => es.emitOpen());
+    act(() => es.emit("chunk", "not-json"));
+    expect(result.current.events[0].data).toEqual({ content: "not-json" });
+  });
+
+  it("caps the event buffer at 500 to bound memory", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+      }),
+    );
+    const es = FakeEventSource.instances[0];
+    act(() => es.emitOpen());
+    act(() => {
+      for (let i = 0; i < 600; i++) {
+        es.emit("chunk", JSON.stringify({ content: `c${i}` }));
+      }
+    });
+    expect(result.current.events.length).toBe(500);
+    // Oldest event dropped — first kept content is c100.
+    expect(
+      (result.current.events[0].data as { content?: string }).content,
+    ).toBe("c100");
+  });
+
+  it("uses a custom buildUrl when supplied", () => {
+    renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        buildUrl: (a, s) => `https://example.test/x/${a}/${s}`,
+      }),
+    );
+    expect(FakeEventSource.instances[0].url).toBe(
+      "https://example.test/x/agent-1/sess-1",
+    );
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import { listSessions, getSessionDetails } from "../http/client";
 import { sessionKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
@@ -27,4 +28,184 @@ export function useSessions(options: QueryOverrides = {}) {
 
 export function useSessionDetails(sessionId: string, options: QueryOverrides = {}) {
   return useQuery(withOverrides(sessionQueries.detail(sessionId), options));
+}
+
+// ---------------------------------------------------------------------------
+// useSessionStream — multi-attach SSE consumer for in-flight session events.
+//
+// Subscribes to `GET /api/agents/{agentId}/sessions/{sessionId}/stream` so
+// that any client (extra browser tab, desktop, CLI) can co-watch the events
+// of a session that another client started. The originating client still
+// sends its turn over `POST /message/stream` (single-consumer mpsc); this
+// hook is for read-only observers.
+//
+// The hook intentionally does NOT go through TanStack Query's cache: an SSE
+// connection is a long-lived stream of imperative events, not cacheable
+// snapshot data. This is the same exception called out in
+// `dashboard/AGENTS.md` ("Streaming / SSE … may call native browser APIs
+// directly").
+//
+// Behaviour:
+// - opens an EventSource when both ids are truthy
+// - closes cleanly on unmount, agent change, or session change
+// - surfaces parsed events as an in-memory append-only list capped at
+//   MAX_EVENTS to bound worst-case memory
+// - swallows the "404 because the route isn't deployed yet / the session
+//   has no active turn" case silently — `lastError` stays null, no toast.
+//   Native EventSource cannot read HTTP status codes, so the heuristic is:
+//   an error event that fires before any payload arrived AND closes the
+//   connection is treated as a no-op. Mid-stream errors after data has
+//   flowed are surfaced via `lastError`.
+// ---------------------------------------------------------------------------
+
+const MAX_EVENTS = 500;
+
+/** Discriminated union of SSE event payloads emitted by the backend stream. */
+export type SessionStreamEvent =
+  | { type: "chunk"; data: { content?: string; [k: string]: unknown }; receivedAt: number }
+  | { type: "tool_use"; data: { tool?: string; input?: unknown; id?: string; [k: string]: unknown }; receivedAt: number }
+  | { type: "tool_result"; data: { tool?: string; result?: unknown; is_error?: boolean; [k: string]: unknown }; receivedAt: number }
+  | { type: "phase"; data: { phase?: string; [k: string]: unknown }; receivedAt: number }
+  | { type: "done"; data: Record<string, unknown>; receivedAt: number }
+  | { type: "owner_notice"; data: { message?: string; [k: string]: unknown }; receivedAt: number };
+
+export type UseSessionStreamResult = {
+  /** Append-only list of parsed events, capped at MAX_EVENTS (oldest dropped). */
+  events: SessionStreamEvent[];
+  /** True while the EventSource is open and accepting events. */
+  isAttached: boolean;
+  /** Last surfaced error, or null. 404-on-open is intentionally swallowed. */
+  lastError: string | null;
+};
+
+export type UseSessionStreamOptions = {
+  /**
+   * Override the default endpoint builder. Tests inject a stub URL; production
+   * callers should not need this.
+   */
+  buildUrl?: (agentId: string, sessionId: string) => string;
+  /**
+   * Optional EventSource constructor — defaults to globalThis.EventSource.
+   * Tests can pass a fake. If the environment has no EventSource (older
+   * browsers, jsdom without polyfill) the hook returns a no-op state.
+   */
+  eventSourceCtor?: typeof EventSource;
+};
+
+const SSE_TYPES = ["chunk", "tool_use", "tool_result", "phase", "done", "owner_notice"] as const;
+type SseType = (typeof SSE_TYPES)[number];
+
+function defaultBuildUrl(agentId: string, sessionId: string): string {
+  return `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/stream`;
+}
+
+export function useSessionStream(
+  agentId: string | null | undefined,
+  sessionId: string | null | undefined,
+  options: UseSessionStreamOptions = {},
+): UseSessionStreamResult {
+  const [events, setEvents] = useState<SessionStreamEvent[]>([]);
+  const [isAttached, setIsAttached] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+  // Track whether any payload arrived before an error fires. If not, an
+  // error+close is almost certainly a 404 / not-deployed / no-active-turn —
+  // swallow it.
+  const receivedAnyRef = useRef(false);
+
+  useEffect(() => {
+    // Reset state when ids change so stale events don't leak across sessions.
+    setEvents([]);
+    setIsAttached(false);
+    setLastError(null);
+    receivedAnyRef.current = false;
+
+    if (!agentId || !sessionId) return;
+    const Ctor = options.eventSourceCtor ?? (typeof EventSource !== "undefined" ? EventSource : undefined);
+    if (!Ctor) return;
+
+    const url = (options.buildUrl ?? defaultBuildUrl)(agentId, sessionId);
+
+    let es: EventSource;
+    try {
+      es = new Ctor(url, { withCredentials: true });
+    } catch {
+      // Constructor itself threw — environment doesn't support EventSource
+      // for this URL (e.g. invalid scheme in tests). Stay detached, silent.
+      return;
+    }
+
+    const handlePayload = (type: SseType, raw: string) => {
+      receivedAnyRef.current = true;
+      let parsed: Record<string, unknown> = {};
+      try {
+        parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+      } catch {
+        // Non-JSON payload — preserve as raw content so callers can still
+        // render it.
+        parsed = { content: raw };
+      }
+      const evt = {
+        type,
+        data: parsed,
+        receivedAt: Date.now(),
+      } as SessionStreamEvent;
+      setEvents((prev) => {
+        const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev;
+        return [...next, evt];
+      });
+      // Auto-detach on terminal "done" so consumers can react without polling.
+      if (type === "done") {
+        setIsAttached(false);
+      }
+    };
+
+    const listeners = SSE_TYPES.map((type) => {
+      const fn = (ev: MessageEvent) => handlePayload(type, typeof ev.data === "string" ? ev.data : "");
+      es.addEventListener(type, fn as EventListener);
+      return { type, fn };
+    });
+
+    const onOpen = () => {
+      setIsAttached(true);
+      setLastError(null);
+    };
+    const onError = () => {
+      // EventSource doesn't expose HTTP status. If we never received any
+      // payload AND the connection closed, assume the route isn't there
+      // (deployed in #3078 but not yet on this client's server) or the
+      // session has no active turn — both of which are valid no-ops.
+      const closed = es.readyState === 2; // EventSource.CLOSED
+      if (!receivedAnyRef.current && closed) {
+        // Silent no-op — don't surface to the UI.
+        setIsAttached(false);
+        return;
+      }
+      if (closed) {
+        // Mid-stream drop after data flowed — worth telling the caller, but
+        // don't toast: a co-watcher dropping isn't a destructive error.
+        setLastError("session stream disconnected");
+        setIsAttached(false);
+      }
+      // Transient errors (readyState === CONNECTING) are EventSource's own
+      // automatic reconnect; ignore them.
+    };
+
+    es.addEventListener("open", onOpen);
+    es.addEventListener("error", onError);
+
+    return () => {
+      es.removeEventListener("open", onOpen);
+      es.removeEventListener("error", onError);
+      for (const { type, fn } of listeners) {
+        es.removeEventListener(type, fn as EventListener);
+      }
+      es.close();
+      setIsAttached(false);
+    };
+    // buildUrl/eventSourceCtor are stable in production; tests pass them
+    // once at mount. Excluding them keeps the connection from churning.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId, sessionId]);
+
+  return { events, isAttached, lastError };
 }

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ import { useMediaProviders } from "../lib/queries/media";
 import { useModels } from "../lib/queries/models";
 import { usePendingApprovals } from "../lib/queries/approvals";
 import { useAgents, useAgentSessions } from "../lib/queries/agents";
+import { useSessionStream } from "../lib/queries/sessions";
 import { useActiveHandsWhen } from "../lib/queries/hands";
 import { approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
@@ -1570,7 +1571,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
 }
 
 // Connection status bar with session dropdown
-function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable, onOpenConfig }: {
+function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable, onOpenConfig, attached, attachedEventCount }: {
   agentName: string; isLoading: boolean; messageCount: number; onClear: () => void; onExport: () => void; wsConnected?: boolean; modelName?: string; modelProvider?: string;
   sessions?: SessionListItem[]; activeSessionId?: string;
   onSwitchSession?: (sessionId: string) => void; onNewSession?: () => void; onDeleteSession?: (sessionId: string) => void;
@@ -1578,6 +1579,10 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
   webSearchAugmentation?: "off" | "auto" | "always"; onWebSearchChange?: (mode: "off" | "auto" | "always") => void;
   webSearchAvailable?: boolean;
   onOpenConfig: () => void;
+  /** True while the multi-client SSE attach stream is open. */
+  attached?: boolean;
+  /** Number of SSE events received on the attach stream (for operator visibility). */
+  attachedEventCount?: number;
 }) {
   const { t } = useTranslation();
   const [sessionOpen, setSessionOpen] = useState(false);
@@ -1707,6 +1712,15 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
           <Badge variant="brand" dot>
             <Zap className="h-2.5 w-2.5 mr-0.5" />
             {t("chat.ws_connected")}
+          </Badge>
+        )}
+        {attached && (
+          <Badge variant="brand" dot>
+            <Eye className="h-2.5 w-2.5 mr-0.5" />
+            {t("chat.session_attach_watching", { defaultValue: "Watching" })}
+            {typeof attachedEventCount === "number" && attachedEventCount > 0
+              ? ` (${attachedEventCount})`
+              : ""}
           </Badge>
         )}
         <span className="text-text-dim/30 hidden sm:inline">&bull;</span>
@@ -2300,6 +2314,17 @@ export function ChatPage() {
   }, [sessionsQuery.data]);
   const activeSessionId = urlSessionId ?? serverActiveSessionId;
 
+  // Multi-attach SSE viewer (issue #3078). Opt-in behind ?attach=1 — the
+  // server-side route ships in a separate PR; until that lands the hook
+  // silently no-ops on the 404 it returns. We watch a session that another
+  // client (CLI, desktop, second browser tab) may already be driving over
+  // its own /message/stream connection.
+  const attachEnabled = search?.attach === "1" && !!selectedAgentId && !!activeSessionId;
+  const sessionStream = useSessionStream(
+    attachEnabled ? selectedAgentId : null,
+    attachEnabled ? activeSessionId ?? null : null,
+  );
+
   // Sidebar clicks update the URL — no switch_agent_session POST. Each tab's
   // URL carries its own sessionId, and the send path forwards it per-request.
   const handleSwitchSession = useCallback(async (sessionId: string) => {
@@ -2548,6 +2573,8 @@ export function ChatPage() {
               onOpenConfig={() => navigate({ to: "/config" })}
               webSearchAugmentation={selectedAgent?.web_search_augmentation}
               webSearchAvailable={webSearchAvailable}
+              attached={attachEnabled && sessionStream.isAttached}
+              attachedEventCount={sessionStream.events.length}
               onWebSearchChange={async (mode) => {
                 try {
                   await patchAgentConfigMutation.mutateAsync({

--- a/crates/librefang-api/dashboard/src/router.tsx
+++ b/crates/librefang-api/dashboard/src/router.tsx
@@ -138,10 +138,14 @@ const channelsRoute = createRoute({
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/chat",
-  validateSearch: (search: Record<string, unknown>): { agentId?: string; sessionId?: string } => {
-    const out: { agentId?: string; sessionId?: string } = {};
+  validateSearch: (search: Record<string, unknown>): { agentId?: string; sessionId?: string; attach?: string } => {
+    const out: { agentId?: string; sessionId?: string; attach?: string } = {};
     if (typeof search.agentId === "string") out.agentId = search.agentId;
     if (typeof search.sessionId === "string") out.sessionId = search.sessionId;
+    // Hidden flag: enables the multi-attach SSE viewer (see useSessionStream).
+    // Functionally testable once #3078 lands; before then the hook silently
+    // no-ops on the 404 the route returns.
+    if (typeof search.attach === "string") out.attach = search.attach;
     return out;
   },
   component: () => <L><ChatPage /></L>


### PR DESCRIPTION
## Summary

- Adds a TanStack-friendly `useSessionStream(agentId, sessionId)` hook that subscribes to the server-side SSE endpoint introduced in #3078 (`GET /api/agents/{id}/sessions/{session_id}/stream`), so any client (extra browser tab, desktop, CLI) can read-only co-watch a session another client is driving over `POST /message/stream`.
- Surfaces a minimal "Watching" Badge in `ChatPage` next to the existing WS badge, opt-in behind a hidden `?attach=1` URL param. Until #3078 is deployed the indicator simply never lights up — the hook silently absorbs the 404 the route returns.
- No Rust changes. The originating-client streaming path (`POST /message/stream`) is untouched; both modes coexist.

## Why now

#3078 unblocks multi-attach on the server. This PR is the client-side wiring so that when #3078 merges, no further frontend work is needed. The hook is built to be a no-op against today's `origin/main`, so it's safe to land first.

## What changed

- `src/lib/queries/sessions.ts` — `useSessionStream` hook + `SessionStreamEvent` discriminated union, capped at 500 events, with clean unmount / agent-change / session-change teardown. Exception to the "all data via TanStack hooks" rule is documented in `dashboard/AGENTS.md` (Streaming/SSE may use native browser APIs).
- `src/lib/queries/sessions-stream.test.tsx` — vitest covering: ids-missing no-op, parsing of `chunk` / `tool_use`, terminal `done` auto-detach, silent 404-style swallow, mid-stream error surfacing, unmount close, session-change reconnect, non-JSON fallback, 500-event memory cap, custom `buildUrl` injection.
- `src/pages/ChatPage.tsx` — wires the hook behind `attachEnabled = search.attach === "1" && agentId && activeSessionId`, passes `attached` + `attachedEventCount` props to `ConnectionBar`, renders an `Eye`-iconed Badge next to the existing `Zap` WS badge.
- `src/router.tsx` — adds `attach?: string` to the chat route `validateSearch`.

## Out of scope

- No Rust / server changes — wholly client-side.
- Existing `POST /message/stream` consumer (the WebSocket-driven turn in `useChatMessages`) is unchanged.
- No other routes, query factories, or domains touched.
- No new top-level UI; the indicator is a single badge inline with the existing connection bar.

## Validation

Validation: gates intentionally not run locally per user instruction; relying on CI to verify build/typecheck/lint/test.

Note: #3078 must merge before this is functionally testable end-to-end. Until then the indicator stays dark when `?attach=1` is set, which is the intended graceful-degradation behavior.

## Test plan

- [ ] CI typecheck green
- [ ] CI lint green
- [ ] CI vitest green (includes the new `sessions-stream.test.tsx`)
- [ ] CI build green
- [ ] After #3078 merges: load `/chat?agentId=...&sessionId=...&attach=1` in a second tab while another tab is mid-turn; verify the Eye badge lights up and the count increments as `chunk` events arrive.
- [ ] After #3078 merges: kill the second tab and confirm the EventSource is closed (DevTools Network tab; no leaked connection).