### PR TITLE
fix(providers): use 127.0.0.1 instead of localhost for local LLM URLs

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1967,7 +1967,10 @@ pub async fn detect_ollama() -> impl IntoResponse {
         }
     };
 
-    match client.get("http://localhost:11434/api/tags").send().await {
+    // Use 127.0.0.1 instead of localhost: on dual-stack hosts (macOS)
+    // localhost resolves to ::1 first and Ollama binds IPv4 only, causing
+    // probes to fail without reliable IPv4 fallback.
+    match client.get("http://127.0.0.1:11434/api/tags").send().await {
         Ok(resp) if resp.status().is_success() => {
             let body: serde_json::Value = resp.json().await.unwrap_or_else(|e| {
                 tracing::warn!("Ollama responded but JSON parse failed: {e}");

--- a/crates/librefang-cli/templates/init_default_config.toml
+++ b/crates/librefang-cli/templates/init_default_config.toml
@@ -95,8 +95,8 @@ debounce_ms = 500
 
 # ── Provider URL Overrides (uncomment to use) ────────────────
 # [provider_urls]
-# ollama = "http://localhost:11434/v1"
-# vllm = "http://localhost:8000/v1"
+# ollama = "http://127.0.0.1:11434/v1"
+# vllm = "http://127.0.0.1:8000/v1"
 
 # ── Fallback Providers (LLM failover chain) ──────────────────
 # [[fallback_providers]]

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1799,9 +1799,13 @@ impl LibreFangKernel {
                 config.default_model.model = model;
                 config.default_model.api_key_env = String::new();
                 if !config.provider_urls.contains_key("ollama") {
+                    // Use 127.0.0.1: on macOS `localhost` resolves to ::1 first
+                    // and Ollama only binds IPv4, so the IPv6 attempt fails
+                    // without reliable fallback. See PROVIDER_REGISTRY in
+                    // librefang-llm-drivers for the same reasoning.
                     config.provider_urls.insert(
                         "ollama".to_string(),
-                        "http://localhost:11434/v1".to_string(),
+                        "http://127.0.0.1:11434/v1".to_string(),
                     );
                 }
             } else {

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -271,7 +271,11 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
     ProviderEntry {
         name: "ollama",
         aliases: &[],
-        base_url: "http://localhost:11434/v1",
+        // Use 127.0.0.1 instead of localhost: on dual-stack hosts (e.g. macOS)
+        // localhost resolves to both ::1 and 127.0.0.1, IPv6 is tried first,
+        // and these local servers usually bind IPv4 only, causing instant
+        // connection-refused errors that don't always fall back to IPv4.
+        base_url: "http://127.0.0.1:11434/v1",
         api_key_env: "OLLAMA_API_KEY",
         key_required: false,
         api_format: ApiFormat::OpenAI,
@@ -281,7 +285,7 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
     ProviderEntry {
         name: "vllm",
         aliases: &[],
-        base_url: "http://localhost:8000/v1",
+        base_url: "http://127.0.0.1:8000/v1",
         api_key_env: "VLLM_API_KEY",
         key_required: false,
         api_format: ApiFormat::OpenAI,
@@ -291,7 +295,7 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
     ProviderEntry {
         name: "lmstudio",
         aliases: &[],
-        base_url: "http://localhost:1234/v1",
+        base_url: "http://127.0.0.1:1234/v1",
         api_key_env: "LMSTUDIO_API_KEY",
         key_required: false,
         api_format: ApiFormat::OpenAI,
@@ -301,7 +305,7 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
     ProviderEntry {
         name: "lemonade",
         aliases: &[],
-        base_url: "http://localhost:8888/api/v1",
+        base_url: "http://127.0.0.1:8888/api/v1",
         api_key_env: "LEMONADE_API_KEY",
         key_required: false,
         api_format: ApiFormat::OpenAI,

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -860,11 +860,14 @@ pub fn create_embedding_driver(
         })
         .map(Ok)
         .unwrap_or_else(|| match provider {
-            // Local providers keep hardcoded defaults: their localhost URLs
-            // aren't registry-tracked and the ports are stable by convention.
-            "ollama" => Ok("http://localhost:11434/v1".to_string()),
-            "vllm" => Ok("http://localhost:8000/v1".to_string()),
-            "lmstudio" => Ok("http://localhost:1234/v1".to_string()),
+            // Local providers keep hardcoded defaults: the ports are stable by
+            // convention. Use 127.0.0.1 instead of `localhost` because on
+            // dual-stack hosts (macOS) `localhost` resolves to ::1 first, but
+            // these servers usually bind IPv4 only — and connection-refused
+            // doesn't always trigger Happy Eyeballs fallback to IPv4.
+            "ollama" => Ok("http://127.0.0.1:11434/v1".to_string()),
+            "vllm" => Ok("http://127.0.0.1:8000/v1".to_string()),
+            "lmstudio" => Ok("http://127.0.0.1:1234/v1".to_string()),
             // Cloud providers MUST come from the model catalog or an explicit
             // override. A hardcoded fallback is exactly the bug class this
             // plumbing is trying to eliminate (stale baked-in URL silently


### PR DESCRIPTION
## Summary

On dual-stack hosts (notably macOS), `localhost` resolves to both `::1` and `127.0.0.1` with IPv6 tried first. Local LLM servers (Ollama / vLLM / LM Studio / Lemonade) installed via the standard scripts bind **IPv4 only**, so reqwest's first connection attempt to `[::1]:<port>` is refused instantly. Happy Eyeballs fallback to IPv4 isn't reliably triggered for connection-refused (vs. timeout), so the probe fails outright and the daemon spams:

```
WARN Configured local provider offline provider=ollama error="error sending request for url (http://localhost:11434/api/tags)"
```

…even though `curl http://localhost:11434/api/tags` works fine (curl explicitly does the IPv6→IPv4 fallback).

## Repro

```sh
$ lsof -iTCP:11434 -sTCP:LISTEN
COMMAND  PID  USER  FD  TYPE  NODE NAME
ollama   ...  ...   5u  IPv4  TCP localhost:11434 (LISTEN)   ← IPv4 only

$ cat /etc/hosts | grep localhost
127.0.0.1  localhost
::1        localhost
```

The TCP-level reachability check at `kernel/mod.rs:1754` already uses `127.0.0.1` directly (and succeeds), but the URL stored in `provider_urls.ollama` was `http://localhost:11434/v1`, so subsequent reqwest calls fail. This PR brings the URL strings in line with the reachability check.

## Changes

Production code:
- `PROVIDER_REGISTRY` defaults for `ollama`, `vllm`, `lmstudio`, `lemonade` (`librefang-llm-drivers`)
- Embedding driver fallback URLs for the same three providers (`librefang-runtime/embedding.rs`)
- Auto-detected ollama URL injected into `provider_urls` (`librefang-kernel/kernel/mod.rs`)
- The standalone Ollama detect probe (`librefang-api/routes/providers.rs::detect_ollama`)
- Example URLs in the init config template (`librefang-cli/templates/init_default_config.toml`)

Existing test fixtures that happen to use `localhost` as an arbitrary input string are intentionally left alone (they're not asserting the default URL constant). The two `model_catalog.rs` tests that DO assert default URLs (`test_set_provider_url`, `test_apply_url_overrides`) still load from the live `librefang-registry` repo via `resolve_home_dir_for_tests`, so they are not affected by this PR — they will need updating in tandem with the registry-repo PR (see below).

## Follow-up needed

The runtime probe URL (the one that actually triggered the warning the user reported) comes from `~/.librefang/registry/providers/ollama.toml`, which is synced from the **`librefang-registry`** repo. A matching PR is needed there to flip those `base_url` fields from `http://localhost:...` to `http://127.0.0.1:...`. After both land, existing installs will pick up the fix on their next registry sync.

## Test plan

- [ ] CI green (workspace build + tests + clippy zero-warnings)
- [ ] On a macOS host with Ollama running and no `provider_urls.ollama` override in `config.toml`: start daemon, confirm no `Configured local provider offline` warning and ollama appears as reachable in the model catalog
- [ ] Manual: send a chat message to an ollama-backed agent end-to-end