### PR TITLE
fix(examples): use "default" provider/model in custom-agent template

### DIFF
--- a/crates/librefang-cli/src/templates.rs
+++ b/crates/librefang-cli/src/templates.rs
@@ -107,3 +107,81 @@ pub fn template_display_hint(t: &AgentTemplate) -> String {
         t.description.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use librefang_types::agent::AgentManifest;
+    use librefang_types::config::DefaultModelConfig;
+
+    /// Mirror the kernel's spawn-time + execute-time default_model overlay so
+    /// we can verify a manifest with empty/"default" provider+model resolves
+    /// to the configured default_model — not to any hardcoded vendor value.
+    fn resolve_effective_model(
+        manifest: &AgentManifest,
+        default_model: &DefaultModelConfig,
+    ) -> (String, String) {
+        let provider_is_default =
+            manifest.model.provider.is_empty() || manifest.model.provider == "default";
+        let model_is_default = manifest.model.model.is_empty() || manifest.model.model == "default";
+        let effective_provider = if provider_is_default {
+            default_model.provider.clone()
+        } else {
+            manifest.model.provider.clone()
+        };
+        let effective_model = if model_is_default {
+            default_model.model.clone()
+        } else {
+            manifest.model.model.clone()
+        };
+        (effective_provider, effective_model)
+    }
+
+    /// Bundled example template must not hardcode a provider; it should defer
+    /// to the user's configured default_model (regression: openfang #967).
+    #[test]
+    fn example_custom_agent_template_does_not_hardcode_provider() {
+        let toml_str = include_str!("../../../examples/custom-agent/agent.toml");
+        let manifest: AgentManifest =
+            toml::from_str(toml_str).expect("example agent.toml must parse");
+
+        // Must not pin any specific vendor — otherwise switching default_model
+        // in config.toml would have no effect on agents spawned from this template.
+        assert_ne!(manifest.model.provider, "groq");
+        assert_ne!(manifest.model.model, "llama-3.3-70b-versatile");
+
+        // Must be either empty or the explicit "default" sentinel so the
+        // kernel's default_model overlay applies.
+        let provider_defers =
+            manifest.model.provider.is_empty() || manifest.model.provider == "default";
+        let model_defers = manifest.model.model.is_empty() || manifest.model.model == "default";
+        assert!(
+            provider_defers && model_defers,
+            "example template must defer to default_model, got provider={:?} model={:?}",
+            manifest.model.provider,
+            manifest.model.model
+        );
+    }
+
+    /// End-to-end: a manifest deferring to default_model resolves to whatever
+    /// the user has configured — not to the legacy groq fallback.
+    #[test]
+    fn manifest_with_default_provider_resolves_to_configured_default_model() {
+        let toml_str = include_str!("../../../examples/custom-agent/agent.toml");
+        let manifest: AgentManifest =
+            toml::from_str(toml_str).expect("example agent.toml must parse");
+
+        // Simulate a user who switched their default to OpenAI.
+        let user_default = DefaultModelConfig {
+            provider: "openai".to_string(),
+            model: "gpt-4o".to_string(),
+            api_key_env: "OPENAI_API_KEY".to_string(),
+            ..Default::default()
+        };
+
+        let (provider, model) = resolve_effective_model(&manifest, &user_default);
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "gpt-4o");
+        assert_ne!(provider, "groq");
+        assert_ne!(model, "llama-3.3-70b-versatile");
+    }
+}

--- a/examples/custom-agent/agent.toml
+++ b/examples/custom-agent/agent.toml
@@ -13,8 +13,10 @@ module = "builtin:chat"
 tags = ["assistant", "example"]
 
 [model]
-provider = "groq"
-model = "llama-3.3-70b-versatile"
+# Use the configured default_model from ~/.librefang/config.toml.
+# Set to a concrete provider/model (e.g. "openai" / "gpt-4o") to pin this agent.
+provider = "default"
+model = "default"
 system_prompt = """
 You are a helpful assistant. You are friendly, concise, and always try to provide actionable answers.
 When you don't know something, you say so honestly.


### PR DESCRIPTION
## Summary
- `examples/custom-agent/agent.toml`: change hardcoded `provider = "groq"` / `model = "llama-3.3-70b-versatile"` to `"default"` so the kernel's `default_model` overlay applies
- Mirrors openfang #968 — without this, agents copied from the example template ignore the user's configured default and stay on groq

## Notes
librefang does not bundle agent templates in the CLI beyond this example, and the kernel already resolves `default_model` per-call (not at spawn), so already-spawned agents track config changes automatically. Only the example needed the fix.

`crates/librefang-cli/src/main.rs` doctor fixtures and `tui/screens/wizard.rs` setup wizard provider metadata were intentionally left alone (different semantics).

## Test plan
- [ ] Copy `examples/custom-agent/agent.toml` → spawned agent uses the configured default model, not groq
- [ ] Switch `default_model` in config → next message on that agent uses the new model
