### PR TITLE
fix(router): pass agents_dir to hand route candidate scan to silence WARN flood

### DIFF
--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -185,6 +185,19 @@ fn load_hand_route_candidates(home_dir: &Path) -> Vec<HandRouteCandidate> {
 
     let dirs = [home_dir.join("registry").join("hands")];
 
+    // Pass the agents registry alongside HAND.toml parsing so hands that
+    // declare `base = "<template>"` for their agents can resolve the
+    // template. Without this the hand parser fails the flat path with
+    // "requires agents registry directory" and emits a WARN on every
+    // routing scan — and routing happens on every inbound message dispatch,
+    // so the warning floods the log.
+    let agents_dir = home_dir.join("registry").join("agents");
+    let agents_dir_arg: Option<&Path> = if agents_dir.is_dir() {
+        Some(agents_dir.as_path())
+    } else {
+        None
+    };
+
     for hands_dir in &dirs {
         let Ok(entries) = fs::read_dir(hands_dir) else {
             continue;
@@ -206,10 +219,11 @@ fn load_hand_route_candidates(home_dir: &Path) -> Vec<HandRouteCandidate> {
             let Ok(toml_content) = fs::read_to_string(&hand_toml) else {
                 continue;
             };
-            let Ok(def) = librefang_hands::registry::parse_hand_toml(
+            let Ok(def) = librefang_hands::registry::parse_hand_toml_with_agents_dir(
                 &toml_content,
                 "",
                 std::collections::HashMap::new(),
+                agents_dir_arg,
             ) else {
                 continue;
             };

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -212,22 +212,30 @@ fn load_hand_route_candidates(home_dir: &Path) -> Vec<HandRouteCandidate> {
                 .and_then(|n| n.to_str())
                 .unwrap_or_default()
                 .to_string();
-            if !seen.insert(name) {
+            if !seen.insert(name.clone()) {
                 continue;
             }
             let hand_toml = hand_dir.join("HAND.toml");
             let Ok(toml_content) = fs::read_to_string(&hand_toml) else {
                 continue;
             };
-            let Ok(def) = librefang_hands::registry::parse_hand_toml_with_agents_dir(
+            // Surface parse failures at WARN — the previous `let Ok else
+            // continue` swallowed the error and the hand was silently
+            // dropped from routing, hiding misconfigured HAND.toml files
+            // (such as the `base = "<template>"` issue this PR fixes).
+            match librefang_hands::registry::parse_hand_toml_with_agents_dir(
                 &toml_content,
                 "",
                 std::collections::HashMap::new(),
                 agents_dir_arg,
-            ) else {
-                continue;
-            };
-            candidates.push(hand_route_candidate_from_definition(def));
+            ) {
+                Ok(def) => candidates.push(hand_route_candidate_from_definition(def)),
+                Err(e) => tracing::warn!(
+                    hand = %name,
+                    error = %e,
+                    "Failed to parse HAND.toml for routing — hand will be unreachable",
+                ),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
The router's HAND.toml scanner called `parse_hand_toml(...)` with no `agents_dir`, so any hand declaring `base = \"<template>\"` for its agents fell out of the flat parse path with `requires agents registry directory`, fell back to the wrapped format (which doesn't match for non-wrapped HAND.toml), and emitted a WARN.

Routing runs on every inbound message dispatch, so this floods the log on **every** `POST /api/agents/{id}/message`:

```
WARN request: Flat parse failed for hand: [agents.engineer]:
`base = "coder"` requires agents registry directory
```

## Fix
Resolve `{home_dir}/registry/agents/` (the canonical templates directory the hands registry already uses elsewhere via `resolve_agents_dir`) and pass it to `parse_hand_toml_with_agents_dir`. When the directory doesn't exist we still pass `None`, so this is a strict superset of the previous behaviour for non-base hands.

`librefang-kernel-router/src/lib.rs:209` was the only call site of the no-`agents_dir` variant in the router.

## Test plan
- [x] grep'd: only call site in router; `librefang-hands::registry::parse_hand_toml_with_agents_dir` already public
- [ ] Manual: run a daemon with a hand that uses `base = \"coder\"` for at least one agent (e.g. the `engineer` hand from the user's report), send a message via `POST /api/agents/{id}/message`, confirm no `Flat parse failed` WARN in the log
- [ ] Manual: confirm hand-based routing still works (alias matches still resolve to the same hand id as before)

## Update — surface parse failures

Added a follow-up commit converting the silent `let Ok else { continue; }` to a `tracing::warn!` with the hand id and underlying error. The silent skip is what hid this very issue: a misconfigured HAND.toml made the hand vanish from routing with no log trace. With this in, future parse misconfigurations are visible at WARN instead of silently making the hand unreachable.
