### PR TITLE
chore(types): rename normalize_schema_recursive + warn on items fallback

### DIFF
--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -22,6 +22,7 @@ fluent = { workspace = true }
 unic-langid = { workspace = true }
 regex-lite = { workspace = true }
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 rmp-serde = { workspace = true }

--- a/crates/librefang-types/src/tool.rs
+++ b/crates/librefang-types/src/tool.rs
@@ -905,8 +905,7 @@ mod tests {
         for provider in ["gemini", "openai", "groq"] {
             let result = normalize_schema_for_provider(&schema, provider);
             assert_eq!(
-                result["properties"]["tags"]["items"]["type"],
-                "string",
+                result["properties"]["tags"]["items"]["type"], "string",
                 "provider={provider} must inject string items fallback"
             );
         }
@@ -915,7 +914,9 @@ mod tests {
         // injected (Anthropic does not require items for array params).
         let anthropic_result = normalize_schema_for_provider(&schema, "anthropic");
         assert!(
-            anthropic_result["properties"]["tags"].get("items").is_none(),
+            anthropic_result["properties"]["tags"]
+                .get("items")
+                .is_none(),
             "anthropic must NOT inject items — schema is passed through unchanged"
         );
     }

--- a/crates/librefang-types/src/tool.rs
+++ b/crates/librefang-types/src/tool.rs
@@ -890,6 +890,63 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_array_without_items_fallback_is_string_for_all_strict_providers() {
+        // The string fallback is NOT Gemini-specific — every strict-validator
+        // provider goes through the same worker. Lock that contract in: the
+        // same input must yield the same fallback for gemini, openai, groq.
+        // (anthropic short-circuits and keeps the schema as-is — also covered.)
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array" }
+            }
+        });
+
+        for provider in ["gemini", "openai", "groq"] {
+            let result = normalize_schema_for_provider(&schema, provider);
+            assert_eq!(
+                result["properties"]["tags"]["items"]["type"],
+                "string",
+                "provider={provider} must inject string items fallback"
+            );
+        }
+
+        // Anthropic short-circuits — schema is preserved verbatim, no items
+        // injected (Anthropic does not require items for array params).
+        let anthropic_result = normalize_schema_for_provider(&schema, "anthropic");
+        assert!(
+            anthropic_result["properties"]["tags"].get("items").is_none(),
+            "anthropic must NOT inject items — schema is passed through unchanged"
+        );
+    }
+
+    #[test]
+    fn test_normalize_array_fallback_warns_caller_via_log() {
+        // The fallback is intentionally lossy when the array's true element
+        // type is not `string` — e.g. an array of integers normalized for
+        // Gemini will be told to emit string elements. We document this here
+        // so future readers cannot mistake the fallback for type inference.
+        //
+        // The accompanying production code emits a `tracing::warn!` on every
+        // fallback so the gap surfaces in logs. We don't capture the log here
+        // (would require an extra dev-dep) — this test exists to:
+        //   1. Pin the fallback type as `string` (regression).
+        //   2. Carry the rationale in code so it's discoverable from a search
+        //      for `array_without_items` or `string_default`.
+        let int_array_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "ids": { "type": "array", "description": "list of numeric ids" }
+            }
+        });
+        let result = normalize_schema_for_provider(&int_array_schema, "gemini");
+        // The fallback is `string`, even though the description hints at numbers.
+        // This is the "better than missing items" trade-off — callers should
+        // declare `items` explicitly to get correct typing.
+        assert_eq!(result["properties"]["ids"]["items"]["type"], "string");
+    }
+
+    #[test]
     fn test_normalize_preserves_existing_items() {
         // If `items` already exists, it must not be overwritten
         let schema = serde_json::json!({

--- a/crates/librefang-types/src/tool.rs
+++ b/crates/librefang-types/src/tool.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 /// Definition of a tool that an agent can use.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -212,11 +213,18 @@ pub struct DecisionTrace {
 
 /// Normalize a JSON Schema for cross-provider compatibility.
 ///
-/// Some providers (Gemini, Groq) reject `anyOf` in tool schemas.
-/// This function:
+/// Several providers (Gemini, Groq, OpenAI strict mode, …) ship strict JSON
+/// Schema validators that reject keywords Anthropic accepts natively (e.g.
+/// `anyOf`, `$ref`, `additionalProperties`, type unions). This function:
 /// - Converts `anyOf` arrays of simple types to flat `enum` arrays
-/// - Strips `$schema` keys (not accepted by most providers)
+/// - Strips `$schema`, `$defs`, `$ref`, `additionalProperties`, `format`, …
+/// - Resolves `$ref` against `$defs` before stripping
 /// - Recursively walks `properties` and `items`
+/// - Injects a fallback `items: {type: "string"}` for `array` schemas missing
+///   `items` (otherwise Gemini returns `INVALID_ARGUMENT`)
+///
+/// Anthropic is short-circuited at the top — its API accepts the schema as-is.
+/// Every other provider goes through `normalize_schema_for_strict_validators`.
 pub fn normalize_schema_for_provider(
     schema: &serde_json::Value,
     provider: &str,
@@ -225,10 +233,17 @@ pub fn normalize_schema_for_provider(
     if provider == "anthropic" {
         return schema.clone();
     }
-    normalize_schema_recursive(schema)
+    normalize_schema_for_strict_validators(schema)
 }
 
-fn normalize_schema_recursive(schema: &serde_json::Value) -> serde_json::Value {
+/// Recursive worker for `normalize_schema_for_provider`.
+///
+/// Despite historical naming this routine is **not Gemini-specific** — it runs
+/// for every non-Anthropic provider (gemini, openai, groq, deepseek, bedrock,
+/// vertex, …) because they all share strict-validator semantics. Any change
+/// here affects all of them; verify against each driver before tightening
+/// behaviour.
+fn normalize_schema_for_strict_validators(schema: &serde_json::Value) -> serde_json::Value {
     let obj = match schema.as_object() {
         Some(o) => o,
         None => {
@@ -237,7 +252,7 @@ fn normalize_schema_recursive(schema: &serde_json::Value) -> serde_json::Value {
             if let Some(s) = schema.as_str() {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s) {
                     if parsed.is_object() {
-                        return normalize_schema_recursive(&parsed);
+                        return normalize_schema_for_strict_validators(&parsed);
                     }
                 }
             }
@@ -328,7 +343,10 @@ fn normalize_schema_recursive(schema: &serde_json::Value) -> serde_json::Value {
             if let Some(props) = value.as_object() {
                 let mut new_props = serde_json::Map::new();
                 for (prop_name, prop_schema) in props {
-                    new_props.insert(prop_name.clone(), normalize_schema_recursive(prop_schema));
+                    new_props.insert(
+                        prop_name.clone(),
+                        normalize_schema_for_strict_validators(prop_schema),
+                    );
                 }
                 result.insert(key.clone(), serde_json::Value::Object(new_props));
                 continue;
@@ -337,19 +355,30 @@ fn normalize_schema_recursive(schema: &serde_json::Value) -> serde_json::Value {
 
         // Recurse into items
         if key == "items" {
-            result.insert(key.clone(), normalize_schema_recursive(value));
+            result.insert(key.clone(), normalize_schema_for_strict_validators(value));
             continue;
         }
 
         result.insert(key.clone(), value.clone());
     }
 
-    // Gemini requires `items` for every array-typed parameter.
-    // JSON Schema allows arrays without `items`, but the Gemini API rejects
-    // such schemas with INVALID_ARGUMENT. Inject a default string items schema
-    // so MCP tools (and any other source) don't break Gemini requests.
+    // Strict-validator providers (Gemini in particular) require `items` for
+    // every array-typed parameter. JSON Schema allows arrays without `items`,
+    // but the Gemini API rejects such schemas with INVALID_ARGUMENT.
+    //
+    // Fallback: inject `{"type": "string"}` so the request is at least accepted.
+    // This is **better than dropping the tool**, but not ideal: when the array
+    // truly contains numbers/objects the model will be told it is a `string[]`
+    // and may produce wrong arguments. Tool authors / MCP servers SHOULD always
+    // declare an explicit `items` schema; we emit a `warn!` so the gap is
+    // surfaced in logs rather than silently papered over.
     if result.get("type").and_then(|t| t.as_str()) == Some("array") && !result.contains_key("items")
     {
+        warn!(
+            "JSON Schema array without `items` — injecting fallback `{{\"type\":\"string\"}}` \
+             for strict-validator providers (Gemini etc.). The schema author should declare \
+             items explicitly; the string fallback may produce wrong tool arguments for non-string arrays."
+        );
         result.insert("items".to_string(), serde_json::json!({"type": "string"}));
     }
 


### PR DESCRIPTION
## Summary
Follow-up review concerns from #3085 (already merged).

- Clarify that `normalize_schema_recursive` scope covers all strict-validator providers, not Gemini specifically — adjusts naming/comments accordingly.
- Add explicit warn log when an `array` parameter lacks an `items` schema and we fall back to a default string item, plus a regression test documenting that path.

Cherry-picks: f7a6687f, 4a39202c

## Test plan
- [x] Existing schema-normalization tests still pass
- [x] New regression test covers the array-without-items warn-and-fallback path