### PR TITLE
feat(scheduler): multi-target cron delivery fan-out

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1264,6 +1264,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         pre_check_script: None,
                     },
                     delivery: librefang_types::scheduler::CronDelivery::None,
+                    delivery_targets: Vec::new(),
                     peer_id: None,
                     session_mode: None,
                     created_at: chrono::Utc::now(),

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1470,6 +1470,7 @@ pub async fn create_schedule(
         schedule: librefang_types::scheduler::CronSchedule::Cron { expr: cron, tz },
         action,
         delivery: librefang_types::scheduler::CronDelivery::None,
+        delivery_targets: Vec::new(),
         peer_id: None,
         session_mode: req["session_mode"]
             .as_str()

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -673,6 +673,7 @@ mod tests {
                 text: "ping".into(),
             },
             delivery: CronDelivery::None,
+            delivery_targets: Vec::new(),
             peer_id: None,
             session_mode: None,
             created_at: Utc::now(),

--- a/crates/librefang-kernel/src/cron_delivery.rs
+++ b/crates/librefang-kernel/src/cron_delivery.rs
@@ -1,0 +1,638 @@
+//! Multi-destination cron output delivery.
+//!
+//! A single [`CronJob`](librefang_types::scheduler::CronJob) may declare zero
+//! or more [`CronDeliveryTarget`]s on its `delivery_targets` field. After the
+//! job fires and produces output, the [`CronDeliveryEngine`] fans out the
+//! same payload to every target concurrently. Failures in one target do not
+//! abort delivery to the others — every target's outcome is captured in a
+//! [`DeliveryResult`].
+//!
+//! This is the LibreFang port of the OpenFang multi-destination cron pattern
+//! (see openfang commit `3db5d3a`): one job → N destinations
+//! (channel / webhook / file / email).
+
+use async_trait::async_trait;
+use futures::future::join_all;
+use librefang_types::scheduler::CronDeliveryTarget;
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+/// Webhook HTTP timeout. Matches the legacy single-target cron webhook
+/// (`cron_deliver_response` in `kernel/mod.rs`).
+const WEBHOOK_TIMEOUT_SECS: u64 = 30;
+
+/// Per-target delivery outcome returned by [`CronDeliveryEngine::deliver`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliveryResult {
+    /// Human-readable target description (e.g.
+    /// `"channel:telegram -> chat_123"`, `"webhook:https://..."`,
+    /// `"file:/tmp/out.log"`, `"email:alice@x"`).
+    pub target: String,
+    /// Whether delivery succeeded.
+    pub success: bool,
+    /// Error message if `success` is `false`.
+    pub error: Option<String>,
+}
+
+impl DeliveryResult {
+    fn ok(target: String) -> Self {
+        Self {
+            target,
+            success: true,
+            error: None,
+        }
+    }
+
+    fn err(target: String, msg: String) -> Self {
+        Self {
+            target,
+            success: false,
+            error: Some(msg),
+        }
+    }
+}
+
+/// Channel dispatcher used by the engine to invoke channel adapters
+/// (telegram, slack, email, …) without depending on the full `KernelHandle`
+/// surface. The kernel implements it by delegating to its existing
+/// `send_channel_message` method.
+///
+/// Defined here (not in `librefang-channels`) because the engine is owned
+/// by the kernel and only needs this single method.
+#[async_trait]
+pub trait CronChannelDispatcher: Send + Sync {
+    /// Send `message` via the named adapter to `recipient`. Returns
+    /// `Err(reason)` on failure.
+    async fn send_channel_message(
+        &self,
+        channel: &str,
+        recipient: &str,
+        message: &str,
+    ) -> Result<(), String>;
+}
+
+/// Fan-out delivery engine for cron job output.
+///
+/// Holds a reference to a `CronChannelDispatcher` (used for channel- and
+/// email-style delivery) and a shared `reqwest::Client` (used for webhook
+/// delivery). Constructed once per kernel and reused across every cron
+/// firing.
+pub struct CronDeliveryEngine {
+    dispatcher: Arc<dyn CronChannelDispatcher>,
+    http: reqwest::Client,
+}
+
+impl CronDeliveryEngine {
+    /// Build a new engine using the given dispatcher and a fresh
+    /// `reqwest::Client` with a 30s timeout. Falls back to the default
+    /// client if the builder fails (effectively never on supported
+    /// platforms).
+    pub fn new(dispatcher: Arc<dyn CronChannelDispatcher>) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(WEBHOOK_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_default();
+        Self { dispatcher, http }
+    }
+
+    /// Build a new engine with an explicit HTTP client — used by tests so
+    /// the client can point at a mock server.
+    pub fn with_http_client(
+        dispatcher: Arc<dyn CronChannelDispatcher>,
+        http: reqwest::Client,
+    ) -> Self {
+        Self { dispatcher, http }
+    }
+
+    /// Deliver `output` (and `job_id` / `agent_id` metadata) to every target
+    /// concurrently.
+    ///
+    /// Returns one `DeliveryResult` per target, in the same order as the
+    /// input slice. One target failing does not short-circuit the others —
+    /// the underlying job already succeeded, fan-out is best-effort.
+    pub async fn deliver(
+        &self,
+        targets: &[CronDeliveryTarget],
+        job_id: &str,
+        agent_id: &str,
+        job_name: &str,
+        output: &str,
+    ) -> Vec<DeliveryResult> {
+        if targets.is_empty() {
+            return Vec::new();
+        }
+        let futures = targets
+            .iter()
+            .map(|t| self.deliver_one(t, job_id, agent_id, job_name, output));
+        join_all(futures).await
+    }
+
+    /// Deliver to a single target. Never panics.
+    async fn deliver_one(
+        &self,
+        target: &CronDeliveryTarget,
+        job_id: &str,
+        agent_id: &str,
+        job_name: &str,
+        output: &str,
+    ) -> DeliveryResult {
+        match target {
+            CronDeliveryTarget::Channel { channel, to } => {
+                let desc = format!("channel:{channel} -> {to}");
+                match self
+                    .dispatcher
+                    .send_channel_message(channel, to, output)
+                    .await
+                {
+                    Ok(()) => {
+                        debug!(target = %desc, "Cron fan-out: channel delivery ok");
+                        DeliveryResult::ok(desc)
+                    }
+                    Err(e) => {
+                        warn!(target = %desc, error = %e, "Cron fan-out: channel delivery failed");
+                        DeliveryResult::err(desc, e)
+                    }
+                }
+            }
+            CronDeliveryTarget::Webhook { url } => {
+                let desc = format!("webhook:{url}");
+                match deliver_webhook(&self.http, url, job_id, agent_id, job_name, output).await {
+                    Ok(()) => {
+                        debug!(target = %desc, "Cron fan-out: webhook delivery ok");
+                        DeliveryResult::ok(desc)
+                    }
+                    Err(e) => {
+                        warn!(target = %desc, error = %e, "Cron fan-out: webhook delivery failed");
+                        DeliveryResult::err(desc, e)
+                    }
+                }
+            }
+            CronDeliveryTarget::File { path } => {
+                let desc = format!("file:{path}");
+                match deliver_file(Path::new(path), output).await {
+                    Ok(()) => {
+                        debug!(target = %desc, "Cron fan-out: file write ok");
+                        DeliveryResult::ok(desc)
+                    }
+                    Err(e) => {
+                        warn!(target = %desc, error = %e, "Cron fan-out: file write failed");
+                        DeliveryResult::err(desc, e)
+                    }
+                }
+            }
+            CronDeliveryTarget::Email { to, subject } => {
+                let desc = format!("email:{to}");
+                let rendered = render_subject(subject.as_deref(), job_name);
+                let body = format!("{rendered}\n\n{output}");
+                // Route via the existing email channel adapter. If no email
+                // adapter is configured the dispatcher returns Err which we
+                // surface as a failed `DeliveryResult` (no silent success).
+                match self
+                    .dispatcher
+                    .send_channel_message("email", to, &body)
+                    .await
+                {
+                    Ok(()) => {
+                        debug!(target = %desc, "Cron fan-out: email delivery ok");
+                        DeliveryResult::ok(desc)
+                    }
+                    Err(e) => {
+                        warn!(target = %desc, error = %e, "Cron fan-out: email delivery failed");
+                        DeliveryResult::err(desc, e)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render an email subject from an optional template. `{job}` is the only
+/// supported placeholder; an empty/`None` template falls back to
+/// `"Cron: <job_name>"`.
+fn render_subject(template: Option<&str>, job_name: &str) -> String {
+    match template {
+        Some(t) if !t.is_empty() => t.replace("{job}", job_name),
+        _ => format!("Cron: {job_name}"),
+    }
+}
+
+/// POST a JSON payload `{job_id, agent_id, content}` to `url`. The 30s
+/// timeout comes from the shared `reqwest::Client` configured in
+/// [`CronDeliveryEngine::new`]. Returns `Err(msg)` on network failure or
+/// non-2xx status.
+async fn deliver_webhook(
+    http: &reqwest::Client,
+    url: &str,
+    job_id: &str,
+    agent_id: &str,
+    job_name: &str,
+    output: &str,
+) -> Result<(), String> {
+    let payload = serde_json::json!({
+        "job_id": job_id,
+        "agent_id": agent_id,
+        "job": job_name,
+        "content": output,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    });
+    let resp = http
+        .post(url)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("webhook send failed: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("webhook returned HTTP {status}"));
+    }
+    Ok(())
+}
+
+/// Append `output` (followed by a newline) to `path`, creating parent
+/// directories as needed. Rejects any path that contains a `..` component
+/// as defence-in-depth on top of the validation already performed in
+/// `CronDeliveryTarget::validate`.
+async fn deliver_file(path: &Path, output: &str) -> Result<(), String> {
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err("path must not contain '..' components".into());
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("create parent dir failed: {e}"))?;
+        }
+    }
+    use tokio::io::AsyncWriteExt;
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .map_err(|e| format!("open failed: {e}"))?;
+    f.write_all(output.as_bytes())
+        .await
+        .map_err(|e| format!("write failed: {e}"))?;
+    // Newline separator between successive runs makes tailing nicer.
+    f.write_all(b"\n")
+        .await
+        .map_err(|e| format!("write newline failed: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records every dispatch call. Optionally fails when the channel name
+    /// matches `fail_on_channel`.
+    struct MockDispatcher {
+        calls: Mutex<Vec<(String, String, String)>>,
+        fail_on_channel: Option<String>,
+    }
+
+    impl MockDispatcher {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+                fail_on_channel: None,
+            })
+        }
+
+        fn failing_on(channel: &str) -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+                fail_on_channel: Some(channel.to_string()),
+            })
+        }
+
+        fn calls(&self) -> Vec<(String, String, String)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl CronChannelDispatcher for MockDispatcher {
+        async fn send_channel_message(
+            &self,
+            channel: &str,
+            recipient: &str,
+            message: &str,
+        ) -> Result<(), String> {
+            self.calls.lock().unwrap().push((
+                channel.to_string(),
+                recipient.to_string(),
+                message.to_string(),
+            ));
+            if let Some(ref f) = self.fail_on_channel {
+                if f == channel {
+                    return Err(format!("mock: forced failure on '{channel}'"));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    fn engine_with(dispatcher: Arc<MockDispatcher>) -> CronDeliveryEngine {
+        CronDeliveryEngine::new(dispatcher)
+    }
+
+    // -- Empty targets -------------------------------------------------------
+
+    #[tokio::test]
+    async fn empty_targets_returns_empty_vec() {
+        let engine = engine_with(MockDispatcher::new());
+        let results = engine.deliver(&[], "j", "a", "name", "x").await;
+        assert!(results.is_empty());
+    }
+
+    // -- Channel: success ----------------------------------------------------
+
+    #[tokio::test]
+    async fn channel_target_invokes_dispatcher() {
+        let mock = MockDispatcher::new();
+        let engine = engine_with(mock.clone());
+        let target = CronDeliveryTarget::Channel {
+            channel: "slack".into(),
+            to: "C12345".into(),
+        };
+        let results = engine
+            .deliver(&[target], "job-1", "agent-1", "alerts", "fire")
+            .await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success, "error: {:?}", results[0].error);
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "slack");
+        assert_eq!(calls[0].1, "C12345");
+        assert_eq!(calls[0].2, "fire");
+    }
+
+    // -- Channel: failure ----------------------------------------------------
+
+    #[tokio::test]
+    async fn channel_target_failure_is_reported() {
+        let mock = MockDispatcher::failing_on("slack");
+        let engine = engine_with(mock);
+        let target = CronDeliveryTarget::Channel {
+            channel: "slack".into(),
+            to: "C1".into(),
+        };
+        let results = engine
+            .deliver(&[target], "job", "agent", "name", "payload")
+            .await;
+        assert!(!results[0].success);
+        assert!(results[0]
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("forced failure"));
+    }
+
+    // -- File: append + creates parents -------------------------------------
+
+    #[tokio::test]
+    async fn file_target_creates_and_appends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested/deep/out.log");
+        let target = CronDeliveryTarget::File {
+            path: path.to_string_lossy().to_string(),
+        };
+        let engine = engine_with(MockDispatcher::new());
+        let r1 = engine
+            .deliver(std::slice::from_ref(&target), "j", "a", "name", "first")
+            .await;
+        let r2 = engine.deliver(&[target], "j", "a", "name", "second").await;
+        assert!(r1[0].success, "{:?}", r1[0].error);
+        assert!(r2[0].success, "{:?}", r2[0].error);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("first") && content.contains("second"),
+            "got: {content:?}"
+        );
+    }
+
+    // -- File: parent-dir traversal rejected --------------------------------
+
+    #[tokio::test]
+    async fn file_target_rejects_parent_dir_components() {
+        let target = CronDeliveryTarget::File {
+            path: "logs/../../escape.txt".into(),
+        };
+        let engine = engine_with(MockDispatcher::new());
+        let results = engine.deliver(&[target], "j", "a", "name", "x").await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success, "must reject '..' paths");
+        assert!(results[0].error.as_deref().unwrap_or("").contains(".."));
+    }
+
+    // -- Webhook: success + payload shape -----------------------------------
+
+    #[tokio::test]
+    async fn webhook_sends_payload_with_metadata() {
+        let (port, rx) = spawn_mock_http_server(200, "OK").await;
+        let url = format!("http://127.0.0.1:{port}/hook");
+        let target = CronDeliveryTarget::Webhook { url };
+        let engine = engine_with(MockDispatcher::new());
+        let results = engine
+            .deliver(&[target], "job-7", "agent-9", "daily", "result body")
+            .await;
+        assert!(results[0].success, "error: {:?}", results[0].error);
+        let captured = rx.await.expect("mock server never received a request");
+        assert!(
+            captured.body.contains("\"job_id\":\"job-7\""),
+            "missing job_id, got: {}",
+            captured.body
+        );
+        assert!(
+            captured.body.contains("\"agent_id\":\"agent-9\""),
+            "missing agent_id, got: {}",
+            captured.body
+        );
+        assert!(
+            captured.body.contains("\"content\":\"result body\""),
+            "missing content, got: {}",
+            captured.body
+        );
+    }
+
+    // -- Webhook: non-2xx ----------------------------------------------------
+
+    #[tokio::test]
+    async fn webhook_reports_non_2xx_status() {
+        let (port, _rx) = spawn_mock_http_server(500, "Internal Server Error").await;
+        let url = format!("http://127.0.0.1:{port}/hook");
+        let target = CronDeliveryTarget::Webhook { url };
+        let engine = engine_with(MockDispatcher::new());
+        let results = engine.deliver(&[target], "j", "a", "name", "x").await;
+        assert!(!results[0].success);
+        assert!(results[0].error.as_deref().unwrap_or("").contains("500"));
+    }
+
+    // -- Email: routes through dispatcher with rendered subject -------------
+
+    #[tokio::test]
+    async fn email_target_routes_via_dispatcher() {
+        let mock = MockDispatcher::new();
+        let engine = engine_with(mock.clone());
+        let target = CronDeliveryTarget::Email {
+            to: "alice@example.com".into(),
+            subject: Some("Report: {job}".into()),
+        };
+        let results = engine
+            .deliver(&[target], "j", "a", "weekly", "the body")
+            .await;
+        assert!(results[0].success, "{:?}", results[0].error);
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "email");
+        assert_eq!(calls[0].1, "alice@example.com");
+        assert!(
+            calls[0].2.starts_with("Report: weekly"),
+            "subject not rendered into body: {}",
+            calls[0].2
+        );
+        assert!(
+            calls[0].2.contains("the body"),
+            "body missing in dispatch: {}",
+            calls[0].2
+        );
+    }
+
+    // -- Mixed success / failure --------------------------------------------
+
+    #[tokio::test]
+    async fn mixed_targets_partial_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ok_path = tmp.path().join("ok.txt");
+        let targets = vec![
+            // Will succeed.
+            CronDeliveryTarget::File {
+                path: ok_path.to_string_lossy().to_string(),
+            },
+            // Will fail (mock dispatcher rejects 'slack').
+            CronDeliveryTarget::Channel {
+                channel: "slack".into(),
+                to: "C1".into(),
+            },
+        ];
+        let engine = engine_with(MockDispatcher::failing_on("slack"));
+        let results = engine
+            .deliver(&targets, "job", "agent", "name", "payload")
+            .await;
+        assert_eq!(results.len(), 2);
+        assert!(results[0].success, "file delivery should succeed");
+        assert!(!results[1].success, "channel delivery should fail");
+        // File was still written even though the other target failed.
+        let content = std::fs::read_to_string(&ok_path).unwrap();
+        assert!(content.contains("payload"));
+    }
+
+    // -- render_subject helper ----------------------------------------------
+
+    #[test]
+    fn render_subject_substitutes_placeholder() {
+        assert_eq!(render_subject(Some("Cron: {job}"), "daily"), "Cron: daily");
+        assert_eq!(
+            render_subject(Some("no placeholder"), "x"),
+            "no placeholder"
+        );
+        assert_eq!(render_subject(None, "daily"), "Cron: daily");
+        assert_eq!(render_subject(Some(""), "daily"), "Cron: daily");
+    }
+
+    // -- Minimal HTTP mock --------------------------------------------------
+    // Adapted from the openfang reference impl at commit 3db5d3a so we can
+    // run webhook tests without a heavy hyper/httpmock dependency.
+
+    struct CapturedRequest {
+        #[allow(dead_code)]
+        headers: Vec<String>,
+        body: String,
+    }
+
+    async fn spawn_mock_http_server(
+        status: u16,
+        reason: &'static str,
+    ) -> (u16, tokio::sync::oneshot::Receiver<CapturedRequest>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+
+            let mut buf = Vec::with_capacity(4096);
+            let mut tmp = [0u8; 1024];
+            let mut headers_end: Option<usize> = None;
+            let mut content_length: Option<usize> = None;
+            loop {
+                let n = match stream.read(&mut tmp).await {
+                    Ok(0) => break,
+                    Ok(n) => n,
+                    Err(_) => return,
+                };
+                buf.extend_from_slice(&tmp[..n]);
+                if headers_end.is_none() {
+                    if let Some(pos) = find_subsequence(&buf, b"\r\n\r\n") {
+                        headers_end = Some(pos + 4);
+                        let head_str = String::from_utf8_lossy(&buf[..pos]);
+                        for line in head_str.lines() {
+                            if let Some(v) = line.strip_prefix("Content-Length: ") {
+                                content_length = v.trim().parse::<usize>().ok();
+                            } else if let Some(v) = line.strip_prefix("content-length: ") {
+                                content_length = v.trim().parse::<usize>().ok();
+                            }
+                        }
+                    }
+                }
+                if let (Some(end), Some(cl)) = (headers_end, content_length) {
+                    if buf.len() >= end + cl {
+                        break;
+                    }
+                }
+                if headers_end.is_some() && content_length.is_none() {
+                    break;
+                }
+            }
+
+            let head_end = headers_end.unwrap_or(buf.len());
+            let head_str = String::from_utf8_lossy(&buf[..head_end.saturating_sub(4)]).to_string();
+            let body_bytes = if head_end < buf.len() {
+                &buf[head_end..]
+            } else {
+                &[][..]
+            };
+            let body = String::from_utf8_lossy(body_bytes).to_string();
+            let headers: Vec<String> = head_str.lines().skip(1).map(|l| l.to_string()).collect();
+
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.flush().await;
+
+            let _ = tx.send(CapturedRequest { headers, body });
+        });
+
+        (port, rx)
+    }
+
+    fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10467,6 +10467,7 @@ system_prompt = "You are a helpful assistant."
                                 let timeout_s = timeout_secs.unwrap_or(120);
                                 let timeout = std::time::Duration::from_secs(timeout_s);
                                 let delivery = job.delivery.clone();
+                                let delivery_targets = job.delivery_targets.clone();
                                 let kh: std::sync::Arc<
                                     dyn librefang_runtime::kernel_handle::KernelHandle,
                                 > = kernel.clone();
@@ -10570,13 +10571,19 @@ system_prompt = "You are a helpful assistant."
                                     Ok(Ok(result)) => {
                                         tracing::info!(job = %job_name, "Cron job completed successfully");
                                         kernel.cron_scheduler.record_success(job_id);
-                                        // Deliver response to configured channel (skip NO_REPLY/silent)
+                                        // Deliver response (skip NO_REPLY/silent). Multi-destination
+                                        // fan-out via `delivery_targets` takes precedence; the
+                                        // legacy single `delivery` path is the fallback when no
+                                        // targets are configured.
                                         if !result.silent {
-                                            cron_deliver_response(
+                                            cron_dispatch_output(
                                                 &kernel,
                                                 agent_id,
+                                                job_id,
+                                                &job_name,
                                                 &result.response,
                                                 &delivery,
+                                                &delivery_targets,
                                             )
                                             .await;
                                         }
@@ -10603,6 +10610,7 @@ system_prompt = "You are a helpful assistant."
                                 tracing::debug!(job = %job_name, workflow = %workflow_id, "Cron: firing workflow");
                                 let input_text = input.clone().unwrap_or_default();
                                 let delivery = job.delivery.clone();
+                                let delivery_targets = job.delivery_targets.clone();
                                 let timeout_s = timeout_secs.unwrap_or(300);
                                 let timeout = std::time::Duration::from_secs(timeout_s);
 
@@ -10630,8 +10638,14 @@ system_prompt = "You are a helpful assistant."
                                             Ok(Ok((_run_id, output))) => {
                                                 tracing::info!(job = %job_name, "Cron workflow completed successfully");
                                                 kernel.cron_scheduler.record_success(job_id);
-                                                cron_deliver_response(
-                                                    &kernel, agent_id, &output, &delivery,
+                                                cron_dispatch_output(
+                                                    &kernel,
+                                                    agent_id,
+                                                    job_id,
+                                                    &job_name,
+                                                    &output,
+                                                    &delivery,
+                                                    &delivery_targets,
                                                 )
                                                 .await;
                                             }
@@ -13319,6 +13333,58 @@ fn parse_wake_gate(script_output: &str) -> bool {
     value.get("wakeAgent") != Some(&serde_json::Value::Bool(false))
 }
 
+/// Dispatch a cron job's output. When `delivery_targets` is non-empty the
+/// multi-destination fan-out engine handles delivery (each target is
+/// attempted concurrently and failures are independent). When empty the
+/// legacy single-destination [`cron_deliver_response`] path runs unchanged
+/// — preserving full backward compatibility for jobs that only use
+/// `job.delivery`.
+async fn cron_dispatch_output(
+    kernel: &Arc<LibreFangKernel>,
+    agent_id: AgentId,
+    job_id: librefang_types::scheduler::CronJobId,
+    job_name: &str,
+    response: &str,
+    delivery: &librefang_types::scheduler::CronDelivery,
+    delivery_targets: &[librefang_types::scheduler::CronDeliveryTarget],
+) {
+    if response.is_empty() {
+        return;
+    }
+
+    if !delivery_targets.is_empty() {
+        let engine = crate::cron_delivery::CronDeliveryEngine::new(kernel.clone());
+        let results = engine
+            .deliver(
+                delivery_targets,
+                &job_id.to_string(),
+                &agent_id.to_string(),
+                job_name,
+                response,
+            )
+            .await;
+        for r in &results {
+            if r.success {
+                tracing::info!(
+                    job = %job_name,
+                    target = %r.target,
+                    "Cron fan-out delivered"
+                );
+            } else {
+                tracing::warn!(
+                    job = %job_name,
+                    target = %r.target,
+                    error = %r.error.as_deref().unwrap_or(""),
+                    "Cron fan-out delivery failed"
+                );
+            }
+        }
+        return;
+    }
+
+    cron_deliver_response(kernel, agent_id, response, delivery).await;
+}
+
 /// Deliver a cron job's agent response to the configured delivery target.
 async fn cron_deliver_response(
     kernel: &LibreFangKernel,
@@ -14087,7 +14153,7 @@ impl KernelHandle for LibreFangKernel {
         job_json: serde_json::Value,
     ) -> Result<String, String> {
         use librefang_types::scheduler::{
-            CronAction, CronDelivery, CronJob, CronJobId, CronSchedule,
+            CronAction, CronDelivery, CronDeliveryTarget, CronJob, CronJobId, CronSchedule,
         };
 
         let name = job_json["name"]
@@ -14109,6 +14175,13 @@ impl KernelHandle for LibreFangKernel {
             // originating channel without explicit `delivery` config.
             // Issue #2338.
             CronDelivery::LastChannel
+        };
+        // Optional multi-destination fan-out targets. Empty when omitted.
+        let delivery_targets: Vec<CronDeliveryTarget> = if job_json["delivery_targets"].is_array() {
+            serde_json::from_value(job_json["delivery_targets"].clone())
+                .map_err(|e| format!("Invalid delivery_targets: {e}"))?
+        } else {
+            Vec::new()
         };
         // At-schedules are inherently single-execution; default one_shot=true for them
         // so the job auto-deletes after firing instead of lingering as a zombie (#2808).
@@ -14134,6 +14207,7 @@ impl KernelHandle for LibreFangKernel {
             schedule,
             action,
             delivery,
+            delivery_targets,
             peer_id: job_json["peer_id"].as_str().map(|s| s.to_string()),
             session_mode,
             enabled: true,
@@ -15979,6 +16053,25 @@ impl librefang_wire::peer::PeerHandle for LibreFangKernel {
 
     fn uptime_secs(&self) -> u64 {
         self.booted_at.elapsed().as_secs()
+    }
+}
+
+/// Allow the cron multi-destination delivery engine to invoke channel
+/// adapters by delegating to the kernel's existing `send_channel_message`
+/// (the same path used for the legacy single-destination cron delivery).
+#[async_trait::async_trait]
+impl crate::cron_delivery::CronChannelDispatcher for LibreFangKernel {
+    async fn send_channel_message(
+        &self,
+        channel: &str,
+        recipient: &str,
+        message: &str,
+    ) -> Result<(), String> {
+        <LibreFangKernel as librefang_runtime::kernel_handle::KernelHandle>::send_channel_message(
+            self, channel, recipient, message, None, None,
+        )
+        .await
+        .map(|_| ())
     }
 }
 

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -12,6 +12,7 @@ pub mod capabilities;
 pub mod config;
 pub mod config_reload;
 pub mod cron;
+pub mod cron_delivery;
 pub mod error;
 pub mod event_bus;
 pub mod heartbeat;
@@ -34,5 +35,6 @@ pub mod whatsapp_gateway;
 pub mod wizard;
 pub mod workflow;
 
+pub use cron_delivery::{CronChannelDispatcher, CronDeliveryEngine, DeliveryResult};
 pub use kernel::DeliveryTracker;
 pub use kernel::LibreFangKernel;

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -171,6 +171,48 @@ pub enum CronDelivery {
 }
 
 // ---------------------------------------------------------------------------
+// CronDeliveryTarget (multi-destination fan-out)
+// ---------------------------------------------------------------------------
+
+/// A single destination for multi-destination cron output fan-out.
+///
+/// A cron job may declare zero or more `CronDeliveryTarget`s on its
+/// `delivery_targets` field. When the job fires and produces output, the
+/// delivery engine sends the same output to every target concurrently.
+/// Failures in one target do not abort delivery to the others.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CronDeliveryTarget {
+    /// Deliver via an existing channel adapter (Telegram/Slack/Discord/etc.).
+    Channel {
+        /// Channel adapter identifier (e.g. `"telegram"`, `"slack"`).
+        channel: String,
+        /// Platform-specific recipient (chat ID, user ID, etc.).
+        to: String,
+    },
+    /// Deliver via HTTP POST to a webhook URL with a JSON payload.
+    Webhook {
+        /// Destination URL (`http://` or `https://`).
+        url: String,
+    },
+    /// Append (or create) a local file on disk with the job output.
+    File {
+        /// Path to the output file. Path components containing `..` are
+        /// rejected at validation time and at delivery time.
+        path: String,
+    },
+    /// Deliver via the existing email channel adapter.
+    Email {
+        /// Recipient email address.
+        to: String,
+        /// Optional subject template (literal `{job}` placeholders are
+        /// replaced with the job name at send time).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subject: Option<String>,
+    },
+}
+
+// ---------------------------------------------------------------------------
 // CronJob
 // ---------------------------------------------------------------------------
 
@@ -189,8 +231,15 @@ pub struct CronJob {
     pub schedule: CronSchedule,
     /// What to do when fired.
     pub action: CronAction,
-    /// Where to deliver the result.
+    /// Legacy single-destination delivery. Retained for backward compatibility.
+    /// When `delivery_targets` is non-empty it takes precedence and this field
+    /// is ignored at runtime.
     pub delivery: CronDelivery,
+    /// Multi-destination fan-out targets. May be empty; each target is
+    /// delivered concurrently after the job produces its output. When
+    /// non-empty this list takes precedence over `delivery`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delivery_targets: Vec<CronDeliveryTarget>,
     /// Optional peer/user ID to use as the `SenderContext.user_id` when the
     /// job fires. When set, memory lookups keyed by peer (e.g.
     /// `peer:{user_id}:KEY`) will resolve correctly. Defaults to `None`
@@ -384,6 +433,71 @@ impl CronJob {
             }
             CronDelivery::None | CronDelivery::LastChannel => {}
         }
+
+        // -- delivery_targets (multi-destination fan-out) --
+        // Each target is independently validated. Empty `delivery_targets`
+        // is the historical case and is fine.
+        for (idx, target) in self.delivery_targets.iter().enumerate() {
+            target
+                .validate()
+                .map_err(|e| format!("delivery_targets[{idx}]: {e}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl CronDeliveryTarget {
+    /// Validate a single target. Mirrors the per-variant rules used for
+    /// the legacy single `CronDelivery` plus the path-traversal guard that
+    /// the engine also enforces at delivery time.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            CronDeliveryTarget::Channel { channel, to } => {
+                if channel.is_empty() {
+                    return Err("channel must not be empty".into());
+                }
+                if to.is_empty() {
+                    return Err("recipient (to) must not be empty".into());
+                }
+            }
+            CronDeliveryTarget::Webhook { url } => {
+                if url.is_empty() {
+                    return Err("webhook url must not be empty".into());
+                }
+                if !url.starts_with("http://") && !url.starts_with("https://") {
+                    return Err("webhook url must start with http:// or https://".into());
+                }
+                if url.len() > MAX_WEBHOOK_URL_LEN {
+                    return Err(format!(
+                        "webhook url too long ({} chars, max {MAX_WEBHOOK_URL_LEN})",
+                        url.len()
+                    ));
+                }
+            }
+            CronDeliveryTarget::File { path } => {
+                if path.is_empty() {
+                    return Err("file path must not be empty".into());
+                }
+                // Reject parent-dir traversal in any path component. The
+                // engine re-checks this at delivery time as defence in depth.
+                let p = std::path::Path::new(path);
+                if p.components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    return Err("file path must not contain '..' components".into());
+                }
+            }
+            CronDeliveryTarget::Email { to, subject } => {
+                if to.is_empty() {
+                    return Err("email recipient (to) must not be empty".into());
+                }
+                if let Some(s) = subject {
+                    if s.is_empty() {
+                        return Err("email subject must not be empty when provided".into());
+                    }
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -445,6 +559,7 @@ mod tests {
                 text: "ping".into(),
             },
             delivery: CronDelivery::None,
+            delivery_targets: Vec::new(),
             peer_id: None,
             session_mode: None,
             created_at: Utc::now(),
@@ -1061,5 +1176,150 @@ mod tests {
         } else {
             panic!("expected Workflow variant");
         }
+    }
+
+    // -- CronDeliveryTarget validation -------------------------------------
+
+    #[test]
+    fn delivery_target_channel_empty_channel() {
+        let t = CronDeliveryTarget::Channel {
+            channel: String::new(),
+            to: "user".into(),
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains("channel must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn delivery_target_channel_empty_to() {
+        let t = CronDeliveryTarget::Channel {
+            channel: "telegram".into(),
+            to: String::new(),
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains("recipient"), "{err}");
+    }
+
+    #[test]
+    fn delivery_target_webhook_bad_scheme() {
+        let t = CronDeliveryTarget::Webhook {
+            url: "ftp://example.com/h".into(),
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains("http://"), "{err}");
+    }
+
+    #[test]
+    fn delivery_target_webhook_ok() {
+        let t = CronDeliveryTarget::Webhook {
+            url: "https://example.com/h".into(),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn delivery_target_file_empty_path() {
+        let t = CronDeliveryTarget::File {
+            path: String::new(),
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains("path must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn delivery_target_file_parent_dir_rejected() {
+        let t = CronDeliveryTarget::File {
+            path: "../etc/passwd".into(),
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains(".."), "{err}");
+
+        let t2 = CronDeliveryTarget::File {
+            path: "logs/../../boot.txt".into(),
+        };
+        let err2 = t2.validate().unwrap_err();
+        assert!(err2.contains(".."), "{err2}");
+    }
+
+    #[test]
+    fn delivery_target_file_ok() {
+        let t = CronDeliveryTarget::File {
+            path: "logs/cron.log".into(),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn delivery_target_email_empty_to() {
+        let t = CronDeliveryTarget::Email {
+            to: String::new(),
+            subject: None,
+        };
+        let err = t.validate().unwrap_err();
+        assert!(err.contains("recipient"), "{err}");
+    }
+
+    #[test]
+    fn delivery_target_email_ok() {
+        let t = CronDeliveryTarget::Email {
+            to: "alice@example.com".into(),
+            subject: Some("Cron: {job}".into()),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn delivery_targets_propagate_errors_in_job() {
+        let mut job = valid_job();
+        job.delivery_targets = vec![
+            CronDeliveryTarget::Channel {
+                channel: "telegram".into(),
+                to: "12345".into(),
+            },
+            CronDeliveryTarget::Webhook {
+                url: "ftp://nope".into(),
+            },
+        ];
+        let err = job.validate(0).unwrap_err();
+        assert!(err.contains("delivery_targets[1]"), "{err}");
+        assert!(err.contains("http://"), "{err}");
+    }
+
+    #[test]
+    fn delivery_targets_empty_is_ok() {
+        let job = valid_job();
+        assert!(job.delivery_targets.is_empty());
+        assert!(job.validate(0).is_ok());
+    }
+
+    #[test]
+    fn delivery_targets_serde_kind_tag() {
+        let t = CronDeliveryTarget::Channel {
+            channel: "slack".into(),
+            to: "C12345".into(),
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        assert!(json.contains("\"kind\":\"channel\""), "{json}");
+        let back: CronDeliveryTarget = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn delivery_targets_serde_default_when_missing() {
+        // Pre-existing JSON without the new field must deserialize fine.
+        let json = serde_json::json!({
+            "id": CronJobId::new().to_string(),
+            "agent_id": AgentId::new().to_string(),
+            "name": "legacy-job",
+            "enabled": true,
+            "schedule": { "kind": "every", "every_secs": 3600 },
+            "action": { "kind": "system_event", "text": "ping" },
+            "delivery": { "kind": "none" },
+            "created_at": Utc::now().to_rfc3339(),
+            "last_run": null,
+            "next_run": null,
+        });
+        let back: CronJob = serde_json::from_value(json).unwrap();
+        assert!(back.delivery_targets.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- New `CronDeliveryTarget` enum: Channel / Webhook / File / Email
- New `cron_delivery` module with concurrent fan-out engine
- Per-target failure isolation via `DeliveryResult`
- Path-traversal (`..`) rejected for File targets
- 30s webhook timeout
- Backwards compatible: legacy single `delivery` field unchanged; `delivery_targets` takes priority when non-empty
- Mirrors openfang 3db5d3a

## Test plan
- [ ] Single channel target success
- [ ] Single webhook target failure surfaces clear error
- [ ] Multi-target with one failing → others still succeed
- [ ] Empty `delivery_targets` falls back to legacy `delivery`
- [ ] File path containing `..` rejected
- [ ] Email target without infra returns `unsupported` error (not silent success)
