### PR TITLE
style(types): unbreak main — fix clippy manual_pattern_char_comparison

### DIFF
--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -554,7 +554,7 @@ fn extract_url_host(url: &str) -> Option<String> {
         .or_else(|| url.strip_prefix("https://"))?;
     // Host runs until the next '/', '?', '#', or end-of-string.
     let host_end = after_scheme
-        .find(|c: char| c == '/' || c == '?' || c == '#')
+        .find(['/', '?', '#'])
         .unwrap_or(after_scheme.len());
     let host_part = &after_scheme[..host_end];
     // Strip optional userinfo (user:pass@host).


### PR DESCRIPTION
Emergency fix — clippy 1.95 introduced `manual_pattern_char_comparison`. The closure form in `extract_url_host` (added in #3139) trips it. One-line fix, no behaviour change.