### PR TITLE
feat(runtime): model metadata lookup pipeline (PR-1/3, layers 1+2+5)

### DIFF
--- a/crates/librefang-hands/src/lib.rs
+++ b/crates/librefang-hands/src/lib.rs
@@ -311,6 +311,8 @@ impl From<LegacyHandAgentConfig> for AgentManifest {
                 system_prompt: legacy.system_prompt,
                 api_key_env: legacy.api_key_env,
                 base_url: legacy.base_url,
+                context_window: None,
+                max_output_tokens: None,
                 extra_params: std::collections::HashMap::new(),
             },
             autonomous: legacy.max_iterations.map(|max_iter| AutonomousConfig {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -450,6 +450,8 @@ fn test_spawn_agent_applies_local_default_model_override() {
                     system_prompt: String::new(),
                     api_key_env: None,
                     base_url: None,
+                    context_window: None,
+                    max_output_tokens: None,
                     extra_params: std::collections::HashMap::new(),
                 },
                 ..Default::default()
@@ -692,6 +694,8 @@ fn test_set_agent_model_clears_overrides_when_provider_changes() {
                     system_prompt: String::new(),
                     api_key_env: Some("CLOUDVERSE_API_KEY".to_string()),
                     base_url: Some("https://cloudverse.freshworkscorp.com/api/v1".to_string()),
+                    context_window: None,
+                    max_output_tokens: None,
                     extra_params: std::collections::HashMap::new(),
                 },
                 ..Default::default()

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -160,6 +160,8 @@ impl SetupWizard {
                 system_prompt,
                 api_key_env: None,
                 base_url: None,
+                context_window: None,
+                max_output_tokens: None,
                 extra_params: std::collections::HashMap::new(),
             },
             resources: ResourceQuota::default(),

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -48,6 +48,7 @@ pub mod mcp_server;
 pub mod media;
 pub mod media_understanding;
 pub mod model_catalog;
+pub mod model_metadata;
 pub mod pdf_text;
 pub mod pii_filter;
 pub mod plugin_manager;

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -64,10 +64,7 @@ impl ModelCatalog {
     /// without going through TOML loading. Used by sibling modules' unit
     /// tests (`model_metadata`, etc.) so they can inject deterministic
     /// fixtures without touching the filesystem.
-    pub fn from_entries(
-        models: Vec<ModelCatalogEntry>,
-        providers: Vec<ProviderInfo>,
-    ) -> Self {
+    pub fn from_entries(models: Vec<ModelCatalogEntry>, providers: Vec<ProviderInfo>) -> Self {
         let mut aliases: HashMap<String, String> = HashMap::new();
         for m in &models {
             for alias in &m.aliases {
@@ -418,9 +415,10 @@ impl ModelCatalog {
 
         // Pass 2: alias resolution restricted to the provider.
         if let Some(canonical) = self.aliases.get(&want_id) {
-            return self.models.iter().find(|m| {
-                m.provider.to_lowercase() == want_provider && m.id == *canonical
-            });
+            return self
+                .models
+                .iter()
+                .find(|m| m.provider.to_lowercase() == want_provider && m.id == *canonical);
         }
 
         None
@@ -1322,11 +1320,9 @@ id = "acme"
     #[test]
     fn test_find_model_for_provider_case_insensitive_provider() {
         let catalog = test_catalog();
-        assert!(
-            catalog
-                .find_model_for_provider("ANTHROPIC", "claude-sonnet-4-20250514")
-                .is_some(),
-        );
+        assert!(catalog
+            .find_model_for_provider("ANTHROPIC", "claude-sonnet-4-20250514")
+            .is_some(),);
     }
 
     /// Alias resolution is also provider-scoped: `"sonnet"` must resolve

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -58,6 +58,34 @@ fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, b
     (supports_vision, true, supports_thinking)
 }
 
+#[cfg(test)]
+impl ModelCatalog {
+    /// Test-only constructor: build a catalog directly from owned entries
+    /// without going through TOML loading. Used by sibling modules' unit
+    /// tests (`model_metadata`, etc.) so they can inject deterministic
+    /// fixtures without touching the filesystem.
+    pub fn from_entries(
+        models: Vec<ModelCatalogEntry>,
+        providers: Vec<ProviderInfo>,
+    ) -> Self {
+        let mut aliases: HashMap<String, String> = HashMap::new();
+        for m in &models {
+            for alias in &m.aliases {
+                aliases
+                    .entry(alias.to_lowercase())
+                    .or_insert_with(|| m.id.clone());
+            }
+        }
+        Self {
+            models,
+            aliases,
+            providers,
+            suppressed_providers: HashSet::new(),
+            overrides: HashMap::new(),
+        }
+    }
+}
+
 impl ModelCatalog {
     /// Create a new catalog by loading providers from `home_dir/providers/`
     /// and aliases from `home_dir/aliases.toml`.
@@ -340,6 +368,62 @@ impl ModelCatalog {
     /// List all models in the catalog.
     pub fn list_models(&self) -> &[ModelCatalogEntry] {
         &self.models
+    }
+
+    /// Find a model by canonical ID restricted to a specific provider.
+    ///
+    /// Same model ID can exist under multiple providers with different
+    /// `context_window` values (e.g. `claude-opus-4-7` is 1M on
+    /// `anthropic` but 128K on `copilot`). [`Self::find_model`] is
+    /// provider-blind and may return the first match — this method
+    /// resolves the ambiguity when the caller knows which provider the
+    /// agent is targeting.
+    ///
+    /// Resolution order:
+    /// 1. Exact `(provider, id)` match (case-insensitive on both).
+    /// 2. Exact `(provider, alias)` match resolved via the alias map.
+    /// 3. `None`. Callers fall back to [`Self::find_model`] for
+    ///    cross-provider lookup.
+    ///
+    /// `provider` matches case-insensitively. An empty `provider`
+    /// disables the provider filter and behaves like
+    /// [`Self::find_model`].
+    pub fn find_model_for_provider(
+        &self,
+        provider: &str,
+        id_or_alias: &str,
+    ) -> Option<&ModelCatalogEntry> {
+        if provider.is_empty() {
+            return self.find_model(id_or_alias);
+        }
+        let want_provider = provider.to_lowercase();
+        let want_id = id_or_alias.to_lowercase();
+
+        // Pass 1: exact (provider, id) match. Custom-tier wins, otherwise
+        // first occurrence (mirrors the precedence in `find_model`).
+        let mut found: Option<&ModelCatalogEntry> = None;
+        for m in &self.models {
+            if m.provider.to_lowercase() == want_provider && m.id.to_lowercase() == want_id {
+                if m.tier == ModelTier::Custom {
+                    return Some(m);
+                }
+                if found.is_none() {
+                    found = Some(m);
+                }
+            }
+        }
+        if let Some(entry) = found {
+            return Some(entry);
+        }
+
+        // Pass 2: alias resolution restricted to the provider.
+        if let Some(canonical) = self.aliases.get(&want_id) {
+            return self.models.iter().find(|m| {
+                m.provider.to_lowercase() == want_provider && m.id == *canonical
+            });
+        }
+
+        None
     }
 
     /// Find a model by its canonical ID, display name, or alias.
@@ -1194,6 +1278,73 @@ id = "acme"
     fn test_find_model_not_found() {
         let catalog = test_catalog();
         assert!(catalog.find_model("nonexistent-model").is_none());
+    }
+
+    /// `find_model_for_provider` must filter by provider so the same model
+    /// id under different providers (which can differ in `context_window`)
+    /// resolves to the right entry. The test catalog has
+    /// `claude-sonnet-4-20250514` only under `anthropic`, so a copilot
+    /// lookup of the same id must miss.
+    #[test]
+    fn test_find_model_for_provider_filters_by_provider() {
+        let catalog = test_catalog();
+        assert!(
+            catalog
+                .find_model_for_provider("anthropic", "claude-sonnet-4-20250514")
+                .is_some(),
+            "anthropic catalog hit expected"
+        );
+        assert!(
+            catalog
+                .find_model_for_provider("copilot", "claude-sonnet-4-20250514")
+                .is_none(),
+            "no copilot entry for the anthropic id should exist",
+        );
+    }
+
+    /// Empty `provider` arg disables filtering and behaves like
+    /// `find_model`. Useful when the agent's manifest has no provider
+    /// configured (e.g. fresh install before any provider key is set).
+    #[test]
+    fn test_find_model_for_provider_empty_provider_falls_back() {
+        let catalog = test_catalog();
+        let via_filtered = catalog
+            .find_model_for_provider("", "claude-sonnet-4-20250514")
+            .expect("empty provider should match anyway");
+        let via_unfiltered = catalog
+            .find_model("claude-sonnet-4-20250514")
+            .expect("unfiltered match");
+        assert_eq!(via_filtered.id, via_unfiltered.id);
+    }
+
+    /// Provider matching is case-insensitive — registries sometimes
+    /// store providers as `Anthropic` while manifests use `anthropic`.
+    #[test]
+    fn test_find_model_for_provider_case_insensitive_provider() {
+        let catalog = test_catalog();
+        assert!(
+            catalog
+                .find_model_for_provider("ANTHROPIC", "claude-sonnet-4-20250514")
+                .is_some(),
+        );
+    }
+
+    /// Alias resolution is also provider-scoped: `"sonnet"` must resolve
+    /// to the anthropic entry under `provider="anthropic"`, but a query
+    /// against an unrelated provider with the same alias must miss.
+    #[test]
+    fn test_find_model_for_provider_alias_is_scoped() {
+        let catalog = test_catalog();
+        let r = catalog
+            .find_model_for_provider("anthropic", "sonnet")
+            .expect("alias under anthropic");
+        assert_eq!(r.id, "claude-sonnet-4-6");
+        assert!(
+            catalog
+                .find_model_for_provider("openai", "sonnet")
+                .is_none(),
+            "alias must not leak across providers",
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_metadata.rs
+++ b/crates/librefang-runtime/src/model_metadata.rs
@@ -1,0 +1,576 @@
+//! Model metadata lookup pipeline.
+//!
+//! Resolves a model's `context_window` (and optionally `max_output_tokens`)
+//! through a layered fallback chain so the agent loop never has to fall back
+//! to a coarse `200_000` default when the catalog misses or the user runs a
+//! self-hosted endpoint with a non-standard window.
+//!
+//! See `.plans/model-metadata-lookup.md` for the full design and the
+//! 5-layer rationale. **PR-1 (this module) lands layers 1, 2, and 5 only**:
+//!
+//! | Layer | Source | This PR |
+//! |---|---|---|
+//! | L1 | Agent manifest override (`model.context_window`) | ✅ |
+//! | L2 | Registry / `ModelCatalog` (provider-aware) | ✅ |
+//! | L3 | Persisted cache (`~/.librefang/cache/model_metadata.json`) | M2 |
+//! | L4 | Runtime probe (`/v1/models`, `/api/show`) | M2 |
+//! | L5 | Hardcoded fallback (< 20 entries) | ✅ |
+//!
+//! `resolve_model_metadata` is currently **passive** — no caller wires it
+//! into `agent_loop` yet. M3 will replace the
+//! `cat.find_model(...).map(|m| m.context_window).filter(|w| *w > 0)`
+//! call sites in `kernel/mod.rs` with a single `resolve_model_metadata`
+//! invocation.
+
+use librefang_types::model_catalog::{ModelCatalogEntry, ModelTier, Modality};
+use std::borrow::Cow;
+
+use crate::model_catalog::ModelCatalog;
+
+/// Result of a metadata lookup, plus the layer that produced it (for
+/// telemetry — the dashboard surfaces this string so users can see *why*
+/// their context window resolved to a particular value).
+#[derive(Debug, Clone)]
+pub struct ResolvedModel<'a> {
+    pub entry: Cow<'a, ModelCatalogEntry>,
+    pub source: MetadataSource,
+}
+
+/// Which layer of the lookup pipeline produced this metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataSource {
+    /// L1 — explicit `[model] context_window = N` in agent.toml.
+    AgentManifest,
+    /// L2 — entry returned by `ModelCatalog::find_model_for_provider`.
+    Registry,
+    /// L3 — fresh entry in the persisted cache (M2 / not yet wired).
+    PersistedCache,
+    /// L4 — live `/v1/models` or `/api/show` probe (M2 / not yet wired).
+    RuntimeProbe,
+    /// L5 — substring match in [`HARDCODED_FALLBACKS`].
+    HardcodedFallback,
+    /// L5 tail — anthropic-host generic default (200K).
+    Default200kAnthropic,
+    /// L5 tail — generic default for unknown providers (32K).
+    Default32k,
+}
+
+impl MetadataSource {
+    /// Stable string used in tracing and the dashboard surface.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentManifest => "agent_manifest",
+            Self::Registry => "registry",
+            Self::PersistedCache => "persisted_cache",
+            Self::RuntimeProbe => "runtime_probe",
+            Self::HardcodedFallback => "hardcoded_fallback",
+            Self::Default200kAnthropic => "default_200k_anthropic",
+            Self::Default32k => "default_32k",
+        }
+    }
+}
+
+/// Inputs to a metadata lookup.
+///
+/// `provider` is the agent's configured provider name (e.g. `"anthropic"`,
+/// `"ollama"`). It can be empty when unknown — the pipeline will then
+/// degrade `find_model_for_provider` to a provider-blind `find_model` and
+/// the substring fallback table will look at the bare model name.
+#[derive(Debug, Clone, Copy)]
+pub struct MetadataRequest<'a> {
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub base_url: Option<&'a str>,
+    pub manifest_override_context: Option<u64>,
+    pub manifest_override_max_output: Option<u64>,
+}
+
+/// Built-in last-resort table for `context_window` lookup.
+///
+/// Each entry is a (lowercase substring, context_window) pair. At lookup
+/// time we lowercase the model ID, sort by **longest key first**, and
+/// take the first substring hit so `claude-sonnet-4-6` matches the 1M
+/// entry instead of the more permissive `claude` 200K entry.
+///
+/// **Deliberately small (< 20 entries).** The registry already covers
+/// every supported model with full pricing/capabilities; this table only
+/// catches the case where the registry is stale (new model id) or
+/// missing (offline daemon, fresh install).
+const HARDCODED_FALLBACKS: &[(&str, u64)] = &[
+    // Anthropic — order matters: longer (more specific) keys first when
+    // the lookup loop sorts them.
+    ("claude-opus-4-7", 1_000_000),
+    ("claude-opus-4-6", 1_000_000),
+    ("claude-sonnet-4-6", 1_000_000),
+    ("claude-haiku-4-5", 200_000),
+    ("claude", 200_000),
+    // OpenAI
+    ("gpt-5.4", 1_050_000),
+    ("gpt-5", 400_000),
+    ("gpt-4.1", 1_047_576),
+    ("gpt-4", 128_000),
+    // Google
+    ("gemini-2", 1_048_576),
+    ("gemini", 1_048_576),
+    ("gemma-3", 131_072),
+    // Open weights
+    ("deepseek", 128_000),
+    ("llama", 131_072),
+    ("qwen3-coder", 262_144),
+    ("qwen", 131_072),
+    ("kimi", 262_144),
+    ("nemotron", 131_072),
+    ("grok-4", 256_000),
+    ("grok", 131_072),
+];
+
+/// Last-resort default when neither registry, cache, probe, nor the
+/// hardcoded table can identify the model. Returned together with
+/// `MetadataSource::Default32k` (or `Default200kAnthropic` when the
+/// provider is recognisably Anthropic).
+const DEFAULT_GENERIC_CONTEXT: u64 = 32_768;
+const DEFAULT_ANTHROPIC_CONTEXT: u64 = 200_000;
+
+/// Provider-prefix tokens stripped from model IDs at the top of the
+/// pipeline (e.g. `openrouter:claude-opus-4-7` → `claude-opus-4-7`).
+///
+/// Mirrors hermes-agent's `_PROVIDER_PREFIXES` frozenset.
+const PROVIDER_PREFIXES: &[&str] = &[
+    "openrouter",
+    "anthropic",
+    "openai",
+    "openai-codex",
+    "gemini",
+    "google",
+    "deepseek",
+    "ollama",
+    "ollama-cloud",
+    "copilot",
+    "github",
+    "github-copilot",
+    "kimi",
+    "moonshot",
+    "stepfun",
+    "minimax",
+    "alibaba",
+    "qwen",
+    "qwen-oauth",
+    "xai",
+    "grok",
+    "z-ai",
+    "zai",
+    "glm",
+    "nvidia",
+    "nim",
+    "bedrock",
+    "groq",
+    "fireworks",
+    "novita",
+    "custom",
+    "local",
+];
+
+/// Strip a leading `provider:` prefix when the prefix is a recognised
+/// provider name. Preserves Ollama-style `model:tag` IDs (e.g. `qwen:7b`,
+/// `llama3:70b-q4`) — for those the part after `:` is a model variant,
+/// not a provider name.
+///
+/// We use a conservative heuristic: strip only when the prefix is in
+/// [`PROVIDER_PREFIXES`] **and** the suffix doesn't match common Ollama
+/// tag patterns (a digit + `b` size suffix, `latest`, quantisation tag,
+/// or one of `instruct/chat/coder/vision/text`).
+fn strip_provider_prefix(model: &str) -> &str {
+    if !model.contains(':') || model.starts_with("http") {
+        return model;
+    }
+    let Some((prefix, suffix)) = model.split_once(':') else {
+        return model;
+    };
+    let prefix_lc = prefix.to_ascii_lowercase();
+    if !PROVIDER_PREFIXES.contains(&prefix_lc.as_str()) {
+        return model;
+    }
+    if looks_like_ollama_tag(suffix) {
+        return model;
+    }
+    suffix
+}
+
+/// Heuristic: does this suffix look like an Ollama model tag rather than
+/// the bare model id under a `provider:` prefix?
+///
+/// Returns `true` for: bare digit-letter size tokens (`7b`, `27b`,
+/// `0.5b`), the literals `latest`/`stable`, quantisation prefixes
+/// (`q4`, `q4_K_M`, `fp16`), and common variant tags (`instruct`,
+/// `chat`, `coder`, `vision`, `text`).
+fn looks_like_ollama_tag(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "latest" | "stable" | "instruct" | "chat" | "coder" | "vision" | "text"
+    ) {
+        return true;
+    }
+    // size: starts with digit, ends with 'b' (with an optional decimal).
+    if lower.ends_with('b') {
+        let body = &lower[..lower.len() - 1];
+        if !body.is_empty() && body.chars().all(|c| c.is_ascii_digit() || c == '.') {
+            return true;
+        }
+    }
+    // quantisation: q\d+, fp\d+
+    let quant_prefix = lower.starts_with('q')
+        && lower
+            .chars()
+            .nth(1)
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false);
+    let fp_prefix = lower.starts_with("fp")
+        && lower
+            .chars()
+            .nth(2)
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false);
+    quant_prefix || fp_prefix
+}
+
+/// Hardcoded substring lookup. Returns the longest matching key's value.
+///
+/// The match is case-insensitive on the model ID. Substring keys are
+/// sorted longest-first at each call (the table is < 20 entries, so the
+/// allocation cost is negligible compared to a full lookup pipeline run).
+fn lookup_hardcoded(model_id: &str) -> Option<u64> {
+    let lower = model_id.to_ascii_lowercase();
+    let mut keys: Vec<(&str, u64)> = HARDCODED_FALLBACKS.to_vec();
+    keys.sort_by_key(|(k, _)| std::cmp::Reverse(k.len()));
+    for (needle, ctx) in keys {
+        if lower.contains(needle) {
+            return Some(ctx);
+        }
+    }
+    None
+}
+
+/// Build a synthetic `ModelCatalogEntry` for a layer that doesn't have a
+/// registry-backed entry to borrow (L1 / L5).
+fn synthesize_entry(
+    model: &str,
+    provider: &str,
+    context_window: u64,
+    max_output_tokens: u64,
+) -> ModelCatalogEntry {
+    ModelCatalogEntry {
+        id: model.to_string(),
+        display_name: model.to_string(),
+        provider: provider.to_string(),
+        tier: ModelTier::Custom,
+        modality: Modality::Text,
+        context_window,
+        max_output_tokens,
+        input_cost_per_m: 0.0,
+        output_cost_per_m: 0.0,
+        image_input_cost_per_m: None,
+        image_output_cost_per_m: None,
+        supports_tools: false,
+        supports_vision: false,
+        supports_streaming: false,
+        supports_thinking: false,
+        aliases: Vec::new(),
+    }
+}
+
+/// Whether this provider name is anthropic-shaped — used to pick the
+/// 200K vs 32K final default. Matches the bare `"anthropic"` provider
+/// plus claude-routed providers like `bedrock` and `vertexai` whose
+/// catalog entries are also Claude models with 200K minimum windows.
+fn is_anthropic_host(provider: &str, model_id: &str) -> bool {
+    let p = provider.to_ascii_lowercase();
+    if p == "anthropic" || p == "claude-code" {
+        return true;
+    }
+    // Heuristic on model id: claude-* models served via OpenRouter,
+    // bedrock, etc. should still get the anthropic default.
+    model_id.to_ascii_lowercase().starts_with("claude")
+}
+
+/// Resolve metadata for a model through layers 1, 2, and 5.
+///
+/// Layers 3 and 4 are placeholders in this PR — when wired in M2 they'll
+/// slot between L2 and L5 without changing this function's signature.
+///
+/// Always returns a populated [`ResolvedModel`]; the worst case is a
+/// `Default32k` synthesised entry. Callers can therefore treat the
+/// `Option<usize>` problem as solved at this boundary.
+pub fn resolve_model_metadata<'a>(
+    catalog: &'a ModelCatalog,
+    request: &MetadataRequest<'_>,
+) -> ResolvedModel<'a> {
+    // ----- Layer 1: agent manifest override -----
+    if let Some(ctx) = request.manifest_override_context.filter(|v| *v > 0) {
+        let max_out = request.manifest_override_max_output.unwrap_or(0);
+        let entry = synthesize_entry(request.model, request.provider, ctx, max_out);
+        return ResolvedModel {
+            entry: Cow::Owned(entry),
+            source: MetadataSource::AgentManifest,
+        };
+    }
+
+    // ----- Layer 2: provider-aware registry lookup -----
+    let stripped = strip_provider_prefix(request.model);
+    if let Some(entry) = catalog.find_model_for_provider(request.provider, stripped) {
+        if entry.context_window > 0 {
+            return ResolvedModel {
+                entry: Cow::Borrowed(entry),
+                source: MetadataSource::Registry,
+            };
+        }
+    }
+    // Fall back to provider-blind lookup: same model under any provider.
+    // Useful when the agent's `provider` is empty or stale relative to
+    // the registry layout (registry providers may rename across syncs).
+    if let Some(entry) = catalog.find_model(stripped) {
+        if entry.context_window > 0 {
+            return ResolvedModel {
+                entry: Cow::Borrowed(entry),
+                source: MetadataSource::Registry,
+            };
+        }
+    }
+
+    // ----- Layer 3 and 4 are M2 — fall through to L5 for now. -----
+
+    // ----- Layer 5: hardcoded substring table + provider default -----
+    if let Some(ctx) = lookup_hardcoded(stripped) {
+        let entry = synthesize_entry(request.model, request.provider, ctx, 0);
+        return ResolvedModel {
+            entry: Cow::Owned(entry),
+            source: MetadataSource::HardcodedFallback,
+        };
+    }
+
+    // Final default: anthropic-shaped → 200K, anything else → 32K.
+    if is_anthropic_host(request.provider, stripped) {
+        let entry = synthesize_entry(
+            request.model,
+            request.provider,
+            DEFAULT_ANTHROPIC_CONTEXT,
+            0,
+        );
+        return ResolvedModel {
+            entry: Cow::Owned(entry),
+            source: MetadataSource::Default200kAnthropic,
+        };
+    }
+    let entry = synthesize_entry(request.model, request.provider, DEFAULT_GENERIC_CONTEXT, 0);
+    ResolvedModel {
+        entry: Cow::Owned(entry),
+        source: MetadataSource::Default32k,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use librefang_types::model_catalog::{ModelCatalogEntry, ModelTier, Modality};
+
+    /// Build a minimal in-memory catalog with the given entries; bypasses
+    /// the TOML loader so unit tests don't need fixtures on disk.
+    fn catalog_with(entries: Vec<ModelCatalogEntry>) -> ModelCatalog {
+        ModelCatalog::from_entries(entries, vec![])
+    }
+
+    fn entry(provider: &str, id: &str, context_window: u64) -> ModelCatalogEntry {
+        ModelCatalogEntry {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            provider: provider.to_string(),
+            tier: ModelTier::Balanced,
+            modality: Modality::Text,
+            context_window,
+            max_output_tokens: 4096,
+            input_cost_per_m: 0.0,
+            output_cost_per_m: 0.0,
+            image_input_cost_per_m: None,
+            image_output_cost_per_m: None,
+            supports_tools: false,
+            supports_vision: false,
+            supports_streaming: false,
+            supports_thinking: false,
+            aliases: vec![],
+        }
+    }
+
+    fn req<'a>(provider: &'a str, model: &'a str) -> MetadataRequest<'a> {
+        MetadataRequest {
+            provider,
+            model,
+            base_url: None,
+            manifest_override_context: None,
+            manifest_override_max_output: None,
+        }
+    }
+
+    #[test]
+    fn layer_1_manifest_override_wins() {
+        let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
+        let mut request = req("anthropic", "claude-opus-4-7");
+        request.manifest_override_context = Some(196_608);
+        let resolved = resolve_model_metadata(&cat, &request);
+        assert_eq!(resolved.source, MetadataSource::AgentManifest);
+        assert_eq!(resolved.entry.context_window, 196_608);
+    }
+
+    #[test]
+    fn layer_1_zero_override_skipped() {
+        let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
+        let mut request = req("anthropic", "claude-opus-4-7");
+        // 0 must be treated as "unset" — falling through to L2.
+        request.manifest_override_context = Some(0);
+        let resolved = resolve_model_metadata(&cat, &request);
+        assert_eq!(resolved.source, MetadataSource::Registry);
+        assert_eq!(resolved.entry.context_window, 1_000_000);
+    }
+
+    #[test]
+    fn layer_2_provider_aware_disambiguates() {
+        // Same id under two providers with different windows.
+        let cat = catalog_with(vec![
+            entry("anthropic", "claude-opus-4-7", 1_000_000),
+            entry("copilot", "claude-opus-4-7", 128_000),
+        ]);
+        let r_anthropic = resolve_model_metadata(&cat, &req("anthropic", "claude-opus-4-7"));
+        assert_eq!(r_anthropic.entry.context_window, 1_000_000);
+        let r_copilot = resolve_model_metadata(&cat, &req("copilot", "claude-opus-4-7"));
+        assert_eq!(r_copilot.entry.context_window, 128_000);
+    }
+
+    #[test]
+    fn layer_2_zero_context_falls_through_to_l5() {
+        // Catalog has the entry but its context_window is 0 (e.g. an
+        // Ollama-discovered model that hasn't been probed yet). L2 must
+        // skip it — registry data with 0 is "unknown", not "zero tokens".
+        let cat = catalog_with(vec![entry("ollama", "qwen3-coder:30b", 0)]);
+        let resolved = resolve_model_metadata(&cat, &req("ollama", "qwen3-coder:30b"));
+        // Hardcoded substring table picks up "qwen3-coder" → 262144.
+        assert_eq!(resolved.source, MetadataSource::HardcodedFallback);
+        assert_eq!(resolved.entry.context_window, 262_144);
+    }
+
+    #[test]
+    fn layer_5_hardcoded_substring_longest_key_wins() {
+        let cat = catalog_with(vec![]);
+        // "claude-opus-4-6" must beat the more permissive "claude" key.
+        let r1 = resolve_model_metadata(&cat, &req("anthropic", "claude-opus-4-6"));
+        assert_eq!(r1.source, MetadataSource::HardcodedFallback);
+        assert_eq!(r1.entry.context_window, 1_000_000);
+
+        // "claude-haiku-4-5" beats bare "claude" (200K both, but the
+        // longest-key precedence is what guarantees the haiku-specific
+        // entry takes effect when its number ever diverges).
+        let r2 = resolve_model_metadata(&cat, &req("anthropic", "claude-haiku-4-5"));
+        assert_eq!(r2.source, MetadataSource::HardcodedFallback);
+
+        // Bare "claude-3-5-sonnet" not in the table → falls to "claude"
+        // catch-all (200K).
+        let r3 = resolve_model_metadata(&cat, &req("anthropic", "claude-3-5-sonnet"));
+        assert_eq!(r3.source, MetadataSource::HardcodedFallback);
+        assert_eq!(r3.entry.context_window, 200_000);
+    }
+
+    #[test]
+    fn layer_5_anthropic_default_for_unknown_claude() {
+        // Model id contains "claude" → the substring table catches it,
+        // not the Default200kAnthropic tail. To reach the tail we need
+        // a model id outside the table but a provider that's anthropic.
+        let cat = catalog_with(vec![]);
+        let r = resolve_model_metadata(&cat, &req("anthropic", "totally-unknown-model"));
+        assert_eq!(r.source, MetadataSource::Default200kAnthropic);
+        assert_eq!(r.entry.context_window, 200_000);
+    }
+
+    #[test]
+    fn layer_5_generic_default_for_unknown_non_anthropic() {
+        let cat = catalog_with(vec![]);
+        let r = resolve_model_metadata(&cat, &req("custom", "totally-unknown-model"));
+        assert_eq!(r.source, MetadataSource::Default32k);
+        assert_eq!(r.entry.context_window, 32_768);
+    }
+
+    #[test]
+    fn provider_prefix_stripped_for_known_providers() {
+        assert_eq!(strip_provider_prefix("openrouter:claude-opus-4-7"), "claude-opus-4-7");
+        assert_eq!(strip_provider_prefix("anthropic:claude-haiku-4-5"), "claude-haiku-4-5");
+        assert_eq!(strip_provider_prefix("local:my-llama"), "my-llama");
+    }
+
+    #[test]
+    fn provider_prefix_preserved_for_ollama_tags() {
+        // Bare model:size form must NOT be stripped (the 7b is the tag,
+        // not a model id under `qwen:` provider).
+        assert_eq!(strip_provider_prefix("qwen:7b"), "qwen:7b");
+        assert_eq!(strip_provider_prefix("llama:0.5b"), "llama:0.5b");
+        assert_eq!(strip_provider_prefix("qwen:latest"), "qwen:latest");
+        assert_eq!(strip_provider_prefix("llama3:70b-q4_K_M"), "llama3:70b-q4_K_M");
+        assert_eq!(strip_provider_prefix("qwen:q4"), "qwen:q4");
+        assert_eq!(strip_provider_prefix("mistral:fp16"), "mistral:fp16");
+        assert_eq!(strip_provider_prefix("llama2:instruct"), "llama2:instruct");
+    }
+
+    #[test]
+    fn provider_prefix_unknown_namespace_preserved() {
+        // `myorg:custom` — myorg isn't in PROVIDER_PREFIXES, so stripping
+        // would drop the namespace and let "custom" leak through.
+        assert_eq!(strip_provider_prefix("myorg:custom"), "myorg:custom");
+        // URLs are also left alone (caller may pass full base_url-style
+        // identifiers in some flows).
+        assert_eq!(
+            strip_provider_prefix("https://example.com/models/foo"),
+            "https://example.com/models/foo",
+        );
+    }
+
+    #[test]
+    fn provider_aware_lookup_with_prefix_in_request() {
+        // Request carries `openrouter:claude-opus-4-7` but the catalog
+        // entry is keyed on the bare id.
+        let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
+        let r = resolve_model_metadata(&cat, &req("anthropic", "openrouter:claude-opus-4-7"));
+        assert_eq!(r.source, MetadataSource::Registry);
+        assert_eq!(r.entry.context_window, 1_000_000);
+    }
+
+    #[test]
+    fn empty_provider_falls_back_to_unscoped_lookup() {
+        let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
+        let r = resolve_model_metadata(&cat, &req("", "claude-opus-4-7"));
+        assert_eq!(r.source, MetadataSource::Registry);
+        assert_eq!(r.entry.context_window, 1_000_000);
+    }
+
+    #[test]
+    fn metadata_source_str_round_trip() {
+        for s in [
+            MetadataSource::AgentManifest,
+            MetadataSource::Registry,
+            MetadataSource::PersistedCache,
+            MetadataSource::RuntimeProbe,
+            MetadataSource::HardcodedFallback,
+            MetadataSource::Default200kAnthropic,
+            MetadataSource::Default32k,
+        ] {
+            assert!(!s.as_str().is_empty());
+        }
+    }
+
+    /// Defence-in-depth: providers also gets dropped into the synthesised
+    /// fallback entry so the kernel can later log `provider=...` even
+    /// when the catalog miss synthesised the result.
+    #[test]
+    fn fallback_entry_carries_request_provider() {
+        let cat = catalog_with(vec![]);
+        let r = resolve_model_metadata(&cat, &req("ollama", "totally-unknown"));
+        assert_eq!(r.entry.provider, "ollama");
+        assert_eq!(r.entry.id, "totally-unknown");
+    }
+
+}

--- a/crates/librefang-runtime/src/model_metadata.rs
+++ b/crates/librefang-runtime/src/model_metadata.rs
@@ -22,7 +22,7 @@
 //! call sites in `kernel/mod.rs` with a single `resolve_model_metadata`
 //! invocation.
 
-use librefang_types::model_catalog::{ModelCatalogEntry, ModelTier, Modality};
+use librefang_types::model_catalog::{Modality, ModelCatalogEntry, ModelTier};
 use std::borrow::Cow;
 
 use crate::model_catalog::ModelCatalog;
@@ -371,7 +371,7 @@ pub fn resolve_model_metadata<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use librefang_types::model_catalog::{ModelCatalogEntry, ModelTier, Modality};
+    use librefang_types::model_catalog::{Modality, ModelCatalogEntry, ModelTier};
 
     /// Build a minimal in-memory catalog with the given entries; bypasses
     /// the TOML loader so unit tests don't need fixtures on disk.
@@ -498,8 +498,14 @@ mod tests {
 
     #[test]
     fn provider_prefix_stripped_for_known_providers() {
-        assert_eq!(strip_provider_prefix("openrouter:claude-opus-4-7"), "claude-opus-4-7");
-        assert_eq!(strip_provider_prefix("anthropic:claude-haiku-4-5"), "claude-haiku-4-5");
+        assert_eq!(
+            strip_provider_prefix("openrouter:claude-opus-4-7"),
+            "claude-opus-4-7"
+        );
+        assert_eq!(
+            strip_provider_prefix("anthropic:claude-haiku-4-5"),
+            "claude-haiku-4-5"
+        );
         assert_eq!(strip_provider_prefix("local:my-llama"), "my-llama");
     }
 
@@ -510,7 +516,10 @@ mod tests {
         assert_eq!(strip_provider_prefix("qwen:7b"), "qwen:7b");
         assert_eq!(strip_provider_prefix("llama:0.5b"), "llama:0.5b");
         assert_eq!(strip_provider_prefix("qwen:latest"), "qwen:latest");
-        assert_eq!(strip_provider_prefix("llama3:70b-q4_K_M"), "llama3:70b-q4_K_M");
+        assert_eq!(
+            strip_provider_prefix("llama3:70b-q4_K_M"),
+            "llama3:70b-q4_K_M"
+        );
         assert_eq!(strip_provider_prefix("qwen:q4"), "qwen:q4");
         assert_eq!(strip_provider_prefix("mistral:fp16"), "mistral:fp16");
         assert_eq!(strip_provider_prefix("llama2:instruct"), "llama2:instruct");
@@ -572,5 +581,4 @@ mod tests {
         assert_eq!(r.entry.provider, "ollama");
         assert_eq!(r.entry.id, "totally-unknown");
     }
-
 }

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -601,6 +601,25 @@ pub struct ModelConfig {
     pub api_key_env: Option<String>,
     /// Optional base URL override for the provider.
     pub base_url: Option<String>,
+    /// Optional override for this model's context window (in tokens).
+    ///
+    /// When set, takes precedence over registry / runtime-probed values.
+    /// Use it to force a value when the model's actual context differs
+    /// from what the catalog reports (e.g. a self-hosted Ollama model
+    /// configured with `num_ctx` smaller than the model's nominal
+    /// length, or a vLLM endpoint with a custom `--max-model-len`).
+    ///
+    /// `None` (the default) means "let the runtime resolve it from the
+    /// registry, persisted cache, or live `/v1/models` probe".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
+    /// Optional override for this model's maximum output tokens.
+    ///
+    /// Same precedence and semantics as [`Self::context_window`]. Useful
+    /// when a self-hosted endpoint advertises a smaller usable cap than
+    /// the catalog default (e.g. a quantised checkpoint).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u64>,
     /// Provider-specific extension parameters that are flattened directly
     /// into the API request body.
     ///
@@ -623,6 +642,8 @@ impl Default for ModelConfig {
             system_prompt: "You are a helpful AI agent.".to_string(),
             api_key_env: None,
             base_url: None,
+            context_window: None,
+            max_output_tokens: None,
             extra_params: std::collections::HashMap::new(),
         }
     }
@@ -1996,6 +2017,8 @@ model = "llama-3.3-70b-versatile"
             system_prompt: "test".to_string(),
             api_key_env: None,
             base_url: None,
+            context_window: None,
+            max_output_tokens: None,
             extra_params: extra,
         };
 

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -502,7 +502,9 @@ impl CronJob {
                 }
                 CronDeliveryTarget::LocalFile { path, .. } => {
                     if path.trim().is_empty() {
-                        return Err(format!("delivery_targets[{i}]: file path must not be empty"));
+                        return Err(format!(
+                            "delivery_targets[{i}]: file path must not be empty"
+                        ));
                     }
                     let p = std::path::Path::new(path);
                     if p.is_absolute() {


### PR DESCRIPTION
## Summary

New module `librefang_runtime::model_metadata` implementing the first half of a 5-layer fallback chain for model `context_window` resolution. Borrows hermes-agent's `get_model_context_length` design but stops short of copying the 80+ `DEFAULT_CONTEXT_LENGTHS` table — LibreFang's registry already covers known models, so the hardcoded layer keeps < 20 substring entries used only when registry / cache / probe all miss.

This PR ships **layers 1, 2, and 5**; layers 3 (persisted cache) and 4 (runtime `/v1/models` probe) are stubs handed off to PR-2. Nothing in the kernel calls `resolve_model_metadata` yet, so runtime behaviour is unchanged. PR-3 will swap the existing `cat.find_model(...).map(|m| m.context_window).filter(|w| *w > 0)` sites in `kernel/mod.rs` over to the pipeline and retire the uniform `200K` default in `agent_loop.rs:1285`.

## What's new

**`crates/librefang-runtime/src/model_metadata.rs`** (new):

- **`MetadataRequest`** — provider + model + base_url + manifest overrides.
- **`ResolvedModel<'a>`** carrying `Cow<'_, ModelCatalogEntry>` + a `MetadataSource` tag (`AgentManifest` / `Registry` / `PersistedCache` / `RuntimeProbe` / `HardcodedFallback` / `Default200kAnthropic` / `Default32k`). The dashboard surface for "why did my context window resolve to N" reads `MetadataSource::as_str`.
- **`resolve_model_metadata`** — sync entry point implementing L1/L2/L5.
- **`strip_provider_prefix`** — strips `openrouter:`, `anthropic:`, `local:`, … while preserving Ollama-style `model:tag` IDs (`qwen:7b`, `llama3:70b-q4_K_M`, `qwen:latest`). `looks_like_ollama_tag` whitelists size suffixes, quantisation prefixes, and common variant tags so unfamiliar provider namespaces (`myorg:custom`) are left intact.
- **`HARDCODED_FALLBACKS`** (18 entries) — substring → context_window map. Longest-key-first at lookup time so `claude-opus-4-6` beats the bare `claude` 200K key.
- **`is_anthropic_host`** — picks the 200K vs 32K final default. Replaces the current uniform 200K assumption (`agent_loop.rs:1285`), which silently truncates Ollama models that report a 16K window.

## Companion changes

**`librefang-types::agent::ModelConfig`**: two optional override fields:

```rust
#[serde(default, skip_serializing_if = "Option::is_none")]
pub context_window: Option<u64>,
#[serde(default, skip_serializing_if = "Option::is_none")]
pub max_output_tokens: Option<u64>,
```

Both `#[serde(default)]` so existing `agent.toml` files round-trip unchanged. `Default` impl + 4 explicit construction sites (in `librefang-hands`, `librefang-kernel/wizard.rs`, `librefang-kernel/kernel/tests.rs`, and the type's own test fixture) get the two new fields.

**`librefang-runtime::model_catalog::ModelCatalog::find_model_for_provider`** — new method that filters by `(provider, id)` and falls back to alias resolution scoped to the same provider. Resolves the ambiguity where `claude-opus-4-7` exists under both `anthropic` (1M context) and `copilot` (128K). An empty `provider` arg degrades to the existing provider-blind `find_model`.

**`ModelCatalog::from_entries`** — `#[cfg(test)]` constructor used by `model_metadata::tests` to build deterministic in-memory catalogs without touching the TOML loader.

## Tests (18 new)

13 in `model_metadata::tests`:

| Test | Asserts |
|---|---|
| `layer_1_manifest_override_wins` | `manifest_override_context = Some(196_608)` overrides catalog hit |
| `layer_1_zero_override_skipped` | `Some(0)` falls through (treated as "unset") |
| `layer_2_provider_aware_disambiguates` | same id / different providers resolve to different windows |
| `layer_2_zero_context_falls_through_to_l5` | catalog entry with `context_window = 0` is "unknown", not "zero tokens" |
| `layer_5_hardcoded_substring_longest_key_wins` | `claude-opus-4-6` beats bare `claude` |
| `layer_5_anthropic_default_for_unknown_claude` | unknown anthropic model → 200K tail |
| `layer_5_generic_default_for_unknown_non_anthropic` | unknown other provider → 32K tail |
| `provider_prefix_stripped_for_known_providers` | `openrouter:claude-opus-4-7` → `claude-opus-4-7` |
| `provider_prefix_preserved_for_ollama_tags` | 7 cases: `qwen:7b`, `llama:0.5b`, `qwen:latest`, `llama3:70b-q4_K_M`, `qwen:q4`, `mistral:fp16`, `llama2:instruct` |
| `provider_prefix_unknown_namespace_preserved` | `myorg:custom` and full URLs left alone |
| `provider_aware_lookup_with_prefix_in_request` | `openrouter:claude-opus-4-7` resolves to anthropic catalog entry after stripping |
| `empty_provider_falls_back_to_unscoped_lookup` | empty `provider` works |
| `metadata_source_str_round_trip` | every `MetadataSource` variant has a non-empty stable string |
| `fallback_entry_carries_request_provider` | synthesised entry preserves caller-supplied provider for telemetry |

4 in `model_catalog::tests`:

- `test_find_model_for_provider_filters_by_provider` — anthropic id misses copilot lookup
- `test_find_model_for_provider_empty_provider_falls_back` — empty provider behaves like `find_model`
- `test_find_model_for_provider_case_insensitive_provider` — `ANTHROPIC` matches `anthropic`
- `test_find_model_for_provider_alias_is_scoped` — alias resolution doesn't leak across providers

Plus 1 existing `agent::ModelConfig` test fixture adapted to the new shape.

## Test plan

- [x] `cargo check --workspace --lib` — clean
- [x] `cargo test -p librefang-runtime --lib -- model_metadata model_catalog` — 18 new + all baseline pass
- [x] `cargo clippy -p librefang-types -p librefang-runtime -p librefang-hands -p librefang-kernel --all-targets -- -D warnings` — clean
- [ ] Live integration — N/A for this PR (no callers). Will be exercised in PR-3 when the kernel call sites are switched over.

## Stack

Independent, base `main`. Follow-ups:

- **PR-2** — L3 persisted cache (`~/.librefang/cache/model_metadata.json` + 24h TTL) + L4 runtime probe (Ollama `/api/show`, Anthropic `/v1/models`, generic OpenAI-compat `/v1/models/{id}`).
- **PR-3** — wire `resolve_model_metadata` into `kernel/mod.rs:4058-4062` and the other catalog-based context lookup sites; retire the `DEFAULT_CONTEXT_WINDOW = 200_000` hardcoded constant; teach `model_catalog.rs:732`'s Ollama merge to stop writing the false `131_072` default.

See `.plans/model-metadata-lookup.md` for the full design.
