### PR TITLE
ci: pull librefang-api into selective lane on librefang-types changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,20 @@ jobs:
           DIRECT=$(printf '%s\n' "$CHANGED" \
             | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
             | sort -u | tr '\n' ' ')
+
+          # Schema-mirror rule. `librefang-types` is the source of the
+          # schemars-derived `KernelConfig` schema, but the golden-file guard
+          # (`kernel_config_schema_matches_golden_fixture`) lives in
+          # `librefang-api`. A types-only PR would otherwise ship without
+          # touching the api crate's tests — the drift then surfaces only on
+          # the main full-run, polluting every subsequent PR's selective
+          # lane. See incident: #3144 → #3162 → #3167.
+          if printf '%s\n' $DIRECT | grep -qx 'librefang-types' \
+              && ! printf '%s\n' $DIRECT | grep -qx 'librefang-api'; then
+            DIRECT="$DIRECT librefang-api"
+            echo "Schema-mirror: librefang-types changed, pulling librefang-api into affected set"
+          fi
+
           echo "crates=$DIRECT" >> "$GITHUB_OUTPUT"
           echo "Affected crates: ${DIRECT:-<none>}"
 


### PR DESCRIPTION
## Summary

Adds one shell stanza to the existing `Detect Changes` job in `.github/workflows/ci.yml`: when a PR's diff touches `crates/librefang-types/` but not `crates/librefang-api/`, force `librefang-api` into the selective lane's affected-crates set. Closes the loophole that produced the #3144 → #3162 → #3167 incident chain.

## Why

The schemars-derived `KernelConfig` schema is generated **from `librefang-types`**, but the golden-file regression guard (`kernel_config_schema_matches_golden_fixture`) lives **in `librefang-api`**.

The selective PR-lane fans out by directly-touched crates only (no downstream walk — by design, see line 26 comment in `ci.yml`). A schema-adding PR that only edits `librefang-types/` therefore skips `librefang-api`'s tests entirely. The drift goes undetected until the push-to-main full-run lane runs — by which point main is already broken, and every subsequent PR whose lane happens to include `librefang-api` (e.g. `#3162`'s dashboard edits) inherits the failure.

Incident timeline:

1. `#3144` (`KernelConfig.parallel_tools` schema) merged with a stale golden fixture. PR-lane ran `librefang-types` only and stayed green.
2. The main-lane CI run on `5436e91c` (the merge commit) failed `kernel_config_schema_matches_golden_fixture` and stayed broken.
3. `#3162` (dashboard-only edits) two days later — its selective lane pulled in `librefang-api`, and the pre-existing drift surfaced as a Test/Ubuntu + Test/macOS red even though the PR's diff didn't touch any Rust.
4. `#3167` regenerated the fixture as a one-shot fix.

This PR makes step 1 fail at PR review time instead of poisoning main.

## Implementation

```yaml
if printf '%s\n' $DIRECT | grep -qx 'librefang-types' \
    && ! printf '%s\n' $DIRECT | grep -qx 'librefang-api'; then
  DIRECT="$DIRECT librefang-api"
  echo "Schema-mirror: librefang-types changed, pulling librefang-api into affected set"
fi
```

- `-qx` matches the **whole** word, so a hypothetical `librefang-types-foo` crate wouldn't false-trigger.
- The `! ... librefang-api` guard avoids the no-op append when both crates are already in the set.
- Logs the augmentation to the job summary so the reason is auditable.

Verified with bash (the GitHub runner shell):

| input | output | result |
|---|---|---|
| `librefang-types` | `librefang-types librefang-api` | pulled in |
| `librefang-types librefang-api` | unchanged | already covered |
| `librefang-runtime` | unchanged | not touched |
| `librefang-types librefang-runtime` | `librefang-types librefang-runtime librefang-api` | pulled in |
| `` (empty) | unchanged | no-op |

## Test plan

- [x] Local bash sanity-check of the shell rule (table above).
- [x] This PR itself touches `.github/workflows/`, so `Detect Changes` will route it through the **full-run** lane (`CI=true`), and the `Affected crates` log line will appear in the job output. The schema-mirror branch isn't exercised by this PR's own diff but the existing `Detect Changes` script still has to parse without error.
- [ ] Future verification: next `librefang-types`-only PR's `Detect Changes` log should include the `Schema-mirror: …` line, and the resulting `librefang-api` test job should run.

## Scope

Intentionally narrow. Two extensions discussed and **not** done here:
- Generalising the rule into a dependency-graph walker — overkill for one schema mirror, and an explicit list of crate-pair invariants is more auditable.
- Moving the golden test into a new `librefang-config-schema` crate — bigger refactor, no clear win over this rule.
