### PR TITLE
feat(channels): central slash command registry (PR-1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4088,6 +4088,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "bitflags 2.11.0",
  "bytes",
  "cbc 0.2.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ async-trait = "0.1"
 # Base64
 base64 = "0.22"
 
+# Bitflags
+bitflags = "2"
+
 # Bytes
 bytes = "1"
 

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -150,6 +150,7 @@ channel-mqtt = ["dep:rumqttc"]
 
 [dependencies]
 librefang-types = { path = "../librefang-types" }
+bitflags = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2440,6 +2440,7 @@ async fn dispatch_message(
                 router,
                 &message.sender,
                 &message.channel,
+                overrides.as_ref(),
             )
             .await;
             send_response(adapter, &message.sender, result, thread_id, output_format).await;
@@ -2774,38 +2775,7 @@ async fn dispatch_message(
             vec![]
         };
 
-        if matches!(
-            cmd,
-            "start"
-                | "help"
-                | "agents"
-                | "agent"
-                | "status"
-                | "models"
-                | "providers"
-                | "new"
-                | "reboot"
-                | "compact"
-                | "model"
-                | "stop"
-                | "usage"
-                | "think"
-                | "skills"
-                | "hands"
-                | "btw"
-                | "workflows"
-                | "workflow"
-                | "triggers"
-                | "trigger"
-                | "schedules"
-                | "schedule"
-                | "approvals"
-                | "approve"
-                | "reject"
-                | "budget"
-                | "peers"
-                | "a2a"
-        ) {
+        if crate::commands::is_channel_command(cmd) {
             if is_command_allowed(cmd, overrides.as_ref()) {
                 // Special-case /agents: send an inline keyboard with one button per agent.
                 if cmd == "agents" {
@@ -2888,6 +2858,7 @@ async fn dispatch_message(
                     router,
                     &message.sender,
                     &message.channel,
+                    overrides.as_ref(),
                 )
                 .await;
                 send_response(adapter, &message.sender, result, thread_id, output_format).await;
@@ -4095,6 +4066,11 @@ async fn dispatch_with_blocks(
 }
 
 /// Handle a bot command (returns the response text).
+///
+/// `overrides` reflects the merged agent + channel policy for the calling
+/// context. It currently affects `/help` rendering (so disabled/blocked
+/// commands don't appear in the help text); other branches treat it as
+/// advisory.
 async fn handle_command(
     name: &str,
     args: &[String],
@@ -4102,6 +4078,7 @@ async fn handle_command(
     router: &Arc<AgentRouter>,
     sender: &ChannelUser,
     channel_type: &crate::types::ChannelType,
+    overrides: Option<&ChannelOverrides>,
 ) -> String {
     match name {
         "start" => {
@@ -4119,50 +4096,7 @@ async fn handle_command(
             msg.push_str("\nCommands:\n/agents - list agents\n/agent <name> - select an agent\n/help - show this help");
             msg
         }
-        "help" => "LibreFang Bot Commands:\n\
-             \n\
-             Session:\n\
-             /agents - list running agents\n\
-             /agent <name> - select which agent to talk to\n\
-             /new - reset session (clear messages)\n\
-             /reboot - hard reset session (full context clear, no summary)\n\
-             /compact - trigger LLM session compaction\n\
-             /model [name] - show or switch agent model\n\
-             /stop - cancel current agent run\n\
-             /usage - show session token usage and cost\n\
-             /think [on|off] - toggle extended thinking\n\
-             \n\
-             Info:\n\
-             /models - list available AI models\n\
-             /providers - show configured providers\n\
-             /skills - list installed skills\n\
-             /hands - list available and active hands\n\
-             /status - show system status\n\
-             \n\
-             Automation:\n\
-             /workflows - list workflows\n\
-             /workflow run <name> [input] - run a workflow\n\
-             /triggers - list event triggers\n\
-             /trigger add <agent> <pattern> <prompt> - create trigger\n\
-             /trigger del <id> - remove trigger\n\
-             /schedules - list cron jobs\n\
-             /schedule add <agent> <cron-5-fields> <message> - create job\n\
-             /schedule del <id> - remove job\n\
-             /schedule run <id> - run job now\n\
-             /approvals - list pending approvals\n\
-             /approve <id> - approve a request\n\
-             /reject <id> - reject a request\n\
-             \n\
-             Monitoring:\n\
-             /budget - show spending limits and current costs\n\
-             /peers - show OFP peer network status\n\
-             /a2a - list discovered external A2A agents\n\
-             \n\
-             /btw <question> - ask a side question (ephemeral, not saved to session)\n\
-             \n\
-             /start - show welcome message\n\
-             /help - show this help"
-            .to_string(),
+        "help" => crate::commands::channel_help_text(overrides),
         "status" => handle.uptime_info().await,
         "agents" => {
             let agents = handle.list_agents().await.unwrap_or_default();
@@ -4617,12 +4551,28 @@ mod tests {
             librefang_user: None,
         };
 
-        let result =
-            handle_command("agents", &[], &handle, &router, &sender, &ChannelType::CLI).await;
+        let result = handle_command(
+            "agents",
+            &[],
+            &handle,
+            &router,
+            &sender,
+            &ChannelType::CLI,
+            None,
+        )
+        .await;
         assert!(result.contains("coder"));
 
-        let result =
-            handle_command("help", &[], &handle, &router, &sender, &ChannelType::CLI).await;
+        let result = handle_command(
+            "help",
+            &[],
+            &handle,
+            &router,
+            &sender,
+            &ChannelType::CLI,
+            None,
+        )
+        .await;
         assert!(result.contains("/agents"));
     }
 
@@ -4647,6 +4597,7 @@ mod tests {
             &router,
             &sender,
             &ChannelType::CLI,
+            None,
         )
         .await;
         assert!(result.contains("Now talking to agent: coder"));
@@ -5133,7 +5084,16 @@ mod tests {
             librefang_user: None,
         };
 
-        let result = handle_command("btw", &[], &handle, &router, &sender, &ChannelType::CLI).await;
+        let result = handle_command(
+            "btw",
+            &[],
+            &handle,
+            &router,
+            &sender,
+            &ChannelType::CLI,
+            None,
+        )
+        .await;
         assert!(result.contains("Usage:"));
     }
 
@@ -5158,6 +5118,7 @@ mod tests {
             &router,
             &sender,
             &ChannelType::CLI,
+            None,
         )
         .await;
         assert!(result.contains("No agent selected"));
@@ -5175,8 +5136,16 @@ mod tests {
             librefang_user: None,
         };
 
-        let result =
-            handle_command("help", &[], &handle, &router, &sender, &ChannelType::CLI).await;
+        let result = handle_command(
+            "help",
+            &[],
+            &handle,
+            &router,
+            &sender,
+            &ChannelType::CLI,
+            None,
+        )
+        .await;
         assert!(result.contains("/btw"));
     }
 

--- a/crates/librefang-channels/src/commands/mod.rs
+++ b/crates/librefang-channels/src/commands/mod.rs
@@ -1,0 +1,747 @@
+//! Central registry of slash commands surfaced by LibreFang.
+//!
+//! Single source of truth for every `/cmd` LibreFang understands. Every
+//! consumer (channel bridge dispatch / `/help` text, Telegram BotCommands menu,
+//! TUI chat runner, future Dashboard command palette) derives from
+//! [`COMMAND_REGISTRY`] instead of maintaining its own copy.
+//!
+//! See `.plans/slash-command-registry.md` for the design rationale and
+//! migration plan.
+//!
+//! Behavior (the actual handler for each command) still lives in
+//! `bridge::handle_command` and per-surface dispatchers; this module only
+//! describes commands.
+
+use bitflags::bitflags;
+use librefang_types::config::ChannelOverrides;
+
+bitflags! {
+    /// Surfaces a command may appear on. A command can be visible on multiple
+    /// surfaces simultaneously (e.g. CHANNEL + CLI).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Scope: u8 {
+        /// `librefang-cli` interactive REPL / TUI chat runner.
+        const CLI       = 0b0000_0001;
+        /// Every channel adapter (Telegram, Slack, Discord, …).
+        const CHANNEL   = 0b0000_0010;
+        /// Dashboard SPA command palette via `GET /api/commands`.
+        const DASHBOARD = 0b0000_0100;
+    }
+}
+
+/// Logical grouping for `/help` rendering.
+///
+/// `Misc` carries an unlabeled trailing block (matches the historical
+/// hand-written `/help` layout where `/btw`, `/start`, `/help` had no header).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    Session,
+    Info,
+    Automation,
+    Monitoring,
+    Misc,
+}
+
+impl Category {
+    /// Section header to render in `/help`. `None` means "no header".
+    fn label(self) -> Option<&'static str> {
+        match self {
+            Self::Session => Some("Session"),
+            Self::Info => Some("Info"),
+            Self::Automation => Some("Automation"),
+            Self::Monitoring => Some("Monitoring"),
+            Self::Misc => None,
+        }
+    }
+}
+
+/// One sub-form of a multi-action command (e.g. `/trigger add …` vs
+/// `/trigger del …`). Renders as its own `/help` line.
+#[derive(Debug, Clone, Copy)]
+pub struct SubCommand {
+    /// Args after the command name, including the verb.
+    /// Example: `"add <agent> <pattern> <prompt>"`.
+    pub args: &'static str,
+    /// Sentence-case description for this sub-form.
+    pub description: &'static str,
+}
+
+/// Static metadata for one slash command.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandDef {
+    /// Bare command name without leading `/` (e.g. `"agents"`).
+    pub name: &'static str,
+    /// Alternate names that resolve to the same command. Empty for now;
+    /// reserved for future use (e.g. abbreviations).
+    pub aliases: &'static [&'static str],
+    /// Logical group for `/help` rendering.
+    pub category: Category,
+    /// Where this command is exposed.
+    pub scope: Scope,
+    /// Sentence-case description, no trailing period.
+    pub description: &'static str,
+    /// Args hint shown in `/help` for the top-level form. `""` when the
+    /// command has no args, or when [`subcommands`] takes over.
+    pub args_hint: &'static str,
+    /// Optional sub-forms; when non-empty, `/help` renders one line per entry
+    /// instead of a single line for the top-level form.
+    pub subcommands: &'static [SubCommand],
+    /// Whether to include this command in the Telegram BotCommands menu
+    /// (the popup shown when the user types `/`). Telegram limits to 100.
+    pub telegram_menu: bool,
+}
+
+// Sub-command tables for multi-form commands.
+//
+// Kept as `static` (not inline) so they have a stable address for the
+// `&'static [SubCommand]` reference inside `CommandDef`.
+
+static TRIGGER_SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        args: "add <agent> <pattern> <prompt>",
+        description: "create trigger",
+    },
+    SubCommand {
+        args: "del <id>",
+        description: "remove trigger",
+    },
+];
+
+static SCHEDULE_SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        args: "add <agent> <cron-5-fields> <message>",
+        description: "create job",
+    },
+    SubCommand {
+        args: "del <id>",
+        description: "remove job",
+    },
+    SubCommand {
+        args: "run <id>",
+        description: "run job now",
+    },
+];
+
+/// The single source of truth for slash commands.
+///
+/// Order is significant: it controls the visual order inside each
+/// [`Category`] in `/help`. Categories themselves are emitted in the order
+/// the first command of each category appears.
+pub const COMMAND_REGISTRY: &[CommandDef] = &[
+    // ---- Session ----
+    CommandDef {
+        name: "agents",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "List running agents",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "agent",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Select which agent to talk to",
+        args_hint: "<name>",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "new",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Reset session (clear messages)",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "reboot",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Hard reset session (full context clear, no summary)",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "compact",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Trigger LLM session compaction",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "model",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Show or switch agent model",
+        args_hint: "[name]",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "stop",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Cancel current agent run",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "usage",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Show session token usage and cost",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "think",
+        aliases: &[],
+        category: Category::Session,
+        scope: Scope::CHANNEL,
+        description: "Toggle extended thinking",
+        args_hint: "[on|off]",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    // ---- Info ----
+    CommandDef {
+        name: "models",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::CHANNEL,
+        description: "List available AI models",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "providers",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::CHANNEL,
+        description: "Show configured providers",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "skills",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::CHANNEL,
+        description: "List installed skills",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "hands",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::CHANNEL,
+        description: "List available and active hands",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "status",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::CHANNEL,
+        description: "Show system status",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    // ---- Automation ----
+    CommandDef {
+        name: "workflows",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "List workflows",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "workflow",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "Run a workflow",
+        args_hint: "run <name> [input]",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "triggers",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "List event triggers",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "trigger",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "Manage event triggers",
+        args_hint: "",
+        subcommands: TRIGGER_SUBCOMMANDS,
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "schedules",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "List cron jobs",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "schedule",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "Manage cron jobs",
+        args_hint: "",
+        subcommands: SCHEDULE_SUBCOMMANDS,
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "approvals",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "List pending approvals",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "approve",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "Approve a request",
+        args_hint: "<id>",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "reject",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL,
+        description: "Reject a request",
+        args_hint: "<id>",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    // ---- Monitoring ----
+    CommandDef {
+        name: "budget",
+        aliases: &[],
+        category: Category::Monitoring,
+        scope: Scope::CHANNEL,
+        description: "Show spending limits and current costs",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "peers",
+        aliases: &[],
+        category: Category::Monitoring,
+        scope: Scope::CHANNEL,
+        description: "Show OFP peer network status",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "a2a",
+        aliases: &[],
+        category: Category::Monitoring,
+        scope: Scope::CHANNEL,
+        description: "List discovered external A2A agents",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    // ---- Misc (no header in /help) ----
+    CommandDef {
+        name: "btw",
+        aliases: &[],
+        category: Category::Misc,
+        scope: Scope::CHANNEL,
+        description: "Ask a side question (ephemeral, not saved to session)",
+        args_hint: "<question>",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "start",
+        aliases: &[],
+        category: Category::Misc,
+        scope: Scope::CHANNEL,
+        description: "Show welcome message",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+    CommandDef {
+        name: "help",
+        aliases: &[],
+        category: Category::Misc,
+        scope: Scope::CHANNEL,
+        description: "Show this help",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: true,
+    },
+];
+
+/// Look up a command by its bare name or any alias. The leading `/` is
+/// optional and stripped if present.
+pub fn lookup(name_or_alias: &str) -> Option<&'static CommandDef> {
+    let bare = name_or_alias.strip_prefix('/').unwrap_or(name_or_alias);
+    COMMAND_REGISTRY
+        .iter()
+        .find(|c| c.name == bare || c.aliases.contains(&bare))
+}
+
+/// Iterate every command visible on at least one of the given surfaces.
+pub fn iter_for(scope: Scope) -> impl Iterator<Item = &'static CommandDef> {
+    COMMAND_REGISTRY
+        .iter()
+        .filter(move |c| c.scope.intersects(scope))
+}
+
+/// Whether `name` is a known channel command (any registered command with
+/// `Scope::CHANNEL`). This is the replacement for the historical hand-written
+/// `matches!(...)` block in `bridge.rs`.
+pub fn is_channel_command(name: &str) -> bool {
+    lookup(name).is_some_and(|c| c.scope.contains(Scope::CHANNEL))
+}
+
+/// Check whether a built-in slash command is permitted given channel
+/// overrides.
+///
+/// Precedence: `disable_commands` > `allowed_commands` (whitelist) >
+/// `blocked_commands` (blacklist). When no overrides are configured,
+/// everything is allowed.
+///
+/// Config entries may be written with or without a leading `/`
+/// (`"agent"` and `"/agent"` both match the dispatcher's bare token).
+pub fn is_command_allowed(cmd: &str, overrides: Option<&ChannelOverrides>) -> bool {
+    let Some(ov) = overrides else { return true };
+    if ov.disable_commands {
+        return false;
+    }
+    let matches = |entry: &String| -> bool {
+        let name = entry.strip_prefix('/').unwrap_or(entry);
+        name == cmd
+    };
+    if !ov.allowed_commands.is_empty() {
+        return ov.allowed_commands.iter().any(matches);
+    }
+    !ov.blocked_commands.iter().any(matches)
+}
+
+/// Render the channel-facing `/help` text.
+///
+/// Honors `overrides` so that disabled / filtered commands don't appear.
+/// Categories with no surviving commands are silently skipped.
+pub fn channel_help_text(overrides: Option<&ChannelOverrides>) -> String {
+    let visible: Vec<&CommandDef> = COMMAND_REGISTRY
+        .iter()
+        .filter(|c| c.scope.contains(Scope::CHANNEL))
+        .filter(|c| is_command_allowed(c.name, overrides))
+        .collect();
+
+    let mut out = String::from("LibreFang Bot Commands:");
+    let mut current_cat: Option<Category> = None;
+    let mut first_in_section = true;
+
+    for c in &visible {
+        if Some(c.category) != current_cat {
+            // Section break: blank line between groups.
+            out.push_str("\n\n");
+            if let Some(label) = c.category.label() {
+                out.push_str(label);
+                out.push_str(":\n");
+            }
+            current_cat = Some(c.category);
+            first_in_section = true;
+        }
+
+        if c.subcommands.is_empty() {
+            if !first_in_section {
+                out.push('\n');
+            }
+            if c.args_hint.is_empty() {
+                out.push_str(&format!("/{} - {}", c.name, c.description));
+            } else {
+                out.push_str(&format!("/{} {} - {}", c.name, c.args_hint, c.description));
+            }
+        } else {
+            for sub in c.subcommands {
+                if !first_in_section {
+                    out.push('\n');
+                }
+                out.push_str(&format!("/{} {} - {}", c.name, sub.args, sub.description));
+                first_in_section = false;
+            }
+            // Defer setting first_in_section=false to common path below
+            // — already handled inside loop.
+            continue;
+        }
+
+        first_in_section = false;
+    }
+
+    out
+}
+
+/// Pairs of `(name, description)` for the Telegram BotCommands menu.
+///
+/// Adapters are responsible for converting to their wire type
+/// (e.g. `telegram::BotCommand`).
+pub fn telegram_bot_commands() -> Vec<(String, String)> {
+    COMMAND_REGISTRY
+        .iter()
+        .filter(|c| c.telegram_menu && c.scope.contains(Scope::CHANNEL))
+        .map(|c| (c.name.to_string(), c.description.to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lookup must accept bare and slash-prefixed names; aliases must
+    /// resolve to the canonical entry.
+    #[test]
+    fn lookup_resolves_bare_and_slashed() {
+        assert_eq!(lookup("agents").map(|c| c.name), Some("agents"));
+        assert_eq!(lookup("/agents").map(|c| c.name), Some("agents"));
+        assert!(lookup("nonexistent").is_none());
+        assert!(lookup("").is_none());
+    }
+
+    /// The channel-visible set must exactly match the historical
+    /// hand-written `matches!` list in `bridge.rs:2777-2808`. This is the
+    /// "anti-drift" golden assertion.
+    #[test]
+    fn channel_command_names_match_historical_set() {
+        let expected: &[&str] = &[
+            "start",
+            "help",
+            "agents",
+            "agent",
+            "status",
+            "models",
+            "providers",
+            "new",
+            "reboot",
+            "compact",
+            "model",
+            "stop",
+            "usage",
+            "think",
+            "skills",
+            "hands",
+            "btw",
+            "workflows",
+            "workflow",
+            "triggers",
+            "trigger",
+            "schedules",
+            "schedule",
+            "approvals",
+            "approve",
+            "reject",
+            "budget",
+            "peers",
+            "a2a",
+        ];
+
+        let actual: std::collections::BTreeSet<&str> =
+            iter_for(Scope::CHANNEL).map(|c| c.name).collect();
+        let want: std::collections::BTreeSet<&str> = expected.iter().copied().collect();
+
+        assert_eq!(
+            actual, want,
+            "channel command set drifted from the historical bridge.rs matches! list"
+        );
+    }
+
+    /// Names + aliases must form a global unique set across the registry,
+    /// otherwise `lookup` becomes ambiguous.
+    #[test]
+    fn names_and_aliases_are_globally_unique() {
+        let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        for c in COMMAND_REGISTRY {
+            for token in std::iter::once(c.name).chain(c.aliases.iter().copied()) {
+                if let Some(prev) = seen.insert(token, c.name) {
+                    panic!(
+                        "duplicate command token `{}` registered by both `{}` and `{}`",
+                        token, prev, c.name
+                    );
+                }
+            }
+        }
+    }
+
+    /// Telegram BotCommands menu has hard limits (Bot API):
+    /// - command name: 1..=32 chars, lowercase letters / digits / underscore.
+    /// - description: 1..=256 chars.
+    /// - at most 100 commands per scope.
+    #[test]
+    fn telegram_menu_respects_bot_api_limits() {
+        let entries = telegram_bot_commands();
+        assert!(
+            entries.len() <= 100,
+            "Telegram allows at most 100 BotCommands; got {}",
+            entries.len()
+        );
+        for (name, desc) in &entries {
+            assert!(
+                (1..=32).contains(&name.len()),
+                "command `{name}` length {} out of [1,32]",
+                name.len()
+            );
+            assert!(
+                name.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                "command `{name}` has invalid chars (Telegram allows [a-z0-9_])"
+            );
+            assert!(
+                (1..=256).contains(&desc.len()),
+                "description for `{name}` length {} out of [1,256]",
+                desc.len()
+            );
+        }
+    }
+
+    #[test]
+    fn is_command_allowed_no_overrides_allows_all() {
+        assert!(is_command_allowed("help", None));
+        assert!(is_command_allowed("agent", None));
+    }
+
+    #[test]
+    fn is_command_allowed_disable_blocks_all() {
+        let ov = ChannelOverrides {
+            disable_commands: true,
+            ..Default::default()
+        };
+        assert!(!is_command_allowed("help", Some(&ov)));
+    }
+
+    #[test]
+    fn is_command_allowed_whitelist_then_blacklist() {
+        let ov = ChannelOverrides {
+            allowed_commands: vec!["help".into(), "/start".into()],
+            blocked_commands: vec!["help".into()],
+            ..Default::default()
+        };
+        // Whitelist wins over blacklist.
+        assert!(is_command_allowed("help", Some(&ov)));
+        assert!(is_command_allowed("start", Some(&ov)));
+        assert!(!is_command_allowed("agent", Some(&ov)));
+    }
+
+    #[test]
+    fn is_command_allowed_blacklist_only() {
+        let ov = ChannelOverrides {
+            blocked_commands: vec!["agent".into(), "/new".into()],
+            ..Default::default()
+        };
+        assert!(!is_command_allowed("agent", Some(&ov)));
+        assert!(!is_command_allowed("new", Some(&ov)));
+        assert!(is_command_allowed("help", Some(&ov)));
+    }
+
+    #[test]
+    fn channel_help_text_groups_categories() {
+        let txt = channel_help_text(None);
+        assert!(txt.starts_with("LibreFang Bot Commands:"));
+        assert!(txt.contains("\n\nSession:\n"));
+        assert!(txt.contains("\n\nInfo:\n"));
+        assert!(txt.contains("\n\nAutomation:\n"));
+        assert!(txt.contains("\n\nMonitoring:\n"));
+        // Misc has no header.
+        assert!(!txt.contains("Misc:"));
+        // Subcommands render multi-line for /trigger and /schedule.
+        assert!(txt.contains("/trigger add <agent> <pattern> <prompt> - create trigger"));
+        assert!(txt.contains("/trigger del <id> - remove trigger"));
+        assert!(txt.contains("/schedule run <id> - run job now"));
+        // Single-arg form.
+        assert!(txt.contains("/agent <name> - Select which agent to talk to"));
+        // No-arg form.
+        assert!(txt.contains("/agents - List running agents"));
+        // Misc (no header) commands appear at the end.
+        let btw_pos = txt.find("/btw").expect("btw missing");
+        let mon_pos = txt.find("Monitoring:").expect("monitoring header missing");
+        assert!(
+            btw_pos > mon_pos,
+            "btw should appear after Monitoring section"
+        );
+    }
+
+    #[test]
+    fn channel_help_text_filters_blocked() {
+        let ov = ChannelOverrides {
+            blocked_commands: vec!["help".into(), "agent".into()],
+            ..Default::default()
+        };
+        let txt = channel_help_text(Some(&ov));
+        assert!(!txt.contains("/help "));
+        assert!(!txt.contains("/help -"));
+        assert!(!txt.contains("/agent <name>"));
+        // Other commands still show up.
+        assert!(txt.contains("/agents - List running agents"));
+    }
+
+    #[test]
+    fn telegram_menu_is_subset_of_channel_set() {
+        let menu: std::collections::BTreeSet<String> = telegram_bot_commands()
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        let channel: std::collections::BTreeSet<String> = iter_for(Scope::CHANNEL)
+            .map(|c| c.name.to_string())
+            .collect();
+        assert!(
+            menu.is_subset(&channel),
+            "telegram menu must be a subset of channel-scoped commands"
+        );
+        // Non-empty so this test catches accidental empty registry.
+        assert!(!menu.is_empty());
+    }
+}

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -8,6 +8,7 @@
 
 // Core infrastructure — always compiled
 pub mod bridge;
+pub mod commands;
 pub mod formatter;
 pub(crate) mod http_client;
 pub mod message_journal;

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -128,42 +128,19 @@ pub struct BotCommand {
     pub description: String,
 }
 
-/// Built-in slash commands exposed in the Telegram command menu.
+/// Build a `Vec<BotCommand>` for the Telegram command menu.
 ///
-/// These mirror the commands handled by the channel bridge's `handle_command`.
-/// When `TelegramAdapter::commands` is empty (the default), the adapter
-/// registers these automatically on `/start` or the first incoming message.
-/// Telegram allows at most 100 commands; we list the most useful subset.
-const BUILTIN_COMMANDS: &[(&str, &str)] = &[
-    ("start", "Show welcome message"),
-    ("help", "Show all available commands"),
-    ("agents", "List running agents"),
-    ("agent", "Select an agent to talk to"),
-    ("new", "Reset session (clear messages)"),
-    ("reboot", "Hard reset session (full context clear)"),
-    ("compact", "Trigger LLM session compaction"),
-    ("model", "Show or switch agent model"),
-    ("stop", "Cancel current agent run"),
-    ("usage", "Show session token usage and cost"),
-    ("think", "Toggle extended thinking"),
-    ("models", "List available AI models"),
-    ("providers", "Show configured providers"),
-    ("skills", "List installed skills"),
-    ("hands", "List available and active hands"),
-    ("status", "Show system status"),
-    ("workflows", "List workflows"),
-    ("workflow", "Run a workflow"),
-    ("budget", "Show spending limits and costs"),
-    ("btw", "Ask a side question (ephemeral)"),
-];
-
-/// Build a `Vec<BotCommand>` from [`BUILTIN_COMMANDS`].
+/// Sourced from [`crate::commands::telegram_bot_commands`] — the central
+/// command registry — so this list never drifts from the bridge's
+/// `handle_command` dispatcher. When `TelegramAdapter::commands` is empty
+/// (the default), the adapter registers these automatically on `/start`
+/// or the first incoming message. Telegram allows at most 100 commands.
 fn builtin_bot_commands() -> Vec<BotCommand> {
-    BUILTIN_COMMANDS
-        .iter()
-        .map(|(cmd, desc)| BotCommand {
-            command: (*cmd).to_string(),
-            description: (*desc).to_string(),
+    crate::commands::telegram_bot_commands()
+        .into_iter()
+        .map(|(command, description)| BotCommand {
+            command,
+            description,
         })
         .collect()
 }
@@ -1381,9 +1358,9 @@ impl TelegramAdapter {
     ///
     /// Uses the default scope (all chats) and no language filter.
     /// Called during `start()` with either explicitly configured commands
-    /// or the built-in defaults from [`BUILTIN_COMMANDS`].  Also re-triggered
-    /// from the polling loop on `/start` or first incoming message
-    /// (via [`TelegramApiCtx::set_my_commands`]).
+    /// or the built-in defaults from [`builtin_bot_commands`]. Also
+    /// re-triggered from the polling loop on `/start` or first incoming
+    /// message (via [`TelegramApiCtx::set_my_commands`]).
     pub async fn api_set_my_commands(
         &self,
         commands: &[BotCommand],


### PR DESCRIPTION
## Summary

Single source of truth for slash commands consumed by all surfaces (channel bridge, Telegram BotCommands, future CLI/TUI/Dashboard). Replaces the historical 4× hardcoded duplication:

- `bridge.rs:2777` `matches!` block (29 command names)
- `bridge.rs:4098` `handle_command` dispatcher
- `bridge.rs:4122-4164` `/help` string literal
- `telegram.rs:137-158` `BUILTIN_COMMANDS` const

Includes a golden anti-drift assertion (`channel_command_names_match_historical_set`) that fails the build if the registry deviates from the historical 29-command set, so future drift is caught at CI rather than in production help text.

## Changes

- **New** `crates/librefang-channels/src/commands/mod.rs` (~750 LOC incl. 11 tests): `CommandDef` struct, `Scope` bitflags (CLI/CHANNEL/DASHBOARD), `Category` enum, `SubCommand` for multi-form commands (e.g. `/trigger add ...` vs `/trigger del ...`), `COMMAND_REGISTRY` static array of 29 commands, derivation helpers (`lookup`, `iter_for`, `is_channel_command`, `channel_help_text`, `telegram_bot_commands`, `is_command_allowed`).
- `bridge.rs`: `matches!` block → `commands::is_channel_command(cmd)`; `/help` string literal → `commands::channel_help_text(overrides)`. `handle_command` grows an `overrides` parameter so `/help` reflects per-channel allowed/blocked policy. **−60 LOC net.**
- `telegram.rs`: drops `BUILTIN_COMMANDS`; `builtin_bot_commands` delegates to `commands::telegram_bot_commands()`. **−25 LOC net.**
- `Cargo.toml`: adds `bitflags = "2"` to workspace deps.

Behavior (the actual handler for each command) still lives in `bridge::handle_command` and per-surface dispatchers; this module only describes commands.

## Test plan

- [x] `cargo test -p librefang-channels --lib` — **796 ok** (including 11 new commands tests)
- [x] `cargo test -p librefang-kernel --lib` — **499 ok** (run independently; `cargo test --workspace` had a SIGABRT once due to local worktree resource contention, not reproducible standalone)
- [x] `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --lib` — clean
- [ ] Live integration (curl `/help` via webhook adapter) — local cargo build is sandbox-blocked here; defer to CI

## Stack

This is the base for two follow-on PRs:
- **PR-2** `feat/slash-command-registry-cli` — CLI/TUI surface
- **PR-3** `feat/slash-command-registry-dashboard` — `GET /api/commands` + SPA hook

See `.plans/slash-command-registry.md` for the design rationale.
