### PR TITLE
refactor(channels): make bridge helpers crate-private

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1501,7 +1501,7 @@ fn leading_vocative_name(text: &str) -> Option<String> {
 /// the matched pattern — this captures the Beeper-screenshot case
 /// `"Caterina, chiedi al Signore..."` where "Signore" is mentioned but the
 /// turn is addressed to Caterina.
-pub fn is_vocative_trigger(text: &str, pattern: &str) -> bool {
+fn is_vocative_trigger(text: &str, pattern: &str) -> bool {
     if text.is_empty() || pattern.is_empty() {
         return false;
     }
@@ -1541,7 +1541,7 @@ pub fn is_vocative_trigger(text: &str, pattern: &str) -> bool {
 /// Heuristic: extract a leading `<Capitalized>[,!]` token and look it up
 /// (case-insensitively) in the participant roster. If found and not equal
 /// to `agent_name`, the turn is addressed to someone else.
-pub fn is_addressed_to_other_participant(
+fn is_addressed_to_other_participant(
     text: &str,
     participants: &[ParticipantRef],
     agent_name: &str,


### PR DESCRIPTION
## Summary
- `is_vocative_trigger` and `is_addressed_to_other_participant` in `crates/librefang-channels/src/bridge.rs` had no callers outside the file (only in-file production paths and child-module tests).
- Demoted both from `pub fn` to private — child test modules can still see private items in their parent, so no test changes required.
- Reduces public surface of the channels crate without behavior change.

Identified as part of an internal anti-bloat audit (cargo-machete + grep-based dead-pub scan across the 24-crate workspace).

## Test plan
- [x] `cargo build -p librefang-channels`
- [x] `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean
- [x] `cargo test -p librefang-channels --lib` — 800 passed / 0 failed
- [x] `cargo build --workspace --lib` — no other crate broke