### PR TITLE
feat(runtime): model metadata L3 cache + L4 Ollama probe (PR-2/3)

### DIFF
--- a/crates/librefang-runtime/src/model_metadata.rs
+++ b/crates/librefang-runtime/src/model_metadata.rs
@@ -6,24 +6,33 @@
 //! self-hosted endpoint with a non-standard window.
 //!
 //! See `.plans/model-metadata-lookup.md` for the full design and the
-//! 5-layer rationale. **PR-1 (this module) lands layers 1, 2, and 5 only**:
+//! 5-layer rationale. **Status after PR-2**: L1 / L2 / L3 / L4 (Ollama)
+//! / L5 are live; PR-2.5 will expand L4 to Anthropic `/v1/models` and
+//! generic OpenAI-compat `/v1/models/{id}`.
 //!
-//! | Layer | Source | This PR |
+//! | Layer | Source | Status |
 //! |---|---|---|
 //! | L1 | Agent manifest override (`model.context_window`) | ✅ |
 //! | L2 | Registry / `ModelCatalog` (provider-aware) | ✅ |
-//! | L3 | Persisted cache (`~/.librefang/cache/model_metadata.json`) | M2 |
-//! | L4 | Runtime probe (`/v1/models`, `/api/show`) | M2 |
-//! | L5 | Hardcoded fallback (< 20 entries) | ✅ |
+//! | L3 | Persisted cache (`~/.librefang/cache/model_metadata.json`, 24h TTL) | ✅ |
+//! | L4 | Runtime probe — Ollama `/api/show` only in PR-2 | ✅ (Ollama only) |
+//! | L5 | Hardcoded fallback (< 20 entries) + provider default | ✅ |
 //!
-//! `resolve_model_metadata` is currently **passive** — no caller wires it
-//! into `agent_loop` yet. M3 will replace the
+//! `resolve_model_metadata` is currently **passive** — no caller wires
+//! it into `agent_loop` yet. PR-3 will replace the
 //! `cat.find_model(...).map(|m| m.context_window).filter(|w| *w > 0)`
 //! call sites in `kernel/mod.rs` with a single `resolve_model_metadata`
-//! invocation.
+//! invocation, and retire the uniform 200K default in
+//! `agent_loop.rs:1285`.
 
+use chrono::{DateTime, Utc};
 use librefang_types::model_catalog::{Modality, ModelCatalogEntry, ModelTier};
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use crate::model_catalog::ModelCatalog;
 
@@ -76,11 +85,15 @@ impl MetadataSource {
 /// `"ollama"`). It can be empty when unknown — the pipeline will then
 /// degrade `find_model_for_provider` to a provider-blind `find_model` and
 /// the substring fallback table will look at the bare model name.
+/// `api_key` is required for L4 probes against authenticated endpoints
+/// (e.g. Anthropic `/v1/models`). Local probes (Ollama `/api/show`) do
+/// not need it.
 #[derive(Debug, Clone, Copy)]
 pub struct MetadataRequest<'a> {
     pub provider: &'a str,
     pub model: &'a str,
     pub base_url: Option<&'a str>,
+    pub api_key: Option<&'a str>,
     pub manifest_override_context: Option<u64>,
     pub manifest_override_max_output: Option<u64>,
 }
@@ -293,16 +306,226 @@ fn is_anthropic_host(provider: &str, model_id: &str) -> bool {
     model_id.to_ascii_lowercase().starts_with("claude")
 }
 
-/// Resolve metadata for a model through layers 1, 2, and 5.
+// ===== Layer 3: persisted cache =====
+
+const CACHE_FILE: &str = "cache/model_metadata.json";
+const CACHE_TTL_SECS: i64 = 86_400;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CacheFile {
+    #[serde(default = "default_cache_version")]
+    version: u32,
+    #[serde(default)]
+    entries: HashMap<String, CacheEntry>,
+}
+
+fn default_cache_version() -> u32 {
+    1
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    context_window: u64,
+    #[serde(default)]
+    max_output_tokens: u64,
+    fetched_at: DateTime<Utc>,
+    #[serde(default)]
+    source: String,
+}
+
+fn cache_key(provider: &str, base_url: Option<&str>, model: &str) -> String {
+    format!("{}|{}|{}", provider, base_url.unwrap_or(""), model)
+}
+
+fn cache_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(CACHE_FILE)
+}
+
+fn read_cache_file_blocking(home_dir: &Path) -> CacheFile {
+    let path = cache_path(home_dir);
+    let Ok(bytes) = std::fs::read(&path) else {
+        return CacheFile::default();
+    };
+    match serde_json::from_slice::<CacheFile>(&bytes) {
+        Ok(f) if f.version == default_cache_version() => f,
+        Ok(_) => {
+            tracing::warn!(
+                target: "librefang::model_metadata",
+                path = %path.display(),
+                "model metadata cache version mismatch, ignoring file"
+            );
+            CacheFile::default()
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "librefang::model_metadata",
+                path = %path.display(),
+                error = %e,
+                "model metadata cache parse failed, ignoring file"
+            );
+            CacheFile::default()
+        }
+    }
+}
+
+fn write_cache_file_blocking(home_dir: &Path, file: &CacheFile) {
+    let path = cache_path(home_dir);
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                target: "librefang::model_metadata",
+                error = %e,
+                "model metadata cache mkdir failed"
+            );
+            return;
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    let Ok(bytes) = serde_json::to_vec_pretty(file) else {
+        return;
+    };
+    if let Err(e) = std::fs::write(&tmp, &bytes) {
+        tracing::warn!(
+            target: "librefang::model_metadata",
+            error = %e,
+            "model metadata cache write failed"
+        );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        tracing::warn!(
+            target: "librefang::model_metadata",
+            error = %e,
+            "model metadata cache atomic rename failed"
+        );
+    }
+}
+
+async fn read_cache_entry(home_dir: &Path, key: &str) -> Option<CacheEntry> {
+    let home = home_dir.to_path_buf();
+    let key = key.to_string();
+    tokio::task::spawn_blocking(move || {
+        let file = read_cache_file_blocking(&home);
+        let entry = file.entries.get(&key).cloned()?;
+        let age = (Utc::now() - entry.fetched_at).num_seconds();
+        if (0..CACHE_TTL_SECS).contains(&age) {
+            Some(entry)
+        } else {
+            None
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn write_cache_entry(home_dir: &Path, key: &str, entry: CacheEntry) {
+    let home = home_dir.to_path_buf();
+    let key = key.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        let mut file = read_cache_file_blocking(&home);
+        file.entries.insert(key, entry);
+        if file.version == 0 {
+            file.version = default_cache_version();
+        }
+        write_cache_file_blocking(&home, &file);
+    })
+    .await;
+}
+
+// ===== Layer 4: runtime probe =====
+
+const PROBE_TIMEOUT_SECS: u64 = 3;
+
+fn probe_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(librefang_http::proxied_client)
+}
+
+/// Parse an Ollama `/api/show` response.
 ///
-/// Layers 3 and 4 are placeholders in this PR — when wired in M2 they'll
-/// slot between L2 and L5 without changing this function's signature.
+/// Two source fields can carry context info:
+/// - `parameters` — multi-line string; the line `num_ctx <N>` is the
+///   *effective* window the server will use.
+/// - `model_info` — object whose `*.context_length` keys carry the
+///   model's *nominal* maximum.
 ///
-/// Always returns a populated [`ResolvedModel`]; the worst case is a
-/// `Default32k` synthesised entry. Callers can therefore treat the
-/// `Option<usize>` problem as solved at this boundary.
-pub fn resolve_model_metadata<'a>(
+/// Prefer `num_ctx` because it's the actual cap (the model might
+/// support 128K but the server is configured for 16K). Fall back to
+/// the first `*.context_length` we see.
+fn parse_ollama_show(json: &serde_json::Value) -> Option<u64> {
+    if let Some(params) = json.get("parameters").and_then(|v| v.as_str()) {
+        for line in params.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("num_ctx ") {
+                if let Ok(n) = rest.trim().parse::<u64>() {
+                    if n > 0 {
+                        return Some(n);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(info) = json.get("model_info").and_then(|v| v.as_object()) {
+        for (k, v) in info {
+            if k.ends_with(".context_length") {
+                if let Some(n) = v.as_u64() {
+                    if n > 0 {
+                        return Some(n);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn probe_ollama(client: &reqwest::Client, base_url: &str, model: &str) -> Option<u64> {
+    let url = format!("{}/api/show", base_url.trim_end_matches('/'));
+    // Ollama expects `name`; the `model` alias was added more recently
+    // and not all server versions accept it. Stick with `name` for
+    // compatibility.
+    let body = serde_json::json!({ "name": model });
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .timeout(Duration::from_secs(PROBE_TIMEOUT_SECS))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = resp.json().await.ok()?;
+    parse_ollama_show(&json)
+}
+
+fn looks_like_ollama(provider: &str, base_url: Option<&str>) -> bool {
+    if provider.eq_ignore_ascii_case("ollama") || provider.eq_ignore_ascii_case("ollama-cloud") {
+        return true;
+    }
+    base_url.map(|u| u.contains(":11434")).unwrap_or(false)
+}
+
+/// L4 dispatcher. PR-2 only ships the Ollama branch; PR-2.5 will add
+/// Anthropic `/v1/models` and generic OpenAI-compat `/v1/models/{id}`.
+async fn probe_runtime(request: &MetadataRequest<'_>) -> Option<u64> {
+    if looks_like_ollama(request.provider, request.base_url) {
+        let base = request.base_url.unwrap_or("http://localhost:11434");
+        return probe_ollama(probe_client(), base, request.model).await;
+    }
+    None
+}
+
+/// Resolve metadata for a model through the layered fallback pipeline.
+///
+/// Layers 1, 2, 3, 4, 5 in order. Always returns a populated
+/// [`ResolvedModel`]; the worst case is a `Default32k` synthesised entry.
+/// Callers can therefore treat the `Option<usize>` problem as solved at
+/// this boundary.
+pub async fn resolve_model_metadata<'a>(
     catalog: &'a ModelCatalog,
+    home_dir: &Path,
     request: &MetadataRequest<'_>,
 ) -> ResolvedModel<'a> {
     // ----- Layer 1: agent manifest override -----
@@ -337,7 +560,44 @@ pub fn resolve_model_metadata<'a>(
         }
     }
 
-    // ----- Layer 3 and 4 are M2 — fall through to L5 for now. -----
+    // ----- Layer 3: persisted cache -----
+    let key = cache_key(request.provider, request.base_url, request.model);
+    if let Some(cached) = read_cache_entry(home_dir, &key).await {
+        if cached.context_window > 0 {
+            let entry = synthesize_entry(
+                request.model,
+                request.provider,
+                cached.context_window,
+                cached.max_output_tokens,
+            );
+            return ResolvedModel {
+                entry: Cow::Owned(entry),
+                source: MetadataSource::PersistedCache,
+            };
+        }
+    }
+
+    // ----- Layer 4: live probe (Ollama in PR-2) -----
+    if let Some(ctx) = probe_runtime(request).await {
+        // Best-effort write — losing the cache write is preferable to
+        // blocking the agent on disk IO.
+        write_cache_entry(
+            home_dir,
+            &key,
+            CacheEntry {
+                context_window: ctx,
+                max_output_tokens: 0,
+                fetched_at: Utc::now(),
+                source: MetadataSource::RuntimeProbe.as_str().to_string(),
+            },
+        )
+        .await;
+        let entry = synthesize_entry(request.model, request.provider, ctx, 0);
+        return ResolvedModel {
+            entry: Cow::Owned(entry),
+            source: MetadataSource::RuntimeProbe,
+        };
+    }
 
     // ----- Layer 5: hardcoded substring table + provider default -----
     if let Some(ctx) = lookup_hardcoded(stripped) {
@@ -405,93 +665,115 @@ mod tests {
             provider,
             model,
             base_url: None,
+            api_key: None,
             manifest_override_context: None,
             manifest_override_max_output: None,
         }
     }
 
-    #[test]
-    fn layer_1_manifest_override_wins() {
+    /// Tempdir-backed `home_dir` used by every async test. The
+    /// `TempDir` is owned by the caller and gets cleaned up at test
+    /// end via Drop, so cache writes never bleed across tests.
+    fn fresh_home() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir for cache home")
+    }
+
+    #[tokio::test]
+    async fn layer_1_manifest_override_wins() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
         let mut request = req("anthropic", "claude-opus-4-7");
         request.manifest_override_context = Some(196_608);
-        let resolved = resolve_model_metadata(&cat, &request);
+        let resolved = resolve_model_metadata(&cat, home, &request).await;
         assert_eq!(resolved.source, MetadataSource::AgentManifest);
         assert_eq!(resolved.entry.context_window, 196_608);
     }
 
-    #[test]
-    fn layer_1_zero_override_skipped() {
+    #[tokio::test]
+    async fn layer_1_zero_override_skipped() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
         let mut request = req("anthropic", "claude-opus-4-7");
         // 0 must be treated as "unset" — falling through to L2.
         request.manifest_override_context = Some(0);
-        let resolved = resolve_model_metadata(&cat, &request);
+        let resolved = resolve_model_metadata(&cat, home, &request).await;
         assert_eq!(resolved.source, MetadataSource::Registry);
         assert_eq!(resolved.entry.context_window, 1_000_000);
     }
 
-    #[test]
-    fn layer_2_provider_aware_disambiguates() {
+    #[tokio::test]
+    async fn layer_2_provider_aware_disambiguates() {
+        let _home = fresh_home();
+        let home = _home.path();
         // Same id under two providers with different windows.
         let cat = catalog_with(vec![
             entry("anthropic", "claude-opus-4-7", 1_000_000),
             entry("copilot", "claude-opus-4-7", 128_000),
         ]);
-        let r_anthropic = resolve_model_metadata(&cat, &req("anthropic", "claude-opus-4-7"));
+        let r_anthropic = resolve_model_metadata(&cat, home, &req("anthropic", "claude-opus-4-7")).await;
         assert_eq!(r_anthropic.entry.context_window, 1_000_000);
-        let r_copilot = resolve_model_metadata(&cat, &req("copilot", "claude-opus-4-7"));
+        let r_copilot = resolve_model_metadata(&cat, home, &req("copilot", "claude-opus-4-7")).await;
         assert_eq!(r_copilot.entry.context_window, 128_000);
     }
 
-    #[test]
-    fn layer_2_zero_context_falls_through_to_l5() {
+    #[tokio::test]
+    async fn layer_2_zero_context_falls_through_to_l5() {
+        let _home = fresh_home();
+        let home = _home.path();
         // Catalog has the entry but its context_window is 0 (e.g. an
         // Ollama-discovered model that hasn't been probed yet). L2 must
         // skip it — registry data with 0 is "unknown", not "zero tokens".
         let cat = catalog_with(vec![entry("ollama", "qwen3-coder:30b", 0)]);
-        let resolved = resolve_model_metadata(&cat, &req("ollama", "qwen3-coder:30b"));
+        let resolved = resolve_model_metadata(&cat, home, &req("ollama", "qwen3-coder:30b")).await;
         // Hardcoded substring table picks up "qwen3-coder" → 262144.
         assert_eq!(resolved.source, MetadataSource::HardcodedFallback);
         assert_eq!(resolved.entry.context_window, 262_144);
     }
 
-    #[test]
-    fn layer_5_hardcoded_substring_longest_key_wins() {
+    #[tokio::test]
+    async fn layer_5_hardcoded_substring_longest_key_wins() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![]);
         // "claude-opus-4-6" must beat the more permissive "claude" key.
-        let r1 = resolve_model_metadata(&cat, &req("anthropic", "claude-opus-4-6"));
+        let r1 = resolve_model_metadata(&cat, home, &req("anthropic", "claude-opus-4-6")).await;
         assert_eq!(r1.source, MetadataSource::HardcodedFallback);
         assert_eq!(r1.entry.context_window, 1_000_000);
 
         // "claude-haiku-4-5" beats bare "claude" (200K both, but the
         // longest-key precedence is what guarantees the haiku-specific
         // entry takes effect when its number ever diverges).
-        let r2 = resolve_model_metadata(&cat, &req("anthropic", "claude-haiku-4-5"));
+        let r2 = resolve_model_metadata(&cat, home, &req("anthropic", "claude-haiku-4-5")).await;
         assert_eq!(r2.source, MetadataSource::HardcodedFallback);
 
         // Bare "claude-3-5-sonnet" not in the table → falls to "claude"
         // catch-all (200K).
-        let r3 = resolve_model_metadata(&cat, &req("anthropic", "claude-3-5-sonnet"));
+        let r3 = resolve_model_metadata(&cat, home, &req("anthropic", "claude-3-5-sonnet")).await;
         assert_eq!(r3.source, MetadataSource::HardcodedFallback);
         assert_eq!(r3.entry.context_window, 200_000);
     }
 
-    #[test]
-    fn layer_5_anthropic_default_for_unknown_claude() {
+    #[tokio::test]
+    async fn layer_5_anthropic_default_for_unknown_claude() {
+        let _home = fresh_home();
+        let home = _home.path();
         // Model id contains "claude" → the substring table catches it,
         // not the Default200kAnthropic tail. To reach the tail we need
         // a model id outside the table but a provider that's anthropic.
         let cat = catalog_with(vec![]);
-        let r = resolve_model_metadata(&cat, &req("anthropic", "totally-unknown-model"));
+        let r = resolve_model_metadata(&cat, home, &req("anthropic", "totally-unknown-model")).await;
         assert_eq!(r.source, MetadataSource::Default200kAnthropic);
         assert_eq!(r.entry.context_window, 200_000);
     }
 
-    #[test]
-    fn layer_5_generic_default_for_unknown_non_anthropic() {
+    #[tokio::test]
+    async fn layer_5_generic_default_for_unknown_non_anthropic() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![]);
-        let r = resolve_model_metadata(&cat, &req("custom", "totally-unknown-model"));
+        let r = resolve_model_metadata(&cat, home, &req("custom", "totally-unknown-model")).await;
         assert_eq!(r.source, MetadataSource::Default32k);
         assert_eq!(r.entry.context_window, 32_768);
     }
@@ -538,20 +820,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn provider_aware_lookup_with_prefix_in_request() {
+    #[tokio::test]
+    async fn provider_aware_lookup_with_prefix_in_request() {
+        let _home = fresh_home();
+        let home = _home.path();
         // Request carries `openrouter:claude-opus-4-7` but the catalog
         // entry is keyed on the bare id.
         let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
-        let r = resolve_model_metadata(&cat, &req("anthropic", "openrouter:claude-opus-4-7"));
+        let r = resolve_model_metadata(&cat, home, &req("anthropic", "openrouter:claude-opus-4-7")).await;
         assert_eq!(r.source, MetadataSource::Registry);
         assert_eq!(r.entry.context_window, 1_000_000);
     }
 
-    #[test]
-    fn empty_provider_falls_back_to_unscoped_lookup() {
+    #[tokio::test]
+    async fn empty_provider_falls_back_to_unscoped_lookup() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![entry("anthropic", "claude-opus-4-7", 1_000_000)]);
-        let r = resolve_model_metadata(&cat, &req("", "claude-opus-4-7"));
+        let r = resolve_model_metadata(&cat, home, &req("", "claude-opus-4-7")).await;
         assert_eq!(r.source, MetadataSource::Registry);
         assert_eq!(r.entry.context_window, 1_000_000);
     }
@@ -574,11 +860,178 @@ mod tests {
     /// Defence-in-depth: providers also gets dropped into the synthesised
     /// fallback entry so the kernel can later log `provider=...` even
     /// when the catalog miss synthesised the result.
-    #[test]
-    fn fallback_entry_carries_request_provider() {
+    #[tokio::test]
+    async fn fallback_entry_carries_request_provider() {
+        let _home = fresh_home();
+        let home = _home.path();
         let cat = catalog_with(vec![]);
-        let r = resolve_model_metadata(&cat, &req("ollama", "totally-unknown"));
+        let r = resolve_model_metadata(&cat, home, &req("ollama", "totally-unknown")).await;
         assert_eq!(r.entry.provider, "ollama");
         assert_eq!(r.entry.id, "totally-unknown");
+    }
+
+    // ---- PR-2 tests: persisted cache + Ollama parser ----
+
+    /// Writing a cache entry then resolving the same key picks it up at
+    /// L3 (PersistedCache). The catalog is empty and the model isn't in
+    /// the hardcoded table, so without the cache we'd fall to L5
+    /// `Default32k`.
+    #[tokio::test]
+    async fn layer_3_cache_round_trip() {
+        let _home = fresh_home();
+        let home = _home.path();
+        let key = cache_key("ollama", Some("http://localhost:11434"), "qwen3-foo:30b");
+        write_cache_entry(
+            home,
+            &key,
+            CacheEntry {
+                context_window: 65_536,
+                max_output_tokens: 0,
+                fetched_at: Utc::now(),
+                source: "runtime_probe".to_string(),
+            },
+        )
+        .await;
+
+        let cat = catalog_with(vec![]);
+        let mut request = req("ollama", "qwen3-foo:30b");
+        request.base_url = Some("http://localhost:11434");
+        let r = resolve_model_metadata(&cat, home, &request).await;
+        assert_eq!(r.source, MetadataSource::PersistedCache);
+        assert_eq!(r.entry.context_window, 65_536);
+    }
+
+    /// A cache entry whose `fetched_at` is older than the TTL must not
+    /// be returned. Falling through here lands on the hardcoded `qwen`
+    /// 131K entry (the model id contains "qwen3-foo" → matches "qwen").
+    #[tokio::test]
+    async fn layer_3_stale_cache_falls_through() {
+        let _home = fresh_home();
+        let home = _home.path();
+        let key = cache_key("ollama", Some("http://localhost:11434"), "qwen3-foo:30b");
+        // Entry fetched 25h ago — past the 24h TTL.
+        let stale_at = Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 3_600);
+        write_cache_entry(
+            home,
+            &key,
+            CacheEntry {
+                context_window: 65_536,
+                max_output_tokens: 0,
+                fetched_at: stale_at,
+                source: "runtime_probe".to_string(),
+            },
+        )
+        .await;
+
+        let cat = catalog_with(vec![]);
+        let mut request = req("ollama", "qwen3-foo:30b");
+        request.base_url = Some("http://localhost:11434");
+        let r = resolve_model_metadata(&cat, home, &request).await;
+        // Expired cache + L4 unreachable in test env (no Ollama running)
+        // → falls to L5 hardcoded "qwen" → 131_072.
+        assert_ne!(r.source, MetadataSource::PersistedCache);
+        assert_eq!(r.entry.context_window, 131_072);
+    }
+
+    /// A corrupted cache file must not block startup or panic the
+    /// pipeline. The reader logs a warning and returns an empty cache.
+    #[tokio::test]
+    async fn layer_3_corrupted_file_does_not_panic() {
+        let _home = fresh_home();
+        let home = _home.path();
+        // Hand-write garbage to the cache path.
+        let path = cache_path(home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"not even close to JSON {{{").unwrap();
+
+        let cat = catalog_with(vec![]);
+        let r = resolve_model_metadata(&cat, home, &req("custom", "totally-unknown")).await;
+        // Expect a clean fallback to L5 generic 32K, not a panic.
+        assert_eq!(r.source, MetadataSource::Default32k);
+    }
+
+    /// Parser: `parameters` carrying `num_ctx 32768` wins over a
+    /// nominal `*.context_length` further down — we want the
+    /// effective server cap, not the model's theoretical max.
+    #[test]
+    fn parse_ollama_show_prefers_num_ctx() {
+        let json = serde_json::json!({
+            "parameters": "stop \"<eos>\"\nnum_ctx 32768\ntemperature 0.7\n",
+            "model_info": { "qwen3.context_length": 262144u64 }
+        });
+        assert_eq!(parse_ollama_show(&json), Some(32_768));
+    }
+
+    /// Parser: when `parameters` lacks `num_ctx`, fall back to the first
+    /// `*.context_length` we find in `model_info`.
+    #[test]
+    fn parse_ollama_show_falls_back_to_model_info() {
+        let json = serde_json::json!({
+            "parameters": "stop \"<eos>\"\ntemperature 0.7\n",
+            "model_info": { "llama.context_length": 8192u64 }
+        });
+        assert_eq!(parse_ollama_show(&json), Some(8_192));
+    }
+
+    /// Parser: empty / missing fields → `None`. The probe layer treats
+    /// `None` as "no value found", falls through to L5 instead of
+    /// caching a misleading zero.
+    #[test]
+    fn parse_ollama_show_returns_none_on_missing_fields() {
+        assert_eq!(parse_ollama_show(&serde_json::json!({})), None);
+        assert_eq!(
+            parse_ollama_show(&serde_json::json!({ "parameters": "stop \"<eos>\"\n" })),
+            None,
+        );
+        assert_eq!(
+            parse_ollama_show(&serde_json::json!({ "model_info": { "foo": "bar" } })),
+            None,
+        );
+    }
+
+    /// Parser: zero values in either field are rejected (a server with
+    /// `num_ctx 0` is a misconfiguration; we'd rather fall back than
+    /// cache zero and break downstream budget math).
+    #[test]
+    fn parse_ollama_show_rejects_zero() {
+        assert_eq!(
+            parse_ollama_show(&serde_json::json!({
+                "parameters": "num_ctx 0\n",
+                "model_info": {}
+            })),
+            None,
+        );
+        assert_eq!(
+            parse_ollama_show(&serde_json::json!({
+                "model_info": { "x.context_length": 0u64 }
+            })),
+            None,
+        );
+    }
+
+    /// `looks_like_ollama` matches both the literal provider tag and a
+    /// generic endpoint hosted on the canonical 11434 port.
+    #[test]
+    fn ollama_detection_provider_or_port() {
+        assert!(looks_like_ollama("ollama", None));
+        assert!(looks_like_ollama("OLLAMA", None));
+        assert!(looks_like_ollama("ollama-cloud", None));
+        assert!(looks_like_ollama("custom", Some("http://10.0.0.5:11434")));
+        assert!(!looks_like_ollama("custom", Some("https://api.example.com")));
+        assert!(!looks_like_ollama("anthropic", None));
+    }
+
+    /// Cache key composition: `provider|base_url|model` triple keeps
+    /// same-id models on different endpoints from sharing entries.
+    #[test]
+    fn cache_key_separates_endpoint_namespaces() {
+        assert_ne!(
+            cache_key("ollama", Some("http://host-a:11434"), "qwen:7b"),
+            cache_key("ollama", Some("http://host-b:11434"), "qwen:7b"),
+        );
+        assert_eq!(
+            cache_key("ollama", None, "qwen:7b"),
+            cache_key("ollama", Some(""), "qwen:7b"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Builds on PR-1 (#3133) by lighting up the persisted-cache and Ollama runtime-probe layers in the lookup pipeline. Still passive — no kernel call site invokes `resolve_model_metadata` yet, so runtime behaviour is unchanged. PR-3 will wire the kernel and retire the uniform 200K default in `agent_loop.rs:1285`.

| Layer | Source | After PR-2 |
|---|---|---|
| L1 | Agent manifest override | ✅ (PR-1) |
| L2 | Registry / `ModelCatalog` | ✅ (PR-1) |
| **L3** | **Persisted cache (24h TTL)** | **✅ (this PR)** |
| **L4** | **Runtime probe — Ollama `/api/show`** | **✅ (this PR)** |
| L5 | Hardcoded fallback (< 20 entries) | ✅ (PR-1) |

PR-2.5 will expand L4 to Anthropic `/v1/models` and generic OpenAI-compat `/v1/models/{id}`.

## Signature change

`resolve_model_metadata` is now `async` (was sync in PR-1). Required for the `spawn_blocking`-wrapped fs IO in L3 and the reqwest-driven HTTP probe in L4. Also grows a `home_dir: &Path` argument so the cache file path is dependency-injected (kernel will pass `config.home_dir` in PR-3). Since PR-1 had no callers in production code, the breaking change is contained to the test suite.

## Layer 3: persisted cache

- File path: `<home_dir>/cache/model_metadata.json`.
- Schema: `{ version: u32, entries: HashMap<String, CacheEntry> }`. Entries carry `context_window`, `max_output_tokens`, `fetched_at` (RFC3339), `source` (string tag for telemetry).
- Cache key: `provider|base_url|model` triple — same model id under different providers / endpoints stays separated (e.g. `claude-opus-4-7` on `anthropic` vs `copilot`).
- 24h TTL; entries past their `fetched_at + ttl` fall through to L4 instead of being returned.
- Atomic-rename writes (write to `.tmp`, rename over the live file). Partial writes never corrupt an existing cache.
- Schema-version mismatch and parse failures both degrade to "empty cache" with a `tracing::warn` — the cache file is **never** load-bearing for daemon startup.
- All file IO routed through `tokio::task::spawn_blocking` so the runtime never stalls on slow disks (encrypted volumes, network mounts, …).

## Layer 4: Ollama `/api/show` probe

- 3-second hard timeout (mirrors hermes-agent's `_PROBE_TIMEOUT`).
- `parse_ollama_show` prefers the `parameters` block's `num_ctx` line (the *effective* server cap) over the nominal `model_info.*.context_length` (the model's *theoretical* max). The model might support 128K but the server is configured for 16K — we want what the user can actually use.
- Zero values rejected. Caching `0` would break downstream `ContextBudget` math; falling through to L5 is safer.
- `looks_like_ollama` matches the literal `ollama` / `ollama-cloud` provider tags **and** any `base_url` containing `:11434` (canonical Ollama port).
- HTTP client is a process-wide `OnceLock<reqwest::Client>` built from `librefang_http::proxied_client` so corporate-proxy environments work transparently. Initialised lazily on first probe.
- L4 dispatcher only routes to Ollama in this PR; PR-2.5 will add Anthropic + generic OpenAI-compat branches.

On a successful probe, the result is written back to L3 (best-effort — write failures log a warn but don't propagate) so subsequent boots skip the network roundtrip.

## Other changes

- `MetadataRequest` grows `api_key: Option<&'a str>` (will be consumed by the Anthropic probe in PR-2.5).
- All 13 PR-1 unit tests refactored to `#[tokio::test]` + a `tempfile::TempDir`-backed `home_dir`. The test helper `fresh_home()` returns an owned `TempDir` so cache files are cleaned up on Drop.
- `MetadataSource::PersistedCache` and `RuntimeProbe` are no longer placeholders.

## Tests (9 new, 23 total)

| Test | Asserts |
|---|---|
| `layer_3_cache_round_trip` | write entry → resolve picks it up at L3 |
| `layer_3_stale_cache_falls_through` | entry fetched 25h ago is rejected; falls to L5 |
| `layer_3_corrupted_file_does_not_panic` | garbage cache file logs a warn and degrades; no panic |
| `parse_ollama_show_prefers_num_ctx` | effective cap (`num_ctx 32768`) wins over nominal (`262144`) |
| `parse_ollama_show_falls_back_to_model_info` | when `num_ctx` is absent, first `*.context_length` is used |
| `parse_ollama_show_returns_none_on_missing_fields` | 3 cases (empty, no `num_ctx`, no `*.context_length`) → None |
| `parse_ollama_show_rejects_zero` | `num_ctx 0` and `*.context_length: 0` both rejected |
| `ollama_detection_provider_or_port` | `looks_like_ollama` matches both literal tag and 11434 port |
| `cache_key_separates_endpoint_namespaces` | distinct hosts → distinct cache keys |

## Test plan

- [x] `cargo check --workspace --lib` — clean
- [x] `cargo test -p librefang-runtime --lib model_metadata` — **23 ok** (14 PR-1 ported to async + 9 new)
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean
- [ ] Live integration deferred to PR-3 — cargo build is sandbox-blocked in the environment that produced this PR; CI will exercise the full pipeline once `resolve_model_metadata` is wired into the kernel.

## Stack

Base: PR-1 (`feat/model-metadata-lookup-m1`, #3133). When #3133 lands the diff against `main` collapses to just this PR's increments.

Follow-ups:
- **PR-2.5** — extend L4 with Anthropic `/v1/models` and generic OpenAI-compat `/v1/models/{id}` branches.
- **PR-3** — wire `resolve_model_metadata` into `kernel/mod.rs:4058-4062` and the other catalog-based context lookup sites; retire `DEFAULT_CONTEXT_WINDOW = 200_000`; teach `model_catalog.rs:732`'s Ollama merge to stop writing the false `131_072` default.

See `.plans/model-metadata-lookup.md` for full design.
