### PR TITLE
fix(kernel): re-render Reference Knowledge + Your Team tails after TOML drift

### DIFF
--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -313,6 +313,18 @@ const TEAM_TAIL_MARKER: &str = "\n\n---\n\n## Your Team";
 /// fenced form is absent. Re-append always uses the fenced form, so a single
 /// drift cycle migrates each agent forward and this constant becomes dead
 /// once every persisted prompt has been re-rendered.
+///
+/// SAFETY: this string is a substring of [`TEAM_TAIL_MARKER`]
+/// (`"\n\n---\n\n## Your Team"`), so a naive `find()` against this constant
+/// will match a fenced prompt and truncate too late, dropping the
+/// `\n\n---\n\n` fence into the visible prompt. Every caller MUST check
+/// [`TEAM_TAIL_MARKER`] first and only fall back to this when the fenced
+/// form is absent (see [`apply_team_block_to_manifest`]).
+///
+/// TODO(remove after migration window): once telemetry confirms every
+/// persisted prompt has been touched by at least one drift cycle (post-#3164
+/// rollout), drop this constant and its fallback branch. Tracking issue:
+/// see `LEGACY_TEAM_TAIL_MARKER` references for the cleanup sites.
 const LEGACY_TEAM_TAIL_MARKER: &str = "\n\n## Your Team";
 
 /// Append (or refresh) the rendered `## User Configuration` block on a

--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -296,6 +296,16 @@ pub(super) fn toml_enabled_false(content: &str) -> bool {
 /// existing one rather than blindly appending a duplicate.
 const USER_CONFIG_TAIL_MARKER: &str = "\n\n---\n\n## User Configuration";
 
+/// Marker that introduces the rendered `## Reference Knowledge` tail —
+/// skill content (per-role override or hand-shared) appended at activation.
+const SKILL_REFERENCE_TAIL_MARKER: &str = "\n\n---\n\n## Reference Knowledge";
+
+/// Marker that introduces the rendered `## Your Team` tail — peer roster
+/// for multi-agent hands. Note the separator differs from the other two
+/// (no leading `\n\n---\n\n`) because activation appends it directly
+/// after the skill content rather than as a fresh markdown section.
+const TEAM_TAIL_MARKER: &str = "\n\n## Your Team";
+
 /// Append (or refresh) the rendered `## User Configuration` block on a
 /// manifest's `model.system_prompt` from a hand's `[[settings]]` schema +
 /// instance config.
@@ -343,6 +353,139 @@ pub(super) fn apply_settings_block_to_manifest(
     );
 
     resolved.env_vars
+}
+
+/// Append (or refresh) the rendered `## Reference Knowledge` block on a
+/// manifest's `model.system_prompt` from a hand's skill content.
+///
+/// Per-role override (`def.agent_skill_content[role.to_lowercase()]`)
+/// takes precedence over the hand-shared `def.skill_content`. When neither
+/// is set, the call only strips any pre-existing tail without re-appending
+/// — covers the case where the hand's SKILL.md was deleted and the prompt
+/// must drop its now-stale reference section.
+///
+/// Idempotency: pre-existing `## Reference Knowledge` tails are stripped
+/// before re-appending, so repeated calls (e.g. drift loop firing
+/// back-to-back) do not duplicate the section.
+///
+/// Both call sites use this helper:
+///
+/// 1. Hand activation (`activate_hand_with_id`) — see `kernel/mod.rs`.
+/// 2. Boot-time TOML drift detection — when the disk manifest replaces
+///    the DB blob, the bare TOML doesn't carry the rendered tail and
+///    without re-rendering here the agent loses skill discoverability on
+///    every restart.
+pub(super) fn apply_skill_reference_block_to_manifest(
+    manifest: &mut AgentManifest,
+    role: &str,
+    def: &librefang_hands::HandDefinition,
+) {
+    // Always strip first — covers the case where skill content is now
+    // empty (skill removed from hand) so the stale tail doesn't linger.
+    if let Some(idx) = manifest
+        .model
+        .system_prompt
+        .find(SKILL_REFERENCE_TAIL_MARKER)
+    {
+        manifest.model.system_prompt.truncate(idx);
+    }
+
+    let role_lower = role.to_lowercase();
+    let effective_skill = def
+        .agent_skill_content
+        .get(&role_lower)
+        .or(def.skill_content.as_ref());
+
+    if let Some(skill_content) = effective_skill {
+        if !skill_content.is_empty() {
+            manifest.model.system_prompt = format!(
+                "{}\n\n---\n\n## Reference Knowledge\n\n{}",
+                manifest.model.system_prompt, skill_content
+            );
+        }
+    }
+}
+
+/// Append (or refresh) the rendered `## Your Team` block on a manifest's
+/// `model.system_prompt` from the hand's peer roster. No-op for
+/// single-agent hands.
+///
+/// Idempotency: pre-existing `## Your Team` tails are stripped before
+/// re-appending, so repeated calls do not duplicate the section.
+///
+/// `role` identifies the agent we're rendering for; the agent's own role
+/// is excluded from the peer list. Each peer line uses
+/// `hand_agent.invoke_hint` when set, falling back to the peer's manifest
+/// description.
+pub(super) fn apply_team_block_to_manifest(
+    manifest: &mut AgentManifest,
+    role: &str,
+    def: &librefang_hands::HandDefinition,
+) {
+    // Always strip first — covers the case where the hand was edited from
+    // multi-agent down to single-agent so the stale Team tail must drop.
+    if let Some(idx) = manifest.model.system_prompt.find(TEAM_TAIL_MARKER) {
+        manifest.model.system_prompt.truncate(idx);
+    }
+
+    if !def.is_multi_agent() {
+        return;
+    }
+
+    let mut peer_lines = Vec::new();
+    for (peer_role, peer_agent) in &def.agents {
+        if peer_role == role {
+            continue;
+        }
+        let hint = peer_agent
+            .invoke_hint
+            .as_deref()
+            .unwrap_or(&peer_agent.manifest.description);
+        peer_lines.push(format!(
+            "- **{peer_role}**: {hint} (use agent_send to message)"
+        ));
+    }
+
+    if !peer_lines.is_empty() {
+        let team_block = format!("\n\n## Your Team\n\n{}", peer_lines.join("\n"));
+        manifest.model.system_prompt = format!("{}{team_block}", manifest.model.system_prompt);
+    }
+}
+
+/// Return a clone of `manifest` with all known runtime-rendered prompt
+/// tails stripped from `model.system_prompt`, suitable for the boot-time
+/// drift comparison.
+///
+/// The drift loop compares the disk TOML manifest against the DB blob and
+/// rewrites the DB when they differ. Without this projection the disk
+/// manifest (which never carries any rendered tail) will always look
+/// "different" from the DB blob (which carries the tails materialized at
+/// activation), triggering a clobber-and-rerender cycle on every restart.
+/// Comparing on the projection means drift only fires when the *raw* TOML
+/// truly diverges from the *raw* DB form.
+///
+/// All known tails are appended in a fixed order
+/// (settings -> reference -> team), so truncating from the earliest
+/// marker drops every tail in one shot. Each marker is checked
+/// individually so prompts carrying only a subset of the tails still get
+/// the correct truncation point.
+pub(super) fn manifest_for_diff(manifest: &AgentManifest) -> AgentManifest {
+    let mut copy = manifest.clone();
+    let prompt = &mut copy.model.system_prompt;
+    let mut earliest_idx: Option<usize> = None;
+    for marker in [
+        USER_CONFIG_TAIL_MARKER,
+        SKILL_REFERENCE_TAIL_MARKER,
+        TEAM_TAIL_MARKER,
+    ] {
+        if let Some(idx) = prompt.find(marker) {
+            earliest_idx = Some(earliest_idx.map_or(idx, |cur| cur.min(idx)));
+        }
+    }
+    if let Some(idx) = earliest_idx {
+        prompt.truncate(idx);
+    }
+    copy
 }
 
 pub fn shared_memory_agent_id() -> AgentId {
@@ -539,6 +682,212 @@ system_prompt = "p"
             &std::collections::HashMap::new(),
         );
         assert!(m.model.system_prompt.contains(USER_CONFIG_TAIL_MARKER));
+    }
+
+    fn parse_hand(toml: &str, skill: &str) -> librefang_hands::HandDefinition {
+        librefang_hands::registry::parse_hand_toml(toml, skill, std::collections::HashMap::new())
+            .expect("hand toml must parse")
+    }
+
+    const SINGLE_AGENT_HAND: &str = r#"
+id = "demo"
+version = "1.0.0"
+name = "Demo"
+description = "t"
+category = "other"
+
+[agents.main]
+name = "demo-main"
+description = "the only agent"
+module = "builtin:chat"
+
+[agents.main.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "BASE"
+"#;
+
+    const MULTI_AGENT_HAND: &str = r#"
+id = "team"
+version = "1.0.0"
+name = "Team"
+description = "t"
+category = "other"
+
+[agents.lead]
+name = "team-lead"
+description = "lead agent"
+module = "builtin:chat"
+invoke_hint = "delegates work"
+
+[agents.lead.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "BASE-LEAD"
+
+[agents.worker]
+name = "team-worker"
+description = "executes tasks"
+module = "builtin:chat"
+
+[agents.worker.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "BASE-WORKER"
+"#;
+
+    #[test]
+    fn apply_skill_reference_appends_tail_when_skill_present() {
+        let def = parse_hand(SINGLE_AGENT_HAND, "RESOURCE A\nRESOURCE B");
+        let mut m = manifest_with_prompt("BASE");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def);
+        assert!(
+            m.model
+                .system_prompt
+                .contains("\n\n---\n\n## Reference Knowledge\n\nRESOURCE A"),
+            "skill content must be appended under the Reference Knowledge heading"
+        );
+    }
+
+    #[test]
+    fn apply_skill_reference_is_noop_when_skill_empty() {
+        let def = parse_hand(SINGLE_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def);
+        assert_eq!(m.model.system_prompt, "BASE");
+    }
+
+    #[test]
+    fn apply_skill_reference_is_idempotent() {
+        let def = parse_hand(SINGLE_AGENT_HAND, "STUFF");
+        let mut m = manifest_with_prompt("BASE");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def);
+        let after_first = m.model.system_prompt.clone();
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def);
+        assert_eq!(m.model.system_prompt, after_first);
+        assert_eq!(
+            m.model
+                .system_prompt
+                .matches("## Reference Knowledge")
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn apply_skill_reference_replaces_stale_tail_when_content_changes() {
+        let def_old = parse_hand(SINGLE_AGENT_HAND, "OLD");
+        let def_new = parse_hand(SINGLE_AGENT_HAND, "NEW");
+        let mut m = manifest_with_prompt("BASE");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def_old);
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def_new);
+        assert!(m.model.system_prompt.contains("NEW"));
+        assert!(!m.model.system_prompt.contains("OLD"));
+    }
+
+    #[test]
+    fn apply_skill_reference_drops_tail_when_skill_removed() {
+        // Hand previously had skill content; on next render the SKILL.md is gone.
+        let def_with = parse_hand(SINGLE_AGENT_HAND, "STUFF");
+        let def_without = parse_hand(SINGLE_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def_with);
+        assert!(m.model.system_prompt.contains("STUFF"));
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def_without);
+        assert_eq!(m.model.system_prompt, "BASE");
+    }
+
+    #[test]
+    fn apply_team_block_noop_for_single_agent_hand() {
+        let def = parse_hand(SINGLE_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_team_block_to_manifest(&mut m, "main", &def);
+        assert_eq!(m.model.system_prompt, "BASE");
+    }
+
+    #[test]
+    fn apply_team_block_appends_peers_excluding_self() {
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        let prompt = &m.model.system_prompt;
+        assert!(prompt.contains("\n\n## Your Team\n\n"));
+        assert!(prompt.contains("- **worker**:"));
+        assert!(prompt.contains("executes tasks (use agent_send to message)"));
+        assert!(
+            !prompt.contains("- **lead**:"),
+            "self must not appear in own team list"
+        );
+    }
+
+    #[test]
+    fn apply_team_block_uses_invoke_hint_when_present() {
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_team_block_to_manifest(&mut m, "worker", &def);
+        // `lead` has invoke_hint = "delegates work", so the line must use that
+        // instead of the manifest description.
+        assert!(m.model.system_prompt.contains("- **lead**: delegates work"));
+        assert!(!m.model.system_prompt.contains("lead agent"));
+    }
+
+    #[test]
+    fn apply_team_block_is_idempotent() {
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        let mut m = manifest_with_prompt("BASE");
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        let after_first = m.model.system_prompt.clone();
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        assert_eq!(m.model.system_prompt, after_first);
+        assert_eq!(m.model.system_prompt.matches("## Your Team").count(), 1);
+    }
+
+    #[test]
+    fn manifest_for_diff_strips_all_known_tails() {
+        // Build a prompt that contains all three tails in activation order.
+        let base = "BASE";
+        let mut m = manifest_with_prompt(base);
+        apply_settings_block_to_manifest(
+            &mut m,
+            &make_settings(),
+            &std::collections::HashMap::new(),
+        );
+        let def = parse_hand(MULTI_AGENT_HAND, "STUFF");
+        apply_skill_reference_block_to_manifest(&mut m, "lead", &def);
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        assert!(m.model.system_prompt.contains("## User Configuration"));
+        assert!(m.model.system_prompt.contains("## Reference Knowledge"));
+        assert!(m.model.system_prompt.contains("## Your Team"));
+
+        let projected = manifest_for_diff(&m);
+        assert_eq!(projected.model.system_prompt, base);
+    }
+
+    #[test]
+    fn manifest_for_diff_strips_tails_in_any_subset() {
+        // Only Team tail present (no settings, no skills).
+        let mut m = manifest_with_prompt("BASE");
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        let projected = manifest_for_diff(&m);
+        assert_eq!(projected.model.system_prompt, "BASE");
+
+        // Only Reference Knowledge.
+        let mut m = manifest_with_prompt("BASE");
+        let def = parse_hand(SINGLE_AGENT_HAND, "STUFF");
+        apply_skill_reference_block_to_manifest(&mut m, "main", &def);
+        let projected = manifest_for_diff(&m);
+        assert_eq!(projected.model.system_prompt, "BASE");
+    }
+
+    #[test]
+    fn manifest_for_diff_no_tails_returns_input_verbatim() {
+        let m = manifest_with_prompt("BASE prompt with no rendered tails");
+        let projected = manifest_for_diff(&m);
+        assert_eq!(
+            projected.model.system_prompt,
+            "BASE prompt with no rendered tails"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -301,10 +301,19 @@ const USER_CONFIG_TAIL_MARKER: &str = "\n\n---\n\n## User Configuration";
 const SKILL_REFERENCE_TAIL_MARKER: &str = "\n\n---\n\n## Reference Knowledge";
 
 /// Marker that introduces the rendered `## Your Team` tail — peer roster
-/// for multi-agent hands. Note the separator differs from the other two
-/// (no leading `\n\n---\n\n`) because activation appends it directly
-/// after the skill content rather than as a fresh markdown section.
-const TEAM_TAIL_MARKER: &str = "\n\n## Your Team";
+/// for multi-agent hands. Uses the same `\n\n---\n\n` fence as the other
+/// two tails so the heading is unambiguous: a SKILL.md or base prompt that
+/// happens to contain a literal `## Your Team` line cannot accidentally
+/// match the marker and cause `find()` to truncate user-authored content.
+const TEAM_TAIL_MARKER: &str = "\n\n---\n\n## Your Team";
+
+/// Pre-fence form of the team marker, kept only for backwards-compatible
+/// strip on agents that were activated before the fence was added. Detection
+/// (`find()`) checks the fenced form first; this is only consulted when the
+/// fenced form is absent. Re-append always uses the fenced form, so a single
+/// drift cycle migrates each agent forward and this constant becomes dead
+/// once every persisted prompt has been re-rendered.
+const LEGACY_TEAM_TAIL_MARKER: &str = "\n\n## Your Team";
 
 /// Append (or refresh) the rendered `## User Configuration` block on a
 /// manifest's `model.system_prompt` from a hand's `[[settings]]` schema +
@@ -382,6 +391,14 @@ pub(super) fn apply_skill_reference_block_to_manifest(
 ) {
     // Always strip first — covers the case where skill content is now
     // empty (skill removed from hand) so the stale tail doesn't linger.
+    //
+    // Ordering note: at activation this helper runs BEFORE
+    // `apply_team_block_to_manifest`, so a stale team tail (which sits
+    // downstream of the skill marker) is also dropped by this truncate
+    // and re-appended afterwards. If callers ever invert the order,
+    // `apply_team_block_to_manifest` must be widened to strip both
+    // markers — otherwise a re-render leaves the team block stranded
+    // before the freshly appended skill block.
     if let Some(idx) = manifest
         .model
         .system_prompt
@@ -424,7 +441,23 @@ pub(super) fn apply_team_block_to_manifest(
 ) {
     // Always strip first — covers the case where the hand was edited from
     // multi-agent down to single-agent so the stale Team tail must drop.
-    if let Some(idx) = manifest.model.system_prompt.find(TEAM_TAIL_MARKER) {
+    //
+    // Check the fenced marker first; fall back to the pre-fence form so
+    // prompts persisted before the fence was introduced still get cleaned
+    // up. Once stripped + re-appended, the prompt carries the fenced form
+    // and the legacy lookup never matches again for that agent.
+    //
+    // Ordering note: this helper is the LAST tail appended at activation
+    // (settings -> reference -> team). Truncating at the team marker only
+    // drops the team block itself — no later tail can be lost. If a future
+    // change inserts a new tail after team, this strip will need to widen
+    // (or that tail's helper must run before this one).
+    let strip_idx = manifest
+        .model
+        .system_prompt
+        .find(TEAM_TAIL_MARKER)
+        .or_else(|| manifest.model.system_prompt.find(LEGACY_TEAM_TAIL_MARKER));
+    if let Some(idx) = strip_idx {
         manifest.model.system_prompt.truncate(idx);
     }
 
@@ -447,7 +480,7 @@ pub(super) fn apply_team_block_to_manifest(
     }
 
     if !peer_lines.is_empty() {
-        let team_block = format!("\n\n## Your Team\n\n{}", peer_lines.join("\n"));
+        let team_block = format!("\n\n---\n\n## Your Team\n\n{}", peer_lines.join("\n"));
         manifest.model.system_prompt = format!("{}{team_block}", manifest.model.system_prompt);
     }
 }
@@ -811,12 +844,43 @@ system_prompt = "BASE-WORKER"
         let mut m = manifest_with_prompt("BASE");
         apply_team_block_to_manifest(&mut m, "lead", &def);
         let prompt = &m.model.system_prompt;
-        assert!(prompt.contains("\n\n## Your Team\n\n"));
+        assert!(
+            prompt.contains("\n\n---\n\n## Your Team\n\n"),
+            "team block must use the fenced marker so a literal `## Your Team` \
+             elsewhere in the prompt cannot collide with the strip lookup"
+        );
         assert!(prompt.contains("- **worker**:"));
         assert!(prompt.contains("executes tasks (use agent_send to message)"));
         assert!(
             !prompt.contains("- **lead**:"),
             "self must not appear in own team list"
+        );
+    }
+
+    #[test]
+    fn apply_team_block_migrates_legacy_unfenced_tail_in_place() {
+        // Regression: agents activated before the fence was added carry the
+        // pre-fence form (`\n\n## Your Team`). Re-rendering must strip the
+        // legacy tail in place and re-append using the fenced form so a
+        // single drift cycle migrates the persisted blob forward.
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        let mut m = manifest_with_prompt(
+            "BASE\n\n## Your Team\n\n- **worker**: stale text (use agent_send to message)",
+        );
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        let prompt = &m.model.system_prompt;
+        assert!(
+            !prompt.contains("stale text"),
+            "legacy unfenced tail must be stripped, not duplicated"
+        );
+        assert_eq!(
+            prompt.matches("## Your Team").count(),
+            1,
+            "exactly one team block must remain after migration"
+        );
+        assert!(
+            prompt.contains("\n\n---\n\n## Your Team\n\n"),
+            "migrated prompt must carry the fenced form"
         );
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2948,9 +2948,25 @@ impl LibreFangKernel {
                                     });
                                 match parsed {
                                     Some(mut disk_manifest) => {
-                                        // Compare key fields to detect changes
-                                        let changed = serde_json::to_value(&disk_manifest).ok()
-                                            != serde_json::to_value(&entry.manifest).ok();
+                                        // Compare manifests on a projection that strips
+                                        // every known runtime-rendered prompt tail
+                                        // (## User Configuration, ## Reference Knowledge,
+                                        // ## Your Team) before serialization. The disk
+                                        // TOML never carries any of these (they are
+                                        // re-rendered at activation/drift time), so a
+                                        // raw diff would always trigger on
+                                        // hand-with-rendered-tail agents and clobber the
+                                        // DB blob with the bare TOML on every restart.
+                                        // Comparing on the projection means drift only
+                                        // fires when the *source* TOML genuinely
+                                        // diverged from the DB form.
+                                        let changed =
+                                            serde_json::to_value(manifest_for_diff(&disk_manifest))
+                                                .ok()
+                                                != serde_json::to_value(manifest_for_diff(
+                                                    &entry.manifest,
+                                                ))
+                                                .ok();
                                         if changed {
                                             info!(
                                                 agent = %name,
@@ -3014,6 +3030,46 @@ impl LibreFangKernel {
                                                             &mut entry.manifest,
                                                             &def.settings,
                                                             cfg_for_settings,
+                                                        );
+                                                    }
+
+                                                    // Re-render `## Reference Knowledge` and
+                                                    // `## Your Team` tails — like the settings
+                                                    // tail above, the bare disk TOML never
+                                                    // carries them, so without re-rendering
+                                                    // here the agent silently loses skill
+                                                    // discoverability and peer awareness on
+                                                    // every restart. Helpers are
+                                                    // unconditionally idempotent: empty skill
+                                                    // content / single-agent hand / no peers
+                                                    // all collapse to a strip-only call that
+                                                    // also clears any stale tail left over
+                                                    // from when the hand previously had
+                                                    // those.
+                                                    //
+                                                    // Recover the agent's role from the
+                                                    // `hand_role:<role>` tag stamped at
+                                                    // activation. Skip silently when the tag
+                                                    // is missing — the agent isn't
+                                                    // hand-derived in a way we recognise, and
+                                                    // the activation path will re-stamp the
+                                                    // tags on the next `hand activate`.
+                                                    let role_opt = entry
+                                                        .manifest
+                                                        .tags
+                                                        .iter()
+                                                        .find_map(|t| t.strip_prefix("hand_role:"))
+                                                        .map(|s| s.to_string());
+                                                    if let Some(role) = role_opt {
+                                                        apply_skill_reference_block_to_manifest(
+                                                            &mut entry.manifest,
+                                                            &role,
+                                                            &def,
+                                                        );
+                                                        apply_team_block_to_manifest(
+                                                            &mut entry.manifest,
+                                                            &role,
+                                                            &def,
                                                         );
                                                     }
                                                 }
@@ -8918,7 +8974,6 @@ system_prompt = "You are a helpful assistant."
         }
 
         let is_multi_agent = def.is_multi_agent();
-        let role_names: Vec<String> = def.agents.keys().cloned().collect();
         let coordinator_role = def.coordinator().map(|(role, _)| role.to_string());
 
         // Kill existing agents with matching hand tag (reactivation cleanup)
@@ -9128,44 +9183,15 @@ system_prompt = "You are a helpful assistant."
                 );
             }
 
-            // Inject skill content: per-role override takes precedence over shared.
-            // SKILL-{role}.md filenames are lowercased during scan, so normalize
-            // the role name to match.
-            let role_lower = role.to_lowercase();
-            let effective_skill = def
-                .agent_skill_content
-                .get(&role_lower)
-                .or(def.skill_content.as_ref());
-            if let Some(skill_content) = effective_skill {
-                manifest.model.system_prompt = format!(
-                    "{}\n\n---\n\n## Reference Knowledge\n\n{}",
-                    manifest.model.system_prompt, skill_content
-                );
-            }
-
-            // For multi-agent hands: inject peer info into system prompt
-            if is_multi_agent {
-                let mut peer_lines = Vec::new();
-                for peer_role in &role_names {
-                    if peer_role == role {
-                        continue;
-                    }
-                    if let Some(peer_agent) = def.agents.get(peer_role) {
-                        let hint = peer_agent
-                            .invoke_hint
-                            .as_deref()
-                            .unwrap_or(&peer_agent.manifest.description);
-                        peer_lines.push(format!(
-                            "- **{peer_role}**: {hint} (use agent_send to message)"
-                        ));
-                    }
-                }
-                if !peer_lines.is_empty() {
-                    let team_block = format!("\n\n## Your Team\n\n{}", peer_lines.join("\n"));
-                    manifest.model.system_prompt =
-                        format!("{}{team_block}", manifest.model.system_prompt);
-                }
-            }
+            // Inject `## Reference Knowledge` and `## Your Team` blocks via
+            // the shared helpers. Both are also called from the boot-time
+            // TOML drift loop in `new_with_config` so the two paths render
+            // identically — the drift loop overwrites the DB blob with the
+            // bare disk TOML, which never carries either rendered tail, and
+            // would otherwise silently strip skill discoverability and peer
+            // awareness from the prompt on every restart.
+            apply_skill_reference_block_to_manifest(&mut manifest, role, &def);
+            apply_team_block_to_manifest(&mut manifest, role, &def);
 
             // Hand workspace: workspaces/<hand-id>/
             // Agent workspace nested under hand: workspaces/hands/<hand-id>/<role>/

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3071,6 +3071,21 @@ impl LibreFangKernel {
                                                             &role,
                                                             &def,
                                                         );
+                                                    } else {
+                                                        // Hand membership is known (we're inside
+                                                        // the `hand:<id>` branch) but the role tag
+                                                        // wasn't stamped — this agent will boot
+                                                        // without skill discoverability or peer
+                                                        // awareness until somebody re-runs
+                                                        // `hand activate`. Log so the silent
+                                                        // degradation is at least greppable.
+                                                        debug!(
+                                                            agent = %name,
+                                                            hand = %hand_id,
+                                                            "hand_role:<role> tag missing on \
+                                                             hand-derived agent; skipping skill/team \
+                                                             tail re-render until next hand activate"
+                                                        );
                                                     }
                                                 }
                                             }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2442,3 +2442,302 @@ system_prompt = "BASE PROMPT"
 
     kernel.shutdown();
 }
+
+/// Regression: hand `## Reference Knowledge` and `## Your Team` tails must
+/// survive a daemon restart (issue #3143).
+///
+/// Same drift mechanism as `boot_drift_preserves_hand_settings_tail`, but
+/// covers the two other rendered tails the activation path appends to a
+/// hand-derived agent's `system_prompt`. Pre-fix, only the settings tail
+/// was re-rendered after drift — the skill section and team roster were
+/// silently stripped on every restart.
+///
+/// Sets up a multi-agent hand whose SKILL.md is loaded into
+/// `def.skill_content`, seeds a DB agent whose manifest carries both
+/// rendered tails, then forces drift via a body-text edit on the disk
+/// TOML. After reboot, both tails must be back.
+#[test]
+fn boot_drift_preserves_skill_and_team_tails() {
+    use librefang_types::agent::{AgentEntry, AgentId, AgentMode, AgentState};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let hand_id = "teamhand";
+    let hand_dir = home_dir.join("registry").join("hands").join(hand_id);
+    std::fs::create_dir_all(&hand_dir).unwrap();
+    std::fs::write(home_dir.join("registry").join(".sync_marker"), "").unwrap();
+
+    let hand_toml = r#"
+id = "teamhand"
+version = "1.0.0"
+name = "Team Hand"
+description = "drift-test multi-agent hand"
+category = "other"
+
+[agents.lead]
+name = "lead"
+description = "lead agent"
+module = "builtin:chat"
+invoke_hint = "delegates work"
+
+[agents.lead.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "BASE PROMPT"
+
+[agents.worker]
+name = "worker"
+description = "executes tasks"
+module = "builtin:chat"
+
+[agents.worker.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "WORKER PROMPT"
+"#;
+    std::fs::write(hand_dir.join("HAND.toml"), hand_toml).unwrap();
+    // SKILL.md is read by HandRegistry::reload_from_disk and stuffed into
+    // def.skill_content — that's the input to apply_skill_reference_block_to_manifest.
+    std::fs::write(
+        hand_dir.join("SKILL.md"),
+        "## Skill\n\nuseful background context",
+    )
+    .unwrap();
+
+    // Mirror the hand TOML at the workspaces location so the drift loop
+    // finds a TOML to compare against. Force a body-text drift via
+    // BASE PROMPT -> BASE PROMPT v2 — this difference survives the
+    // sanitized projection (manifest_for_diff strips only the rendered
+    // tails, not the base prompt body) so the drift branch fires.
+    let workspaces_hand_dir = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("lead");
+    std::fs::create_dir_all(&workspaces_hand_dir).unwrap();
+    let workspaces_hand_toml = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("hand.toml");
+    std::fs::create_dir_all(workspaces_hand_toml.parent().unwrap()).unwrap();
+    let drift_toml = hand_toml.replace("BASE PROMPT", "BASE PROMPT v2");
+    std::fs::write(&workspaces_hand_toml, drift_toml).unwrap();
+
+    // First boot — initialise SQLite, then seed a DB entry that mimics a
+    // previously-activated lead agent (carries Reference Knowledge + Your
+    // Team tails).
+    {
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+        let kernel = LibreFangKernel::boot_with_config(config).expect("first boot");
+
+        let agent_id = AgentId::from_hand_agent(hand_id, "lead", Some(uuid::Uuid::new_v4()));
+        let agent_name = format!("{hand_id}:lead");
+        let mut manifest = librefang_types::agent::AgentManifest {
+            name: agent_name.clone(),
+            description: "lead agent".to_string(),
+            module: "builtin:chat".to_string(),
+            ..Default::default()
+        };
+        manifest.model.provider = "openrouter".to_string();
+        manifest.model.model = "x".to_string();
+        manifest.model.system_prompt = "BASE PROMPT\n\n---\n\n## Reference Knowledge\n\nuseful background context\n\n## Your Team\n\n- **worker**: executes tasks (use agent_send to message)".to_string();
+        manifest.tags = vec![format!("hand:{hand_id}"), "hand_role:lead".to_string()];
+
+        let entry = AgentEntry {
+            id: agent_id,
+            name: agent_name,
+            manifest,
+            state: AgentState::Running,
+            mode: AgentMode::default(),
+            created_at: chrono::Utc::now(),
+            last_active: chrono::Utc::now(),
+            parent: None,
+            children: vec![],
+            session_id: SessionId::new(),
+            source_toml_path: Some(workspaces_hand_toml.clone()),
+            tags: vec![format!("hand:{hand_id}"), "hand_role:lead".to_string()],
+            identity: Default::default(),
+            onboarding_completed: false,
+            onboarding_completed_at: None,
+            is_hand: false,
+            ..Default::default()
+        };
+        kernel.memory.save_agent(&entry).expect("seed save_agent");
+        kernel.shutdown();
+    }
+
+    // Second boot: drift fires (BASE PROMPT vs BASE PROMPT v2 in the
+    // sanitized projection); the fix re-renders both tails before
+    // save_agent persists the new blob.
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("second boot");
+
+    let agent_name = format!("{hand_id}:lead");
+    let restored = kernel
+        .registry
+        .find_by_name(&agent_name)
+        .expect("hand agent must be restored from DB");
+    let prompt = restored.manifest.model.system_prompt;
+    assert!(
+        prompt.contains("BASE PROMPT v2"),
+        "drift must have applied disk TOML body; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("## Reference Knowledge"),
+        "Reference Knowledge tail must be re-rendered after drift; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("useful background context"),
+        "skill content from SKILL.md must be present; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("## Your Team"),
+        "Your Team tail must be re-rendered after drift; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("- **worker**:"),
+        "peer line must be present; got: {prompt}"
+    );
+
+    kernel.shutdown();
+}
+
+/// Regression: when only the rendered tails differ (no real TOML drift),
+/// the boot loop must NOT treat that as a meaningful diff and must NOT
+/// rewrite the DB blob unnecessarily. The sanitized `manifest_for_diff`
+/// projection covers this — without it, every restart of a hand-with-tails
+/// agent would burn a save_agent write even when the source TOML was
+/// unchanged.
+#[test]
+fn boot_drift_skipped_when_only_rendered_tails_differ() {
+    use librefang_types::agent::{AgentEntry, AgentId, AgentMode, AgentState};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let hand_id = "stillhand";
+    let hand_dir = home_dir.join("registry").join("hands").join(hand_id);
+    std::fs::create_dir_all(&hand_dir).unwrap();
+    std::fs::write(home_dir.join("registry").join(".sync_marker"), "").unwrap();
+
+    let hand_toml = r#"
+id = "stillhand"
+version = "1.0.0"
+name = "Still Hand"
+description = "no-drift test"
+category = "other"
+
+[agents.main]
+name = "operator"
+description = "the only agent"
+module = "builtin:chat"
+
+[agents.main.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "STABLE PROMPT"
+"#;
+    std::fs::write(hand_dir.join("HAND.toml"), hand_toml).unwrap();
+    std::fs::write(hand_dir.join("SKILL.md"), "stable skill notes").unwrap();
+
+    let workspaces_hand_dir = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("main");
+    std::fs::create_dir_all(&workspaces_hand_dir).unwrap();
+    let workspaces_hand_toml = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("hand.toml");
+    std::fs::create_dir_all(workspaces_hand_toml.parent().unwrap()).unwrap();
+    // Disk TOML matches registry exactly — no real source-of-truth drift.
+    std::fs::write(&workspaces_hand_toml, hand_toml).unwrap();
+
+    {
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+        let kernel = LibreFangKernel::boot_with_config(config).expect("first boot");
+
+        let agent_id = AgentId::from_hand_agent(hand_id, "main", Some(uuid::Uuid::new_v4()));
+        let agent_name = format!("{hand_id}:operator");
+        let mut manifest = librefang_types::agent::AgentManifest {
+            name: agent_name.clone(),
+            description: "the only agent".to_string(),
+            module: "builtin:chat".to_string(),
+            ..Default::default()
+        };
+        manifest.model.provider = "openrouter".to_string();
+        manifest.model.model = "x".to_string();
+        // Seeded prompt carries the rendered Reference Knowledge tail.
+        // Without manifest_for_diff this would always look "different"
+        // from the bare disk TOML and trigger a clobber every boot.
+        manifest.model.system_prompt =
+            "STABLE PROMPT\n\n---\n\n## Reference Knowledge\n\nstable skill notes".to_string();
+        manifest.tags = vec![format!("hand:{hand_id}"), "hand_role:main".to_string()];
+
+        let entry = AgentEntry {
+            id: agent_id,
+            name: agent_name,
+            manifest,
+            state: AgentState::Running,
+            mode: AgentMode::default(),
+            created_at: chrono::Utc::now(),
+            last_active: chrono::Utc::now(),
+            parent: None,
+            children: vec![],
+            session_id: SessionId::new(),
+            source_toml_path: Some(workspaces_hand_toml.clone()),
+            tags: vec![format!("hand:{hand_id}"), "hand_role:main".to_string()],
+            identity: Default::default(),
+            onboarding_completed: false,
+            onboarding_completed_at: None,
+            is_hand: false,
+            ..Default::default()
+        };
+        kernel.memory.save_agent(&entry).expect("seed save_agent");
+        kernel.shutdown();
+    }
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("second boot");
+
+    let agent_name = format!("{hand_id}:operator");
+    let restored = kernel
+        .registry
+        .find_by_name(&agent_name)
+        .expect("hand agent must be restored from DB");
+    let prompt = restored.manifest.model.system_prompt;
+    // Tail must still be intact — drift did not fire, so the seeded
+    // tail-carrying prompt is what we get back.
+    assert!(
+        prompt.starts_with("STABLE PROMPT"),
+        "base body must be unchanged; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("## Reference Knowledge"),
+        "tail must survive a no-op restart; got: {prompt}"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2741,3 +2741,141 @@ system_prompt = "STABLE PROMPT"
 
     kernel.shutdown();
 }
+
+/// Negative-path coverage for the `hand_role:` tag lookup at
+/// `kernel/mod.rs:~3057`. When a hand-derived agent carries the `hand:<id>`
+/// tag but is missing the `hand_role:<role>` companion (e.g. activated by an
+/// older codepath that didn't stamp it, or a hand-stitched record imported
+/// from elsewhere), the drift branch must:
+///
+///   1. Not panic — the role lookup is a guard, not an assertion.
+///   2. Apply the disk TOML body change so config edits still propagate.
+///   3. Skip the skill / team re-render — without the role we can't pick the
+///      right per-role override, so we'd rather drop the rendered tails than
+///      stamp the wrong content.
+///
+/// The next `hand activate` re-stamps both tags and restores the tails; this
+/// test only proves the boot path degrades gracefully in the meantime.
+#[test]
+fn boot_drift_skips_tail_render_when_hand_role_tag_missing() {
+    use librefang_types::agent::{AgentEntry, AgentId, AgentMode, AgentState};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let hand_id = "rolelesshand";
+    let hand_dir = home_dir.join("registry").join("hands").join(hand_id);
+    std::fs::create_dir_all(&hand_dir).unwrap();
+    std::fs::write(home_dir.join("registry").join(".sync_marker"), "").unwrap();
+
+    let hand_toml = r#"
+id = "rolelesshand"
+version = "1.0.0"
+name = "Roleless Hand"
+description = "missing-role drift test"
+category = "other"
+
+[agents.main]
+name = "operator"
+description = "the only agent"
+module = "builtin:chat"
+
+[agents.main.model]
+provider = "openrouter"
+model = "x"
+system_prompt = "BASE PROMPT"
+"#;
+    std::fs::write(hand_dir.join("HAND.toml"), hand_toml).unwrap();
+    std::fs::write(hand_dir.join("SKILL.md"), "skill notes").unwrap();
+
+    let workspaces_hand_dir = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("main");
+    std::fs::create_dir_all(&workspaces_hand_dir).unwrap();
+    let workspaces_hand_toml = home_dir
+        .join("workspaces")
+        .join("hands")
+        .join(hand_id)
+        .join("hand.toml");
+    std::fs::create_dir_all(workspaces_hand_toml.parent().unwrap()).unwrap();
+    // Force a body-text drift so the drift branch fires.
+    let drift_toml = hand_toml.replace("BASE PROMPT", "BASE PROMPT v2");
+    std::fs::write(&workspaces_hand_toml, drift_toml).unwrap();
+
+    {
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+        let kernel = LibreFangKernel::boot_with_config(config).expect("first boot");
+
+        let agent_id = AgentId::from_hand_agent(hand_id, "main", Some(uuid::Uuid::new_v4()));
+        let agent_name = format!("{hand_id}:operator");
+        let mut manifest = librefang_types::agent::AgentManifest {
+            name: agent_name.clone(),
+            description: "the only agent".to_string(),
+            module: "builtin:chat".to_string(),
+            ..Default::default()
+        };
+        manifest.model.provider = "openrouter".to_string();
+        manifest.model.model = "x".to_string();
+        manifest.model.system_prompt =
+            "BASE PROMPT\n\n---\n\n## Reference Knowledge\n\nskill notes".to_string();
+        // Crucial: only the `hand:` tag is stamped — `hand_role:` is missing.
+        manifest.tags = vec![format!("hand:{hand_id}")];
+
+        let entry = AgentEntry {
+            id: agent_id,
+            name: agent_name,
+            manifest,
+            state: AgentState::Running,
+            mode: AgentMode::default(),
+            created_at: chrono::Utc::now(),
+            last_active: chrono::Utc::now(),
+            parent: None,
+            children: vec![],
+            session_id: SessionId::new(),
+            source_toml_path: Some(workspaces_hand_toml.clone()),
+            tags: vec![format!("hand:{hand_id}")],
+            identity: Default::default(),
+            onboarding_completed: false,
+            onboarding_completed_at: None,
+            is_hand: false,
+            ..Default::default()
+        };
+        kernel.memory.save_agent(&entry).expect("seed save_agent");
+        kernel.shutdown();
+    }
+
+    // Second boot must not panic even though hand_role tag is absent.
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("second boot");
+
+    let agent_name = format!("{hand_id}:operator");
+    let restored = kernel
+        .registry
+        .find_by_name(&agent_name)
+        .expect("hand agent must be restored from DB");
+    let prompt = restored.manifest.model.system_prompt;
+    // Drift applied the disk TOML body change.
+    assert!(
+        prompt.contains("BASE PROMPT v2"),
+        "drift must have applied disk TOML body even without hand_role; got: {prompt}"
+    );
+    // Reference Knowledge tail is gone — disk_manifest replaced the prompt
+    // and the role-keyed re-render was skipped.
+    assert!(
+        !prompt.contains("## Reference Knowledge"),
+        "skill tail must NOT be re-rendered when hand_role tag is missing; got: {prompt}"
+    );
+
+    kernel.shutdown();
+}


### PR DESCRIPTION
## Summary

Closes #3143. Follow-up to #3142 — extends the same drift-aware re-render
pattern to the two other runtime-rendered prompt tails the boot-time
TOML drift loop was clobbering.

## What was still broken after #3142

#3142 fixed `## User Configuration`. The drift block
(`kernel/mod.rs:~2929`) was still stripping two more rendered tails
appended by `activate_hand_with_id` (~`kernel/mod.rs:9131-9168`) on
every restart:

- `## Reference Knowledge` — skill content from `def.skill_content`
  (shared) or `def.agent_skill_content` (per-role override). Loss
  meant the agent dropped its skill discoverability summary; it
  could still call `skill_read_file({skill, path})` on demand but only
  if it knew what to ask for, so first-turn skill *consideration* was
  silently degraded — most visible on `session_mode=new` triggers and
  cron fires.
- `## Your Team` — peer roster for multi-agent hands. Loss meant the
  agent stopped knowing who its peers were and started calling
  `agent_list` redundantly at the top of every session, plus
  `agent_send` to peers became guesswork.

Both were silent: no error, no warning, just degraded context.

## Approach (option B from #3143)

1. **New idempotent helpers in `manifest_helpers.rs`** modelled on
   `apply_settings_block_to_manifest`:
   - `apply_skill_reference_block_to_manifest(manifest, role, def)`
     — strips any pre-existing `## Reference Knowledge` tail, then
     re-appends from per-role override (`def.agent_skill_content`)
     falling back to shared `def.skill_content`. When neither is set
     the call is strip-only — covers the case where a skill was
     removed from the hand and the stale tail must drop.
   - `apply_team_block_to_manifest(manifest, role, def)` — strips
     any pre-existing `## Your Team` tail, then re-appends the peer
     roster excluding self. No-op for single-agent hands; gracefully
     drops the tail if a hand was edited from multi-agent down to
     single-agent.
   - Both use marker-anchored truncation
     (`SKILL_REFERENCE_TAIL_MARKER`, `TEAM_TAIL_MARKER`) for
     idempotency, same pattern as `USER_CONFIG_TAIL_MARKER`.

2. **`manifest_for_diff()` projection** strips all three known
   runtime-rendered tails before the JSON compare in the boot drift
   loop. Without it the disk TOML always looks "different" from the DB
   blob on hand-with-tails agents and drift fires every restart,
   burning a `save_agent` write and clobbering the rendered tails.
   With it, drift only fires when the *raw* TOML genuinely diverged
   from the *raw* DB form.

3. **Activation site refactored** to call both new helpers instead of
   inlining the rendering. The drift block calls them after the
   existing settings re-render. Both code paths now route through one
   source of truth — same pattern #3142 established for settings.

## Why approach B and not A

#3143 outlined two paths. A (per-tail helper, no projection) only
prevents tail loss on a *legitimate* drift fire; B adds the projection
on top, so a hand with rendered tails no longer triggers a spurious
drift fire on every boot. The class of bug recurs every time someone
adds a new rendered tail; the marker registry approach scales —
register the marker, the projection picks it up automatically.

## Tests

14 new unit tests + 2 boot drift integration tests, all green:

- `apply_skill_reference_*` — appends when present / no-op when empty /
  idempotent / replaces stale tail / drops tail when skill removed.
- `apply_team_block_*` — no-op for single-agent / appends peers
  excluding self / uses `invoke_hint` over description / idempotent.
- `manifest_for_diff_*` — strips all known tails / strips any subset /
  no-op on prompts without tails.
- `boot_drift_preserves_skill_and_team_tails` — multi-agent hand with
  SKILL.md, force drift via body-text edit, assert both tails are
  re-rendered after reboot.
- `boot_drift_skipped_when_only_rendered_tails_differ` — proves the
  sanitized projection prevents spurious drift fires when nothing
  changed except the rendered tails (which are runtime-only and
  expected to differ between disk TOML and DB blob).

```
cargo test -p librefang-kernel --lib
# 26 new tests pass; the 9 pre-existing failures
# (config::tests::test_load_config_defaults + 8 cron_delivery::*)
# are unchanged from main and unrelated to this PR.
```

`cargo build --workspace --lib`, `cargo test --workspace`, and
`cargo clippy --workspace --all-targets -- -D warnings` all clean.

## Risk / blast radius

Low. Helpers are idempotent; the activation path's behaviour is
byte-identical to the old inline rendering on a fresh hand, and
distinguishable only on a re-render where the new path correctly
*replaces* a stale tail rather than letting it accumulate. Standalone
agents (no `hand:<id>` tag, no role tag) skip the new code path
entirely.
