### PR TITLE
feat(dashboard): right-side drawer pattern for inspect-detail surfaces

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -17,6 +17,11 @@ interface ModalProps {
   zIndex?: number;
   /** Allow content to overflow the modal container (e.g. for cmdk dropdowns). Defaults to false. */
   overflowVisible?: boolean;
+  /** Container shape. `modal` (default) is centered with max-h-[90vh].
+   *  `drawer-right` docks to the right edge at full viewport height — used
+   *  for inspector workflows where the underlying list should stay visible
+   *  for quick context-switching (Linear / Figma right panel pattern). */
+  variant?: "modal" | "drawer-right";
   children: ReactNode;
 }
 
@@ -52,6 +57,7 @@ export const Modal = memo(function Modal({
   disableBackdropClose,
   zIndex = 50,
   overflowVisible = false,
+  variant = "modal",
   children,
 }: ModalProps) {
   const { t } = useTranslation();
@@ -88,18 +94,38 @@ export const Modal = memo(function Modal({
     onClose();
   };
 
+  const isDrawer = variant === "drawer-right";
+  // Drawer vs Modal differ in three ways:
+  //   1. Position: drawer hugs the right edge full-height; modal centres.
+  //   2. Dim: modal dims the page (focus on dialog); drawer leaves the
+  //      page un-dimmed because the surrounding context — typically a
+  //      list — should stay legible while the drawer inspects one item.
+  //   3. Click-through: clicks outside the drawer panel pass through to
+  //      the underlying page so users can pick another row in the list
+  //      and the drawer updates in place (Linear / Figma inspector).
+  //      The Modal still closes on backdrop click — that's its contract.
+  const containerClass = isDrawer
+    ? "fixed inset-0 flex items-stretch justify-end pointer-events-none"
+    : "fixed inset-0 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm p-0 sm:p-4";
+  const dialogClass = isDrawer
+    ? `pointer-events-auto relative w-full ${SIZE_CLASSES[size]} h-full sm:rounded-l-2xl sm:border-l border-border-subtle bg-surface shadow-2xl animate-slide-in-right ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`
+    : `relative w-full ${SIZE_CLASSES[size]} rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl animate-fade-in-scale max-h-[90vh] ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`;
+
   return (
     <div
-      className="fixed inset-0 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm p-0 sm:p-4"
+      className={containerClass}
       style={{ zIndex }}
-      onClick={disableBackdropClose ? undefined : handleBackdropClick}
+      // Backdrop dismissal is a modal contract; the drawer relies on Esc
+      // and its explicit close button instead, since "click outside to
+      // close" would race with the list-click-to-switch interaction.
+      onClick={isDrawer || disableBackdropClose ? undefined : handleBackdropClick}
     >
       <div
         ref={dialogRef}
         role="dialog"
-        aria-modal="true"
+        aria-modal={isDrawer ? "false" : "true"}
         aria-labelledby={titleId}
-        className={`relative w-full ${SIZE_CLASSES[size]} rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl animate-fade-in-scale max-h-[90vh] ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`}
+        className={dialogClass}
         onClick={(e) => e.stopPropagation()}
       >
         {(title || !hideCloseButton) && (

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -64,7 +64,12 @@ export const Modal = memo(function Modal({
   const dialogRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   const titleId = useId();
-  useFocusTrap(isOpen, dialogRef, true);
+  const isDrawer = variant === "drawer-right";
+  // Modal traps Tab inside the dialog (no escape from the focus loop).
+  // Drawer leaves Tab free so keyboard users can hop back into the
+  // underlying list (which is still interactive — see container's
+  // pointer-events-none) without first hitting Esc.
+  useFocusTrap(isOpen, dialogRef, true, !isDrawer);
 
   useEffect(() => {
     onCloseRef.current = onClose;
@@ -94,7 +99,6 @@ export const Modal = memo(function Modal({
     onClose();
   };
 
-  const isDrawer = variant === "drawer-right";
   // Drawer vs Modal differ in three ways:
   //   1. Position: drawer hugs the right edge full-height; modal centres.
   //   2. Dim: modal dims the page (focus on dialog); drawer leaves the

--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -155,6 +155,21 @@ body {
   animation: fade-in-scale 0.5s var(--apple-bounce);
 }
 
+@keyframes slide-in-right {
+  from {
+    transform: translate3d(100%, 0, 0);
+    opacity: 0.6;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right 0.28s var(--apple-ease);
+}
+
 .animate-shimmer {
   animation: shimmer 1.5s ease-in-out infinite;
 }

--- a/crates/librefang-api/dashboard/src/lib/useFocusTrap.ts
+++ b/crates/librefang-api/dashboard/src/lib/useFocusTrap.ts
@@ -17,6 +17,10 @@ const FOCUSABLE_SELECTOR = [
 /// Use `setAriaModal` for actual dialog/modal surfaces so the hook can stay
 /// generic for other focus-contained UIs.
 ///
+/// Pass `trap = false` for non-modal surfaces (e.g. inspector drawers)
+/// where Tab should be free to leave the container — the hook still does
+/// initial focus and focus restoration, it just skips the Tab interception.
+///
 /// Usage:
 ///   const ref = useRef<HTMLDivElement>(null);
 ///   useFocusTrap(isOpen, ref, true);
@@ -29,6 +33,7 @@ export function useFocusTrap(
   isOpen: boolean,
   containerRef: React.RefObject<HTMLElement | null>,
   setAriaModal = false,
+  trap = true,
 ) {
   const previouslyFocused = useRef<HTMLElement | null>(null);
   const appliedAriaModalRef = useRef(false);
@@ -89,9 +94,13 @@ export function useFocusTrap(
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
+    if (trap) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      if (trap) {
+        window.removeEventListener("keydown", handleKeyDown);
+      }
       if (container && setAriaModal) {
         if (appliedAriaModalRef.current) {
           container.removeAttribute("aria-modal");
@@ -111,5 +120,5 @@ export function useFocusTrap(
       }
       previouslyFocused.current = null;
     };
-  }, [isOpen, containerRef, setAriaModal]);
+  }, [isOpen, containerRef, setAriaModal, trap]);
 }

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -102,12 +102,20 @@ function SystemPromptSection({ prompt }: { prompt: string }) {
           </button>
         )}
       </div>
-      <div
-        className={`rounded-lg bg-main border border-border-subtle p-4 text-sm text-text leading-relaxed whitespace-pre-wrap ${
-          isLong && !expanded ? "max-h-72 overflow-y-auto" : ""
-        }`}
-      >
-        {prompt}
+      <div className="relative">
+        <div
+          className={`rounded-lg bg-main border border-border-subtle p-4 text-sm text-text leading-relaxed whitespace-pre-wrap ${
+            isLong && !expanded ? "max-h-40 overflow-hidden" : ""
+          }`}
+        >
+          {prompt}
+        </div>
+        {isLong && !expanded && (
+          // Fade-out at the bottom so the cut feels intentional rather than
+          // a clip, without introducing an inner scroll. The modal's outer
+          // scroll is the single source of truth — no nested scrolling.
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 rounded-b-lg bg-linear-to-t from-main to-transparent" />
+        )}
       </div>
     </section>
   );

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -743,9 +743,12 @@ export function AgentsPage() {
           {coreAgents.map(agent => renderAgentCard(agent))}
         </div>
       )}
-      {/* Agent Detail / Edit Modal. Sticky header for identity + status,
-          scrolling body for inspectable sections, sticky footer for
-          actions so primary controls stay reachable on long agent specs. */}
+      {/* Agent Detail Drawer. Right-side inspector pattern (Linear / Figma):
+          the agents list stays interactive while the drawer is open, so
+          clicking another agent in the list updates the drawer's content
+          in place — no close-then-reopen needed. Sticky header / footer
+          keep identity and primary actions pinned while the inspectable
+          sections scroll in the middle. */}
       {detailAgent && (() => {
         const detailState = ((detailAgent as any).state || "").toLowerCase();
         const isDetailSuspended = detailState === "suspended";
@@ -773,7 +776,8 @@ export function AgentsPage() {
         <Modal
           isOpen
           onClose={closeDetailModal}
-          size="4xl"
+          variant="drawer-right"
+          size="xl"
           hideCloseButton
           disableBackdropClose={lockBackdropDismiss}
         >

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -586,7 +586,7 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
   const models = modelsQuery.data?.models ?? [];
 
   return (
-    <Modal isOpen onClose={onClose} title={provider.display_name || provider.id} size="lg">
+    <Modal isOpen onClose={onClose} title={provider.display_name || provider.id} size="lg" variant="drawer-right">
       <div className="p-6 space-y-4">
         {/* Header info */}
         <div className="flex items-center gap-3">

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1173,6 +1173,7 @@ function SkillDetailModal({
       onClose={onClose}
       title={detail?.name ?? skillName ?? ""}
       size="xl"
+      variant="drawer-right"
     >
       {isLoading ? (
         <div className="flex items-center justify-center py-12">


### PR DESCRIPTION
## Summary

Follow-up to #3159. Reshape the inspect-detail UX across the dashboard from centred modal to right-docked drawer for the three list-and-inspect flows where the surrounding list context matters.

## Changes

### `Modal` gets a `variant` prop

- `modal` (default, **unchanged**) — centred, dim backdrop, click-to-dismiss. All existing call sites keep this contract.
- `drawer-right` — docks to right edge full-height, no dim backdrop, container is `pointer-events-none` so clicks pass through to the underlying page. `aria-modal=false` because the page IS still interactive. Dismissal: Esc + explicit close button.
- New `slide-in-right` keyframe + `.animate-slide-in-right` utility paired with `--apple-ease`.
- `useFocusTrap` gains a fourth `trap` parameter (default `true`, all current call sites unchanged); Modal passes `false` in drawer mode so Tab can leave the panel and reach the underlying list. Initial focus and focus-restoration on close still happen.

### Three pages opt into `variant="drawer-right"`

- **AgentsPage** detail (size `xl`, 576 px) — also drops the nested scroll inside the system-prompt section (`overflow-y-auto` → `overflow-hidden` + bottom fade).
- **ProvidersPage** `ProviderDetailModal` (size `lg`, 512 px) — provider inspector with auth status, model count, latency, model list.
- **SkillsPage** `SkillDetailModal` (size `xl`, 576 px) — installed-skill inspector with evolve panes.

Click another row in the list while the drawer is open → drawer content updates in place; no close-then-reopen.

### Deliberately not converted

- `MarketplaceDetailModal` (Skills) — install flow is transactional, not browse-comparing.
- All Create / Edit / Add form modals across the dashboard — drawer's click-through would silently drop in-flight form state.
- `HandsPage.HandDetailPanel` — uses its own bespoke JSX rather than the shared `<Modal>`; converting it to drawer needs a full panel rewrite, out of scope here.

## Test plan

- [ ] Manual on AgentsPage / ProvidersPage / SkillsPage: click an item → drawer slides in from right; click a different item in the list → drawer content swaps without close/reopen
- [ ] Manual: Esc closes; X button closes; rest of page (header, sidebar, filter bar) stays interactive while drawer is open
- [ ] Manual `<sm:` viewport: drawer becomes full-screen sheet (no awkward sliver)
- [ ] Manual keyboard: Tab can leave drawer and land in the underlying list (focus trap disabled in drawer); Esc still closes
- [ ] Manual: every existing modal usage (ConfirmDialog / Tools editor / Create Agent / SchedulerPage forms / etc.) still centres and still closes on backdrop click — no regression to the modal contract
- [ ] CI green
