### PR TITLE
test(model_catalog): align localhost test expectations with #3112 default change

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1799,7 +1799,7 @@ id = "acme"
     fn test_set_provider_url() {
         let mut catalog = test_catalog();
         let old_url = catalog.get_provider("ollama").unwrap().base_url.clone();
-        assert_eq!(old_url, "http://localhost:11434/v1");
+        assert_eq!(old_url, "http://127.0.0.1:11434/v1");
 
         let updated = catalog.set_provider_url("ollama", "http://192.168.1.100:11434/v1");
         assert!(updated);
@@ -1844,7 +1844,7 @@ id = "acme"
         // lmstudio should be unchanged
         assert_eq!(
             catalog.get_provider("lmstudio").unwrap().base_url,
-            "http://localhost:1234/v1"
+            "http://127.0.0.1:1234/v1"
         );
     }
 


### PR DESCRIPTION
## Summary
PR #3112 (`fix(providers): use 127.0.0.1 instead of localhost for local LLM URLs`) updated the runtime defaults but missed two assertions in `model_catalog::tests` that checked the now-obsolete `localhost` URLs. Main is currently red on Test/Ubuntu, Test/macOS, Test/Windows.

```
FAIL model_catalog::tests::test_apply_url_overrides
  left:  "http://127.0.0.1:1234/v1"
  right: "http://localhost:1234/v1"
FAIL model_catalog::tests::test_set_provider_url
  left:  "http://127.0.0.1:11434/v1"
  right: "http://localhost:11434/v1"
```

## Fix
Two-line change in `crates/librefang-runtime/src/model_catalog.rs`:

- L1802: expected ollama default → `http://127.0.0.1:11434/v1`
- L1847: expected lmstudio default → `http://127.0.0.1:1234/v1`

`test_set_provider_url_unknown` (L1816/L1822) is **not** changed — it deliberately passes a `localhost` URL as input to verify custom-provider auto-registration round-trips the user-supplied string verbatim, which is unrelated to the default-URL change.

## Test plan
- [x] grep'd workspace for any other `localhost` defaults that could fail under #3112's change — only the two test assertions above; remaining `localhost` references are SSRF allow/block lists, WS origin validation, and MCP auth host-header checks (all intentional)
- [ ] CI green on Test/Ubuntu, Test/macOS, Test/Windows
