### PR TITLE
feat(chat): support PDF and text/code file attachments end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +615,15 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
@@ -670,6 +688,12 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -782,6 +806,15 @@ dependencies = [
 
 [[package]]
 name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
@@ -817,6 +850,12 @@ dependencies = [
  "fnv",
  "uuid",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-expr"
@@ -1936,6 +1975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2156,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3482,6 +3539,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -3491,7 +3549,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "block-padding",
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -4031,7 +4089,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "cbc",
+ "cbc 0.2.0",
  "chrono",
  "criterion",
  "dashmap",
@@ -4405,6 +4463,7 @@ dependencies = [
  "librefang-types",
  "once_cell",
  "parking_lot",
+ "pdf-extract",
  "rand 0.10.0",
  "regex-lite",
  "reqwest 0.13.2",
@@ -4655,6 +4714,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes 0.8.4",
+ "bitflags 2.11.0",
+ "cbc 0.1.2",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap 2.14.0",
+ "itoa",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand 0.9.2",
+ "rangemap",
+ "sha2",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4773,6 +4860,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -5040,6 +5137,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -5572,6 +5680,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pdf-extract"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
+dependencies = [
+ "adobe-cmap-parser",
+ "cff-parser",
+ "encoding_rs",
+ "euclid 0.20.14",
+ "log",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6018,6 +6143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6055,6 +6186,12 @@ dependencies = [
  "embedded-io 0.6.1",
  "serde",
 ]
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -6503,6 +6640,12 @@ checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
@@ -7958,6 +8101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9212,6 +9366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9236,6 +9396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash",
+]
+
+[[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
 ]
 
 [[package]]
@@ -9339,10 +9508,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -10209,6 +10399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10274,7 +10470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
 dependencies = [
  "bitflags 1.3.2",
- "euclid",
+ "euclid 0.22.14",
  "lazy_static",
  "serde",
  "wezterm-dynamic",

--- a/crates/librefang-api/dashboard/src/components/SchemaForm.tsx
+++ b/crates/librefang-api/dashboard/src/components/SchemaForm.tsx
@@ -125,7 +125,7 @@ function validateSectionRequired(
     const v = values[fKey];
     if (f.required && (v === undefined || v === null || v === "")) {
       errors.push(`${pathPrefix}.${fKey}`);
-    } else if (f.type === "number" && hasInvalidNumberValue(v, f.required)) {
+    } else if (f.type === "number" && hasInvalidNumberValue(v, f.required ?? false)) {
       errors.push(`${pathPrefix}.${fKey}`);
     }
   }
@@ -162,7 +162,7 @@ function validateRequired(
     const v = values[key];
     if (field.required && (v === undefined || v === null || v === "")) {
       errors.push(key);
-    } else if (field.type === "number" && hasInvalidNumberValue(v, field.required)) {
+    } else if (field.type === "number" && hasInvalidNumberValue(v, field.required ?? false)) {
       errors.push(key);
     }
   }

--- a/crates/librefang-api/dashboard/src/components/ui/PageHeader.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PageHeader.tsx
@@ -7,13 +7,15 @@ interface PageHeaderProps {
   icon: ReactNode;
   title: string;
   subtitle?: string;
+  /** Optional small label rendered next to the title (e.g. "Beta", count). */
+  badge?: string;
   actions?: ReactNode;
   isFetching?: boolean;
   onRefresh?: () => void;
   helpText?: string;
 }
 
-export function PageHeader({ icon, title, subtitle, actions, isFetching, onRefresh, helpText }: PageHeaderProps) {
+export function PageHeader({ icon, title, subtitle, badge, actions, isFetching, onRefresh, helpText }: PageHeaderProps) {
   const { t } = useTranslation();
   const [showHelp, setShowHelp] = useState(false);
 
@@ -23,7 +25,14 @@ export function PageHeader({ icon, title, subtitle, actions, isFetching, onRefre
         <div className="flex items-center gap-2 min-w-0">
           <div className="p-1.5 rounded-lg bg-brand/10 text-brand shrink-0">{icon}</div>
           <div className="min-w-0">
-            <h1 className="text-base font-extrabold tracking-tight">{title}</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-base font-extrabold tracking-tight">{title}</h1>
+              {badge && (
+                <span className="inline-flex items-center rounded-md border border-border-subtle bg-main/40 px-1.5 py-0.5 text-[10px] font-semibold text-text-dim">
+                  {badge}
+                </span>
+              )}
+            </div>
             {subtitle && <p className="text-[11px] text-text-dim hidden sm:block">{subtitle}</p>}
           </div>
         </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1098,14 +1098,59 @@ function AttachmentChip({ attachment, onRemove }: { attachment: PendingAttachmen
 // Mirrored client-side so we can reject locally before pushing bytes over
 // the wire — the backend still enforces the real limit.
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
-// Restricted to image MIMEs because that's the only branch the agent loop
-// currently consumes: `routes/agents.rs::resolve_attachments()` skips any
-// attachment whose Content-Type doesn't start with `image/`. The /upload
-// endpoint itself accepts a wider set (audio for transcription, pdf/text)
-// but those paths aren't wired into the chat send pipeline yet — offering
-// them here would silently drop user context. Mirrors
-// `librefang_types::media::ALLOWED_IMAGE_TYPES`.
-const ATTACHMENT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
+// Types the agent loop currently consumes via
+// `routes/agents.rs::resolve_attachments()`:
+//   - image/* — passed inline as base64 image blocks
+//   - application/pdf — text-extracted via pdf-extract
+//   - text-like files (text/*, JSON, YAML, TOML, code/data extensions) —
+//     read as UTF-8 and inlined as a text block, truncated at 200K chars
+// audio/* is accepted by `/upload` (auto-transcribed via the media engine)
+// but the transcription path returns a stub today, so it's left out here.
+//
+// Extensions in the accept attribute are needed because browsers commonly
+// set empty / `application/octet-stream` for code files like .rs / .py.
+const PDF_MIME = "application/pdf";
+const TEXT_LIKE_EXTENSIONS = [
+  // Plain text & docs
+  ".txt", ".md", ".markdown", ".rst", ".csv", ".tsv", ".log",
+  // Config & data
+  ".json", ".yaml", ".yml", ".toml", ".xml", ".ini", ".conf", ".cfg", ".env", ".properties",
+  // Web
+  ".html", ".htm", ".css", ".scss", ".sass", ".less",
+  // JS/TS family
+  ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".vue", ".svelte",
+  // Other languages
+  ".py", ".rs", ".go", ".java", ".kt", ".kts", ".swift", ".scala", ".clj", ".ex", ".exs",
+  ".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hh", ".m", ".mm",
+  ".rb", ".php", ".pl", ".lua", ".r", ".jl", ".dart", ".zig", ".nim",
+  // Shell
+  ".sh", ".bash", ".zsh", ".fish", ".ps1",
+  // Query / schema
+  ".sql", ".graphql", ".gql", ".proto",
+  // Notebooks
+  ".ipynb",
+];
+const TEXT_LIKE_MIMES = [
+  "text/*",
+  "application/json",
+  "application/xml",
+  "application/yaml",
+  "application/x-yaml",
+  "application/toml",
+  "application/x-toml",
+  "application/x-ipynb+json",
+  "application/javascript",
+  "application/x-javascript",
+  "application/typescript",
+  "application/sql",
+  "application/graphql",
+];
+const ATTACHMENT_ACCEPT = [
+  "image/png", "image/jpeg", "image/webp", "image/gif",
+  PDF_MIME,
+  ...TEXT_LIKE_MIMES,
+  ...TEXT_LIKE_EXTENSIONS,
+].join(",");
 
 interface PendingAttachment {
   /** Stable client id used to track this entry across upload state changes. */
@@ -1210,6 +1255,23 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
   // ── Attachment upload pipeline ────────────────────────────────────────────
 
   const isImageMime = (mime: string) => mime.startsWith("image/");
+  const isPdfMime = (mime: string) => mime === PDF_MIME;
+  const isTextLikeMime = (mime: string) => {
+    if (mime.startsWith("text/")) return true;
+    return TEXT_LIKE_MIMES.includes(mime);
+  };
+  const hasTextLikeExtension = (filename: string) => {
+    const lower = filename.toLowerCase();
+    return TEXT_LIKE_EXTENSIONS.some(ext => lower.endsWith(ext));
+  };
+  // Browsers often leave `file.type` empty for code files (e.g. `.rs`),
+  // so we fall back to extension matching — matching the backend's
+  // `is_text_like_attachment` logic.
+  const isSupportedFile = (file: File) =>
+    isImageMime(file.type)
+    || isPdfMime(file.type)
+    || isTextLikeMime(file.type)
+    || hasTextLikeExtension(file.name);
 
   const enqueueFiles = useCallback((files: File[]) => {
     if (!agentId || files.length === 0) return;
@@ -1217,11 +1279,12 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
       const localId = `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const tooLarge = file.size > MAX_ATTACHMENT_BYTES;
       const isImage = isImageMime(file.type);
+      // Local preview only makes sense for images; PDFs render as a file chip.
       const previewUrl = isImage ? URL.createObjectURL(file) : undefined;
-      // Drop/paste bypasses <input accept>, so we still need to enforce
-      // image-only here — non-image attachments would upload but the agent
-      // loop would silently discard them.
-      if (!isImage) {
+      // Drop/paste bypasses <input accept>, so we still enforce the
+      // supported-type check here — anything else would upload but the agent
+      // loop would silently discard it.
+      if (!isSupportedFile(file)) {
         setAttachments(prev => [...prev, {
           localId,
           filename: file.name,
@@ -1229,7 +1292,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
           contentType: file.type || "application/octet-stream",
           previewUrl,
           status: "error",
-          errorMessage: t("chat.attachment_unsupported_type", { defaultValue: "Only images are supported (png, jpeg, webp, gif)" }),
+          errorMessage: t("chat.attachment_unsupported_type", { defaultValue: "Unsupported file type. Allowed: images, PDF, and common text/code files." }),
         }]);
         continue;
       }
@@ -1489,7 +1552,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
         </button>
       </div>
       )}
-      <div className="flex gap-2 sm:gap-3 items-end">
+      <div className="flex gap-2 sm:gap-3 items-start">
         <div className="flex-1">
           <textarea
             ref={textareaRef}

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -902,10 +902,82 @@ pub async fn list_agents(
     .into_response()
 }
 
-/// Resolve uploaded file attachments into ContentBlock::Image blocks.
+/// Hard cap on inlined text-attachment length (chars). Mirrors the PDF
+/// truncation cap so a 5 MB `.log` paste doesn't blow the LLM context.
+const MAX_TEXT_ATTACHMENT_CHARS: usize = 200_000;
+const TEXT_TRUNCATION_MARKER: &str =
+    "\n\n[…file truncated at 200K chars; content continues beyond this point…]";
+
+/// Decide whether an attachment looks like a UTF-8 text/code/data file
+/// the LLM can read directly. Browsers don't set `content_type` reliably
+/// for code files (`.rs`, `.py` typically come through as empty or
+/// `application/octet-stream`), so we fall back to extension matching.
+fn is_text_like_attachment(content_type: &str, filename: &str) -> bool {
+    if content_type.starts_with("text/") {
+        return true;
+    }
+    let known_mime = matches!(
+        content_type,
+        "application/json"
+            | "application/xml"
+            | "application/yaml"
+            | "application/x-yaml"
+            | "application/toml"
+            | "application/x-toml"
+            | "application/x-ipynb+json"
+            | "application/javascript"
+            | "application/x-javascript"
+            | "application/typescript"
+            | "application/sql"
+            | "application/graphql"
+    );
+    if known_mime {
+        return true;
+    }
+    let ext = filename
+        .rsplit('.')
+        .next()
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    matches!(
+        ext.as_str(),
+        // Plain text & docs
+        "txt" | "md" | "markdown" | "rst" | "csv" | "tsv" | "log"
+        // Config & data
+        | "json" | "yaml" | "yml" | "toml" | "xml" | "ini" | "conf" | "cfg" | "env" | "properties"
+        // Web
+        | "html" | "htm" | "css" | "scss" | "sass" | "less"
+        // JS/TS family
+        | "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "vue" | "svelte"
+        // Other languages
+        | "py" | "rs" | "go" | "java" | "kt" | "kts" | "swift" | "scala" | "clj" | "ex" | "exs"
+        | "c" | "cpp" | "cc" | "cxx" | "h" | "hpp" | "hh" | "m" | "mm"
+        | "rb" | "php" | "pl" | "lua" | "r" | "jl" | "dart" | "zig" | "nim"
+        // Shell
+        | "sh" | "bash" | "zsh" | "fish" | "ps1"
+        // Query / schema
+        | "sql" | "graphql" | "gql" | "proto"
+        // Notebooks
+        | "ipynb"
+        // Build files (no extension is rare; keep names like Dockerfile out — accept attribute can't match those)
+        | "dockerfile" | "makefile"
+    )
+}
+
+/// Resolve uploaded file attachments into content blocks.
 ///
-/// Reads each file from the upload directory, base64-encodes it, and
-/// returns image content blocks ready to insert into a session message.
+/// Reads each file from the upload directory and produces blocks the
+/// agent loop can consume:
+///   - `image/*` → `ContentBlock::Image` (base64-encoded inline)
+///   - `application/pdf` → `ContentBlock::Text` with a `[Attached PDF: <filename>]`
+///     header followed by extracted plain text (truncated at 200K chars).
+///     Scanned/image-only PDFs surface as a text note explaining no text
+///     was extractable, so the LLM at least sees the attachment exists.
+///   - text-like files (any `text/*`, `application/json|xml|yaml|toml|…`,
+///     plus common code/data extensions) → `ContentBlock::Text` with a
+///     `[Attached file: <filename>]` header. Read as UTF-8 lossy and
+///     truncated at 200K chars.
+///   - everything else → skipped with a warn log.
 pub fn resolve_attachments(
     attachments: &[AttachmentRef],
 ) -> Vec<librefang_types::message::ContentBlock> {
@@ -917,18 +989,13 @@ pub fn resolve_attachments(
     for att in attachments {
         // Look up metadata from the upload registry
         let meta = UPLOAD_REGISTRY.get(&att.file_id);
-        let content_type = if let Some(ref m) = meta {
-            m.content_type.clone()
+        let (content_type, filename) = if let Some(ref m) = meta {
+            (m.content_type.clone(), m.filename.clone())
         } else if !att.content_type.is_empty() {
-            att.content_type.clone()
+            (att.content_type.clone(), att.file_id.clone())
         } else {
             continue; // Skip unknown attachments
         };
-
-        // Only process image types
-        if !content_type.starts_with("image/") {
-            continue;
-        }
 
         // Validate file_id is a UUID to prevent path traversal
         if uuid::Uuid::parse_str(&att.file_id).is_err() {
@@ -936,37 +1003,129 @@ pub fn resolve_attachments(
         }
 
         let file_path = upload_dir.join(&att.file_id);
-        match std::fs::read(&file_path) {
-            Ok(data) => {
-                let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
-                blocks.push(librefang_types::message::ContentBlock::Image {
-                    media_type: content_type,
-                    data: b64,
-                });
+
+        if content_type.starts_with("image/") {
+            match std::fs::read(&file_path) {
+                Ok(data) => {
+                    let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+                    tracing::info!(
+                        file_id = %att.file_id,
+                        filename = %filename,
+                        content_type = %content_type,
+                        size_bytes = data.len(),
+                        "Resolved image attachment into Image block"
+                    );
+                    blocks.push(librefang_types::message::ContentBlock::Image {
+                        media_type: content_type,
+                        data: b64,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read image upload");
+                }
             }
-            Err(e) => {
-                tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read upload for attachment");
+        } else if content_type == "application/pdf" {
+            match std::fs::read(&file_path) {
+                Ok(data) => {
+                    let header = format!("[Attached PDF: {} ({} bytes)]", filename, data.len());
+                    let body = match librefang_runtime::pdf_text::extract_text_from_pdf(&data) {
+                        Ok(text) => text,
+                        Err(e) => {
+                            tracing::warn!(
+                                file_id = %att.file_id,
+                                filename = %filename,
+                                error = %e,
+                                "PDF text extraction failed; surfacing as note to LLM"
+                            );
+                            format!("[Could not extract text: {e}]")
+                        }
+                    };
+                    tracing::info!(
+                        file_id = %att.file_id,
+                        filename = %filename,
+                        size_bytes = data.len(),
+                        extracted_chars = body.chars().count(),
+                        "Resolved PDF attachment into Text block"
+                    );
+                    blocks.push(librefang_types::message::ContentBlock::Text {
+                        text: format!("{header}\n\n{body}"),
+                        provider_metadata: None,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read PDF upload");
+                }
             }
+        } else if is_text_like_attachment(&content_type, &filename) {
+            match std::fs::read(&file_path) {
+                Ok(data) => {
+                    let raw = String::from_utf8_lossy(&data);
+                    let total_chars = raw.chars().count();
+                    let (body, truncated) = if total_chars > MAX_TEXT_ATTACHMENT_CHARS {
+                        let mut s: String = raw.chars().take(MAX_TEXT_ATTACHMENT_CHARS).collect();
+                        s.push_str(TEXT_TRUNCATION_MARKER);
+                        (s, true)
+                    } else {
+                        (raw.into_owned(), false)
+                    };
+                    let suffix = if truncated { ", truncated" } else { "" };
+                    let header = format!(
+                        "[Attached file: {} ({} bytes{})]",
+                        filename,
+                        data.len(),
+                        suffix
+                    );
+                    tracing::info!(
+                        file_id = %att.file_id,
+                        filename = %filename,
+                        content_type = %content_type,
+                        size_bytes = data.len(),
+                        kept_chars = body.chars().count(),
+                        truncated,
+                        "Resolved text attachment into Text block"
+                    );
+                    blocks.push(librefang_types::message::ContentBlock::Text {
+                        text: format!("{header}\n\n{body}"),
+                        provider_metadata: None,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read text upload");
+                }
+            }
+        } else {
+            tracing::warn!(
+                file_id = %att.file_id,
+                content_type = %content_type,
+                filename = %filename,
+                "Attachment type not yet wired into the agent loop; skipping"
+            );
         }
     }
 
     blocks
 }
 
-/// Pre-insert image attachments into an agent's session so the LLM can see them.
+/// Pre-insert attachment content blocks (image / extracted-text-from-PDF /
+/// text files) into an agent's session so the LLM can see them.
 ///
-/// This injects image content blocks into the session BEFORE the kernel
-/// adds the text user message, so the LLM receives: [..., User(images), User(text)].
+/// Injects a single user-role message containing all blocks BEFORE the
+/// kernel adds the user's text message, so the LLM receives:
+/// `[..., User(attach_blocks), User(text)]`. session_repair will merge
+/// those two consecutive user-role messages into one for the wire format.
 pub fn inject_attachments_into_session(
     kernel: &LibreFangKernel,
     agent_id: AgentId,
-    image_blocks: Vec<librefang_types::message::ContentBlock>,
+    attachment_blocks: Vec<librefang_types::message::ContentBlock>,
 ) {
     use librefang_types::message::{Message, MessageContent, Role};
 
     let entry = match kernel.agent_registry().get(agent_id) {
         Some(e) => e,
-        None => return,
+        None => {
+            tracing::warn!(agent_id = ?agent_id, "Cannot inject attachments: agent not found in registry");
+            return;
+        }
     };
 
     let mut session = match kernel.memory_substrate().get_session(entry.session_id) {
@@ -980,15 +1139,46 @@ pub fn inject_attachments_into_session(
         },
     };
 
+    let block_count = attachment_blocks.len();
+    let block_kinds: Vec<&'static str> = attachment_blocks
+        .iter()
+        .map(|b| match b {
+            librefang_types::message::ContentBlock::Image { .. } => "image",
+            librefang_types::message::ContentBlock::Text { .. } => "text",
+            librefang_types::message::ContentBlock::ImageFile { .. } => "image_file",
+            librefang_types::message::ContentBlock::ToolUse { .. } => "tool_use",
+            librefang_types::message::ContentBlock::ToolResult { .. } => "tool_result",
+            librefang_types::message::ContentBlock::Thinking { .. } => "thinking",
+            librefang_types::message::ContentBlock::Unknown => "unknown",
+        })
+        .collect();
+
     session.messages.push(Message {
         role: Role::User,
-        content: MessageContent::Blocks(image_blocks),
+        content: MessageContent::Blocks(attachment_blocks),
         pinned: false,
         timestamp: Some(chrono::Utc::now()),
     });
 
+    let total_messages_after = session.messages.len();
+
     if let Err(e) = kernel.memory_substrate().save_session(&session) {
-        tracing::warn!(error = %e, "Failed to save session with image attachments");
+        tracing::warn!(
+            agent_id = ?agent_id,
+            session_id = ?entry.session_id,
+            block_count,
+            error = %e,
+            "Failed to save session with attachment blocks"
+        );
+    } else {
+        tracing::info!(
+            agent_id = ?agent_id,
+            session_id = ?entry.session_id,
+            block_count,
+            block_kinds = ?block_kinds,
+            total_messages_after,
+            "Injected attachment blocks into session"
+        );
     }
 }
 
@@ -4222,30 +4412,72 @@ const MAX_UPLOAD_SIZE: usize = 10 * 1024 * 1024;
 /// sourced from `librefang_types::media::{ALLOWED_IMAGE_TYPES,
 /// ALLOWED_AUDIO_TYPES}` so the upload endpoint, the channel bridge, and
 /// `MediaAttachment::validate()` can never drift.
-const EXTRA_ALLOWED_UPLOAD_TYPES: &[&str] =
-    &["text/plain", "text/markdown", "text/csv", "application/pdf"];
-
-/// Exact-match MIME allowlist for `/api/agents/{id}/upload`.
 ///
-/// Historically this was the prefix list `["image/", "text/",
-/// "application/pdf", "audio/"]`, which accepted any `image/*` subtype —
-/// including `image/svg+xml` (scriptable → XSS / SSRF via `<use
-/// xlink:href>`), `image/x-icon`, `image/tiff`, `image/heic` — and every
-/// `text/*` subtype including `text/html` and `text/xml`. That
+/// Browsers send a wide variety of `Content-Type` values for the same file
+/// kind (`.json` → `application/json`; `.yaml` → `application/x-yaml` /
+/// `application/yaml`; `.ipynb` → `application/x-ipynb+json` / sometimes
+/// `application/json`), so this list is intentionally exhaustive on the
+/// safe subset.
+const EXTRA_ALLOWED_UPLOAD_TYPES: &[&str] = &[
+    "application/pdf",
+    // Plain text + tables
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/tab-separated-values",
+    // Structured data
+    "application/json",
+    "application/x-ipynb+json",
+    "application/xml",
+    "application/yaml",
+    "application/x-yaml",
+    "application/toml",
+    "application/x-toml",
+    "application/sql",
+    "application/graphql",
+    // Code (often delivered with these MIMEs)
+    "application/javascript",
+    "application/x-javascript",
+    "application/typescript",
+];
+
+/// MIME allowlist for `/api/agents/{id}/upload`.
+///
+/// Historically this was a permissive prefix list (`image/`, `text/`,
+/// `application/pdf`, `audio/`) which accepted dangerous subtypes like
+/// `image/svg+xml` (scriptable → XSS / SSRF), `text/html` (stored XSS
+/// via downstream renderers), and `text/xml` (XXE / SSRF). That
 /// contradicted the SECURITY.md promise of *"Media type whitelist
 /// (png/jpeg/gif/webp)"*.
 ///
-/// The new check is exact-match against the canonical
-/// `librefang_types::media::ALLOWED_IMAGE_TYPES` +
-/// `ALLOWED_AUDIO_TYPES` constants, so the upload endpoint and
-/// `MediaAttachment::validate()` share a single source of truth and
-/// cannot drift.
+/// The check now combines:
+///   1. Exact match against the canonical media constants
+///      (`ALLOWED_IMAGE_TYPES`, `ALLOWED_AUDIO_TYPES`).
+///   2. Exact match against `EXTRA_ALLOWED_UPLOAD_TYPES` (PDF + curated
+///      text/data/code MIMEs).
+///   3. **Any other `text/*` subtype** EXCEPT `text/html` and `text/xml`.
+///      Browsers tag many code files (`.rs`, `.py`, `.go`, `.sh`, …) as
+///      `text/x-rust`, `text/x-python`, `text/x-shellscript` etc. — those
+///      are safe to inline because the agent loop reads them as plain
+///      UTF-8 and never executes/renders them. HTML/XML stay blocked
+///      because downstream consumers (markdown renderer, XML parsers)
+///      could be tricked into XSS / XXE.
 fn is_allowed_content_type(ct: &str) -> bool {
     use librefang_types::media::{mime_base, ALLOWED_AUDIO_TYPES, ALLOWED_IMAGE_TYPES};
     let base = mime_base(ct);
-    ALLOWED_IMAGE_TYPES.contains(&base.as_str())
+    if ALLOWED_IMAGE_TYPES.contains(&base.as_str())
         || ALLOWED_AUDIO_TYPES.contains(&base.as_str())
         || EXTRA_ALLOWED_UPLOAD_TYPES.contains(&base.as_str())
+    {
+        return true;
+    }
+    if let Some(subtype) = base.strip_prefix("text/") {
+        // Anything text-like is fine to ingest as a plain-text attachment,
+        // except formats that get rendered/parsed by downstream tooling
+        // and could carry an exploit payload.
+        return !matches!(subtype, "html" | "xml");
+    }
+    false
 }
 
 /// POST /api/agents/{id}/upload — Upload a file attachment.

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -4924,7 +4924,6 @@ mod tests {
             "text/xml",
             "audio/vnd.rn-realaudio",
             "application/octet-stream",
-            "application/javascript",
         ] {
             assert!(
                 !is_allowed_content_type(bad),

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -989,13 +989,19 @@ pub fn resolve_attachments(
     for att in attachments {
         // Look up metadata from the upload registry
         let meta = UPLOAD_REGISTRY.get(&att.file_id);
-        let (content_type, filename) = if let Some(ref m) = meta {
+        let (raw_content_type, filename) = if let Some(ref m) = meta {
             (m.content_type.clone(), m.filename.clone())
         } else if !att.content_type.is_empty() {
             (att.content_type.clone(), att.file_id.clone())
         } else {
             continue; // Skip unknown attachments
         };
+
+        // Normalize MIME for downstream branching: drop parameters
+        // (`application/pdf; charset=binary`) and lowercase. Without this,
+        // a `Content-Type: Application/PDF` header would skip the PDF branch
+        // and silently drop the attachment.
+        let content_type = librefang_types::media::mime_base(&raw_content_type);
 
         // Validate file_id is a UUID to prevent path traversal
         if uuid::Uuid::parse_str(&att.file_id).is_err() {

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -422,7 +422,22 @@ async fn handle_agent_ws(
     _guard: WsConnectionGuard,
     explicit_session: Option<SessionId>,
 ) {
-    info!(agent_id = %id_str, "WebSocket connected");
+    // Per-connection identity. Lets us distinguish concurrent reconnects
+    // (same agent_id, different conn_id) from a single client retrying.
+    let conn_id = uuid::Uuid::new_v4().simple().to_string();
+    let connected_at = std::time::Instant::now();
+    info!(
+        agent_id = %id_str,
+        conn_id = %conn_id,
+        client_ip = %client_ip,
+        explicit_session = ?explicit_session.map(|s| s.to_string()),
+        "WebSocket connected"
+    );
+
+    // Reason for the eventual disconnect — set at each exit point so the
+    // closing log line tells you whether it was a client close, an idle
+    // timeout, a protocol error, or stream EOF.
+    let mut disconnect_reason: &'static str = "stream_end";
 
     let (sender, mut receiver) = socket.split();
     let sender = Arc::new(Mutex::new(sender));
@@ -508,12 +523,13 @@ async fn handle_agent_ws(
             msg = receiver.next() => {
                 match msg {
                     Some(m) => m,
-                    None => break, // Stream ended
+                    // Init value of `disconnect_reason` ("stream_end") is read here.
+                    None => break,
                 }
             }
             _ = tokio::time::sleep(ws_idle_timeout.saturating_sub(last_activity.elapsed())) => {
                 let timeout_secs = ws_idle_timeout.as_secs();
-                info!(agent_id = %id_str, timeout_secs, "WebSocket idle timeout");
+                info!(agent_id = %id_str, conn_id = %conn_id, timeout_secs, "WebSocket idle timeout");
                 let _ = send_json(
                     &sender,
                     &serde_json::json!({
@@ -521,6 +537,7 @@ async fn handle_agent_ws(
                         "content": format!("Connection closed due to inactivity ({timeout_secs}s timeout)"),
                     }),
                 ).await;
+                disconnect_reason = "idle_timeout";
                 break;
             }
         };
@@ -528,7 +545,8 @@ async fn handle_agent_ws(
         let msg = match msg {
             Ok(m) => m,
             Err(e) => {
-                debug!(error = %e, "WebSocket receive error");
+                debug!(agent_id = %id_str, conn_id = %conn_id, error = %e, "WebSocket receive error");
+                disconnect_reason = "receive_error";
                 break;
             }
         };
@@ -578,8 +596,23 @@ async fn handle_agent_ws(
                 )
                 .await;
             }
-            Message::Close(_) => {
-                info!(agent_id = %id_str, "WebSocket closed by client");
+            Message::Close(frame) => {
+                let close_code = frame
+                    .as_ref()
+                    .map(|f| f.code.to_string())
+                    .unwrap_or_else(|| "<none>".to_string());
+                let close_reason_text = frame
+                    .as_ref()
+                    .map(|f| f.reason.to_string())
+                    .unwrap_or_default();
+                info!(
+                    agent_id = %id_str,
+                    conn_id = %conn_id,
+                    close_code = %close_code,
+                    close_reason = %close_reason_text,
+                    "WebSocket closed by client"
+                );
+                disconnect_reason = "client_close";
                 break;
             }
             Message::Ping(data) => {
@@ -593,7 +626,13 @@ async fn handle_agent_ws(
 
     // Cleanup
     update_handle.abort();
-    info!(agent_id = %id_str, "WebSocket disconnected");
+    info!(
+        agent_id = %id_str,
+        conn_id = %conn_id,
+        reason = %disconnect_reason,
+        duration_secs = connected_at.elapsed().as_secs(),
+        "WebSocket disconnected"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -632,9 +632,26 @@ impl OpenAIDriver {
                         }
                     }
                     if !parts.is_empty() && !has_tool_results {
+                        // session_repair already coalesced adjacent Text
+                        // blocks at the message-content layer, so `parts`
+                        // contains at most one Text run plus any Image /
+                        // File parts. If the whole thing collapses to a
+                        // single Text part we send it as a plain string —
+                        // maximally compatible with the long tail of
+                        // OpenAI-compatible backends whose multi-part
+                        // handling is shaky even at size 1.
+                        let content = if parts.len() == 1 {
+                            if let OaiContentPart::Text { text } = &parts[0] {
+                                OaiMessageContent::Text(text.clone())
+                            } else {
+                                OaiMessageContent::Parts(parts)
+                            }
+                        } else {
+                            OaiMessageContent::Parts(parts)
+                        };
                         oai_messages.push(OaiMessage {
                             role: "user".to_string(),
-                            content: Some(OaiMessageContent::Parts(parts)),
+                            content: Some(content),
                             tool_calls: None,
                             tool_call_id: None,
                             reasoning_content: None,

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -59,6 +59,7 @@ dirs = { workspace = true }
 tempfile = { workspace = true }
 landlock = { version = "0.4", optional = true }
 seccompiler = { version = "0.5", optional = true }
+pdf-extract = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2091,6 +2091,14 @@ fn prepare_llm_messages(
         .cloned()
         .collect();
 
+    debug!(
+        agent = %manifest.name,
+        session_id = %session.id,
+        msg_count = llm_messages.len(),
+        last_two_roles = ?llm_messages.iter().rev().take(2).map(|m| m.role).collect::<Vec<_>>(),
+        "Pre-repair message snapshot (prepare_llm_messages)"
+    );
+
     let (mut messages, repair_stats) =
         crate::session_repair::validate_and_repair_with_stats(&llm_messages);
 

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod mcp_server;
 pub mod media;
 pub mod media_understanding;
 pub mod model_catalog;
+pub mod pdf_text;
 pub mod pii_filter;
 pub mod plugin_manager;
 pub mod plugin_runtime;

--- a/crates/librefang-runtime/src/pdf_text.rs
+++ b/crates/librefang-runtime/src/pdf_text.rs
@@ -1,0 +1,85 @@
+//! PDF text extraction for chat attachments.
+//!
+//! Wraps `pdf_extract::extract_text_from_mem` with two pieces of safety
+//! the chat send pipeline needs:
+//!   1. Panic isolation. `pdf-extract` (and its lopdf dependency) is
+//!      historically panic-happy on malformed/encrypted PDFs. We catch
+//!      unwinds so a single bad attachment never takes down the request.
+//!   2. Output capping. The agent loop forwards the extracted text into
+//!      the LLM context — a 200-page report would otherwise blow through
+//!      the context window. We truncate at `MAX_PDF_TEXT_CHARS` and append
+//!      a clear marker so callers know it happened.
+
+use std::panic::AssertUnwindSafe;
+
+/// Hard cap on extracted text length (characters, not bytes). 200K chars
+/// is roughly 40-50K tokens — enough for most contracts/papers, well under
+/// any frontier model's context. If callers want the full document they
+/// should chunk + summarize, not jam it into a single user message.
+pub const MAX_PDF_TEXT_CHARS: usize = 200_000;
+
+/// Suffix appended when truncation occurs.
+const TRUNCATION_MARKER: &str = "\n\n[…PDF truncated at 200K chars; original document is longer…]";
+
+/// Extract plain text from PDF bytes.
+///
+/// Returns `Ok(text)` on success. Empty/whitespace-only output (typical
+/// of scanned/image-only PDFs) is converted to `Err` so callers can
+/// surface a useful message instead of feeding the LLM a blank attachment.
+pub fn extract_text_from_pdf(bytes: &[u8]) -> Result<String, String> {
+    if bytes.is_empty() {
+        return Err("PDF is empty".to_string());
+    }
+
+    // Catch unwind because pdf-extract / lopdf can panic on malformed
+    // or encrypted documents. We keep the request alive and turn the
+    // panic into a structured error string.
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        pdf_extract::extract_text_from_mem(bytes)
+    }));
+
+    let raw = match result {
+        Ok(Ok(text)) => text,
+        Ok(Err(e)) => return Err(format!("PDF parse failed: {e}")),
+        Err(_) => return Err("PDF parser panicked (likely malformed or encrypted)".to_string()),
+    };
+
+    if raw.trim().is_empty() {
+        return Err(
+            "PDF contains no extractable text (scanned image-only PDF — OCR is not supported yet)"
+                .to_string(),
+        );
+    }
+
+    // Truncate by char count, not byte count, so we don't split a UTF-8 codepoint.
+    let mut out =
+        String::with_capacity(raw.len().min(MAX_PDF_TEXT_CHARS + TRUNCATION_MARKER.len()));
+    let mut count = 0usize;
+    for c in raw.chars() {
+        if count >= MAX_PDF_TEXT_CHARS {
+            out.push_str(TRUNCATION_MARKER);
+            break;
+        }
+        out.push(c);
+        count += 1;
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_errors() {
+        assert!(extract_text_from_pdf(&[]).is_err());
+    }
+
+    #[test]
+    fn non_pdf_garbage_errors_without_panic() {
+        // Random bytes that look nothing like a PDF — must not panic the test.
+        let result = extract_text_from_pdf(b"not a pdf, definitely not");
+        assert!(result.is_err());
+    }
+}

--- a/crates/librefang-runtime/src/pdf_text.rs
+++ b/crates/librefang-runtime/src/pdf_text.rs
@@ -54,14 +54,12 @@ pub fn extract_text_from_pdf(bytes: &[u8]) -> Result<String, String> {
     // Truncate by char count, not byte count, so we don't split a UTF-8 codepoint.
     let mut out =
         String::with_capacity(raw.len().min(MAX_PDF_TEXT_CHARS + TRUNCATION_MARKER.len()));
-    let mut count = 0usize;
-    for c in raw.chars() {
+    for (count, c) in raw.chars().enumerate() {
         if count >= MAX_PDF_TEXT_CHARS {
             out.push_str(TRUNCATION_MARKER);
             break;
         }
         out.push(c);
-        count += 1;
     }
 
     Ok(out)

--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -183,6 +183,10 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
     let pre_merge_len = cleaned.len();
     let mut merged: Vec<Message> = Vec::with_capacity(cleaned.len());
     for msg in cleaned {
+        // Snapshot the would-be merge target's index before borrowing
+        // `merged` mutably below — `merged.last_mut()` holds the borrow
+        // for the rest of the if-let scope.
+        let target_idx = merged.len().wrapping_sub(1);
         if let Some(last) = merged.last_mut() {
             if last.role == msg.role
                 && !message_has_tool_use(last)
@@ -190,6 +194,16 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
                 && !message_has_tool_use(&msg)
                 && !message_is_only_tool_results(last)
             {
+                let last_chars = content_char_len(&last.content);
+                let msg_chars = content_char_len(&msg.content);
+                let role = last.role;
+                debug!(
+                    target_idx,
+                    role = ?role,
+                    last_chars,
+                    msg_chars,
+                    "Merging consecutive same-role messages"
+                );
                 merge_content(&mut last.content, msg.content);
                 stats.messages_merged += 1;
                 continue;
@@ -206,6 +220,36 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
         );
     }
 
+    // Normalize each message's blocks: collapse adjacent Text blocks into a
+    // single Text. Why this lives here, not in each driver:
+    //   • After consecutive same-role messages get merged above, a typical
+    //     attachment send produces `Blocks([Text(attach_header+content),
+    //     Text(user_prompt)])`. Provider APIs accept array content, but
+    //     small chat-tuned local models behind Ollama / llama.cpp / vLLM /
+    //     LM Studio frequently attend only to the first or last Text part
+    //     and drop the rest — the user reports "the model didn't see my
+    //     attachment". Frontier models handle multi-part fine, but they
+    //     don't actually need it for plain-text payloads either; they
+    //     happily read one big text part.
+    //   • Image / ToolUse / ToolResult / Thinking blocks stay separate so
+    //     vision and tool-calling pipelines are unchanged.
+    // Doing it here keeps every driver's serialization logic simple and
+    // delivers the same "attachments work everywhere" UX without a
+    // backend-detection special case in each driver.
+    let mut text_blocks_coalesced = 0usize;
+    for msg in merged.iter_mut() {
+        if let MessageContent::Blocks(blocks) = &mut msg.content {
+            let saved = coalesce_adjacent_text_blocks(blocks);
+            text_blocks_coalesced += saved;
+        }
+    }
+    if text_blocks_coalesced > 0 {
+        debug!(
+            text_blocks_coalesced,
+            "Coalesced adjacent Text blocks within messages"
+        );
+    }
+
     if stats != RepairStats::default() {
         warn!(
             orphaned = stats.orphaned_results_removed,
@@ -216,6 +260,8 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
             duplicates = stats.duplicates_removed,
             rescued = stats.misplaced_results_rescued,
             positional_synthetic = stats.positional_synthetic_inserted,
+            messages_before = pre_merge_len,
+            messages_after = post_merge_len,
             "Session repair applied fixes"
         );
     }
@@ -984,6 +1030,77 @@ pub fn prune_heartbeat_turns(messages: &mut Vec<Message>, keep_recent: usize) {
     );
 }
 
+/// In-place coalesce: if the block list contains runs of `ContentBlock::Text`,
+/// merge each run into a single Text block (joined with a blank-line
+/// separator). All other block kinds — Image, ImageFile, ToolUse,
+/// ToolResult, Thinking, Unknown — are kept untouched and act as run
+/// boundaries. Returns the number of blocks removed (i.e. how many merges
+/// happened) so the caller can summarize the work.
+///
+/// Provider-side rationale lives at the call site in
+/// `validate_and_repair_with_stats` — this is the pure transform.
+fn coalesce_adjacent_text_blocks(blocks: &mut Vec<ContentBlock>) -> usize {
+    if blocks.len() < 2 {
+        return 0;
+    }
+    let original_len = blocks.len();
+    let drained: Vec<ContentBlock> = std::mem::take(blocks);
+    let mut out: Vec<ContentBlock> = Vec::with_capacity(drained.len());
+    for block in drained {
+        match block {
+            ContentBlock::Text {
+                text,
+                provider_metadata,
+            } => {
+                if let Some(ContentBlock::Text {
+                    text: existing,
+                    provider_metadata: existing_meta,
+                }) = out.last_mut()
+                {
+                    existing.push_str("\n\n");
+                    existing.push_str(&text);
+                    // Keep the first non-None provider_metadata; if both
+                    // sides set it, keep the existing (older) value so we
+                    // don't lose any field the provider needs to round-trip.
+                    if existing_meta.is_none() {
+                        *existing_meta = provider_metadata;
+                    }
+                    continue;
+                }
+                out.push(ContentBlock::Text {
+                    text,
+                    provider_metadata,
+                });
+            }
+            other => out.push(other),
+        }
+    }
+    *blocks = out;
+    original_len.saturating_sub(blocks.len())
+}
+
+/// Diagnostic helper: rough char count of a message's text payload.
+/// Used only for debug logging when consecutive same-role messages
+/// are merged — gives operators a sense of "is this a tiny reconnect
+/// duplicate or a large dropped streaming response?". Image data is
+/// counted as `[image]` placeholder length, not the base64 size.
+fn content_char_len(content: &MessageContent) -> usize {
+    match content {
+        MessageContent::Text(s) => s.chars().count(),
+        MessageContent::Blocks(blocks) => blocks
+            .iter()
+            .map(|b| match b {
+                ContentBlock::Text { text, .. } => text.chars().count(),
+                ContentBlock::Thinking { thinking, .. } => thinking.chars().count(),
+                ContentBlock::ToolResult { content, .. } => content.chars().count(),
+                ContentBlock::ToolUse { .. } => 16,
+                ContentBlock::Image { .. } | ContentBlock::ImageFile { .. } => 8,
+                ContentBlock::Unknown => 0,
+            })
+            .sum(),
+    }
+}
+
 /// Merge the content of `src` into `dst`.
 fn merge_content(dst: &mut MessageContent, src: MessageContent) {
     // Convert both to blocks, then append
@@ -1089,6 +1206,111 @@ fn is_safe_boundary(messages: &[Message], i: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn text_block(t: &str) -> ContentBlock {
+        ContentBlock::Text {
+            text: t.to_string(),
+            provider_metadata: None,
+        }
+    }
+
+    fn image_block() -> ContentBlock {
+        ContentBlock::Image {
+            media_type: "image/png".to_string(),
+            data: "xxx".to_string(),
+        }
+    }
+
+    #[test]
+    fn coalesce_merges_consecutive_text_blocks() {
+        let mut blocks = vec![text_block("a"), text_block("b"), text_block("c")];
+        let removed = coalesce_adjacent_text_blocks(&mut blocks);
+        assert_eq!(removed, 2);
+        assert_eq!(blocks.len(), 1);
+        if let ContentBlock::Text { text, .. } = &blocks[0] {
+            assert_eq!(text, "a\n\nb\n\nc");
+        } else {
+            panic!("expected Text block");
+        }
+    }
+
+    #[test]
+    fn coalesce_keeps_image_as_run_boundary() {
+        // Real chat scenario: attach text + image + user prompt.
+        // Image must stay where it is; surrounding text runs collapse.
+        let mut blocks = vec![
+            text_block("attach"),
+            text_block("more attach"),
+            image_block(),
+            text_block("user prompt"),
+            text_block("more prompt"),
+        ];
+        let removed = coalesce_adjacent_text_blocks(&mut blocks);
+        assert_eq!(removed, 2);
+        assert_eq!(blocks.len(), 3);
+        assert!(
+            matches!(&blocks[0], ContentBlock::Text { text, .. } if text == "attach\n\nmore attach")
+        );
+        assert!(matches!(&blocks[1], ContentBlock::Image { .. }));
+        assert!(
+            matches!(&blocks[2], ContentBlock::Text { text, .. } if text == "user prompt\n\nmore prompt")
+        );
+    }
+
+    #[test]
+    fn coalesce_noop_on_single_block() {
+        let mut blocks = vec![text_block("solo")];
+        assert_eq!(coalesce_adjacent_text_blocks(&mut blocks), 0);
+        assert_eq!(blocks.len(), 1);
+    }
+
+    #[test]
+    fn coalesce_noop_on_empty() {
+        let mut blocks: Vec<ContentBlock> = vec![];
+        assert_eq!(coalesce_adjacent_text_blocks(&mut blocks), 0);
+    }
+
+    #[test]
+    fn validate_and_repair_attachment_then_prompt_yields_single_text_block() {
+        // End-to-end: simulate the inject_attachments_into_session flow
+        // followed by the user's typed prompt. Two consecutive user
+        // messages: attach (Blocks([Text])) + prompt (Text). After repair
+        // they merge into one user message, and the resulting Blocks must
+        // contain a single Text — what every driver downstream relies on.
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: MessageContent::Blocks(vec![text_block(
+                    "[Attached file: spec.md (4181 bytes)]\n\n# Spec\n\nbody",
+                )]),
+                pinned: false,
+                timestamp: None,
+            },
+            Message {
+                role: Role::User,
+                content: MessageContent::Text("总结一下".to_string()),
+                pinned: false,
+                timestamp: None,
+            },
+        ];
+        let (repaired, _stats) = validate_and_repair_with_stats(&messages);
+        assert_eq!(repaired.len(), 1, "two same-role messages merge");
+        match &repaired[0].content {
+            MessageContent::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 1, "adjacent text blocks coalesce");
+                if let ContentBlock::Text { text, .. } = &blocks[0] {
+                    assert!(text.contains("[Attached file: spec.md"));
+                    assert!(text.contains("总结一下"));
+                    let attach_pos = text.find("[Attached").unwrap();
+                    let prompt_pos = text.find("总结一下").unwrap();
+                    assert!(attach_pos < prompt_pos, "order preserved");
+                } else {
+                    panic!("expected Text block");
+                }
+            }
+            other => panic!("expected Blocks, got {other:?}"),
+        }
+    }
 
     fn tool_use_block(id: &str) -> ContentBlock {
         ContentBlock::ToolUse {


### PR DESCRIPTION
## Summary

- Wire PDF + text/code file uploads all the way to the LLM. Before this PR, dashboard's attach picker only accepted images; uploading a `.md` or `.pdf` returned `200 OK` but `resolve_attachments()` silently dropped it, so the model replied "please paste the content you want me to summarize."
- Add `librefang_runtime::pdf_text` (panic-isolated `pdf-extract` wrapper, 200K-char cap) and a new text-like branch in `resolve_attachments()` covering `text/*`, `application/{json,xml,yaml,toml,…}`, plus extension fallback for code files browsers tag with empty / `application/octet-stream` content_type (`.rs`, `.py`, `.go`, `.ts`, …).
- Cross-driver fix in `session_repair`: after merging same-role messages, run a new `coalesce_adjacent_text_blocks` pass so the resulting `Blocks` contain at most one Text run plus image / tool / thinking blocks. Without this, small chat-tuned models behind Ollama / llama.cpp / vLLM / LM Studio attended only to the first or last Text part of a multi-part user message and dropped the attachment. Doing it at the repair layer means every driver downstream gets a normalized shape — no per-driver special case.
- Diagnostics that made the bug obvious: WebSocket `conn_id` + `client_ip` + `explicit_session` on connect, `reason` + `duration_secs` + `close_code` on disconnect; `messages_before` / `messages_after` on the session-repair WARN; per-merge DEBUG with role + char counts; INFO at every successful attachment resolve / inject.
- Dashboard: `ATTACHMENT_ACCEPT` widened to the full MIME + extension set, `isSupportedFile()` mirrors backend's `is_text_like_attachment()` so drag/paste cannot bypass with an unsupported type, attach + mic + send buttons switched to `items-start` so they pin to the textarea top when it grows multi-line.
- Drive-by tsc cleanup (separate commit): `PageHeader` `badge` prop and `SchemaForm`'s `boolean | undefined` coercion — both block any dashboard build today.

## Why now

Reported by a user uploading a Chinese-named markdown to gemma4 via Ollama: `200 OK` upload + `4096 in / 100 out` LLM call + "please paste the content" reply. Three independent bugs stacked: backend silently dropped non-image, `is_allowed_content_type` rejected most code MIMEs anyway, multi-part user content broke local small models. All three are addressed.

## Test plan

- [x] cargo check -p librefang-runtime -p librefang-llm-drivers -p librefang-api --lib
- [x] cargo test -p librefang-runtime --lib pdf_text — empty / non-PDF garbage panic-resistance
- [x] cargo test -p librefang-runtime --lib coalesce — 4 cases (consecutive merge, image boundary, single block, empty)
- [x] cargo test -p librefang-runtime --lib validate_and_repair_attachment — end-to-end attach + prompt → single coalesced Text in source order
- [x] Live dashboard test (just dev + ollama gemma4): upload .md + "总结一下" → real summary instead of "please paste the content"
- [ ] CI green on all platforms
- [ ] Manual: upload .pdf to a frontier model (anthropic / openai) — verify the extracted text appears in the assistant response and image-vision flows still work