### PR TITLE
ci: install libdbus-1-dev for OpenAPI Drift job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install system deps for keyring/secret-service
+        # libdbus-sys (pulled in transitively by the keyring crate via
+        # secret-service on Linux) needs dbus-1 dev headers + pkg-config.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev libsecret-1-dev pkg-config
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Regenerate openapi.json


### PR DESCRIPTION
## Summary
The `OpenAPI Drift` CI job is currently failing on **every** PR that touches Rust code (and on `main` itself since #3178 merged).

Root cause: PR #3178 added a `keyring` dep for OS keyring vault wiring. On Linux, `keyring` pulls in `secret-service` → `dbus` → `libdbus-sys`, which needs `dbus-1` dev headers + `pkg-config` to compile. Other Rust jobs (`Test`, `Quality`, `Build`) get these transitively via `libwebkit2gtk-4.1-dev`, but the `openapi-drift` job installs **no** system deps — so `cargo xtask codegen --openapi` errors out:

```
error: failed to run custom build command for `libdbus-sys v0.2.7`
pkg-config exited with status code 1
> pkg-config --libs --cflags dbus-1 'dbus-1 >= 1.6'
```

This adds an explicit `apt-get install libdbus-1-dev libsecret-1-dev pkg-config` step before the codegen step. Tiny + targeted — only the openapi-drift job is changed.

## Test plan
- [x] Will be self-validating: this PR's own openapi-drift run is the proof
- [x] After merge, all currently-red Rust PRs (#3181 / #3182 / #3184 / #3185) should turn green on retry