### PR TITLE
chore: ignore local .plans/ working notes directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ prediction_report_*.md
 BUILD_LOG.md
 message_journal.jsonl
 
+# Local working notes / design plans (ultrareview, brainstorm scratch)
+.plans/
+
 # Node.js (packages/)
 node_modules/
 


### PR DESCRIPTION
## Summary
Add `.plans/` to `.gitignore` so local working-notes / design-plan markdown files (e.g. ultrareview output, brainstorm scratch) don't show up as untracked on every `git status`. They're transient per-developer scratch, not something we want in tree.

Sits in the existing "Runtime artifacts" cluster — same intent (local-only files that the daemon / dev workflow generates).

## Test plan
- [x] `git status` after adding files under `.plans/` shows clean
- [x] No effect on existing tracked files
