### PR TITLE
fix(session-repair): downgrade pure-normalization to debug, keep WARN for real repair

### DIFF
--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -250,7 +250,23 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
         );
     }
 
-    if stats != RepairStats::default() {
+    // Distinguish "real repair" (data-integrity issues we had to clean
+    // up) from "routine normalization" (consecutive same-role merge or
+    // tool-result reordering — both are legitimate session-history
+    // shapes that this pass intentionally collapses every turn).
+    // `messages_merged` fires on every multi-turn streaming session with
+    // back-to-back assistant chunks, so logging it at WARN trains
+    // operators to ignore the message — and a real
+    // `orphaned`/`synthetic`/`rescued`/`positional_synthetic`/
+    // `duplicates`/`empty_messages` event later gets tuned out with it.
+    let had_real_repair = stats.orphaned_results_removed > 0
+        || stats.empty_messages_removed > 0
+        || stats.synthetic_results_inserted > 0
+        || stats.duplicates_removed > 0
+        || stats.misplaced_results_rescued > 0
+        || stats.positional_synthetic_inserted > 0;
+
+    if had_real_repair {
         warn!(
             orphaned = stats.orphaned_results_removed,
             empty = stats.empty_messages_removed,
@@ -263,6 +279,14 @@ pub fn validate_and_repair_with_stats(messages: &[Message]) -> (Vec<Message>, Re
             messages_before = pre_merge_len,
             messages_after = post_merge_len,
             "Session repair applied fixes"
+        );
+    } else if stats != RepairStats::default() {
+        debug!(
+            merged = stats.messages_merged,
+            reordered = stats.results_reordered,
+            messages_before = pre_merge_len,
+            messages_after = post_merge_len,
+            "Session repair normalized history (no integrity issues)"
         );
     }
 


### PR DESCRIPTION
## Why this WARN was always firing
The post-pass emitter logged WARN whenever any field of `RepairStats` was non-zero — including the routine `messages_merged` and `results_reordered` counters. Both are legitimate normalization shapes that the repair pass intentionally collapses every turn:

- `messages_merged` fires on **every** multi-turn streaming session with back-to-back assistant chunks (this is the common case)
- `results_reordered` fires whenever the model emits a tool-result before its matching tool-use in the wire shape

Result: a stream of:

```
WARN Session repair applied fixes orphaned=0 empty=0 merged=2
     reordered=0 synthetic=0 duplicates=0 rescued=0
     positional_synthetic=0 messages_before=12 messages_after=10
```

…on every healthy turn. This trains operators to filter the line out — at which point a real `orphaned` / `synthetic` / `rescued` / `positional_synthetic` / `duplicates` event later gets tuned out with it.

## What changed
Split the emit into two paths:

- **WARN** when any of the six "real integrity issue" counters is non-zero: `orphaned_results_removed`, `empty_messages_removed`, `synthetic_results_inserted`, `duplicates_removed`, `misplaced_results_rescued`, `positional_synthetic_inserted`. Same wording, same fields, same severity — so any alerting rule scraping for "Session repair applied fixes" still fires only on actual data-integrity events.
- **DEBUG** when only `messages_merged` and/or `results_reordered` are non-zero: distinct message ("Session repair normalized history (no integrity issues)"), smaller field set.

No behaviour change to the repair itself; purely log-level hygiene.

## Test plan
- [x] grep'd for callers / log-scraping rules — only one emit site in `session_repair.rs`
- [ ] Manual: run a multi-turn streaming chat (back-to-back assistant chunks) — daemon log should be quiet at default RUST_LOG, no more "Session repair applied fixes" on healthy turns
- [ ] Manual: deliberately corrupt a session file (e.g. drop a `ToolResult`'s matching `ToolUse`), verify the WARN still fires with the integrity counter set
