### PR TITLE
fix: cron preservation across hand reactivation + telegram startup timeout + token estimation includes ToolUse

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -23,6 +23,10 @@ use zeroize::Zeroizing;
 
 // Backoff and long-poll timeout are now configurable via TelegramConfig.
 
+/// Bound startup control-plane calls so a flaky Local Bot API cannot block
+/// daemon boot forever.
+const STARTUP_API_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Default Telegram Bot API base URL.
 const DEFAULT_API_URL: &str = "https://api.telegram.org";
 
@@ -1394,7 +1398,13 @@ impl TelegramAdapter {
             .map(|c| serde_json::json!({"command": c.command, "description": c.description}))
             .collect();
         let body = serde_json::json!({ "commands": cmds });
-        let resp = self.client.post(&url).json(&body).send().await?;
+        let resp = self
+            .client
+            .post(&url)
+            .timeout(STARTUP_API_TIMEOUT)
+            .json(&body)
+            .send()
+            .await?;
         if !resp.status().is_success() {
             let body_text = resp.text().await.unwrap_or_default();
             warn!("Telegram setMyCommands failed: {body_text}");
@@ -1656,6 +1666,7 @@ impl ChannelAdapter for TelegramAdapter {
                 .client
                 .post(&delete_url)
                 .json(&serde_json::json!({"drop_pending_updates": false}))
+                .timeout(STARTUP_API_TIMEOUT)
                 .send()
                 .await
             {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8612,7 +8612,7 @@ system_prompt = "You are a helpful assistant."
                 if !taken_crons.is_empty() {
                     saved_crons
                         .entry(old_role.clone())
-                        .or_insert_with(Vec::new)
+                        .or_default()
                         .extend(taken_crons);
                 }
                 if let Err(e) = self.kill_agent(old_id) {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8580,6 +8580,17 @@ system_prompt = "You are a helpful assistant."
         // Kill existing agents with matching hand tag (reactivation cleanup)
         let hand_tag = format!("hand:{hand_id}");
         let mut saved_triggers = std::collections::BTreeMap::new();
+        // Snapshot cron jobs per-role BEFORE kill_agent destroys them.
+        // kill_agent calls remove_agent_jobs() which deletes the jobs from
+        // memory and persists an empty cron_jobs.json to disk. The
+        // reassign_agent_jobs() call below would always be a no-op without
+        // this snapshot — same pattern as saved_triggers above. Fixes the
+        // silent loss of cron jobs across every daemon restart for
+        // hand-style agents.
+        let mut saved_crons: std::collections::BTreeMap<
+            String,
+            Vec<librefang_types::scheduler::CronJob>,
+        > = std::collections::BTreeMap::new();
         for entry in self.registry.list() {
             if entry.tags.contains(&hand_tag) {
                 let old_id = entry.id;
@@ -8597,13 +8608,22 @@ system_prompt = "You are a helpful assistant."
                         .or_insert_with(Vec::new)
                         .extend(taken_triggers);
                 }
+                let taken_crons = self.cron_scheduler.list_jobs(old_id);
+                if !taken_crons.is_empty() {
+                    saved_crons
+                        .entry(old_role.clone())
+                        .or_insert_with(Vec::new)
+                        .extend(taken_crons);
+                }
                 if let Err(e) = self.kill_agent(old_id) {
                     warn!(agent = %old_id, error = %e, "Failed to kill old hand agent");
                 }
-                // Migrate cron jobs to the same role in the new hand.
-                // Pass `instance_id` (the caller's parameter) so that
-                // `activate_hand()` (None) preserves legacy IDs while
-                // `activate_hand_with_id(_, _, Some(uuid))` uses the new format.
+                // Belt-and-braces: also reassign any jobs that somehow still
+                // reference the old UUID. After kill_agent's remove_agent_jobs
+                // wipes everything, this is a no-op in practice — the snapshot
+                // above is the primary mechanism. Kept as a safety net for
+                // edge cases like out-of-band cron creation between kill and
+                // respawn.
                 let new_id = AgentId::from_hand_agent(hand_id, &old_role, instance_id);
                 let migrated = self.cron_scheduler.reassign_agent_jobs(old_id, new_id);
                 if migrated > 0 {
@@ -8881,6 +8901,47 @@ system_prompt = "You are a helpful assistant."
             }
             if let Err(e) = self.triggers.persist() {
                 warn!("Failed to persist trigger jobs after hand reactivation: {e}");
+            }
+        }
+
+        // Restore cron jobs that were snapshotted before kill_agent. They're
+        // re-added under the new agent_id for the same role. Runtime state
+        // (next_run, last_run) is reset so jobs get a fresh start.
+        if !saved_crons.is_empty() {
+            let mut total_restored = 0usize;
+            for (role, jobs) in saved_crons {
+                if let Some(&new_id) = agent_ids_map.get(&role) {
+                    let mut restored = 0usize;
+                    for mut job in jobs {
+                        job.agent_id = new_id;
+                        job.next_run = None;
+                        job.last_run = None;
+                        if self.cron_scheduler.add_job(job, false).is_ok() {
+                            restored += 1;
+                        }
+                    }
+                    if restored > 0 {
+                        info!(
+                            hand = %hand_id,
+                            role = %role,
+                            agent = %new_id,
+                            restored,
+                            "Restored cron jobs after hand reactivation"
+                        );
+                    }
+                    total_restored += restored;
+                } else {
+                    warn!(
+                        hand = %hand_id,
+                        role = %role,
+                        "Dropping saved cron jobs for removed hand role during reactivation"
+                    );
+                }
+            }
+            if total_restored > 0 {
+                if let Err(e) = self.cron_scheduler.persist() {
+                    warn!("Failed to persist cron jobs after restoration: {e}");
+                }
             }
         }
 

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -179,8 +179,10 @@ impl MessageContent {
                     ContentBlock::Text { text, .. } => text.len(),
                     ContentBlock::ToolResult { content, .. } => content.len(),
                     ContentBlock::Thinking { thinking, .. } => thinking.len(),
-                    ContentBlock::ToolUse { .. }
-                    | ContentBlock::Image { .. }
+                    ContentBlock::ToolUse { name, input, .. } => {
+                        name.len() + input.to_string().len()
+                    }
+                    ContentBlock::Image { .. }
                     | ContentBlock::ImageFile { .. }
                     | ContentBlock::Unknown => 0,
                 })


### PR DESCRIPTION
## Summary
Three independent small fixes ported from openfang, in three independent commits:

### 1. `fix(kernel): preserve cron jobs across hand reactivation`
`activate_hand` previously killed the old agent (which clears its cron jobs) before spawning the replacement, and the existing `reassign_agent_jobs` was a dead path because it ran after `kill_agent`. Result: any `activate` lost the agent's scheduled jobs. Now we snapshot per-role cron jobs into `BTreeMap<String, Vec<CronJob>>` before `kill_agent`, and re-add them keyed by the new agent_id after spawn. Adapted from openfang `df22a3d` to LibreFang's multi-role saved_triggers pattern.

### 2. `fix(channels): add startup timeout for telegram control-plane calls`
`setMyCommands` and `deleteWebhook` calls during channel startup had no timeout — if the Telegram Bot API stalled, the entire daemon hung indefinitely. New `STARTUP_API_TIMEOUT = 10s` constant wraps both. Ported from openfang `fc902a9`.

### 3. `fix(types): include ToolUse arguments in token estimation`
`Message::text_length()` returned 0 for `ContentBlock::ToolUse`, so large `web_search` / `memory_store` calls disappeared from the budget — leading to premature "Token limit exceeded" or compaction skips. Now counts `name.len() + input.to_string().len()`. Ported from openfang `55395c8`.

## Test plan
- [x] grep'd LibreFang main — all three fixes verified absent
- [ ] Manual: schedule a cron, run `librefang hand activate <role>`, verify the cron survives the rotation
- [ ] Manual: block Telegram API at `api.telegram.org` and start daemon — should fail fast within 10s instead of hanging
- [ ] Manual: long tool-use conversation — verify token budget reflects ToolUse args (no more "no compaction" surprises)

## Notes
- Three independent commits (1c5de827 / 471b3555 / 3bea436d) so reviewers can land them piecemeal.
- No schema changes; no fixture impact.
