### PR TITLE
feat(security): RBAC M2 — audit user/channel attribution + stable UserId (#3054)

### DIFF
--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -111,7 +111,7 @@ impl AuthManager {
         };
 
         for config in user_configs {
-            let user_id = UserId::new();
+            let user_id = UserId::from_name(&config.name);
             let role = UserRole::from_str_role(&config.role);
             let identity = UserIdentity {
                 id: user_id,
@@ -312,5 +312,32 @@ mod tests {
         assert_eq!(UserRole::from_str_role("user"), UserRole::User);
         assert_eq!(UserRole::from_str_role("OWNER"), UserRole::Owner);
         assert_eq!(UserRole::from_str_role("unknown"), UserRole::User);
+    }
+
+    #[test]
+    fn test_user_ids_stable_across_manager_rebuilds() {
+        // RBAC M1: AuthManager now derives ids via UserId::from_name so
+        // restarting the daemon (or rebuilding the manager from the same
+        // config) keeps audit-log attribution intact. Random v4 ids would
+        // break correlation on every boot.
+        let cfg = test_configs();
+        let m1 = AuthManager::new(&cfg);
+        let m2 = AuthManager::new(&cfg);
+
+        let alice1 = m1.identify("telegram", "123456").unwrap();
+        let alice2 = m2.identify("telegram", "123456").unwrap();
+        assert_eq!(alice1, alice2, "same name must map to the same UserId");
+
+        // The id is also discoverable directly from the configured name —
+        // this is the contract the API-key path in middleware.rs depends on.
+        assert_eq!(alice1, UserId::from_name("Alice"));
+    }
+
+    #[test]
+    fn test_distinct_users_get_distinct_ids() {
+        let manager = AuthManager::new(&test_configs());
+        let alice = manager.identify("telegram", "123456").unwrap();
+        let guest = manager.identify("telegram", "999999").unwrap();
+        assert_ne!(alice, guest);
     }
 }

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 21;
+const SCHEMA_VERSION: u32 = 22;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -93,6 +93,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 21 {
         migrate_v21(conn)?;
+    }
+
+    if current_version < 22 {
+        migrate_v22(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -690,6 +694,34 @@ fn migrate_v21(conn: &Connection) -> Result<(), rusqlite::Error> {
     Ok(())
 }
 
+/// Version 22: Add user_id and channel columns to audit_entries for RBAC M1.
+///
+/// Both columns are nullable so pre-M1 entries (no user attribution) keep
+/// verifying with their original Merkle hashes — the hash function omits
+/// absent fields, so NULL columns produce the pre-migration hash unchanged.
+fn migrate_v22(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !column_exists(conn, "audit_entries", "user_id") {
+        conn.execute("ALTER TABLE audit_entries ADD COLUMN user_id TEXT", [])?;
+    }
+    if !column_exists(conn, "audit_entries", "channel") {
+        conn.execute("ALTER TABLE audit_entries ADD COLUMN channel TEXT", [])?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_entries(user_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_channel ON audit_entries(channel)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (22, datetime('now'), 'Add user_id and channel columns to audit_entries for RBAC M1 attribution')",
+        [],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -741,5 +773,105 @@ mod tests {
         assert!(tables.contains(&"prompt_experiments".to_string()));
         assert!(tables.contains(&"experiment_variants".to_string()));
         assert!(tables.contains(&"experiment_metrics".to_string()));
+    }
+
+    #[test]
+    fn test_migrate_v22_adds_user_id_and_channel_columns() {
+        // RBAC M1: pre-existing audit_entries rows must keep working after
+        // the schema upgrade — both columns must be NULL-able.
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        assert!(column_exists(&conn, "audit_entries", "user_id"));
+        assert!(column_exists(&conn, "audit_entries", "channel"));
+
+        // Insert with the legacy column list (omitting user_id/channel) —
+        // must succeed with NULLs. This is the path callers using the
+        // pre-M1 INSERT signature take.
+        conn.execute(
+            "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                0_i64,
+                "2026-04-26T00:00:00+00:00",
+                "agent-1",
+                "AgentSpawn",
+                "boot",
+                "ok",
+                "0".repeat(64),
+                "deadbeef".repeat(8),
+            ],
+        )
+        .expect("legacy INSERT must still work after v22");
+
+        let (uid, ch): (Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT user_id, channel FROM audit_entries WHERE seq = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(uid, None);
+        assert_eq!(ch, None);
+    }
+
+    #[test]
+    fn test_migrate_v22_preserves_existing_rows() {
+        // Simulate an upgrade from v21: create a v21-shape audit_entries
+        // table by hand, drop in a row, then run migrations. The row must
+        // survive intact and gain NULL user_id / channel columns.
+        let conn = Connection::open_in_memory().unwrap();
+        // Run the pre-v22 migrations only by stopping at v21 state.
+        // Easiest: run all migrations, drop the column, and re-add via v22
+        // logic. But that defeats the test. Instead build the legacy
+        // schema explicitly.
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            );
+            CREATE TABLE migrations (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT);
+            INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, prev_hash, hash) \
+              VALUES (0, '2026-01-01T00:00:00+00:00', 'agent-1', 'AgentSpawn', 'boot', 'ok', '0', 'h');",
+        )
+        .unwrap();
+
+        // Apply just the v22 step.
+        migrate_v22(&conn).unwrap();
+
+        assert!(column_exists(&conn, "audit_entries", "user_id"));
+        assert!(column_exists(&conn, "audit_entries", "channel"));
+
+        // Original row must be intact, with NULL for the new columns.
+        let (agent, uid, ch): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT agent_id, user_id, channel FROM audit_entries WHERE seq = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(agent, "agent-1");
+        assert_eq!(uid, None);
+        assert_eq!(ch, None);
+    }
+
+    #[test]
+    fn test_migrate_v22_is_idempotent() {
+        // Running run_migrations twice on the same DB must be a no-op
+        // for the v22 step — `column_exists` guards the ALTER TABLE so
+        // re-running does not try to add the same column twice.
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        // Second run on already-v22 schema must succeed.
+        run_migrations(&conn).unwrap();
+        assert!(column_exists(&conn, "audit_entries", "user_id"));
+        assert!(column_exists(&conn, "audit_entries", "channel"));
+        // Schema version stays at the latest.
+        assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
     }
 }

--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -8,6 +8,7 @@
 //! the `audit_entries` table (schema V8) so the trail survives daemon restarts.
 
 use chrono::Utc;
+use librefang_types::agent::UserId;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -54,6 +55,16 @@ pub struct AuditEntry {
     pub detail: String,
     /// The outcome of the action (e.g. "ok", "denied", an error message).
     pub outcome: String,
+    /// LibreFang user that triggered the action, if known. `None` for kernel
+    /// internal events (cron jobs, startup tasks) and pre-migration entries
+    /// recorded before user attribution was added in M1.
+    #[serde(default)]
+    pub user_id: Option<UserId>,
+    /// Channel the action originated from (e.g. "telegram", "slack",
+    /// "dashboard", "cli"). `None` for kernel-internal events and
+    /// pre-migration entries.
+    #[serde(default)]
+    pub channel: Option<String>,
     /// SHA-256 hash of the previous entry (or all-zeros for the genesis).
     pub prev_hash: String,
     /// SHA-256 hash of this entry's content concatenated with `prev_hash`.
@@ -61,6 +72,19 @@ pub struct AuditEntry {
 }
 
 /// Computes the SHA-256 hash for a single audit entry from its fields.
+///
+/// `user_id` and `channel` are folded into the hash only when present so
+/// pre-M1 entries — recorded before user attribution existed — verify with
+/// the same hash they were originally written with. New entries that supply
+/// either field commit it to the chain so a later attempt to strip user
+/// attribution from a row would break the Merkle link.
+//
+// Argument count exceeds clippy's default; folding the inputs into a
+// struct would either require building a temporary on every record/verify
+// call or change the on-disk hash inputs, both of which are strictly worse
+// than the readability cost of nine plain arguments. This is private and
+// purely additive — the previous six fields hash identically.
+#[allow(clippy::too_many_arguments)]
 fn compute_entry_hash(
     seq: u64,
     timestamp: &str,
@@ -68,6 +92,8 @@ fn compute_entry_hash(
     action: &AuditAction,
     detail: &str,
     outcome: &str,
+    user_id: Option<&UserId>,
+    channel: Option<&str>,
     prev_hash: &str,
 ) -> String {
     let mut hasher = Sha256::new();
@@ -77,6 +103,14 @@ fn compute_entry_hash(
     hasher.update(action.to_string().as_bytes());
     hasher.update(detail.as_bytes());
     hasher.update(outcome.as_bytes());
+    if let Some(uid) = user_id {
+        hasher.update(b"\x1fuser_id=");
+        hasher.update(uid.0.as_bytes());
+    }
+    if let Some(ch) = channel {
+        hasher.update(b"\x1fchannel=");
+        hasher.update(ch.as_bytes());
+    }
     hasher.update(prev_hash.as_bytes());
     hex::encode(hasher.finalize())
 }
@@ -263,10 +297,14 @@ impl AuditLog {
         let mut entries = Vec::new();
         let mut tip = "0".repeat(64);
 
-        // Load existing entries from database
+        // Load existing entries from database. Schema v22 added the
+        // `user_id` / `channel` columns; rows persisted before that
+        // migration return NULL for both, which deserialises to `None`
+        // and keeps the original hash intact (the hash function omits
+        // absent fields, see `compute_entry_hash`).
         if let Ok(db) = conn.lock() {
             let result = db.prepare(
-                "SELECT seq, timestamp, agent_id, action, detail, outcome, prev_hash, hash FROM audit_entries ORDER BY seq ASC",
+                "SELECT seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash FROM audit_entries ORDER BY seq ASC",
             );
             if let Ok(mut stmt) = result {
                 let rows = stmt.query_map([], |row| {
@@ -290,6 +328,9 @@ impl AuditLog {
                     let seq_raw: i64 = row.get(0)?;
                     let seq = u64::try_from(seq_raw)
                         .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, seq_raw))?;
+                    let user_id_str: Option<String> = row.get(6)?;
+                    let user_id = user_id_str.as_deref().and_then(|s| s.parse().ok());
+                    let channel: Option<String> = row.get(7)?;
                     Ok(AuditEntry {
                         seq,
                         timestamp: row.get(1)?,
@@ -297,8 +338,10 @@ impl AuditLog {
                         action,
                         detail: row.get(4)?,
                         outcome: row.get(5)?,
-                        prev_hash: row.get(6)?,
-                        hash: row.get(7)?,
+                        user_id,
+                        channel,
+                        prev_hash: row.get(8)?,
+                        hash: row.get(9)?,
                     })
                 });
                 if let Ok(rows) = rows {
@@ -332,15 +375,33 @@ impl AuditLog {
 
     /// Records a new auditable event and returns the SHA-256 hash of the entry.
     ///
-    /// The entry is atomically appended to the chain with the current tip as
-    /// its `prev_hash`, and the tip is advanced to the new hash.
-    /// If a database connection is available, the entry is also persisted.
+    /// Convenience wrapper over [`AuditLog::record_with_context`] that omits
+    /// user / channel attribution. Prefer the contextual variant when the
+    /// caller knows who or where the action originated from — pre-M1 call
+    /// sites use this form and remain valid.
     pub fn record(
         &self,
         agent_id: impl Into<String>,
         action: AuditAction,
         detail: impl Into<String>,
         outcome: impl Into<String>,
+    ) -> String {
+        self.record_with_context(agent_id, action, detail, outcome, None, None)
+    }
+
+    /// Records a new auditable event with optional user / channel attribution.
+    ///
+    /// The entry is atomically appended to the chain with the current tip as
+    /// its `prev_hash`, and the tip is advanced to the new hash.
+    /// If a database connection is available, the entry is also persisted.
+    pub fn record_with_context(
+        &self,
+        agent_id: impl Into<String>,
+        action: AuditAction,
+        detail: impl Into<String>,
+        outcome: impl Into<String>,
+        user_id: Option<UserId>,
+        channel: Option<String>,
     ) -> String {
         let agent_id = agent_id.into();
         let detail = detail.into();
@@ -354,7 +415,15 @@ impl AuditLog {
         let prev_hash = tip.clone();
 
         let hash = compute_entry_hash(
-            seq, &timestamp, &agent_id, &action, &detail, &outcome, &prev_hash,
+            seq,
+            &timestamp,
+            &agent_id,
+            &action,
+            &detail,
+            &outcome,
+            user_id.as_ref(),
+            channel.as_deref(),
+            &prev_hash,
         );
 
         let entry = AuditEntry {
@@ -364,15 +433,19 @@ impl AuditLog {
             action,
             detail,
             outcome,
+            user_id,
+            channel,
             prev_hash,
             hash: hash.clone(),
         };
 
-        // Persist to database if available
+        // Persist to database if available. Schema v22 added the
+        // `user_id` / `channel` columns; old NULL rows keep working
+        // because the hash function omits absent fields.
         if let Some(ref db) = self.db {
             if let Ok(conn) = db.lock() {
                 let _ = conn.execute(
-                    "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                     rusqlite::params![
                         entry.seq as i64,
                         &entry.timestamp,
@@ -380,6 +453,8 @@ impl AuditLog {
                         entry.action.to_string(),
                         &entry.detail,
                         &entry.outcome,
+                        entry.user_id.map(|u| u.to_string()),
+                        entry.channel.as_deref(),
                         &entry.prev_hash,
                         &entry.hash,
                     ],
@@ -433,6 +508,8 @@ impl AuditLog {
                 &entry.action,
                 &entry.detail,
                 &entry.outcome,
+                entry.user_id.as_ref(),
+                entry.channel.as_deref(),
                 &entry.prev_hash,
             );
 
@@ -629,6 +706,111 @@ mod tests {
     }
 
     #[test]
+    fn test_record_with_context_round_trips_user_and_channel() {
+        // RBAC M1: AuditEntry carries user_id + channel attribution. Both
+        // are optional so legacy `record(...)` still works (folds to None).
+        let log = AuditLog::new();
+        let alice = UserId::from_name("Alice");
+
+        log.record("agent-1", AuditAction::AgentSpawn, "boot", "ok"); // legacy
+        log.record_with_context(
+            "agent-1",
+            AuditAction::ToolInvoke,
+            "file_read /tmp/x",
+            "ok",
+            Some(alice),
+            Some("api".to_string()),
+        );
+
+        assert!(log.verify_integrity().is_ok());
+
+        let entries = log.recent(2);
+        assert_eq!(entries[0].user_id, None);
+        assert_eq!(entries[0].channel, None);
+        assert_eq!(entries[1].user_id, Some(alice));
+        assert_eq!(entries[1].channel.as_deref(), Some("api"));
+
+        // Tampering with a recorded user_id must break the chain — proves
+        // attribution is committed to the Merkle hash, not a side note.
+        let tampered_hash = compute_entry_hash(
+            entries[1].seq,
+            &entries[1].timestamp,
+            &entries[1].agent_id,
+            &entries[1].action,
+            &entries[1].detail,
+            &entries[1].outcome,
+            None, // pretend user_id was never there
+            entries[1].channel.as_deref(),
+            &entries[1].prev_hash,
+        );
+        assert_ne!(
+            tampered_hash, entries[1].hash,
+            "stripping user_id must change the hash"
+        );
+    }
+
+    #[test]
+    fn test_record_with_context_persists_user_and_channel() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+
+        let db = Arc::new(Mutex::new(conn));
+        let bob = UserId::from_name("Bob");
+
+        let log = AuditLog::with_db(Arc::clone(&db));
+        log.record("agent-1", AuditAction::AgentSpawn, "boot", "ok");
+        log.record_with_context(
+            "agent-1",
+            AuditAction::ConfigChange,
+            "config set: x",
+            "ok",
+            Some(bob),
+            Some("api".to_string()),
+        );
+
+        // Reopen — chain must verify and the contextual entry must round-trip.
+        let log2 = AuditLog::with_db(Arc::clone(&db));
+        assert_eq!(log2.len(), 2);
+        assert!(log2.verify_integrity().is_ok());
+        let entries = log2.recent(2);
+        assert_eq!(entries[1].user_id, Some(bob));
+        assert_eq!(entries[1].channel.as_deref(), Some("api"));
+    }
+
+    #[test]
+    fn test_user_id_from_name_is_stable_across_audit_writes() {
+        // The whole point of `UserId::from_name` is that audit attribution
+        // survives a daemon restart. Re-deriving the id from the same name
+        // must yield the same UUID written into earlier entries.
+        let log = AuditLog::new();
+        log.record_with_context(
+            "agent-1",
+            AuditAction::AgentMessage,
+            "ping",
+            "ok",
+            Some(UserId::from_name("Alice")),
+            Some("telegram".to_string()),
+        );
+        let recorded = log.recent(1)[0].user_id.unwrap();
+        let rederived = UserId::from_name("Alice");
+        assert_eq!(recorded, rederived);
+    }
+
+    #[test]
     fn test_audit_persists_to_db() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -639,6 +821,8 @@ mod tests {
                 action TEXT NOT NULL,
                 detail TEXT NOT NULL,
                 outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
                 prev_hash TEXT NOT NULL,
                 hash TEXT NOT NULL
             )",
@@ -695,6 +879,8 @@ mod tests {
                 action TEXT NOT NULL,
                 detail TEXT NOT NULL,
                 outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
                 prev_hash TEXT NOT NULL,
                 hash TEXT NOT NULL
             )",
@@ -751,7 +937,8 @@ mod tests {
             ];
             for (seq, aid, action, detail, outcome) in fabricated {
                 let ts = "2026-04-14T00:00:00+00:00";
-                let hash = compute_entry_hash(seq, ts, aid, &action, detail, outcome, &prev);
+                let hash =
+                    compute_entry_hash(seq, ts, aid, &action, detail, outcome, None, None, &prev);
                 conn.execute(
                     "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                     rusqlite::params![
@@ -799,6 +986,8 @@ mod tests {
                 action TEXT NOT NULL,
                 detail TEXT NOT NULL,
                 outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
                 prev_hash TEXT NOT NULL,
                 hash TEXT NOT NULL
             )",

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -10,14 +10,35 @@ use uuid::Uuid;
 /// Metadata key for stable prefix mode flag.
 pub const STABLE_PREFIX_MODE_METADATA_KEY: &str = "stable_prefix_mode";
 
+/// Stable namespace for deriving deterministic [`UserId`] values from
+/// [`UserConfig::name`]. Generated once and frozen — changing this constant
+/// rotates every existing `UserId` and breaks audit-log correlation across
+/// the whole fleet, so it must never be changed.
+pub const LIBREFANG_USER_NAMESPACE: Uuid =
+    Uuid::from_u128(0x4c46_4147_5f55_5345_525f_4e53_5f76_3501);
+
 /// Unique identifier for a user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UserId(pub Uuid);
 
 impl UserId {
     /// Generate a new random UserId.
+    ///
+    /// Prefer [`UserId::from_name`] for users that come from configuration —
+    /// random UUIDs change on every restart, which makes audit-log
+    /// correlation across daemon restarts impossible.
     pub fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    /// Derive a stable UserId from a user's configured name.
+    ///
+    /// Uses UUID v5 with [`LIBREFANG_USER_NAMESPACE`] so the same name
+    /// always maps to the same id — across restarts, across config reloads,
+    /// across nodes. Renaming a user produces a new id (intentionally —
+    /// rename = new identity, old audit history stays attached to the old id).
+    pub fn from_name(name: &str) -> Self {
+        Self(Uuid::new_v5(&LIBREFANG_USER_NAMESPACE, name.as_bytes()))
     }
 }
 
@@ -1305,6 +1326,28 @@ mod tests {
         let json = serde_json::to_string(&u).unwrap();
         let back: UserId = serde_json::from_str(&json).unwrap();
         assert_eq!(u, back);
+    }
+
+    #[test]
+    fn test_user_id_from_name_is_stable() {
+        // Same name → same id, across calls. This is the contract that lets
+        // audit log entries survive daemon restarts.
+        assert_eq!(UserId::from_name("Alice"), UserId::from_name("Alice"));
+        assert_eq!(UserId::from_name(""), UserId::from_name(""));
+    }
+
+    #[test]
+    fn test_user_id_from_name_differs_per_name() {
+        assert_ne!(UserId::from_name("Alice"), UserId::from_name("Bob"));
+        // Case-sensitive — caller controls normalization.
+        assert_ne!(UserId::from_name("alice"), UserId::from_name("Alice"));
+    }
+
+    #[test]
+    fn test_user_id_from_name_is_v5() {
+        // UUID v5 (SHA-1 + namespace) — version nibble must be 5.
+        let id = UserId::from_name("Alice");
+        assert_eq!(id.0.get_version_num(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **Phase 3** (Channel Mapping & Audit) of the unified RBAC plan in #3054 by attributing every audit-log entry to the user and channel that triggered it. Stable user IDs make this attribution survive daemon restarts.

This is the next slice on top of RBAC M1 (which shipped the role model, agent access lists, and `/api/authz/*` CRUD). Phase 2 (tool/memory policies) and the rest of Phase 3 (Telegram/Discord channel mapping, `/api/audit/query` + `/api/audit/export`, per-user budgets) are deferred to follow-up PRs.

### Changes

- **`librefang-types`**: New `UserId::from_name(name)` derives a deterministic v5 UUID under a frozen namespace constant. Replaces random v4 ids in `AuthManager` so the same configured name yields the same id forever — across restarts, config reloads, and nodes. Renaming a user produces a new id by design (old audit history stays attached to the old identity).
- **`librefang-memory`**: Schema migration **v22** adds nullable `user_id` and `channel` columns to `audit_entries` plus indexes, idempotent via `column_exists`. Pre-M1 rows keep their original Merkle hashes because the hash function omits absent fields.
- **`librefang-runtime`**: `AuditEntry` carries optional `user_id` / `channel`. New `AuditLog::record_with_context(...)` records attribution; legacy `record(...)` is now a thin wrapper passing `None`/`None`, so every existing call site stays valid. Attribution is committed to the SHA-256 chain — stripping it from a stored row breaks `verify_integrity`.
- **`librefang-api`**: `ApiUserAuth` / `AuthenticatedApiUser` carry the stable `UserId`, pre-computed at config-load. The three kernel-mutating config endpoints (`shutdown`, `config_reload`, `config_set`) thread the caller through to `record_with_context` with `channel = "api"`. No new public routes, so the auth `is_public` allowlist is unchanged.

### Backward compatibility

- Schema migration is purely additive; both new columns are nullable.
- Pre-M1 audit rows verify with their original hash (the hash skips absent fields).
- Existing `record(...)` call sites compile and run unchanged.
- Legacy 8-column `INSERT INTO audit_entries` (no user_id/channel) still works after v22 — covered by an explicit test.

### Phase coverage of #3054

| Phase | Status |
|-------|--------|
| Phase 1 — Role model & agent access | shipped in M1 |
| Phase 2 — Tool & memory policies | **deferred** |
| Phase 3 — Channel mapping & audit | **this PR (audit slice + stable id)** |
| Phase 3 — Telegram/Discord channel mapping, `/api/audit/query`, `/api/audit/export`, per-user budgets | **deferred** |
| Phase 4 — Dashboard, identity linking, simulator, LDAP/OIDC | **deferred** |

## Test plan

Unit tests added (all green locally):

- `librefang-types::agent::tests`
  - `test_user_id_from_name_is_stable` — same name → same id across calls
  - `test_user_id_from_name_differs_per_name` — distinct names → distinct ids; case-sensitive
  - `test_user_id_from_name_is_v5` — version nibble must be 5
- `librefang-kernel::auth::tests`
  - `test_user_ids_stable_across_manager_rebuilds` — restarting `AuthManager` keeps ids stable
  - `test_distinct_users_get_distinct_ids` — sanity check
- `librefang-memory::migration::tests`
  - `test_migrate_v22_adds_user_id_and_channel_columns` — columns present + legacy 8-column INSERT still works
  - `test_migrate_v22_preserves_existing_rows` — pre-existing rows survive intact with NULL attribution
  - `test_migrate_v22_is_idempotent` — running migrations twice is a no-op
- `librefang-runtime::audit::tests`
  - `test_record_with_context_round_trips_user_and_channel` — attribution persists in memory + tampering with user_id breaks the chain
  - `test_record_with_context_persists_user_and_channel` — DB round-trip after simulated restart
  - `test_user_id_from_name_is_stable_across_audit_writes` — re-derived id matches recorded id

Local verification:

- [x] `cargo check -p librefang-kernel -p librefang-types -p librefang-memory -p librefang-api -p librefang-runtime` — clean
- [x] `cargo test -p librefang-kernel auth::` — 10 passed
- [x] `cargo test -p librefang-memory migration::` — 6 passed (3 new)
- [x] `cargo test -p librefang-runtime audit::` — 11 passed (3 new)
- [x] `cargo test -p librefang-types user_id` — 5 passed (3 new)
- [x] `cargo clippy -p librefang-kernel -p librefang-runtime -- -D warnings` — clean

Live integration verification deferred — daemon-up testing requires a focused workspace and parallel agents are running on other worktrees on this disk.

Refs #3054
