### PR TITLE
fix(dashboard): surface provider model list above the fold

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -613,6 +613,28 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
           </div>
         </div>
 
+        {/* Model list — placed right under the count so users see what
+            actually counts toward the number rather than scrolling past
+            properties to find it. No inner scroll: the drawer's own
+            overflow-y-auto handles overflow. */}
+        <div className="space-y-3">
+          <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("providers.provider_models")}</h3>
+          {modelsQuery.isLoading ? (
+            <p className="text-xs text-text-dim">{t("common.loading")}</p>
+          ) : models.length === 0 ? (
+            <p className="text-xs text-text-dim">{t("providers.no_models_for_provider")}</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+              {models.map(m => (
+                <div key={m.id} className="flex items-center gap-2 p-2 rounded-lg bg-main/20 text-xs">
+                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${m.available ? "bg-success" : "bg-text-dim/30"}`} />
+                  <span className="truncate font-mono">{m.display_name || m.id}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
         {/* Properties */}
         <div className="space-y-3">
           <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("common.properties")}</h3>
@@ -654,25 +676,6 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
               </div>
             )}
           </div>
-        </div>
-
-        {/* Model list */}
-        <div className="space-y-3">
-          <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("providers.provider_models")}</h3>
-          {modelsQuery.isLoading ? (
-            <p className="text-xs text-text-dim">{t("common.loading")}</p>
-          ) : models.length === 0 ? (
-            <p className="text-xs text-text-dim">{t("providers.no_models_for_provider")}</p>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 max-h-48 overflow-y-auto">
-              {models.map(m => (
-                <div key={m.id} className="flex items-center gap-2 p-2 rounded-lg bg-main/20 text-xs">
-                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${m.available ? "bg-success" : "bg-text-dim/30"}`} />
-                  <span className="truncate font-mono">{m.display_name || m.id}</span>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
 
         {provider.error_message && (


### PR DESCRIPTION
## Summary

Follow-up to #3175. The Providers page drawer (introduced as the `drawer-right` variant) already rendered the per-provider model list, but it sat **below** the Properties section (Base URL, API Key, Status, Health, Key required, Last test). Users clicking a provider expecting to see "which models are available" had to scroll past every property line to find the list.

## Fix

- Move the model list section directly under the Stats card so it sits next to the count (natural pairing).
- Drop the `max-h-48 overflow-y-auto` inner scroll on the model grid. The drawer's outer `overflow-y-auto` is the single scroll source; the inner one was the same nested-scroll papercut the drawer rollout already swatted elsewhere.

## Test plan

- [ ] Open ProvidersPage, click a provider with multiple models → drawer slides in → both the count and the model list are visible without further scrolling on a typical viewport
- [ ] Provider with many models — only the outer drawer scrolls
- [ ] Provider with zero models — empty state still renders in the same position
- [ ] CI green
