### PR TITLE
feat(cli): slash command registry — CLI/TUI surface (PR-2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "fluent",
  "libc",
  "librefang-api",
+ "librefang-channels",
  "librefang-extensions",
  "librefang-kernel",
  "librefang-migrate",

--- a/crates/librefang-channels/src/commands/mod.rs
+++ b/crates/librefang-channels/src/commands/mod.rs
@@ -183,7 +183,8 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         name: "model",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        // TUI uses /model for direct switch / picker; channels use it for show/switch.
+        scope: Scope::CHANNEL.union(Scope::CLI),
         description: "Show or switch agent model",
         args_hint: "[name]",
         subcommands: &[],
@@ -264,7 +265,8 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         name: "status",
         aliases: &[],
         category: Category::Info,
-        scope: Scope::CHANNEL,
+        // Channels show system status; TUI shows connection / agent info.
+        scope: Scope::CHANNEL.union(Scope::CLI),
         description: "Show system status",
         args_hint: "",
         subcommands: &[],
@@ -417,11 +419,42 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         name: "help",
         aliases: &[],
         category: Category::Misc,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::CLI),
         description: "Show this help",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+    },
+    // ---- TUI-only control commands (Scope::CLI) ----
+    CommandDef {
+        name: "clear",
+        aliases: &[],
+        category: Category::Misc,
+        scope: Scope::CLI,
+        description: "Clear chat history",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "kill",
+        aliases: &[],
+        category: Category::Misc,
+        scope: Scope::CLI,
+        description: "Kill the current agent and quit",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+    },
+    CommandDef {
+        name: "exit",
+        aliases: &["quit"],
+        category: Category::Misc,
+        scope: Scope::CLI,
+        description: "End chat session",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
     },
 ];
 
@@ -524,6 +557,50 @@ pub fn channel_help_text(overrides: Option<&ChannelOverrides>) -> String {
         first_in_section = false;
     }
 
+    out
+}
+
+/// Render the CLI / TUI-facing `/help` text.
+///
+/// Lists every command visible to `Scope::CLI`. Output is a flat list aligned
+/// with em-dashes (matching the historical TUI `/help` style); category headers
+/// are not used because the CLI surface has only a handful of commands.
+pub fn cli_help_text() -> String {
+    // Build (display_lhs, description) pairs first so we can align em-dashes.
+    let mut rows: Vec<(String, &'static str)> = Vec::new();
+    for c in iter_for(Scope::CLI) {
+        if c.subcommands.is_empty() {
+            let lhs = if c.args_hint.is_empty() {
+                format!("/{}", c.name)
+            } else {
+                format!("/{} {}", c.name, c.args_hint)
+            };
+            rows.push((lhs, c.description));
+        } else {
+            for sub in c.subcommands {
+                rows.push((format!("/{} {}", c.name, sub.args), sub.description));
+            }
+        }
+    }
+
+    let width = rows
+        .iter()
+        .map(|(l, _)| l.chars().count())
+        .max()
+        .unwrap_or(0);
+    let mut out = String::new();
+    for (i, (lhs, desc)) in rows.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let pad = width - lhs.chars().count();
+        out.push_str(lhs);
+        for _ in 0..pad {
+            out.push(' ');
+        }
+        out.push_str(" \u{2014} ");
+        out.push_str(desc);
+    }
     out
 }
 
@@ -726,6 +803,55 @@ mod tests {
         assert!(!txt.contains("/agent <name>"));
         // Other commands still show up.
         assert!(txt.contains("/agents - List running agents"));
+    }
+
+    /// `cli_help_text()` must include all TUI-only commands and the
+    /// CLI-shared ones (status, model, help). Format uses em-dash separators.
+    #[test]
+    fn cli_help_text_lists_tui_commands() {
+        let txt = cli_help_text();
+        // TUI-only
+        assert!(txt.contains("/clear"), "missing /clear: {txt}");
+        assert!(txt.contains("/kill"), "missing /kill: {txt}");
+        assert!(txt.contains("/exit"), "missing /exit: {txt}");
+        // Shared with channels
+        assert!(txt.contains("/help"), "missing /help: {txt}");
+        assert!(txt.contains("/status"), "missing /status: {txt}");
+        assert!(txt.contains("/model"), "missing /model: {txt}");
+        // Em-dash separator (U+2014)
+        assert!(txt.contains(" \u{2014} "), "missing em-dash: {txt}");
+        // Should NOT include channel-only commands like /agents, /budget, /btw
+        assert!(!txt.contains("/agents"), "/agents leaked into CLI help");
+        assert!(!txt.contains("/budget"), "/budget leaked into CLI help");
+        assert!(!txt.contains("/btw"), "/btw leaked into CLI help");
+    }
+
+    /// `/quit` must resolve via the `/exit` alias.
+    #[test]
+    fn quit_resolves_via_exit_alias() {
+        assert_eq!(lookup("quit").map(|c| c.name), Some("exit"));
+        assert_eq!(lookup("/quit").map(|c| c.name), Some("exit"));
+        assert_eq!(lookup("exit").map(|c| c.name), Some("exit"));
+    }
+
+    /// Adding `Scope::CLI` to existing channel commands must not change the
+    /// channel-visible set (golden assertion guard).
+    #[test]
+    fn cli_scope_does_not_leak_into_channel_set() {
+        // Running this alongside `channel_command_names_match_historical_set`
+        // catches any future drift where someone adds a CLI-only command but
+        // accidentally tags it `Scope::CHANNEL`.
+        let cli_only: Vec<&str> = COMMAND_REGISTRY
+            .iter()
+            .filter(|c| c.scope == Scope::CLI)
+            .map(|c| c.name)
+            .collect();
+        for name in &cli_only {
+            assert!(
+                !is_channel_command(name),
+                "CLI-only command `{name}` must not appear as channel command"
+            );
+        }
     }
 
     #[test]

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 librefang-types = { path = "../librefang-types" }
 librefang-kernel = { path = "../librefang-kernel" }
 librefang-api = { path = "../librefang-api", default-features = false }
+librefang-channels = { path = "../librefang-channels", default-features = false }
 librefang-migrate = { path = "../librefang-migrate" }
 librefang-skills = { path = "../librefang-skills" }
 librefang-extensions = { path = "../librefang-extensions" }

--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -270,27 +270,32 @@ impl StandaloneChat {
     // ── Slash commands (subset — no tab navigation) ──────────────────────────
 
     fn handle_slash_command(&mut self, cmd: &str) {
+        use librefang_channels::commands::{self, Scope};
+
         let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
-        match parts[0] {
-            "/exit" | "/quit" => {
+        let head = parts[0];
+        let bare = head.strip_prefix('/').unwrap_or(head);
+
+        // Resolve through the central registry so unknown commands are
+        // rejected uniformly and aliases like `/quit -> /exit` are honored.
+        let canonical = match commands::lookup(bare) {
+            Some(def) if def.scope.contains(Scope::CLI) => def.name,
+            _ => {
+                self.chat
+                    .push_message(Role::System, format!("Unknown command: {head}. Type /help"));
+                return;
+            }
+        };
+
+        match canonical {
+            "exit" => {
                 self.should_quit = true;
             }
-            "/help" => {
-                self.chat.push_message(
-                    Role::System,
-                    [
-                        "/help         \u{2014} show this help",
-                        "/model        \u{2014} open model picker (Ctrl+M)",
-                        "/model <name> \u{2014} switch to model directly",
-                        "/status       \u{2014} connection & agent info",
-                        "/clear        \u{2014} clear chat history",
-                        "/kill         \u{2014} kill the current agent & quit",
-                        "/exit         \u{2014} end chat session",
-                    ]
-                    .join("\n"),
-                );
+            "help" => {
+                self.chat
+                    .push_message(Role::System, commands::cli_help_text());
             }
-            "/status" => {
+            "status" => {
                 let mut s = Vec::new();
                 match &self.backend {
                     Backend::Daemon { base_url } => {
@@ -306,7 +311,7 @@ impl StandaloneChat {
                 }
                 self.chat.push_message(Role::System, s.join("\n"));
             }
-            "/model" => {
+            "model" => {
                 let args = parts.get(1).map(|s| s.trim()).unwrap_or("");
                 if args.is_empty() {
                     // No argument: open the model picker
@@ -316,7 +321,7 @@ impl StandaloneChat {
                     self.switch_model(args);
                 }
             }
-            "/clear" => {
+            "clear" => {
                 let name = self.chat.agent_name.clone();
                 let model = self.chat.model_label.clone();
                 let mode = self.chat.mode_label.clone();
@@ -327,7 +332,7 @@ impl StandaloneChat {
                 self.chat
                     .push_message(Role::System, "Chat history cleared.".to_string());
             }
-            "/kill" => {
+            "kill" => {
                 let name = self.agent_name.clone();
                 match &self.backend {
                     Backend::Daemon { base_url } => {
@@ -374,12 +379,9 @@ impl StandaloneChat {
                     }
                 }
             }
-            _ => {
-                self.chat.push_message(
-                    Role::System,
-                    format!("Unknown command: {}. Type /help", parts[0]),
-                );
-            }
+            // The pre-flight `commands::lookup` guarantees `canonical` is one
+            // of the names matched above.
+            other => unreachable!("unhandled CLI command `{other}`"),
         }
     }
 


### PR DESCRIPTION
## Summary

Builds on PR-1 (`feat/slash-command-registry`) to make the TUI chat runner derive its slash commands from the central registry instead of maintaining a parallel hand-coded match block.

- Promotes `/model`, `/status`, `/help` to `Scope::CHANNEL | Scope::CLI` so they appear on both surfaces.
- Adds `/clear`, `/kill`, `/exit` (with `quit` alias) under `Scope::CLI` as TUI-only commands.
- `handle_slash_command` now does a pre-flight `commands::lookup` with scope check; unknown commands fall through to a single uniform error path.

## Changes

- `crates/librefang-channels/src/commands/mod.rs`: scope unions + 4 new TUI command entries + `cli_help_text()` rendering all CLI-scoped commands with em-dash alignment + 3 unit tests (`cli_help_text_lists_tui_commands`, `quit_resolves_via_exit_alias`, `cli_scope_does_not_leak_into_channel_set`).
- `crates/librefang-cli/src/tui/chat_runner.rs`: dispatch rewritten — match arms now use bare names (`exit`, `help`, `clear`, ...); former `_ =>` "Unknown command" fallback becomes `unreachable!` because `lookup` already filtered.
- `crates/librefang-cli/Cargo.toml`: depends on `librefang-channels`.

## `/help` output (TUI)

```
/model [name] — Show or switch agent model
/status       — Show system status
/help         — Show this help
/clear        — Clear chat history
/kill         — Kill the current agent and quit
/exit         — End chat session
```

## Test plan

- [x] `cargo test -p librefang-channels --lib commands::` — **14 ok** (11 PR-1 + 3 new). PR-1's anti-drift `channel_command_names_match_historical_set` still PASS.
- [x] `cargo test -p librefang-cli` — **83 ok**
- [x] `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --lib` — clean

## Stack

Base: **PR-1** (`feat/slash-command-registry`).
