### PR TITLE
feat(embedding): extend detect_embedding_provider with vLLM + LM Studio fallback

### DIFF
--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -664,8 +664,10 @@ impl EmbeddingDriver for BedrockEmbeddingDriver {
 /// 4. `TOGETHER_API_KEY`   → `"together"`
 /// 5. `FIREWORKS_API_KEY`  → `"fireworks"`
 /// 6. `COHERE_API_KEY`     → `"cohere"`
-/// 7. `OLLAMA_HOST` set, or Ollama running on localhost → `"ollama"`
-/// 8. `None` if nothing is available
+/// 7. `OLLAMA_HOST`     set → `"ollama"`
+/// 8. `VLLM_BASE_URL`   set → `"vllm"`
+/// 9. `LMSTUDIO_BASE_URL` set → `"lmstudio"`
+/// 10. `None` if nothing is available
 ///
 /// `GROQ_API_KEY` is deliberately **not** in this list. Groq has no
 /// `/v1/embeddings` endpoint (verify with `GET api.groq.com/openai/v1/models`
@@ -689,11 +691,19 @@ pub fn detect_embedding_provider() -> Option<&'static str> {
         }
     }
 
-    // Local Ollama — available if OLLAMA_HOST is set and non-empty. We don't
-    // attempt a live TCP probe here (that would be async and would require a
-    // runtime); a non-empty env var is sufficient signal.
+    // Local providers — available if their respective base URL env var is
+    // set and non-empty. No live TCP probe (that would be async); a non-empty
+    // env var is sufficient signal that the user has intentionally configured
+    // a local server. Order: Ollama → vLLM → LM Studio (matching the
+    // create_embedding_driver builder's local provider order).
     if std::env::var("OLLAMA_HOST").is_ok_and(|v| !v.trim().is_empty()) {
         return Some("ollama");
+    }
+    if std::env::var("VLLM_BASE_URL").is_ok_and(|v| !v.trim().is_empty()) {
+        return Some("vllm");
+    }
+    if std::env::var("LMSTUDIO_BASE_URL").is_ok_and(|v| !v.trim().is_empty()) {
+        return Some("lmstudio");
     }
 
     None
@@ -1479,6 +1489,8 @@ mod tests {
             "FIREWORKS_API_KEY",
             "COHERE_API_KEY",
             "OLLAMA_HOST",
+            "VLLM_BASE_URL",
+            "LMSTUDIO_BASE_URL",
         ];
         let saved = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
         for k in keys {
@@ -1540,6 +1552,55 @@ mod tests {
     fn test_detect_embedding_provider_none_when_nothing_set() {
         let saved = clear_detect_env();
         assert_eq!(detect_embedding_provider(), None);
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_picks_vllm_when_only_vllm_url_set() {
+        let saved = clear_detect_env();
+        std::env::set_var("VLLM_BASE_URL", "http://localhost:8000/v1");
+
+        assert_eq!(detect_embedding_provider(), Some("vllm"));
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_picks_lmstudio_when_only_lmstudio_url_set() {
+        let saved = clear_detect_env();
+        std::env::set_var("LMSTUDIO_BASE_URL", "http://localhost:1234/v1");
+
+        assert_eq!(detect_embedding_provider(), Some("lmstudio"));
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_local_priority_ollama_beats_vllm_beats_lmstudio() {
+        // Local order matches create_embedding_driver's local builder order.
+        let saved = clear_detect_env();
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+        std::env::set_var("VLLM_BASE_URL", "http://localhost:8000/v1");
+        std::env::set_var("LMSTUDIO_BASE_URL", "http://localhost:1234/v1");
+
+        assert_eq!(detect_embedding_provider(), Some("ollama"));
+        std::env::remove_var("OLLAMA_HOST");
+        assert_eq!(detect_embedding_provider(), Some("vllm"));
+        std::env::remove_var("VLLM_BASE_URL");
+        assert_eq!(detect_embedding_provider(), Some("lmstudio"));
+
+        restore_detect_env(saved);
+    }
+
+    #[test]
+    fn test_detect_embedding_provider_cloud_beats_local() {
+        // A configured API key still wins over a local server URL.
+        let saved = clear_detect_env();
+        std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+        std::env::set_var("VLLM_BASE_URL", "http://localhost:8000/v1");
+
+        assert_eq!(detect_embedding_provider(), Some("openai"));
+
         restore_detect_env(saved);
     }
 


### PR DESCRIPTION
## Summary
`vLLM` and `LM Studio` were already supported in `create_embedding_driver` but weren't reachable through `provider = "auto"` because `detect_embedding_provider` only checked `OLLAMA_HOST` among local servers. A user who sets `VLLM_BASE_URL` (or `LMSTUDIO_BASE_URL`) and selects `auto` was getting `MissingApiKey` even though they had a working local server.

Added `VLLM_BASE_URL` and `LMSTUDIO_BASE_URL` as ranks 8 and 9 in the priority list, after Ollama (matching the local builder order in `create_embedding_driver`).

Cloud API keys still win over local URLs (`OPENAI_API_KEY` beats `VLLM_BASE_URL`); Groq stays explicitly excluded (no `/v1/embeddings` endpoint, regression-tested).

## What changed
- `detect_embedding_provider` extended with two non-empty-env-var checks
- doc comment priority list updated (1–10, with rationale why Groq is missing)
- `clear_detect_env()` test helper scrubs the two new vars so existing regression tests stay hermetic
- 4 new tests:
  - vLLM-only → `"vllm"`
  - LM Studio-only → `"lmstudio"`
  - all three local set → Ollama → vLLM → LM Studio order
  - cloud (OpenAI) beats local (vLLM)

This was the only real gap surfaced by the deep cross-repo diff; the original "Embedding auto-detection 扩展" task was already done by `4d0b8393`.

## Test plan
- [x] grep'd LibreFang main — `VLLM_BASE_URL` / `LMSTUDIO_BASE_URL` not in detect path
- [x] 4 new unit tests
- [ ] Manual: `VLLM_BASE_URL=http://localhost:8000/v1` + `provider = "auto"` in embedding config — should pick vllm
