### PR TITLE
fix(ollama): probe /api/tags instead of falling back to non-existent gemma4

### DIFF
--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -13,7 +13,22 @@ use crate::tui::widgets;
 
 /// Return the first model ID for `provider` from the local catalog, falling
 /// back to `fallback` when the catalog is empty or unavailable.
+///
+/// For local providers (currently `ollama`) we probe the live endpoint first
+/// so the wizard prefills a model the user actually has installed instead of
+/// a catalog placeholder that may not match their setup.
 fn catalog_default_model(provider: &str, fallback: &str) -> String {
+    if provider == "ollama" {
+        let probe = librefang_runtime::provider_health::probe_provider_blocking(
+            "ollama",
+            "http://127.0.0.1:11434/v1",
+            None,
+        );
+        if let Some(model) = librefang_runtime::provider_health::first_chat_model(&probe) {
+            return model;
+        }
+    }
+
     let home = std::env::var("LIBREFANG_HOME")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
@@ -151,8 +166,13 @@ const PROVIDERS: &[ProviderInfo] = &[
     },
     ProviderInfo {
         name: "ollama",
+        // Empty fallback: ollama models are runtime-discovered (see
+        // `catalog_default_model`). If both the live probe and the catalog
+        // come back empty, leave the field blank so the user is forced to
+        // type their actually-installed model name rather than accepting a
+        // placeholder that doesn't exist on their box.
         env_var: "OLLAMA_API_KEY",
-        default_model: "gemma4",
+        default_model: "",
         needs_key: false,
     },
     ProviderInfo {
@@ -424,6 +444,18 @@ impl WizardState {
         } else {
             &self.model_input
         };
+
+        // Refuse to write `model = ""` — for providers without a hardcoded
+        // default (e.g. ollama, where the model depends on what the user
+        // pulled), we need the user to fill it in. Saving an empty string
+        // produces a daemon that can't actually call any model.
+        if model.is_empty() {
+            self.status_msg =
+                "Model name is required. Type the model ID (e.g. llama3.3, qwen2.5:7b)."
+                    .to_string();
+            self.step = WizardStep::Model;
+            return;
+        }
 
         let config = format!(
             r#"# LibreFang Agent OS configuration

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1845,29 +1845,58 @@ impl LibreFangKernel {
                 config.default_model.model = model;
                 config.default_model.api_key_env = env_var.to_string();
             } else if is_ollama_reachable() {
-                // Ollama is running locally — use the catalog's default model, not a hardcoded one.
-                let model = librefang_runtime::model_catalog::ModelCatalog::default()
-                    .default_model_for_provider("ollama")
-                    .unwrap_or_else(|| {
-                        warn!("Model catalog has no default for ollama — falling back to gemma4");
-                        "gemma4".to_string()
-                    });
-                info!(
-                    model = %model,
-                    "No API keys detected — Ollama is running locally, using as default"
+                // Ollama is up — discover what's actually installed via /api/tags
+                // before trusting the static catalog. The catalog ships placeholder
+                // entries (e.g. the registry's historical "gemma4" stub, which is
+                // not a real Ollama tag) that confuse users when the chat call
+                // fails with "model not found". Probing live ensures we set a
+                // model the user actually has.
+                let probe = librefang_runtime::provider_health::probe_provider_blocking(
+                    "ollama",
+                    "http://127.0.0.1:11434/v1",
+                    None,
                 );
-                config.default_model.provider = "ollama".to_string();
-                config.default_model.model = model;
-                config.default_model.api_key_env = String::new();
-                if !config.provider_urls.contains_key("ollama") {
-                    // Use 127.0.0.1: on macOS `localhost` resolves to ::1 first
-                    // and Ollama only binds IPv4, so the IPv6 attempt fails
-                    // without reliable fallback. See PROVIDER_REGISTRY in
-                    // librefang-llm-drivers for the same reasoning.
-                    config.provider_urls.insert(
-                        "ollama".to_string(),
-                        "http://127.0.0.1:11434/v1".to_string(),
-                    );
+                let installed_default =
+                    librefang_runtime::provider_health::first_chat_model(&probe);
+                let catalog_default = librefang_runtime::model_catalog::ModelCatalog::default()
+                    .default_model_for_provider("ollama");
+
+                // Prefer an actually-installed model. Only fall back to the
+                // catalog default if the catalog default is also installed
+                // (probe lists it). Otherwise skip auto-set entirely: a stale
+                // catalog default that the user hasn't pulled would just
+                // produce the same "Model not found" error on first chat.
+                let chosen = installed_default.clone().or_else(|| {
+                    catalog_default.filter(|m| probe.discovered_models.iter().any(|n| n == m))
+                });
+
+                match chosen {
+                    Some(model) => {
+                        info!(
+                            model = %model,
+                            "No API keys detected — Ollama is running locally, using as default"
+                        );
+                        config.default_model.provider = "ollama".to_string();
+                        config.default_model.model = model;
+                        config.default_model.api_key_env = String::new();
+                        if !config.provider_urls.contains_key("ollama") {
+                            // Use 127.0.0.1: on macOS `localhost` resolves to ::1 first
+                            // and Ollama only binds IPv4, so the IPv6 attempt fails
+                            // without reliable fallback. See PROVIDER_REGISTRY in
+                            // librefang-llm-drivers for the same reasoning.
+                            config.provider_urls.insert(
+                                "ollama".to_string(),
+                                "http://127.0.0.1:11434/v1".to_string(),
+                            );
+                        }
+                    }
+                    None => {
+                        warn!(
+                            "Ollama is reachable but no installed chat models were found via \
+                             /api/tags. Run `ollama pull <model>` (e.g. `ollama pull llama3.3`) \
+                             then set [default_model] in ~/.librefang/config.toml."
+                        );
+                    }
                 }
             } else {
                 warn!(

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -454,6 +454,65 @@ pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str
     }
 }
 
+/// Synchronous wrapper around [`probe_provider`].
+///
+/// Spawns a dedicated OS thread with its own current-thread Tokio runtime so
+/// it can be called safely from anywhere — sync `fn main`, inside a
+/// multi-threaded async runtime, or inside a current-thread one — without
+/// risking the `block_in_place`-on-current-thread panic. Used by boot-time
+/// detection (`kernel::boot_with_config`) and the TUI setup wizard, both of
+/// which need a one-shot Ollama probe from a synchronous context.
+///
+/// On any error (thread spawn, runtime build) returns `ProbeResult::default()`
+/// — callers should treat that the same as "no models discovered".
+pub fn probe_provider_blocking(
+    provider: &str,
+    base_url: &str,
+    api_key: Option<&str>,
+) -> ProbeResult {
+    let provider = provider.to_string();
+    let base_url = base_url.to_string();
+    let api_key = api_key.map(str::to_string);
+
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(_) => return ProbeResult::default(),
+        };
+        rt.block_on(probe_provider(&provider, &base_url, api_key.as_deref()))
+    })
+    .join()
+    .unwrap_or_default()
+}
+
+/// Pick the first chat-capable model from a probe result.
+///
+/// Filters out embedding-only models (which can't be used as a default chat
+/// model) using the `capabilities` field discovered in `/api/tags`. Returns
+/// `None` if the probe failed or no chat-capable model was discovered.
+pub fn first_chat_model(probe: &ProbeResult) -> Option<String> {
+    if !probe.reachable {
+        return None;
+    }
+    // Prefer enriched info so we can filter out embedding models.
+    if !probe.discovered_model_info.is_empty() {
+        for m in &probe.discovered_model_info {
+            let is_embedding_only = !m.capabilities.is_empty()
+                && m.capabilities
+                    .iter()
+                    .all(|c| c.eq_ignore_ascii_case("embedding"));
+            if !is_embedding_only {
+                return Some(m.name.clone());
+            }
+        }
+        return None;
+    }
+    probe.discovered_models.first().cloned()
+}
+
 /// Probe a provider, returning a cached result when available.
 ///
 /// If the cache contains a non-expired entry the HTTP request is skipped
@@ -735,5 +794,105 @@ mod tests {
     fn test_infer_ollama_capabilities_chat_only() {
         let caps = infer_ollama_capabilities("llama3.2:latest", Some("llama"));
         assert_eq!(caps, vec!["completion"]);
+    }
+
+    #[test]
+    fn test_first_chat_model_unreachable_returns_none() {
+        let probe = ProbeResult::default();
+        assert_eq!(first_chat_model(&probe), None);
+    }
+
+    #[test]
+    fn test_first_chat_model_skips_embedding_only() {
+        // Two models reported, the first is embedding-only — picker must skip it.
+        let probe = ProbeResult {
+            reachable: true,
+            discovered_models: vec!["nomic-embed-text".to_string(), "llama3.3".to_string()],
+            discovered_model_info: vec![
+                DiscoveredModelInfo {
+                    name: "nomic-embed-text".to_string(),
+                    parameter_size: None,
+                    quantization_level: None,
+                    family: Some("bert".to_string()),
+                    families: None,
+                    size: None,
+                    capabilities: vec!["embedding".to_string()],
+                },
+                DiscoveredModelInfo {
+                    name: "llama3.3".to_string(),
+                    parameter_size: None,
+                    quantization_level: None,
+                    family: Some("llama".to_string()),
+                    families: None,
+                    size: None,
+                    capabilities: vec!["completion".to_string(), "tools".to_string()],
+                },
+            ],
+            ..Default::default()
+        };
+        assert_eq!(first_chat_model(&probe), Some("llama3.3".to_string()));
+    }
+
+    #[test]
+    fn test_first_chat_model_falls_back_to_names_when_info_missing() {
+        // Older Ollama / non-Ollama probes don't populate model_info — picker
+        // should still return the first listed name.
+        let probe = ProbeResult {
+            reachable: true,
+            discovered_models: vec!["llama3.3:latest".to_string(), "qwen2.5".to_string()],
+            discovered_model_info: vec![],
+            ..Default::default()
+        };
+        assert_eq!(
+            first_chat_model(&probe),
+            Some("llama3.3:latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_first_chat_model_returns_none_when_only_embedding_models() {
+        // Probe succeeded but every model is embedding-only — no chat default
+        // available, caller should warn the user instead of guessing.
+        let probe = ProbeResult {
+            reachable: true,
+            discovered_models: vec!["nomic-embed-text".to_string()],
+            discovered_model_info: vec![DiscoveredModelInfo {
+                name: "nomic-embed-text".to_string(),
+                parameter_size: None,
+                quantization_level: None,
+                family: Some("bert".to_string()),
+                families: None,
+                size: None,
+                capabilities: vec!["embedding".to_string()],
+            }],
+            ..Default::default()
+        };
+        assert_eq!(first_chat_model(&probe), None);
+    }
+
+    #[test]
+    fn test_probe_provider_blocking_unreachable_returns_default() {
+        // Sync wrapper must work outside any tokio runtime context — and
+        // must not panic on probe failure.
+        let result = probe_provider_blocking("ollama", "http://127.0.0.1:19997/v1", None);
+        assert!(!result.reachable);
+        assert!(result.discovered_models.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_probe_provider_blocking_inside_multi_thread_runtime() {
+        // Calling the sync wrapper from inside a multi-threaded tokio runtime
+        // must not deadlock — the dedicated-thread design is what makes this
+        // safe (block_in_place would panic on a current_thread runtime).
+        let result = probe_provider_blocking("ollama", "http://127.0.0.1:19996/v1", None);
+        assert!(!result.reachable);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_probe_provider_blocking_inside_current_thread_runtime() {
+        // Same guarantee for current-thread runtimes (this is where naïve
+        // block_in_place + Handle::current().block_on() patterns blow up).
+        let result = probe_provider_blocking("ollama", "http://127.0.0.1:19995/v1", None);
+        assert!(!result.reachable);
     }
 }


### PR DESCRIPTION
Closes #3191.

## Summary

Issue #3191's reporter diagnosed the wrong root cause (claiming the Ollama driver hits the wrong endpoint path). The actual bug they hit is the literal string `gemma4` — a hardcoded model-name fallback that is **not** a real Ollama tag — leaking into their config and being sent to the provider, which correctly responds "Model gemma4 was not found".

`gemma4` was hardcoded in two places:
- `crates/librefang-kernel/src/kernel/mod.rs` — boot-time auto-detect fallback
- `crates/librefang-cli/src/tui/screens/wizard.rs` — TUI setup wizard's per-provider default

Both fire when the model catalog has no entry for ollama (or, more insidiously, when the catalog *does* have a placeholder entry — the upstream `librefang-registry` historically shipped `id = "gemma4"` as the first entry in `providers/ollama.toml`, see follow-up below).

## Fix

Replaced the hardcoded fallback with a live `/api/tags` probe in both call sites:

1. **New `provider_health::probe_provider_blocking`** — sync wrapper around the existing async `probe_provider`, runtime-flavor-safe (spawns a dedicated OS thread with its own current-thread runtime, so it's callable from sync `fn main`, multi-threaded async runtimes, and current-thread async runtimes alike — `block_in_place + Handle::current().block_on()` panics on the latter).
2. **New `provider_health::first_chat_model`** — picks the first installed chat-capable model from a probe result, skipping embedding-only models so a box with only `nomic-embed-text` doesn't get auto-set as a chat default.
3. **Kernel auto-detect (`boot_with_config`)** — probes Ollama, picks the first installed chat model. Only falls back to the catalog default if the catalog default is *also* in the discovered list (otherwise the same "Model not found" error would resurface on first chat). If neither yields a model, logs a clear warning telling the user to `ollama pull <model>` and **does not** auto-set ollama as default — better to leave the slot empty than to lie.
4. **TUI wizard** — same probe runs when the user selects ollama. The hardcoded `default_model: "gemma4"` becomes `default_model: ""`. `save_config` now refuses to write an empty model and bounces the user back to the Model step with a clear message.

## What this PR does **not** fix (deliberately, separate PRs)

- **`librefang-registry/providers/ollama.toml`** still ships `id = "gemma4"` (and `llama4`) as static catalog entries. Those bogus rows surface in the dashboard's Models page until the registry is patched. That repo lives outside this codebase — I'll send a separate PR there.
- **Dashboard Models page for local providers** is still backed by the static catalog rather than a live `/v1/models` query of the configured provider URL. That's the deeper fix (and would also surface correct vision/tools capability flags from the live response). Out of scope for a focused #3191 fix.

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo test --workspace -p librefang-runtime provider_health::tests`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New unit tests cover: `first_chat_model` skipping embedding-only models, name-only fallback when capability info missing, all-embedding probe yielding `None`, and `probe_provider_blocking` returning a default `ProbeResult` from outside any runtime, inside a multi-threaded runtime, and inside a current-thread runtime (the runtime-flavor coverage is the actual reason for the dedicated-thread design).
