### PR TITLE
fix(kernel): seed [[settings]] defaults into hand instance config on activation

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8852,7 +8852,7 @@ system_prompt = "You are a helpful assistant."
     pub fn activate_hand_with_id(
         &self,
         hand_id: &str,
-        config: std::collections::HashMap<String, serde_json::Value>,
+        mut config: std::collections::HashMap<String, serde_json::Value>,
         instance_id: Option<uuid::Uuid>,
         timestamps: Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)>,
     ) -> KernelResult<librefang_hands::HandInstance> {
@@ -8887,13 +8887,10 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Seed missing keys from the schema defaults so the persisted state
-        // matches what the renderer (`resolve_settings`) will actually show.
-        // The user's explicit overrides (already in `config`) take precedence
-        // — only fill keys the user hasn't touched. This makes "no value set"
-        // and "value matches default" distinguishable on disk and lets schema
-        // default changes require an explicit operator action to propagate.
-        let mut config = config;
+        // Seed schema defaults so persisted state matches what
+        // `resolve_settings` shows. Lets schema default changes require an
+        // explicit operator action and disambiguates "accepted default" from
+        // "never reviewed" on disk.
         for setting in &def.settings {
             config
                 .entry(setting.key.clone())

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8887,6 +8887,19 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        // Seed missing keys from the schema defaults so the persisted state
+        // matches what the renderer (`resolve_settings`) will actually show.
+        // The user's explicit overrides (already in `config`) take precedence
+        // — only fill keys the user hasn't touched. This makes "no value set"
+        // and "value matches default" distinguishable on disk and lets schema
+        // default changes require an explicit operator action to propagate.
+        let mut config = config;
+        for setting in &def.settings {
+            config
+                .entry(setting.key.clone())
+                .or_insert_with(|| serde_json::Value::String(setting.default.clone()));
+        }
+
         // Create the instance in the registry
         let instance = self
             .hand_registry

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -408,6 +408,115 @@ fn test_multi_agent_hand_state_persists_coordinator_role() {
     kernel.shutdown();
 }
 
+/// A hand with `[[settings]]` declaring two keys with non-empty defaults.
+const HAND_WITH_SETTINGS: &str = r#"
+id = "test-settings"
+name = "Test Settings Hand"
+description = "Has [[settings]] for default-seeding tests"
+category = "content"
+icon = "⚙️"
+
+[[settings]]
+key = "verbosity"
+label = "Verbosity"
+setting_type = "select"
+default = "normal"
+[[settings.options]]
+value = "quiet"
+label = "Quiet"
+[[settings.options]]
+value = "normal"
+label = "Normal"
+
+[[settings]]
+key = "max_concurrency"
+label = "Max concurrency"
+setting_type = "text"
+default = "5"
+
+[agent]
+name = "settings-agent"
+description = "Test agent"
+module = "builtin:chat"
+provider = "default"
+model = "default"
+system_prompt = "You are a settings agent."
+"#;
+
+#[test]
+fn test_activation_seeds_schema_defaults_into_config() {
+    let config = test_config("seed-defaults");
+    let state_path = config.home_dir.join("data").join("hand_state.json");
+
+    let kernel = LibreFangKernel::boot_with_config(config).unwrap();
+    install_hand(&kernel, HAND_WITH_SETTINGS);
+
+    // Activate with NO user overrides — all keys should be filled from defaults.
+    let instance = kernel
+        .activate_hand("test-settings", HashMap::new())
+        .unwrap();
+
+    assert_eq!(
+        instance.config.get("verbosity").and_then(|v| v.as_str()),
+        Some("normal"),
+        "verbosity should be seeded from schema default"
+    );
+    assert_eq!(
+        instance
+            .config
+            .get("max_concurrency")
+            .and_then(|v| v.as_str()),
+        Some("5"),
+        "max_concurrency should be seeded from schema default"
+    );
+
+    // Persisted state on disk should reflect the seeded values, not `{}`.
+    let state_json = std::fs::read_to_string(&state_path).unwrap();
+    let state: serde_json::Value = serde_json::from_str(&state_json).unwrap();
+    let inst = state["instances"]
+        .as_array()
+        .and_then(|a| a.iter().find(|i| i["hand_id"] == "test-settings"))
+        .expect("persisted instance should exist");
+    assert_eq!(inst["config"]["verbosity"], "normal");
+    assert_eq!(inst["config"]["max_concurrency"], "5");
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_activation_preserves_user_overrides_over_defaults() {
+    let kernel =
+        LibreFangKernel::boot_with_config(test_config("seed-defaults-override")).unwrap();
+    install_hand(&kernel, HAND_WITH_SETTINGS);
+
+    // User overrides one key; the other should still get the default.
+    let mut user_config = HashMap::new();
+    user_config.insert(
+        "verbosity".to_string(),
+        serde_json::Value::String("quiet".to_string()),
+    );
+
+    let instance = kernel
+        .activate_hand("test-settings", user_config)
+        .unwrap();
+
+    assert_eq!(
+        instance.config.get("verbosity").and_then(|v| v.as_str()),
+        Some("quiet"),
+        "user override must win over schema default"
+    );
+    assert_eq!(
+        instance
+            .config
+            .get("max_concurrency")
+            .and_then(|v| v.as_str()),
+        Some("5"),
+        "untouched key should still receive its schema default"
+    );
+
+    kernel.shutdown();
+}
+
 #[test]
 fn test_multiple_hands_coexist() {
     let kernel = LibreFangKernel::boot_with_config(test_config("coexist")).unwrap();

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -485,8 +485,7 @@ fn test_activation_seeds_schema_defaults_into_config() {
 
 #[test]
 fn test_activation_preserves_user_overrides_over_defaults() {
-    let kernel =
-        LibreFangKernel::boot_with_config(test_config("seed-defaults-override")).unwrap();
+    let kernel = LibreFangKernel::boot_with_config(test_config("seed-defaults-override")).unwrap();
     install_hand(&kernel, HAND_WITH_SETTINGS);
 
     // User overrides one key; the other should still get the default.
@@ -496,9 +495,7 @@ fn test_activation_preserves_user_overrides_over_defaults() {
         serde_json::Value::String("quiet".to_string()),
     );
 
-    let instance = kernel
-        .activate_hand("test-settings", user_config)
-        .unwrap();
+    let instance = kernel.activate_hand("test-settings", user_config).unwrap();
 
     assert_eq!(
         instance.config.get("verbosity").and_then(|v| v.as_str()),
@@ -512,6 +509,44 @@ fn test_activation_preserves_user_overrides_over_defaults() {
             .and_then(|v| v.as_str()),
         Some("5"),
         "untouched key should still receive its schema default"
+    );
+
+    kernel.shutdown();
+}
+
+/// Schema-evolution backfill: when the persisted config is missing a key
+/// that the current schema declares (e.g. the hand was first activated
+/// against an older HAND.toml that didn't have the key, or the hand_state.json
+/// pre-dates this PR), re-activation must fill the missing key from the
+/// schema default while leaving every other previously-accepted value alone.
+#[test]
+fn test_reactivation_backfills_missing_schema_keys() {
+    let kernel = LibreFangKernel::boot_with_config(test_config("seed-backfill")).unwrap();
+    install_hand(&kernel, HAND_WITH_SETTINGS);
+
+    // Mimic restart-recovery: hand_state.json carries a partial config —
+    // `max_concurrency` was accepted by the operator at "12", but `verbosity`
+    // is missing entirely (older state file, or schema added the key later).
+    let mut prior_config = HashMap::new();
+    prior_config.insert(
+        "max_concurrency".to_string(),
+        serde_json::Value::String("12".to_string()),
+    );
+
+    let instance = kernel.activate_hand("test-settings", prior_config).unwrap();
+
+    assert_eq!(
+        instance
+            .config
+            .get("max_concurrency")
+            .and_then(|v| v.as_str()),
+        Some("12"),
+        "previously-accepted user value must survive backfill"
+    );
+    assert_eq!(
+        instance.config.get("verbosity").and_then(|v| v.as_str()),
+        Some("normal"),
+        "key absent from prior config must be backfilled with its schema default"
     );
 
     kernel.shutdown();


### PR DESCRIPTION
Closes #3154.

## Problem

When a hand is activated, the kernel persists the instance to
`data/hand_state.json` with `config: {}` (or just the user-overridden
subset). The schema defaults from `[[settings]]` are never written into
the instance config — they're only consulted at render time via the
`unwrap_or(&setting.default)` fallback inside
`librefang_hands::resolve_settings`.

That fallback masks intent on disk. After `hand activate example`:

```json
{
  "hand_id": "example",
  "instance_id": "...",
  "config": {},                 ← empty, even though defaults exist
  "status": "Active"
}
```

Symptoms:

- `librefang hand settings example` and the dashboard cannot
  distinguish "user accepted the default" from "user never reviewed
  this".
- A schema-side `default = "5"` → `default = "20"` bump silently
  changes behavior for every existing instance — including ones whose
  operator had previously accepted `"5"`.
- The `## User Configuration` block in the rendered system prompt
  always looks identical regardless of whether anything was set, so
  there's no quick "did I forget a setting?" check.
- A settings UI that shows "current value" has nothing useful to
  display when the underlying state is empty.

## Fix

In `LibreFangKernel::activate_hand_with_id`, before handing `config`
to `hand_registry.activate_with_id`, fill any unset key from its
schema default:

```rust
let mut config = config;
for setting in &def.settings {
    config
        .entry(setting.key.clone())
        .or_insert_with(|| serde_json::Value::String(setting.default.clone()));
}
```

Properties:

- User-supplied overrides win — `Entry::or_insert_with` only fills
  keys the caller didn't pass.
- Idempotent across daemon restarts: when boot recovery re-activates
  a hand with the persisted (already-seeded) config, the `or_insert_with`
  is a no-op for keys present, and a backfill for keys that the
  schema added since the instance was first activated.
- Composes with `librefang_hands::resolve_settings` — the existing
  fallback there is now defense-in-depth that should not normally
  fire.
- Composes with #3142 — `boot_with_config` reads `hand_state.json`
  directly to re-render the system-prompt tail. Seeded configs make
  that re-render reflect what the operator actually accepted, not
  whatever the schema default happens to be at this moment.

## Out of scope (matches the issue)

- `value_source: "default" | "user"` per-key marker.
- Defaults for `requires` (env vars / API keys) — those have a
  different lifecycle (presence check at activation, not config
  values).
- In-place migration of already-persisted instances. They auto-heal
  on the next activation cycle (e.g. daemon restart re-activates each
  persisted hand and the new seeding fills in missing keys; the next
  `persist_hand_state` writes the complete config to disk).

## Tests

`crates/librefang-kernel/tests/multi_agent_test.rs`:

- `test_activation_seeds_schema_defaults_into_config` — activates
  with no user config, asserts both schema keys appear in
  `instance.config` AND in the on-disk `hand_state.json`.
- `test_activation_preserves_user_overrides_over_defaults` —
  activates with one key overridden, asserts the override survives
  and the other key still gets the schema default.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — 0
  warnings.
- `cargo test -p librefang-kernel --test multi_agent_test` — 23
  passed (21 existing + 2 new).
- `cargo test -p librefang-hands` — 75 passed.
