### PR TITLE
fix(api): regenerate config_schema golden after parallel_tools addition

### DIFF
--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -9540,6 +9540,37 @@
       },
       "type": "object"
     },
+    "ParallelToolsConfig": {
+      "description": "Configuration for the agent loop's parallel tool dispatcher.\n\nPR-3 ships the schema only; the agent loop still runs tool calls strictly sequentially. PR-4 wires the dispatcher into the runtime and PR-5 flips `enabled` on by default.\n\n```toml [parallel_tools] enabled = false max_concurrent = 4 mcp_default_safety = \"write_shared\"   # or \"read_only\" mcp_readonly_allowlist = [\"mcp__github__list_issues\"] ```\n\nFalls back to fully sequential execution when `enabled = false`.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Master switch. Default `false` so PR-3 ships with no behaviour change. PR-5 will flip the default to `true` after the streaming dispatcher integration lands.",
+          "type": "boolean"
+        },
+        "max_concurrent": {
+          "default": 4,
+          "description": "Cap on concurrent tool calls within a single bucket. `0` = uncapped (use the bucket size). The dispatcher honours this when launching futures via `join_all`.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "mcp_default_safety": {
+          "default": "write_shared",
+          "description": "Default `ParallelSafety` class assigned to MCP tools whose servers don't carry `readOnlyHint` annotations. Conservative default `\"write_shared\"` keeps unannotated MCP tools serialised (one per bucket) instead of optimistically parallelising. Accepted values: `\"read_only\"` | `\"write_shared\"`. PR-4 will promote this to a typed enum once the dispatcher consumes it.",
+          "type": "string"
+        },
+        "mcp_readonly_allowlist": {
+          "default": [],
+          "description": "Explicit allowlist of MCP tool names that should be treated as `ReadOnly` regardless of `mcp_default_safety`. Names match the fully-namespaced form (`mcp__server__name`).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "PerplexitySearchConfig": {
       "description": "Perplexity Search API configuration.",
       "properties": {
@@ -13894,6 +13925,20 @@
         "token_expiry_secs": 300
       },
       "description": "Device pairing configuration."
+    },
+    "parallel_tools": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ParallelToolsConfig"
+        }
+      ],
+      "default": {
+        "enabled": false,
+        "max_concurrent": 4,
+        "mcp_default_safety": "write_shared",
+        "mcp_readonly_allowlist": []
+      },
+      "description": "Parallel-tool dispatcher configuration. PR-3 schema only — runtime integration lands in PR-4. See [`ParallelToolsConfig`]."
     },
     "plugins": {
       "allOf": [


### PR DESCRIPTION
## Summary

Regenerates `crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json` to match the schemars-derived `KernelConfig` schema in current `main`. Fixes the `kernel_config_schema_matches_golden_fixture` test failure that has been flaring on:

- every full-run main-lane CI build since #3144 merged (`5436e91c` failure recorded on the main run list);
- any subsequent PR whose selective lane happens to test `librefang-api` — e.g. #3162's dashboard-only edits, where the failure surfaced as Test/Ubuntu + Test/macOS red while the diff didn't touch any Rust at all.

## Root cause

PR #3144 (`feat(types): KernelConfig.parallel_tools section`) added a new top-level config section (`ParallelToolsConfig` definition + `parallel_tools` field) but didn't refresh the golden fixture. The PR-lane CI on #3144 was selective and only ran `librefang-types` jobs, so the drift went undetected at merge time. Since then every push to main has been failing this guard.

## Diff

The 45-line addition is exactly:

- `definitions.ParallelToolsConfig` — the new schema entry (5 properties: `enabled`, `max_concurrent`, `mcp_default_safety`, `mcp_readonly_allowlist`, plus the docstring block).
- `properties.parallel_tools` — the `$ref` + default-value reference at the `KernelConfig` level.

Generated with the documented procedure:

```
cargo test -p librefang-api --test config_schema_golden \
    -- --ignored regenerate_golden --nocapture
```

Verified against `main` HEAD `53dde25a`.

## Test plan

- [x] CI: `Test / Ubuntu`, `Test / macOS`, `Test / Windows` — `kernel_config_schema_matches_golden_fixture` should pass.
- [x] No code changes; fixture-only update.

Once this lands, #3162 just needs a rebase on `main`.
