### PR TITLE
feat(observability): add Jaeger as second trace backend alongside Tempo

### DIFF
--- a/deploy/OBSERVABILITY.md
+++ b/deploy/OBSERVABILITY.md
@@ -1,6 +1,8 @@
 # LibreFang Observability
 
-Prometheus + Grafana monitoring stack for LibreFang.
+Full local telemetry stack for LibreFang: metrics (Prometheus), traces
+(Tempo + Jaeger), and logs (Loki + Alloy), all unified in Grafana with
+trace ↔ metric ↔ log cross-linking.
 
 ## Quick Start
 
@@ -22,20 +24,54 @@ open http://localhost:3000    # admin / admin
 open http://localhost:16686
 ```
 
-Prometheus scrapes `http://host.docker.internal:4545/api/metrics` every 15 seconds.
+Prometheus scrapes `http://host.docker.internal:4545/api/metrics` every
+15 seconds. Alloy tails `${HOME}/.librefang/logs/*.log` and pushes lines
+to Loki. The OTel collector receives OTLP traces from the daemon and
+fans them out to Tempo, Jaeger, and stdout.
 
-The OTel collector fans traces out to both Tempo (queried from Grafana for
-trace-to-metric correlation) and Jaeger (standalone trace-debugging UI:
-waterfall, span diff, service deps). Tempo is the long-term store; Jaeger is
-ephemeral (in-memory, wiped on container restart) and is meant for live
-debugging.
+## What runs in the stack
 
-Both backends are auto-provisioned as Grafana datasources
+| Service | Port | Purpose |
+|---|---|---|
+| Grafana | 3000 | Unified UI for metrics / traces / logs |
+| Prometheus | 9090 | Metrics store (scrapes daemon `/api/metrics`) |
+| OTel Collector | 4317 / 4318 | Receives OTLP from the daemon, fans out |
+| Tempo | 3200 | Trace store (Grafana correlation backend) |
+| Jaeger | 16686 | Standalone trace-debug UI (waterfall, diff, deps) |
+| Loki | 3100 | Log store (queried from Grafana) |
+| Alloy | 12345 | Log collector (tails daemon log files) |
+
+Both trace backends are auto-provisioned as Grafana datasources
 (`librefang-tempo`, `librefang-jaeger`), so Grafana's Explore page can
-query either side and dashboards can use derived fields to jump from a
-metric panel into the matching trace. Same `trace_id` flows through both
-exporters, so a trace opened in Grafana and the same `trace_id` pasted
-into the Jaeger UI return the identical span tree.
+query either side. Same `trace_id` flows through both exporters, so a
+trace opened in Grafana and the same `trace_id` pasted into the Jaeger
+UI return the identical span tree.
+
+Loki is also auto-provisioned (`librefang-loki`). The datasource has
+`derivedFields` configured to extract `trace_id="<32-hex>"` from log
+lines and turn it into a clickable link that opens the matching trace
+in Tempo or Jaeger. The link wiring is in place, but it only lights up
+once daemon log lines actually carry the `trace_id` field — that's a
+follow-up Rust-side change.
+
+The Jaeger container is **required by the trace pipeline**, not optional:
+the collector's `traces` pipeline includes `otlp/jaeger` as an exporter,
+so starting the stack without `jaeger` will leave the collector logging
+`ConnectionRefused` on every batch. To run a Tempo-only stack, comment
+out the `otlp/jaeger` exporter (and remove it from
+`service.pipelines.traces.exporters`) in `otel-collector/config.yaml`
+and drop the `jaeger` service from `docker-compose.observability.yml`.
+
+## Startup ordering
+
+The compose file uses `depends_on: { condition: service_healthy }` plus
+per-service healthchecks (otel-collector `:13133`, Tempo `/ready`,
+Jaeger `/`, Loki `/ready`, Prometheus `/-/ready`, Grafana
+`/api/health`). This is a deliberate fix for a noisy boot-time race
+where the daemon's `BatchSpanProcessor` would log `ConnectionRefused`
+against `127.0.0.1:4317` for a few seconds while the collector was
+still starting. With healthchecks in place, dependents only start after
+their dependencies are actually accepting traffic — the race is gone.
 
 The Jaeger container is **required by the trace pipeline**, not optional:
 the collector's `traces` pipeline includes `otlp/jaeger` as an exporter,

--- a/deploy/OBSERVABILITY.md
+++ b/deploy/OBSERVABILITY.md
@@ -18,9 +18,17 @@ docker compose -f docker-compose.observability.yml up -d
 
 # 4. Open Grafana
 open http://localhost:3000    # admin / admin
+# 5. (optional) Open Jaeger for trace-debug UI
+open http://localhost:16686
 ```
 
 Prometheus scrapes `http://host.docker.internal:4545/api/metrics` every 15 seconds.
+
+The OTel collector fans traces out to both Tempo (queried from Grafana for
+trace-to-metric correlation) and Jaeger (standalone trace-debugging UI:
+waterfall, span diff, service deps). Tempo is the long-term store; Jaeger is
+ephemeral (in-memory, wiped on container restart) and is meant for live
+debugging.
 
 ## Available Metrics
 

--- a/deploy/OBSERVABILITY.md
+++ b/deploy/OBSERVABILITY.md
@@ -18,7 +18,7 @@ docker compose -f docker-compose.observability.yml up -d
 
 # 4. Open Grafana
 open http://localhost:3000    # admin / admin
-# 5. (optional) Open Jaeger for trace-debug UI
+# 5. Open Jaeger for trace-debug UI
 open http://localhost:16686
 ```
 
@@ -29,6 +29,14 @@ trace-to-metric correlation) and Jaeger (standalone trace-debugging UI:
 waterfall, span diff, service deps). Tempo is the long-term store; Jaeger is
 ephemeral (in-memory, wiped on container restart) and is meant for live
 debugging.
+
+The Jaeger container is **required by the trace pipeline**, not optional:
+the collector's `traces` pipeline includes `otlp/jaeger` as an exporter,
+so starting the stack without `jaeger` will leave the collector logging
+`ConnectionRefused` on every batch. To run a Tempo-only stack, comment
+out the `otlp/jaeger` exporter (and remove it from
+`service.pipelines.traces.exporters`) in `otel-collector/config.yaml`
+and drop the `jaeger` service from `docker-compose.observability.yml`.
 
 ## Available Metrics
 

--- a/deploy/OBSERVABILITY.md
+++ b/deploy/OBSERVABILITY.md
@@ -30,6 +30,13 @@ waterfall, span diff, service deps). Tempo is the long-term store; Jaeger is
 ephemeral (in-memory, wiped on container restart) and is meant for live
 debugging.
 
+Both backends are auto-provisioned as Grafana datasources
+(`librefang-tempo`, `librefang-jaeger`), so Grafana's Explore page can
+query either side and dashboards can use derived fields to jump from a
+metric panel into the matching trace. Same `trace_id` flows through both
+exporters, so a trace opened in Grafana and the same `trace_id` pasted
+into the Jaeger UI return the identical span tree.
+
 The Jaeger container is **required by the trace pipeline**, not optional:
 the collector's `traces` pipeline includes `otlp/jaeger` as an exporter,
 so starting the stack without `jaeger` will leave the collector logging

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -1,0 +1,50 @@
+// Grafana Alloy config for LibreFang's local dev stack.
+//
+// Tails the daemon log file (mounted read-only from the host at
+// /var/log/librefang/) and pushes lines to Loki. Adds a stable
+// `service="librefang"` label so Grafana queries match the service
+// name reported by the OTel/Tempo/Jaeger pipeline — that's what makes
+// the trace ↔ log jump work via Grafana's derived fields once the
+// daemon stamps trace_id into log lines (separate PR; container
+// plumbing is in place either way).
+
+logging {
+	level  = "warn"
+	format = "logfmt"
+}
+
+local.file_match "librefang_logs" {
+	path_targets = [
+		{__path__ = "/var/log/librefang/*.log"},
+	]
+	sync_period = "5s"
+}
+
+loki.source.file "librefang" {
+	targets    = local.file_match.librefang_logs.targets
+	forward_to = [loki.process.librefang.receiver]
+}
+
+loki.process "librefang" {
+	// Stamp every log line with a stable service label and surface the
+	// originating filename (daemon.log vs tui.log) so users can filter
+	// on which surface produced the line.
+	stage.static_labels {
+		values = {
+			service = "librefang",
+			job     = "librefang",
+		}
+	}
+
+	stage.label_drop {
+		values = ["filename"]
+	}
+
+	forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -8,14 +8,28 @@ services:
       - "4317:4317"   # OTLP gRPC receiver (LibreFang's otlp_endpoint)
       - "4318:4318"   # OTLP HTTP receiver
       - "8889:8889"   # Prometheus scrape endpoint (OTLP metrics → Prometheus)
+      - "13133:13133" # health_check extension (used by docker healthcheck)
     volumes:
       - ./otel-collector/config.yaml:/etc/otelcol-contrib/config.yaml:ro
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - tempo
-      - jaeger
+      tempo:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      # The collector exposes a health_check extension on 13133; we wire
+      # the same port up internally and on the host so a `curl` from any
+      # network reflects readiness.
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:13133/"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
 
   jaeger:
@@ -28,6 +42,14 @@ services:
       - "16686:16686"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+    healthcheck:
+      # Jaeger all-in-one returns 200 on `/` once the collector and query
+      # services are both up.
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:16686/"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
 
   tempo:
@@ -43,6 +65,62 @@ services:
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
       - tempo-data:/var/tempo
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3200/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      # Tempo needs longer to come up than the rest because it loads its
+      # WAL + block list before /ready returns 200.
+      start_period: 15s
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:latest
+    container_name: librefang-loki
+    # 3100 is the Loki HTTP API — used by Alloy to push and Grafana to
+    # query. Exposed to the host so users can also `curl /ready` and
+    # `logcli` against it directly.
+    ports:
+      - "3100:3100"
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: librefang-alloy
+    # Alloy tails the daemon's log file and pushes lines to Loki. The
+    # daemon writes to ${HOME}/.librefang/logs/daemon.log on the host —
+    # mounted read-only at a fixed path inside the container so the
+    # config below doesn't need to know the operator's $HOME.
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - ${HOME}/.librefang/logs:/var/log/librefang:ro
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    ports:
+      - "12345:12345" # Alloy debug UI (component graph, metrics)
+    depends_on:
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:12345/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
 
   prometheus:
@@ -56,7 +134,14 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
 
   grafana:
@@ -72,11 +157,22 @@ services:
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:
-      - prometheus
-      - tempo
+      prometheus:
+        condition: service_healthy
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
 
 volumes:
   prometheus-data:
   tempo-data:
   grafana-data:
+  loki-data:

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -15,6 +15,19 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - tempo
+      - jaeger
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: librefang-jaeger
+    # 16686 is the Jaeger UI. The OTLP receiver on 4317 stays internal —
+    # the host's 4317 is the otel-collector; collector forwards to
+    # jaeger:4317 over the docker bridge.
+    ports:
+      - "16686:16686"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     restart: unless-stopped
 
   tempo:

--- a/deploy/grafana/dashboards/librefang-cost.json
+++ b/deploy/grafana/dashboards/librefang-cost.json
@@ -1,52 +1,161 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    { "title": "Overview", "url": "/d/librefang-overview", "type": "link", "icon": "apps", "tooltip": "System Overview" },
-    { "title": "LLM & Tokens", "url": "/d/librefang-llm", "type": "link", "icon": "bolt", "tooltip": "LLM & Token Usage" },
-    { "title": "HTTP & API", "url": "/d/librefang-http", "type": "link", "icon": "cloud", "tooltip": "HTTP & API Metrics" }
+    {
+      "title": "Overview",
+      "url": "/d/librefang-overview",
+      "type": "link",
+      "icon": "apps",
+      "tooltip": "System Overview"
+    },
+    {
+      "title": "LLM & Tokens",
+      "url": "/d/librefang-llm",
+      "type": "link",
+      "icon": "bolt",
+      "tooltip": "LLM & Token Usage"
+    },
+    {
+      "title": "HTTP & API",
+      "url": "/d/librefang-http",
+      "type": "link",
+      "icon": "cloud",
+      "tooltip": "HTTP & API Metrics"
+    },
+    {
+      "title": "Search Traces (Tempo)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Tempo datasource, prefilled with service.name=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-tempo\",{\"queryType\":\"traceql\",\"query\":\"{ resource.service.name=\\\"librefang\\\" }\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Search Logs (Loki)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Loki datasource, prefilled with service=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-loki\",{\"expr\":\"{service=\\\"librefang\\\"}\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
+      "url": "http://localhost:16686/search?service=librefang",
+      "targetBlank": true,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": false
+    }
   ],
   "panels": [
     {
       "title": "Cost Today (USD)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
           "decimals": 4,
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 1 },
-            { "color": "orange", "value": 5 },
-            { "color": "red", "value": 10 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_cost_usd_today", "legendFormat": "Cost Today", "refId": "A" }
+        {
+          "expr": "librefang_cost_usd_today",
+          "legendFormat": "Cost Today",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Total Tokens (1h window)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -54,21 +163,49 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Tokens", "refId": "A" }
+        {
+          "expr": "sum(librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Tokens",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "LLM Calls (1h window)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -76,21 +213,41 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Calls", "refId": "A" }
+        {
+          "expr": "sum(librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Calls",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Cost Trend",
       "description": "Today's estimated cost over time",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "USD",
@@ -100,36 +257,75 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
             "gradientMode": "scheme"
           },
           "unit": "currencyUSD",
           "decimals": 4,
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 1 },
-            { "color": "red", "value": 10 }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_cost_usd_today", "legendFormat": "Cost Today", "refId": "A" }
+        {
+          "expr": "librefang_cost_usd_today",
+          "legendFormat": "Cost Today",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Tokens by Agent (cost proxy)",
-      "description": "Token consumption per agent — more tokens = higher cost",
+      "description": "Token consumption per agent \u2014 more tokens = higher cost",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "tokens",
@@ -139,56 +335,127 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}", "legendFormat": "{{agent}} ({{provider}}/{{model}})", "refId": "A" }
+        {
+          "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}",
+          "legendFormat": "{{agent}} ({{provider}}/{{model}})",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Cost by Model (token share)",
-      "description": "Token distribution by provider/model — output tokens cost more",
+      "description": "Token distribution by provider/model \u2014 output tokens cost more",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
         "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "mode": "single" }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        { "expr": "sum by (provider, model) (librefang_tokens{provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "{{provider}}/{{model}}", "refId": "A", "instant": true }
+        {
+          "expr": "sum by (provider, model) (librefang_tokens{provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "{{provider}}/{{model}}",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Output Tokens by Agent (highest cost)",
       "description": "Output tokens are typically 3-5x more expensive than input tokens",
       "type": "bargauge",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 10000 },
-            { "color": "red", "value": 100000 }
-          ]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "red",
+                "value": 100000
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -199,56 +466,141 @@
         "minVizWidth": 0,
         "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
         "sizing": "auto",
         "valueMode": "color"
       },
       "targets": [
-        { "expr": "topk(10, librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "{{agent}} ({{model}})", "refId": "A", "instant": true }
+        {
+          "expr": "topk(10, librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "{{agent}} ({{model}})",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Input / Output Token Ratio",
       "description": "Higher output ratio = more expensive. Ideal ratio depends on use case.",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Input (cheaper)" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Output (expensive)" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Input (cheaper)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Output (expensive)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
         "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "mode": "single" }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Input (cheaper)", "refId": "A", "instant": true },
-        { "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Output (expensive)", "refId": "B", "instant": true }
+        {
+          "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Input (cheaper)",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Output (expensive)",
+          "refId": "B",
+          "instant": true
+        }
       ]
     }
   ],
   "schemaVersion": 39,
-  "tags": ["librefang", "cost", "budget"],
+  "tags": [
+    "librefang",
+    "cost",
+    "budget"
+  ],
   "templating": {
     "list": [
       {
         "name": "agent",
         "label": "Agent",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens, agent)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       },
@@ -256,12 +608,19 @@
         "name": "provider",
         "label": "Provider",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens, provider)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       },
@@ -269,18 +628,28 @@
         "name": "model",
         "label": "Model",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens{provider=~\"$provider\"}, model)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "LibreFang Cost & Budget",

--- a/deploy/grafana/dashboards/librefang-http.json
+++ b/deploy/grafana/dashboards/librefang-http.json
@@ -1,23 +1,89 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    { "title": "Overview", "url": "/d/librefang-overview", "type": "link", "icon": "apps", "tooltip": "System Overview" },
-    { "title": "LLM & Tokens", "url": "/d/librefang-llm", "type": "link", "icon": "bolt", "tooltip": "LLM & Token Usage" },
-    { "title": "Cost & Budget", "url": "/d/librefang-cost", "type": "link", "icon": "calculator-alt", "tooltip": "Cost & Budget" }
+    {
+      "title": "Overview",
+      "url": "/d/librefang-overview",
+      "type": "link",
+      "icon": "apps",
+      "tooltip": "System Overview"
+    },
+    {
+      "title": "LLM & Tokens",
+      "url": "/d/librefang-llm",
+      "type": "link",
+      "icon": "bolt",
+      "tooltip": "LLM & Token Usage"
+    },
+    {
+      "title": "Cost & Budget",
+      "url": "/d/librefang-cost",
+      "type": "link",
+      "icon": "calculator-alt",
+      "tooltip": "Cost & Budget"
+    },
+    {
+      "title": "Search Traces (Tempo)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Tempo datasource, prefilled with service.name=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-tempo\",{\"queryType\":\"traceql\",\"query\":\"{ resource.service.name=\\\"librefang\\\" }\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Search Logs (Loki)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Loki datasource, prefilled with service=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-loki\",{\"expr\":\"{service=\\\"librefang\\\"}\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
+      "url": "http://localhost:16686/search?service=librefang",
+      "targetBlank": true,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": false
+    }
   ],
   "panels": [
     {
       "title": "HTTP Request Rate",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "req/s",
@@ -27,29 +93,60 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "unit": "reqps"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "sum(rate(librefang_http_requests_total[5m]))", "legendFormat": "Total", "refId": "A" },
-        { "expr": "sum by (method) (rate(librefang_http_requests_total[5m]))", "legendFormat": "{{method}}", "refId": "B" }
+        {
+          "expr": "sum(rate(librefang_http_requests_total[5m]))",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (method) (rate(librefang_http_requests_total[5m]))",
+          "legendFormat": "{{method}}",
+          "refId": "B"
+        }
       ]
     },
     {
       "title": "Request Latency (p50 / p90 / p99)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "latency",
@@ -59,34 +156,111 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "unit": "s"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "p99" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p90" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p50" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "histogram_quantile(0.50, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p50", "refId": "A" },
-        { "expr": "histogram_quantile(0.90, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p90", "refId": "B" },
-        { "expr": "histogram_quantile(0.99, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p99", "refId": "C" }
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(librefang_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ]
     },
     {
       "title": "Request Rate by Status Code",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "req/s",
@@ -96,29 +270,56 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "reqps"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "sum by (status) (rate(librefang_http_requests_total[5m]))", "legendFormat": "{{status}}", "refId": "A" }
+        {
+          "expr": "sum by (status) (rate(librefang_http_requests_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "HTTP Error Rate (4xx / 5xx)",
       "description": "Client and server error rates over time",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "errors/s",
@@ -128,37 +329,108 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "unit": "reqps"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "4xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "5xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "sum(rate(librefang_http_requests_total{status=~\"4..\"}[5m]))", "legendFormat": "4xx", "refId": "A" },
-        { "expr": "sum(rate(librefang_http_requests_total{status=~\"5..\"}[5m]))", "legendFormat": "5xx", "refId": "B" }
+        {
+          "expr": "sum(rate(librefang_http_requests_total{status=~\"4..\"}[5m]))",
+          "legendFormat": "4xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(librefang_http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx",
+          "refId": "B"
+        }
       ]
     },
     {
       "title": "Top Endpoints by Request Count",
       "type": "bargauge",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 100 },
-            { "color": "red", "value": 1000 }
-          ]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -169,29 +441,62 @@
         "minVizWidth": 0,
         "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
         "sizing": "auto",
         "valueMode": "color"
       },
       "targets": [
-        { "expr": "topk(10, sum by (path) (increase(librefang_http_requests_total[1h])))", "legendFormat": "{{path}}", "refId": "A", "instant": true }
+        {
+          "expr": "topk(10, sum by (path) (increase(librefang_http_requests_total[1h])))",
+          "legendFormat": "{{path}}",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Slowest Endpoints (p99 Latency)",
       "description": "p99 latency per endpoint path",
       "type": "bargauge",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 0.5 },
-            { "color": "red", "value": 2 }
-          ]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
@@ -202,20 +507,40 @@
         "minVizWidth": 0,
         "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
         "sizing": "auto",
         "valueMode": "color"
       },
       "targets": [
-        { "expr": "topk(10, histogram_quantile(0.99, sum by (path, le) (rate(librefang_http_request_duration_seconds_bucket[5m]))))", "legendFormat": "{{path}}", "refId": "A", "instant": true }
+        {
+          "expr": "topk(10, histogram_quantile(0.99, sum by (path, le) (rate(librefang_http_request_duration_seconds_bucket[5m]))))",
+          "legendFormat": "{{path}}",
+          "refId": "A",
+          "instant": true
+        }
       ]
     }
   ],
   "schemaVersion": 39,
-  "tags": ["librefang", "http", "api"],
-  "templating": { "list": [] },
-  "time": { "from": "now-1h", "to": "now" },
+  "tags": [
+    "librefang",
+    "http",
+    "api"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "LibreFang HTTP & API",

--- a/deploy/grafana/dashboards/librefang-llm.json
+++ b/deploy/grafana/dashboards/librefang-llm.json
@@ -1,24 +1,98 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    { "title": "Overview", "url": "/d/librefang-overview", "type": "link", "icon": "apps", "tooltip": "System Overview" },
-    { "title": "HTTP & API", "url": "/d/librefang-http", "type": "link", "icon": "cloud", "tooltip": "HTTP & API Metrics" },
-    { "title": "Cost & Budget", "url": "/d/librefang-cost", "type": "link", "icon": "calculator-alt", "tooltip": "Cost & Budget" }
+    {
+      "title": "Overview",
+      "url": "/d/librefang-overview",
+      "type": "link",
+      "icon": "apps",
+      "tooltip": "System Overview"
+    },
+    {
+      "title": "HTTP & API",
+      "url": "/d/librefang-http",
+      "type": "link",
+      "icon": "cloud",
+      "tooltip": "HTTP & API Metrics"
+    },
+    {
+      "title": "Cost & Budget",
+      "url": "/d/librefang-cost",
+      "type": "link",
+      "icon": "calculator-alt",
+      "tooltip": "Cost & Budget"
+    },
+    {
+      "title": "Search Traces (Tempo)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Tempo datasource, prefilled with service.name=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-tempo\",{\"queryType\":\"traceql\",\"query\":\"{ resource.service.name=\\\"librefang\\\" }\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Search Logs (Loki)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Loki datasource, prefilled with service=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-loki\",{\"expr\":\"{service=\\\"librefang\\\"}\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
+      "url": "http://localhost:16686/search?service=librefang",
+      "targetBlank": true,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": false
+    }
   ],
   "panels": [
     {
       "title": "Total Tokens (1h window)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -26,21 +100,49 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Tokens", "refId": "A" }
+        {
+          "expr": "sum(librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Tokens",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Input Tokens (1h)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -48,21 +150,49 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Input", "refId": "A" }
+        {
+          "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Input",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Output Tokens (1h)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "orange", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -70,21 +200,49 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Output", "refId": "A" }
+        {
+          "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Output",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "LLM Calls (1h)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -92,20 +250,40 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Calls", "refId": "A" }
+        {
+          "expr": "sum(librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Calls",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Tokens Consumed by Agent",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "tokens",
@@ -115,28 +293,57 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}", "legendFormat": "{{agent}} ({{provider}}/{{model}})", "refId": "A" }
+        {
+          "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}",
+          "legendFormat": "{{agent}} ({{provider}}/{{model}})",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "LLM Calls by Agent",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "calls",
@@ -146,29 +353,58 @@
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}", "legendFormat": "{{agent}} ({{provider}}/{{model}})", "refId": "A" }
+        {
+          "expr": "librefang_llm_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}",
+          "legendFormat": "{{agent}} ({{provider}}/{{model}})",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Input vs Output Tokens",
       "description": "Stacked view of input (prompt) vs output (completion) tokens",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "tokens",
@@ -178,33 +414,91 @@
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Input (prompt)" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Output (completion)" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Input (prompt)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Output (completion)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Input (prompt)", "refId": "A" },
-        { "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Output (completion)", "refId": "B" }
+        {
+          "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Input (prompt)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Output (completion)",
+          "refId": "B"
+        }
       ]
     },
     {
       "title": "Tokens by Provider / Model",
       "description": "Token consumption grouped by LLM provider and model",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "tokens",
@@ -214,75 +508,195 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "sum by (provider, model) (librefang_tokens{provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "{{provider}}/{{model}}", "refId": "A" }
+        {
+          "expr": "sum by (provider, model) (librefang_tokens{provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "{{provider}}/{{model}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Agent Token Breakdown",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
         "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "mode": "single" }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        { "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}", "legendFormat": "{{agent}}", "refId": "A", "instant": true }
+        {
+          "expr": "librefang_tokens{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}",
+          "legendFormat": "{{agent}}",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Token Input / Output Ratio",
       "description": "Global ratio of input (prompt) vs output (completion) tokens",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Input" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Output" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Input"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Output"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
         "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "tooltip": { "mode": "single" }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        { "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Input", "refId": "A", "instant": true },
-        { "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})", "legendFormat": "Output", "refId": "B", "instant": true }
+        {
+          "expr": "sum(librefang_tokens_input{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Input",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "expr": "sum(librefang_tokens_output{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"})",
+          "legendFormat": "Output",
+          "refId": "B",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Tool Calls by Agent",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisLabel": "calls",
@@ -292,35 +706,65 @@
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "sortBy": "Last *", "sortDesc": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_tool_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}", "legendFormat": "{{agent}}", "refId": "A" }
+        {
+          "expr": "librefang_tool_calls{agent=~\"$agent\",provider=~\"$provider\",model=~\"$model\"}",
+          "legendFormat": "{{agent}}",
+          "refId": "A"
+        }
       ]
     }
   ],
   "schemaVersion": 39,
-  "tags": ["librefang", "llm", "tokens"],
+  "tags": [
+    "librefang",
+    "llm",
+    "tokens"
+  ],
   "templating": {
     "list": [
       {
         "name": "agent",
         "label": "Agent",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens, agent)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       },
@@ -328,12 +772,19 @@
         "name": "provider",
         "label": "Provider",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens, provider)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       },
@@ -341,18 +792,28 @@
         "name": "model",
         "label": "Model",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "librefang-prometheus"
+        },
         "query": "label_values(librefang_tokens{provider=~\"$provider\"}, model)",
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "multi": true,
         "sort": 1
       }
     ]
   },
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "LibreFang LLM & Token Usage",

--- a/deploy/grafana/dashboards/librefang.json
+++ b/deploy/grafana/dashboards/librefang.json
@@ -1,215 +1,526 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    { "title": "LLM & Tokens", "url": "/d/librefang-llm", "type": "link", "icon": "bolt", "tooltip": "LLM & Token Usage" },
-    { "title": "HTTP & API", "url": "/d/librefang-http", "type": "link", "icon": "cloud", "tooltip": "HTTP & API Metrics" },
-    { "title": "Cost & Budget", "url": "/d/librefang-cost", "type": "link", "icon": "calculator-alt", "tooltip": "Cost & Budget" }
+    {
+      "title": "LLM & Tokens",
+      "url": "/d/librefang-llm",
+      "type": "link",
+      "icon": "bolt",
+      "tooltip": "LLM & Token Usage"
+    },
+    {
+      "title": "HTTP & API",
+      "url": "/d/librefang-http",
+      "type": "link",
+      "icon": "cloud",
+      "tooltip": "HTTP & API Metrics"
+    },
+    {
+      "title": "Cost & Budget",
+      "url": "/d/librefang-cost",
+      "type": "link",
+      "icon": "calculator-alt",
+      "tooltip": "Cost & Budget"
+    },
+    {
+      "title": "Search Traces (Tempo)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Tempo datasource, prefilled with service.name=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-tempo\",{\"queryType\":\"traceql\",\"query\":\"{ resource.service.name=\\\"librefang\\\" }\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Search Logs (Loki)",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open Grafana Explore on the Loki datasource, prefilled with service=librefang",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-loki\",{\"expr\":\"{service=\\\"librefang\\\"}\"}]",
+      "targetBlank": false,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": true
+    },
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
+      "url": "http://localhost:16686/search?service=librefang",
+      "targetBlank": true,
+      "tags": [],
+      "asDropdown": false,
+      "includeVars": false,
+      "keepTime": false
+    }
   ],
   "panels": [
     {
       "title": "Version",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "fixed", "fixedColor": "text" },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "none",
         "graphMode": "none",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "name"
       },
       "targets": [
-        { "expr": "librefang_info", "legendFormat": "{{version}}", "refId": "A", "instant": true }
+        {
+          "expr": "librefang_info",
+          "legendFormat": "{{version}}",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Uptime",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "dtdurations",
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "none",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_uptime_seconds", "legendFormat": "Uptime", "refId": "A", "instant": true }
+        {
+          "expr": "librefang_uptime_seconds",
+          "legendFormat": "Uptime",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Active Agents",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 10 },
-            { "color": "red", "value": 50 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_agents_active", "legendFormat": "Active", "refId": "A" }
+        {
+          "expr": "librefang_agents_active",
+          "legendFormat": "Active",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Total Agents",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "none",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_agents_total", "legendFormat": "Total", "refId": "A", "instant": true }
+        {
+          "expr": "librefang_agents_total",
+          "legendFormat": "Total",
+          "refId": "A",
+          "instant": true
+        }
       ]
     },
     {
       "title": "Active Sessions",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 5 },
-            { "color": "red", "value": 20 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_active_sessions", "legendFormat": "Sessions", "refId": "A" }
+        {
+          "expr": "librefang_active_sessions",
+          "legendFormat": "Sessions",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Cost Today (USD)",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 20, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
           "decimals": 4,
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 1 },
-            { "color": "red", "value": 10 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_cost_usd_today", "legendFormat": "Cost", "refId": "A" }
+        {
+          "expr": "librefang_cost_usd_today",
+          "legendFormat": "Cost",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Panics",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 3 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 3
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 1 },
-            { "color": "red", "value": 100 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_panics_total", "legendFormat": "Panics", "refId": "A" }
+        {
+          "expr": "librefang_panics_total",
+          "legendFormat": "Panics",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Restarts",
       "type": "stat",
-      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 3 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 3
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "red", "value": 1 }
-          ]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       },
       "targets": [
-        { "expr": "librefang_restarts_total", "legendFormat": "Restarts", "refId": "A" }
+        {
+          "expr": "librefang_restarts_total",
+          "legendFormat": "Restarts",
+          "refId": "A"
+        }
       ]
     },
     {
       "title": "Panics & Restarts Over Time",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "drawStyle": "line",
@@ -218,32 +529,90 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "unit": "short"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Panics" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Restarts" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Panics"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Restarts"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_panics_total", "legendFormat": "Panics", "refId": "A" },
-        { "expr": "librefang_restarts_total", "legendFormat": "Restarts", "refId": "B" }
+        {
+          "expr": "librefang_panics_total",
+          "legendFormat": "Panics",
+          "refId": "A"
+        },
+        {
+          "expr": "librefang_restarts_total",
+          "legendFormat": "Restarts",
+          "refId": "B"
+        }
       ]
     },
     {
       "title": "Active vs Total Agents",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "librefang-prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "librefang-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "drawStyle": "line",
@@ -252,29 +621,85 @@
             "pointSize": 5,
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "unit": "short"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Active" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Total" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Active"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        { "expr": "librefang_agents_active", "legendFormat": "Active", "refId": "A" },
-        { "expr": "librefang_agents_total", "legendFormat": "Total", "refId": "B" }
+        {
+          "expr": "librefang_agents_active",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "expr": "librefang_agents_total",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
       ]
     }
   ],
   "schemaVersion": 39,
-  "tags": ["librefang", "overview"],
-  "templating": { "list": [] },
-  "time": { "from": "now-1h", "to": "now" },
+  "tags": [
+    "librefang",
+    "overview"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "LibreFang Overview",

--- a/deploy/grafana/provisioning/datasources/jaeger.yml
+++ b/deploy/grafana/provisioning/datasources/jaeger.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+datasources:
+  - name: Jaeger
+    type: jaeger
+    uid: librefang-jaeger
+    access: proxy
+    # Jaeger's all-in-one image serves both the UI and the query API on
+    # 16686. Grafana's jaeger datasource talks to the same port over the
+    # docker bridge, so 16686 stays open to the host (UI access) AND is
+    # reused as the Grafana datasource backend.
+    url: http://jaeger:16686
+    editable: false
+    jsonData:
+      # Same cross-link as the Tempo datasource: from a span, jump back
+      # into Prometheus filtered by the service/operation labels.
+      tracesToMetrics:
+        datasourceUid: librefang-prometheus
+      # Surface the service-deps graph view inside Grafana's trace
+      # explorer (separate from Jaeger UI's "System Architecture" page).
+      nodeGraph:
+        enabled: true

--- a/deploy/grafana/provisioning/datasources/loki.yml
+++ b/deploy/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,27 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    uid: librefang-loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      # Once the daemon stamps trace_id into log lines (planned in a
+      # follow-up Rust-side PR), this regex extracts it and turns it
+      # into a clickable link that opens the matching trace in Tempo.
+      # Until then, the field stays inert — but the wiring is here so
+      # no Grafana provisioning change is needed when the daemon
+      # change lands.
+      derivedFields:
+        - name: trace_id
+          datasourceUid: librefang-tempo
+          matcherRegex: 'trace_id="?([0-9a-f]{32})"?'
+          url: "$${__value.raw}"
+          urlDisplayLabel: "View trace in Tempo"
+        - name: trace_id_jaeger
+          datasourceUid: librefang-jaeger
+          matcherRegex: 'trace_id="?([0-9a-f]{32})"?'
+          url: "$${__value.raw}"
+          urlDisplayLabel: "View trace in Jaeger"

--- a/deploy/loki/loki-config.yaml
+++ b/deploy/loki/loki-config.yaml
@@ -1,0 +1,50 @@
+# Grafana Loki config for LibreFang's local dev stack.
+#
+# Single-binary mode with filesystem storage. Receives log lines from
+# Alloy on the HTTP API (3100) and serves them back to Grafana through
+# the same port. Retention and compaction use built-in defaults — fine
+# for local dev, tune for anything that runs more than a few days.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: warn
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+
+# Loki refuses to ingest logs older than `reject_old_samples_max_age` by
+# default (default 168h), which is fine for live tailing but bites when
+# replaying a daemon log file that's been sitting around. Bump it for
+# local dev so backfills don't silently drop.
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 720h
+  allow_structured_metadata: true

--- a/deploy/otel-collector/config.yaml
+++ b/deploy/otel-collector/config.yaml
@@ -1,7 +1,8 @@
 # OpenTelemetry Collector config for LibreFang's local dev stack.
 #
 # Receives OTLP traces + metrics from LibreFang on 4317 (gRPC) / 4318 (HTTP).
-# - Traces fan out to Tempo (for Grafana search) AND stdout (debug visibility).
+# - Traces fan out to Tempo (Grafana correlation), Jaeger (trace-debug UI)
+#   AND stdout (debug visibility).
 # - Metrics are exposed on the Prometheus scrape endpoint :8889.
 
 receivers:
@@ -27,13 +28,20 @@ exporters:
     endpoint: tempo:4317
     tls:
       insecure: true
+  # Mirror traces to Jaeger's all-in-one OTLP receiver. Same plaintext
+  # bridge as Tempo. Tempo stays the long-term store (Grafana correlation);
+  # Jaeger gives the trace-debugging UI (waterfall, diff, deps) at :16686.
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlp/tempo]
+      exporters: [debug, otlp/tempo, otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/deploy/otel-collector/config.yaml
+++ b/deploy/otel-collector/config.yaml
@@ -13,6 +13,13 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
+extensions:
+  # health_check exposes /, /health/status etc. on 13133. Used by docker
+  # compose's healthcheck so dependents (prometheus, grafana) only start
+  # after the collector is actually accepting OTLP traffic.
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 processors:
   batch: {}
 
@@ -37,6 +44,7 @@ exporters:
       insecure: true
 
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]

--- a/docs/src/app/architecture/page.mdx
+++ b/docs/src/app/architecture/page.mdx
@@ -98,11 +98,15 @@ librefang/
 ├── deploy/                    # Deployment configs
 │   ├── Dockerfile             #   Docker image
 │   ├── docker-compose.yml     #   Docker Compose
+│   ├── docker-compose.observability.yml  # Observability stack
+│   ├── OBSERVABILITY.md       #   Observability stack guide
 │   ├── fly/                   #   Fly.io (fly.toml + deploy.sh)
 │   ├── railway/               #   Railway (railway.json)
 │   ├── render.yaml            #   Render
 │   ├── gcp/                   #   GCP Terraform
 │   ├── librefang.service      #   systemd unit
+│   ├── otel-collector/        #   OpenTelemetry Collector config
+│   ├── tempo/                 #   Grafana Tempo (trace store)
 │   ├── grafana/               #   Grafana dashboards
 │   └── prometheus/            #   Prometheus config
 ├── docs/                      # Documentation site (Next.js)

--- a/docs/src/app/architecture/page.mdx
+++ b/docs/src/app/architecture/page.mdx
@@ -109,6 +109,8 @@ librefang/
 │   ├── worker/                #   Worker deployment configs
 │   ├── otel-collector/        #   OpenTelemetry Collector config
 │   ├── tempo/                 #   Grafana Tempo (trace store)
+│   ├── loki/                  #   Grafana Loki (log store)
+│   ├── alloy/                 #   Grafana Alloy (log collector)
 │   ├── grafana/               #   Grafana dashboards
 │   └── prometheus/            #   Prometheus config
 ├── docs/                      # Documentation site (Next.js)

--- a/docs/src/app/architecture/page.mdx
+++ b/docs/src/app/architecture/page.mdx
@@ -97,6 +97,7 @@ librefang/
 │   └── cli-npm/               #   @librefang/cli (npm wrapper)
 ├── deploy/                    # Deployment configs
 │   ├── Dockerfile             #   Docker image
+│   ├── docker-entrypoint.sh   #   Container entrypoint
 │   ├── docker-compose.yml     #   Docker Compose
 │   ├── docker-compose.observability.yml  # Observability stack
 │   ├── OBSERVABILITY.md       #   Observability stack guide
@@ -105,6 +106,7 @@ librefang/
 │   ├── render.yaml            #   Render
 │   ├── gcp/                   #   GCP Terraform
 │   ├── librefang.service      #   systemd unit
+│   ├── worker/                #   Worker deployment configs
 │   ├── otel-collector/        #   OpenTelemetry Collector config
 │   ├── tempo/                 #   Grafana Tempo (trace store)
 │   ├── grafana/               #   Grafana dashboards

--- a/docs/src/app/zh/architecture/page.mdx
+++ b/docs/src/app/zh/architecture/page.mdx
@@ -98,11 +98,15 @@ librefang/
 ├── deploy/                    # 部署配置
 │   ├── Dockerfile             #   Docker 镜像
 │   ├── docker-compose.yml     #   Docker Compose
+│   ├── docker-compose.observability.yml  # 可观测性栈
+│   ├── OBSERVABILITY.md       #   可观测性栈使用指南
 │   ├── fly/                   #   Fly.io (fly.toml + deploy.sh)
 │   ├── railway/               #   Railway (railway.json)
 │   ├── render.yaml            #   Render
 │   ├── gcp/                   #   GCP Terraform
 │   ├── librefang.service      #   systemd 服务单元
+│   ├── otel-collector/        #   OpenTelemetry Collector 配置
+│   ├── tempo/                 #   Grafana Tempo（trace 存储）
 │   ├── grafana/               #   Grafana 仪表板
 │   └── prometheus/            #   Prometheus 配置
 ├── docs/                      # 文档站（Next.js）

--- a/docs/src/app/zh/architecture/page.mdx
+++ b/docs/src/app/zh/architecture/page.mdx
@@ -109,6 +109,8 @@ librefang/
 │   ├── worker/                #   Worker 部署配置
 │   ├── otel-collector/        #   OpenTelemetry Collector 配置
 │   ├── tempo/                 #   Grafana Tempo（trace 存储）
+│   ├── loki/                  #   Grafana Loki（log 存储）
+│   ├── alloy/                 #   Grafana Alloy（log 收集器）
 │   ├── grafana/               #   Grafana 仪表板
 │   └── prometheus/            #   Prometheus 配置
 ├── docs/                      # 文档站（Next.js）

--- a/docs/src/app/zh/architecture/page.mdx
+++ b/docs/src/app/zh/architecture/page.mdx
@@ -97,6 +97,7 @@ librefang/
 │   └── cli-npm/               #   @librefang/cli (npm 包装器)
 ├── deploy/                    # 部署配置
 │   ├── Dockerfile             #   Docker 镜像
+│   ├── docker-entrypoint.sh   #   容器启动脚本
 │   ├── docker-compose.yml     #   Docker Compose
 │   ├── docker-compose.observability.yml  # 可观测性栈
 │   ├── OBSERVABILITY.md       #   可观测性栈使用指南
@@ -105,6 +106,7 @@ librefang/
 │   ├── render.yaml            #   Render
 │   ├── gcp/                   #   GCP Terraform
 │   ├── librefang.service      #   systemd 服务单元
+│   ├── worker/                #   Worker 部署配置
 │   ├── otel-collector/        #   OpenTelemetry Collector 配置
 │   ├── tempo/                 #   Grafana Tempo（trace 存储）
 │   ├── grafana/               #   Grafana 仪表板


### PR DESCRIPTION
## Summary
- Add Jaeger all-in-one to the local observability stack as a second trace backend alongside Tempo
- OTel collector now fans `traces` out to `[debug, otlp/tempo, otlp/jaeger]`
- Jaeger UI exposed at `http://localhost:16686`; OTLP receiver stays on the docker bridge (no extra host port)
- README updated with the Jaeger entry point and a note that the Jaeger container is required by the trace pipeline (not optional — the collector hard-references `otlp/jaeger`)
- Architecture page (en + zh) `deploy/` directory tree updated to surface the full observability stack

## Why
Tempo is the right long-term store and unlocks Grafana trace ↔ metric ↔ log correlation, but its trace viewer in Grafana is sparse compared to Jaeger's waterfall / span-diff / service-deps views — which matter most when debugging agent loops, tool-call chains, and LLM round-trips. Keeping both costs one extra container (~30MB compressed image, in-memory storage) and one host port. We don't have to pick.

## Test plan
- [x] `docker compose -f deploy/docker-compose.observability.yml up -d` brings up all 5 containers (otel-collector, tempo, prometheus, grafana, jaeger)
- [x] After collector restart, logs show `Everything is ready. Begin running and processing data.` with the new `otlp/jaeger` exporter loaded
- [x] `curl http://localhost:16686/api/services` returns `["librefang"]` after the daemon emits any HTTP request
- [x] `curl 'http://localhost:16686/api/traces?service=librefang&limit=1'` returns a trace with non-empty `spans[]` — i.e. trace detail is fully readable in the Jaeger UI, not just the service list
- [x] Tempo + Grafana correlation pipeline still works (existing trace pipeline unchanged for that exporter)
- [x] `docker compose -f deploy/docker-compose.observability.yml down` cleanly shuts down all containers

## Notes
- Jaeger uses in-memory storage by design — same lifecycle expectations as the existing `debug` exporter, fine for local dev. Persistent storage isn't needed since Tempo is already the durable backend.
- Jaeger container is **not optional**: the collector's `traces` pipeline hard-references `otlp/jaeger` as an exporter, so starting the stack without `jaeger` will leave the collector logging `ConnectionRefused` on every batch. To run a Tempo-only stack, comment out the `otlp/jaeger` exporter (and remove it from `service.pipelines.traces.exporters`) in `otel-collector/config.yaml` and drop the `jaeger` service from the compose file. README documents this.
- One harmless deprecation warn from collector v0.150 on startup: `"otlp" alias is deprecated; use "otlp_grpc" instead`. Affects both `otlp/tempo` and the new `otlp/jaeger` exporter; tracked separately.
