### PR TITLE
refactor(cli/tui): rename Action enums to disambiguate from domain types

### DIFF
--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -1508,17 +1508,17 @@ impl App {
         }
     }
 
-    fn handle_memory_action(&mut self, action: memory::MemoryAction) {
+    fn handle_memory_action(&mut self, action: memory::MemoryUIAction) {
         match action {
-            memory::MemoryAction::Continue => {}
-            memory::MemoryAction::LoadAgents => self.refresh_memory(),
-            memory::MemoryAction::LoadKv(agent_id) => {
+            memory::MemoryUIAction::Continue => {}
+            memory::MemoryUIAction::LoadAgents => self.refresh_memory(),
+            memory::MemoryUIAction::LoadKv(agent_id) => {
                 if let Some(backend) = self.backend.to_ref() {
                     self.memory.loading = true;
                     event::spawn_fetch_memory_kv(backend, agent_id, self.event_tx.clone());
                 }
             }
-            memory::MemoryAction::SaveKv {
+            memory::MemoryUIAction::SaveKv {
                 agent_id,
                 key,
                 value,
@@ -1533,7 +1533,7 @@ impl App {
                     );
                 }
             }
-            memory::MemoryAction::DeleteKv { agent_id, key } => {
+            memory::MemoryUIAction::DeleteKv { agent_id, key } => {
                 if let Some(backend) = self.backend.to_ref() {
                     event::spawn_delete_memory_kv(backend, agent_id, key, self.event_tx.clone());
                 }
@@ -1662,11 +1662,11 @@ impl App {
         }
     }
 
-    fn handle_audit_action(&mut self, action: audit::AuditAction) {
+    fn handle_audit_action(&mut self, action: audit::AuditUIAction) {
         match action {
-            audit::AuditAction::Continue => {}
-            audit::AuditAction::Refresh => self.refresh_audit(),
-            audit::AuditAction::VerifyChain => {
+            audit::AuditUIAction::Continue => {}
+            audit::AuditUIAction::Refresh => self.refresh_audit(),
+            audit::AuditUIAction::VerifyChain => {
                 if let Some(backend) = self.backend.to_ref() {
                     event::spawn_verify_chain(backend, self.event_tx.clone());
                 }

--- a/crates/librefang-cli/src/tui/screens/audit.rs
+++ b/crates/librefang-cli/src/tui/screens/audit.rs
@@ -119,7 +119,7 @@ pub struct AuditState {
     pub status_msg: String,
 }
 
-pub enum AuditAction {
+pub enum AuditUIAction {
     Continue,
     Refresh,
     VerifyChain,
@@ -158,9 +158,9 @@ impl AuditState {
         }
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) -> AuditAction {
+    pub fn handle_key(&mut self, key: KeyEvent) -> AuditUIAction {
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            return AuditAction::Continue;
+            return AuditUIAction::Continue;
         }
 
         let total = self.filtered.len();
@@ -179,11 +179,11 @@ impl AuditState {
                 self.action_filter = self.action_filter.next();
                 self.refilter();
             }
-            KeyCode::Char('v') => return AuditAction::VerifyChain,
-            KeyCode::Char('r') => return AuditAction::Refresh,
+            KeyCode::Char('v') => return AuditUIAction::VerifyChain,
+            KeyCode::Char('r') => return AuditUIAction::Refresh,
             _ => {}
         }
-        AuditAction::Continue
+        AuditUIAction::Continue
     }
 }
 

--- a/crates/librefang-cli/src/tui/screens/memory.rs
+++ b/crates/librefang-cli/src/tui/screens/memory.rs
@@ -55,7 +55,7 @@ pub struct MemoryState {
     pub status_msg: String,
 }
 
-pub enum MemoryAction {
+pub enum MemoryUIAction {
     Continue,
     LoadAgents,
     LoadKv(String),
@@ -93,9 +93,9 @@ impl MemoryState {
         self.tick = self.tick.wrapping_add(1);
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) -> MemoryAction {
+    pub fn handle_key(&mut self, key: KeyEvent) -> MemoryUIAction {
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            return MemoryAction::Continue;
+            return MemoryUIAction::Continue;
         }
         match self.sub {
             MemorySub::AgentSelect => self.handle_agent_select(key),
@@ -104,7 +104,7 @@ impl MemoryState {
         }
     }
 
-    fn handle_agent_select(&mut self, key: KeyEvent) -> MemoryAction {
+    fn handle_agent_select(&mut self, key: KeyEvent) -> MemoryUIAction {
         let total = self.agents.len();
         match key.code {
             KeyCode::Up | KeyCode::Char('k') if total > 0 => {
@@ -125,17 +125,17 @@ impl MemoryState {
                         self.selected_agent = Some(agent);
                         self.sub = MemorySub::KvBrowser;
                         self.loading = true;
-                        return MemoryAction::LoadKv(id);
+                        return MemoryUIAction::LoadKv(id);
                     }
                 }
             }
-            KeyCode::Char('r') => return MemoryAction::LoadAgents,
+            KeyCode::Char('r') => return MemoryUIAction::LoadAgents,
             _ => {}
         }
-        MemoryAction::Continue
+        MemoryUIAction::Continue
     }
 
-    fn handle_kv_browser(&mut self, key: KeyEvent) -> MemoryAction {
+    fn handle_kv_browser(&mut self, key: KeyEvent) -> MemoryUIAction {
         if self.confirm_delete {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
@@ -144,7 +144,7 @@ impl MemoryState {
                         (&self.selected_agent, self.kv_list_state.selected())
                     {
                         if sel < self.kv_pairs.len() {
-                            return MemoryAction::DeleteKv {
+                            return MemoryUIAction::DeleteKv {
                                 agent_id: agent.id.clone(),
                                 key: self.kv_pairs[sel].key.clone(),
                             };
@@ -153,7 +153,7 @@ impl MemoryState {
                 }
                 _ => self.confirm_delete = false,
             }
-            return MemoryAction::Continue;
+            return MemoryUIAction::Continue;
         }
 
         let total = self.kv_pairs.len();
@@ -195,15 +195,15 @@ impl MemoryState {
             KeyCode::Char('r') if self.selected_agent.is_some() => {
                 if let Some(agent) = &self.selected_agent {
                     self.loading = true;
-                    return MemoryAction::LoadKv(agent.id.clone());
+                    return MemoryUIAction::LoadKv(agent.id.clone());
                 }
             }
             _ => {}
         }
-        MemoryAction::Continue
+        MemoryUIAction::Continue
     }
 
-    fn handle_edit(&mut self, key: KeyEvent) -> MemoryAction {
+    fn handle_edit(&mut self, key: KeyEvent) -> MemoryUIAction {
         match key.code {
             KeyCode::Esc => {
                 self.sub = MemorySub::KvBrowser;
@@ -217,7 +217,7 @@ impl MemoryState {
             KeyCode::Enter => {
                 if !self.key_buf.is_empty() {
                     if let Some(agent) = &self.selected_agent {
-                        let action = MemoryAction::SaveKv {
+                        let action = MemoryUIAction::SaveKv {
                             agent_id: agent.id.clone(),
                             key: self.key_buf.clone(),
                             value: self.value_buf.clone(),
@@ -244,7 +244,7 @@ impl MemoryState {
             },
             _ => {}
         }
-        MemoryAction::Continue
+        MemoryUIAction::Continue
     }
 }
 


### PR DESCRIPTION
## Summary
Two TUI-internal `Action` enums in `librefang-cli/src/tui/screens/` had names that collided with completely-unrelated domain enums elsewhere in the workspace.

| Old name (TUI) | New name | Collided with |
|---|---|---|
| `MemoryAction` (state-machine actions: `Continue` / `LoadAgents` / `LoadKv` / `SaveKv` / `DeleteKv`) | `MemoryUIAction` | `librefang-types::memory::MemoryAction` (memory lifecycle: `Add` / `Update` / `Noop`) |
| `AuditAction` (TUI events: `Continue` / `Refresh` / `VerifyChain`) | `AuditUIAction` | `librefang-runtime::audit::AuditAction` (13 audit-log variants like `ToolInvoke`, `CapabilityCheck`, `AgentSpawn`) |

Domain enums are unchanged — only the TUI-local versions are renamed. No behavior change.

## Test plan
- [x] `cargo build -p librefang-cli`
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace --lib` — no other crate broke