### PR TITLE
feat(dashboard): roll out drawer/panel pattern across all page modals

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -17,11 +17,21 @@ interface ModalProps {
   zIndex?: number;
   /** Allow content to overflow the modal container (e.g. for cmdk dropdowns). Defaults to false. */
   overflowVisible?: boolean;
-  /** Container shape. `modal` (default) is centered with max-h-[90vh].
-   *  `drawer-right` docks to the right edge at full viewport height — used
-   *  for inspector workflows where the underlying list should stay visible
-   *  for quick context-switching (Linear / Figma right panel pattern). */
-  variant?: "modal" | "drawer-right";
+  /** Container shape + dismissal behaviour.
+   *
+   *  - `modal` (default): centred, max-h-[90vh], dim backdrop, click-outside
+   *    closes. The classic blocking dialog.
+   *  - `drawer-right`: right-docked, full height, **no** dim backdrop, clicks
+   *    pass through to the underlying page so users can pick another row in
+   *    the list while the drawer is open (Linear / Figma inspector). Esc and
+   *    the explicit close button are the only dismissal paths — click-outside
+   *    would race with the list-click-to-switch interaction.
+   *  - `panel-right`: right-docked, full height, dim backdrop, click-outside
+   *    closes. Same shape as `drawer-right` but blocks the underlying page —
+   *    use for forms / configuration / sub-modals where the user MUST commit
+   *    or cancel before the rest of the page is interactive again. Visually
+   *    consistent with drawer pages, behaviourally consistent with modals. */
+  variant?: "modal" | "drawer-right" | "panel-right";
   children: ReactNode;
 }
 
@@ -65,6 +75,8 @@ export const Modal = memo(function Modal({
   const onCloseRef = useRef(onClose);
   const titleId = useId();
   const isDrawer = variant === "drawer-right";
+  const isPanel = variant === "panel-right";
+  const isRightDocked = isDrawer || isPanel;
   // Modal traps Tab inside the dialog (no escape from the focus loop).
   // Drawer leaves Tab free so keyboard users can hop back into the
   // underlying list (which is still interactive — see container's
@@ -99,20 +111,20 @@ export const Modal = memo(function Modal({
     onClose();
   };
 
-  // Drawer vs Modal differ in three ways:
-  //   1. Position: drawer hugs the right edge full-height; modal centres.
-  //   2. Dim: modal dims the page (focus on dialog); drawer leaves the
-  //      page un-dimmed because the surrounding context — typically a
-  //      list — should stay legible while the drawer inspects one item.
-  //   3. Click-through: clicks outside the drawer panel pass through to
-  //      the underlying page so users can pick another row in the list
-  //      and the drawer updates in place (Linear / Figma inspector).
-  //      The Modal still closes on backdrop click — that's its contract.
+  // Three layout shapes:
+  //   - modal: centred, dim backdrop, click-outside closes
+  //   - drawer-right: right-docked, NO backdrop, clicks pass through to the
+  //     page so a sibling list stays interactive (Linear / Figma inspector)
+  //   - panel-right: right-docked, dim backdrop, click-outside closes — same
+  //     shape as drawer-right but the modal blocking semantics so forms /
+  //     sub-modals don't conflict with click-through interactions
   const containerClass = isDrawer
     ? "fixed inset-0 flex items-stretch justify-end pointer-events-none"
+    : isPanel
+    ? "fixed inset-0 flex items-stretch justify-end bg-black/40 backdrop-blur-sm"
     : "fixed inset-0 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm p-0 sm:p-4";
-  const dialogClass = isDrawer
-    ? `pointer-events-auto relative w-full ${SIZE_CLASSES[size]} h-full sm:rounded-l-2xl sm:border-l border-border-subtle bg-surface shadow-2xl animate-slide-in-right ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`
+  const dialogClass = isRightDocked
+    ? `${isDrawer ? "pointer-events-auto " : ""}relative w-full ${SIZE_CLASSES[size]} h-full sm:rounded-l-2xl sm:border-l border-border-subtle bg-surface shadow-2xl animate-slide-in-right ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`
     : `relative w-full ${SIZE_CLASSES[size]} rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl animate-fade-in-scale max-h-[90vh] ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`;
 
   return (

--- a/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./Button";
+import { Modal } from "./Modal";
 
 type ScheduleType = "interval_min" | "interval_hour" | "daily" | "weekday" | "weekly" | "monthly" | "custom";
 
@@ -191,32 +192,12 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
     [t],
   );
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown, isOpen]);
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="schedule-modal-title"
-      className="fixed inset-0 z-100 flex items-center justify-center bg-black/50 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div className="w-full max-w-140 mx-4 rounded-2xl bg-surface border border-border-subtle shadow-2xl animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-        {/* Header */}
-        <div className="p-5 pb-3">
-          <h3 id="schedule-modal-title" className="text-base font-black">{title}</h3>
+    <Modal isOpen={isOpen} onClose={onClose} variant="panel-right" size="xl" hideCloseButton>
+      {/* Header — kept inline so the optional subtitle line renders below
+          the title; Modal's built-in title bar only takes a string. */}
+      <div className="p-5 pb-3 border-b border-border-subtle">
+        <h3 id="schedule-modal-title" className="text-base font-black">{title}</h3>
           {subtitle && <p className="text-[11px] text-text-dim mt-0.5 truncate">{subtitle}</p>}
         </div>
 
@@ -332,7 +313,6 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
           <Button variant="primary" className="flex-1" onClick={() => onSave(previewCron, timezone)} disabled={!cronValid}>{t("common.save")}</Button>
           <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/A2APage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.tsx
@@ -7,6 +7,7 @@ import { useA2AAgents } from "../lib/queries/network";
 import { useDiscoverA2AAgent } from "../lib/mutations/network";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
+import { Modal } from "../components/ui/Modal";
 import { Badge } from "../components/ui/Badge";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -205,41 +206,45 @@ export function A2APage() {
             )}
           </div>
 
-          {/* Send task modal */}
+          {/* Send task panel */}
           {taskAgent && (
-            <div className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setTaskAgent(null)}>
-              <div className="w-full sm:max-w-lg sm:mx-4 animate-fade-in-scale" onClick={(e) => e.stopPropagation()}>
-                <Card padding="lg">
-                  <h3 className="text-lg font-black mb-1">{t("a2a.send_task")}</h3>
-                  <p className="text-xs text-text-dim mb-4">
-                    {t("a2a.send_to")} <span className="font-bold text-brand">{taskAgent.name || taskAgent.url}</span>
-                  </p>
-                  <textarea
-                    value={taskMessage}
-                    onChange={(e) => setTaskMessage(e.target.value)}
-                    placeholder={t("a2a.task_placeholder")}
-                    rows={4}
-                    className="w-full rounded-xl border border-border-subtle bg-main px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none resize-none"
-                  />
-                  <div className="flex justify-end gap-3 mt-4">
-                    <button
-                      onClick={() => setTaskAgent(null)}
-                      className="px-4 py-2 rounded-xl text-sm font-bold text-text-dim hover:bg-surface-hover transition-colors"
-                    >
-                      {t("common.cancel")}
-                    </button>
-                    <button
-                      onClick={handleSendTask}
-                      disabled={isSending || !taskMessage.trim()}
-                      className="flex items-center gap-2 rounded-xl bg-brand px-5 py-2 text-sm font-bold text-white hover:bg-brand/90 disabled:opacity-40 transition-colors"
-                    >
-                      {isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-                      {t("a2a.send")}
-                    </button>
-                  </div>
-                </Card>
+            <Modal
+              isOpen
+              onClose={() => setTaskAgent(null)}
+              variant="panel-right"
+              size="lg"
+              title={t("a2a.send_task")}
+              zIndex={200}
+            >
+              <div className="p-5 space-y-4">
+                <p className="text-xs text-text-dim">
+                  {t("a2a.send_to")} <span className="font-bold text-brand">{taskAgent.name || taskAgent.url}</span>
+                </p>
+                <textarea
+                  value={taskMessage}
+                  onChange={(e) => setTaskMessage(e.target.value)}
+                  placeholder={t("a2a.task_placeholder")}
+                  rows={4}
+                  className="w-full rounded-xl border border-border-subtle bg-main px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none resize-none"
+                />
+                <div className="flex justify-end gap-3">
+                  <button
+                    onClick={() => setTaskAgent(null)}
+                    className="px-4 py-2 rounded-xl text-sm font-bold text-text-dim hover:bg-surface-hover transition-colors"
+                  >
+                    {t("common.cancel")}
+                  </button>
+                  <button
+                    onClick={handleSendTask}
+                    disabled={isSending || !taskMessage.trim()}
+                    className="flex items-center gap-2 rounded-xl bg-brand px-5 py-2 text-sm font-bold text-white hover:bg-brand/90 disabled:opacity-40 transition-colors"
+                  >
+                    {isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                    {t("a2a.send")}
+                  </button>
+                </div>
               </div>
-            </div>
+            </Modal>
           )}
 
           {/* Tracked tasks */}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1243,7 +1243,7 @@ export function AgentsPage() {
 
       {/* Tools Editor Modal */}
       {showToolsEditor && toolsEditorAgentId && (
-        <Modal isOpen={showToolsEditor} onClose={closeToolsEditor} title={t("agents.tools_editor_title", { defaultValue: "Agent Tools" })} size="lg" zIndex={60} overflowVisible>
+        <Modal isOpen={showToolsEditor} onClose={closeToolsEditor} title={t("agents.tools_editor_title", { defaultValue: "Agent Tools" })} size="lg" zIndex={60} overflowVisible variant="panel-right">
           <div className="p-6 space-y-5">
             <div>
               <p className="text-[11px] text-text-dim/70">
@@ -1376,7 +1376,8 @@ export function AgentsPage() {
         isOpen={showCreate}
         onClose={closeCreateModal}
         title={t("agents.create_agent")}
-        size="4xl"
+        size="2xl"
+        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {/* Mode tabs — switching between Form and TOML round-trips the

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -26,6 +26,7 @@ import "@xyflow/react/dist/style.css";
 import { listAgents, listWorkflows, getWorkflow, createSchedule, type AgentItem, type WorkflowItem, type WorkflowTemplate as ApiWorkflowTemplate, type DryRunResult, type WorkflowStepResult } from "../api";
 import { Card } from "../components/ui/Card";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
+import { Modal } from "../components/ui/Modal";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { InlineEmpty } from "../components/ui/InlineEmpty";
@@ -331,10 +332,9 @@ function TemplateBrowser({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm p-0 sm:p-4" onClick={onClose}>
-      <div className="bg-surface rounded-t-2xl sm:rounded-2xl shadow-2xl border border-border-subtle w-full sm:w-[640px] sm:max-w-[90vw] max-h-[85vh] sm:max-h-[80vh] flex flex-col animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
+    <Modal isOpen onClose={onClose} variant="panel-right" size="2xl" hideCloseButton>
+        {/* Header — matches the existing inline icon + custom X. */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle sticky top-0 bg-surface z-10">
           <div className="flex items-center gap-2">
             <LayoutTemplate className="w-4 h-4 text-brand" />
             <h3 className="text-sm font-bold">{t("canvas.browse_templates")}</h3>
@@ -343,8 +343,8 @@ function TemplateBrowser({
         </div>
 
         {selectedTemplate ? (
-          /* Template detail + params form */
-          <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          /* Template detail + params form — Modal handles outer scroll */
+          <div className="p-5 space-y-4">
             <button onClick={() => setSelectedTemplate(null)} className="text-xs text-brand hover:underline flex items-center gap-1">
               <ArrowLeft className="w-3 h-3" /> {t("common.back")}
             </button>
@@ -391,8 +391,8 @@ function TemplateBrowser({
             </Button>
           </div>
         ) : (
-          /* Template list */
-          <div className="flex-1 overflow-y-auto">
+          /* Template list — Modal handles outer scroll */
+          <div>
             {/* Search */}
             <div className="px-5 pt-4 pb-2">
               <div className="relative">
@@ -447,8 +447,7 @@ function TemplateBrowser({
             )}
           </div>
         )}
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -13,6 +13,7 @@ import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
+import { Modal } from "../components/ui/Modal";
 import {
   Network, Search, CheckCircle2, XCircle, ChevronRight, X, Grid3X3, List,
   Settings, Key, Clock, AlertCircle, CheckSquare, Square,
@@ -176,10 +177,10 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
   t: (key: string) => string
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
-      <div className="bg-surface rounded-2xl border border-border-subtle w-full sm:max-w-lg shadow-2xl rounded-t-2xl sm:rounded-2xl max-h-[90vh] overflow-y-auto animate-fade-in-scale" onClick={e => e.stopPropagation()}>
-        {/* Header */}
-        <div className={`h-2 bg-linear-to-r ${channel.configured ? "from-success via-success/60 to-success/30" : "from-brand via-brand/60 to-brand/30"} rounded-t-2xl`} />
+    <Modal isOpen onClose={onClose} variant="drawer-right" size="lg" hideCloseButton>
+        {/* Coloured strip + custom header are kept inline so the
+            configured/unconfigured stripe still renders. */}
+        <div className={`h-2 bg-linear-to-r ${channel.configured ? "from-success via-success/60 to-success/30" : "from-brand via-brand/60 to-brand/30"}`} />
         <div className="p-6 border-b border-border-subtle">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -309,8 +310,7 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
         <div className="p-4 border-t border-border-subtle flex justify-end">
           <Button variant="ghost" onClick={onClose}>{t("common.close")}</Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -369,8 +369,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-end sm:items-center justify-center z-50 backdrop-blur-sm" onClick={onClose}>
-      <div className="bg-surface border border-border-subtle rounded-2xl w-full sm:max-w-md shadow-2xl rounded-t-2xl sm:rounded-2xl animate-fade-in-scale" onClick={e => e.stopPropagation()}>
+    <Modal isOpen onClose={onClose} variant="panel-right" size="md" hideCloseButton>
         <div className="px-6 py-5 border-b border-border-subtle">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -451,8 +450,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
           </Button>
         </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -541,8 +539,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
   useEffect(() => { startQr(); }, [startQr]);
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-end sm:items-center justify-center z-50 backdrop-blur-xl backdrop-saturate-150" onClick={onClose}>
-      <div className="bg-surface border border-border-subtle rounded-2xl w-full sm:max-w-md shadow-2xl rounded-t-2xl sm:rounded-2xl animate-fade-in-scale" onClick={e => e.stopPropagation()}>
+    <Modal isOpen onClose={onClose} variant="panel-right" size="md" hideCloseButton>
         <div className="px-6 py-5 border-b border-border-subtle">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -590,8 +587,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
         <div className="p-4 border-t border-border-subtle flex justify-end">
           <Button variant="ghost" onClick={onClose}>{t("common.close")}</Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -1120,6 +1120,7 @@ export function McpServersPage() {
         onClose={() => { setShowAddModal(false); setEditingServer(null); setForm(defaultForm); }}
         title={editingServer ? t("mcp.edit_server") : t("mcp.add_server")}
         size="lg"
+        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {/* Name */}
@@ -1252,6 +1253,7 @@ export function McpServersPage() {
         onClose={() => { setInstallingTemplate(null); setEnvInputs({}); }}
         title={t("mcp.env_setup_title", { name: installingTemplate?.name ?? "" })}
         size="md"
+        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           <p className="text-xs text-text-dim">{t("mcp.env_setup_desc")}</p>

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -36,7 +36,7 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.add_memory")} size="md">
+    <Modal isOpen={true} onClose={onClose} title={t("memory.add_memory")} size="md" variant="panel-right">
       <div className="p-4 sm:p-6">
         <div className="space-y-4">
           <div>
@@ -102,7 +102,7 @@ function EditMemoryDialog({ memory, onClose }: { memory: { id: string; content?:
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.edit_memory")} size="md">
+    <Modal isOpen={true} onClose={onClose} title={t("memory.edit_memory")} size="md" variant="panel-right">
       <div className="p-4 sm:p-6">
         <div>
           <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.content")}</label>
@@ -219,7 +219,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   const labelCls = "text-[10px] font-bold uppercase tracking-widest text-text-dim mb-1 block";
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.config_title", { defaultValue: "Memory Configuration" })} size="lg">
+    <Modal isOpen={true} onClose={onClose} title={t("memory.config_title", { defaultValue: "Memory Configuration" })} size="lg" variant="panel-right">
       <p className="text-xs text-text-dim -mt-2 mb-4">{t("memory.config_desc", { defaultValue: "Changes are written to config.toml. Restart required for full effect." })}</p>
 
       {configQuery.isLoading || !form ? (

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -606,8 +606,8 @@ export function ModelsPage() {
       )}
 
       {/* Add Model Modal */}
-      <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">
-        <form onSubmit={handleAdd} className="p-5 space-y-4 max-h-[70vh] overflow-y-auto">
+      <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg" variant="panel-right">
+        <form onSubmit={handleAdd} className="p-5 space-y-4">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div className="sm:col-span-2">
                   <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.model_id")} *</label>
@@ -790,7 +790,7 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
 
   if (overridesQuery.isLoading) {
     return (
-      <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg">
+      <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg" variant="panel-right">
         <div className="flex items-center justify-center p-12">
           <Loader2 className="w-6 h-6 animate-spin text-brand" />
         </div>
@@ -799,8 +799,8 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
   }
 
   return (
-    <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg">
-      <div className="p-5 space-y-5 max-h-[75vh] overflow-y-auto">
+    <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg" variant="panel-right">
+      <div className="p-5 space-y-5">
         {/* Model header */}
         <div className="flex items-center gap-3">
           <Cpu className="w-5 h-5 text-brand" />

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -331,7 +331,7 @@ export function PluginsPage() {
       )}
 
       {/* Install Modal */}
-      <Modal isOpen={showInstall} onClose={() => setShowInstall(false)} title={t("plugins.install_title")} size="md">
+      <Modal isOpen={showInstall} onClose={() => setShowInstall(false)} title={t("plugins.install_title")} size="md" variant="panel-right">
         <div className="p-5 space-y-4">
               {/* Source Tabs */}
               <div>
@@ -398,7 +398,7 @@ export function PluginsPage() {
       </Modal>
 
       {/* Scaffold Modal */}
-      <Modal isOpen={showScaffold} onClose={() => setShowScaffold(false)} title={t("plugins.scaffold_title")} size="sm">
+      <Modal isOpen={showScaffold} onClose={() => setShowScaffold(false)} title={t("plugins.scaffold_title")} size="sm" variant="panel-right">
         <div className="p-5 space-y-4">
           <div>
             <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1331,7 +1331,7 @@ export function ProvidersPage() {
       )}
 
       {/* Config Modal */}
-      <Modal isOpen={!!config.provider} onClose={config.close} title={t("providers.configure_provider")} size="md">
+      <Modal isOpen={!!config.provider} onClose={config.close} title={t("providers.configure_provider")} size="md" variant="panel-right">
         {config.provider && (
           <div className="p-5 space-y-4">
             <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
@@ -1451,7 +1451,7 @@ export function ProvidersPage() {
       </Modal>
 
       {/* Create Provider Wizard */}
-      <Modal isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton>
+      <Modal isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton variant="panel-right">
         <CreateProviderWizard
           onSubmit={async (values) => {
             await createRegistryContent("provider", values);

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -440,7 +440,7 @@ export function SchedulerPage() {
       </div>
 
       {/* Create Modal */}
-      <Modal isOpen={showCreate} onClose={() => setShowCreate(false)} title={t("scheduler.create_job")} size="md">
+      <Modal isOpen={showCreate} onClose={() => setShowCreate(false)} title={t("scheduler.create_job")} size="md" variant="panel-right">
         {/* Mode tabs */}
         <div className="flex gap-1 px-5 pt-4">
           <button
@@ -610,6 +610,7 @@ export function SchedulerPage() {
         }}
         title={t("scheduler.delivery.edit_modal_title", { defaultValue: "Edit delivery targets" })}
         size="lg"
+        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {editTargetsSchedule && (
@@ -665,7 +666,7 @@ export function SchedulerPage() {
       </Modal>
 
       {/* Edit Trigger Modal */}
-      <Modal isOpen={!!editTrigger} onClose={() => setEditTrigger(null)} title="Edit trigger" size="md">
+      <Modal isOpen={!!editTrigger} onClose={() => setEditTrigger(null)} title="Edit trigger" size="md" variant="panel-right">
         <form onSubmit={handleEditTrigger} className="p-5 space-y-4">
           {editTrigger && (
             <div className="rounded-xl bg-warning/5 border border-warning/20 px-3 py-2 text-[10px] text-text-dim/60">

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -434,7 +434,7 @@ function MarketplaceDetailModal({
 }) {
   const isPending = pendingId === skill.slug;
   return (
-    <Modal isOpen onClose={onClose} title={skill.name} size="md">
+    <Modal isOpen onClose={onClose} title={skill.name} size="md" variant="panel-right">
       <div className="p-5 space-y-4">
         <div className="p-4 rounded-xl bg-surface-2">
           <p className="text-sm text-text-dim leading-relaxed">{skill.description}</p>
@@ -628,6 +628,7 @@ function CreateSkillModal({
       onClose={onClose}
       title={t("skills.evo_create_title", { defaultValue: "Create Skill" })}
       size="xl"
+      variant="panel-right"
     >
       <div className="space-y-4 p-1">
         <div>


### PR DESCRIPTION
## Summary

Completes the dashboard drawer rollout from #3166. Adds a third `Modal` variant `panel-right` for forms and sub-modals, then converts every remaining centred modal — including bespoke `fixed inset-0` wrappers that didn't use `<Modal>` — to one of the three shapes.

## The three variants

| variant | position | backdrop | click-outside | use case |
|---|---|---|---|---|
| `modal` (default, unchanged) | centred | dim | closes | confirms, viewers, small popups |
| `drawer-right` (#3166) | right-docked | none | passes through | inspect detail with list-click-to-switch |
| `panel-right` (new) | right-docked | dim | closes | forms / sub-modals — drawer **shape** with modal **semantics** |

Why `panel-right` exists: with the inspector drawer's click-through, a "Create Agent" form would race against the agents list — clicking another card opens a *second* drawer on top of the form. Forms also have state worth protecting; click-outside-to-close is the established escape hatch. `panel-right` keeps the visual consistency (right-docked side surface) while staying blocking.

## Conversions to drawer / panel

### Pages already on `<Modal>` (one-line variant flips, sometimes inner-scroll cleanup)

| page | modals → variant |
|---|---|
| **PluginsPage** | Install, Scaffold → panel-right |
| **SchedulerPage** | Create Job, Edit Delivery Targets, Edit Trigger → panel-right |
| **ModelsPage** | Add Custom Model, Settings → panel-right (also drops `max-h-[70vh]/[75vh] overflow-y-auto` nested scrolls) |
| **MemoryPage** | Add, Edit, Config → panel-right |
| **McpServersPage** | Add / Edit Server, Env Setup → panel-right |
| **AgentsPage** | Tools editor, Create Agent → panel-right (`size="4xl"` → `"2xl"`; 4xl was awkwardly wide as a side panel) |
| **ProvidersPage** | Configure, Add → panel-right |
| **SkillsPage** | Marketplace detail, Create Skill → panel-right |

### Bespoke `fixed inset-0` wrappers refactored to `<Modal>`

| location | wrapper | → variant |
|---|---|---|
| `components/ui/ScheduleModal.tsx` | bespoke | panel-right (drops local Esc handler / `useEffect` / `useCallback`) |
| `pages/A2APage.tsx` | "Send task" form | panel-right |
| `pages/CanvasPage.tsx` | "Browse templates" gallery | panel-right (drops two `flex-1 overflow-y-auto` nested scrolls) |
| `pages/ChannelsPage.tsx` `DetailsModal` | channel inspect | drawer-right |
| `pages/ChannelsPage.tsx` `ConfigDialog` | channel config form | panel-right |
| `pages/ChannelsPage.tsx` `QrLoginDialog` | QR login flow | panel-right |

Each bespoke conversion is the same pattern: replace `<div fixed inset-0>` + inner panel `<div>` with a single `<Modal variant="..." hideCloseButton>`, lift any sub-modals to siblings inside a fragment, drop local Esc handlers (Modal already wires window-level Escape).

## Deliberately kept as `modal`

- **ProvidersPage Delete Confirm** — destructive, must block (forced yes/no decision)
- **TomlViewer** — read-only code/file viewer; centred works for scrolling raw TOML
- **PageHeader help popup** — small inline contextual help, not a page-scale surface
- **ConfirmDialog**, **CommandPalette**, **ShortcutsHelp** — separate components, not built on `<Modal>`; small reference / blocking surfaces that fit centred better
- **CanvasPage shortcut-help popup** — same shape as the global ShortcutsHelp
- **CanvasPage / TerminalPage fullscreen toggles** — not modals (the page itself goes fullscreen)
- **WorkflowEditor**, **NotificationCenter** — not modals (full-screen editor / dropdown backdrop)

## Test plan

- [ ] Manual every panel / drawer: opens as right-docked surface; backdrop dim where applicable; clicking outside on `panel-right` closes; on `drawer-right` passes through to the page; Esc closes everywhere; rest of page interactivity matches the variant
- [ ] Manual `<sm:` viewport on each: drawer/panel becomes full-screen sheet
- [ ] Manual: existing `drawer-right` inspector flows unchanged (Agents/Providers/Skills detail still click-through)
- [ ] Manual: ScheduleModal (cron picker) opens from inside an agent/hand form — layers correctly above the parent panel
- [ ] Manual: ProvidersPage delete confirm still centres + dims as a modal
- [ ] CI green
