### PR TITLE
refactor: merge duplicate type definitions across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1176,7 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1189,7 +1199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1694,6 +1704,27 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
 
 [[package]]
 name = "debugid"
@@ -3874,6 +3905,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,6 +4033,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -4146,6 +4201,7 @@ dependencies = [
  "librefang-channels",
  "librefang-extensions",
  "librefang-kernel",
+ "librefang-memory",
  "librefang-migrate",
  "librefang-runtime",
  "librefang-skills",
@@ -4213,6 +4269,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs 6.0.0",
+ "keyring",
  "librefang-runtime",
  "librefang-types",
  "rand 0.10.0",
@@ -4642,6 +4699,7 @@ dependencies = [
  "tracing",
  "unic-langid",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -7199,7 +7257,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -7227,7 +7285,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.21.1",
  "log",
@@ -7236,7 +7294,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7248,7 +7306,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -7257,7 +7315,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7420,12 +7478,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -8224,7 +8295,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -23,6 +23,7 @@ librefang-channels = { path = "../librefang-channels", default-features = false 
 librefang-migrate = { path = "../librefang-migrate" }
 librefang-skills = { path = "../librefang-skills" }
 librefang-extensions = { path = "../librefang-extensions" }
+librefang-memory = { path = "../librefang-memory" }
 zeroize = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/librefang-cli/src/tui/screens/usage.rs
+++ b/crates/librefang-cli/src/tui/screens/usage.rs
@@ -10,6 +10,14 @@ use ratatui::widgets::{Block, Borders, ListItem, ListState, Paragraph};
 use ratatui::Frame;
 
 // ── Data types ──────────────────────────────────────────────────────────────
+//
+// These are display-only projections of the canonical usage records that live
+// in `librefang-memory`. They drop fields the screen does not show
+// (`total_tool_calls` on summary; latency / total tokens on model rows) and
+// rename `call_count` → `total_calls` / `model` → `model_id` to match the UI
+// labels rendered below. Use the `From<&memory::…>` impls below when the data
+// originates in-process from the kernel; the daemon JSON path in
+// `tui/event.rs` reads the wire keys directly.
 
 #[derive(Clone, Default)]
 pub struct UsageSummary {
@@ -19,6 +27,19 @@ pub struct UsageSummary {
     pub total_calls: u64,
 }
 
+impl From<&librefang_memory::usage::UsageSummary> for UsageSummary {
+    fn from(s: &librefang_memory::usage::UsageSummary) -> Self {
+        // The memory side also tracks `total_tool_calls`, which the Summary
+        // screen does not surface today.
+        Self {
+            total_input_tokens: s.total_input_tokens,
+            total_output_tokens: s.total_output_tokens,
+            total_cost_usd: s.total_cost_usd,
+            total_calls: s.call_count,
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct ModelUsage {
     pub model_id: String,
@@ -26,6 +47,18 @@ pub struct ModelUsage {
     pub output_tokens: u64,
     pub cost_usd: f64,
     pub calls: u64,
+}
+
+impl From<&librefang_memory::usage::ModelUsage> for ModelUsage {
+    fn from(m: &librefang_memory::usage::ModelUsage) -> Self {
+        Self {
+            model_id: m.model.clone(),
+            input_tokens: m.total_input_tokens,
+            output_tokens: m.total_output_tokens,
+            cost_usd: m.total_cost_usd,
+            calls: m.call_count,
+        }
+    }
 }
 
 #[derive(Clone, Default)]

--- a/crates/librefang-extensions/src/oauth.rs
+++ b/crates/librefang-extensions/src/oauth.rs
@@ -5,13 +5,17 @@
 //! All tokens are stored in the credential vault with `Zeroizing<String>`.
 
 use crate::{ExtensionError, ExtensionResult, OAuthTemplate};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex};
 use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
+
+// Canonical OAuth token type lives in `librefang-types`. Re-export so existing
+// callers can keep their `extensions::oauth::OAuthTokens` import path.
+pub use librefang_types::oauth::OAuthTokens;
 
 /// Default OAuth client IDs for public PKCE flows.
 /// These are safe to embed — PKCE doesn't require a client_secret.
@@ -49,39 +53,6 @@ pub fn resolve_client_ids(
     }
 
     resolved
-}
-
-/// OAuth2 token response (raw from provider, for deserialization).
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OAuthTokens {
-    /// Access token for API calls.
-    pub access_token: String,
-    /// Refresh token for renewal (if provided).
-    #[serde(default)]
-    pub refresh_token: Option<String>,
-    /// Token type (usually "Bearer").
-    #[serde(default)]
-    pub token_type: String,
-    /// Seconds until access_token expires.
-    #[serde(default)]
-    pub expires_in: u64,
-    /// Scopes granted.
-    #[serde(default)]
-    pub scope: String,
-}
-
-impl OAuthTokens {
-    /// Get the access token as a Zeroizing string.
-    pub fn access_token_zeroizing(&self) -> Zeroizing<String> {
-        Zeroizing::new(self.access_token.clone())
-    }
-
-    /// Get the refresh token as a Zeroizing string.
-    pub fn refresh_token_zeroizing(&self) -> Option<Zeroizing<String>> {
-        self.refresh_token
-            .as_ref()
-            .map(|t| Zeroizing::new(t.clone()))
-    }
 }
 
 /// PKCE code verifier and challenge pair.

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -6732,7 +6732,7 @@ system_prompt = "You are a helpful assistant."
         // we must not touch the `force_session_wipe` / `resume_pending` flags
         // that belong to the persistent session path.
         {
-            use crate::session_policy::SessionResetPolicy as KernelPolicy;
+            use crate::session_policy::SessionResetPolicyExt;
             let effective_mode = session_mode_override.unwrap_or(entry.manifest.session_mode);
             // `New` mode creates a fresh ephemeral session_id on every call;
             // there is nothing persistent to reset, and mutating
@@ -6740,7 +6740,7 @@ system_prompt = "You are a helpful assistant."
             // for future persistent-mode invocations.
             let skip_reset = matches!(effective_mode, librefang_types::agent::SessionMode::New);
             if !skip_reset {
-                let policy: KernelPolicy = cfg.session.reset.clone().into();
+                let policy = cfg.session.reset.clone();
                 let last_active: std::time::SystemTime = entry.last_active.into();
                 if let Some(reason) = policy.should_reset(last_active, entry.force_session_wipe) {
                     tracing::info!(
@@ -6765,10 +6765,7 @@ system_prompt = "You are a helpful assistant."
                             "Failed to persist session after auto-reset"
                         );
                     }
-                    let types_reason: librefang_types::config::SessionResetReason = reason.into();
-                    let _ = self
-                        .registry
-                        .update_session_reset_state(agent_id, types_reason);
+                    let _ = self.registry.update_session_reset_state(agent_id, reason);
                     // Persist the updated entry so the reset state survives a crash.
                     // Other registry updates (update_skills, update_mcp_servers, etc.)
                     // follow the same pattern: update + save_agent.

--- a/crates/librefang-kernel/src/session_policy.rs
+++ b/crates/librefang-kernel/src/session_policy.rs
@@ -1,9 +1,12 @@
-//! Session auto-reset policy for the LibreFang kernel.
+//! Session auto-reset policy evaluation for the LibreFang kernel.
 //!
-//! Implements idle-timeout and daily fixed-time session reset strategies,
-//! mirroring the `SessionResetPolicy` logic from hermes-agent/gateway/session.py.
+//! The configuration types (`SessionResetPolicy`, `SessionResetMode`,
+//! `SessionResetReason`) live in `librefang_types::config` so that they can be
+//! deserialized from `config.toml` without any runtime dependency on the
+//! kernel.  This module re-exports those types and adds the runtime evaluation
+//! logic that decides when a session should be reset.
 //!
-//! # Strategies
+//! # Strategies (see [`SessionResetMode`])
 //! - `Off`   – no automatic reset (default, fully backward-compatible)
 //! - `Idle`  – reset when last-active is older than `idle_minutes`
 //! - `Daily` – reset once per day at a fixed local hour (`daily_at_hour`)
@@ -16,173 +19,110 @@
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use serde::{Deserialize, Serialize};
+// Canonical types live in `librefang-types`. Re-export under historical paths
+// so the rest of the kernel can keep using `session_policy::SessionResetPolicy`
+// / `SessionResetMode` / `SessionResetReason` unchanged.
+pub use librefang_types::config::{SessionResetMode, SessionResetPolicy, SessionResetReason};
 
 // ---------------------------------------------------------------------------
-// Public types
+// Reset evaluation extension trait
 // ---------------------------------------------------------------------------
 
-/// Which automatic-reset strategy is active.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ResetMode {
-    /// No automatic reset. Existing sessions persist indefinitely. (default)
-    #[default]
-    Off,
-    /// Reset after `idle_minutes` of inactivity.
-    Idle,
-    /// Reset once per day at `daily_at_hour` (local clock, 0-23).
-    Daily,
-    /// Reset when *either* idle or daily condition is satisfied.
-    Both,
-}
-
-/// Why a session was reset.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ResetReason {
-    /// Last-active exceeded `idle_minutes`.
-    Idle,
-    /// The daily fixed-time boundary was crossed.
-    Daily,
-    /// Session was flagged `suspended` (forced by operator / stuck-loop recovery).
-    Suspended,
-    /// Manual reset requested via API or CLI.
-    Manual,
-}
-
-impl std::fmt::Display for ResetReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Idle => f.write_str("idle"),
-            Self::Daily => f.write_str("daily"),
-            Self::Suspended => f.write_str("suspended"),
-            Self::Manual => f.write_str("manual"),
-        }
-    }
-}
-
-/// Per-agent (or global) session auto-reset policy.
-///
-/// The default is `mode = Off`, which keeps all pre-existing behaviour.
-///
-/// ```toml
-/// [session.reset]
-/// mode = "idle"
-/// idle_minutes = 1440   # 24 h
-///
-/// # or
-/// mode = "both"
-/// idle_minutes = 60
-/// daily_at_hour = 4
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct SessionResetPolicy {
-    /// Which strategy (or strategies) to apply.
-    pub mode: ResetMode,
-    /// Inactivity threshold in minutes for the `Idle` / `Both` modes.
-    /// Default: 1440 (24 hours).
-    pub idle_minutes: u64,
-    /// Hour of day (0-23, local clock) at which the `Daily` / `Both` reset fires.
-    /// Default: 4 (04:00 local).
-    pub daily_at_hour: u8,
-}
-
-impl Default for SessionResetPolicy {
-    fn default() -> Self {
-        Self {
-            mode: ResetMode::Off,
-            idle_minutes: 1440,
-            daily_at_hour: 4,
-        }
-    }
-}
-
-impl SessionResetPolicy {
+/// Runtime methods for [`SessionResetPolicy`].  Defined as an extension trait
+/// because the data type lives in `librefang-types` (which has no business
+/// logic) while the evaluation logic depends on the local clock and lives
+/// here.
+pub trait SessionResetPolicyExt {
     /// Evaluate whether a session should be reset.
     ///
     /// # Parameters
-    /// - `last_active`  – [`SystemTime`] of the last user/agent interaction.
-    /// - `suspended`    – when `true`, always returns [`ResetReason::Suspended`]
-    ///   regardless of the configured mode (hard-wipe flag).
+    /// - `last_active` – [`SystemTime`] of the last user/agent interaction.
+    /// - `suspended`   – when `true`, always returns
+    ///   [`SessionResetReason::Suspended`] regardless of the configured mode
+    ///   (hard-wipe flag).
     ///
     /// Returns `Some(reason)` if the session should be reset, `None` if it is
     /// still valid.
-    pub fn should_reset(&self, last_active: SystemTime, suspended: bool) -> Option<ResetReason> {
+    fn should_reset(&self, last_active: SystemTime, suspended: bool) -> Option<SessionResetReason>;
+}
+
+impl SessionResetPolicyExt for SessionResetPolicy {
+    fn should_reset(&self, last_active: SystemTime, suspended: bool) -> Option<SessionResetReason> {
         // The `suspended` flag is a hard forced-wipe signal that bypasses
         // every other check.
         if suspended {
-            return Some(ResetReason::Suspended);
+            return Some(SessionResetReason::Suspended);
         }
 
-        if self.mode == ResetMode::Off {
+        if self.mode == SessionResetMode::Off {
             return None;
         }
 
         let now = SystemTime::now();
 
-        if matches!(self.mode, ResetMode::Idle | ResetMode::Both) {
+        if matches!(self.mode, SessionResetMode::Idle | SessionResetMode::Both) {
             let idle_threshold = Duration::from_secs(self.idle_minutes * 60);
             if now
                 .duration_since(last_active)
                 .map(|elapsed| elapsed >= idle_threshold)
                 .unwrap_or(false)
             {
-                return Some(ResetReason::Idle);
+                return Some(SessionResetReason::Idle);
             }
         }
 
-        if matches!(self.mode, ResetMode::Daily | ResetMode::Both) {
+        if matches!(self.mode, SessionResetMode::Daily | SessionResetMode::Both) {
             // Guard: daily_at_hour must be 0-23.  Values ≥ 24 would produce a
             // target_secs_into_day that exceeds 86 400, causing the boundary
             // calculation to pick yesterday's slot every time and fire on
             // every invocation.  Treat out-of-range values as misconfiguration
             // and skip the check entirely rather than silently misfiring.
-            if self.daily_at_hour <= 23 && self.crossed_daily_boundary(last_active, now) {
-                return Some(ResetReason::Daily);
+            if self.daily_at_hour <= 23 && crossed_daily_boundary(self, last_active, now) {
+                return Some(SessionResetReason::Daily);
             }
         }
 
         None
     }
+}
 
-    /// Returns `true` when `last_active` was before the most-recent occurrence
-    /// of `daily_at_hour:00:00` (local time), and that occurrence is ≤ `now`.
-    ///
-    /// Implementation: work in UTC seconds, offset by the local UTC offset
-    /// inferred from [`chrono::Local`] when that crate is available.  We keep
-    /// the dependency surface small by computing the local offset once per call
-    /// via the system timezone.
-    fn crossed_daily_boundary(&self, last_active: SystemTime, now: SystemTime) -> bool {
-        // Convert SystemTime → seconds since UNIX epoch.
-        let last_secs = system_time_to_secs(last_active);
-        let now_secs = system_time_to_secs(now);
+/// Returns `true` when `last_active` was before the most-recent occurrence
+/// of `daily_at_hour:00:00` (local time), and that occurrence is ≤ `now`.
+///
+/// Implementation: work in UTC seconds, offset by the local UTC offset
+/// inferred from [`chrono::Local`].
+fn crossed_daily_boundary(
+    policy: &SessionResetPolicy,
+    last_active: SystemTime,
+    now: SystemTime,
+) -> bool {
+    // Convert SystemTime → seconds since UNIX epoch.
+    let last_secs = system_time_to_secs(last_active);
+    let now_secs = system_time_to_secs(now);
 
-        // Determine the local UTC offset in seconds (sign: east = positive).
-        let utc_offset_secs = local_utc_offset_secs();
+    // Determine the local UTC offset in seconds (sign: east = positive).
+    let utc_offset_secs = local_utc_offset_secs();
 
-        // Local day seconds for `now` and `last_active`.
-        let now_local = now_secs + utc_offset_secs;
-        let last_local = last_secs + utc_offset_secs;
+    // Local day seconds for `now` and `last_active`.
+    let now_local = now_secs + utc_offset_secs;
+    let last_local = last_secs + utc_offset_secs;
 
-        let secs_per_day: i64 = 86_400;
-        let target_secs_into_day = (self.daily_at_hour as i64) * 3600;
+    let secs_per_day: i64 = 86_400;
+    let target_secs_into_day = (policy.daily_at_hour as i64) * 3600;
 
-        // Midnight (00:00) of the current local day (epoch-aligned).
-        let now_day_start = (now_local / secs_per_day) * secs_per_day;
-        let reset_today = now_day_start + target_secs_into_day;
+    // Midnight (00:00) of the current local day (epoch-aligned).
+    let now_day_start = (now_local / secs_per_day) * secs_per_day;
+    let reset_today = now_day_start + target_secs_into_day;
 
-        // Most-recent reset boundary that has already passed.
-        let last_boundary = if now_local >= now_day_start + target_secs_into_day {
-            reset_today
-        } else {
-            reset_today - secs_per_day
-        };
+    // Most-recent reset boundary that has already passed.
+    let last_boundary = if now_local >= now_day_start + target_secs_into_day {
+        reset_today
+    } else {
+        reset_today - secs_per_day
+    };
 
-        // `last_active` is before that boundary.
-        last_local < last_boundary
-    }
+    // `last_active` is before that boundary.
+    last_local < last_boundary
 }
 
 // ---------------------------------------------------------------------------
@@ -196,59 +136,12 @@ fn system_time_to_secs(t: SystemTime) -> i64 {
     }
 }
 
-/// Approximate local UTC offset by comparing `std::time::SystemTime::now()`
-/// to `chrono::Local::now()` — but since we can't take chrono as a dep from
-/// inside the kernel without checking, we use a fallback approach:
-/// read the `TZ` environment variable and parse a numeric offset, or use 0.
-///
-/// In practice LibreFang runs in environments where either chrono is already
-/// a transitive dep (it is, via `librefang-types`) or the local offset is UTC.
-/// For correctness we try chrono first via the types crate.
+/// Local UTC offset in seconds via `chrono::Local`. `chrono` is already a
+/// transitive dependency through `librefang-types`.
 fn local_utc_offset_secs() -> i64 {
-    // chrono is a dependency of librefang-types which is always in scope.
     use chrono::{Local, Offset};
     let offset = Local::now().offset().fix();
     offset.local_minus_utc() as i64
-}
-
-// ---------------------------------------------------------------------------
-// Conversions from librefang-types config types
-// ---------------------------------------------------------------------------
-
-impl From<librefang_types::config::SessionResetMode> for ResetMode {
-    fn from(m: librefang_types::config::SessionResetMode) -> Self {
-        use librefang_types::config::SessionResetMode as T;
-        match m {
-            T::Off => ResetMode::Off,
-            T::Idle => ResetMode::Idle,
-            T::Daily => ResetMode::Daily,
-            T::Both => ResetMode::Both,
-        }
-    }
-}
-
-impl From<librefang_types::config::SessionResetPolicy> for SessionResetPolicy {
-    fn from(p: librefang_types::config::SessionResetPolicy) -> Self {
-        SessionResetPolicy {
-            mode: p.mode.into(),
-            idle_minutes: p.idle_minutes,
-            daily_at_hour: p.daily_at_hour,
-        }
-    }
-}
-
-/// Convert a kernel-internal [`ResetReason`] into the types-layer
-/// [`librefang_types::config::SessionResetReason`] for storage on `AgentEntry`.
-impl From<ResetReason> for librefang_types::config::SessionResetReason {
-    fn from(r: ResetReason) -> Self {
-        use librefang_types::config::SessionResetReason as T;
-        match r {
-            ResetReason::Idle => T::Idle,
-            ResetReason::Daily => T::Daily,
-            ResetReason::Suspended => T::Suspended,
-            ResetReason::Manual => T::Manual,
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -267,7 +160,7 @@ mod tests {
     #[test]
     fn off_mode_never_resets() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Off,
+            mode: SessionResetMode::Off,
             ..Default::default()
         };
         // Even with a very old last_active, Off mode returns None.
@@ -279,21 +172,21 @@ mod tests {
         let policy = SessionResetPolicy::default(); // Off mode
         assert_eq!(
             policy.should_reset(mins_ago(1), true),
-            Some(ResetReason::Suspended)
+            Some(SessionResetReason::Suspended)
         );
     }
 
     #[test]
     fn idle_triggers_after_threshold() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Idle,
+            mode: SessionResetMode::Idle,
             idle_minutes: 30,
             ..Default::default()
         };
         // Active 31 minutes ago → should reset
         assert_eq!(
             policy.should_reset(mins_ago(31), false),
-            Some(ResetReason::Idle)
+            Some(SessionResetReason::Idle)
         );
         // Active 29 minutes ago → still valid
         assert_eq!(policy.should_reset(mins_ago(29), false), None);
@@ -302,7 +195,7 @@ mod tests {
     #[test]
     fn idle_does_not_trigger_below_threshold() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Idle,
+            mode: SessionResetMode::Idle,
             idle_minutes: 1440,
             ..Default::default()
         };
@@ -312,32 +205,32 @@ mod tests {
     #[test]
     fn both_mode_idle_wins_first() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Both,
+            mode: SessionResetMode::Both,
             idle_minutes: 10,
             daily_at_hour: 4,
         };
         assert_eq!(
             policy.should_reset(mins_ago(15), false),
-            Some(ResetReason::Idle)
+            Some(SessionResetReason::Idle)
         );
     }
 
     #[test]
     fn suspended_overrides_off_mode() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Off,
+            mode: SessionResetMode::Off,
             ..Default::default()
         };
         assert_eq!(
             policy.should_reset(SystemTime::now(), true),
-            Some(ResetReason::Suspended)
+            Some(SessionResetReason::Suspended)
         );
     }
 
     #[test]
     fn default_policy_is_off() {
         let policy = SessionResetPolicy::default();
-        assert_eq!(policy.mode, ResetMode::Off);
+        assert_eq!(policy.mode, SessionResetMode::Off);
         assert_eq!(policy.idle_minutes, 1440);
         assert_eq!(policy.daily_at_hour, 4);
     }
@@ -348,7 +241,7 @@ mod tests {
     fn daily_mode_triggers_when_before_boundary() {
         // Use a large offset to make last_active clearly before today's boundary.
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 4,
             ..Default::default()
         };
@@ -357,7 +250,7 @@ mod tests {
         let last = SystemTime::now() - Duration::from_secs(25 * 3600);
         let result = policy.should_reset(last, false);
         assert!(
-            matches!(result, Some(ResetReason::Daily)),
+            matches!(result, Some(SessionResetReason::Daily)),
             "should trigger daily reset"
         );
     }
@@ -365,7 +258,7 @@ mod tests {
     #[test]
     fn daily_mode_does_not_trigger_when_after_boundary_but_same_day() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 4,
             ..Default::default()
         };
@@ -384,7 +277,7 @@ mod tests {
     #[test]
     fn daily_mode_does_not_fire_multiple_times_same_day() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 4,
             ..Default::default()
         };
@@ -392,7 +285,7 @@ mod tests {
         let last_before = SystemTime::now() - Duration::from_secs(25 * 3600);
         assert!(matches!(
             policy.should_reset(last_before, false),
-            Some(ResetReason::Daily)
+            Some(SessionResetReason::Daily)
         ));
 
         // Second call, same `now`, but last_active is NOW (after reset, last_active = now)
@@ -409,7 +302,7 @@ mod tests {
         // equals secs_per_day, causing the boundary calculation to always pick
         // yesterday and fire on every invocation.
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 24, // invalid — out of 0-23 range
             ..Default::default()
         };
@@ -427,7 +320,7 @@ mod tests {
         // Also verify that u8 values like 255 (which serde accepts for u8)
         // are similarly handled.
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 255,
             ..Default::default()
         };
@@ -444,7 +337,7 @@ mod tests {
         // Idle threshold = 10 min, last_active = 5 min ago → idle doesn't fire.
         // Daily boundary is crossed → daily should fire.
         let policy = SessionResetPolicy {
-            mode: ResetMode::Both,
+            mode: SessionResetMode::Both,
             idle_minutes: 10_000_000,
             daily_at_hour: 4,
         };
@@ -452,7 +345,7 @@ mod tests {
         let last = SystemTime::now() - Duration::from_secs(25 * 3600);
         let result = policy.should_reset(last, false);
         assert!(
-            matches!(result, Some(ResetReason::Daily)),
+            matches!(result, Some(SessionResetReason::Daily)),
             "both mode with idle-safe but crossed-daily-boundary should fire Daily"
         );
     }
@@ -462,14 +355,14 @@ mod tests {
         // Active 15 min ago → idle threshold breached (10 min).
         // Also crossed daily boundary → but idle is checked first and wins.
         let policy = SessionResetPolicy {
-            mode: ResetMode::Both,
+            mode: SessionResetMode::Both,
             idle_minutes: 10,
             daily_at_hour: 4,
         };
         let last = SystemTime::now() - Duration::from_secs(15 * 60);
         let result = policy.should_reset(last, false);
         assert!(
-            matches!(result, Some(ResetReason::Idle)),
+            matches!(result, Some(SessionResetReason::Idle)),
             "both mode with both conditions met should fire Idle (checked first)"
         );
     }
@@ -477,14 +370,14 @@ mod tests {
     #[test]
     fn suspended_overrides_daily() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Daily,
+            mode: SessionResetMode::Daily,
             daily_at_hour: 4,
             ..Default::default()
         };
         assert!(
             matches!(
                 policy.should_reset(SystemTime::now(), true),
-                Some(ResetReason::Suspended)
+                Some(SessionResetReason::Suspended)
             ),
             "suspended must win over daily even when daily would fire"
         );
@@ -493,7 +386,7 @@ mod tests {
     #[test]
     fn suspended_overrides_both() {
         let policy = SessionResetPolicy {
-            mode: ResetMode::Both,
+            mode: SessionResetMode::Both,
             idle_minutes: 1,
             daily_at_hour: 4,
         };
@@ -501,7 +394,7 @@ mod tests {
         assert!(
             matches!(
                 policy.should_reset(SystemTime::now(), true),
-                Some(ResetReason::Suspended)
+                Some(SessionResetReason::Suspended)
             ),
             "suspended must win over both idle and daily"
         );

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -14,6 +14,10 @@ use std::collections::HashMap;
 use tracing::{debug, warn};
 use url::Url;
 
+// Canonical OAuth token type lives in `librefang-types`.  Re-export so existing
+// callers can keep their `runtime::mcp_oauth::OAuthTokens` import path.
+pub use librefang_types::oauth::OAuthTokens;
+
 // ---------------------------------------------------------------------------
 // Core types
 // ---------------------------------------------------------------------------
@@ -63,24 +67,6 @@ pub enum McpAuthState {
 
 /// Shared map of per-server MCP OAuth authentication states.
 pub type McpAuthStates = tokio::sync::Mutex<std::collections::HashMap<String, McpAuthState>>;
-
-/// OAuth token response from the token endpoint.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OAuthTokens {
-    pub access_token: String,
-    #[serde(default)]
-    pub refresh_token: Option<String>,
-    #[serde(default = "default_token_type")]
-    pub token_type: String,
-    #[serde(default)]
-    pub expires_in: u64,
-    #[serde(default)]
-    pub scope: String,
-}
-
-fn default_token_type() -> String {
-    "Bearer".to_string()
-}
 
 // ---------------------------------------------------------------------------
 // WWW-Authenticate parsing

--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -18,6 +18,7 @@ ed25519-dalek = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
+zeroize = { workspace = true }
 fluent = { workspace = true }
 unic-langid = { workspace = true }
 regex-lite = { workspace = true }

--- a/crates/librefang-types/src/lib.rs
+++ b/crates/librefang-types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod media;
 pub mod memory;
 pub mod message;
 pub mod model_catalog;
+pub mod oauth;
 pub mod registry_schema;
 pub mod scheduler;
 pub mod serde_compat;

--- a/crates/librefang-types/src/oauth.rs
+++ b/crates/librefang-types/src/oauth.rs
@@ -1,0 +1,129 @@
+//! Canonical OAuth2 token types shared across LibreFang crates.
+//!
+//! [`OAuthTokens`] is the deserialized response from an OAuth2 token endpoint
+//! (`access_token`, optional `refresh_token`, `token_type`, `expires_in`,
+//! `scope`).  It is used both by the public PKCE flow in `librefang-extensions`
+//! (Google / GitHub / Microsoft / Slack one-click integrations) and by the
+//! MCP OAuth flow in `librefang-runtime-mcp` / `librefang-api`.
+//!
+//! The struct lives here to avoid two divergent definitions and to give every
+//! caller a single canonical type for trait signatures (`McpOAuthProvider`,
+//! `ExtensionResult`, etc.).
+
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+/// OAuth2 token response from the token endpoint.
+///
+/// Field defaults follow the providers we have observed:
+/// - `refresh_token` is optional (Slack and many bot tokens omit it)
+/// - `token_type` defaults to `"Bearer"` when the server omits it
+/// - `expires_in` defaults to `0` (some providers omit when token doesn't expire)
+/// - `scope` defaults to empty (some providers omit when no scopes apply)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthTokens {
+    /// Access token used to authenticate API calls.
+    pub access_token: String,
+    /// Refresh token used to obtain a new access token (when provided).
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    /// Token type, typically `"Bearer"`.
+    #[serde(default = "default_token_type")]
+    pub token_type: String,
+    /// Seconds until `access_token` expires.
+    #[serde(default)]
+    pub expires_in: u64,
+    /// Space-delimited scopes granted by the authorization server.
+    #[serde(default)]
+    pub scope: String,
+}
+
+/// Default `token_type` value applied when the provider omits it. RFC 6749
+/// allows the field to be absent for `Bearer` tokens.
+pub fn default_token_type() -> String {
+    "Bearer".to_string()
+}
+
+impl OAuthTokens {
+    /// Wrap the access token in a [`Zeroizing`] string so it is wiped on drop.
+    pub fn access_token_zeroizing(&self) -> Zeroizing<String> {
+        Zeroizing::new(self.access_token.clone())
+    }
+
+    /// Wrap the refresh token in a [`Zeroizing`] string when present.
+    pub fn refresh_token_zeroizing(&self) -> Option<Zeroizing<String>> {
+        self.refresh_token
+            .as_ref()
+            .map(|t| Zeroizing::new(t.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_minimal_response() {
+        let body = r#"{"access_token": "abc"}"#;
+        let tokens: OAuthTokens = serde_json::from_str(body).unwrap();
+        assert_eq!(tokens.access_token, "abc");
+        assert!(tokens.refresh_token.is_none());
+        assert_eq!(tokens.token_type, "Bearer");
+        assert_eq!(tokens.expires_in, 0);
+        assert_eq!(tokens.scope, "");
+    }
+
+    #[test]
+    fn deserialize_full_response() {
+        let body = r#"{
+            "access_token": "abc",
+            "refresh_token": "rrr",
+            "token_type": "bearer",
+            "expires_in": 3600,
+            "scope": "read write"
+        }"#;
+        let tokens: OAuthTokens = serde_json::from_str(body).unwrap();
+        assert_eq!(tokens.access_token, "abc");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("rrr"));
+        assert_eq!(tokens.token_type, "bearer");
+        assert_eq!(tokens.expires_in, 3600);
+        assert_eq!(tokens.scope, "read write");
+    }
+
+    #[test]
+    fn access_token_zeroizing_returns_value() {
+        let tokens = OAuthTokens {
+            access_token: "secret".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            expires_in: 0,
+            scope: String::new(),
+        };
+        let z = tokens.access_token_zeroizing();
+        assert_eq!(&*z, "secret");
+    }
+
+    #[test]
+    fn refresh_token_zeroizing_some() {
+        let tokens = OAuthTokens {
+            access_token: "a".to_string(),
+            refresh_token: Some("r".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_in: 0,
+            scope: String::new(),
+        };
+        assert_eq!(&*tokens.refresh_token_zeroizing().unwrap(), "r");
+    }
+
+    #[test]
+    fn refresh_token_zeroizing_none() {
+        let tokens = OAuthTokens {
+            access_token: "a".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            expires_in: 0,
+            scope: String::new(),
+        };
+        assert!(tokens.refresh_token_zeroizing().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Three pairs of duplicated/near-duplicated types consolidated:

### 1. `OAuthTokens` (was duplicated in extensions + runtime-mcp)
- New canonical home: `crates/librefang-types/src/oauth.rs`
- Both helper methods preserved (`access_token_zeroizing`, `refresh_token_zeroizing`, `default_token_type`)
- `zeroize` added as a `librefang-types` dep
- Old definitions in `librefang-extensions` and `librefang-runtime-mcp` replaced with `pub use` re-exports — **0 call-site renames**, 6 import paths kept working transparently

### 2. `SessionResetPolicy` (was duplicated in kernel + types)
- Kernel-side `ResetMode` enum and policy struct deleted
- `librefang-kernel/src/session_policy.rs` now re-exports the canonical `librefang_types::config::{SessionResetPolicy, SessionResetMode, SessionResetReason}`
- Runtime-only logic moved to a `SessionResetPolicyExt` trait (`should_reset`)
- ~20 test references updated to use the canonical enum names

### 3. `UsageSummary` + `ModelUsage` (TUI vs memory)
- **Kept separate** — TUI versions are intentional display projections (different field names: `model_id`/`total_calls` vs `model`/`call_count`)
- Added explicit `From<&memory::UsageSummary>` and `From<&memory::ModelUsage>` impls so the conversion is no longer ad-hoc
- `librefang-memory` added as a `librefang-cli` dep
- Comment added explaining why both shapes coexist

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — passes (one pre-existing env-leak test in `librefang-runtime::embedding::tests` flakes only when `OPENAI_API_KEY` is set in shell; unrelated to this refactor)