### PR TITLE
fix(config): include SearXNG in web_search_available check

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -2665,7 +2665,7 @@ export function ChatPage() {
               onDeleteSession={handleDeleteSession}
               agentId={selectedAgentId}
               onModelChange={() => void agentsQuery.refetch()}
-              onOpenConfig={() => navigate({ to: "/config" })}
+              onOpenConfig={() => navigate({ to: "/config/tools" })}
               webSearchAugmentation={selectedAgent?.web_search_augmentation}
               webSearchAvailable={webSearchAvailable}
               attached={attachEnabled && sessionStream.isAttached}

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -130,6 +130,25 @@ fn current_process_rss_mb() -> Option<u64> {
     }
 }
 
+/// Returns `true` when at least one web search provider is configured —
+/// either an API-key-based provider with its env var set, or SearXNG with a
+/// non-empty URL. Drives the dashboard's "Configure API key" warning chip;
+/// must stay in sync with the providers actually wired into the search
+/// runtime, otherwise the UI nags users who already have a working setup.
+fn is_web_search_configured(web: &librefang_types::config::WebConfig) -> bool {
+    let env_set = |env_var: &str| {
+        std::env::var(env_var)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .is_some()
+    };
+    !web.searxng.url.trim().is_empty()
+        || env_set(&web.tavily.api_key_env)
+        || env_set(&web.brave.api_key_env)
+        || env_set(&web.jina.api_key_env)
+        || env_set(&web.perplexity.api_key_env)
+}
+
 #[utoipa::path(
     get,
     path = "/api/status",
@@ -870,20 +889,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     );
 
     // ── Web ──
-    // Check if at least one search provider has a configured API key
-    let search_available = [
-        &config.web.tavily.api_key_env,
-        &config.web.brave.api_key_env,
-        &config.web.jina.api_key_env,
-        &config.web.perplexity.api_key_env,
-    ]
-    .iter()
-    .any(|env_var| {
-        std::env::var(env_var)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .is_some()
-    });
+    let search_available = is_web_search_configured(&config.web);
     set!("web", {
         "search_provider": format!("{:?}", config.web.search_provider),
         "cache_ttl_minutes": config.web.cache_ttl_minutes,
@@ -2243,20 +2249,7 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
     let providers = providers_result.unwrap_or_default();
     let channels = channels_result.unwrap_or_default();
 
-    // Check if at least one web search provider has a configured API key
-    let web_search_available = [
-        &cfg.web.tavily.api_key_env,
-        &cfg.web.brave.api_key_env,
-        &cfg.web.jina.api_key_env,
-        &cfg.web.perplexity.api_key_env,
-    ]
-    .iter()
-    .any(|env_var| {
-        std::env::var(env_var)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .is_some()
-    });
+    let web_search_available = is_web_search_configured(&cfg.web);
 
     serde_json::json!({
         "health": health,
@@ -2268,4 +2261,53 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         "workflowCount": workflow_count,
         "webSearchAvailable": web_search_available,
     })
+}
+
+#[cfg(test)]
+mod web_search_configured_tests {
+    use super::is_web_search_configured;
+    use librefang_types::config::WebConfig;
+
+    /// Point every API-key env-var lookup at a unique never-set name so the
+    /// helper's only path to "configured" in these tests is via SearXNG. This
+    /// keeps the assertions stable even on hosts that happen to export
+    /// `TAVILY_API_KEY` / `BRAVE_API_KEY` / etc. for unrelated reasons.
+    fn web_with_unset_keys(suffix: &str) -> WebConfig {
+        let mut web = WebConfig::default();
+        web.tavily.api_key_env = format!("LF_TEST_TAVILY_UNSET_{suffix}");
+        web.brave.api_key_env = format!("LF_TEST_BRAVE_UNSET_{suffix}");
+        web.jina.api_key_env = format!("LF_TEST_JINA_UNSET_{suffix}");
+        web.perplexity.api_key_env = format!("LF_TEST_PERPLEXITY_UNSET_{suffix}");
+        web.searxng.url = String::new();
+        web
+    }
+
+    #[test]
+    fn searxng_url_alone_counts_as_configured() {
+        let mut web = web_with_unset_keys("searxng_alone");
+        web.searxng.url = "https://search.example.com".to_string();
+        assert!(
+            is_web_search_configured(&web),
+            "non-empty SearXNG URL must satisfy the configured check — it does not need an API key"
+        );
+    }
+
+    #[test]
+    fn empty_searxng_and_unset_keys_is_unconfigured() {
+        let web = web_with_unset_keys("all_empty");
+        assert!(
+            !is_web_search_configured(&web),
+            "no SearXNG URL and no API keys must report unconfigured"
+        );
+    }
+
+    #[test]
+    fn whitespace_only_searxng_url_does_not_count() {
+        let mut web = web_with_unset_keys("whitespace");
+        web.searxng.url = "   ".to_string();
+        assert!(
+            !is_web_search_configured(&web),
+            "whitespace-only SearXNG URL must not satisfy the configured check"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two bugs in the chat page's web-search "Configure API key" chip, both fixed here:

1. **Backend (`config.rs`)**: `search_available` / `webSearchAvailable` only checked Tavily / Brave / Jina / Perplexity API-key env vars. SearXNG is configured purely by URL in `[web.searxng]` and was never consulted, so a SearXNG-only setup was reported as `false` and the dashboard nagged the user forever.
2. **Dashboard (`ChatPage.tsx`)**: when the nag *did* legitimately fire, clicking it navigated to `/config` → which redirects to `/config/general` (a totally unrelated category). The web-search settings live under `/config/tools` (where `web` is the default first tab).

## Fix

- Extract `is_web_search_configured(&WebConfig)` that ORs `web.searxng.url` (trimmed) with the four env-var providers, and call it from both `config_snapshot` and `status_snapshot`. The two callers no longer drift.
- Change the chat page's `onOpenConfig` target from `/config` to `/config/tools`.

## Test plan

- [x] Unit tests in `web_search_configured_tests`:
  - `searxng_url_alone_counts_as_configured` — primary regression case
  - `empty_searxng_and_unset_keys_is_unconfigured` — negative case
  - `whitespace_only_searxng_url_does_not_count` — guards `.trim()`
  - All three rebind the API-key env-var names to unique never-set strings, so they don't false-pass on hosts that happen to export `BRAVE_API_KEY` etc. for unrelated reasons.
- [ ] Manual: with `[web.searxng].url = "https://searxng-macbook.yldm.tech"` and no Tavily/Brave/Jina/Perplexity keys, `/api/config` returns `web.search_available = true` and the chat page no longer shows the orange "Configure API key" chip.
- [ ] Manual: with all providers genuinely unset, clicking the nag chip lands on `/config/tools` with the Web section already active.
- [ ] CI green
