### PR TITLE
fix(provider-health): relax probe timeout for remote local-provider URLs

### DIFF
--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -8,6 +8,7 @@
 //! on TCP connect timeouts to unreachable local services.
 
 use dashmap::DashMap;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 /// Enriched metadata for a discovered model (Ollama-specific fields are optional).
@@ -114,23 +115,23 @@ pub fn is_local_provider(provider: &str) -> bool {
     )
 }
 
-/// Overall request timeout for local provider health probes (connect + response).
+/// Per-request total timeout for loopback probe targets.
 ///
-/// Tight default for loopback addresses where the daemon should be milliseconds
-/// away — a 2 s budget makes the model switcher recognize a dead local ollama
-/// quickly. Remote-fronted setups (e.g. Open WebUI proxy over HTTPS, see
-/// [`PROBE_REMOTE_TIMEOUT_SECS`]) need a looser budget for TLS + WAN latency.
+/// The shared probe client (see [`PROBE_CLIENT`]) is configured with the
+/// relaxed remote budget so it can serve HTTPS reverse-proxy fronts; loopback
+/// callers tighten the total via `RequestBuilder::timeout(...)` so a dead
+/// local daemon still surfaces fast. `connect_timeout` cannot be overridden
+/// per-request — both profiles share the client's 3 s connect budget — but
+/// this 2 s request budget fires first on any pathological local stall.
 const PROBE_TIMEOUT_SECS: u64 = 2;
-
-/// TCP connect timeout — fail fast when the local port is not listening.
-const PROBE_CONNECT_TIMEOUT_SECS: u64 = 1;
 
 /// Total request timeout for non-loopback probe targets (HTTPS reverse proxies,
 /// remote ollama, etc.). 8 s comfortably absorbs cold-start TLS handshakes
 /// (~1–3 s on first connect) plus end-to-end WAN latency.
 const PROBE_REMOTE_TIMEOUT_SECS: u64 = 8;
 
-/// TCP connect timeout for non-loopback probe targets.
+/// TCP connect timeout for the shared probe client. Applied uniformly because
+/// reqwest does not expose per-request connect timeouts.
 const PROBE_REMOTE_CONNECT_TIMEOUT_SECS: u64 = 3;
 
 /// Format a `reqwest::Error` with its cause chain so probe failures stay
@@ -161,13 +162,55 @@ fn format_request_error(err: &reqwest::Error) -> String {
     parts.join(": ")
 }
 
-/// Returns `true` when `base_url` points at a loopback host. Loopback hosts get
-/// the tight [`PROBE_TIMEOUT_SECS`] / [`PROBE_CONNECT_TIMEOUT_SECS`] budgets;
-/// everything else uses the relaxed [`PROBE_REMOTE_TIMEOUT_SECS`] /
-/// [`PROBE_REMOTE_CONNECT_TIMEOUT_SECS`] pair.
+/// Process-wide cache for the probe HTTP client. Constructed once on first
+/// use so the connection pool and TLS sessions persist across probe cycles —
+/// otherwise every 60-second probe to an HTTPS reverse-proxy front (Open WebUI
+/// etc.) pays a fresh ~1–2 s cold-start TLS handshake.
 ///
-/// Unparseable URLs are treated as loopback to preserve the original
-/// fast-fail behaviour for plain `localhost:11434` style strings.
+/// Configured with the relaxed remote timeouts; loopback callers tighten the
+/// total request budget via per-request `RequestBuilder::timeout(...)`. The
+/// connect timeout cannot be overridden per-request, so loopback uses the
+/// same 3-second connect budget as remote — acceptable because a localhost
+/// daemon that can't accept TCP within 3 s is already broken.
+///
+/// Limitation: not invalidated on `[proxy]` config reload. Users who change
+/// `http_proxy` / `https_proxy` at runtime need to restart the daemon for
+/// probe traffic to pick up the new forward proxy. Acceptable because the
+/// motivating case (reverse-proxy ollama URLs like Open WebUI) does not
+/// involve forward proxies, and `[proxy]` reloads are rare in practice.
+static PROBE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// Return the shared probe HTTP client, building it on first call.
+fn probe_client() -> &'static reqwest::Client {
+    PROBE_CLIENT.get_or_init(|| {
+        crate::http_client::proxied_client_builder()
+            .connect_timeout(Duration::from_secs(PROBE_REMOTE_CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(PROBE_REMOTE_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_else(|e| {
+                // Build can fail in exotic TLS configurations. Fall back to a
+                // default reqwest::Client so probes still run rather than
+                // failing every cycle with the same construction error.
+                tracing::warn!(
+                    error = %e,
+                    "probe HTTP client build failed; falling back to default reqwest::Client"
+                );
+                reqwest::Client::new()
+            })
+    })
+}
+
+/// Returns `true` when `base_url` points at a loopback host. Loopback hosts
+/// get the tight [`PROBE_TIMEOUT_SECS`] per-request total; everything else
+/// uses the shared client's [`PROBE_REMOTE_TIMEOUT_SECS`] default.
+///
+/// Both profiles share the [`PROBE_REMOTE_CONNECT_TIMEOUT_SECS`] connect
+/// budget because reqwest does not expose per-request connect timeouts; this
+/// is tolerable since a localhost daemon that cannot accept TCP within 3 s is
+/// already broken.
+///
+/// Unparseable URLs are treated as loopback to preserve fast-fail behaviour
+/// for plain `localhost:11434` style strings.
 fn is_loopback_base_url(base_url: &str) -> bool {
     match url::Url::parse(base_url) {
         Ok(u) => match u.host_str() {
@@ -247,25 +290,8 @@ impl Default for ProbeCache {
 pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str>) -> ProbeResult {
     let start = Instant::now();
 
-    let (connect_timeout_secs, total_timeout_secs) = if is_loopback_base_url(base_url) {
-        (PROBE_CONNECT_TIMEOUT_SECS, PROBE_TIMEOUT_SECS)
-    } else {
-        (PROBE_REMOTE_CONNECT_TIMEOUT_SECS, PROBE_REMOTE_TIMEOUT_SECS)
-    };
-
-    let client = match crate::http_client::proxied_client_builder()
-        .connect_timeout(Duration::from_secs(connect_timeout_secs))
-        .timeout(Duration::from_secs(total_timeout_secs))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return ProbeResult {
-                error: Some(format!("Failed to build HTTP client: {e}")),
-                ..Default::default()
-            };
-        }
-    };
+    let client = probe_client();
+    let is_loopback = is_loopback_base_url(base_url);
 
     let lower = provider.to_lowercase();
 
@@ -290,6 +316,14 @@ pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str
     // catalog flips to LocalOffline even though the underlying ollama
     // is healthy.
     let mut req = client.get(&url);
+    if is_loopback {
+        // Tighten the request budget for loopback targets so a dead local
+        // daemon still surfaces fast. The shared client carries the relaxed
+        // remote timeout; per-request `.timeout()` overrides it for this call.
+        // (`connect_timeout` is fixed at client build, but the 2 s request
+        // timeout fires first on any pathological local stall.)
+        req = req.timeout(Duration::from_secs(PROBE_TIMEOUT_SECS));
+    }
     if let Some(key) = api_key {
         let trimmed = key.trim();
         if !trimmed.is_empty() {
@@ -539,13 +573,22 @@ mod tests {
     #[test]
     fn test_probe_timeout_value() {
         assert_eq!(PROBE_TIMEOUT_SECS, 2);
-        assert_eq!(PROBE_CONNECT_TIMEOUT_SECS, 1);
         assert_eq!(PROBE_REMOTE_TIMEOUT_SECS, 8);
         assert_eq!(PROBE_REMOTE_CONNECT_TIMEOUT_SECS, 3);
-        // Remote budget must always exceed the loopback budget; otherwise we
-        // would slow remote probes for no reason.
+        // Remote budget must always exceed the loopback per-request override;
+        // otherwise loopback callers would slow themselves down vs the shared
+        // client's default.
         assert!(PROBE_REMOTE_TIMEOUT_SECS > PROBE_TIMEOUT_SECS);
-        assert!(PROBE_REMOTE_CONNECT_TIMEOUT_SECS > PROBE_CONNECT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_probe_client_is_shared() {
+        // The shared client is initialised lazily and persisted via OnceLock —
+        // every probe call must see the same instance so the connection pool
+        // and TLS sessions actually amortise across the 60-second probe loop.
+        let a = probe_client();
+        let b = probe_client();
+        assert!(std::ptr::eq(a, b));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -115,10 +115,61 @@ pub fn is_local_provider(provider: &str) -> bool {
 }
 
 /// Overall request timeout for local provider health probes (connect + response).
+///
+/// Tight default for loopback addresses where the daemon should be milliseconds
+/// away — a 2 s budget makes the model switcher recognize a dead local ollama
+/// quickly. Remote-fronted setups (e.g. Open WebUI proxy over HTTPS, see
+/// [`PROBE_REMOTE_TIMEOUT_SECS`]) need a looser budget for TLS + WAN latency.
 const PROBE_TIMEOUT_SECS: u64 = 2;
 
 /// TCP connect timeout — fail fast when the local port is not listening.
 const PROBE_CONNECT_TIMEOUT_SECS: u64 = 1;
+
+/// Total request timeout for non-loopback probe targets (HTTPS reverse proxies,
+/// remote ollama, etc.). 8 s comfortably absorbs cold-start TLS handshakes
+/// (~1–3 s on first connect) plus end-to-end WAN latency.
+const PROBE_REMOTE_TIMEOUT_SECS: u64 = 8;
+
+/// TCP connect timeout for non-loopback probe targets.
+const PROBE_REMOTE_CONNECT_TIMEOUT_SECS: u64 = 3;
+
+/// Format a `reqwest::Error` with its cause chain so probe failures stay
+/// diagnosable. The default `Display` impl drops the inner cause, leaving the
+/// generic `error sending request for url (...)` line for everything from a
+/// timeout to a TLS handshake failure to DNS — flatten the chain so the WARN
+/// line tells operators which it actually was.
+fn format_request_error(err: &reqwest::Error) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source: Option<&dyn std::error::Error> = std::error::Error::source(err);
+    while let Some(cause) = source {
+        parts.push(cause.to_string());
+        source = cause.source();
+    }
+    if err.is_timeout() && !parts.iter().any(|p| p.to_lowercase().contains("timeout")) {
+        parts.push("timed out".to_string());
+    }
+    parts.join(": ")
+}
+
+/// Returns `true` when `base_url` points at a loopback host. Loopback hosts get
+/// the tight [`PROBE_TIMEOUT_SECS`] / [`PROBE_CONNECT_TIMEOUT_SECS`] budgets;
+/// everything else uses the relaxed [`PROBE_REMOTE_TIMEOUT_SECS`] /
+/// [`PROBE_REMOTE_CONNECT_TIMEOUT_SECS`] pair.
+///
+/// Unparseable URLs are treated as loopback to preserve the original
+/// fast-fail behaviour for plain `localhost:11434` style strings.
+fn is_loopback_base_url(base_url: &str) -> bool {
+    match url::Url::parse(base_url) {
+        Ok(u) => match u.host_str() {
+            Some(h) => matches!(
+                h.to_ascii_lowercase().as_str(),
+                "localhost" | "127.0.0.1" | "::1" | "[::1]"
+            ),
+            None => true,
+        },
+        Err(_) => true,
+    }
+}
 
 /// Default TTL for cached probe results (seconds).
 const PROBE_CACHE_TTL_SECS: u64 = 60;
@@ -186,9 +237,15 @@ impl Default for ProbeCache {
 pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str>) -> ProbeResult {
     let start = Instant::now();
 
+    let (connect_timeout_secs, total_timeout_secs) = if is_loopback_base_url(base_url) {
+        (PROBE_CONNECT_TIMEOUT_SECS, PROBE_TIMEOUT_SECS)
+    } else {
+        (PROBE_REMOTE_CONNECT_TIMEOUT_SECS, PROBE_REMOTE_TIMEOUT_SECS)
+    };
+
     let client = match crate::http_client::proxied_client_builder()
-        .connect_timeout(Duration::from_secs(PROBE_CONNECT_TIMEOUT_SECS))
-        .timeout(Duration::from_secs(PROBE_TIMEOUT_SECS))
+        .connect_timeout(Duration::from_secs(connect_timeout_secs))
+        .timeout(Duration::from_secs(total_timeout_secs))
         .build()
     {
         Ok(c) => c,
@@ -235,7 +292,7 @@ pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str
         Err(e) => {
             return ProbeResult {
                 latency_ms: start.elapsed().as_millis() as u64,
-                error: Some(format!("{e}")),
+                error: Some(format_request_error(&e)),
                 ..Default::default()
             };
         }
@@ -473,6 +530,41 @@ mod tests {
     fn test_probe_timeout_value() {
         assert_eq!(PROBE_TIMEOUT_SECS, 2);
         assert_eq!(PROBE_CONNECT_TIMEOUT_SECS, 1);
+        assert_eq!(PROBE_REMOTE_TIMEOUT_SECS, 8);
+        assert_eq!(PROBE_REMOTE_CONNECT_TIMEOUT_SECS, 3);
+        // Remote budget must always exceed the loopback budget; otherwise we
+        // would slow remote probes for no reason.
+        assert!(PROBE_REMOTE_TIMEOUT_SECS > PROBE_TIMEOUT_SECS);
+        assert!(PROBE_REMOTE_CONNECT_TIMEOUT_SECS > PROBE_CONNECT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_is_loopback_base_url_loopback_hosts() {
+        assert!(is_loopback_base_url("http://127.0.0.1:11434/v1"));
+        assert!(is_loopback_base_url("http://localhost:11434/v1"));
+        assert!(is_loopback_base_url("http://LOCALHOST:11434"));
+        assert!(is_loopback_base_url("http://[::1]:11434/v1"));
+        assert!(is_loopback_base_url("http://127.0.0.1:8000/"));
+    }
+
+    #[test]
+    fn test_is_loopback_base_url_remote_hosts() {
+        assert!(!is_loopback_base_url(
+            "https://webui.example.com/ollama/v1"
+        ));
+        assert!(!is_loopback_base_url("http://192.168.1.10:11434"));
+        assert!(!is_loopback_base_url("https://api.openai.com/v1"));
+        // LAN hosts that resolve via mDNS / private DNS are still "remote"
+        // for the probe — they cross a network boundary.
+        assert!(!is_loopback_base_url("http://nas.local:11434"));
+    }
+
+    #[test]
+    fn test_is_loopback_base_url_unparseable_falls_back_to_loopback() {
+        // Unparseable URLs preserve the legacy fast-fail budget rather than
+        // mysteriously slowing every probe in a malformed-config scenario.
+        assert!(is_loopback_base_url("not a url"));
+        assert!(is_loopback_base_url(""));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -576,7 +576,7 @@ mod tests {
         // Remote budget must always exceed the loopback per-request override;
         // otherwise loopback callers would slow themselves down vs the shared
         // client's default.
-        assert!(PROBE_REMOTE_TIMEOUT_SECS > PROBE_TIMEOUT_SECS);
+        const { assert!(PROBE_REMOTE_TIMEOUT_SECS > PROBE_TIMEOUT_SECS) };
     }
 
     #[test]

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -145,7 +145,17 @@ fn format_request_error(err: &reqwest::Error) -> String {
         parts.push(cause.to_string());
         source = cause.source();
     }
-    if err.is_timeout() && !parts.iter().any(|p| p.to_lowercase().contains("timeout")) {
+    // reqwest renders timeouts as "operation timed out" / "timed out" — the
+    // substring is "timed out", not "timeout". Check both so we don't
+    // double-append the marker when the cause chain already mentioned it.
+    if err.is_timeout()
+        && !parts
+            .iter()
+            .any(|p| {
+                let s = p.to_lowercase();
+                s.contains("timeout") || s.contains("timed out")
+            })
+    {
         parts.push("timed out".to_string());
     }
     parts.join(": ")

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -150,12 +150,10 @@ fn format_request_error(err: &reqwest::Error) -> String {
     // substring is "timed out", not "timeout". Check both so we don't
     // double-append the marker when the cause chain already mentioned it.
     if err.is_timeout()
-        && !parts
-            .iter()
-            .any(|p| {
-                let s = p.to_lowercase();
-                s.contains("timeout") || s.contains("timed out")
-            })
+        && !parts.iter().any(|p| {
+            let s = p.to_lowercase();
+            s.contains("timeout") || s.contains("timed out")
+        })
     {
         parts.push("timed out".to_string());
     }
@@ -602,9 +600,7 @@ mod tests {
 
     #[test]
     fn test_is_loopback_base_url_remote_hosts() {
-        assert!(!is_loopback_base_url(
-            "https://webui.example.com/ollama/v1"
-        ));
+        assert!(!is_loopback_base_url("https://webui.example.com/ollama/v1"));
         assert!(!is_loopback_base_url("http://192.168.1.10:11434"));
         assert!(!is_loopback_base_url("https://api.openai.com/v1"));
         // LAN hosts that resolve via mDNS / private DNS are still "remote"


### PR DESCRIPTION
## Summary

Local-provider probes (ollama / vLLM / LM Studio / lemonade) used hard-coded 1 s connect / 2 s total timeouts tuned for a loopback daemon. When the same provider is fronted by a remote reverse-proxy — Open WebUI exposing ollama under `https://host/ollama/v1`, a remote vLLM, etc. — TLS handshake plus WAN latency routinely exceeds 2 s on cold connections, so the probe intermittently times out and the catalog flips to `LocalOffline`. The visible symptom is periodic

```
WARN Configured local provider offline provider=ollama error="error sending request for url (https://host/ollama/api/tags)"
```

even when the upstream ollama is healthy and curl from the same host returns 200 in ~1 s.

## Fix

- Pick the timeout pair from `base_url`:
  - **Loopback hosts** (`127.0.0.1`, `localhost`, `::1`) keep the original `1 s / 2 s` budget so a dead local daemon still surfaces quickly.
  - **Remote hosts** get `3 s / 8 s` — comfortable for a cold TLS handshake plus several WAN round-trips.
- Unparseable URLs fall back to the loopback budget so a malformed config doesn't silently slow every probe.
- Flatten reqwest's `Display` chain into the WARN's `error=...` field. Previously every transport failure rendered as the generic `error sending request for url (...)`; now operators see whether it was a timeout, DNS, TLS handshake, or status code without flipping log level.

## Test plan

- [x] `provider_health` unit tests added for `is_loopback_base_url` covering loopback, remote, LAN-mDNS, and unparseable inputs.
- [x] Existing `test_probe_timeout_value` extended to assert the new constants and the invariant `remote > local`.
- [ ] CI green
- [ ] Manual: with `[provider_urls].ollama = "https://webui-host/ollama/v1"` and `OLLAMA_API_KEY` set, no more periodic `Configured local provider offline` WARNs over a 5-minute window.
