### PR TITLE
fix(dashboard): stop drawer scroll chaining into the page

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -148,7 +148,13 @@ export const Modal = memo(function Modal({
             )}
           </div>
         )}
-        <div className="flex-1 overflow-y-auto scrollbar-thin">{children}</div>
+        {/* `overscroll-contain` stops wheel events from chaining into the
+            page once the dialog hits its top/bottom — the bug surfaces
+            in the drawer variant (page is interactive behind the panel)
+            but the centred modal benefits too: a long modal pinned over
+            a long page used to scroll the page after the modal bottomed
+            out, which feels like the modal "leaks" the gesture. */}
+        <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Bug from #3166: scrolling inside an agent / provider / skill drawer past its top or bottom edge propagated the wheel gesture to the underlying page. The drawer variant intentionally leaves the page interactive (no dim backdrop, `pointer-events-none` on the container), so scroll chaining was visible — the page slid under the drawer mid-scroll, jarring.

## Fix

One Tailwind class on `Modal`'s scroll wrapper:

```diff
- <div className="flex-1 overflow-y-auto scrollbar-thin">{children}</div>
+ <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">{children}</div>
```

`overscroll-behavior: contain` tells the browser to stop the wheel event at this element's boundary instead of propagating to ancestors. Standard CSS, well-supported.

The change applies to centred modals too, which silently fixes a pre-existing papercut: a long modal over a long page used to scroll the page once the modal bottomed out, even though the dim backdrop suggested the page was locked.

## Test plan

- [ ] Manual: open agent drawer with long detail content, scroll inside drawer past bottom → underlying agents list should NOT scroll (it did before this PR)
- [ ] Manual: same for provider / skill / hand drawers (#3168 still in flight covers HandsPage)
- [ ] Manual centred-modal regression: open Tools editor or Create Agent modal over a scrolled-down list, scroll past modal bottom → list should NOT scroll
- [ ] CI green
