### PR TITLE
feat(kernel): session lifecycle event bus (additive, no subscribers yet)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -305,6 +305,8 @@ pub struct LibreFangKernel {
     pub(crate) capabilities: CapabilityManager,
     /// Event bus.
     pub(crate) event_bus: EventBus,
+    /// Session lifecycle event bus (push-based pub/sub for session-scoped events).
+    pub(crate) session_lifecycle_bus: Arc<crate::session_lifecycle::SessionLifecycleBus>,
     /// Agent scheduler.
     pub(crate) scheduler: AgentScheduler,
     /// Memory substrate.
@@ -1431,6 +1433,13 @@ impl LibreFangKernel {
     #[inline]
     pub fn event_bus_ref(&self) -> &EventBus {
         &self.event_bus
+    }
+
+    /// Session lifecycle event bus (clone-shared `Arc` so subscribers can hold
+    /// it across tasks).
+    #[inline]
+    pub fn session_lifecycle_bus(&self) -> Arc<crate::session_lifecycle::SessionLifecycleBus> {
+        Arc::clone(&self.session_lifecycle_bus)
     }
 
     /// OFP peer node (set once at startup).
@@ -2631,6 +2640,9 @@ impl LibreFangKernel {
             registry: AgentRegistry::new(),
             capabilities: CapabilityManager::new(),
             event_bus: EventBus::new(),
+            session_lifecycle_bus: Arc::new(crate::session_lifecycle::SessionLifecycleBus::new(
+                256,
+            )),
             scheduler: AgentScheduler::new(),
             memory: memory.clone(),
             proactive_memory: OnceLock::new(),
@@ -5048,17 +5060,28 @@ system_prompt = "You are a helpful assistant."
             }
         };
 
-        let mut session = self
+        let existing_session = self
             .memory
             .get_session(effective_session_id)
-            .map_err(KernelError::LibreFang)?
-            .unwrap_or_else(|| librefang_memory::session::Session {
-                id: effective_session_id,
-                agent_id,
-                messages: Vec::new(),
-                context_window_tokens: 0,
-                label: None,
-            });
+            .map_err(KernelError::LibreFang)?;
+        let session_was_new = existing_session.is_none();
+        let mut session = existing_session.unwrap_or_else(|| librefang_memory::session::Session {
+            id: effective_session_id,
+            agent_id,
+            messages: Vec::new(),
+            context_window_tokens: 0,
+            label: None,
+        });
+
+        // Lifecycle: emit SessionCreated only when get_session returned None.
+        if session_was_new {
+            self.session_lifecycle_bus.publish(
+                crate::session_lifecycle::SessionLifecycleEvent::SessionCreated {
+                    agent_id,
+                    session_id: effective_session_id,
+                },
+            );
+        }
 
         // Check if auto-compaction is needed: message-count OR token-count trigger
         let needs_compact = {
@@ -5317,6 +5340,15 @@ system_prompt = "You are a helpful assistant."
         // reload barrier before spawning the async task.
         drop(_config_guard);
 
+        // Lifecycle: emit TurnStarted right before the spawn. Cloning the bus
+        // Arc separately keeps it usable inside the async block via `kernel_clone`.
+        self.session_lifecycle_bus.publish(
+            crate::session_lifecycle::SessionLifecycleEvent::TurnStarted {
+                agent_id,
+                session_id: effective_session_id,
+            },
+        );
+
         let handle = tokio::spawn(async move {
             // Auto-compact if the session is large before running the loop.
             // Pass the in-turn session id so the compactor operates on
@@ -5516,6 +5548,16 @@ system_prompt = "You are a helpful assistant."
                         .scheduler
                         .record_tool_calls(agent_id, tool_count);
 
+                    // Lifecycle: emit TurnCompleted alongside record_usage. Use
+                    // post-loop session length for message_count.
+                    kernel_clone.session_lifecycle_bus.publish(
+                        crate::session_lifecycle::SessionLifecycleEvent::TurnCompleted {
+                            agent_id,
+                            session_id: effective_session_id,
+                            message_count: session.messages.len(),
+                        },
+                    );
+
                     // Atomically check quotas and persist usage to SQLite
                     // (mirrors non-streaming path — prevents TOCTOU race)
                     let model = &manifest.model.model;
@@ -5643,6 +5685,15 @@ system_prompt = "You are a helpful assistant."
                 Err(e) => {
                     kernel_clone.supervisor.record_panic();
                     warn!(agent_id = %agent_id, error = %e, "Streaming agent loop failed");
+                    // Lifecycle: emit TurnFailed before cleanup so subscribers
+                    // see the failure with the live session_id still valid.
+                    kernel_clone.session_lifecycle_bus.publish(
+                        crate::session_lifecycle::SessionLifecycleEvent::TurnFailed {
+                            agent_id,
+                            session_id: effective_session_id,
+                            error: e.to_string(),
+                        },
+                    );
                     if !loop_opts.is_fork {
                         kernel_clone.session_interrupts.remove(&agent_id);
                         kernel_clone.running_tasks.remove(&agent_id);
@@ -8487,6 +8538,17 @@ system_prompt = "You are a helpful assistant."
             librefang_runtime::audit::AuditAction::AgentKill,
             format!("name={}", entry.name),
             "ok",
+        );
+
+        // Lifecycle: agent has been removed from the registry; sessions tied
+        // to this agent are no longer active. Use the agent name as the
+        // best-effort reason — call sites that need richer context can extend
+        // the variant in a future change.
+        self.session_lifecycle_bus.publish(
+            crate::session_lifecycle::SessionLifecycleEvent::AgentTerminated {
+                agent_id,
+                reason: format!("kill_agent(name={})", entry.name),
+            },
         );
 
         info!(agent = %entry.name, id = %agent_id, "Agent killed");

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pairing;
 pub mod registry;
 pub use librefang_kernel_router as router;
 pub mod scheduler;
+pub mod session_lifecycle;
 pub mod session_policy;
 pub mod supervisor;
 pub mod triggers;

--- a/crates/librefang-kernel/src/session_lifecycle.rs
+++ b/crates/librefang-kernel/src/session_lifecycle.rs
@@ -1,0 +1,193 @@
+//! Session lifecycle event bus.
+//!
+//! Narrow, push-based pub/sub for session-scoped events: created, turn
+//! started, turn completed, turn failed, agent terminated.
+//!
+//! Modeled after openclaw's `src/sessions/session-lifecycle-events.ts`.
+//!
+//! This bus is intentionally separate from [`crate::event_bus::EventBus`],
+//! which carries broader inter-agent and system events. Subsystems that only
+//! care about session lifecycle (triggers, observability, audit) can subscribe
+//! here without paying the cost of the wider event stream.
+//!
+//! Publishing is fire-and-forget — `publish` never blocks the kernel and
+//! silently drops the event if no subscriber is listening.
+
+use librefang_types::agent::{AgentId, SessionId};
+use tokio::sync::broadcast;
+
+/// Default capacity for the broadcast channel ring buffer.
+const DEFAULT_CAPACITY: usize = 256;
+
+/// Lifecycle events emitted by the kernel for each session/turn.
+#[derive(Debug, Clone)]
+pub enum SessionLifecycleEvent {
+    /// A new session row was created in memory (first turn for that sid).
+    SessionCreated {
+        agent_id: AgentId,
+        session_id: SessionId,
+    },
+    /// An agent loop turn started for a session.
+    TurnStarted {
+        agent_id: AgentId,
+        session_id: SessionId,
+    },
+    /// A turn completed (success).
+    TurnCompleted {
+        agent_id: AgentId,
+        session_id: SessionId,
+        message_count: usize,
+    },
+    /// A turn failed (loop returned an error or panicked).
+    TurnFailed {
+        agent_id: AgentId,
+        session_id: SessionId,
+        error: String,
+    },
+    /// An agent was terminated; its sessions are no longer active.
+    AgentTerminated { agent_id: AgentId, reason: String },
+}
+
+/// Broadcast bus for [`SessionLifecycleEvent`].
+///
+/// Holds a single tokio `broadcast::Sender`. Subscribers obtain a
+/// `broadcast::Receiver` via [`SessionLifecycleBus::subscribe`]. When the
+/// channel buffer overflows for a slow subscriber, the standard tokio
+/// broadcast `Lagged` error is delivered on `recv` — callers should handle
+/// it explicitly.
+#[derive(Debug)]
+pub struct SessionLifecycleBus {
+    sender: broadcast::Sender<SessionLifecycleEvent>,
+}
+
+impl SessionLifecycleBus {
+    /// Create a new bus with the given broadcast channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity.max(1));
+        Self { sender }
+    }
+
+    /// Publish an event. Best-effort — drops silently when no subscribers.
+    ///
+    /// Never blocks: tokio's `broadcast::Sender::send` returns immediately,
+    /// and we ignore the `SendError` raised when the receiver count is zero.
+    pub fn publish(&self, event: SessionLifecycleEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    /// Subscribe to lifecycle events.
+    pub fn subscribe(&self) -> broadcast::Receiver<SessionLifecycleEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Number of currently active subscribers.
+    pub fn receiver_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+}
+
+impl Default for SessionLifecycleBus {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matches_turn_started(
+        ev: &SessionLifecycleEvent,
+        expected_agent: AgentId,
+        expected_session: SessionId,
+    ) -> bool {
+        matches!(
+            ev,
+            SessionLifecycleEvent::TurnStarted { agent_id, session_id }
+                if *agent_id == expected_agent && *session_id == expected_session
+        )
+    }
+
+    #[tokio::test]
+    async fn publish_then_subscribe_receives_event() {
+        let bus = SessionLifecycleBus::new(16);
+        let mut rx = bus.subscribe();
+
+        let agent_id = AgentId::new();
+        let session_id = SessionId::new();
+        bus.publish(SessionLifecycleEvent::TurnStarted {
+            agent_id,
+            session_id,
+        });
+
+        let received = rx.recv().await.expect("receive event");
+        assert!(matches_turn_started(&received, agent_id, session_id));
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_all_receive_event() {
+        let bus = SessionLifecycleBus::new(16);
+        let mut rx1 = bus.subscribe();
+        let mut rx2 = bus.subscribe();
+        let mut rx3 = bus.subscribe();
+
+        let agent_id = AgentId::new();
+        let session_id = SessionId::new();
+        bus.publish(SessionLifecycleEvent::SessionCreated {
+            agent_id,
+            session_id,
+        });
+
+        for rx in [&mut rx1, &mut rx2, &mut rx3] {
+            let ev = rx.recv().await.expect("receive event");
+            assert!(matches!(
+                ev,
+                SessionLifecycleEvent::SessionCreated { agent_id: a, session_id: s }
+                    if a == agent_id && s == session_id
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_with_no_subscribers_is_no_op() {
+        let bus = SessionLifecycleBus::new(16);
+        assert_eq!(bus.receiver_count(), 0);
+
+        // No panic, no error returned to caller.
+        bus.publish(SessionLifecycleEvent::AgentTerminated {
+            agent_id: AgentId::new(),
+            reason: "test".to_string(),
+        });
+
+        assert_eq!(bus.receiver_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_subscriber_does_not_break_others() {
+        let bus = SessionLifecycleBus::new(16);
+        let mut rx_keep = bus.subscribe();
+        let rx_drop = bus.subscribe();
+        assert_eq!(bus.receiver_count(), 2);
+
+        drop(rx_drop);
+        assert_eq!(bus.receiver_count(), 1);
+
+        let agent_id = AgentId::new();
+        let session_id = SessionId::new();
+        bus.publish(SessionLifecycleEvent::TurnCompleted {
+            agent_id,
+            session_id,
+            message_count: 5,
+        });
+
+        let received = rx_keep.recv().await.expect("receive event");
+        assert!(matches!(
+            received,
+            SessionLifecycleEvent::TurnCompleted {
+                agent_id: a,
+                session_id: s,
+                message_count: 5,
+            } if a == agent_id && s == session_id
+        ));
+    }
+}


### PR DESCRIPTION
## Why

Today, subsystems that need to react to session-level state changes (trigger engine, future observability, future audit) poll the kernel. Polling is wasteful and inherently lossy — short-lived state transitions (turn started / turn failed) can be missed entirely between polls.

This PR adds a narrow, push-based pub/sub bus for session-scoped events, modeled after openclaw's `src/sessions/session-lifecycle-events.ts`. It is the foundation for migrating triggers off polling and for plugging in span-level observability later.

This is intentionally a *foundation* PR. **No existing poller is migrated to subscribe yet** — that's a follow-up so the surface area of this change stays small and reviewable.

## What's in

- New `crates/librefang-kernel/src/session_lifecycle.rs` defining:
  - `SessionLifecycleEvent` enum with 5 variants: `SessionCreated`, `TurnStarted`, `TurnCompleted`, `TurnFailed`, `AgentTerminated`.
  - `SessionLifecycleBus` wrapping a `tokio::sync::broadcast::Sender` (capacity 256). `publish` is fire-and-forget — never blocks, never errors when there are no subscribers.
- `LibreFangKernel` gains a `session_lifecycle_bus: Arc<SessionLifecycleBus>` field plus a `session_lifecycle_bus()` accessor.
- The kernel emits events at five precise sites:
  - `SessionCreated` — only when `memory.get_session(effective_session_id)` returns `None` in `execute_llm_agent_streaming`.
  - `TurnStarted` — right before the `tokio::spawn` that runs `run_agent_loop_streaming`.
  - `TurnCompleted` — in the `Ok(result) =>` arm, alongside `record_usage`. `message_count` is `session.messages.len()` post-loop.
  - `TurnFailed` — in the `Err(e) =>` arm, before cleanup so the session_id is still meaningful.
  - `AgentTerminated` — in `kill_agent`, after the audit log record.
- Unit tests for the bus: publish-then-subscribe, multiple subscribers, no-subscriber no-op, drop-subscriber-others-keep-receiving.

## Out of scope (deliberately)

- No trigger engine / inbox / poller migration — future PR.
- No new event variants beyond the 5 above.
- The existing `EventBus` (broader inter-agent events) is untouched.
- No `AppState` wiring in `librefang-api` — future PR once a subscriber lands.
- No integration test that boots the kernel.

> Validation: gates intentionally not run locally per user instruction; relying on CI to verify build/test/clippy.

## Test plan
- [ ] CI: `cargo build --workspace --lib`
- [ ] CI: `cargo test --workspace` — including the 4 new unit tests in `session_lifecycle.rs`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`