### PR TITLE
feat(kernel): trajectory export endpoint with privacy redaction

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -60,6 +60,7 @@ use crate::types;
         routes::create_agent_session,
         routes::switch_agent_session,
         routes::export_session,
+        routes::export_session_trajectory,
         routes::import_session,
         routes::reset_session,
         routes::reboot_session,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2258,24 +2258,44 @@ pub async fn export_session_trajectory(
         system_prompt: agent_entry.manifest.model.system_prompt.clone(),
     };
 
-    let bundle = match exporter.export_session(agent_id, session_id, agent_ctx) {
-        Ok(b) => b,
-        Err(librefang_types::error::LibreFangError::Memory(msg)) if msg.contains("not found") => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({"error": err_session_not_found})),
-            )
-                .into_response();
+    // Sessions are persisted lazily on first message. If the row is missing
+    // but the requested session_id matches the agent's currently-registered
+    // session (authoritative ownership signal from the registry), treat it
+    // as an empty session rather than 404.
+    let bundle = match state.kernel.memory_substrate().get_session(session_id) {
+        Ok(None) if session_id == agent_entry.session_id => {
+            exporter.empty_bundle(agent_id, session_id, agent_ctx)
         }
-        Err(librefang_types::error::LibreFangError::Memory(msg))
-            if msg.contains("does not belong") =>
-        {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({"error": err_session_not_found})),
-            )
-                .into_response();
-        }
+        Ok(_) => match exporter.export_session(agent_id, session_id, agent_ctx) {
+            Ok(b) => b,
+            Err(librefang_types::error::LibreFangError::Memory(msg))
+                if msg.contains("not found") =>
+            {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": err_session_not_found})),
+                )
+                    .into_response();
+            }
+            Err(librefang_types::error::LibreFangError::Memory(msg))
+                if msg.contains("does not belong") =>
+            {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": err_session_not_found})),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+                let msg = t.t_args(&err_generic_key, &[("error", &e.to_string())]);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": msg})),
+                )
+                    .into_response();
+            }
+        },
         Err(e) => {
             let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
             let msg = t.t_args(&err_generic_key, &[("error", &e.to_string())]);

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -69,6 +69,10 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::get(export_session),
         )
         .route(
+            "/agents/{id}/sessions/{session_id}/trajectory",
+            axum::routing::get(export_session_trajectory),
+        )
+        .route(
             "/agents/{id}/sessions/import",
             axum::routing::post(import_session),
         )
@@ -2148,6 +2152,167 @@ pub async fn export_session(
             ),
         ),
     }
+}
+
+/// GET /api/agents/{id}/sessions/{session_id}/trajectory — Export a redacted
+/// trajectory (audit trail) for the given session.
+///
+/// Returns a privacy-redacted bundle of the session messages plus metadata
+/// (agent name, model, system prompt fingerprint, librefang version). Intended
+/// for support, audit, and compliance flows.
+///
+/// Query parameters:
+/// - `format=json` (default): single JSON object response.
+/// - `format=jsonl`: NDJSON, first line is metadata header, subsequent lines
+///   are messages one-per-line. `Content-Type: application/x-ndjson`.
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/sessions/{session_id}/trajectory",
+    tag = "agents",
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("session_id" = String, Path, description = "Session ID to export"),
+        ("format" = Option<String>, Query, description = "Response format: 'json' (default) or 'jsonl'"),
+    ),
+    responses(
+        (status = 200, description = "Redacted trajectory bundle", body = serde_json::Value),
+        (status = 400, description = "Invalid agent or session ID"),
+        (status = 404, description = "Agent or session not found"),
+    )
+)]
+pub async fn export_session_trajectory(
+    State(state): State<Arc<AppState>>,
+    Path((id, session_id_str)): Path<(String, String)>,
+    Query(params): Query<HashMap<String, String>>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> axum::response::Response {
+    use axum::http::header;
+    use axum::response::IntoResponse;
+    use librefang_kernel::trajectory::{AgentContext, RedactionPolicy, TrajectoryExporter};
+
+    let (
+        err_invalid_id,
+        err_session_invalid,
+        err_not_found,
+        err_session_not_found,
+        err_generic_key,
+    ) = {
+        let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+        (
+            t.t("api-error-agent-invalid-id"),
+            t.t("api-error-session-invalid-id"),
+            t.t("api-error-agent-not-found"),
+            "Session not found".to_string(),
+            "api-error-generic".to_string(),
+        )
+    };
+
+    // Parse agent ID.
+    let agent_id: AgentId = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": err_invalid_id})),
+            )
+                .into_response();
+        }
+    };
+
+    // Parse session ID.
+    let session_id = match session_id_str.parse::<uuid::Uuid>() {
+        Ok(uuid) => librefang_types::agent::SessionId(uuid),
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": err_session_invalid})),
+            )
+                .into_response();
+        }
+    };
+
+    // Lookup agent → 404 if missing.
+    let agent_entry = match state.kernel.agent_registry().get(agent_id) {
+        Some(e) => e,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": err_not_found})),
+            )
+                .into_response();
+        }
+    };
+
+    // Build redaction policy. Use the agent's workspace as the path-collapse
+    // root when present.
+    let mut policy = RedactionPolicy::default();
+    if let Some(ws) = agent_entry.manifest.workspace.clone() {
+        policy = policy.with_workspace_root(ws);
+    }
+
+    let exporter = TrajectoryExporter::new(state.kernel.memory_substrate().clone(), policy);
+    let agent_ctx = AgentContext {
+        name: agent_entry.name.clone(),
+        model: agent_entry.manifest.model.model.clone(),
+        provider: agent_entry.manifest.model.provider.clone(),
+        system_prompt: agent_entry.manifest.model.system_prompt.clone(),
+    };
+
+    let bundle = match exporter.export_session(agent_id, session_id, agent_ctx) {
+        Ok(b) => b,
+        Err(librefang_types::error::LibreFangError::Memory(msg)) if msg.contains("not found") => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": err_session_not_found})),
+            )
+                .into_response();
+        }
+        Err(librefang_types::error::LibreFangError::Memory(msg))
+            if msg.contains("does not belong") =>
+        {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": err_session_not_found})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            let msg = t.t_args(&err_generic_key, &[("error", &e.to_string())]);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": msg})),
+            )
+                .into_response();
+        }
+    };
+
+    let format = params
+        .get("format")
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_else(|| "json".to_string());
+
+    let (body, content_type, ext): (String, &'static str, &'static str) = if format == "jsonl" {
+        (bundle.to_jsonl(), "application/x-ndjson", "jsonl")
+    } else {
+        (bundle.to_json().to_string(), "application/json", "json")
+    };
+
+    let filename = format!("trajectory-{}.{}", session_id.0, ext);
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_DISPOSITION, disposition)
+        .body(axum::body::Body::from(body))
+        .unwrap_or_else(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "failed to build response"})),
+            )
+                .into_response()
+        })
 }
 
 /// POST /api/agents/{id}/sessions/import — Import a previously exported session.

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -137,6 +137,10 @@ async fn start_test_server_with_provider(
             axum::routing::get(routes::get_agent_session),
         )
         .route(
+            "/api/agents/{id}/sessions/{session_id}/trajectory",
+            axum::routing::get(routes::export_session_trajectory),
+        )
+        .route(
             "/api/agents/{id}/metrics",
             axum::routing::get(routes::agent_metrics),
         )
@@ -696,6 +700,128 @@ async fn test_agent_session_empty() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["message_count"], 0);
     assert_eq!(body["messages"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_agent_session_trajectory_export_empty() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Spawn agent
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let agent_id = body["agent_id"].as_str().unwrap().to_string();
+
+    // Read session to discover session_id.
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/session",
+            server.base_url, agent_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let session_body: serde_json::Value = resp.json().await.unwrap();
+    let session_id = session_body["session_id"].as_str().unwrap().to_string();
+
+    // Default (json) format
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/sessions/{}/trajectory",
+            server.base_url, agent_id, session_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(ct.starts_with("application/json"), "got content-type: {ct}");
+    let disp = resp
+        .headers()
+        .get("content-disposition")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        disp.contains("trajectory-") && disp.contains(".json"),
+        "got disposition: {disp}"
+    );
+    let bundle: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(bundle["schema_version"], 1);
+    assert_eq!(bundle["metadata"]["agent_id"], agent_id);
+    assert_eq!(bundle["metadata"]["session_id"], session_id);
+    assert_eq!(bundle["metadata"]["model"], "test-model");
+    assert_eq!(bundle["metadata"]["provider"], "ollama");
+    assert!(bundle["metadata"]["system_prompt_sha256"].is_string());
+    assert!(bundle["metadata"]["librefang_version"].is_string());
+    assert_eq!(bundle["metadata"]["message_count"], 0);
+    assert!(bundle["messages"].as_array().unwrap().is_empty());
+
+    // jsonl format
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/sessions/{}/trajectory?format=jsonl",
+            server.base_url, agent_id, session_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        ct.starts_with("application/x-ndjson"),
+        "got content-type: {ct}"
+    );
+    let body_text = resp.text().await.unwrap();
+    let lines: Vec<&str> = body_text.lines().collect();
+    // empty session → only metadata header line
+    assert_eq!(lines.len(), 1, "expected 1 line, got {}", lines.len());
+    assert!(lines[0].contains("\"kind\":\"metadata\""));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_agent_session_trajectory_404_on_unknown_session() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Spawn an agent so we have a valid agent_id
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let agent_id = body["agent_id"].as_str().unwrap().to_string();
+
+    // Random valid-shape session UUID that doesn't exist.
+    let bogus = uuid::Uuid::new_v4().to_string();
+    let resp = client
+        .get(format!(
+            "{}/api/agents/{}/sessions/{}/trajectory",
+            server.base_url, agent_id, bogus
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1397,6 +1523,10 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         .route(
             "/api/agents/{id}/session",
             axum::routing::get(routes::get_agent_session),
+        )
+        .route(
+            "/api/agents/{id}/sessions/{session_id}/trajectory",
+            axum::routing::get(routes::export_session_trajectory),
         )
         .route(
             "/api/agents/{id}/metrics",

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -27,6 +27,7 @@ pub use librefang_kernel_router as router;
 pub mod scheduler;
 pub mod session_policy;
 pub mod supervisor;
+pub mod trajectory;
 pub mod triggers;
 pub mod whatsapp_gateway;
 pub mod wizard;

--- a/crates/librefang-kernel/src/trajectory/mod.rs
+++ b/crates/librefang-kernel/src/trajectory/mod.rs
@@ -322,6 +322,41 @@ impl TrajectoryExporter {
         })
     }
 
+    /// Build an empty bundle without consulting the memory substrate.
+    ///
+    /// Sessions are persisted lazily — a freshly spawned agent has a
+    /// `session_id` but no DB row until the first message is written.
+    /// Callers that have already verified ownership via the agent registry
+    /// (e.g. `agent_entry.session_id == session_id`) can use this to emit
+    /// an empty bundle for that "not yet persisted" case.
+    pub fn empty_bundle(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+        agent: AgentContext,
+    ) -> TrajectoryBundle {
+        let metadata = TrajectoryMetadata {
+            agent_id: agent_id.0.to_string(),
+            agent_name: agent.name,
+            session_id: session_id.0.to_string(),
+            session_label: None,
+            model: agent.model,
+            provider: agent.provider,
+            system_prompt_sha256: sha256_hex(agent.system_prompt.as_bytes()),
+            message_count: 0,
+            context_window_tokens: 0,
+            exported_at: Utc::now().to_rfc3339(),
+            librefang_version: env!("CARGO_PKG_VERSION").to_string(),
+            redaction_credentials: self.policy.mask_credentials,
+            redaction_workspace_paths: self.policy.workspace_root.is_some(),
+        };
+        TrajectoryBundle {
+            schema_version: 1,
+            metadata,
+            messages: Vec::new(),
+        }
+    }
+
     fn redact_message(&self, m: &Message) -> RedactedMessage {
         let role = match m.role {
             Role::System => "system",

--- a/crates/librefang-kernel/src/trajectory/mod.rs
+++ b/crates/librefang-kernel/src/trajectory/mod.rs
@@ -1,0 +1,682 @@
+//! On-demand session trajectory export with privacy redaction.
+//!
+//! Produces a structured `.jsonl` (or JSON) audit trail of an agent session
+//! — messages, tool calls, model/config metadata — with credentials and
+//! workspace-absolute paths redacted. Intended for support, audit, and
+//! compliance workflows.
+//!
+//! # Design
+//!
+//! - **On-demand only.** Reads an existing session from `MemorySubstrate`
+//!   at request time. No background writers, no per-turn file IO, no
+//!   kernel loop modifications.
+//! - **Read-only.** Never mutates session state; safe to call concurrently
+//!   with the agent loop.
+//! - **Privacy by default.** Default `RedactionPolicy` masks API-key-shaped
+//!   strings, JWTs, and large base64 blobs.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let exporter = TrajectoryExporter::new(
+//!     kernel.memory_substrate().clone(),
+//!     RedactionPolicy::default().with_workspace_root(workspace.clone()),
+//! );
+//! let bundle = exporter.export_session(agent_id, session_id, agent_meta)?;
+//! let jsonl = bundle.to_jsonl();
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use librefang_memory::MemorySubstrate;
+use librefang_types::agent::{AgentId, SessionId};
+use librefang_types::error::{LibreFangError, LibreFangResult};
+use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+/// Redaction policy applied to message content before export.
+///
+/// Defaults to mask credential-shaped strings; callers should set
+/// `workspace_root` so absolute paths under the agent workspace can be
+/// collapsed to `<WORKSPACE>/...`.
+#[derive(Debug, Clone)]
+pub struct RedactionPolicy {
+    /// Mask anything that looks like an API key, JWT, or large base64 blob.
+    pub mask_credentials: bool,
+    /// Workspace root — absolute paths starting with this prefix are
+    /// rewritten to `<WORKSPACE>/...`. `None` disables path collapsing.
+    pub workspace_root: Option<PathBuf>,
+    /// Additional caller-provided regex patterns. Matches are replaced with
+    /// `<REDACTED>`.
+    pub custom_patterns: Vec<Regex>,
+}
+
+impl Default for RedactionPolicy {
+    fn default() -> Self {
+        Self {
+            mask_credentials: true,
+            workspace_root: None,
+            custom_patterns: Vec::new(),
+        }
+    }
+}
+
+impl RedactionPolicy {
+    /// Builder: set the workspace root for path collapsing.
+    pub fn with_workspace_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = Some(root.into());
+        self
+    }
+
+    /// Builder: append a custom regex pattern.
+    pub fn with_pattern(mut self, pattern: Regex) -> Self {
+        self.custom_patterns.push(pattern);
+        self
+    }
+
+    /// Builder: disable credential masking (use only when the caller has
+    /// already sanitized content out-of-band).
+    pub fn without_credential_masking(mut self) -> Self {
+        self.mask_credentials = false;
+        self
+    }
+}
+
+// ── Compiled regex set ──────────────────────────────────────────────────
+
+/// Lazy-compiled credential patterns. Compiled once per process via OnceLock.
+struct CompiledPatterns {
+    /// `sk_live_…`, `api-key=…`, `key_…`, etc.
+    api_key: Regex,
+    /// JWT-shaped tokens — three base64url segments separated by dots.
+    jwt: Regex,
+    /// Long opaque base64 blobs (>40 chars). Loose: catches PEM bodies,
+    /// long bearer tokens, etc. Intentionally narrow to avoid eating prose.
+    long_b64: Regex,
+}
+
+impl CompiledPatterns {
+    fn get() -> &'static CompiledPatterns {
+        use std::sync::OnceLock;
+        static PATTERNS: OnceLock<CompiledPatterns> = OnceLock::new();
+        PATTERNS.get_or_init(|| {
+            CompiledPatterns {
+                // Matches "sk", "api", "key", "token", "secret", "bearer"
+                // followed by an optional separator and a long alphanumeric
+                // run. Case-insensitive.
+                api_key: Regex::new(
+                    r"(?i)\b(?:sk|api[_-]?key|key|token|secret|bearer)[_\-=:\s]+[A-Za-z0-9_\-]{16,}\b",
+                )
+                .expect("api_key regex must compile"),
+                // JWT: header.payload.signature, each base64url, payload
+                // typically >= 20 chars.
+                jwt: Regex::new(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b")
+                    .expect("jwt regex must compile"),
+                // Standalone base64-ish blob > 40 chars. Word-bounded.
+                long_b64: Regex::new(r"\b[A-Za-z0-9+/=]{40,}\b")
+                    .expect("long_b64 regex must compile"),
+            }
+        })
+    }
+}
+
+// ── Bundle types ────────────────────────────────────────────────────────
+
+/// Top-level export bundle. Serializes to JSON or JSONL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryBundle {
+    /// Schema version. Bump when the on-disk shape changes.
+    pub schema_version: u32,
+    /// Static metadata describing the export.
+    pub metadata: TrajectoryMetadata,
+    /// Redacted conversation turns, in original order.
+    pub messages: Vec<RedactedMessage>,
+}
+
+/// Static metadata recorded with each export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryMetadata {
+    /// Agent UUID at export time.
+    pub agent_id: String,
+    /// Human-readable agent name (may have changed since the session began).
+    pub agent_name: String,
+    /// Session UUID.
+    pub session_id: String,
+    /// Optional human-readable session label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_label: Option<String>,
+    /// Model identifier at export time (e.g. `groq:llama-3.3-70b-versatile`).
+    pub model: String,
+    /// Provider name (e.g. `groq`, `anthropic`, `openai`).
+    pub provider: String,
+    /// SHA-256 hash of the system prompt — fingerprint without leaking content.
+    pub system_prompt_sha256: String,
+    /// Number of messages in the session.
+    pub message_count: usize,
+    /// Estimated context window token count at export time.
+    pub context_window_tokens: u64,
+    /// ISO-8601 UTC timestamp when the export was created.
+    pub exported_at: String,
+    /// `librefang-kernel` crate version.
+    pub librefang_version: String,
+    /// Whether credential masking was applied.
+    pub redaction_credentials: bool,
+    /// Whether workspace path collapsing was applied (root was set).
+    pub redaction_workspace_paths: bool,
+}
+
+/// A message turn after redaction. Keeps the original shape so consumers
+/// can re-render it; only string contents are rewritten.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RedactedMessage {
+    /// `system` / `user` / `assistant`.
+    pub role: String,
+    /// Whether the message was pinned.
+    pub pinned: bool,
+    /// ISO-8601 timestamp if recorded on the original message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    /// Redacted content blocks.
+    pub content: Vec<RedactedBlock>,
+}
+
+/// A redacted content block. Mirrors `ContentBlock` but with strings already
+/// sanitized.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RedactedBlock {
+    Text {
+        text: String,
+    },
+    Thinking {
+        thinking: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        tool_name: String,
+        content: String,
+        is_error: bool,
+    },
+    Image {
+        media_type: String,
+        /// Base64 data is replaced with a placeholder; emit only the size.
+        data_bytes: usize,
+    },
+    ImageFile {
+        media_type: String,
+        path: String,
+    },
+    Unknown,
+}
+
+impl TrajectoryBundle {
+    /// Serialize to a JSON value (full bundle as a single object).
+    pub fn to_json(&self) -> serde_json::Value {
+        // serde_json on a derive-ser type cannot fail unless a custom impl
+        // panics; bundle has only string/usize/Vec primitives so this is safe.
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Serialize to NDJSON (JSON Lines): first line is the metadata header,
+    /// subsequent lines are messages one-per-line. This is the audit-friendly
+    /// shape that grep / jq / log tooling expects.
+    pub fn to_jsonl(&self) -> String {
+        let mut out = String::new();
+        let header = serde_json::json!({
+            "kind": "metadata",
+            "schema_version": self.schema_version,
+            "metadata": &self.metadata,
+        });
+        out.push_str(&header.to_string());
+        out.push('\n');
+        for (idx, m) in self.messages.iter().enumerate() {
+            let line = serde_json::json!({
+                "kind": "message",
+                "index": idx,
+                "message": m,
+            });
+            out.push_str(&line.to_string());
+            out.push('\n');
+        }
+        out
+    }
+}
+
+// ── Exporter ────────────────────────────────────────────────────────────
+
+/// Reads sessions from the memory substrate and emits redacted bundles.
+pub struct TrajectoryExporter {
+    memory: Arc<MemorySubstrate>,
+    policy: RedactionPolicy,
+}
+
+/// Caller-supplied agent context (so the exporter doesn't need to reach
+/// back into the kernel registry).
+#[derive(Debug, Clone)]
+pub struct AgentContext {
+    pub name: String,
+    pub model: String,
+    pub provider: String,
+    pub system_prompt: String,
+}
+
+impl TrajectoryExporter {
+    /// Create a new exporter.
+    pub fn new(memory: Arc<MemorySubstrate>, policy: RedactionPolicy) -> Self {
+        Self { memory, policy }
+    }
+
+    /// Export a single session. Returns `Err` if the session does not exist
+    /// or does not belong to `agent_id`.
+    pub fn export_session(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+        agent: AgentContext,
+    ) -> LibreFangResult<TrajectoryBundle> {
+        let session = self
+            .memory
+            .get_session(session_id)?
+            .ok_or_else(|| LibreFangError::Memory(format!("session {} not found", session_id.0)))?;
+        if session.agent_id != agent_id {
+            return Err(LibreFangError::Memory(format!(
+                "session {} does not belong to agent {}",
+                session_id.0, agent_id.0
+            )));
+        }
+
+        let messages: Vec<RedactedMessage> = session
+            .messages
+            .iter()
+            .map(|m| self.redact_message(m))
+            .collect();
+
+        let metadata = TrajectoryMetadata {
+            agent_id: agent_id.0.to_string(),
+            agent_name: agent.name,
+            session_id: session_id.0.to_string(),
+            session_label: session.label.clone(),
+            model: agent.model,
+            provider: agent.provider,
+            system_prompt_sha256: sha256_hex(agent.system_prompt.as_bytes()),
+            message_count: session.messages.len(),
+            context_window_tokens: session.context_window_tokens,
+            exported_at: Utc::now().to_rfc3339(),
+            librefang_version: env!("CARGO_PKG_VERSION").to_string(),
+            redaction_credentials: self.policy.mask_credentials,
+            redaction_workspace_paths: self.policy.workspace_root.is_some(),
+        };
+
+        Ok(TrajectoryBundle {
+            schema_version: 1,
+            metadata,
+            messages,
+        })
+    }
+
+    fn redact_message(&self, m: &Message) -> RedactedMessage {
+        let role = match m.role {
+            Role::System => "system",
+            Role::User => "user",
+            Role::Assistant => "assistant",
+        }
+        .to_string();
+
+        let blocks: Vec<RedactedBlock> = match &m.content {
+            MessageContent::Text(s) => vec![RedactedBlock::Text {
+                text: self.redact_text(s),
+            }],
+            MessageContent::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| self.redact_block(b))
+                .collect::<Vec<_>>(),
+        };
+
+        RedactedMessage {
+            role,
+            pinned: m.pinned,
+            timestamp: m.timestamp.map(|t| t.to_rfc3339()),
+            content: blocks,
+        }
+    }
+
+    fn redact_block(&self, b: &ContentBlock) -> RedactedBlock {
+        match b {
+            ContentBlock::Text { text, .. } => RedactedBlock::Text {
+                text: self.redact_text(text),
+            },
+            ContentBlock::Thinking { thinking, .. } => RedactedBlock::Thinking {
+                thinking: self.redact_text(thinking),
+            },
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => RedactedBlock::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: self.redact_json(input.clone()),
+            },
+            ContentBlock::ToolResult {
+                tool_use_id,
+                tool_name,
+                content,
+                is_error,
+                ..
+            } => RedactedBlock::ToolResult {
+                tool_use_id: tool_use_id.clone(),
+                tool_name: tool_name.clone(),
+                content: self.redact_text(content),
+                is_error: *is_error,
+            },
+            ContentBlock::Image { media_type, data } => RedactedBlock::Image {
+                media_type: media_type.clone(),
+                data_bytes: data.len(),
+            },
+            ContentBlock::ImageFile { media_type, path } => RedactedBlock::ImageFile {
+                media_type: media_type.clone(),
+                path: self.redact_text(path),
+            },
+            ContentBlock::Unknown => RedactedBlock::Unknown,
+        }
+    }
+
+    /// Redact a single string. Order matters: collapse paths first (so
+    /// they're not eaten by the long-b64 matcher), then mask credentials.
+    pub fn redact_text(&self, input: &str) -> String {
+        let mut out = collapse_workspace_paths(input, self.policy.workspace_root.as_deref());
+
+        if self.policy.mask_credentials {
+            let p = CompiledPatterns::get();
+            // JWT first (most specific shape).
+            out = p.jwt.replace_all(&out, "<REDACTED:JWT>").into_owned();
+            // Then api-key-shaped.
+            out = p
+                .api_key
+                .replace_all(&out, "<REDACTED:CREDENTIAL>")
+                .into_owned();
+            // Then catch-all long base64 (must come last; broadest).
+            out = p.long_b64.replace_all(&out, "<REDACTED:BLOB>").into_owned();
+        }
+
+        for re in &self.policy.custom_patterns {
+            out = re.replace_all(&out, "<REDACTED>").into_owned();
+        }
+
+        out
+    }
+
+    /// Recursively redact every string inside a JSON value. Keys are left
+    /// untouched (they're typically not secret-bearing in tool inputs).
+    fn redact_json(&self, v: serde_json::Value) -> serde_json::Value {
+        use serde_json::Value;
+        match v {
+            Value::String(s) => Value::String(self.redact_text(&s)),
+            Value::Array(arr) => {
+                Value::Array(arr.into_iter().map(|x| self.redact_json(x)).collect())
+            }
+            Value::Object(map) => {
+                let mut out = serde_json::Map::with_capacity(map.len());
+                for (k, val) in map {
+                    out.insert(k, self.redact_json(val));
+                }
+                Value::Object(out)
+            }
+            other => other,
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn collapse_workspace_paths(input: &str, root: Option<&std::path::Path>) -> String {
+    let Some(root) = root else {
+        return input.to_string();
+    };
+    let root_str = root.to_string_lossy();
+    if root_str.is_empty() {
+        return input.to_string();
+    }
+    // Replace forward-slash form. We don't try to handle UNC / Windows
+    // backslashes here — the librefang workspace_root is normalized to
+    // forward slashes upstream. Callers on Windows can pre-normalize if
+    // needed.
+    let normalized = root_str.replace('\\', "/");
+    let mut out = input.replace(normalized.as_str(), "<WORKSPACE>");
+    // Also handle the original (non-normalized) form for robustness.
+    if normalized != root_str.as_ref() {
+        out = out.replace(root_str.as_ref(), "<WORKSPACE>");
+    }
+    out
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    // Minimal SHA-256 via the `sha2` crate would add a dep; we already
+    // have a kernel-internal need for prompt fingerprinting elsewhere,
+    // so we use a tiny inline implementation here that delegates to the
+    // kernel's existing hasher if present. To keep this module self-contained
+    // and avoid a new dependency, fall back to FNV-1a 64 if no sha is
+    // available — clearly labelled in the field name (`system_prompt_sha256`
+    // is misleading then). To avoid that mismatch, depend on the fact that
+    // `librefang-kernel` already pulls in `hex` and use a vendored sha256
+    // through the `chrono` chain… not viable.
+    //
+    // Pragmatic answer: use the existing `sha2`-shaped path through the
+    // hex crate by leveraging blake3 which the workspace ships? No — keep
+    // this module dep-free and emit a stable non-cryptographic digest with
+    // a clear field name. Rename field accordingly.
+    //
+    // Implementation: SHA-256 via a minimal inline implementation.
+    sha256(bytes)
+}
+
+/// Minimal SHA-256 implementation (RFC 6234). Inlined to keep this module
+/// dependency-free; the hash is used only as a stable fingerprint of the
+/// system prompt so consumers can correlate exports without leaking the
+/// prompt content itself.
+fn sha256(input: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    // Pre-processing — pad to 512-bit blocks.
+    let bit_len = (input.len() as u64).wrapping_mul(8);
+    let mut data = input.to_vec();
+    data.push(0x80);
+    while data.len() % 64 != 56 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in data.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for i in 0..16 {
+            w[i] = u32::from_be_bytes([
+                chunk[i * 4],
+                chunk[i * 4 + 1],
+                chunk[i * 4 + 2],
+                chunk[i * 4 + 3],
+            ]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let (mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh) =
+            (h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]);
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let temp1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+    let mut out = String::with_capacity(64);
+    for word in h {
+        out.push_str(&format!("{:08x}", word));
+    }
+    out
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy_with_workspace(root: &str) -> RedactionPolicy {
+        RedactionPolicy::default().with_workspace_root(PathBuf::from(root))
+    }
+
+    fn dummy_exporter(policy: RedactionPolicy) -> TrajectoryExporter {
+        // We don't exercise memory in redaction-only tests; build a
+        // throwaway in-memory substrate so Arc<MemorySubstrate> exists.
+        let mem = MemorySubstrate::open_in_memory(0.01).expect("substrate boots");
+        TrajectoryExporter::new(Arc::new(mem), policy)
+    }
+
+    #[test]
+    fn redacts_api_key_shaped_strings() {
+        let exp = dummy_exporter(RedactionPolicy::default());
+        let s = exp.redact_text("here is my key: sk_live_abcdef0123456789ABCDEF and more text");
+        assert!(s.contains("<REDACTED:CREDENTIAL>"), "got: {s}");
+        assert!(!s.contains("sk_live_abcdef0123456789ABCDEF"), "leaked: {s}");
+    }
+
+    #[test]
+    fn redacts_bearer_tokens() {
+        let exp = dummy_exporter(RedactionPolicy::default());
+        let s = exp.redact_text("Authorization: Bearer abcdef0123456789ABCDEF0123456789");
+        assert!(s.contains("<REDACTED"), "got: {s}");
+    }
+
+    #[test]
+    fn redacts_jwt_shaped_tokens() {
+        let exp = dummy_exporter(RedactionPolicy::default());
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        let s = exp.redact_text(&format!("token={}", jwt));
+        assert!(
+            s.contains("<REDACTED:JWT>") || s.contains("<REDACTED"),
+            "got: {s}"
+        );
+        assert!(!s.contains(jwt), "jwt leaked: {s}");
+    }
+
+    #[test]
+    fn collapses_workspace_paths() {
+        let exp = dummy_exporter(policy_with_workspace(
+            "/home/alice/.librefang/workspaces/agent42",
+        ));
+        let s = exp.redact_text("opened /home/alice/.librefang/workspaces/agent42/notes.md ok");
+        assert!(s.contains("<WORKSPACE>/notes.md"), "got: {s}");
+        assert!(!s.contains("/home/alice"), "leaked path: {s}");
+    }
+
+    #[test]
+    fn leaves_short_strings_alone() {
+        let exp = dummy_exporter(RedactionPolicy::default());
+        let s = exp.redact_text("hello world this is a normal message");
+        assert_eq!(s, "hello world this is a normal message");
+    }
+
+    #[test]
+    fn custom_pattern_applies() {
+        let policy = RedactionPolicy::default()
+            .with_pattern(Regex::new(r"INTERNAL-[A-Z]{4}-\d{4}").expect("valid"));
+        let exp = dummy_exporter(policy);
+        let s = exp.redact_text("ticket=INTERNAL-ACME-0042 priority=high");
+        assert!(s.contains("<REDACTED>"), "got: {s}");
+        assert!(!s.contains("INTERNAL-ACME-0042"), "leaked: {s}");
+    }
+
+    #[test]
+    fn jsonl_emits_metadata_then_messages() {
+        let bundle = TrajectoryBundle {
+            schema_version: 1,
+            metadata: TrajectoryMetadata {
+                agent_id: "00000000-0000-0000-0000-000000000001".into(),
+                agent_name: "test".into(),
+                session_id: "00000000-0000-0000-0000-000000000002".into(),
+                session_label: None,
+                model: "test-model".into(),
+                provider: "ollama".into(),
+                system_prompt_sha256: "deadbeef".into(),
+                message_count: 1,
+                context_window_tokens: 0,
+                exported_at: "2026-01-01T00:00:00Z".into(),
+                librefang_version: "0.0.0".into(),
+                redaction_credentials: true,
+                redaction_workspace_paths: false,
+            },
+            messages: vec![RedactedMessage {
+                role: "user".into(),
+                pinned: false,
+                timestamp: None,
+                content: vec![RedactedBlock::Text { text: "hi".into() }],
+            }],
+        };
+        let jsonl = bundle.to_jsonl();
+        let lines: Vec<&str> = jsonl.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"kind\":\"metadata\""));
+        assert!(lines[1].contains("\"kind\":\"message\""));
+    }
+
+    #[test]
+    fn sha256_known_vector() {
+        // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1576,6 +1576,61 @@
         }
       }
     },
+    "/api/agents/{id}/sessions/{session_id}/trajectory": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /api/agents/{id}/sessions/{session_id}/trajectory — Export a redacted\ntrajectory (audit trail) for the given session.",
+        "description": "Returns a privacy-redacted bundle of the session messages plus metadata\n(agent name, model, system prompt fingerprint, librefang version). Intended\nfor support, audit, and compliance flows.\n\nQuery parameters:\n- `format=json` (default): single JSON object response.\n- `format=jsonl`: NDJSON, first line is metadata header, subsequent lines\n  are messages one-per-line. `Content-Type: application/x-ndjson`.",
+        "operationId": "export_session_trajectory",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID to export",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Response format: 'json' (default) or 'jsonl'",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Redacted trajectory bundle",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent or session ID"
+          },
+          "404": {
+            "description": "Agent or session not found"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/skills": {
       "get": {
         "tags": [

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -400,6 +400,10 @@ func (r *AgentsResource) SwitchAgentSession(id string, session_id string) (inter
 	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/sessions/%s/switch", id, session_id), nil, nil)
 }
 
+func (r *AgentsResource) ExportSessionTrajectory(id string, session_id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/sessions/%s/trajectory", id, session_id), nil, query)
+}
+
 func (r *AgentsResource) GetAgentSkills(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/skills", id), nil, nil)
 }

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -268,6 +268,10 @@ class AgentsResource {
     return this._c._request("POST", `/api/agents/${id}/sessions/${session_id}/switch`);
   }
 
+  async exportSessionTrajectory(id, session_id, query) {
+    return this._c._request("GET", `/api/agents/${id}/sessions/${session_id}/trajectory`, undefined, query);
+  }
+
   async getAgentSkills(id) {
     return this._c._request("GET", `/api/agents/${id}/skills`);
   }

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -243,6 +243,9 @@ class _AgentsResource(_Resource):
     def switch_agent_session(self, id: str, session_id: str):
         return self._c._request("POST", f"/api/agents/{id}/sessions/{session_id}/switch")
 
+    def export_session_trajectory(self, id: str, session_id: str, format: Any = None):
+        return self._c._request("GET", f"/api/agents/{id}/sessions/{session_id}/trajectory", None, query={"format": format})
+
     def get_agent_skills(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/skills")
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -376,6 +376,10 @@ impl AgentsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/switch", id, session_id), None, &[]).await
     }
 
+    pub async fn export_session_trajectory(&self, id: &str, session_id: &str, format: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/trajectory", id, session_id), None, &[("format", format)]).await
+    }
+
     pub async fn get_agent_skills(&self, id: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/skills", id), None, &[]).await
     }


### PR DESCRIPTION
## Why

Audit, compliance, and support teams currently have no first-class way to extract a structured record of an agent session that is safe to ship outside the host. The dashboard's hibernation export ships raw messages including credentials, absolute workspace paths, and full system prompts — fine for round-tripping a session into another instance, but not safe to send to a customer support engineer or store in an audit lake.

This PR adds an **on-demand**, redacted trajectory export — modeled after openclaw's `src/trajectory/export.ts`, but implemented as a read-only export of the existing session at request time rather than an always-on per-turn file writer. That keeps risk and surface area small: no kernel-loop changes, no background tasks, no new memory backends.

## What's in

- **New module `librefang-kernel/src/trajectory/mod.rs`**
  - `TrajectoryExporter` reads a session from `MemorySubstrate` and produces a `TrajectoryBundle` (metadata + redacted messages).
  - `RedactionPolicy` (default: on) masks API-key-shaped strings, JWTs, and long base64 blobs; collapses absolute paths under the agent's `workspace` to `<WORKSPACE>/...`; supports caller-provided regex patterns.
  - `TrajectoryBundle::to_json()` and `to_jsonl()` provide both a single-document JSON shape and an audit-friendly NDJSON shape (first line is the metadata header, subsequent lines are messages one-per-line).
  - System prompt is recorded as a SHA-256 fingerprint, not the prompt content.
  - Inline unit tests cover credential masking, bearer tokens, JWTs, workspace path collapsing, custom patterns, JSONL framing, and a SHA-256 known-vector check.

- **New route `GET /api/agents/{id}/sessions/{session_id}/trajectory`**
  - Validates that the session belongs to the agent (404 if it does not).
  - Optional `?format=jsonl` switches the response to `application/x-ndjson`; default is `application/json`.
  - `Content-Disposition: attachment; filename=\"trajectory-<session_id>.{json|jsonl}\"`.
  - 400 on malformed agent/session IDs, 404 on missing agent or session.
  - Registered in `routes/agents.rs::router()`, the `openapi.rs` paths list, and both hand-rolled routers in `tests/api_integration_test.rs`.

- **Integration tests in `api_integration_test.rs`**
  - `test_agent_session_trajectory_export_empty` — spawns an agent, fetches the trajectory in both JSON and JSONL forms, and asserts the metadata fields, headers, and message-count.
  - `test_agent_session_trajectory_404_on_unknown_session` — confirms a valid-shape but non-existent session returns 404.

- `openapi.json` and the four generated SDKs are updated by the pre-commit codegen hook.

## Out of scope

- No on-disk per-turn writers, no kernel-loop changes, no new daemon threads.
- No new dashboard UI; this PR adds only the backend endpoint.
- `MemorySubstrate` API is unchanged.

## Test plan

- [ ] CI: `cargo build --workspace --lib` passes
- [ ] CI: `cargo test --workspace` passes (new unit tests in `trajectory/mod.rs`, new integration tests in `api_integration_test.rs`)
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] CI: `openapi.json` matches the regenerated spec (the pre-commit hook already regenerated it locally)
- [ ] Manual: hit `GET /api/agents/{id}/sessions/{sid}/trajectory` against a running daemon with a real session and confirm credentials/paths are masked

> Validation: gates intentionally not run locally per user instruction; relying on CI to verify build/test/clippy.