### PR TITLE
fix(memory): degrade Memory page gracefully when proactive memory is disabled

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -545,6 +545,9 @@ export interface MemoryListResponse {
   total?: number;
   offset?: number;
   limit?: number;
+  // Server signals whether proactive memory is enabled in config so the
+  // dashboard can render an explanatory note + fall back to per-agent KV.
+  proactive_enabled?: boolean;
 }
 
 export interface MemoryStatsResponse {
@@ -557,6 +560,23 @@ export interface MemoryStatsResponse {
   auto_memorize_enabled?: boolean;
   auto_retrieve_enabled?: boolean;
   llm_extraction?: boolean;
+  // Mirrors MemoryListResponse — see field doc above.
+  proactive_enabled?: boolean;
+}
+
+// Per-agent KV pair returned by `GET /api/memory/agents/:id/kv`.
+//
+// `created_at` and `source` are best-effort: the underlying substrate may not
+// populate them today, so the dashboard treats them as optional.
+export interface AgentKvPair {
+  key: string;
+  value: unknown;
+  source?: string;
+  created_at?: string;
+}
+
+export interface AgentKvResponse {
+  kv_pairs?: AgentKvPair[];
 }
 
 export interface UsageSummaryResponse {
@@ -2179,6 +2199,13 @@ export async function getMemoryStats(agentId?: string): Promise<MemoryStatsRespo
     return get<MemoryStatsResponse>(`/api/memory/agents/${encodeURIComponent(agentId)}/stats`);
   }
   return get<MemoryStatsResponse>("/api/memory/stats");
+}
+
+// List the per-agent KV memory store (always available — independent of
+// `[proactive_memory] enabled`). Used as the fallback view when proactive
+// memory is disabled, and as a complementary view when it is enabled.
+export async function getAgentKvMemory(agentId: string): Promise<AgentKvResponse> {
+  return get<AgentKvResponse>(`/api/memory/agents/${encodeURIComponent(agentId)}/kv`);
 }
 
 export async function addMemoryFromText(

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -66,6 +66,7 @@ export {
   searchMemories,
   getMemoryStats,
   getMemoryConfig,
+  getAgentKvMemory,
   // models
   listModels,
   getModelOverrides,
@@ -282,6 +283,8 @@ export type {
   McpAuthStartResponse,
   McpAuthStatusResponse,
   MemoryItem,
+  AgentKvPair,
+  AgentKvResponse,
   ModelOverrides,
   MediaImageResult,
   MediaMusicResult,

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -200,6 +200,17 @@ describe("query key factories", () => {
       expect(memoryKeys.stats().slice(0, prefix.length)).toEqual(prefix);
       expect(memoryKeys.stats("a1").slice(0, prefix.length)).toEqual(prefix);
     });
+
+    it("agentKv keys are nested under memoryKeys.all and agentKvs", () => {
+      expect(memoryKeys.agentKvs()).toEqual(["memory", "agentKv"]);
+      expect(memoryKeys.agentKv("a1")).toEqual(["memory", "agentKv", "a1"]);
+      const prefix = memoryKeys.agentKvs();
+      expect(memoryKeys.agentKv("a1").slice(0, prefix.length)).toEqual(prefix);
+      // Ensure agentKv subtree is disjoint from list/stats subtrees so
+      // invalidating proactive memory doesn't blow KV away.
+      expect(memoryKeys.agentKvs()).not.toEqual(memoryKeys.lists());
+      expect(memoryKeys.agentKvs()).not.toEqual(memoryKeys.statsAll());
+    });
   });
 
   describe("structural stability", () => {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -199,6 +199,12 @@ export const memoryKeys = {
   stats: (agentId?: string) =>
     [...memoryKeys.statsAll(), agentId] as const,
   config: () => [...memoryKeys.all, "config"] as const,
+  // Per-agent KV memory store — distinct subtree from proactive memory
+  // so invalidating proactive entries doesn't invalidate KV reads (and
+  // vice versa). Always keyed by agentId; no list-level invalidation
+  // needed because each agent's KV is rendered independently.
+  agentKvs: () => [...memoryKeys.all, "agentKv"] as const,
+  agentKv: (agentId: string) => [...memoryKeys.agentKvs(), agentId] as const,
 };
 
 export const usageKeys = {

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.test.tsx
@@ -1,10 +1,23 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
-import { useMemoryHealth } from "./memory";
+import { useMemoryHealth, useAgentKvMemory } from "./memory";
 import { healthDetailQueryOptions } from "./runtime";
-import { runtimeKeys } from "./keys";
+import { runtimeKeys, memoryKeys } from "./keys";
 import { createQueryClientWrapper } from "../test/query-client";
+import * as httpClient from "../http/client";
+
+vi.mock("../http/client", async () => {
+  const actual = await vi.importActual<typeof import("../http/client")>("../http/client");
+  return {
+    ...actual,
+    getAgentKvMemory: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("useMemoryHealth", () => {
   it("should return true when data.memory.embedding_available is true", async () => {
@@ -81,5 +94,64 @@ describe("useMemoryHealth", () => {
 
     expect(healthResult.current.data).toBe(sharedQueryState);
     expect(queryClient.getQueryData(runtimeKeys.healthDetail())).toBe(sharedQueryState);
+  });
+});
+
+describe("useAgentKvMemory", () => {
+  it("should be disabled when agentId is empty string", () => {
+    const { result } = renderHook(() => useAgentKvMemory(""), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.getAgentKvMemory).not.toHaveBeenCalled();
+  });
+
+  it("should fetch and unwrap kv_pairs when agentId is provided", async () => {
+    vi.mocked(httpClient.getAgentKvMemory).mockResolvedValue({
+      kv_pairs: [
+        { key: "name", value: "alice" },
+        { key: "tz", value: "UTC" },
+      ],
+    });
+
+    const { result } = renderHook(() => useAgentKvMemory("agent-1"), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(httpClient.getAgentKvMemory).toHaveBeenCalledWith("agent-1");
+    expect(result.current.data).toEqual([
+      { key: "name", value: "alice" },
+      { key: "tz", value: "UTC" },
+    ]);
+  });
+
+  it("should normalize missing kv_pairs to an empty array", async () => {
+    vi.mocked(httpClient.getAgentKvMemory).mockResolvedValue({});
+
+    const { result } = renderHook(() => useAgentKvMemory("agent-1"), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("should cache under memoryKeys.agentKv(agentId)", async () => {
+    vi.mocked(httpClient.getAgentKvMemory).mockResolvedValue({
+      kv_pairs: [{ key: "k", value: "v" }],
+    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    renderHook(() => useAgentKvMemory("agent-xyz"), { wrapper });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(memoryKeys.agentKv("agent-xyz"))).toEqual([
+        { key: "k", value: "v" },
+      ]);
+    });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.ts
@@ -4,7 +4,9 @@ import {
   searchMemories,
   getMemoryStats,
   getMemoryConfig,
+  getAgentKvMemory,
   type MemoryItem,
+  type AgentKvPair,
 } from "../http/client";
 import { healthDetailQueryOptions } from "./runtime";
 import { memoryKeys } from "./keys";
@@ -13,6 +15,7 @@ import { withOverrides, type QueryOverrides } from "./options";
 const REFRESH_MS = 30_000;
 const STALE_MS = 30_000;
 const CONFIG_STALE_MS = 300_000;
+const KV_STALE_MS = 30_000;
 
 export const memoryQueries = {
 
@@ -33,8 +36,18 @@ export const memoryQueries = {
 
 
 
+// Propagates `proactive_enabled` from the list endpoint so the page can
+// decide whether to render proactive sections without making a second
+// request. The search endpoint does not expose this flag today; in search
+// mode we leave it `undefined` and let the page rely on the list-mode
+// response (search is hidden when proactive is disabled, so this never
+// becomes ambiguous in practice).
 export const memorySearchOrListQueryOptions = (search: string) =>
-  queryOptions<{ memories: MemoryItem[]; total: number }>({
+  queryOptions<{
+    memories: MemoryItem[];
+    total: number;
+    proactive_enabled?: boolean;
+  }>({
     queryKey: memoryKeys.searchOrList(search),
     queryFn: async () => {
       if (search.trim()) {
@@ -42,7 +55,11 @@ export const memorySearchOrListQueryOptions = (search: string) =>
         return { memories: items, total: items.length };
       }
       const res = await listMemories({ offset: 0, limit: 10000 });
-      return { memories: res.memories ?? [], total: res.total ?? 0 };
+      return {
+        memories: res.memories ?? [],
+        total: res.total ?? 0,
+        proactive_enabled: res.proactive_enabled,
+      };
     },
     staleTime: STALE_MS,
     refetchInterval: REFRESH_MS,
@@ -50,6 +67,25 @@ export const memorySearchOrListQueryOptions = (search: string) =>
 
 export function useMemorySearchOrList(search: string) {
   return useQuery(memorySearchOrListQueryOptions(search));
+}
+
+// Per-agent KV memory store. Independent of proactive memory — works even
+// when `[proactive_memory] enabled = false`. Returns `kv_pairs` directly
+// (server already returns `{kv_pairs: [...]}`); we normalize undefined to
+// an empty array so consumers can iterate without null checks.
+export const agentKvMemoryQueryOptions = (agentId: string) =>
+  queryOptions<AgentKvPair[]>({
+    queryKey: memoryKeys.agentKv(agentId),
+    queryFn: async () => {
+      const res = await getAgentKvMemory(agentId);
+      return res.kv_pairs ?? [];
+    },
+    enabled: !!agentId,
+    staleTime: KV_STALE_MS,
+  });
+
+export function useAgentKvMemory(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentKvMemoryQueryOptions(agentId), options));
 }
 
 export function useMemoryStats(agentId?: string) {

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -2,8 +2,10 @@ import { formatDateTime } from "../lib/datetime";
 import { useState, useEffect, useMemo, useDeferredValue } from "react";
 import { useTranslation } from "react-i18next";
 import { type MemoryStatsResponse } from "../api";
-import { useMemoryStats, useMemoryConfig, useMemoryHealth, useMemorySearchOrList } from "../lib/queries/memory";
+import { useMemoryStats, useMemoryConfig, useMemoryHealth, useMemorySearchOrList, useAgentKvMemory } from "../lib/queries/memory";
+import { useAgents } from "../lib/queries/agents";
 import { useAddMemory, useUpdateMemory, useDeleteMemory, useCleanupMemories, useUpdateMemoryConfig } from "../lib/mutations/memory";
+import type { AgentItem, AgentKvPair } from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -302,6 +304,123 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   );
 }
 
+// Truncate long KV values for table rendering — full value still available
+// in the title attribute on hover.
+function formatKvValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+const KV_VALUE_TRUNCATE = 200;
+
+function AgentKvRows({ agentId }: { agentId: string }) {
+  const { t } = useTranslation();
+  const kvQuery = useAgentKvMemory(agentId);
+
+  if (kvQuery.isLoading) {
+    return (
+      <tr>
+        <td colSpan={4} className="px-3 py-2 text-xs text-text-dim">
+          <Loader2 className="w-3.5 h-3.5 animate-spin inline" />
+        </td>
+      </tr>
+    );
+  }
+  if (kvQuery.isError) {
+    return (
+      <tr>
+        <td colSpan={4} className="px-3 py-2 text-xs text-error">
+          {kvQuery.error instanceof Error ? kvQuery.error.message : t("common.error")}
+        </td>
+      </tr>
+    );
+  }
+
+  const pairs = kvQuery.data ?? [];
+  if (pairs.length === 0) {
+    return (
+      <tr>
+        <td colSpan={4} className="px-3 py-2 text-xs text-text-dim/60 italic">
+          {t("memory.kv_empty", { defaultValue: "No KV entries" })}
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      {pairs.map((pair: AgentKvPair) => {
+        const formatted = formatKvValue(pair.value);
+        const truncated =
+          formatted.length > KV_VALUE_TRUNCATE
+            ? formatted.slice(0, KV_VALUE_TRUNCATE) + "…"
+            : formatted;
+        return (
+          <tr key={pair.key} className="border-t border-border-subtle/40">
+            <td className="px-3 py-2 text-xs font-mono break-all">{pair.key}</td>
+            <td className="px-3 py-2 text-xs font-mono text-text-dim break-all" title={formatted}>
+              {truncated}
+            </td>
+            <td className="px-3 py-2 text-xs text-text-dim">{pair.source ?? "-"}</td>
+            <td className="px-3 py-2 text-xs text-text-dim">
+              {pair.created_at ? formatDateTime(pair.created_at) : "-"}
+            </td>
+          </tr>
+        );
+      })}
+    </>
+  );
+}
+
+function AgentKvSection({ agents }: { agents: AgentItem[] }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-bold">
+        {t("memory.kv_section_title", { defaultValue: "Per-agent KV memory" })}
+      </h3>
+      {agents.length === 0 ? (
+        <EmptyState
+          title={t("memory.kv_no_agents", { defaultValue: "No agents available" })}
+          icon={<Database className="h-6 w-6" />}
+        />
+      ) : (
+        <div className="grid gap-4">
+          {agents.map((agent) => (
+            <Card key={agent.id} padding="md">
+              <div className="flex items-center gap-2 mb-3 flex-wrap">
+                <h4 className="text-xs font-bold">{agent.name}</h4>
+                <span className="text-[10px] font-mono text-text-dim">{agent.id.slice(0, 8)}</span>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-left">
+                  <thead>
+                    <tr className="text-[10px] font-bold uppercase tracking-widest text-text-dim/60">
+                      <th className="px-3 py-2">{t("memory.kv_key", { defaultValue: "Key" })}</th>
+                      <th className="px-3 py-2">{t("memory.kv_value", { defaultValue: "Value" })}</th>
+                      <th className="px-3 py-2">{t("memory.kv_source", { defaultValue: "Source" })}</th>
+                      <th className="px-3 py-2">{t("memory.created", { defaultValue: "Created" })}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <AgentKvRows agentId={agent.id} />
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function MemoryPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
@@ -340,6 +459,18 @@ export function MemoryPage() {
   const memories = memoryQuery.data?.memories ?? [];
   const totalCount = memoryQuery.data?.total ?? 0;
 
+  // Source of truth for "is proactive memory available right now":
+  //   1. The /api/memory response carries `proactive_enabled` (preferred —
+  //      reflects runtime store presence, not just config intent).
+  //   2. Fall back to /api/memory/config while the list query is in flight
+  //      so the UI doesn't flicker the proactive sections during load.
+  // While both are still loading we default to `true` to avoid flashing
+  // the "disabled" notice on first paint.
+  const proactiveEnabled =
+    memoryQuery.data?.proactive_enabled ??
+    memoryConfig?.proactive_memory_enabled ??
+    true;
+
   const filteredMemories = useMemo(() => {
     if (levelFilter === "all") return memories;
     return memories.filter(m => m.level === levelFilter);
@@ -349,6 +480,11 @@ export function MemoryPage() {
     () => Array.from(new Set(memories.map(m => m.level).filter(Boolean))),
     [memories],
   );
+
+  // Always-on per-agent KV view. Loaded regardless of proactive state so
+  // the page remains useful even when proactive memory is disabled.
+  const agentsQuery = useAgents();
+  const agents = agentsQuery.data ?? [];
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -362,33 +498,51 @@ export function MemoryPage() {
         helpText={t("memory.help")}
         actions={
           <div className="flex items-center gap-1 sm:gap-2 flex-wrap">
-<Button variant="secondary" size="sm" onClick={() => setShowConfigDialog(true)}>
+            <Button variant="secondary" size="sm" onClick={() => setShowConfigDialog(true)}>
               <Settings className="w-4 h-4" />
             </Button>
-            <Button variant="secondary" size="sm" onClick={() => cleanupMutation.mutate(undefined, {
-              onSuccess: () => addToast(t("memory.cleanup_success", { defaultValue: "Cleanup complete" }), "success"),
-              onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
-            })} disabled={cleanupMutation.isPending}>
-              {cleanupMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
-              <span className="hidden sm:inline">{t("memory.cleanup")}</span>
-            </Button>
-<Button variant="primary" size="sm" onClick={() => setShowAddDialog(true)}>
-              <Plus className="w-4 h-4" />
-              <span className="hidden sm:inline ml-1">{t("memory.add")}</span>
-            </Button>
+            {proactiveEnabled && (
+              <>
+                <Button variant="secondary" size="sm" onClick={() => cleanupMutation.mutate(undefined, {
+                  onSuccess: () => addToast(t("memory.cleanup_success", { defaultValue: "Cleanup complete" }), "success"),
+                  onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
+                })} disabled={cleanupMutation.isPending}>
+                  {cleanupMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                  <span className="hidden sm:inline">{t("memory.cleanup")}</span>
+                </Button>
+                <Button variant="primary" size="sm" onClick={() => setShowAddDialog(true)}>
+                  <Plus className="w-4 h-4" />
+                  <span className="hidden sm:inline ml-1">{t("memory.add")}</span>
+                </Button>
+              </>
+            )}
           </div>
         }
       />
 
-      {/* Stats */}
-      {statsQuery.isError ? (
-        <EmptyState
-          title={t("common.error")}
-          description={t("common.error_loading_stats", { defaultValue: "Failed to load memory stats" })}
-          icon={<Database className="h-6 w-6" />}
-        />
-      ) : (
-        <MemoryStats stats={statsQuery.data ?? null} />
+      {/* Proactive-disabled notice */}
+      {!proactiveEnabled && (
+        <Card padding="md">
+          <p className="text-xs text-text-dim">
+            {t("memory.proactive_disabled_notice", {
+              defaultValue:
+                "Proactive memory is disabled in config — showing per-agent KV memories instead.",
+            })}
+          </p>
+        </Card>
+      )}
+
+      {/* Stats — proactive only */}
+      {proactiveEnabled && (
+        statsQuery.isError ? (
+          <EmptyState
+            title={t("common.error")}
+            description={t("common.error_loading_stats", { defaultValue: "Failed to load memory stats" })}
+            icon={<Database className="h-6 w-6" />}
+          />
+        ) : (
+          <MemoryStats stats={statsQuery.data ?? null} />
+        )
       )}
 
       {/* Memory Config */}
@@ -421,116 +575,124 @@ export function MemoryPage() {
         </Card>
       )}
 
-      {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="flex-1">
-          <Input
-            value={search}
-            onChange={(e) => { setSearch(e.target.value); }}
-            placeholder={t("common.search")}
-            leftIcon={<Search className="w-4 h-4" />}
-            rightIcon={search && (
-              <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search", { defaultValue: "Clear search" })}>
-                <X className="w-3 h-3" />
+      {/* Proactive memory: search + filters + list */}
+      {proactiveEnabled && (
+        <>
+          {/* Filters */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex-1">
+              <Input
+                value={search}
+                onChange={(e) => { setSearch(e.target.value); }}
+                placeholder={t("common.search")}
+                leftIcon={<Search className="w-4 h-4" />}
+                rightIcon={search && (
+                  <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search", { defaultValue: "Clear search" })}>
+                    <X className="w-3 h-3" />
+                  </button>
+                )}
+              />
+            </div>
+            <div className="flex gap-1 p-1 bg-main/30 rounded-lg">
+              <button
+                onClick={() => setLevelFilter("all")}
+                className={`px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${levelFilter === "all" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
+              >
+                {t("memory.filter_all")}
               </button>
-            )}
-          />
-        </div>
-        <div className="flex gap-1 p-1 bg-main/30 rounded-lg">
-          <button
-            onClick={() => setLevelFilter("all")}
-            className={`px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${levelFilter === "all" ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-          >
-            {t("memory.filter_all")}
-          </button>
-          {levels.map(level => (
-            <button
-              key={level}
-              onClick={() => setLevelFilter(level || "all")}
-              className={`px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${levelFilter === level ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
-            >
-              {level}
-            </button>
-          ))}
-        </div>
-      </div>
+              {levels.map(level => (
+                <button
+                  key={level}
+                  onClick={() => setLevelFilter(level || "all")}
+                  className={`px-3 py-1.5 rounded-md text-xs font-bold transition-colors ${levelFilter === level ? "bg-surface shadow-sm" : "text-text-dim hover:text-text-main"}`}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+          </div>
 
-      {/* Count */}
-      <div className="text-xs text-text-dim">
-        {t("memory.showing", { count: filteredMemories.length, total: totalCount })}
-      </div>
+          {/* Count */}
+          <div className="text-xs text-text-dim">
+            {t("memory.showing", { count: filteredMemories.length, total: totalCount })}
+          </div>
 
-      {/* List */}
-      {memoryQuery.isLoading ? (
-        <div className="grid gap-4">
-          {[1, 2, 3, 4, 5].map(i => <CardSkeleton key={i} />)}
-        </div>
-      ) : memoryQuery.isError ? (
-        <EmptyState
-          title={t("common.error")}
-          description={t("common.error_loading_data", { defaultValue: "Failed to load memories" })}
-          icon={<Database className="h-6 w-6" />}
-        />
-      ) : filteredMemories.length === 0 ? (
-        <EmptyState
-          title={search || levelFilter !== "all" ? t("common.no_data") : t("memory.no_memories")}
-          icon={<Database className="h-6 w-6" />}
-        />
-      ) : (
-        <div className="grid gap-4">
-          {filteredMemories.map((m) => (
-            <Card key={m.id} hover padding="md">
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 sm:gap-2 mb-2">
-                <div className="flex items-center gap-2 min-w-0 flex-wrap">
-                  <h2 className="text-xs sm:text-sm font-black truncate font-mono max-w-45 sm:max-w-none">{m.id}</h2>
-                  <Badge variant={m.level === "user" ? "info" : m.level === "session" ? "warning" : m.level === "agent" ? "brand" : "default"}>
-                    {m.level || t("memory.session", { defaultValue: "session" })}
-                  </Badge>
-                  {m.source && (
-                    <Badge variant="default">{m.source}</Badge>
-                  )}
-                  {m.confidence != null && (
-                    <Badge variant={m.confidence > 0.7 ? "success" : m.confidence > 0.3 ? "warning" : "default"}>
-                      {Math.round(m.confidence * 100)}%
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex items-center gap-1 shrink-0 self-end sm:self-auto">
-                  <Button variant="ghost" size="sm" onClick={() => setEditingMemory(m)}>
-                    <Edit2 className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button variant="ghost" size="sm" className="text-error! hover:bg-error/10!" onClick={() => deleteMutation.mutate(m.id, {
-                    onSuccess: () => addToast(t("memory.delete_success", { defaultValue: "Memory deleted" }), "success"),
-                    onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
-                  })}>
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              </div>
-              <MarkdownContent className="text-xs text-text-dim leading-relaxed h-16 overflow-y-auto">
-                {m.content || t("common.no_data")}
-              </MarkdownContent>
-              <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-text-dim/50">
-                {m.created_at && (
-                  <span>{t("memory.created")}: {formatDateTime(m.created_at)}</span>
-                )}
-                {m.accessed_at && (
-                  <span>{t("memory.last_access", { defaultValue: "Last access" })}: {formatDateTime(m.accessed_at)}</span>
-                )}
-                {m.access_count != null && m.access_count > 0 && (
-                  <span>{t("memory.access_count", { defaultValue: "Accessed" })}: {m.access_count}x</span>
-                )}
-                {m.agent_id && (
-                  <span>{t("memory.agent_label", { defaultValue: "Agent:" })} <span className="font-mono">{m.agent_id.slice(0, 8)}</span></span>
-                )}
-                {m.category && (
-                  <span>{t("memory.category", { defaultValue: "Category" })}: {m.category}</span>
-                )}
-              </div>
-            </Card>
-          ))}
-        </div>
+          {/* List */}
+          {memoryQuery.isLoading ? (
+            <div className="grid gap-4">
+              {[1, 2, 3, 4, 5].map(i => <CardSkeleton key={i} />)}
+            </div>
+          ) : memoryQuery.isError ? (
+            <EmptyState
+              title={t("common.error")}
+              description={t("common.error_loading_data", { defaultValue: "Failed to load memories" })}
+              icon={<Database className="h-6 w-6" />}
+            />
+          ) : filteredMemories.length === 0 ? (
+            <EmptyState
+              title={search || levelFilter !== "all" ? t("common.no_data") : t("memory.no_memories")}
+              icon={<Database className="h-6 w-6" />}
+            />
+          ) : (
+            <div className="grid gap-4">
+              {filteredMemories.map((m) => (
+                <Card key={m.id} hover padding="md">
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 sm:gap-2 mb-2">
+                    <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                      <h2 className="text-xs sm:text-sm font-black truncate font-mono max-w-45 sm:max-w-none">{m.id}</h2>
+                      <Badge variant={m.level === "user" ? "info" : m.level === "session" ? "warning" : m.level === "agent" ? "brand" : "default"}>
+                        {m.level || t("memory.session", { defaultValue: "session" })}
+                      </Badge>
+                      {m.source && (
+                        <Badge variant="default">{m.source}</Badge>
+                      )}
+                      {m.confidence != null && (
+                        <Badge variant={m.confidence > 0.7 ? "success" : m.confidence > 0.3 ? "warning" : "default"}>
+                          {Math.round(m.confidence * 100)}%
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0 self-end sm:self-auto">
+                      <Button variant="ghost" size="sm" onClick={() => setEditingMemory(m)}>
+                        <Edit2 className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button variant="ghost" size="sm" className="text-error! hover:bg-error/10!" onClick={() => deleteMutation.mutate(m.id, {
+                        onSuccess: () => addToast(t("memory.delete_success", { defaultValue: "Memory deleted" }), "success"),
+                        onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
+                      })}>
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                  <MarkdownContent className="text-xs text-text-dim leading-relaxed h-16 overflow-y-auto">
+                    {m.content || t("common.no_data")}
+                  </MarkdownContent>
+                  <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-text-dim/50">
+                    {m.created_at && (
+                      <span>{t("memory.created")}: {formatDateTime(m.created_at)}</span>
+                    )}
+                    {m.accessed_at && (
+                      <span>{t("memory.last_access", { defaultValue: "Last access" })}: {formatDateTime(m.accessed_at)}</span>
+                    )}
+                    {m.access_count != null && m.access_count > 0 && (
+                      <span>{t("memory.access_count", { defaultValue: "Accessed" })}: {m.access_count}x</span>
+                    )}
+                    {m.agent_id && (
+                      <span>{t("memory.agent_label", { defaultValue: "Agent:" })} <span className="font-mono">{m.agent_id.slice(0, 8)}</span></span>
+                    )}
+                    {m.category && (
+                      <span>{t("memory.category", { defaultValue: "Category" })}: {m.category}</span>
+                    )}
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
       )}
+
+      {/* Per-agent KV memory — always shown */}
+      <AgentKvSection agents={agents} />
 
 
       {/* Dialogs */}

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -317,6 +317,10 @@ function formatKvValue(value: unknown): string {
 }
 
 const KV_VALUE_TRUNCATE = 200;
+// Cap the hover-preview too — large KV values (multi-KB JSON blobs) would
+// otherwise live in the DOM as a giant `title` attribute on every row,
+// inflating page memory for what's only meant to be a quick peek.
+const KV_TITLE_TRUNCATE = 2000;
 
 function AgentKvRows({ agentId }: { agentId: string }) {
   const { t } = useTranslation();
@@ -360,10 +364,14 @@ function AgentKvRows({ agentId }: { agentId: string }) {
           formatted.length > KV_VALUE_TRUNCATE
             ? formatted.slice(0, KV_VALUE_TRUNCATE) + "…"
             : formatted;
+        const titlePreview =
+          formatted.length > KV_TITLE_TRUNCATE
+            ? formatted.slice(0, KV_TITLE_TRUNCATE) + "…"
+            : formatted;
         return (
           <tr key={pair.key} className="border-t border-border-subtle/40">
             <td className="px-3 py-2 text-xs font-mono break-all">{pair.key}</td>
-            <td className="px-3 py-2 text-xs font-mono text-text-dim break-all" title={formatted}>
+            <td className="px-3 py-2 text-xs font-mono text-text-dim break-all" title={titlePreview}>
               {truncated}
             </td>
             <td className="px-3 py-2 text-xs text-text-dim">{pair.source ?? "-"}</td>

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -189,6 +189,10 @@ pub async fn memory_search(
 // ---------------------------------------------------------------------------
 
 /// List all proactive memories, optionally filtered by category, with pagination.
+///
+/// When proactive memory is disabled in config, returns an empty list with
+/// `proactive_enabled: false` (HTTP 200) so the dashboard can render an
+/// explanatory note instead of treating a config state as a server error.
 #[utoipa::path(
     get,
     path = "/api/memory",
@@ -204,9 +208,18 @@ pub async fn memory_list(
     State(state): State<Arc<AppState>>,
     Query(params): Query<MemoryListQuery>,
 ) -> impl IntoResponse {
-    let store = match get_pm_store(&state) {
-        Ok(s) => s,
-        Err(e) => return e,
+    // Graceful degradation: proactive memory disabled → empty list, not 500.
+    let Some(store) = state.kernel.proactive_memory_store().cloned() else {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "memories": [],
+                "total": 0,
+                "offset": params.offset,
+                "limit": params.limit.min(100),
+                "proactive_enabled": false,
+            })),
+        );
     };
 
     let limit = params.limit.min(100);
@@ -224,6 +237,7 @@ pub async fn memory_list(
                     "total": total,
                     "offset": offset,
                     "limit": limit,
+                    "proactive_enabled": true,
                 })),
             )
         }
@@ -453,6 +467,9 @@ pub async fn memory_bulk_delete(
 // ---------------------------------------------------------------------------
 
 /// Get memory statistics across all agents.
+///
+/// When proactive memory is disabled, returns `{stats: null, proactive_enabled: false}`
+/// at HTTP 200 — disabled is a config state, not an error.
 #[utoipa::path(
     get,
     path = "/api/memory/stats",
@@ -460,14 +477,31 @@ pub async fn memory_bulk_delete(
     responses((status = 200, description = "Memory statistics", body = serde_json::Value))
 )]
 pub async fn memory_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let store = match get_pm_store(&state) {
-        Ok(s) => s,
-        Err(e) => return e,
+    // Graceful degradation: proactive memory disabled → null stats, not 500.
+    let Some(store) = state.kernel.proactive_memory_store().cloned() else {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "stats": null,
+                "proactive_enabled": false,
+            })),
+        );
     };
 
-    // Aggregate stats across ALL agents so the dashboard shows global totals
+    // Aggregate stats across ALL agents so the dashboard shows global totals.
+    // Merge `proactive_enabled: true` into the stats object so callers can
+    // branch on a single field regardless of which path returned.
     match store.stats_all().await {
-        Ok(stats) => (StatusCode::OK, Json(serde_json::json!(stats))),
+        Ok(stats) => {
+            let mut value = serde_json::json!(stats);
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert(
+                    "proactive_enabled".to_string(),
+                    serde_json::Value::Bool(true),
+                );
+            }
+            (StatusCode::OK, Json(value))
+        }
         Err(e) => internal_error(e),
     }
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2388,10 +2388,7 @@ async fn start_full_router_with_proactive(enabled: bool) -> FullRouterHarness {
 /// dev-UX semantics). Without this, oneshot tests have no `ConnectInfo`
 /// extension and the fail-closed branch returns 401 for non-public paths.
 fn loopback_get(uri: &str) -> Request<Body> {
-    let mut request = Request::builder()
-        .uri(uri)
-        .body(Body::empty())
-        .unwrap();
+    let mut request = Request::builder().uri(uri).body(Body::empty()).unwrap();
     request
         .extensions_mut()
         .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2327,3 +2327,186 @@ async fn test_attach_session_stream_fans_out_to_multiple_clients() {
         "client B body should contain published event: {body_b}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Memory endpoint regression tests for issue #3070:
+// When `[proactive_memory] enabled = false`, GET /api/memory and
+// GET /api/memory/stats must return 200 with `proactive_enabled: false`,
+// not 500. Disabled is a config state, not a server error.
+// ---------------------------------------------------------------------------
+
+/// Build a router harness with `proactive_memory.enabled` toggleable.
+async fn start_full_router_with_proactive(enabled: bool) -> FullRouterHarness {
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
+
+    librefang_runtime::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_runtime::registry_sync::DEFAULT_CACHE_TTL_SECS,
+        "",
+    );
+
+    let proactive = librefang_types::memory::ProactiveMemoryConfig {
+        enabled,
+        ..librefang_types::memory::ProactiveMemoryConfig::default()
+    };
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        proactive_memory: proactive,
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+
+    let (app, state) = server::build_router(
+        kernel,
+        "127.0.0.1:0".parse().expect("listen addr should parse"),
+    )
+    .await;
+
+    FullRouterHarness {
+        app,
+        state,
+        _tmp: tmp,
+    }
+}
+
+/// Build a GET request to `uri` and inject loopback `ConnectInfo` so the
+/// auth middleware treats it as a localhost caller (matching production
+/// dev-UX semantics). Without this, oneshot tests have no `ConnectInfo`
+/// extension and the fail-closed branch returns 401 for non-public paths.
+fn loopback_get(uri: &str) -> Request<Body> {
+    let mut request = Request::builder()
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+    request
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_memory_list_returns_200_when_proactive_disabled() {
+    let harness = start_full_router_with_proactive(false).await;
+
+    let response = harness
+        .app
+        .clone()
+        .oneshot(loopback_get("/api/memory"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/api/memory must not 500 when proactive memory is disabled"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["proactive_enabled"], serde_json::json!(false));
+    assert_eq!(json["total"], serde_json::json!(0));
+    assert!(
+        json["memories"].as_array().is_some_and(|a| a.is_empty()),
+        "memories must be an empty array, got {}",
+        json["memories"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_memory_stats_returns_200_when_proactive_disabled() {
+    let harness = start_full_router_with_proactive(false).await;
+
+    let response = harness
+        .app
+        .clone()
+        .oneshot(loopback_get("/api/memory/stats"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/api/memory/stats must not 500 when proactive memory is disabled"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["proactive_enabled"], serde_json::json!(false));
+    assert!(
+        json["stats"].is_null(),
+        "stats must be null when disabled, got {}",
+        json["stats"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_memory_list_includes_proactive_enabled_when_enabled() {
+    let harness = start_full_router_with_proactive(true).await;
+
+    let response = harness
+        .app
+        .clone()
+        .oneshot(loopback_get("/api/memory"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // When enabled the legacy fields stay intact and `proactive_enabled: true`
+    // is added so the dashboard can branch on a single field.
+    assert_eq!(json["proactive_enabled"], serde_json::json!(true));
+    assert!(json["memories"].is_array(), "memories must be an array");
+    assert!(json["total"].is_number(), "total must be a number");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_memory_stats_includes_proactive_enabled_when_enabled() {
+    let harness = start_full_router_with_proactive(true).await;
+
+    let response = harness
+        .app
+        .clone()
+        .oneshot(loopback_get("/api/memory/stats"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["proactive_enabled"], serde_json::json!(true));
+    // Existing fields remain present; we only assert their types so we don't
+    // couple to a specific empty-database snapshot.
+    assert!(json["total"].is_number() || json["total"].is_null());
+}

--- a/openapi.json
+++ b/openapi.json
@@ -4595,6 +4595,7 @@
           "proactive-memory"
         ],
         "summary": "List all proactive memories, optionally filtered by category, with pagination.",
+        "description": "When proactive memory is disabled in config, returns an empty list with\n`proactive_enabled: false` (HTTP 200) so the dashboard can render an\nexplanatory note instead of treating a config state as a server error.",
         "operationId": "memory_list",
         "parameters": [
           {
@@ -5305,6 +5306,7 @@
           "proactive-memory"
         ],
         "summary": "Get memory statistics across all agents.",
+        "description": "When proactive memory is disabled, returns `{stats: null, proactive_enabled: false}`\nat HTTP 200 — disabled is a config state, not an error.",
         "operationId": "memory_stats",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary
Fixes #3070 — Memory page was unusable when `[memory.proactive] enabled = false`. Two underlying issues, both addressed in this PR.

### Server (`crates/librefang-api/src/routes/memory.rs`)
- `/api/memory` and `/api/memory/stats` previously returned **500** with `"Proactive memory is not enabled"` when proactive was off. That's a config state, not a server error.
- Now return **200**:
  - `GET /api/memory` → `{ memories: [], total: 0, proactive_enabled: false }`
  - `GET /api/memory/stats` → `{ stats: null, proactive_enabled: false }`
- When proactive IS enabled the responses gain a `proactive_enabled: true` flag alongside the existing fields — no breaking changes to the response shape.
- The internal `get_pm_store()` helper still returns its 500 for endpoints that genuinely require proactive memory (search, ingest, etc.); only the read-list and stats endpoints degrade gracefully.

### Dashboard (`MemoryPage.tsx` + new query)
- New `useAgentKvMemory(agentId)` hook hitting `/api/memory/agents/{id}/kv`. Query key from `memoryKeys.agentKv(agentId)` factory entry — never inline arrays.
- New "Per-agent KV memory" section renders **unconditionally** — lists agents and shows each agent's KV pairs (key / value / source / created_at).
- When `proactive_enabled === false`: hide proactive sections (search, semantic, stats), show a small notice card explaining the state, keep KV section visible.
- When `proactive_enabled === true`: keep the proactive sections as before AND show the KV section underneath. Most users don't distinguish proactive vs KV — issue prefers the unified view.

## Test plan
Server-side tests already in `crates/librefang-api/tests/api_integration_test.rs` (4 cases):
- `test_memory_list_returns_200_when_proactive_disabled`
- `test_memory_stats_returns_200_when_proactive_disabled`
- `test_memory_list_includes_proactive_enabled_when_enabled`
- `test_memory_stats_includes_proactive_enabled_when_enabled`

Dashboard manual checks:
- [ ] `[memory.proactive] enabled = false` → Memory page renders KV memories without error
- [ ] `[memory.proactive] enabled = true` → Memory page renders proactive sections + KV section underneath
- [ ] Agent with no KV memories → empty-state row, no error
- [ ] Existing `useMemoryStats` callers still get the same fields (stats top-level just gains `proactive_enabled: true`)

Closes #3070.
