### PR TITLE
feat(kernel): cron pre_script execution + silent_marker + wake-gate path allowlist (PR-2/3)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10676,6 +10676,8 @@ system_prompt = "You are a helpful assistant."
                                 message,
                                 timeout_secs,
                                 pre_check_script,
+                                pre_script,
+                                silent_marker,
                                 ..
                             } => {
                                 tracing::debug!(job = %job_name, agent = %agent_id, "Cron: firing agent turn");
@@ -10684,7 +10686,13 @@ system_prompt = "You are a helpful assistant."
                                 // {"wakeAgent": false} in the last non-empty output line.
                                 // Only fires when the script exits successfully.
                                 if let Some(script_path) = pre_check_script {
-                                    if !cron_script_wake_gate(&job_name, script_path).await {
+                                    if !cron_script_wake_gate(
+                                        &job_name,
+                                        script_path,
+                                        kernel.home_dir(),
+                                    )
+                                    .await
+                                    {
                                         tracing::info!(
                                             job = %job_name,
                                             "cron: script gate wakeAgent=false, skipping agent"
@@ -10693,6 +10701,47 @@ system_prompt = "You are a helpful assistant."
                                         continue;
                                     }
                                 }
+
+                                // Pre-script: run before the LLM turn fires and
+                                // inject stdout into the prompt as additional
+                                // context. Validation against the home/scripts
+                                // allowlist runs first; on validation or runtime
+                                // failure the agent still fires (failsafe) but
+                                // without injected context.
+                                let injected_context = if let Some(ps) = pre_script {
+                                    match librefang_types::scheduler::validate_pre_script(
+                                        ps,
+                                        kernel.home_dir(),
+                                    ) {
+                                        Ok(()) => run_cron_pre_script(&job_name, ps).await,
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                job = %job_name,
+                                                error = %e,
+                                                "cron: pre_script validation failed, skipping injection"
+                                            );
+                                            None
+                                        }
+                                    }
+                                } else {
+                                    None
+                                };
+
+                                // Build the prompt: the scheduled message plus
+                                // pre_script stdout (when produced and non-empty).
+                                let final_message = match injected_context.as_deref() {
+                                    Some(ctx) if !ctx.trim().is_empty() => format!(
+                                        "{}\n\n--- pre_script output ---\n{}",
+                                        message, ctx
+                                    ),
+                                    _ => message.clone(),
+                                };
+
+                                // Snapshot the silent_marker once: borrowing
+                                // `&job.action` past `send_message_full` would
+                                // pin `job` across the await.
+                                let silent_marker_resolved =
+                                    silent_marker.clone().unwrap_or_else(|| "[SILENT]".into());
 
                                 let timeout_s = timeout_secs.unwrap_or(120);
                                 let timeout = std::time::Duration::from_secs(timeout_s);
@@ -10787,7 +10836,7 @@ system_prompt = "You are a helpful assistant."
                                     timeout,
                                     kernel.send_message_full(
                                         agent_id,
-                                        message,
+                                        &final_message,
                                         Some(kh),
                                         None,
                                         sender_ctx,
@@ -10801,8 +10850,24 @@ system_prompt = "You are a helpful assistant."
                                     Ok(Ok(result)) => {
                                         tracing::info!(job = %job_name, "Cron job completed successfully");
                                         kernel.cron_scheduler.record_success(job_id);
-                                        // Deliver response to configured channel (skip NO_REPLY/silent)
-                                        if !result.silent {
+                                        // silent_marker: when the response's
+                                        // last non-empty line equals the marker,
+                                        // suppress all delivery for this fire
+                                        // (no channel send, no fan-out). The
+                                        // job itself still counts as success —
+                                        // the agent intentionally chose to stay
+                                        // quiet this run.
+                                        let suppress_silent = is_silent_response(
+                                            &result.response,
+                                            &silent_marker_resolved,
+                                        );
+                                        if suppress_silent {
+                                            tracing::info!(
+                                                job = %job_name,
+                                                "cron: silent_marker matched, suppressing delivery"
+                                            );
+                                        } else if !result.silent {
+                                            // Deliver response to configured channel (skip NO_REPLY/silent)
                                             cron_deliver_response(
                                                 &kernel,
                                                 agent_id,
@@ -13506,12 +13571,58 @@ fn sanitize_reviewer_block(s: &str, max_chars: usize) -> String {
 /// - Find the last non-empty stdout line and try to parse it as JSON.
 /// - If the parsed object has `"wakeAgent": false` (strict bool), return false.
 /// - Everything else (non-JSON, missing key, null, 0, "") → return true.
-async fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
+///
+/// Path-allowlist hardening: `script_path` must canonicalize under
+/// `<home_dir>/scripts/`. Anything that escapes the allowlist (relative path
+/// joined onto an unexpected cwd, symlink pointing outside, missing file)
+/// short-circuits to `true` (failsafe — wake the agent rather than silently
+/// running a script outside the trust root).
+async fn cron_script_wake_gate(job_name: &str, script_path: &str, home_dir: &Path) -> bool {
     use tokio::process::Command;
+
+    // Allowlist check first: never spawn a process whose binary lives outside
+    // `<home_dir>/scripts/`. We follow symlinks (canonicalize) so a symlink
+    // inside the allowlist pointing outside it is also rejected.
+    let scripts_dir = home_dir.join("scripts");
+    let canonical = match std::fs::canonicalize(script_path) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                job = %job_name,
+                script = %script_path,
+                error = %e,
+                "cron: pre_check_script not found, waking agent"
+            );
+            return true;
+        }
+    };
+    let scripts_canon = match std::fs::canonicalize(&scripts_dir) {
+        Ok(p) => p,
+        Err(_) => {
+            // <home>/scripts doesn't exist — by definition nothing is on the
+            // allowlist, so any configured script_path is outside it. Wake
+            // failsafe rather than silently executing.
+            tracing::warn!(
+                job = %job_name,
+                script = %script_path,
+                "cron: pre_check_script outside allowlist (scripts dir missing), waking agent"
+            );
+            return true;
+        }
+    };
+    if !canonical.starts_with(&scripts_canon) {
+        tracing::warn!(
+            job = %job_name,
+            script = %script_path,
+            allowlist = %scripts_canon.display(),
+            "cron: pre_check_script outside allowlist, waking agent"
+        );
+        return true;
+    }
 
     // Hard cap: pre-check scripts must complete within 30 s.
     // A hung script would otherwise block the cron dispatcher indefinitely.
-    let run = async { Command::new(script_path).output().await };
+    let run = async { Command::new(&canonical).output().await };
 
     let output = match tokio::time::timeout(std::time::Duration::from_secs(30), run).await {
         Err(_elapsed) => {
@@ -13546,6 +13657,93 @@ async fn cron_script_wake_gate(job_name: &str, script_path: &str) -> bool {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     parse_wake_gate(&stdout)
+}
+
+/// Hard cap for `pre_script` execution. Pre-scripts can do real work (HTTP
+/// scrape, file diff, computation) so we allow more headroom than the 30 s
+/// wake-gate cap — but still bound so a hung script can't pin the cron loop.
+const CRON_PRE_SCRIPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Run a cron job's `pre_script`, returning captured stdout as the context
+/// to inject into the next LLM turn.
+///
+/// On any failure (timeout, launch error, non-zero exit) returns `None` so
+/// the agent still fires — pre_script is *additive context*, not a wake gate.
+/// The wake gate is `pre_check_script` (separate field, separate semantics).
+async fn run_cron_pre_script(
+    job_name: &str,
+    script: &librefang_types::scheduler::PreScript,
+) -> Option<String> {
+    run_cron_pre_script_with_timeout(job_name, script, CRON_PRE_SCRIPT_TIMEOUT).await
+}
+
+/// Test-injectable variant of [`run_cron_pre_script`] that accepts an
+/// explicit timeout so unit tests can exercise the timeout branch without
+/// waiting the full 60 s production cap.
+async fn run_cron_pre_script_with_timeout(
+    job_name: &str,
+    script: &librefang_types::scheduler::PreScript,
+    timeout: std::time::Duration,
+) -> Option<String> {
+    use tokio::process::Command;
+
+    // argv[0] is the binary; remaining argv are passed verbatim (no shell).
+    // PreScript validation upstream guarantees argv is non-empty.
+    let mut cmd = Command::new(&script.argv[0]);
+    if script.argv.len() > 1 {
+        cmd.args(&script.argv[1..]);
+    }
+    if let Some(cwd) = &script.cwd {
+        cmd.current_dir(cwd);
+    }
+    for (k, v) in &script.env {
+        cmd.env(k, v);
+    }
+    // Kill the child process on drop so a timeout doesn't leak a sleep/curl
+    // beyond the dispatcher's awareness — without this the OS keeps the
+    // child alive after `output()` is dropped.
+    cmd.kill_on_drop(true);
+
+    let run = async { cmd.output().await };
+    let output = match tokio::time::timeout(timeout, run).await {
+        Err(_) => {
+            tracing::warn!(
+                job = %job_name,
+                timeout_s = timeout.as_secs(),
+                "cron: pre_script timed out"
+            );
+            return None;
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(job = %job_name, error = %e, "cron: pre_script launch failed");
+            return None;
+        }
+        Ok(Ok(o)) => o,
+    };
+
+    if !output.status.success() {
+        tracing::warn!(
+            job = %job_name,
+            code = ?output.status.code(),
+            "cron: pre_script exited non-zero"
+        );
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Pure helper: does `response` end with `marker` on its last non-empty
+/// trimmed line? Strict equality — a marker mentioned mid-response does not
+/// suppress delivery, only a marker that the model put on the very last
+/// non-blank line does.
+fn is_silent_response(response: &str, marker: &str) -> bool {
+    response
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim() == marker)
+        .unwrap_or(false)
 }
 
 /// Atomically write a TOML file by staging the new content in a sibling

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2257,3 +2257,227 @@ fn atomic_write_no_partial_state_under_concurrency() {
         "no .tmp staging files should remain after concurrent writes"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Cron pre_script + silent_marker + wake-gate path-allowlist (PR-2/3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cron_silent_marker_match_at_end_suppresses() {
+    // Marker on the last non-empty trimmed line → suppress.
+    let resp = "Did the work, no news.\n\n[SILENT]\n";
+    assert!(is_silent_response(resp, "[SILENT]"));
+}
+
+#[test]
+fn cron_silent_marker_mid_response_does_not_match() {
+    // Marker mid-response is not the last non-empty line → fire delivery.
+    let resp = "[SILENT]\nbut actually here is the report\n";
+    assert!(!is_silent_response(resp, "[SILENT]"));
+}
+
+#[test]
+fn cron_silent_marker_default_when_none() {
+    // The dispatcher resolves `silent_marker: None` → "[SILENT]". Mirror that
+    // resolution rule here so a future refactor that changes the default
+    // string trips this guard. Wrapped in a helper rather than inlining
+    // `Option::<String>::None.unwrap_or_else(...)` so clippy's
+    // `unnecessary_literal_unwrap` doesn't flag the literal None.
+    fn resolve_marker(silent_marker: Option<String>) -> String {
+        silent_marker.unwrap_or_else(|| "[SILENT]".into())
+    }
+    let marker = resolve_marker(None);
+    assert_eq!(marker, "[SILENT]");
+    assert!(is_silent_response("ok\n[SILENT]", &marker));
+    assert!(!is_silent_response("ok\n[OTHER]", &marker));
+
+    // Explicit override is honoured verbatim.
+    let custom = resolve_marker(Some("[QUIET]".into()));
+    assert_eq!(custom, "[QUIET]");
+    assert!(is_silent_response("ok\n[QUIET]", &custom));
+    assert!(!is_silent_response("ok\n[SILENT]", &custom));
+}
+
+#[test]
+fn cron_silent_marker_trailing_blank_lines_still_match() {
+    // Trailing whitespace must not defeat the match — the helper finds the
+    // last *non-empty* trimmed line.
+    let resp = "result\n[SILENT]\n   \n\n";
+    assert!(is_silent_response(resp, "[SILENT]"));
+}
+
+#[test]
+fn cron_silent_marker_empty_response_does_not_match() {
+    assert!(!is_silent_response("", "[SILENT]"));
+    assert!(!is_silent_response("   \n\n", "[SILENT]"));
+}
+
+#[tokio::test]
+async fn cron_pre_script_timeout_returns_none() {
+    // A `sleep 100` is launched and the dispatcher's tokio timeout fires
+    // first. We use the test-injectable variant with a small (300 ms)
+    // timeout so the unit test completes quickly — the production code path
+    // calls run_cron_pre_script which uses CRON_PRE_SCRIPT_TIMEOUT (60 s).
+    // `kill_on_drop(true)` ensures the spawned `sleep` is reaped when the
+    // future is dropped, so the timeout doesn't leak a child process.
+    use librefang_types::scheduler::PreScript;
+    use std::collections::HashMap;
+
+    let script = PreScript {
+        argv: vec!["sleep".to_string(), "100".to_string()],
+        cwd: None,
+        env: HashMap::new(),
+    };
+    let result = run_cron_pre_script_with_timeout(
+        "timeout-test",
+        &script,
+        std::time::Duration::from_millis(300),
+    )
+    .await;
+    assert!(result.is_none(), "expected None on timeout, got {result:?}");
+}
+
+#[tokio::test]
+async fn cron_pre_script_non_zero_exit_returns_none() {
+    use librefang_types::scheduler::PreScript;
+    use std::collections::HashMap;
+
+    // `false` exits non-zero on every Unix; on Windows the kernel runs in WSL/
+    // bash-ish env per CLAUDE.md so this is portable enough.
+    let script = PreScript {
+        argv: vec!["false".to_string()],
+        cwd: None,
+        env: HashMap::new(),
+    };
+    let result = run_cron_pre_script("nonzero-test", &script).await;
+    assert!(
+        result.is_none(),
+        "expected None on non-zero exit, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn cron_pre_script_success_returns_stdout() {
+    use librefang_types::scheduler::PreScript;
+    use std::collections::HashMap;
+
+    // `echo hello` exits 0 with "hello\n" on stdout — the dispatcher
+    // returns it verbatim.
+    let script = PreScript {
+        argv: vec!["echo".to_string(), "hello".to_string()],
+        cwd: None,
+        env: HashMap::new(),
+    };
+    let result = run_cron_pre_script("ok-test", &script).await;
+    let stdout = result.expect("echo should succeed");
+    assert!(
+        stdout.contains("hello"),
+        "expected stdout to contain 'hello', got: {stdout:?}"
+    );
+}
+
+#[tokio::test]
+async fn cron_pre_script_launch_failure_returns_none() {
+    use librefang_types::scheduler::PreScript;
+    use std::collections::HashMap;
+
+    // A binary that does not exist anywhere on PATH triggers the launch-error
+    // branch (Command::output returns Err before the process starts).
+    let script = PreScript {
+        argv: vec!["__librefang_definitely_nonexistent_binary__".to_string()],
+        cwd: None,
+        env: HashMap::new(),
+    };
+    let result = run_cron_pre_script("launchfail-test", &script).await;
+    assert!(
+        result.is_none(),
+        "expected None on launch failure, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn wake_gate_path_outside_allowlist_falls_through_to_wake() {
+    // script_path lives outside <home>/scripts/ — wake gate must short-circuit
+    // to true (failsafe wake) without executing the binary.
+    let home = tempfile::tempdir().expect("home dir");
+    std::fs::create_dir_all(home.path().join("scripts")).expect("scripts dir");
+
+    // Drop a marker script in /tmp (outside the allowlist) that would *say*
+    // wakeAgent=false if it ran. If hardening is correct it never executes,
+    // so we expect wake=true regardless of the script's would-be output.
+    let outside_dir = tempfile::tempdir().expect("outside dir");
+    let outside_script = outside_dir.path().join("evil.sh");
+    std::fs::write(
+        &outside_script,
+        "#!/bin/sh\necho '{\"wakeAgent\": false}'\n",
+    )
+    .expect("write");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&outside_script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&outside_script, perms).unwrap();
+    }
+
+    let wake = cron_script_wake_gate(
+        "outside-test",
+        outside_script.to_str().unwrap(),
+        home.path(),
+    )
+    .await;
+    assert!(
+        wake,
+        "script outside allowlist must wake (failsafe), not be executed"
+    );
+}
+
+#[tokio::test]
+async fn wake_gate_path_inside_allowlist_runs_normally() {
+    // Tempdir simulating <home>/scripts/foo.sh — the script *does* run and
+    // its `{"wakeAgent": false}` line is honoured.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().expect("home dir");
+        let scripts_dir = home.path().join("scripts");
+        std::fs::create_dir_all(&scripts_dir).expect("scripts dir");
+
+        let script_path = scripts_dir.join("gate.sh");
+        std::fs::write(&script_path, "#!/bin/sh\necho '{\"wakeAgent\": false}'\n")
+            .expect("write");
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+
+        let wake = cron_script_wake_gate(
+            "inside-test",
+            script_path.to_str().unwrap(),
+            home.path(),
+        )
+        .await;
+        assert!(
+            !wake,
+            "script inside allowlist returning wakeAgent=false must skip"
+        );
+    }
+}
+
+#[tokio::test]
+async fn wake_gate_missing_scripts_dir_falls_through_to_wake() {
+    // <home>/scripts does not exist — every script_path is outside the
+    // (empty) allowlist by definition, so we wake failsafe.
+    let home = tempfile::tempdir().expect("home dir");
+    // Note: we deliberately don't create <home>/scripts.
+
+    // Even a script that *would* canonicalize successfully (e.g. /bin/echo)
+    // should be rejected because the allowlist root doesn't exist.
+    let wake = cron_script_wake_gate(
+        "no-scripts-dir",
+        "/bin/echo", // exists, but allowlist root missing
+        home.path(),
+    )
+    .await;
+    assert!(wake, "missing scripts dir must wake failsafe");
+}


### PR DESCRIPTION
## Summary

PR-2 of the cron-script-preprocessing stack — wires the schema added in
PR-1 (#3145) into the kernel's cron dispatcher. The agent loop now actually
runs `pre_script`, injects its stdout into the next LLM turn, honours
`silent_marker` to suppress delivery, and the existing wake-gate
(`pre_check_script`) gains the same path-allowlist hardening that PR-1
shipped for `pre_script`.

## pre_script execution

In the `CronAction::AgentTurn` branch:

1. After the wake-gate check, validate the configured `pre_script` against
   `<home_dir>/scripts/` via `librefang_types::scheduler::validate_pre_script`.
2. On success, spawn argv (no shell — `Command::new` + `args`), apply
   per-job `cwd`/`env`, capture stdout under a 60 s tokio timeout
   (`CRON_PRE_SCRIPT_TIMEOUT`). `kill_on_drop(true)` so a timed-out child
   doesn't leak past the dispatcher.
3. Build the LLM prompt as `"{message}\n\n--- pre_script output ---\n{stdout}"`
   only when stdout is non-empty.
4. Failures (validation / launch / non-zero exit / timeout) return `None`
   — failsafe to fire the agent without injected context, never to skip.
   This matches the design doc: pre_script is *additive context*, not a
   wake gate (the wake gate stays `pre_check_script`).

`run_cron_pre_script_with_timeout` is a thin internal split so unit tests
can exercise the timeout branch in 300 ms instead of 60 s.

## silent_marker delivery suppression

After the LLM turn returns, `is_silent_response(&response, &marker)`
checks whether the response's last non-empty trimmed line equals the
marker. If so, the dispatcher records the job as success but skips both
the legacy single-`delivery` send and the `delivery_targets` fan-out.
`silent_marker = None` resolves to `"[SILENT]"`. Strict equality — a
mid-response mention of `[SILENT]` does not suppress.

## wake-gate hardening

`cron_script_wake_gate` now takes `home_dir: &Path` and canonicalizes
both the script path and `<home_dir>/scripts/` before a component-level
`starts_with` allowlist check. Symlinks are followed (canonicalize), so
a symlink inside the allowlist pointing outside it is rejected. Three
new failsafe branches all return `true` (wake the agent rather than
silently run an untrusted binary):

- script_path canonicalize fails (file missing / unreadable)
- `<home_dir>/scripts/` doesn't exist (empty allowlist)
- canonicalized path is outside the allowlist

The dispatcher's single call site at `kernel/mod.rs:~10688` passes
`kernel.home_dir()`.

## Tests

12 new tests in `crates/librefang-kernel/src/kernel/tests.rs`:

- `cron_silent_marker_match_at_end_suppresses`
- `cron_silent_marker_mid_response_does_not_match`
- `cron_silent_marker_default_when_none`
- `cron_silent_marker_trailing_blank_lines_still_match`
- `cron_silent_marker_empty_response_does_not_match`
- `cron_pre_script_timeout_returns_none` (300 ms injected timeout)
- `cron_pre_script_non_zero_exit_returns_none` (`false` cmd)
- `cron_pre_script_success_returns_stdout` (`echo hello`)
- `cron_pre_script_launch_failure_returns_none` (nonexistent binary)
- `wake_gate_path_outside_allowlist_falls_through_to_wake` (script in /tmp)
- `wake_gate_path_inside_allowlist_runs_normally` (tempdir scripts/foo.sh)
- `wake_gate_missing_scripts_dir_falls_through_to_wake`

Verification:
- `cargo test -p librefang-kernel --lib` — green
- `cargo check --workspace --lib` — clean
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean

## Stack

- PR-1 (#3145): schema + validator (`feat/cron-script-preprocessing-m1`,
  base `main`).
- PR-2 (this): kernel dispatcher (base `feat/cron-script-preprocessing-m1`).
- PR-3 (next): dashboard editor + optional TOTP approval for
  `pre_script` enrolment, base this PR.

No new dependencies. `session_mode` semantics for cron unchanged
(CLAUDE.md note still applies — every fire shares
`(agent, channel="cron")`).
