### PR TITLE
fix(workspace): allow named workspaces in read-side path resolution

### DIFF
--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -599,4 +599,20 @@ pub trait KernelHandle: Send + Sync {
     fn readonly_workspace_prefixes(&self, _agent_id: &str) -> Vec<std::path::PathBuf> {
         vec![]
     }
+
+    /// Return the canonicalized absolute paths of ALL named workspaces declared
+    /// for the given agent, paired with their access modes. Used by file-read,
+    /// file-list, file-write, and apply-patch tools to widen the sandbox
+    /// accept-list to include declared shared workspaces (PR #2958 wired
+    /// `[workspaces]` into write-side denial only; this surfaces the full
+    /// allowlist to the read-side path resolver).
+    ///
+    /// Default: no named workspaces — read-side resolution falls back to the
+    /// primary workspace root only.
+    fn named_workspace_prefixes(
+        &self,
+        _agent_id: &str,
+    ) -> Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)> {
+        Vec::new()
+    }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -15770,8 +15770,8 @@ impl KernelHandle for LibreFangKernel {
         entry
             .manifest
             .workspaces
-            .iter()
-            .filter_map(|(_, decl)| {
+            .values()
+            .filter_map(|decl| {
                 if decl.path.is_absolute() || has_unsafe_relative_components(&decl.path) {
                     return None;
                 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -15749,6 +15749,14 @@ impl KernelHandle for LibreFangKernel {
     }
 
     fn readonly_workspace_prefixes(&self, agent_id: &str) -> Vec<std::path::PathBuf> {
+        self.named_workspace_prefixes(agent_id)
+            .into_iter()
+            .filter(|(_, mode)| *mode == WorkspaceMode::ReadOnly)
+            .map(|(p, _)| p)
+            .collect()
+    }
+
+    fn named_workspace_prefixes(&self, agent_id: &str) -> Vec<(std::path::PathBuf, WorkspaceMode)> {
         let Ok(aid) = agent_id.parse::<AgentId>() else {
             return vec![];
         };
@@ -15763,12 +15771,15 @@ impl KernelHandle for LibreFangKernel {
             .manifest
             .workspaces
             .iter()
-            .filter(|(_, decl)| decl.mode == WorkspaceMode::ReadOnly)
             .filter_map(|(_, decl)| {
                 if decl.path.is_absolute() || has_unsafe_relative_components(&decl.path) {
                     return None;
                 }
-                workspaces_root.join(&decl.path).canonicalize().ok()
+                workspaces_root
+                    .join(&decl.path)
+                    .canonicalize()
+                    .ok()
+                    .map(|p| (p, decl.mode.clone()))
             })
             .collect()
     }

--- a/crates/librefang-runtime/src/apply_patch.rs
+++ b/crates/librefang-runtime/src/apply_patch.rs
@@ -272,40 +272,52 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchOp>, String> {
 }
 
 /// Resolve a patch path through workspace confinement.
-fn resolve_patch_path(raw: &str, workspace_root: &Path) -> Result<PathBuf, String> {
-    crate::workspace_sandbox::resolve_sandbox_path(raw, workspace_root)
+fn resolve_patch_path(
+    raw: &str,
+    workspace_root: &Path,
+    additional_roots: &[&Path],
+) -> Result<PathBuf, String> {
+    crate::workspace_sandbox::resolve_sandbox_path_ext(raw, workspace_root, additional_roots)
 }
 
 /// Apply parsed patch operations against the filesystem.
 ///
-/// All file paths are confined to `workspace_root` via sandbox resolution.
-pub async fn apply_patch(ops: &[PatchOp], workspace_root: &Path) -> PatchResult {
+/// All file paths are confined to `workspace_root` (or one of `additional_roots`)
+/// via sandbox resolution. `additional_roots` should already be canonical and
+/// represent named workspaces declared in the agent's manifest.
+pub async fn apply_patch(
+    ops: &[PatchOp],
+    workspace_root: &Path,
+    additional_roots: &[&Path],
+) -> PatchResult {
     let mut result = PatchResult::default();
 
     for op in ops {
         match op {
-            PatchOp::AddFile { path, content } => match resolve_patch_path(path, workspace_root) {
-                Ok(resolved) => {
-                    if let Some(parent) = resolved.parent() {
-                        if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                            result.errors.push(format!("mkdir {}: {}", path, e));
-                            continue;
+            PatchOp::AddFile { path, content } => {
+                match resolve_patch_path(path, workspace_root, additional_roots) {
+                    Ok(resolved) => {
+                        if let Some(parent) = resolved.parent() {
+                            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                                result.errors.push(format!("mkdir {}: {}", path, e));
+                                continue;
+                            }
+                        }
+                        match tokio::fs::write(&resolved, content).await {
+                            Ok(()) => result.files_added += 1,
+                            Err(e) => result.errors.push(format!("write {}: {}", path, e)),
                         }
                     }
-                    match tokio::fs::write(&resolved, content).await {
-                        Ok(()) => result.files_added += 1,
-                        Err(e) => result.errors.push(format!("write {}: {}", path, e)),
-                    }
+                    Err(e) => result.errors.push(format!("{}: {}", path, e)),
                 }
-                Err(e) => result.errors.push(format!("{}: {}", path, e)),
-            },
+            }
 
             PatchOp::UpdateFile {
                 path,
                 move_to,
                 hunks,
             } => {
-                let resolved = match resolve_patch_path(path, workspace_root) {
+                let resolved = match resolve_patch_path(path, workspace_root, additional_roots) {
                     Ok(r) => r,
                     Err(e) => {
                         result.errors.push(format!("{}: {}", path, e));
@@ -327,7 +339,7 @@ pub async fn apply_patch(ops: &[PatchOp], workspace_root: &Path) -> PatchResult 
                     Ok(patched) => {
                         // Determine target path (move or in-place)
                         let target = if let Some(new_path) = move_to {
-                            match resolve_patch_path(new_path, workspace_root) {
+                            match resolve_patch_path(new_path, workspace_root, additional_roots) {
                                 Ok(t) => {
                                     result.files_moved += 1;
                                     t
@@ -364,15 +376,17 @@ pub async fn apply_patch(ops: &[PatchOp], workspace_root: &Path) -> PatchResult 
                 }
             }
 
-            PatchOp::DeleteFile { path } => match resolve_patch_path(path, workspace_root) {
-                Ok(resolved) => match tokio::fs::remove_file(&resolved).await {
-                    Ok(()) => result.files_deleted += 1,
-                    Err(e) => {
-                        result.errors.push(format!("delete {}: {}", path, e));
-                    }
-                },
-                Err(e) => result.errors.push(format!("{}: {}", path, e)),
-            },
+            PatchOp::DeleteFile { path } => {
+                match resolve_patch_path(path, workspace_root, additional_roots) {
+                    Ok(resolved) => match tokio::fs::remove_file(&resolved).await {
+                        Ok(()) => result.files_deleted += 1,
+                        Err(e) => {
+                            result.errors.push(format!("delete {}: {}", path, e));
+                        }
+                    },
+                    Err(e) => result.errors.push(format!("{}: {}", path, e)),
+                }
+            }
         }
     }
 
@@ -736,7 +750,7 @@ mod tests {
             },
         ];
 
-        let result = apply_patch(&ops, &dir).await;
+        let result = apply_patch(&ops, &dir, &[]).await;
         assert!(result.is_ok());
         assert_eq!(result.files_added, 1);
         assert_eq!(result.files_updated, 1);
@@ -770,7 +784,7 @@ mod tests {
             path: "doomed.txt".to_string(),
         }];
 
-        let result = apply_patch(&ops, &dir).await;
+        let result = apply_patch(&ops, &dir, &[]).await;
         assert!(result.is_ok());
         assert_eq!(result.files_deleted, 1);
         assert!(!dir.join("doomed.txt").exists());

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -6929,6 +6929,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_apply_patch_allows_rw_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let target = shared_canon.join("added.txt");
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadWrite)]);
+
+        let patch = format!(
+            "*** Begin Patch\n*** Add File: {}\n+hello-from-patch\n*** End Patch\n",
+            target.to_str().unwrap()
+        );
+
+        let result = execute_tool(
+            "test-id",
+            "apply_patch",
+            &serde_json::json!({"patch": patch}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000006"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(!result.is_error, "got error: {}", result.content);
+        let written = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(written, "hello-from-patch");
+    }
+
+    #[tokio::test]
+    async fn test_apply_patch_denies_readonly_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let target = shared_canon.join("added.txt");
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadOnly)]);
+
+        let patch = format!(
+            "*** Begin Patch\n*** Add File: {}\n+should-not-write\n*** End Patch\n",
+            target.to_str().unwrap()
+        );
+
+        let result = execute_tool(
+            "test-id",
+            "apply_patch",
+            &serde_json::json!({"patch": patch}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000007"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_error, "expected denial, got: {}", result.content);
+        assert!(!target.exists(), "file should not have been written");
+    }
+
+    #[tokio::test]
     async fn test_web_search() {
         let result = execute_tool(
             "test-id",

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -411,7 +411,11 @@ pub async fn execute_tool_raw(
 
     let result = match tool_name {
         // Filesystem tools
-        "file_read" => tool_file_read(input, *workspace_root).await,
+        "file_read" => {
+            let extra = named_ws_prefixes(*kernel, *caller_agent_id);
+            let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
+            tool_file_read(input, *workspace_root, &extra_refs).await
+        }
         "file_write" => {
             // Enforce named workspace read-only restrictions before the sandbox resolves the path.
             // Agents learn absolute workspace paths from TOOLS.md; an absolute path that falls
@@ -434,12 +438,21 @@ pub async fn execute_tool_raw(
                 }
             }
             maybe_snapshot(checkpoint_manager, *workspace_root, "pre file_write").await;
-            tool_file_write(input, *workspace_root).await
+            let extra = named_ws_prefixes_writable(*kernel, *caller_agent_id);
+            let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
+            tool_file_write(input, *workspace_root, &extra_refs).await
         }
-        "file_list" => tool_file_list(input, *workspace_root).await,
+        "file_list" => {
+            let extra = named_ws_prefixes(*kernel, *caller_agent_id);
+            let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
+            tool_file_list(input, *workspace_root, &extra_refs).await
+        }
         "apply_patch" => {
             maybe_snapshot(checkpoint_manager, *workspace_root, "pre apply_patch").await;
-            tool_apply_patch(input, *workspace_root).await
+            // apply_patch needs write access — restrict to rw named workspaces only.
+            let extra = named_ws_prefixes_writable(*kernel, *caller_agent_id);
+            let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
+            tool_apply_patch(input, *workspace_root, &extra_refs).await
         }
 
         // Web tools (upgraded: multi-provider search, SSRF-protected fetch)
@@ -2203,11 +2216,55 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
 /// unrestricted filesystem access. All file operations MUST be confined
 /// to the agent's workspace directory.
 fn resolve_file_path(raw_path: &str, workspace_root: Option<&Path>) -> Result<PathBuf, String> {
+    resolve_file_path_ext(raw_path, workspace_root, &[])
+}
+
+/// Like [`resolve_file_path`] but accepts additional canonical roots that
+/// should also be considered "inside the sandbox" — used to honor named
+/// workspaces declared in the agent's manifest.
+fn resolve_file_path_ext(
+    raw_path: &str,
+    workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
+) -> Result<PathBuf, String> {
     let root = workspace_root.ok_or(
         "Workspace sandbox not configured: file operations are disabled. \
          Set a workspace_root in the agent manifest or kernel config to enable file tools.",
     )?;
-    crate::workspace_sandbox::resolve_sandbox_path(raw_path, root)
+    crate::workspace_sandbox::resolve_sandbox_path_ext(raw_path, root, additional_roots)
+}
+
+/// Fetch the named-workspace prefixes (all modes) for the calling agent.
+/// Returns an empty vec when either kernel or agent id is missing.
+fn named_ws_prefixes(
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> Vec<std::path::PathBuf> {
+    match (kernel, caller_agent_id) {
+        (Some(k), Some(aid)) => k
+            .named_workspace_prefixes(aid)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Like [`named_ws_prefixes`] but only returns prefixes for read-write
+/// workspaces. Used by `file_write` to widen the writable allowlist.
+fn named_ws_prefixes_writable(
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> Vec<std::path::PathBuf> {
+    match (kernel, caller_agent_id) {
+        (Some(k), Some(aid)) => k
+            .named_workspace_prefixes(aid)
+            .into_iter()
+            .filter(|(_, mode)| *mode == librefang_types::agent::WorkspaceMode::ReadWrite)
+            .map(|(p, _)| p)
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2269,9 +2326,10 @@ async fn maybe_snapshot(
 async fn tool_file_read(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
 ) -> Result<String, String> {
     let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
-    let resolved = resolve_file_path(raw_path, workspace_root)?;
+    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
     tokio::fs::read_to_string(&resolved)
         .await
         .map_err(|e| format!("Failed to read file: {e}"))
@@ -2280,9 +2338,10 @@ async fn tool_file_read(
 async fn tool_file_write(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
 ) -> Result<String, String> {
     let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
-    let resolved = resolve_file_path(raw_path, workspace_root)?;
+    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
     let content = input["content"]
         .as_str()
         .ok_or("Missing 'content' parameter")?;
@@ -2304,11 +2363,12 @@ async fn tool_file_write(
 async fn tool_file_list(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
 ) -> Result<String, String> {
     let raw_path = input["path"].as_str().ok_or(
         "Missing 'path' parameter — retry with {\"path\": \".\"} to list the workspace root",
     )?;
-    let resolved = resolve_file_path(raw_path, workspace_root)?;
+    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
     let mut entries = tokio::fs::read_dir(&resolved)
         .await
         .map_err(|e| format!("Failed to list directory: {e}"))?;
@@ -2337,11 +2397,12 @@ async fn tool_file_list(
 async fn tool_apply_patch(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
 ) -> Result<String, String> {
     let patch_str = input["patch"].as_str().ok_or("Missing 'patch' parameter")?;
     let root = workspace_root.ok_or("apply_patch requires a workspace root")?;
     let ops = crate::apply_patch::parse_patch(patch_str)?;
-    let result = crate::apply_patch::apply_patch(&ops, root).await;
+    let result = crate::apply_patch::apply_patch(&ops, root, additional_roots).await;
     if result.is_ok() {
         Ok(result.summary())
     } else {
@@ -6484,6 +6545,387 @@ mod tests {
         .await;
         assert!(result.is_error);
         assert!(result.content.contains("traversal"));
+    }
+
+    // ── Named-workspace read-side support ────────────────────────────────
+    //
+    // Mock kernel that surfaces a configurable list of named workspaces
+    // (paired with their access modes) via `named_workspace_prefixes`.
+    // `readonly_workspace_prefixes` is derived from that list so the existing
+    // file_write denial path stays consistent.
+
+    struct NamedWsKernel {
+        named: Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)>,
+    }
+
+    #[async_trait]
+    impl KernelHandle for NamedWsKernel {
+        async fn spawn_agent(
+            &self,
+            _manifest_toml: &str,
+            _parent_id: Option<&str>,
+        ) -> Result<(String, String), String> {
+            Err("not used".to_string())
+        }
+        async fn send_to_agent(&self, _agent_id: &str, _message: &str) -> Result<String, String> {
+            Err("not used".to_string())
+        }
+        fn list_agents(&self) -> Vec<AgentInfo> {
+            vec![]
+        }
+        fn kill_agent(&self, _agent_id: &str) -> Result<(), String> {
+            Err("not used".to_string())
+        }
+        fn memory_store(
+            &self,
+            _key: &str,
+            _value: serde_json::Value,
+            _peer_id: Option<&str>,
+        ) -> Result<(), String> {
+            Err("not used".to_string())
+        }
+        fn memory_recall(
+            &self,
+            _key: &str,
+            _peer_id: Option<&str>,
+        ) -> Result<Option<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+        fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
+            Err("not used".to_string())
+        }
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+        async fn task_post(
+            &self,
+            _title: &str,
+            _description: &str,
+            _assigned_to: Option<&str>,
+            _created_by: Option<&str>,
+        ) -> Result<String, String> {
+            Err("not used".to_string())
+        }
+        async fn task_claim(&self, _agent_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+        async fn task_complete(
+            &self,
+            _agent_id: &str,
+            _task_id: &str,
+            _result: &str,
+        ) -> Result<(), String> {
+            Err("not used".to_string())
+        }
+        async fn task_list(&self, _status: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+        async fn task_delete(&self, _task_id: &str) -> Result<bool, String> {
+            Err("not used".to_string())
+        }
+        async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
+            Err("not used".to_string())
+        }
+        async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Err("not used".to_string())
+        }
+        async fn task_update_status(
+            &self,
+            _task_id: &str,
+            _new_status: &str,
+        ) -> Result<bool, String> {
+            Err("not used".to_string())
+        }
+        async fn publish_event(
+            &self,
+            _event_type: &str,
+            _payload: serde_json::Value,
+        ) -> Result<(), String> {
+            Err("not used".to_string())
+        }
+        async fn knowledge_add_entity(
+            &self,
+            _entity: librefang_types::memory::Entity,
+        ) -> Result<String, String> {
+            Err("not used".to_string())
+        }
+        async fn knowledge_add_relation(
+            &self,
+            _relation: librefang_types::memory::Relation,
+        ) -> Result<String, String> {
+            Err("not used".to_string())
+        }
+        async fn knowledge_query(
+            &self,
+            _pattern: librefang_types::memory::GraphPattern,
+        ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
+            Err("not used".to_string())
+        }
+        fn named_workspace_prefixes(
+            &self,
+            _agent_id: &str,
+        ) -> Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)> {
+            self.named.clone()
+        }
+        fn readonly_workspace_prefixes(&self, _agent_id: &str) -> Vec<std::path::PathBuf> {
+            self.named
+                .iter()
+                .filter(|(_, m)| *m == librefang_types::agent::WorkspaceMode::ReadOnly)
+                .map(|(p, _)| p.clone())
+                .collect()
+        }
+    }
+
+    fn make_named_ws_kernel(
+        named: Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)>,
+    ) -> Arc<dyn KernelHandle> {
+        Arc::new(NamedWsKernel { named })
+    }
+
+    #[tokio::test]
+    async fn test_file_read_allows_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let target = shared_canon.join("note.txt");
+        std::fs::write(&target, "hello shared").unwrap();
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadWrite)]);
+
+        let result = execute_tool(
+            "test-id",
+            "file_read",
+            &serde_json::json!({"path": target.to_str().unwrap()}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert_eq!(result.content, "hello shared");
+    }
+
+    #[tokio::test]
+    async fn test_file_list_allows_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        std::fs::write(shared_canon.join("a.txt"), "a").unwrap();
+        std::fs::write(shared_canon.join("b.txt"), "b").unwrap();
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadOnly)]);
+
+        let result = execute_tool(
+            "test-id",
+            "file_list",
+            &serde_json::json!({"path": shared_canon.to_str().unwrap()}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000002"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(result.content.contains("a.txt"));
+        assert!(result.content.contains("b.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_file_write_allows_rw_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let target = shared_canon.join("out.txt");
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadWrite)]);
+
+        let result = execute_tool(
+            "test-id",
+            "file_write",
+            &serde_json::json!({
+                "path": target.to_str().unwrap(),
+                "content": "wrote-it",
+            }),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000003"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(!result.is_error, "got error: {}", result.content);
+        let written = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(written, "wrote-it");
+    }
+
+    #[tokio::test]
+    async fn test_file_write_denies_readonly_named_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let target = shared_canon.join("out.txt");
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadOnly)]);
+
+        let result = execute_tool(
+            "test-id",
+            "file_write",
+            &serde_json::json!({
+                "path": target.to_str().unwrap(),
+                "content": "should-not-write",
+            }),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000004"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_error);
+        assert!(
+            result.content.contains("read-only"),
+            "expected read-only denial, got: {}",
+            result.content
+        );
+        assert!(!target.exists(), "file should not have been written");
+    }
+
+    #[tokio::test]
+    async fn test_file_read_outside_all_workspaces_still_blocked() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let other = tempfile::tempdir().expect("other");
+        let shared_canon = shared.path().canonicalize().unwrap();
+        let other_path = other.path().canonicalize().unwrap().join("nope.txt");
+        std::fs::write(&other_path, "secret").unwrap();
+
+        let kernel = make_named_ws_kernel(vec![(shared_canon, WorkspaceMode::ReadWrite)]);
+
+        let result = execute_tool(
+            "test-id",
+            "file_read",
+            &serde_json::json!({"path": other_path.to_str().unwrap()}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000005"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_error);
+        assert!(
+            result.content.contains("Access denied"),
+            "expected sandbox denial, got: {}",
+            result.content
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/workspace_sandbox.rs
+++ b/crates/librefang-runtime/src/workspace_sandbox.rs
@@ -21,6 +21,29 @@ pub const ERR_SANDBOX_ESCAPE: &str = "resolves outside workspace";
 /// - For new files: canonicalizes the parent directory and appends the filename.
 /// - The final canonical path must start with the canonical workspace root.
 pub fn resolve_sandbox_path(user_path: &str, workspace_root: &Path) -> Result<PathBuf, String> {
+    resolve_sandbox_path_ext(user_path, workspace_root, &[])
+}
+
+/// Resolve a user-supplied path within a workspace sandbox, allowing additional
+/// canonical roots (e.g. named workspaces declared in the agent manifest).
+///
+/// Behavior:
+/// - Rejects `..` components outright.
+/// - Relative paths join with `workspace_root` (the primary workspace remains
+///   the implicit base — named workspaces are addressed by their absolute path).
+/// - Absolute paths are accepted if they canonicalize underneath the primary
+///   workspace root OR any of the supplied `additional_roots`.
+/// - `additional_roots` are expected to be ALREADY canonical. Callers that
+///   maintain a list of named-workspace prefixes should canonicalize once at
+///   construction time rather than per-call.
+/// - Symlink-escape protection is preserved: a symlink whose target leaves
+///   every allowed root is still rejected because the canonicalized candidate
+///   no longer starts with any allowed prefix.
+pub fn resolve_sandbox_path_ext(
+    user_path: &str,
+    workspace_root: &Path,
+    additional_roots: &[&Path],
+) -> Result<PathBuf, String> {
     let path = Path::new(user_path);
 
     // Reject any `..` components
@@ -65,23 +88,44 @@ pub fn resolve_sandbox_path(user_path: &str, workspace_root: &Path) -> Result<Pa
                 .map_err(|e| format!("Failed to resolve parent directory: {e}"))?;
             canon_parent.join(filename)
         } else {
-            // Parent doesn't exist yet. Build the path from the *canonical* workspace
-            // root so the starts_with check below passes on platforms where the
-            // workspace root itself is a symlink (e.g. macOS /tmp -> /private/tmp).
-            // This is safe because:
-            // 1. We already rejected '..' components
-            // 2. The relative suffix is derived from workspace_root.join(path),
-            //    so no symlinks can exist in the non-existent subtree
-            let relative = candidate
-                .strip_prefix(workspace_root)
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|_| candidate.clone());
-            canon_root.join(relative)
+            // Parent doesn't exist yet. Build the path from the *canonical* root
+            // it lives under so the starts_with check below passes on platforms
+            // where the root itself is a symlink (e.g. macOS /tmp -> /private/tmp).
+            //
+            // For an absolute candidate whose ancestor is one of the additional
+            // roots, rebase onto that canonical root. Otherwise rebase onto the
+            // canonical primary workspace root. This is safe because:
+            // 1. We already rejected `..` components.
+            // 2. The relative suffix is appended to a canonical root and no
+            //    symlinks can exist in the (non-existent) subtree.
+            let mut rebased: Option<PathBuf> = None;
+            if path.is_absolute() {
+                for root in additional_roots {
+                    if let Ok(rel) = candidate.strip_prefix(root) {
+                        rebased = Some(root.join(rel));
+                        break;
+                    }
+                }
+            }
+            if let Some(p) = rebased {
+                p
+            } else {
+                let relative = candidate
+                    .strip_prefix(workspace_root)
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|_| candidate.clone());
+                canon_root.join(relative)
+            }
         }
     };
 
-    // Verify the canonical path is inside the workspace
-    if !canon_candidate.starts_with(&canon_root) {
+    // Verify the canonical path is inside the primary workspace OR one of the
+    // additional allowed roots.
+    let inside_primary = canon_candidate.starts_with(&canon_root);
+    let inside_additional = additional_roots
+        .iter()
+        .any(|root| canon_candidate.starts_with(root));
+    if !inside_primary && !inside_additional {
         return Err(format!(
             "Access denied: path '{}' {ERR_SANDBOX_ESCAPE}. \
              If you have an MCP filesystem server configured, use the \
@@ -180,6 +224,100 @@ mod tests {
         std::os::unix::fs::symlink(outside.path(), &link_path).unwrap();
 
         let result = resolve_sandbox_path("escape/secret.txt", dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Access denied"));
+    }
+
+    // ---- additional_roots tests (named-workspace read-side support) ----
+
+    #[test]
+    fn test_relative_path_inside_primary_workspace_with_additional() {
+        // Relative paths still resolve under the primary workspace root, even
+        // when additional roots are supplied — additional roots are absolute-only.
+        let primary = TempDir::new().unwrap();
+        let extra = TempDir::new().unwrap();
+        std::fs::write(primary.path().join("hello.txt"), "hi").unwrap();
+
+        let extra_canon = extra.path().canonicalize().unwrap();
+        let result =
+            resolve_sandbox_path_ext("hello.txt", primary.path(), &[extra_canon.as_path()]);
+        assert!(result.is_ok(), "got: {:?}", result);
+        let resolved = result.unwrap();
+        assert!(resolved.starts_with(primary.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn test_absolute_path_inside_additional_root_allowed() {
+        let primary = TempDir::new().unwrap();
+        let extra = TempDir::new().unwrap();
+        std::fs::write(extra.path().join("shared.txt"), "shared").unwrap();
+        let extra_canon = extra.path().canonicalize().unwrap();
+        let abs = extra_canon.join("shared.txt");
+
+        let result = resolve_sandbox_path_ext(
+            abs.to_str().unwrap(),
+            primary.path(),
+            &[extra_canon.as_path()],
+        );
+        assert!(result.is_ok(), "got: {:?}", result);
+        let resolved = result.unwrap();
+        assert!(resolved.starts_with(&extra_canon));
+    }
+
+    #[test]
+    fn test_absolute_path_outside_all_roots_blocked() {
+        let primary = TempDir::new().unwrap();
+        let extra = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        std::fs::write(other.path().join("nope.txt"), "no").unwrap();
+        let extra_canon = extra.path().canonicalize().unwrap();
+        let abs = other.path().join("nope.txt");
+
+        let result = resolve_sandbox_path_ext(
+            abs.to_str().unwrap(),
+            primary.path(),
+            &[extra_canon.as_path()],
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Access denied"), "got: {err}");
+    }
+
+    #[test]
+    fn test_dotdot_still_blocked_with_additional_roots() {
+        let primary = TempDir::new().unwrap();
+        let extra = TempDir::new().unwrap();
+        let extra_canon = extra.path().canonicalize().unwrap();
+
+        let result = resolve_sandbox_path_ext(
+            "../../../etc/passwd",
+            primary.path(),
+            &[extra_canon.as_path()],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Path traversal denied"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_escape_still_blocked_via_additional_root() {
+        // A symlink that lives inside an additional root but points to a third
+        // directory (outside both primary and additional) must still be denied.
+        let primary = TempDir::new().unwrap();
+        let extra = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+
+        let extra_canon = extra.path().canonicalize().unwrap();
+        let link = extra_canon.join("escape");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let abs = extra_canon.join("escape").join("secret.txt");
+
+        let result = resolve_sandbox_path_ext(
+            abs.to_str().unwrap(),
+            primary.path(),
+            &[extra_canon.as_path()],
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Access denied"));
     }

--- a/crates/librefang-runtime/src/workspace_sandbox.rs
+++ b/crates/librefang-runtime/src/workspace_sandbox.rs
@@ -126,10 +126,20 @@ pub fn resolve_sandbox_path_ext(
         .iter()
         .any(|root| canon_candidate.starts_with(root));
     if !inside_primary && !inside_additional {
+        let named_hint = if additional_roots.is_empty() {
+            "If the path lives in a shared location, declare it under \
+             [workspaces] in agent.toml (e.g. `foo = { path = \"shared/foo\", \
+             mode = \"rw\" }`) so it becomes accessible as a named workspace. "
+        } else {
+            "The agent has named workspaces declared, but this path is not \
+             inside any of them. Check the [workspaces] entries in agent.toml \
+             and the @-prefixed roots listed in TOOLS.md. "
+        };
         return Err(format!(
             "Access denied: path '{}' {ERR_SANDBOX_ESCAPE}. \
-             If you have an MCP filesystem server configured, use the \
-             mcp_filesystem_* tools (e.g. mcp_filesystem_read_file, \
+             {named_hint}\
+             Alternatively, if you have an MCP filesystem server configured, \
+             use the mcp_filesystem_* tools (e.g. mcp_filesystem_read_file, \
              mcp_filesystem_list_directory) to access files outside \
              the workspace.",
             user_path


### PR DESCRIPTION
## Summary

PR #2958 added named workspaces (`[workspaces]` in `agent.toml` / `HAND.toml` agent sections) and wired them into write-side denial — `tool_runner.rs:419–434` checks `kernel.readonly_workspace_prefixes()` to reject writes into read-only named workspaces. But the corresponding read-side allowance was never wired: `file_read`, `file_list`, and `apply_patch` go through `workspace_sandbox::resolve_sandbox_path` which only checks the canonical *primary* workspace root.

Result: an agent that legitimately declares `foo = { path = "shared/foo", mode = "rw" }` and learns the absolute path from the auto-generated `TOOLS.md` line `@foo → /abs/path/shared/foo (read-write)` can `shell_exec cat <path>` against it (no sandbox check on shell), but `file_read({"path": "<same path>"})` returns:

```
Access denied: path '/.../shared/foo/...' resolves outside workspace.
```

This PR closes the asymmetry.

## Why no test caught it

`crates/librefang-runtime/src/workspace_sandbox.rs` tests all use a single workspace root. There's no positive case asserting that read tools succeed against a declared named workspace path. PR #2958's review feedback caught the write-side denial gap (the "address code review issues" commit added `file_write` enforcement), but no one noticed reads were also broken because no test asserted positive read-allowed behavior on named workspaces.

## Design

1. **`KernelHandle::named_workspace_prefixes(agent_id) -> Vec<(PathBuf, WorkspaceMode)>`** — new method returning all canonical absolute paths with their modes. The kernel impl canonicalizes once. `readonly_workspace_prefixes` becomes a thin filter on top so canonical resolution isn't duplicated.

2. **`workspace_sandbox::resolve_sandbox_path_ext(user_path, workspace_root, additional_roots: &[&Path])`** — the existing two-arg `resolve_sandbox_path` is preserved as a wrapper. The new function widens acceptance to `inside_primary || inside_any_additional`. `..` rejection and the symlink-escape predicate are unchanged. Relative paths still join with `workspace_root` only — additional roots are absolute-only entry points.

3. **Tool dispatch wires the prefixes**:
   - `file_read` / `file_list` / `apply_patch` → all named-workspace prefixes (rw and r both allowed for reads).
   - `file_write` → rw-filtered prefixes only. The existing read-only denial check (`readonly_workspace_prefixes`) still runs *before* path resolution, preserving the spec'd behavior of a clear "Write denied: read-only named workspace" error message rather than a generic sandbox rejection.

The leaf functions (`tool_file_read/write/list`, `apply_patch`) gained an `additional_roots: &[&Path]` parameter; two file-private helpers in `tool_runner.rs` (`named_ws_prefixes`, `named_ws_prefixes_writable`) build the slice from the kernel handle.

## Files changed

| File | Change |
|------|--------|
| `crates/librefang-kernel-handle/src/lib.rs` | New default `named_workspace_prefixes()` returning empty |
| `crates/librefang-kernel/src/kernel/mod.rs` | Implements `named_workspace_prefixes`; refactors `readonly_workspace_prefixes` as a filter on top |
| `crates/librefang-runtime/src/workspace_sandbox.rs` | Adds `resolve_sandbox_path_ext`; existing fn becomes a wrapper. New unit tests. |
| `crates/librefang-runtime/src/apply_patch.rs` | `apply_patch` and `resolve_patch_path` accept `additional_roots` |
| `crates/librefang-runtime/src/tool_runner.rs` | Helpers + threading + integration tests |

## Tests

- `workspace_sandbox.rs` — went from 7 → 12 unit tests:
  - `test_relative_path_inside_primary_workspace_with_additional` — relative still joins primary
  - `test_absolute_path_inside_additional_root_allowed` — absolute under an additional root succeeds
  - `test_absolute_path_outside_all_roots_blocked` — neither primary nor additional → denied
  - `test_dotdot_still_blocked_with_additional_roots` — `..` still rejected
  - `test_symlink_escape_still_blocked_via_additional_root` — symlink escape from additional root denied
- `tool_runner.rs` — 5 new integration tests using a small `NamedWsKernel` mock that drives `named_workspace_prefixes` directly. Covers: file_read against rw, file_read against r, file_list, file_write against rw, file_write against r returns the existing read-only denial.

## Verification

```
cargo build --workspace --lib                                # clean
cargo clippy --workspace --all-targets -- -D warnings        # clean
cargo test --lib -p librefang-runtime                        # 1314 pass, 0 fail
```

`cargo test --workspace --lib` shows 9 pre-existing failures (`config::tests::test_load_config_defaults`, 8 `cron_delivery` tests rejecting loopback URLs / absolute paths). Verified independently on `upstream/main` — same 9 failures. Unrelated to this change.

## Note on a small extension to the design

The non-existent-parent rebase branch in `resolve_sandbox_path_ext` (the path that supports writing new files whose parent dir doesn't exist yet) needed to be extended: when the candidate is absolute and lives under an additional root, the file-doesn't-yet-exist path rebases onto the additional root rather than the primary canon root. Without that, `file_write` of a new file inside a named workspace would `starts_with`-fail. This preserves the symlink-handling rationale of the original code and is exercised by the integration tests.

## Risk / blast radius

Low. Read-side tools only widen acceptance; no path that was previously allowed becomes denied. Write-side denial preserved. The `KernelHandle` gets one new default-impl method, so any third-party `KernelHandle` implementor compiles unchanged.

## Repro before this PR

```toml
# agent.toml
[workspaces]
foo = { path = "shared/foo", mode = "rw" }
```

```
$ # absolute path picked up from TOOLS.md auto-generated entry
$ # @foo → /home/.../shared/foo (read-write)
$ # via file_read tool:
file_read({"path": "/home/.../shared/foo/x.json"})
→ Access denied: path '...' resolves outside workspace.
$ # via shell_exec — works (no sandbox check):
shell_exec({"command": "cat /home/.../shared/foo/x.json"})
→ <file contents>
```

After this PR: both succeed. `file_write` against an `r`-mode named workspace continues to return the existing "Write denied" error.

Closes the read-side half of the contract introduced by #2958.