### PR TITLE
fix(providers): unbreak local provider config in GUI

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -580,6 +580,7 @@
     "optional": "optional",
     "remove_key": "Remove Key",
     "base_url": "Base URL",
+    "base_url_hint": "Bare host:port URLs (e.g. http://192.168.1.10:11434) will get /v1 appended automatically for OpenAI-compatible endpoints.",
     "proxy_url": "Proxy URL",
     "proxy_url_placeholder": "http://proxy:8080 or socks5://proxy:1080",
     "api_key": "API Key",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -579,6 +579,7 @@
     "optional": "可选",
     "remove_key": "移除 Key",
     "base_url": "Base URL",
+    "base_url_hint": "仅填 host:port (如 http://192.168.1.10:11434) 时会自动追加 /v1,适配 OpenAI 兼容端点。",
     "proxy_url": "代理 URL",
     "proxy_url_placeholder": "http://proxy:8080 或 socks5://proxy:1080",
     "api_key": "API Key",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1179,6 +1179,15 @@ export function ProvidersPage() {
     && config.urlInput === (config.provider.base_url || "")
     && config.proxyInput === (config.provider.proxy_url || "");
   const saveDisabled = !config.provider || config.saving || config.testing || isUnchanged;
+  // Local providers (Ollama / vLLM / LM Studio) declare `key_required: false`
+  // — for them, the Test button must NOT require a key, otherwise users have
+  // no way to verify their custom base_url. Issue #3138.
+  const testDisabled =
+    config.saving
+    || config.testing
+    || (config.provider?.key_required !== false
+        && !config.hasStoredKey
+        && !config.keyInput.trim());
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -1352,6 +1361,12 @@ export function ProvidersPage() {
               <input type="text" value={config.urlInput} onChange={e => config.setUrlInput(e.target.value)}
                 placeholder="https://api.example.com/v1"
                 className="mt-1 w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono outline-none focus:border-brand focus:ring-1 focus:ring-brand/20" />
+              <p className="mt-1 text-[10px] text-text-dim/60 leading-snug">
+                {t("providers.base_url_hint", {
+                  defaultValue:
+                    "Bare host:port URLs (e.g. http://192.168.1.10:11434) will get /v1 appended automatically for OpenAI-compatible endpoints.",
+                })}
+              </p>
             </div>
 
             <div>
@@ -1381,7 +1396,7 @@ export function ProvidersPage() {
                 {config.saving ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Key className="w-4 h-4 mr-1" />}
                 {t("common.save")}
               </Button>
-              <Button variant="secondary" onClick={config.testKey} disabled={config.saving || config.testing || (!config.hasStoredKey && !config.keyInput.trim())}>
+              <Button variant="secondary" onClick={config.testKey} disabled={testDisabled}>
                 {config.testing ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Zap className="w-4 h-4 mr-1" />}
                 {t("providers.test")}
               </Button>

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1435,7 +1435,7 @@ pub async fn set_provider_url(
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     // Accept any provider name — custom providers are supported via OpenAI-compatible format.
-    let base_url = match body["base_url"].as_str() {
+    let base_url_raw = match body["base_url"].as_str() {
         Some(u) if !u.trim().is_empty() => u.trim().to_string(),
         _ => {
             return ApiErrorResponse::bad_request("Missing or empty 'base_url' field")
@@ -1444,10 +1444,19 @@ pub async fn set_provider_url(
     };
 
     // Validate URL scheme
-    if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+    if !base_url_raw.starts_with("http://") && !base_url_raw.starts_with("https://") {
         return ApiErrorResponse::bad_request("base_url must start with http:// or https://")
             .into_json_tuple();
     }
+
+    // Normalize for the common Ollama / vLLM / LM Studio mistake: users
+    // paste `http://host:port` (no path) and the OpenAI driver then hits
+    // `/chat/completions` instead of `/v1/chat/completions`, getting a 404.
+    // If the user gave us a host-only URL (path is empty or just "/"),
+    // append `/v1` so OpenAI-compatible endpoints work out of the box.
+    // Custom paths (`/api/openai`, `/openai/v1`, etc.) are left alone.
+    // Issue #3138.
+    let base_url = normalize_base_url(&base_url_raw);
 
     // Optional proxy_url in same request
     let proxy_url = body["proxy_url"].as_str().map(|s| s.trim().to_string());
@@ -1703,6 +1712,79 @@ fn persist_default_model(
     root.insert("default_model".to_string(), toml::Value::Table(dm_table));
     std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
     Ok(())
+}
+
+/// Normalize a user-supplied provider base URL.
+///
+/// `http://host:port` (no path) and `http://host:port/` are rewritten to
+/// `http://host:port/v1` because every OpenAI-compatible local server we
+/// support (Ollama, vLLM, LM Studio, LlamaSwap, llama-server, etc.) serves
+/// its chat-completions endpoint at `/v1/chat/completions`. Without the
+/// normalisation the OpenAI driver produces `/chat/completions` and the
+/// server returns HTTP 404 — see issue #3138.
+///
+/// Custom paths (`/api/openai`, `/openai/v1`, `/router/some/path`) are left
+/// untouched: if a user explicitly typed a path we trust it.
+fn normalize_base_url(input: &str) -> String {
+    let trimmed = input.trim().trim_end_matches('/').to_string();
+    // After scheme there must be host[:port][/path…]. Find the first '/'
+    // after the scheme separator to know whether a path was supplied.
+    let after_scheme = trimmed.split_once("://").map(|(_, rest)| rest).unwrap_or("");
+    let has_path = after_scheme.find('/').is_some();
+    if has_path {
+        // User supplied an explicit path — respect it.
+        trimmed
+    } else {
+        // Bare host[:port] — assume OpenAI-compatible default.
+        format!("{trimmed}/v1")
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn normalize_base_url_appends_v1_for_bare_host() {
+    assert_eq!(
+        normalize_base_url("http://192.168.1.10:11434"),
+        "http://192.168.1.10:11434/v1"
+    );
+    assert_eq!(
+        normalize_base_url("http://192.168.1.10:11434/"),
+        "http://192.168.1.10:11434/v1"
+    );
+    assert_eq!(
+        normalize_base_url("http://localhost:8000"),
+        "http://localhost:8000/v1"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn normalize_base_url_preserves_explicit_path() {
+    assert_eq!(
+        normalize_base_url("http://192.168.1.10:11434/v1"),
+        "http://192.168.1.10:11434/v1"
+    );
+    assert_eq!(
+        normalize_base_url("http://192.168.1.10:11434/v1/"),
+        "http://192.168.1.10:11434/v1"
+    );
+    assert_eq!(
+        normalize_base_url("https://api.openai.com/v1"),
+        "https://api.openai.com/v1"
+    );
+    assert_eq!(
+        normalize_base_url("https://example.com/api/openai"),
+        "https://example.com/api/openai"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn normalize_base_url_trims_whitespace() {
+    assert_eq!(
+        normalize_base_url("  http://localhost:11434  "),
+        "http://localhost:11434/v1"
+    );
 }
 
 /// Upsert a provider URL in the `[provider_urls]` section of config.toml.

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1729,7 +1729,10 @@ fn normalize_base_url(input: &str) -> String {
     let trimmed = input.trim().trim_end_matches('/').to_string();
     // After scheme there must be host[:port][/path…]. Find the first '/'
     // after the scheme separator to know whether a path was supplied.
-    let after_scheme = trimmed.split_once("://").map(|(_, rest)| rest).unwrap_or("");
+    let after_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
     let has_path = after_scheme.find('/').is_some();
     if has_path {
         // User supplied an explicit path — respect it.


### PR DESCRIPTION
## Summary
Closes #3138 — local providers (Ollama, vLLM, LM Studio, Lemonade, LlamaSwap, etc.) couldn't be configured through the GUI:

1. The Test button stayed grey for any provider whose `key_required` is `false`. The disable rule required a stored or freshly-typed key, which doesn't apply to local providers — so users had no way to verify their custom `base_url` from the UI.
2. After saving, the provider returned **HTTP 404**. Users typically paste a host like `http://192.168.1.10:11434`, the OpenAI driver then builds `…/chat/completions` (no `/v1`), and Ollama / vLLM / LM Studio / etc. only expose chat completions at `/v1/chat/completions`.

## Fix

### Test button (dashboard)
`testDisabled` now treats `key_required === false` providers as exempt from the "must have a key" precondition. Save button rule unchanged.

### base_url normalisation (backend)
`set_provider_url` runs the input through `normalize_base_url`:

- `http://host:port` and `http://host:port/` → `http://host:port/v1`
- `http://host:port/v1`, `/v1/`, custom paths like `/api/openai` → preserved verbatim
- whitespace trimmed

Tests cover all three branches.

### URL input hint (dashboard)
Added a small caption under the Base URL field explaining the auto-`/v1` behaviour so users understand why their bare-host paste was rewritten.

## Test plan
- [ ] Open Configure on Ollama, paste `http://localhost:11434`, click Test → should be enabled and reachable
- [ ] After Save, the persisted `base_url` ends with `/v1`
- [ ] Configure with explicit path like `http://x.com/api/openai` → preserved unchanged
- [ ] Paid provider (OpenAI, Anthropic, …) without a stored key → Test still grey until you type one
