### PR TITLE
feat(runtime): cache_hit_ratio metric + trajectory field (M2/2)

### DIFF
--- a/crates/librefang-kernel/src/trajectory/mod.rs
+++ b/crates/librefang-kernel/src/trajectory/mod.rs
@@ -225,18 +225,10 @@ pub enum RedactedBlock {
 
 /// Compute the prompt-cache hit ratio for an aggregate `TokenUsage`.
 ///
-/// Returns `None` when neither cache_read nor cache_creation tokens were
-/// reported (e.g. provider doesn't support prompt caching). Returns
-/// `Some(ratio)` in `[0.0, 1.0]` otherwise — `Some(0.0)` for a cold-start
-/// turn where caching was active but produced no hits, `Some(1.0)` for a
-/// fully-cached turn.
+/// Thin re-export over [`TokenUsage::cache_hit_ratio`] kept for callers
+/// that already pass usage through this module's public API.
 pub fn compute_cache_hit_ratio(usage: &TokenUsage) -> Option<f32> {
-    let denom = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
-    if denom == 0 {
-        None
-    } else {
-        Some(usage.cache_read_input_tokens as f32 / denom as f32)
-    }
+    usage.cache_hit_ratio()
 }
 
 impl TrajectoryBundle {
@@ -273,13 +265,17 @@ impl TrajectoryBundle {
 
     /// Stamp the trajectory's metadata with a cache hit ratio computed from
     /// the supplied aggregate `TokenUsage`. Convenience wrapper around
-    /// [`compute_cache_hit_ratio`].
+    /// [`TokenUsage::cache_hit_ratio`].
     ///
-    /// Intended to be called by export sites (HTTP route, CLI exporter)
-    /// once they've gathered cumulative usage for the session — the
-    /// exporter itself does not see token counts.
+    /// `TrajectoryExporter` itself never sees per-turn token counts (the
+    /// `Session` substrate stores `context_window_tokens` only, not the
+    /// `cache_creation` / `cache_read` split). This builder is the API
+    /// surface for callers further up the stack — the HTTP export route
+    /// and CLI exporter — that aggregate `TokenUsage` from the kernel's
+    /// metering layer and stamp the bundle before serialization. Wiring
+    /// those call sites is a follow-up.
     pub fn with_cache_hit_ratio(mut self, usage: &TokenUsage) -> Self {
-        self.metadata.cache_hit_ratio = compute_cache_hit_ratio(usage);
+        self.metadata.cache_hit_ratio = usage.cache_hit_ratio();
         self
     }
 }
@@ -801,31 +797,18 @@ mod tests {
     }
 
     #[test]
-    fn compute_cache_hit_ratio_none_when_no_caching() {
-        let usage = TokenUsage::default();
-        assert_eq!(compute_cache_hit_ratio(&usage), None);
-    }
-
-    #[test]
-    fn compute_cache_hit_ratio_full_hit() {
+    fn compute_cache_hit_ratio_delegates_to_token_usage() {
+        // Smoke test for the public re-export — full coverage of the
+        // ratio math lives in `librefang_types::message::TokenUsage`.
+        assert_eq!(compute_cache_hit_ratio(&TokenUsage::default()), None);
         let usage = TokenUsage {
             input_tokens: 100,
             output_tokens: 0,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 30,
+            cache_read_input_tokens: 70,
         };
-        assert_eq!(compute_cache_hit_ratio(&usage), Some(1.0));
-    }
-
-    #[test]
-    fn compute_cache_hit_ratio_cold_start_returns_some_zero() {
-        let usage = TokenUsage {
-            input_tokens: 100,
-            output_tokens: 0,
-            cache_creation_input_tokens: 100,
-            cache_read_input_tokens: 0,
-        };
-        assert_eq!(compute_cache_hit_ratio(&usage), Some(0.0));
+        let ratio = compute_cache_hit_ratio(&usage).expect("ratio set");
+        assert!((ratio - 0.7).abs() < 1e-6, "got {ratio}");
     }
 
     #[test]

--- a/crates/librefang-kernel/src/trajectory/mod.rs
+++ b/crates/librefang-kernel/src/trajectory/mod.rs
@@ -33,7 +33,7 @@ use chrono::Utc;
 use librefang_memory::MemorySubstrate;
 use librefang_types::agent::{AgentId, SessionId};
 use librefang_types::error::{LibreFangError, LibreFangResult};
-use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+use librefang_types::message::{ContentBlock, Message, MessageContent, Role, TokenUsage};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -166,6 +166,12 @@ pub struct TrajectoryMetadata {
     pub redaction_credentials: bool,
     /// Whether workspace path collapsing was applied (root was set).
     pub redaction_workspace_paths: bool,
+    /// Cache hit ratio for this trajectory's turns: `cache_read / (cache_read + cache_creation)`.
+    /// `None` when the trajectory predates this field or the model didn't
+    /// support prompt caching. `Some(0.0)` means caching was active but
+    /// nothing hit (cold start / first turn).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_hit_ratio: Option<f32>,
 }
 
 /// A message turn after redaction. Keeps the original shape so consumers
@@ -217,6 +223,22 @@ pub enum RedactedBlock {
     Unknown,
 }
 
+/// Compute the prompt-cache hit ratio for an aggregate `TokenUsage`.
+///
+/// Returns `None` when neither cache_read nor cache_creation tokens were
+/// reported (e.g. provider doesn't support prompt caching). Returns
+/// `Some(ratio)` in `[0.0, 1.0]` otherwise — `Some(0.0)` for a cold-start
+/// turn where caching was active but produced no hits, `Some(1.0)` for a
+/// fully-cached turn.
+pub fn compute_cache_hit_ratio(usage: &TokenUsage) -> Option<f32> {
+    let denom = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+    if denom == 0 {
+        None
+    } else {
+        Some(usage.cache_read_input_tokens as f32 / denom as f32)
+    }
+}
+
 impl TrajectoryBundle {
     /// Serialize to a JSON value (full bundle as a single object).
     pub fn to_json(&self) -> serde_json::Value {
@@ -247,6 +269,18 @@ impl TrajectoryBundle {
             out.push('\n');
         }
         out
+    }
+
+    /// Stamp the trajectory's metadata with a cache hit ratio computed from
+    /// the supplied aggregate `TokenUsage`. Convenience wrapper around
+    /// [`compute_cache_hit_ratio`].
+    ///
+    /// Intended to be called by export sites (HTTP route, CLI exporter)
+    /// once they've gathered cumulative usage for the session — the
+    /// exporter itself does not see token counts.
+    pub fn with_cache_hit_ratio(mut self, usage: &TokenUsage) -> Self {
+        self.metadata.cache_hit_ratio = compute_cache_hit_ratio(usage);
+        self
     }
 }
 
@@ -313,6 +347,7 @@ impl TrajectoryExporter {
             librefang_version: env!("CARGO_PKG_VERSION").to_string(),
             redaction_credentials: self.policy.mask_credentials,
             redaction_workspace_paths: self.policy.workspace_root.is_some(),
+            cache_hit_ratio: None,
         };
 
         Ok(TrajectoryBundle {
@@ -349,6 +384,7 @@ impl TrajectoryExporter {
             librefang_version: env!("CARGO_PKG_VERSION").to_string(),
             redaction_credentials: self.policy.mask_credentials,
             redaction_workspace_paths: self.policy.workspace_root.is_some(),
+            cache_hit_ratio: None,
         };
         TrajectoryBundle {
             schema_version: 1,
@@ -686,6 +722,7 @@ mod tests {
                 librefang_version: "0.0.0".into(),
                 redaction_credentials: true,
                 redaction_workspace_paths: false,
+                cache_hit_ratio: None,
             },
             messages: vec![RedactedMessage {
                 role: "user".into(),
@@ -699,6 +736,114 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("\"kind\":\"metadata\""));
         assert!(lines[1].contains("\"kind\":\"message\""));
+    }
+
+    // ── cache_hit_ratio metadata field (PR-2/2 M2) ─────────────────────────
+
+    fn sample_metadata(cache_hit_ratio: Option<f32>) -> TrajectoryMetadata {
+        TrajectoryMetadata {
+            agent_id: "00000000-0000-0000-0000-000000000001".into(),
+            agent_name: "test".into(),
+            session_id: "00000000-0000-0000-0000-000000000002".into(),
+            session_label: None,
+            model: "test-model".into(),
+            provider: "ollama".into(),
+            system_prompt_sha256: "deadbeef".into(),
+            message_count: 0,
+            context_window_tokens: 0,
+            exported_at: "2026-01-01T00:00:00Z".into(),
+            librefang_version: "0.0.0".into(),
+            redaction_credentials: true,
+            redaction_workspace_paths: false,
+            cache_hit_ratio,
+        }
+    }
+
+    #[test]
+    fn trajectory_metadata_cache_hit_ratio_serde_round_trip() {
+        let meta = sample_metadata(Some(0.85));
+        let json = serde_json::to_string(&meta).expect("serialize");
+        assert!(
+            json.contains("\"cache_hit_ratio\":0.85"),
+            "field missing in JSON: {json}"
+        );
+        let back: TrajectoryMetadata = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.cache_hit_ratio, Some(0.85));
+    }
+
+    #[test]
+    fn trajectory_metadata_cache_hit_ratio_legacy_compat() {
+        // Legacy trajectory JSON predating the field — must deserialize
+        // cleanly with `cache_hit_ratio == None` and the field must be
+        // omitted on re-serialization.
+        let legacy = r#"{
+            "agent_id":"00000000-0000-0000-0000-000000000001",
+            "agent_name":"test",
+            "session_id":"00000000-0000-0000-0000-000000000002",
+            "model":"test-model",
+            "provider":"ollama",
+            "system_prompt_sha256":"deadbeef",
+            "message_count":0,
+            "context_window_tokens":0,
+            "exported_at":"2026-01-01T00:00:00Z",
+            "librefang_version":"0.0.0",
+            "redaction_credentials":true,
+            "redaction_workspace_paths":false
+        }"#;
+        let meta: TrajectoryMetadata = serde_json::from_str(legacy).expect("legacy deserialize");
+        assert_eq!(meta.cache_hit_ratio, None);
+
+        let reserialized = serde_json::to_string(&meta).expect("reserialize");
+        assert!(
+            !reserialized.contains("cache_hit_ratio"),
+            "None should be skipped: {reserialized}"
+        );
+    }
+
+    #[test]
+    fn compute_cache_hit_ratio_none_when_no_caching() {
+        let usage = TokenUsage::default();
+        assert_eq!(compute_cache_hit_ratio(&usage), None);
+    }
+
+    #[test]
+    fn compute_cache_hit_ratio_full_hit() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 100,
+        };
+        assert_eq!(compute_cache_hit_ratio(&usage), Some(1.0));
+    }
+
+    #[test]
+    fn compute_cache_hit_ratio_cold_start_returns_some_zero() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 0,
+        };
+        assert_eq!(compute_cache_hit_ratio(&usage), Some(0.0));
+    }
+
+    #[test]
+    fn bundle_with_cache_hit_ratio_stamps_metadata() {
+        let bundle = TrajectoryBundle {
+            schema_version: 1,
+            metadata: sample_metadata(None),
+            messages: Vec::new(),
+        };
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 30,
+            cache_read_input_tokens: 70,
+        };
+        let stamped = bundle.with_cache_hit_ratio(&usage);
+        let ratio = stamped.metadata.cache_hit_ratio.expect("ratio set");
+        assert!((ratio - 0.7).abs() < 1e-6, "got {ratio}");
     }
 
     #[test]

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -409,6 +409,19 @@ fn accumulate_token_usage(total_usage: &mut TokenUsage, usage: &TokenUsage) {
     total_usage.cache_read_input_tokens += usage.cache_read_input_tokens;
 }
 
+/// Prompt-cache hit ratio for a turn.
+///
+/// `cache_read / (cache_read + cache_creation)`, in `[0.0, 1.0]`.
+/// Returns `0.0` when both are zero (caching not active for this turn).
+fn cache_hit_ratio(usage: &TokenUsage) -> f32 {
+    let denom = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+    if denom == 0 {
+        0.0
+    } else {
+        usage.cache_read_input_tokens as f32 / denom as f32
+    }
+}
+
 fn tool_use_blocks_from_calls(tool_calls: &[ToolCall]) -> Vec<ContentBlock> {
     tool_calls
         .iter()
@@ -2662,6 +2675,18 @@ async fn finalize_successful_end_turn(
         } else {
             "Agent loop completed"
         }
+    );
+
+    // Prompt-cache observability (M2): emit a single-line metric so log
+    // pipelines can compute hit-rate trends per agent without parsing the
+    // surrounding loop summary.
+    tracing::info!(
+        target: "librefang::cache",
+        agent = ctx.agent_id_str,
+        hit_ratio = cache_hit_ratio(&end_turn.total_usage),
+        creation = end_turn.total_usage.cache_creation_input_tokens,
+        read = end_turn.total_usage.cache_read_input_tokens,
+        "prompt cache metrics for turn"
     );
 
     if !ctx.opts.is_fork {
@@ -5961,6 +5986,47 @@ mod tests {
             MAX_ITERATIONS,
             librefang_types::agent::AutonomousConfig::DEFAULT_MAX_ITERATIONS
         );
+    }
+
+    // ── cache_hit_ratio (PR-2/2 M2) ────────────────────────────────────────
+
+    #[test]
+    fn cache_hit_ratio_zero_when_no_caching() {
+        let usage = TokenUsage::default();
+        assert_eq!(cache_hit_ratio(&usage), 0.0);
+    }
+
+    #[test]
+    fn cache_hit_ratio_full_hit() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 100,
+        };
+        assert_eq!(cache_hit_ratio(&usage), 1.0);
+    }
+
+    #[test]
+    fn cache_hit_ratio_partial() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 30,
+            cache_read_input_tokens: 70,
+        };
+        assert!((cache_hit_ratio(&usage) - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cache_hit_ratio_cold_start() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 0,
+        };
+        assert_eq!(cache_hit_ratio(&usage), 0.0);
     }
 
     // ── push_accumulated_text bounded growth ──────────────────────────────

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -409,19 +409,6 @@ fn accumulate_token_usage(total_usage: &mut TokenUsage, usage: &TokenUsage) {
     total_usage.cache_read_input_tokens += usage.cache_read_input_tokens;
 }
 
-/// Prompt-cache hit ratio for a turn.
-///
-/// `cache_read / (cache_read + cache_creation)`, in `[0.0, 1.0]`.
-/// Returns `0.0` when both are zero (caching not active for this turn).
-fn cache_hit_ratio(usage: &TokenUsage) -> f32 {
-    let denom = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
-    if denom == 0 {
-        0.0
-    } else {
-        usage.cache_read_input_tokens as f32 / denom as f32
-    }
-}
-
 fn tool_use_blocks_from_calls(tool_calls: &[ToolCall]) -> Vec<ContentBlock> {
     tool_calls
         .iter()
@@ -2679,11 +2666,13 @@ async fn finalize_successful_end_turn(
 
     // Prompt-cache observability (M2): emit a single-line metric so log
     // pipelines can compute hit-rate trends per agent without parsing the
-    // surrounding loop summary.
+    // surrounding loop summary. `None` (no caching activity) is folded to
+    // 0.0 for the log field; readers wanting to distinguish "no caching"
+    // from "0% hit" should look at the `creation` + `read` totals.
     tracing::info!(
         target: "librefang::cache",
         agent = ctx.agent_id_str,
-        hit_ratio = cache_hit_ratio(&end_turn.total_usage),
+        hit_ratio = end_turn.total_usage.cache_hit_ratio().unwrap_or(0.0),
         creation = end_turn.total_usage.cache_creation_input_tokens,
         read = end_turn.total_usage.cache_read_input_tokens,
         "prompt cache metrics for turn"
@@ -5986,47 +5975,6 @@ mod tests {
             MAX_ITERATIONS,
             librefang_types::agent::AutonomousConfig::DEFAULT_MAX_ITERATIONS
         );
-    }
-
-    // ── cache_hit_ratio (PR-2/2 M2) ────────────────────────────────────────
-
-    #[test]
-    fn cache_hit_ratio_zero_when_no_caching() {
-        let usage = TokenUsage::default();
-        assert_eq!(cache_hit_ratio(&usage), 0.0);
-    }
-
-    #[test]
-    fn cache_hit_ratio_full_hit() {
-        let usage = TokenUsage {
-            input_tokens: 100,
-            output_tokens: 0,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 100,
-        };
-        assert_eq!(cache_hit_ratio(&usage), 1.0);
-    }
-
-    #[test]
-    fn cache_hit_ratio_partial() {
-        let usage = TokenUsage {
-            input_tokens: 100,
-            output_tokens: 0,
-            cache_creation_input_tokens: 30,
-            cache_read_input_tokens: 70,
-        };
-        assert!((cache_hit_ratio(&usage) - 0.7).abs() < 1e-6);
-    }
-
-    #[test]
-    fn cache_hit_ratio_cold_start() {
-        let usage = TokenUsage {
-            input_tokens: 100,
-            output_tokens: 0,
-            cache_creation_input_tokens: 100,
-            cache_read_input_tokens: 0,
-        };
-        assert_eq!(cache_hit_ratio(&usage), 0.0);
     }
 
     // ── push_accumulated_text bounded growth ──────────────────────────────

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -349,6 +349,22 @@ impl TokenUsage {
     pub fn total(&self) -> u64 {
         self.input_tokens + self.output_tokens
     }
+
+    /// Prompt-cache hit ratio: `cache_read / (cache_read + cache_creation)`.
+    ///
+    /// Returns `None` when neither value was reported (provider doesn't
+    /// support prompt caching, or no caching activity this turn). Returns
+    /// `Some(ratio)` in `[0.0, 1.0]` otherwise — `Some(0.0)` for a cold
+    /// start where caching was active but produced no hits, `Some(1.0)`
+    /// for a fully-cached turn.
+    pub fn cache_hit_ratio(&self) -> Option<f32> {
+        let denom = self.cache_read_input_tokens + self.cache_creation_input_tokens;
+        if denom == 0 {
+            None
+        } else {
+            Some(self.cache_read_input_tokens as f32 / denom as f32)
+        }
+    }
 }
 
 /// Reply directives extracted from agent output.
@@ -413,6 +429,45 @@ mod tests {
         let usage: TokenUsage = serde_json::from_str(json).unwrap();
         assert_eq!(usage.cache_creation_input_tokens, 0);
         assert_eq!(usage.cache_read_input_tokens, 0);
+    }
+
+    #[test]
+    fn token_usage_cache_hit_ratio_none_when_no_caching() {
+        assert_eq!(TokenUsage::default().cache_hit_ratio(), None);
+    }
+
+    #[test]
+    fn token_usage_cache_hit_ratio_full_hit() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 100,
+        };
+        assert_eq!(usage.cache_hit_ratio(), Some(1.0));
+    }
+
+    #[test]
+    fn token_usage_cache_hit_ratio_partial() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 30,
+            cache_read_input_tokens: 70,
+        };
+        let ratio = usage.cache_hit_ratio().expect("ratio set");
+        assert!((ratio - 0.7).abs() < 1e-6, "got {ratio}");
+    }
+
+    #[test]
+    fn token_usage_cache_hit_ratio_cold_start_returns_some_zero() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 0,
+        };
+        assert_eq!(usage.cache_hit_ratio(), Some(0.0));
     }
 
     #[test]

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -554,7 +554,7 @@ fn extract_url_host(url: &str) -> Option<String> {
         .or_else(|| url.strip_prefix("https://"))?;
     // Host runs until the next '/', '?', '#', or end-of-string.
     let host_end = after_scheme
-        .find(|c: char| c == '/' || c == '?' || c == '#')
+        .find(['/', '?', '#'])
         .unwrap_or(after_scheme.len());
     let host_part = &after_scheme[..host_end];
     // Strip optional userinfo (user:pass@host).


### PR DESCRIPTION
## Summary

Builds on PR-1 (#3126, the `system_and_3` stamping). Adds the single-value observability metric the dashboard surfaces so users can see at a glance whether prompt caching is paying off for their workload. **Pure observability — no behaviour change.**

```
cache_hit_ratio = cache_read / (cache_read + cache_creation), in [0.0, 1.0]
```

`Some(1.0)` means a perfect hit (everything was prefix-cached). `Some(0.0)` is a cold start where caching was active but nothing was hit yet. `None` (in the trajectory metadata) means caching wasn't active at all for the run — the runtime log folds this to `0.0` for the float field, with `creation` and `read` totals alongside so readers can disambiguate.

## Changes

**`crates/librefang-types/src/message.rs`**:

- `TokenUsage::cache_hit_ratio() -> Option<f32>` — the authoritative implementation. Both runtime and kernel callers delegate.

**`crates/librefang-runtime/src/agent_loop.rs`**:

- Per-turn `tracing::info!` on the `librefang::cache` target with `agent`, `hit_ratio`, `creation`, `read` fields so existing log pipelines (Tempo, Grafana) pick it up without dashboard changes. `hit_ratio` field uses `.unwrap_or(0.0)` for log-friendliness.

**`crates/librefang-kernel/src/trajectory/mod.rs`**:

- `TrajectoryMetadata` grows `cache_hit_ratio: Option<f32>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`).
- Legacy trajectories without the field deserialise to `None`; replays don't need to know about caching to round-trip cleanly.
- `TrajectoryBundle::with_cache_hit_ratio(usage)` builder added for the HTTP export route / CLI exporter to stamp the bundle once they've aggregated cumulative `TokenUsage` from the metering layer. (Wiring those call sites is a follow-up — the exporter itself doesn't see token counts.)
- `compute_cache_hit_ratio()` is a thin re-export of `TokenUsage::cache_hit_ratio()` for callers already routing through this module.

## Tests

Authoritative coverage lives with the implementation in `librefang-types`:

| Test | Asserts |
|---|---|
| `token_usage_cache_hit_ratio_none_when_no_caching` | read=0, creation=0 → `None` |
| `token_usage_cache_hit_ratio_full_hit` | read=100, creation=0 → `Some(1.0)` |
| `token_usage_cache_hit_ratio_partial` | read=70, creation=30 → `Some(0.7)` |
| `token_usage_cache_hit_ratio_cold_start_returns_some_zero` | read=0, creation=100 → `Some(0.0)` |

Plus, in `librefang-kernel`:

| Test | Asserts |
|---|---|
| `trajectory_metadata_cache_hit_ratio_serde_round_trip` | `Some(0.85)` preserved |
| `trajectory_metadata_cache_hit_ratio_legacy_compat` | legacy JSON without field → `None`; re-serialization omits |
| `compute_cache_hit_ratio_delegates_to_token_usage` | smoke test for the public re-export |
| `bundle_with_cache_hit_ratio_stamps_metadata` | builder writes the ratio onto `metadata` |

## Test plan

- [x] `cargo test -p librefang-types --lib token_usage` — **8 ok**
- [x] `cargo test -p librefang-runtime --lib agent_loop` — **163 ok**
- [x] `cargo test -p librefang-kernel --lib trajectory` — **12 ok**
- [x] `cargo clippy -p librefang-types -p librefang-runtime -p librefang-kernel --all-targets -- -D warnings` — clean

## Stack

Independent, base `main`. **Closes the `prompt-caching-system-and-3` plan** — system_and_3 stamping (PR-1) plus this PR cover the full "borrow hermes-agent's cache strategy" scope.

See `.plans/prompt-caching-system-and-3.md` for full design.
