### PR TITLE
fix(vault): wire OS keyring (libsecret/Keychain/Credential Manager)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,11 @@ tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip",
 # Home directory resolution
 dirs = "6"
 
+# OS keyring access — libsecret on Linux, Keychain on macOS, Credential Manager
+# on Windows. Falls back to the file-based AES-256-GCM keyring in vault.rs if
+# the OS keyring is genuinely unavailable.
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+
 # YAML parsing
 serde_yaml = "0.9"
 

--- a/crates/librefang-extensions/Cargo.toml
+++ b/crates/librefang-extensions/Cargo.toml
@@ -32,6 +32,9 @@ base64 = { workspace = true }
 aes-gcm = { workspace = true }
 argon2 = { workspace = true }
 
+# OS keyring (libsecret / Keychain / Credential Manager)
+keyring = { workspace = true }
+
 [dev-dependencies]
 tokio-test = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -21,8 +21,10 @@ use zeroize::Zeroizing;
 /// Service name for OS keyring storage.
 #[cfg(not(test))]
 const KEYRING_SERVICE: &str = "librefang-vault";
-/// Username for OS keyring (used by platform keyring backends).
-#[allow(dead_code)]
+/// Username for OS keyring entry. Each librefang install stores a single
+/// master key per host, so the username is a fixed sentinel — the keyring
+/// crate's `Entry` constructor needs both a service and a username regardless.
+#[cfg(not(test))]
 const KEYRING_USER: &str = "master-key";
 /// Env var fallback for vault key.
 const VAULT_KEY_ENV: &str = "LIBREFANG_VAULT_KEY";
@@ -431,10 +433,35 @@ struct KeyringFile {
     ciphertext: String,
 }
 
-/// Store the master key in the OS keyring (file-based fallback with AES-256-GCM).
+/// Store the master key in the OS keyring (libsecret on Linux, Keychain on
+/// macOS, Credential Manager on Windows). Falls back to a file-based
+/// AES-256-GCM wrapped store only when the OS keyring is genuinely
+/// unavailable (e.g. headless Linux without a Secret Service daemon).
 fn store_keyring_key(key_b64: &str) -> Result<(), String> {
     #[cfg(not(test))]
     {
+        // Try the OS keyring first. The previous behaviour silently dropped
+        // through to the file fallback even on hosts that had a working
+        // keyring — see issue #3178.
+        match keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER) {
+            Ok(entry) => match entry.set_password(key_b64) {
+                Ok(()) => {
+                    debug!("Stored master key in OS keyring");
+                    return Ok(());
+                }
+                Err(e) => {
+                    debug!(
+                        "OS keyring set_password failed ({e}) — falling back to file-based store"
+                    );
+                }
+            },
+            Err(e) => {
+                debug!(
+                    "OS keyring entry initialisation failed ({e}) — falling back to file-based store"
+                );
+            }
+        }
+
         // File-based fallback — wraps the master key with AES-256-GCM using an
         // Argon2id-derived wrapping key from the machine fingerprint.
         let keyring_path = dirs::data_local_dir()
@@ -489,10 +516,28 @@ fn store_keyring_key(key_b64: &str) -> Result<(), String> {
     }
 }
 
-/// Load the master key from the OS keyring (file-based fallback).
+/// Load the master key, preferring the OS keyring and falling back to the
+/// file-based AES-256-GCM wrapped store. Symmetric with `store_keyring_key`.
 fn load_keyring_key() -> Result<Zeroizing<String>, String> {
     #[cfg(not(test))]
     {
+        // OS keyring first (issue #3178).
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_USER) {
+            match entry.get_password() {
+                Ok(s) => {
+                    debug!("Loaded master key from OS keyring");
+                    return Ok(Zeroizing::new(s));
+                }
+                Err(keyring::Error::NoEntry) => {
+                    // Empty keyring is normal for a host that previously stored
+                    // the key in the file fallback — drop through silently.
+                }
+                Err(e) => {
+                    debug!("OS keyring get_password failed ({e}) — trying file-based fallback");
+                }
+            }
+        }
+
         let keyring_path = dirs::data_local_dir()
             .unwrap_or_else(std::env::temp_dir)
             .join("librefang")


### PR DESCRIPTION
## Summary

Closes #3178.

The vault docs (`docs/src/app/security/network-api/page.mdx`, `docs/src/app/architecture/security/page.mdx`) promised:

> The vault uses AES-256-GCM encryption with a master key stored in the OS keyring (macOS Keychain / Windows Credential Manager / Linux Secret Service)…

But `store_keyring_key` / `load_keyring_key` in `vault.rs` only ever exercised the file-based AES-256-GCM fallback path. Every `librefang init` on Linux printed:

```
WARN OS keyring unavailable — falling back to file-based key storage at "/home/.../.keyring".
```

…even when `gnome-keyring` + `libsecret` were running fine. Contradicts the docs; unnerving for security-conscious users.

The previous developer had even reserved a `KEYRING_USER = "master-key"` constant gated under `#[allow(dead_code)]` — the rest of the OS-keyring wiring just never landed.

## Fix

- Add `keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }` to the workspace and to `librefang-extensions`. Covers macOS Keychain, Windows Credential Manager, and libsecret-based Linux Secret Service implementations.
- `store_keyring_key`: try `keyring::Entry::set_password` first; only fall back to the file-based wrapped store on failure. The existing `WARN OS keyring unavailable` line is now scoped to that real-fallback path so it no longer fires on healthy hosts.
- `load_keyring_key`: try `keyring::Entry::get_password` first. `NoEntry` drops through silently to the file path so existing installs that previously wrote a fallback keep loading without WARN noise; other errors are `debug!`-logged and the file path is tried as a last resort.

## Test plan

- [ ] Manual on macOS: fresh `librefang init` → no fallback WARN → master key visible in **Keychain Access** under service `librefang-vault`, account `master-key`. Subsequent runs unlock vault from Keychain.
- [ ] Manual on Linux with `gnome-keyring`: fresh `librefang init` → no fallback WARN → key visible via `secret-tool lookup service librefang-vault username master-key`. Headless install without Secret Service still falls back to file with the existing WARN.
- [ ] Manual on Linux without Secret Service (e.g. `unset DBUS_SESSION_BUS_ADDRESS`): WARN still fires, file fallback works.
- [ ] Migration: existing install with file-based keyring → upgrade → load still succeeds via file fallback (NoEntry on OS keyring, then file path).
- [ ] CI green
