### PR TITLE
refactor(runtime): remove unused public helpers

### DIFF
--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -3414,7 +3414,7 @@ fn validate_plugin_name(name: &str) -> LibreFangResult<()> {
     Ok(())
 }
 
-pub fn load_plugin(
+fn load_plugin(
     plugin_name: &str,
 ) -> LibreFangResult<(
     librefang_types::config::PluginManifest,
@@ -3557,25 +3557,6 @@ pub fn load_plugin(
     );
 
     Ok((manifest, resolved_hooks))
-}
-
-/// List all installed plugins in `~/.librefang/plugins/`.
-pub fn list_installed_plugins() -> Vec<librefang_types::config::PluginManifest> {
-    let dir = plugins_dir();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-
-    entries
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            if !entry.file_type().ok()?.is_dir() {
-                return None;
-            }
-            let name = entry.file_name().to_string_lossy().into_owned();
-            load_plugin(&name).ok().map(|(manifest, _)| manifest)
-        })
-        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -4808,14 +4789,6 @@ printf '{"type":"ingest_result","memories":[{"content":"full-path-runtime"}]}\n'
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not found"));
-    }
-
-    #[test]
-    fn test_list_installed_plugins_empty() {
-        // Should not panic even if the plugins dir doesn't exist
-        let plugins = list_installed_plugins();
-        // May or may not be empty depending on the environment
-        let _ = plugins;
     }
 
     #[test]

--- a/crates/librefang-runtime/src/dangerous_command.rs
+++ b/crates/librefang-runtime/src/dangerous_command.rs
@@ -280,18 +280,6 @@ impl DangerousCommandChecker {
 }
 
 // ---------------------------------------------------------------------------
-// Convenience free function
-// ---------------------------------------------------------------------------
-
-/// One-shot check with no session state.
-///
-/// Useful for quick call-sites that do not maintain a [`DangerousCommandChecker`].
-pub fn detect_dangerous_command(command: &str) -> CheckResult {
-    let checker = DangerousCommandChecker::new(ApprovalMode::Manual);
-    checker.check(command)
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -299,12 +287,16 @@ pub fn detect_dangerous_command(command: &str) -> CheckResult {
 mod tests {
     use super::*;
 
+    fn check(cmd: &str) -> CheckResult {
+        DangerousCommandChecker::new(ApprovalMode::Manual).check(cmd)
+    }
+
     fn safe(cmd: &str) -> bool {
-        matches!(detect_dangerous_command(cmd), CheckResult::Safe)
+        matches!(check(cmd), CheckResult::Safe)
     }
 
     fn dangerous(cmd: &str) -> bool {
-        matches!(detect_dangerous_command(cmd), CheckResult::Dangerous { .. })
+        matches!(check(cmd), CheckResult::Dangerous { .. })
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Three `pub` helpers in `librefang-runtime` had zero callers outside their own files:

- `detect_dangerous_command` (`dangerous_command.rs`) — only used by an in-file test; **deleted**, replaced with a small private helper colocated in the test module.
- `load_plugin` (`context_engine.rs`) — only same-file callers; **demoted to private**.
- `list_installed_plugins` (`context_engine.rs`) — only used by a trivial smoke test; both function and test **deleted**.

No external API change. Identified as part of an internal anti-bloat audit.

## Test plan
- [x] `cargo build -p librefang-runtime`
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean
- [x] `cargo test -p librefang-runtime --lib` — 1371 passed / 0 failed / 2 ignored
- [x] `cargo build --workspace --lib` — no other crate broke