### PR TITLE
fix(api/ws): percent-decode WS auth token to preserve base64 characters

### DIFF
--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -3,6 +3,39 @@
 //! Exposes agent management, status, and chat via JSON REST endpoints.
 //! The kernel runs in-process; the CLI connects over HTTP.
 
+/// Decode percent-encoded strings (e.g. `%2B` -> `+`).
+///
+/// Used to normalise `?token=` values without using
+/// `application/x-www-form-urlencoded` semantics — i.e. literal `+` characters
+/// are preserved (not turned into spaces). This matters for base64-derived API
+/// keys / session tokens that contain `+`, `/`, or `=`.
+pub(crate) fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push(hi << 4 | lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| input.to_string())
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
 pub mod channel_bridge;
 pub mod middleware;
 pub mod oauth;

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -515,13 +515,18 @@ pub async fn auth(
 
     // Also check ?token= query parameter (for EventSource/SSE clients that
     // cannot set custom headers, same approach as WebSocket auth).
-    let query_token = request
+    //
+    // Percent-decode (but NOT form-urlencoded) so literal `+` characters in
+    // base64-derived tokens are preserved instead of being turned into spaces.
+    // See issue #962 (ported from openfang).
+    let query_token_decoded = request
         .uri()
         .query()
-        .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")));
+        .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
+        .map(crate::percent_decode);
 
     // SECURITY: Use constant-time comparison to prevent timing attacks.
-    let query_auth = query_token.map(&matches_any);
+    let query_auth = query_token_decoded.as_deref().map(&matches_any);
 
     // Accept if either auth method matches a static API key or legacy token
     if header_auth == Some(true) || query_auth == Some(true) {
@@ -532,7 +537,7 @@ pub async fn auth(
     // Also prune expired sessions opportunistically. Cookie token is only
     // consulted for `/dashboard/*` navigation (filtered upstream).
     let provided_token = api_token
-        .or(query_token)
+        .or(query_token_decoded.as_deref())
         .or(cookie_session_token.as_deref());
     if let Some(token_str) = provided_token {
         let mut sessions = auth_state.active_sessions.write().await;

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -135,7 +135,14 @@ pub fn ws_auth_token(headers: &HeaderMap, uri: &Uri) -> Option<String> {
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(ToOwned::to_owned)
-        .or_else(|| ws_query_param(uri, "token"))
+        .or_else(|| {
+            // Use plain percent-decoding (NOT form-urlencoded) so literal `+`
+            // characters in base64-derived tokens are preserved instead of
+            // being turned into spaces. See issue #962 (ported from openfang).
+            uri.query()
+                .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
+                .map(crate::percent_decode)
+        })
 }
 
 /// Validates the WebSocket `Origin` header against allowed origins.
@@ -1784,6 +1791,48 @@ mod tests {
             ws_auth_token(&headers, &uri).as_deref(),
             Some("header-token")
         );
+    }
+
+    /// Issue #962 (ported from openfang): WS auth tokens often contain
+    /// base64 chars (`+`, `/`, `=`). The query-param branch must percent-decode
+    /// (so `%2B` -> `+`) but must NOT apply form-urlencoded semantics
+    /// (which would turn a literal `+` into a space).
+    #[test]
+    fn test_ws_auth_token_percent_decodes_base64_chars() {
+        // Percent-encoded base64 token round-trips losslessly.
+        let uri: Uri = "/ws?token=abc%2Bdef%2Fghi%3D".parse().unwrap();
+        assert_eq!(
+            ws_auth_token(&HeaderMap::new(), &uri).as_deref(),
+            Some("abc+def/ghi=")
+        );
+    }
+
+    #[test]
+    fn test_ws_auth_token_preserves_literal_plus() {
+        // Literal `+` (not %20 / not space) MUST be preserved as `+`,
+        // not turned into a space the way x-www-form-urlencoded would.
+        let uri: Uri = "/ws?token=abc+def/ghi=".parse().unwrap();
+        assert_eq!(
+            ws_auth_token(&HeaderMap::new(), &uri).as_deref(),
+            Some("abc+def/ghi=")
+        );
+    }
+
+    #[test]
+    fn test_percent_decode_round_trip() {
+        use crate::percent_decode;
+        assert_eq!(percent_decode("abc%2Bdef"), "abc+def");
+        assert_eq!(percent_decode("a%2Fb%3D"), "a/b=");
+        // Literal `+` is preserved (not converted to space).
+        assert_eq!(percent_decode("abc+def"), "abc+def");
+        // Mixed: literal `+` and percent-encoded `/` together.
+        assert_eq!(percent_decode("a+b%2Fc"), "a+b/c");
+        // Lowercase hex.
+        assert_eq!(percent_decode("%2b%2f%3d"), "+/=");
+        // Malformed escape: leave as-is.
+        assert_eq!(percent_decode("%ZZ"), "%ZZ");
+        // Trailing `%` with no hex pair: leave as-is.
+        assert_eq!(percent_decode("abc%"), "abc%");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Base64 tokens contain `+`, `/`, `=` — when those arrive via a URL query string, `url::form_urlencoded::parse` rewrites literal `+` to a space, mangling the token before the auth check. The handshake then fails with a misleading "invalid token" even when the client sent the correct value.

Fix: split + strip + `percent_decode` the raw query for `?token=` (both the WebSocket upgrade path and the SSE/EventSource path), bypassing `form_urlencoded` only for the token. Other query params (e.g. `session_id`) keep using `ws_query_param` since they aren't expected to carry base64.

Ported from openfang `605ce74` (#962). Other 5 bugs in that commit not in scope here.

## Test plan
- [x] grep'd LibreFang main — no `percent_decode` / `hex_val` exists, fix is missing
- [x] 4 unit tests:
  - `%2B%2F%3D` round-trips correctly
  - literal `+` is preserved (no space conversion)
  - `percent_decode` handles lowercase hex, malformed `%ZZ`, trailing `%`
  - SSE `?token=` path covered
- [ ] Manual: connect a WS client with a token containing `+`/`/`/`=` and verify the auth no longer fails
