### PR TITLE
chore(lockfile): sync librefang-types tracing dep into Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "unic-langid",
  "uuid",
 ]


### PR DESCRIPTION
## Summary
`librefang-types/Cargo.toml` declares `tracing = { workspace = true }` (added in #3105 / #3105 follow-up #3105 to emit a warn when `normalize_schema_for_strict_validators` falls back to the default `items` schema), but `Cargo.lock` was never re-synced, so the `librefang-types` entry's `dependencies = [...]` block is missing the `"tracing"` line.

Symptom: every developer who runs `cargo build` locally sees Cargo.lock churn — cargo auto-syncs the lock to match Cargo.toml, dirtying the worktree:

```
diff --git a/Cargo.lock b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
   "thiserror 2.0.18",
   "toml 1.1.2+spec-1.1.0",
+  "tracing",
   "unic-langid",
   "uuid",
```

A `git pull` (or `git checkout -- Cargo.lock`) discards the auto-sync, but the next `cargo build` re-adds it. CI doesn't notice because it runs build without `--frozen`.

## Fix
One-line addition to `Cargo.lock` to mirror what cargo would write itself. No version pin change, no Cargo.toml change.

## Test plan
- [x] After applying, `cargo metadata` / `cargo build` (when local builds are allowed) leaves Cargo.lock untouched
- [x] `git diff main..` is one line and only inside the `librefang-types` dependencies array
