### PR TITLE
chore(kernel): drop LEGACY_TEAM_TAIL_MARKER fallback

### DIFF
--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -840,6 +840,41 @@ system_prompt = "BASE-WORKER"
     }
 
     #[test]
+    fn apply_team_block_ignores_legacy_unfenced_tail() {
+        // Lock-down for the LEGACY_TEAM_TAIL_MARKER cleanup. The pre-fence
+        // form (`\n\n## Your Team`) is no longer recognised by the strip
+        // logic, so a prompt carrying it gets a fresh fenced block appended
+        // alongside (not replacing the legacy text). If a future change
+        // reintroduces unfenced detection it should fail this assertion
+        // first — that's a deliberate design choice, not a regression.
+        //
+        // The duplicate is harmless: drift loop never repopulates the
+        // unfenced form, and any operator-visible `## Your Team` heading is
+        // the fresh fenced one. The only path to this state is a
+        // cross-version DB copy from pre-#3164 directly into a
+        // post-cleanup binary, which is not a supported upgrade flow.
+        let def = parse_hand(MULTI_AGENT_HAND, "");
+        let mut m = manifest_with_prompt(
+            "BASE\n\n## Your Team\n\n- **worker**: stale (use agent_send to message)",
+        );
+        apply_team_block_to_manifest(&mut m, "lead", &def);
+        let prompt = &m.model.system_prompt;
+        assert!(
+            prompt.contains("stale"),
+            "legacy unfenced text must NOT be stripped after cleanup; got: {prompt}"
+        );
+        assert!(
+            prompt.contains("\n\n---\n\n## Your Team\n\n"),
+            "fresh fenced block must still be appended; got: {prompt}"
+        );
+        assert_eq!(
+            prompt.matches("## Your Team").count(),
+            2,
+            "exactly two team headings: the leftover legacy one and the new fenced one; got: {prompt}"
+        );
+    }
+
+    #[test]
     fn apply_team_block_uses_invoke_hint_when_present() {
         let def = parse_hand(MULTI_AGENT_HAND, "");
         let mut m = manifest_with_prompt("BASE");

--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -307,26 +307,6 @@ const SKILL_REFERENCE_TAIL_MARKER: &str = "\n\n---\n\n## Reference Knowledge";
 /// match the marker and cause `find()` to truncate user-authored content.
 const TEAM_TAIL_MARKER: &str = "\n\n---\n\n## Your Team";
 
-/// Pre-fence form of the team marker, kept only for backwards-compatible
-/// strip on agents that were activated before the fence was added. Detection
-/// (`find()`) checks the fenced form first; this is only consulted when the
-/// fenced form is absent. Re-append always uses the fenced form, so a single
-/// drift cycle migrates each agent forward and this constant becomes dead
-/// once every persisted prompt has been re-rendered.
-///
-/// SAFETY: this string is a substring of [`TEAM_TAIL_MARKER`]
-/// (`"\n\n---\n\n## Your Team"`), so a naive `find()` against this constant
-/// will match a fenced prompt and truncate too late, dropping the
-/// `\n\n---\n\n` fence into the visible prompt. Every caller MUST check
-/// [`TEAM_TAIL_MARKER`] first and only fall back to this when the fenced
-/// form is absent (see [`apply_team_block_to_manifest`]).
-///
-/// TODO(remove after migration window): once telemetry confirms every
-/// persisted prompt has been touched by at least one drift cycle (post-#3164
-/// rollout), drop this constant and its fallback branch. Tracking issue:
-/// see `LEGACY_TEAM_TAIL_MARKER` references for the cleanup sites.
-const LEGACY_TEAM_TAIL_MARKER: &str = "\n\n## Your Team";
-
 /// Append (or refresh) the rendered `## User Configuration` block on a
 /// manifest's `model.system_prompt` from a hand's `[[settings]]` schema +
 /// instance config.
@@ -454,22 +434,12 @@ pub(super) fn apply_team_block_to_manifest(
     // Always strip first — covers the case where the hand was edited from
     // multi-agent down to single-agent so the stale Team tail must drop.
     //
-    // Check the fenced marker first; fall back to the pre-fence form so
-    // prompts persisted before the fence was introduced still get cleaned
-    // up. Once stripped + re-appended, the prompt carries the fenced form
-    // and the legacy lookup never matches again for that agent.
-    //
     // Ordering note: this helper is the LAST tail appended at activation
     // (settings -> reference -> team). Truncating at the team marker only
     // drops the team block itself — no later tail can be lost. If a future
     // change inserts a new tail after team, this strip will need to widen
     // (or that tail's helper must run before this one).
-    let strip_idx = manifest
-        .model
-        .system_prompt
-        .find(TEAM_TAIL_MARKER)
-        .or_else(|| manifest.model.system_prompt.find(LEGACY_TEAM_TAIL_MARKER));
-    if let Some(idx) = strip_idx {
+    if let Some(idx) = manifest.model.system_prompt.find(TEAM_TAIL_MARKER) {
         manifest.model.system_prompt.truncate(idx);
     }
 
@@ -866,33 +836,6 @@ system_prompt = "BASE-WORKER"
         assert!(
             !prompt.contains("- **lead**:"),
             "self must not appear in own team list"
-        );
-    }
-
-    #[test]
-    fn apply_team_block_migrates_legacy_unfenced_tail_in_place() {
-        // Regression: agents activated before the fence was added carry the
-        // pre-fence form (`\n\n## Your Team`). Re-rendering must strip the
-        // legacy tail in place and re-append using the fenced form so a
-        // single drift cycle migrates the persisted blob forward.
-        let def = parse_hand(MULTI_AGENT_HAND, "");
-        let mut m = manifest_with_prompt(
-            "BASE\n\n## Your Team\n\n- **worker**: stale text (use agent_send to message)",
-        );
-        apply_team_block_to_manifest(&mut m, "lead", &def);
-        let prompt = &m.model.system_prompt;
-        assert!(
-            !prompt.contains("stale text"),
-            "legacy unfenced tail must be stripped, not duplicated"
-        );
-        assert_eq!(
-            prompt.matches("## Your Team").count(),
-            1,
-            "exactly one team block must remain after migration"
-        );
-        assert!(
-            prompt.contains("\n\n---\n\n## Your Team\n\n"),
-            "migrated prompt must carry the fenced form"
         );
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #3164. Drops `LEGACY_TEAM_TAIL_MARKER` and the unfenced-form fallback branch in `apply_team_block_to_manifest` now that #3164 is merged.

## Why
The legacy `\n\n## Your Team` strip path was added in #3164 to migrate hand-derived agents persisted before the fence was introduced. The `manifest_for_diff` projection (also added in #3164) deliberately does not strip the legacy form, so any persisted prompt carrying it will look "different" from the disk TOML on the very first boot post-#3164 and get rewritten with the fenced form. The fallback is single-use; once #3164 has shipped and any active instance has booted at least once with that code, no remaining DB blob carries the unfenced form.

User base is small enough that we don't need a multi-release migration window or telemetry confirmation — going straight to the cleanup as a follow-up.

## What's removed
- `LEGACY_TEAM_TAIL_MARKER` constant + its `SAFETY:` / `TODO(remove after migration window)` doc block
- the `.or_else(... LEGACY_TEAM_TAIL_MARKER)` fallback in `apply_team_block_to_manifest` — now a plain fenced `find()` + `truncate()`
- the `apply_team_block_migrates_legacy_unfenced_tail_in_place` test (the migration code path is gone)

## What's added
A regression test (`apply_team_block_ignores_legacy_unfenced_tail`) that locks in the post-cleanup behavior: a prompt carrying the pre-fence form keeps it untouched and gets a fresh fenced block appended alongside (i.e. two `## Your Team` headings end up in the prompt). Any future change that reintroduces unfenced detection will fail this assertion first — making the trade-off explicit.

Net `-58 / +37` lines (was `-58 / +1` before the lock-down test).

## Edge case (corrected)
"DB blob carrying the unfenced form is copied directly into a post-cleanup binary without ever passing through a #3164-era version" (e.g. cross-version DB snapshot restore).

The previous draft of this PR claimed the duplicate would be "self-healing on the next `hand activate`" — that is **wrong**. The fenced strip only matches `\n\n---\n\n## Your Team`, so it lands on the new fenced block and truncates from there; the leading unfenced block is never reached. Re-rendering then appends another fenced block, leaving the prompt with one stale unfenced section followed by one fresh fenced section. This state is stable, not self-healing.

The duplicate is harmless in practice: the fresh fenced block carries the current peer roster and is what the agent reads top-down; the leftover legacy text is just visual clutter. Cross-version DB copy isn't a supported upgrade path so optimising for it isn't worth a migration script. If it ever becomes a real concern the fix is to widen `manifest_for_diff` to also strip the unfenced form so drift fires and the activation path produces a clean rewrite.

## Test plan
- [x] `cargo test -p librefang-kernel --lib manifest_helpers` — 24 passed (incl. new `apply_team_block_ignores_legacy_unfenced_tail` lock-down)
- [x] `cargo clippy -p librefang-kernel --tests --lib -- -D warnings` — clean
- [x] `cargo test -p librefang-kernel --lib boot_drift` — all 4 boot drift integration tests still pass
