### PR TITLE
fix(nix): provide .desktop entry and icon for librefang-desktop (#3156)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,31 +119,47 @@
 
         desktopCargoArtifacts = craneLib.buildDepsOnly desktopArgs;
 
+        # Desktop entry assembled with the standard nixpkgs helper so the
+        # output matches XDG conventions (proper escaping, hicolor icon
+        # theme layout, no manual heredoc).
+        librefangDesktopItem = pkgs.makeDesktopItem {
+          name = "librefang-desktop";
+          desktopName = "LibreFang";
+          comment = "Open-source Agent Operating System";
+          exec = "librefang-desktop";
+          icon = "librefang-desktop";
+          terminal = false;
+          type = "Application";
+          categories = [ "Development" "Utility" ];
+          keywords = [ "AI" "Agent" "LLM" "Automation" ];
+          # Match the GTK app id Tauri reports so launchers can pair the
+          # window with its menu entry / icon.
+          startupWMClass = "librefang-desktop";
+        };
+
         librefang-desktop = craneLib.buildPackage (desktopArgs // {
           cargoArtifacts = desktopCargoArtifacts;
           doCheck = false;
+          # `copyDesktopItems` is a no-op on darwin; gating the hook on
+          # Linux keeps the macOS build path unchanged.
+          nativeBuildInputs = nativeBuildInputs
+            ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.copyDesktopItems ];
+          desktopItems = pkgs.lib.optionals pkgs.stdenv.isLinux [ librefangDesktopItem ];
           postFixup = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
             patchelf --add-rpath "${pkgs.libayatana-appindicator}/lib" "$out/bin/librefang-desktop"
           '';
           postInstall = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-            mkdir -p "$out/share/applications"
-            mkdir -p "$out/share/icons/hicolor/128x128/apps"
-
-            cat > "$out/share/applications/librefang-desktop.desktop" << 'EOF'
-[Desktop Entry]
-Name=LibreFang
-Comment=Open-source Agent Operating System
-Exec=librefang-desktop
-Icon=librefang-desktop
-Terminal=false
-Type=Application
-Categories=Productivity;AI;
-Keywords=AI;Agent;LLM;Automation;
-StartupWMClass=librefang-desktop
-EOF
-
-            cp ${./crates/librefang-desktop/icons/icon.png} "$out/share/icons/hicolor/128x128/apps/librefang-desktop.png"
-            update-desktop-database "$out/share/applications" 2>/dev/null || true
+            # Install icons into the hicolor theme at every native size we
+            # ship in the repo so DEs can pick the right one without
+            # rescaling. Icon name must match the desktop entry's Icon= key.
+            install -Dm644 ${./crates/librefang-desktop/icons/32x32.png} \
+              "$out/share/icons/hicolor/32x32/apps/librefang-desktop.png"
+            install -Dm644 ${./crates/librefang-desktop/icons/128x128.png} \
+              "$out/share/icons/hicolor/128x128/apps/librefang-desktop.png"
+            install -Dm644 ${./crates/librefang-desktop/icons/128x128@2x.png} \
+              "$out/share/icons/hicolor/256x256/apps/librefang-desktop.png"
+            install -Dm644 ${./crates/librefang-desktop/icons/icon.png} \
+              "$out/share/icons/hicolor/512x512/apps/librefang-desktop.png"
           '';
           meta = with pkgs.lib; {
             description = "LibreFang — Open-source Agent Operating System (desktop UI)";

--- a/flake.nix
+++ b/flake.nix
@@ -148,19 +148,28 @@
           postFixup = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
             patchelf --add-rpath "${pkgs.libayatana-appindicator}/lib" "$out/bin/librefang-desktop"
           '';
-          postInstall = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-            # Install icons into the hicolor theme at every native size we
-            # ship in the repo so DEs can pick the right one without
-            # rescaling. Icon name must match the desktop entry's Icon= key.
-            install -Dm644 ${./crates/librefang-desktop/icons/32x32.png} \
-              "$out/share/icons/hicolor/32x32/apps/librefang-desktop.png"
-            install -Dm644 ${./crates/librefang-desktop/icons/128x128.png} \
-              "$out/share/icons/hicolor/128x128/apps/librefang-desktop.png"
-            install -Dm644 ${./crates/librefang-desktop/icons/128x128@2x.png} \
-              "$out/share/icons/hicolor/256x256/apps/librefang-desktop.png"
-            install -Dm644 ${./crates/librefang-desktop/icons/icon.png} \
-              "$out/share/icons/hicolor/512x512/apps/librefang-desktop.png"
-          '';
+          postInstall =
+            let
+              # `128x128@2x.png` contains an `@`, which is not a legal
+              # character inside `${…}` Nix path-expression interpolation,
+              # so we bind the icons directory once and concatenate the
+              # filenames at the shell layer.
+              iconsDir = ./crates/librefang-desktop/icons;
+            in
+            pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              # Install icons into the hicolor theme at every native size
+              # we ship in the repo so DEs can pick the right one without
+              # rescaling. Icon name must match the desktop entry's Icon=
+              # key.
+              install -Dm644 "${iconsDir}/32x32.png" \
+                "$out/share/icons/hicolor/32x32/apps/librefang-desktop.png"
+              install -Dm644 "${iconsDir}/128x128.png" \
+                "$out/share/icons/hicolor/128x128/apps/librefang-desktop.png"
+              install -Dm644 "${iconsDir}/128x128@2x.png" \
+                "$out/share/icons/hicolor/256x256/apps/librefang-desktop.png"
+              install -Dm644 "${iconsDir}/icon.png" \
+                "$out/share/icons/hicolor/512x512/apps/librefang-desktop.png"
+            '';
           meta = with pkgs.lib; {
             description = "LibreFang — Open-source Agent Operating System (desktop UI)";
             homepage = "https://github.com/librefang/librefang";


### PR DESCRIPTION
## Summary

Refactors the `librefang-desktop` Nix derivation to follow the standard nixpkgs pattern for shipping a Linux desktop application, addressing the underlying cause of #3156.

The previous fix (#3157) wrote the `.desktop` file via an inline heredoc and only installed a single 128x128 icon. This PR moves to the `makeDesktopItem` + `copyDesktopItems` helpers and installs every icon size already shipped in `crates/librefang-desktop/icons/`, so launchers under GNOME / KDE / sway / etc. can pick the closest match without rescaling.

## Changes

`flake.nix` (only the `librefang-desktop` package — CLI, devShell, checks untouched, no new flake inputs, `flake.lock` not modified):

- Define `librefangDesktopItem` via `pkgs.makeDesktopItem` (proper XDG escaping, no manual heredoc).
- Add `copyDesktopItems` to `nativeBuildInputs` (Linux only — no-op on darwin).
- Install icons at 32x32, 128x128, 256x256 (from `128x128@2x.png`) and 512x512 (from `icon.png`) under `$out/share/icons/hicolor/<size>/apps/librefang-desktop.png`.
- Drop the manual `update-desktop-database` call — that cache is maintained by the user environment, not the package output.
- Replace the non-standard `AI` value in `Categories` (which `desktop-file-validate` flags) with the standard `Development;Utility;` pair. Keywords still expose `AI;Agent;LLM;Automation;` for search.
- Keep `Icon=librefang-desktop` and `StartupWMClass=librefang-desktop` so launchers correlate the menu entry with the running Tauri window.

## Verification (ssh to a NixOS machine required)

The CI sandbox in this environment cannot run `nix build`, so the changes were not built locally. A reviewer with access to a Linux NixOS machine should run:

```bash
nix build .#librefang-desktop

# 1. Desktop entry exists and validates cleanly
ls -la result/share/applications/
test -f result/share/applications/librefang-desktop.desktop
desktop-file-validate result/share/applications/librefang-desktop.desktop  # expect 0 errors

# 2. Icon tree populated at every advertised size
ls -la result/share/icons/hicolor/
test -f result/share/icons/hicolor/32x32/apps/librefang-desktop.png
test -f result/share/icons/hicolor/128x128/apps/librefang-desktop.png
test -f result/share/icons/hicolor/256x256/apps/librefang-desktop.png
test -f result/share/icons/hicolor/512x512/apps/librefang-desktop.png

# 3. End-to-end smoke test: install into the user profile, restart the
#    desktop session (or run `update-desktop-database ~/.local/share/applications`
#    + `gtk-update-icon-cache`), then verify "LibreFang" shows up in the
#    GNOME / KDE / wofi / rofi application menu with the correct icon.
nix profile install .#librefang-desktop
```

Expected: launching from the menu starts `librefang-desktop`, the window's launcher icon (via `StartupWMClass`) matches the menu icon, and #3156 is closed.

## Notes

- No new flake inputs; `makeDesktopItem` and `copyDesktopItems` ship in nixpkgs.
- `flake.lock` is intentionally unchanged.
- macOS build path is unchanged: `copyDesktopItems` and the `postInstall` icon installs are gated on `pkgs.stdenv.isLinux`.
