### PR TITLE
fix(provider-health): forward api_key as Bearer in local provider probe

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -444,21 +444,42 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
     };
 
     // Collect local providers that need probing
-    let local_providers: Vec<(usize, String, String)> = provider_list
+    let local_providers: Vec<(usize, String, String, Option<String>)> = provider_list
         .iter()
         .enumerate()
         .filter(|(_, p)| {
             librefang_runtime::provider_health::is_local_provider(&p.id) && !p.base_url.is_empty()
         })
-        .map(|(i, p)| (i, p.id.clone(), p.base_url.clone()))
+        .map(|(i, p)| {
+            // Resolve the provider's api_key env var (catalog field, falling
+            // back to the {PROVIDER}_API_KEY convention) and read its value
+            // for the probe. Local providers fronted by an authenticating
+            // reverse proxy (Open WebUI, LiteLLM, etc.) need this Bearer
+            // token forwarded; bare-localhost setups have nothing in the
+            // env so the probe runs unauthenticated as before.
+            let env_var = if p.api_key_env.trim().is_empty() {
+                format!("{}_API_KEY", p.id.to_uppercase().replace('-', "_"))
+            } else {
+                p.api_key_env.clone()
+            };
+            let api_key = std::env::var(&env_var)
+                .ok()
+                .filter(|v| !v.trim().is_empty());
+            (i, p.id.clone(), p.base_url.clone(), api_key)
+        })
         .collect();
 
     // Fire all probes concurrently (cached results return instantly)
     let cache = &state.provider_probe_cache;
     let probe_futures: Vec<_> = local_providers
         .iter()
-        .map(|(_, id, url)| {
-            librefang_runtime::provider_health::probe_provider_cached(id, url, cache)
+        .map(|(_, id, url, api_key)| {
+            librefang_runtime::provider_health::probe_provider_cached(
+                id,
+                url,
+                api_key.as_deref(),
+                cache,
+            )
         })
         .collect();
     let probe_results = futures::future::join_all(probe_futures).await;
@@ -466,7 +487,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
     // Index probe results by provider list position for O(1) lookup
     let mut probe_map: HashMap<usize, librefang_runtime::provider_health::ProbeResult> =
         HashMap::with_capacity(local_providers.len());
-    for ((idx, _, _), result) in local_providers.iter().zip(probe_results) {
+    for ((idx, _, _, _), result) in local_providers.iter().zip(probe_results) {
         probe_map.insert(*idx, result);
     }
 
@@ -559,27 +580,44 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
         catalog.list_providers().to_vec()
     };
 
-    let local_providers: Vec<(usize, String, String)> = provider_list
+    let local_providers: Vec<(usize, String, String, Option<String>)> = provider_list
         .iter()
         .enumerate()
         .filter(|(_, p)| {
             librefang_runtime::provider_health::is_local_provider(&p.id) && !p.base_url.is_empty()
         })
-        .map(|(i, p)| (i, p.id.clone(), p.base_url.clone()))
+        .map(|(i, p)| {
+            // See sibling site above — same env-var resolution so Open WebUI
+            // / LiteLLM-fronted local providers get a Bearer token attached.
+            let env_var = if p.api_key_env.trim().is_empty() {
+                format!("{}_API_KEY", p.id.to_uppercase().replace('-', "_"))
+            } else {
+                p.api_key_env.clone()
+            };
+            let api_key = std::env::var(&env_var)
+                .ok()
+                .filter(|v| !v.trim().is_empty());
+            (i, p.id.clone(), p.base_url.clone(), api_key)
+        })
         .collect();
 
     let cache = &state.provider_probe_cache;
     let probe_futures: Vec<_> = local_providers
         .iter()
-        .map(|(_, id, url)| {
-            librefang_runtime::provider_health::probe_provider_cached(id, url, cache)
+        .map(|(_, id, url, api_key)| {
+            librefang_runtime::provider_health::probe_provider_cached(
+                id,
+                url,
+                api_key.as_deref(),
+                cache,
+            )
         })
         .collect();
     let probe_results = futures::future::join_all(probe_futures).await;
 
     let mut probe_map: HashMap<usize, librefang_runtime::provider_health::ProbeResult> =
         HashMap::with_capacity(local_providers.len());
-    for ((idx, _, _), result) in local_providers.iter().zip(probe_results) {
+    for ((idx, _, _, _), result) in local_providers.iter().zip(probe_results) {
         probe_map.insert(*idx, result);
     }
 
@@ -681,9 +719,20 @@ pub async fn get_provider(
         && !provider.base_url.is_empty()
     {
         let cache = &state.provider_probe_cache;
+        // Forward the api_key when present so reverse-proxy-fronted local
+        // providers (Open WebUI, LiteLLM) get a valid Bearer token.
+        let env_var = if provider.api_key_env.trim().is_empty() {
+            format!("{}_API_KEY", provider.id.to_uppercase().replace('-', "_"))
+        } else {
+            provider.api_key_env.clone()
+        };
+        let api_key = std::env::var(&env_var)
+            .ok()
+            .filter(|v| !v.trim().is_empty());
         let probe = librefang_runtime::provider_health::probe_provider_cached(
             &provider.id,
             &provider.base_url,
+            api_key.as_deref(),
             cache,
         )
         .await;
@@ -1440,8 +1489,31 @@ pub async fn set_provider_url(
         }
     }
 
-    // Probe reachability at the new URL
-    let probe = librefang_runtime::provider_health::probe_provider(&name, &base_url).await;
+    // Probe reachability at the new URL. Forward the configured api_key so
+    // reverse-proxy-fronted endpoints (Open WebUI, LiteLLM, etc.) accept
+    // the listing request — without this, they return 401 even when the
+    // backing model server is healthy.
+    let probe_env_var = {
+        let catalog = state
+            .kernel
+            .model_catalog_ref()
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        catalog
+            .get_provider(&name)
+            .map(|p| p.api_key_env.clone())
+            .filter(|env| !env.trim().is_empty())
+            .unwrap_or_else(|| format!("{}_API_KEY", name.to_uppercase().replace('-', "_")))
+    };
+    let probe_api_key = std::env::var(&probe_env_var)
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let probe = librefang_runtime::provider_health::probe_provider(
+        &name,
+        &base_url,
+        probe_api_key.as_deref(),
+    )
+    .await;
 
     // Merge discovered models into catalog
     if !probe.discovered_models.is_empty() {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -15807,7 +15807,28 @@ pub async fn probe_and_update_local_provider(
     base_url: &str,
     log_offline_as_warn: bool,
 ) -> librefang_runtime::provider_health::ProbeResult {
-    let result = librefang_runtime::provider_health::probe_provider(provider_id, base_url).await;
+    // Forward the provider's api_key (when configured) so reverse-proxy
+    // frontends like Open WebUI accept the listing request. Without this,
+    // the probe always 401s and the catalog flips to LocalOffline even
+    // when the underlying ollama is healthy.
+    let api_key = {
+        let catalog = kernel
+            .model_catalog
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        let env_var = catalog
+            .get_provider(provider_id)
+            .map(|p| p.api_key_env.clone())
+            .filter(|env| !env.trim().is_empty())
+            .unwrap_or_else(|| format!("{}_API_KEY", provider_id.to_uppercase().replace('-', "_")));
+        std::env::var(env_var).ok().filter(|v| !v.trim().is_empty())
+    };
+    let result = librefang_runtime::provider_health::probe_provider(
+        provider_id,
+        base_url,
+        api_key.as_deref(),
+    )
+    .await;
     if result.reachable {
         info!(
             provider = %provider_id,

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -177,7 +177,13 @@ impl Default for ProbeCache {
 ///
 /// `base_url` should be the provider's base URL from the catalog (e.g.,
 /// `http://localhost:11434/v1` for Ollama, `http://localhost:8000/v1` for vLLM).
-pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
+///
+/// `api_key` is forwarded as `Authorization: Bearer <key>` when `Some` and
+/// non-empty. Required when the local provider is fronted by an
+/// authenticating reverse proxy (e.g. Open WebUI exposes ollama under
+/// `/ollama/v1` behind a JWT) — a bare `None` keeps the original
+/// "no auth" behaviour for direct-to-localhost setups.
+pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str>) -> ProbeResult {
     let start = Instant::now();
 
     let client = match crate::http_client::proxied_client_builder()
@@ -210,7 +216,21 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
         (format!("{trimmed}/models"), false)
     };
 
-    let resp = match client.get(&url).send().await {
+    // Attach Bearer token when an api_key was supplied. Ollama itself
+    // ignores Authorization headers (and bare ollama servers should not
+    // be passed a key here), but reverse-proxy frontends like Open WebUI
+    // require them — without this, the probe always 401s and the
+    // catalog flips to LocalOffline even though the underlying ollama
+    // is healthy.
+    let mut req = client.get(&url);
+    if let Some(key) = api_key {
+        let trimmed = key.trim();
+        if !trimmed.is_empty() {
+            req = req.header("Authorization", format!("Bearer {trimmed}"));
+        }
+    }
+
+    let resp = match req.send().await {
         Ok(r) => r,
         Err(e) => {
             return ProbeResult {
@@ -342,12 +362,13 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
 pub async fn probe_provider_cached(
     provider: &str,
     base_url: &str,
+    api_key: Option<&str>,
     cache: &ProbeCache,
 ) -> ProbeResult {
     if let Some(cached) = cache.get(provider) {
         return cached;
     }
-    let result = probe_provider(provider, base_url).await;
+    let result = probe_provider(provider, base_url, api_key).await;
     cache.insert(provider, result.clone());
     result
 }
@@ -443,7 +464,7 @@ mod tests {
     #[tokio::test]
     async fn test_probe_unreachable_returns_error() {
         // Probe a port that's almost certainly not running a server
-        let result = probe_provider("ollama", "http://127.0.0.1:19999").await;
+        let result = probe_provider("ollama", "http://127.0.0.1:19999", None).await;
         assert!(!result.reachable);
         assert!(result.error.is_some());
     }


### PR DESCRIPTION
## Why
Local-provider probe (`provider_health::probe_provider`) didn't forward an `Authorization` header. That's fine when ollama is bound directly to localhost — the original assumption — but breaks when ollama (or vLLM / LM Studio) is fronted by an authenticating reverse proxy like Open WebUI:

- Open WebUI exposes ollama at `https://host/ollama/v1` behind a JWT
- librefang config: `[provider_urls].ollama = "https://host/ollama/v1"` + `OLLAMA_API_KEY=<jwt>` in env
- Driver (OpenAI format) actually attaches `Authorization: Bearer <key>` correctly
- **But the probe doesn't** → returns 401 → catalog marks the provider `LocalOffline` → the agent message gate (`auth_status.is_available()`) returns 412 `API key not configured`, blocking every chat

User-visible symptom on a perfectly working ollama-via-Open-WebUI setup:

```
WARN Configured local provider offline provider=ollama error="HTTP 401 Unauthorized"
HTTP 412 — API key not configured for this provider (provider: ollama)
```

## What changed
- `provider_health::probe_provider` and `probe_provider_cached` now take `api_key: Option<&str>`. Bare `None` keeps the original "no auth" behaviour for direct-to-localhost; `Some(<key>)` attaches `Authorization: Bearer <key>` (after trim — empty strings still result in no header).
- All 5 callers updated:
  - `librefang-api/routes/providers.rs` × 4 (list + snapshot + by-id + URL-update flows)
  - `librefang-kernel/kernel/mod.rs` × 1 (`probe_and_update_local_provider`)
- Each caller resolves the api_key via the catalog's `api_key_env` (falling back to the `{PROVIDER}_API_KEY` convention) and reads `std::env::var(...)` with the same empty-trim filter the routes already use elsewhere.

No new public surface, no schema changes, no fixture impact. The ollama / vllm / lmstudio drivers themselves were unchanged — they were already attaching the Bearer correctly.

## Test plan
- [x] Unchanged tests for `probe_provider` (the `unreachable` test now passes `None` for `api_key`)
- [x] grep: 5 caller sites covered, no remaining 2-arg / 3-arg signatures
- [ ] Manual: `[provider_urls].ollama = "https://<openwebui>/ollama/v1"` + `OLLAMA_API_KEY=<openwebui-jwt>` in `~/.librefang/.env`, restart daemon → `/api/providers` shows ollama `auth_status: Configured`, agent message succeeds with 200

## Notes
- The probe cache (`ProbeCache`) keys on provider name, not on (name, api_key). If a user rotates the api_key the cached result lives 60s before being re-probed — same blast radius as today's url cache.
- Once this lands, `librefang config set-key ollama <jwt>` (which writes to `~/.librefang/.env`) is the canonical way to configure ollama-via-proxy. No code path requires editing `[provider_api_keys]` in `config.toml`.
