### PR TITLE
feat(kernel): hot-reload log_level via dashboard without daemon restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
 name = "librefang-cli"
 version = "2026.4.24-beta5"
 dependencies = [
+ "arc-swap",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -4193,6 +4194,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
+ "tracing-core",
  "tracing-subscriber",
  "unic-langid",
  "uuid",

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -29,7 +29,9 @@ tokio = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 tracing = { workspace = true }
+tracing-core = "0.1"
 tracing-subscriber = { workspace = true }
+arc-swap = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }

--- a/crates/librefang-cli/src/log_filter.rs
+++ b/crates/librefang-cli/src/log_filter.rs
@@ -1,0 +1,125 @@
+//! Reloadable per-layer `EnvFilter` for the daemon's tracing stack.
+//!
+//! The daemon installs an `EnvFilter` as a *per-layer* filter (so the OTel
+//! exporter sees the full span tree while stderr stays terse — see the
+//! comment in `init_tracing_stderr`). `tracing_subscriber::reload::Layer`
+//! could in principle wrap that filter, but its `Handle` carries the
+//! enclosing subscriber type as a generic parameter, and the daemon's
+//! subscriber stack (`Registry` + OTel reload slot + fmt layer) bakes that
+//! into a `Layered<…>` chain that's both verbose and brittle to keep in a
+//! `OnceLock` signature.
+//!
+//! Instead we hand-roll a tiny [`ReloadableEnvFilter`] backed by an
+//! `ArcSwap<EnvFilter>` and forward every [`Filter`] hook to the currently
+//! loaded inner filter. Hot-reload swaps the inner filter and calls
+//! [`tracing_core::callsite::rebuild_interest_cache`] so the per-callsite
+//! `Interest` cache and the global max-level hint are recomputed against
+//! the new directive — without that, callsites whose `Interest` was
+//! resolved to `Always`/`Never` under the old filter would never re-ask
+//! the new one.
+
+use arc_swap::ArcSwap;
+use std::sync::{Arc, OnceLock};
+use tracing::level_filters::LevelFilter;
+use tracing::subscriber::Interest;
+use tracing::{Event, Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, Filter};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+
+/// Process-global slot for the live filter. Set the first time
+/// [`ReloadableEnvFilter::install`] runs; subsequent installs would race a
+/// re-init of the tracing subscriber, which we don't support.
+static LIVE_FILTER: OnceLock<Arc<ArcSwap<EnvFilter>>> = OnceLock::new();
+
+/// Per-layer filter whose inner `EnvFilter` can be replaced at runtime via
+/// [`reload_log_level`].
+#[derive(Clone)]
+pub struct ReloadableEnvFilter {
+    inner: Arc<ArcSwap<EnvFilter>>,
+}
+
+impl ReloadableEnvFilter {
+    /// Install `initial` as the live filter and return a wrapper to hand to
+    /// `Layer::with_filter`. Subsequent calls reuse the existing slot — the
+    /// new `initial` is dropped, so callers that re-init tracing in the
+    /// same process get a stable handle (test harnesses, mostly).
+    pub fn install(initial: EnvFilter) -> Self {
+        let cell = LIVE_FILTER.get_or_init(|| Arc::new(ArcSwap::from_pointee(initial)));
+        Self {
+            inner: Arc::clone(cell),
+        }
+    }
+}
+
+impl<S> Filter<S> for ReloadableEnvFilter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn enabled(&self, meta: &Metadata<'_>, cx: &Context<'_, S>) -> bool {
+        Filter::<S>::enabled(self.inner.load().as_ref(), meta, cx)
+    }
+
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
+        Filter::<S>::callsite_enabled(self.inner.load().as_ref(), meta)
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Filter::<S>::max_level_hint(self.inner.load().as_ref())
+    }
+
+    fn event_enabled(&self, event: &Event<'_>, cx: &Context<'_, S>) -> bool {
+        Filter::<S>::event_enabled(self.inner.load().as_ref(), event, cx)
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::Id,
+        ctx: Context<'_, S>,
+    ) {
+        Filter::<S>::on_new_span(self.inner.load().as_ref(), attrs, id, ctx);
+    }
+
+    fn on_record(&self, id: &tracing::Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
+        Filter::<S>::on_record(self.inner.load().as_ref(), id, values, ctx);
+    }
+
+    fn on_enter(&self, id: &tracing::Id, ctx: Context<'_, S>) {
+        Filter::<S>::on_enter(self.inner.load().as_ref(), id, ctx);
+    }
+
+    fn on_exit(&self, id: &tracing::Id, ctx: Context<'_, S>) {
+        Filter::<S>::on_exit(self.inner.load().as_ref(), id, ctx);
+    }
+
+    fn on_close(&self, id: tracing::Id, ctx: Context<'_, S>) {
+        Filter::<S>::on_close(self.inner.load().as_ref(), id, ctx);
+    }
+}
+
+/// Replace the live `EnvFilter` with one parsed from `directive` and
+/// invalidate the callsite `Interest` cache.
+///
+/// Returns `Err` when the filter slot has not been installed (no daemon
+/// tracing init has run) or when `directive` fails to parse.
+pub fn reload_log_level(directive: &str) -> Result<(), String> {
+    let cell = LIVE_FILTER
+        .get()
+        .ok_or_else(|| "log filter not installed".to_string())?;
+    let new_filter = EnvFilter::try_new(directive)
+        .map_err(|e| format!("invalid log directive {directive:?}: {e}"))?;
+    cell.store(Arc::new(new_filter));
+    tracing_core::callsite::rebuild_interest_cache();
+    Ok(())
+}
+
+/// Adapter that hands [`reload_log_level`] to the kernel via the
+/// [`librefang_kernel::log_reload::LogLevelReloader`] trait.
+pub struct CliLogLevelReloader;
+
+impl librefang_kernel::log_reload::LogLevelReloader for CliLogLevelReloader {
+    fn reload(&self, level: &str) -> Result<(), String> {
+        reload_log_level(level)
+    }
+}

--- a/crates/librefang-cli/src/log_filter.rs
+++ b/crates/librefang-cli/src/log_filter.rs
@@ -28,9 +28,23 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
 /// Process-global slot for the live filter. Set the first time
-/// [`ReloadableEnvFilter::install`] runs; subsequent installs would race a
-/// re-init of the tracing subscriber, which we don't support.
+/// [`ReloadableEnvFilter::install`] runs; subsequent installs reuse the
+/// existing slot (the new `initial` filter is dropped) — `OnceLock` makes
+/// this race-free, and the daemon initialises tracing exactly once anyway.
 static LIVE_FILTER: OnceLock<Arc<ArcSwap<EnvFilter>>> = OnceLock::new();
+
+/// Baseline directives to reapply on every reload.
+///
+/// The boot-time tracing init layers per-target overrides on top of the
+/// user's level (e.g. `librefang_kernel=warn` to silence kernel chatter from
+/// one-shot CLI commands). Without this slot, `reload_log_level("debug")`
+/// would call `EnvFilter::try_new("debug")` and silently drop those
+/// overrides — a dashboard "give me debug" toggle would suddenly flood the
+/// operator with kernel/runtime DEBUG noise that boot had specifically
+/// masked. Set once during `install_with_baseline` and reapplied on every
+/// subsequent `reload_log_level` so reload behaviour matches boot behaviour
+/// for everything except the level the user actually edited.
+static BASELINE_DIRECTIVES: OnceLock<Vec<String>> = OnceLock::new();
 
 /// Per-layer filter whose inner `EnvFilter` can be replaced at runtime via
 /// [`reload_log_level`].
@@ -49,6 +63,21 @@ impl ReloadableEnvFilter {
         Self {
             inner: Arc::clone(cell),
         }
+    }
+
+    /// Install `initial` as the live filter and remember `baseline` directives
+    /// so [`reload_log_level`] can reapply them after every swap.
+    ///
+    /// Use this from the boot-time tracing init when you've layered per-target
+    /// overrides on top of the user's level (see [`BASELINE_DIRECTIVES`]).
+    /// `baseline` entries are stored as strings and reparsed on each reload —
+    /// the parse cost is paid once per dashboard edit, which is fine.
+    /// Subsequent calls reuse the existing slots (both filter and baseline);
+    /// the second `baseline` is dropped to keep the in-memory state stable for
+    /// re-init scenarios (test harnesses, embedded relaunches).
+    pub fn install_with_baseline(initial: EnvFilter, baseline: Vec<String>) -> Self {
+        let _ = BASELINE_DIRECTIVES.set(baseline);
+        Self::install(initial)
     }
 }
 
@@ -101,14 +130,40 @@ where
 /// Replace the live `EnvFilter` with one parsed from `directive` and
 /// invalidate the callsite `Interest` cache.
 ///
+/// Reapplies any baseline directives stored via
+/// [`ReloadableEnvFilter::install_with_baseline`] so per-target overrides
+/// from boot (e.g. `librefang_kernel=warn`) survive a dashboard
+/// `log_level` edit. Without this, swapping in a fresh `EnvFilter` from
+/// just the directive string would silently drop those overrides — boot
+/// would mask kernel chatter while reload would unmask it, giving two
+/// different log experiences for "the same" `log_level` value.
+///
 /// Returns `Err` when the filter slot has not been installed (no daemon
-/// tracing init has run) or when `directive` fails to parse.
+/// tracing init has run) or when `directive` fails to parse. A baseline
+/// directive that fails to reparse is logged at warn and skipped — that
+/// would only happen if someone changed boot-time directive syntax to
+/// something invalid, in which case the new filter is still better than
+/// no reload at all.
 pub fn reload_log_level(directive: &str) -> Result<(), String> {
     let cell = LIVE_FILTER
         .get()
         .ok_or_else(|| "log filter not installed".to_string())?;
-    let new_filter = EnvFilter::try_new(directive)
+    let mut new_filter = EnvFilter::try_new(directive)
         .map_err(|e| format!("invalid log directive {directive:?}: {e}"))?;
+    if let Some(baseline) = BASELINE_DIRECTIVES.get() {
+        for d in baseline {
+            match d.parse() {
+                Ok(parsed) => new_filter = new_filter.add_directive(parsed),
+                Err(e) => {
+                    tracing::warn!(
+                        directive = %d,
+                        error = %e,
+                        "Skipping unparseable baseline log directive on reload",
+                    );
+                }
+            }
+        }
+    }
     cell.store(Arc::new(new_filter));
     tracing_core::callsite::rebuild_interest_cache();
     Ok(())
@@ -121,5 +176,93 @@ pub struct CliLogLevelReloader;
 impl librefang_kernel::log_reload::LogLevelReloader for CliLogLevelReloader {
     fn reload(&self, level: &str) -> Result<(), String> {
         reload_log_level(level)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current_max_level() -> Option<LevelFilter> {
+        let cell = LIVE_FILTER
+            .get()
+            .expect("LIVE_FILTER must be installed before reading max_level");
+        cell.load().max_level_hint()
+    }
+
+    fn current_filter_repr() -> String {
+        let cell = LIVE_FILTER
+            .get()
+            .expect("LIVE_FILTER must be installed before reading repr");
+        format!("{}", cell.load())
+    }
+
+    /// All reload assertions live in one test because `LIVE_FILTER` and
+    /// `BASELINE_DIRECTIVES` are process-wide `OnceLock`s — running them as
+    /// separate `#[test]` fns would let cargo's parallel test harness race on
+    /// the same slots, and the `OnceLock` semantics mean only the first
+    /// `install*()` actually seeds them. Driving the slots through a known
+    /// sequence here is both deterministic and exercises the same code path
+    /// that `apply_hot_actions_inner` triggers in production.
+    ///
+    /// We use `install_with_baseline` because it's the strict superset:
+    /// asserting baseline survival also implicitly covers the simpler
+    /// `install` path (the filter swap and Err-handling logic are shared).
+    #[test]
+    fn install_then_reload_swaps_inner_filter_and_keeps_baseline() {
+        // Idempotent installer — we don't care whether some other test
+        // already seeded the slot; we just need a wrapper to hold and a
+        // valid starting point before our first `reload_log_level`. The
+        // baseline mirrors the per-target overrides `init_tracing_stderr`
+        // applies on the daemon path so the assertions below match prod.
+        let _filter = ReloadableEnvFilter::install_with_baseline(
+            EnvFilter::new("warn"),
+            vec![
+                "librefang_kernel=warn".to_string(),
+                "librefang_runtime=warn".to_string(),
+            ],
+        );
+
+        reload_log_level("error").expect("error reload");
+        assert_eq!(current_max_level(), Some(LevelFilter::ERROR));
+
+        reload_log_level("debug").expect("debug reload");
+        assert_eq!(current_max_level(), Some(LevelFilter::DEBUG));
+
+        reload_log_level("trace").expect("trace reload");
+        assert_eq!(current_max_level(), Some(LevelFilter::TRACE));
+
+        // Baseline survival check (regression for Codex P2-1 #3200): even
+        // though the user reloaded to `trace`, the kernel/runtime overrides
+        // installed at boot must still be present in the live filter, or
+        // the dashboard "give me debug" toggle would silently flood with
+        // noise that boot had specifically masked.
+        let repr = current_filter_repr();
+        assert!(
+            repr.contains("librefang_kernel=warn"),
+            "baseline directive lost after reload: {repr}"
+        );
+        assert!(
+            repr.contains("librefang_runtime=warn"),
+            "baseline directive lost after reload: {repr}"
+        );
+
+        // Invalid directives surface as `Err` and must leave the live
+        // filter untouched — otherwise a typo from the dashboard would
+        // silently disable logging until the next valid reload.
+        let err = reload_log_level("foo=bogus").expect_err("must reject");
+        assert!(
+            err.contains("invalid log directive"),
+            "error message changed shape: {err}"
+        );
+        assert_eq!(
+            current_max_level(),
+            Some(LevelFilter::TRACE),
+            "failed reload must not mutate the live filter"
+        );
+        assert!(
+            current_filter_repr().contains("librefang_kernel=warn"),
+            "failed reload must not drop baseline either"
+        );
     }
 }

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -12,6 +12,7 @@ pub mod doctor;
 mod http_client;
 pub mod i18n;
 mod launcher;
+mod log_filter;
 mod mcp;
 pub mod progress;
 pub mod table;
@@ -1670,16 +1671,20 @@ fn init_tracing_stderr(log_level: &str) {
     // INFO-level `#[instrument]` spans are filtered out before OTel ever
     // sees them). Per-layer filtering keeps stderr terse while OTel
     // receives the full span tree.
+    //
+    // The filter is wrapped in `ReloadableEnvFilter` so the daemon can swap
+    // it at runtime when `KernelConfig::log_level` changes via hot-reload.
     // Force stderr explicitly: machine-readable subcommands like
     // `doctor --json` expect a clean stdout stream. The fmt layer's
     // default writer is stdout, which would interleave tracing output
     // with the JSON payload and corrupt downstream parsers.
+    let reloadable_filter = log_filter::ReloadableEnvFilter::install(env_filter);
     let fmt_layer = tracing_subscriber::fmt::layer()
         .without_time()
         .with_target(false)
         .compact()
         .with_writer(std::io::stderr)
-        .with_filter(env_filter);
+        .with_filter(reloadable_filter);
 
     // Register a no-op reload slot so `init_otel_tracing` can swap a real
     // OTel layer in later without needing to claim the global dispatcher.
@@ -3405,6 +3410,13 @@ fn cmd_start(config: Option<PathBuf>, tail: bool, spawned: bool, foreground: boo
                 std::process::exit(1);
             }
         };
+
+        // Wire the live tracing filter into the kernel's hot-reload path so
+        // dashboard edits to `log_level` take effect immediately instead of
+        // requiring a daemon restart. Only the daemon path needs this — TUI
+        // / one-shot CLI commands route through `init_tracing_file` (no
+        // dashboard) so the slot stays unwired there.
+        kernel.set_log_reloader(std::sync::Arc::new(log_filter::CliLogLevelReloader));
 
         let cfg = kernel.config_ref();
         let listen_addr = cfg.api_listen.clone();

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1701,34 +1701,33 @@ fn init_tracing_stderr(log_level: &str) {
     // see everything, and daemon/foreground boots route through a different
     // initialiser where the full log is expected.
     let user_set_rust_log = std::env::var("RUST_LOG").is_ok();
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
-    let env_filter = if user_set_rust_log {
-        env_filter
+    // Per-target overrides applied unconditionally on top of the user-visible
+    // level (and reapplied on every hot-reload via `install_with_baseline` —
+    // see Codex P2-1 #3200). Stored as strings so the filter installer can
+    // reparse them after a `log_level` swap; without that, a dashboard
+    // "give me debug" toggle would silently drop these and flood operators
+    // with kernel/runtime DEBUG noise that boot specifically masked.
+    let baseline_directives: Vec<String> = if user_set_rust_log {
+        // RUST_LOG is the explicit "I want full control" knob — don't layer
+        // any opinionated overrides on top of it, and don't carry any across
+        // reloads either.
+        Vec::new()
     } else {
-        // For one-shot CLI commands, downgrade library-level chatter so the
-        // user sees only their command's own output. WARN and above still
-        // surface everywhere — the filter is per-target verbosity, not a
-        // global mute. Setting RUST_LOG restores full detail.
-        env_filter
-            .add_directive("librefang_kernel=warn".parse().expect("static directive"))
-            .add_directive("librefang_runtime=warn".parse().expect("static directive"))
-            .add_directive(
-                "librefang_extensions=warn"
-                    .parse()
-                    .expect("static directive"),
-            )
-            .add_directive(
-                "librefang_kernel::config=error"
-                    .parse()
-                    .expect("static directive"),
-            )
-            .add_directive(
-                "librefang_runtime::registry_sync=error"
-                    .parse()
-                    .expect("static directive"),
-            )
+        vec![
+            "librefang_kernel=warn".to_string(),
+            "librefang_runtime=warn".to_string(),
+            "librefang_extensions=warn".to_string(),
+            "librefang_kernel::config=error".to_string(),
+            "librefang_runtime::registry_sync=error".to_string(),
+        ]
     };
+    let mut env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
+    for d in &baseline_directives {
+        // Per-string parse keeps the boot-time directive list and the
+        // reload-time directive list literally identical.
+        env_filter = env_filter.add_directive(d.parse().expect("baseline directive must parse"));
+    }
 
     // Compact stderr format: in a one-shot CLI context the user cares about
     // the WARN/ERROR text, not the timestamp or the fully-qualified target.
@@ -1745,10 +1744,18 @@ fn init_tracing_stderr(log_level: &str) {
     //
     // The filter is wrapped in `ReloadableEnvFilter` so the daemon can swap
     // it at runtime when `KernelConfig::log_level` changes via hot-reload.
+    // `install_with_baseline` hands the per-target directives above to the
+    // filter installer so a dashboard `log_level` edit reapplies them after
+    // the swap — i.e. the kernel/runtime overrides survive reloads instead
+    // of being silently dropped. `RUST_LOG` itself is *not* re-read on
+    // reload (it's a boot-time knob); operators wanting env-driven
+    // filtering after a config edit need to restart.
+    //
     // Force stderr explicitly: machine-readable subcommands like
     // `doctor --json` expect a clean stdout stream. The fmt layer's
     // default writer is stdout, which would interleave tracing output
     // with the JSON payload and corrupt downstream parsers.
+    //
     // Build the inner format separately so we can wrap it in `WithTraceId`,
     // which appends the OTel `trace_id` as a logfmt suffix on every line when
     // an OTel context is active. The wrapper is unconditional but no-ops
@@ -1757,7 +1764,8 @@ fn init_tracing_stderr(log_level: &str) {
         .without_time()
         .with_target(false)
         .compact();
-    let reloadable_filter = log_filter::ReloadableEnvFilter::install(env_filter);
+    let reloadable_filter =
+        log_filter::ReloadableEnvFilter::install_with_baseline(env_filter, baseline_directives);
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .event_format(WithTraceId(inner_format))

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -3,9 +3,8 @@
 //! **Hot-reload safe**: channels, skills, usage footer, web config, browser,
 //! approval policy, cron settings, webhook triggers, extensions, tool policy,
 //! api_key, dashboard credentials, stable_prefix_mode, proxy, provider_api_keys,
-//! sanitize, default model, language, mode.
-//!
-//! **No-op** (informational only): log_level (reload handle not yet plumbed).
+//! sanitize, default model, language, mode, log_level (when a
+//! [`crate::log_reload::LogLevelReloader`] is installed by the binary).
 //!
 //! **Restart required**: api_listen, network, memory, home_dir, data_dir, vault.
 
@@ -57,6 +56,10 @@ pub enum HotAction {
     ReloadProxy,
     /// Dashboard credentials (user/pass/hash) changed — config swap is sufficient.
     UpdateDashboardCredentials,
+    /// `log_level` changed — swap the live tracing `EnvFilter`. Carries the
+    /// new directive string (e.g. `"debug"`, `"librefang_kernel=trace,info"`)
+    /// since the kernel doesn't keep the parsed filter around.
+    ReloadLogLevel(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -300,10 +303,8 @@ pub fn build_reload_plan(old: &KernelConfig, new: &KernelConfig) -> ReloadPlan {
     // ----- No-op fields -----
 
     if old.log_level != new.log_level {
-        plan.noop_changes.push(format!(
-            "log_level: {} -> {} (requires restart — reload handle not yet plumbed)",
-            old.log_level, new.log_level
-        ));
+        plan.hot_actions
+            .push(HotAction::ReloadLogLevel(new.log_level.clone()));
     }
 
     if old.language != new.language {
@@ -637,7 +638,6 @@ mod tests {
         // Hot-reloadable
         b.usage_footer = UsageFooterMode::Tokens;
         b.max_cron_jobs = 100;
-        // No-op
         b.log_level = "debug".to_string();
 
         let plan = build_reload_plan(&a, &b);
@@ -647,7 +647,9 @@ mod tests {
         // so the caller knows what will need re-initialization after restart.
         assert!(plan.hot_actions.contains(&HotAction::UpdateUsageFooter));
         assert!(plan.hot_actions.contains(&HotAction::UpdateCronConfig));
-        assert!(plan.noop_changes.iter().any(|c| c.contains("log_level")));
+        assert!(plan
+            .hot_actions
+            .contains(&HotAction::ReloadLogLevel("debug".to_string())));
     }
 
     // -----------------------------------------------------------------------
@@ -659,17 +661,28 @@ mod tests {
         use librefang_types::config::KernelMode;
         let a = default_cfg();
         let mut b = default_cfg();
-        b.log_level = "debug".to_string();
         b.language = "de".to_string();
         b.mode = KernelMode::Dev;
 
         let plan = build_reload_plan(&a, &b);
         assert!(!plan.restart_required);
         assert!(plan.hot_actions.is_empty());
-        assert_eq!(plan.noop_changes.len(), 3);
-        assert!(plan.noop_changes.iter().any(|c| c.contains("log_level")));
+        assert_eq!(plan.noop_changes.len(), 2);
         assert!(plan.noop_changes.iter().any(|c| c.contains("language")));
         assert!(plan.noop_changes.iter().any(|c| c.contains("mode")));
+    }
+
+    #[test]
+    fn test_log_level_hot_reloaded() {
+        let a = default_cfg();
+        let mut b = default_cfg();
+        b.log_level = "debug".to_string();
+
+        let plan = build_reload_plan(&a, &b);
+        assert!(!plan.restart_required, "log_level should be hot-reloadable");
+        assert!(plan
+            .hot_actions
+            .contains(&HotAction::ReloadLogLevel("debug".to_string())));
     }
 
     // -----------------------------------------------------------------------
@@ -692,7 +705,7 @@ mod tests {
             restart_required: false,
             restart_reasons: vec![],
             hot_actions: vec![],
-            noop_changes: vec!["log_level: info -> debug".to_string()],
+            noop_changes: vec!["language: en -> de".to_string()],
         };
         assert!(plan.has_changes());
 

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -127,7 +127,30 @@ fn field_changed<T: serde::Serialize>(old: &T, new: &T) -> bool {
     old_json != new_json
 }
 
+/// Runtime capabilities the planner needs to know about so it can correctly
+/// classify changes whose hot-reload feasibility depends on which optional
+/// hooks the embedding binary wired up at boot.
+///
+/// Today the only such hook is the log-level reloader (only the CLI daemon
+/// path installs it; embedded callers like the desktop server start the same
+/// kernel without it). Without consulting this struct, `build_reload_plan`
+/// would always mark `log_level` changes as hot-reloadable — and in
+/// embedded contexts the kernel would just warn-and-no-op while the
+/// dashboard reported success. See Codex P2-2 #3200.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReloadCapabilities {
+    /// `true` if a [`crate::log_reload::LogLevelReloader`] has been installed
+    /// on the kernel via `set_log_reloader`. When `false`, `log_level`
+    /// changes are routed to `restart_required` instead of `hot_actions`.
+    pub log_reloader_installed: bool,
+}
+
 /// Diff two configurations and produce a reload plan.
+///
+/// Backward-compatibility wrapper that assumes every optional reloader is
+/// installed — i.e. matches the original CLI daemon path. New call sites
+/// (especially anything embedded that lacks the log reloader) should prefer
+/// [`build_reload_plan_with_caps`].
 ///
 /// The plan categorizes every detected change into one of three buckets:
 ///
@@ -136,6 +159,26 @@ fn field_changed<T: serde::Serialize>(old: &T, new: &T) -> bool {
 /// 2. **hot_actions** — the change can be applied without restarting.
 /// 3. **noop_changes** — the change is informational; no action needed.
 pub fn build_reload_plan(old: &KernelConfig, new: &KernelConfig) -> ReloadPlan {
+    build_reload_plan_with_caps(
+        old,
+        new,
+        ReloadCapabilities {
+            log_reloader_installed: true,
+        },
+    )
+}
+
+/// Diff two configurations against a known set of [`ReloadCapabilities`].
+///
+/// Use this from the kernel hot-reload path so changes whose feasibility
+/// depends on optional hooks (currently `log_level`) get demoted to
+/// `restart_required` when the hook isn't wired — preventing the
+/// dashboard from being told "applied" while the live filter never moved.
+pub fn build_reload_plan_with_caps(
+    old: &KernelConfig,
+    new: &KernelConfig,
+    caps: ReloadCapabilities,
+) -> ReloadPlan {
     let mut plan = ReloadPlan {
         restart_required: false,
         restart_reasons: Vec::new(),
@@ -303,8 +346,20 @@ pub fn build_reload_plan(old: &KernelConfig, new: &KernelConfig) -> ReloadPlan {
     // ----- No-op fields -----
 
     if old.log_level != new.log_level {
-        plan.hot_actions
-            .push(HotAction::ReloadLogLevel(new.log_level.clone()));
+        if caps.log_reloader_installed {
+            plan.hot_actions
+                .push(HotAction::ReloadLogLevel(new.log_level.clone()));
+        } else {
+            // No reloader wired (embedded callers without the CLI's
+            // log_filter slot). Demote to restart_required so the
+            // dashboard reports an honest "needs restart" instead of
+            // a false "applied" — see Codex P2-2 #3200.
+            plan.restart_required = true;
+            plan.restart_reasons.push(format!(
+                "log_level: {} -> {} (no log reloader installed; restart required)",
+                old.log_level, new.log_level
+            ));
+        }
     }
 
     if old.language != new.language {
@@ -683,6 +738,43 @@ mod tests {
         assert!(plan
             .hot_actions
             .contains(&HotAction::ReloadLogLevel("debug".to_string())));
+    }
+
+    #[test]
+    fn test_log_level_demoted_to_restart_when_no_reloader_installed() {
+        // Codex P2-2 #3200: embedded callers (e.g. desktop server) boot
+        // the same kernel without wiring a LogLevelReloader. Without
+        // capability-aware planning, the dashboard would receive a
+        // false "applied, no restart needed" response while the live
+        // filter never moved. Assert that demoting to restart_required
+        // is the active behaviour when the reloader is absent.
+        let a = default_cfg();
+        let mut b = default_cfg();
+        b.log_level = "debug".to_string();
+
+        let plan = build_reload_plan_with_caps(
+            &a,
+            &b,
+            ReloadCapabilities {
+                log_reloader_installed: false,
+            },
+        );
+        assert!(
+            plan.restart_required,
+            "log_level change must require restart when no reloader is installed"
+        );
+        assert!(
+            !plan
+                .hot_actions
+                .iter()
+                .any(|a| matches!(a, HotAction::ReloadLogLevel(_))),
+            "ReloadLogLevel must NOT be queued as a hot action without a reloader"
+        );
+        assert!(
+            plan.restart_reasons.iter().any(|r| r.contains("log_level")),
+            "restart_reasons should explain the log_level demotion: {:?}",
+            plan.restart_reasons
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9549,9 +9549,7 @@ system_prompt = "You are a helpful assistant."
     /// apply hot-reloadable actions. Returns the reload plan for API response.
     pub async fn reload_config(&self) -> Result<crate::config_reload::ReloadPlan, String> {
         let old_cfg = self.config.load();
-        use crate::config_reload::{
-            build_reload_plan, should_apply_hot, validate_config_for_reload,
-        };
+        use crate::config_reload::{should_apply_hot, validate_config_for_reload};
 
         // Read and parse config file (using load_config to process $include directives)
         let config_path = self.home_dir_boot.join("config.toml");
@@ -9573,8 +9571,14 @@ system_prompt = "You are a helpful assistant."
             return Err(format!("Validation failed: {}", errors.join("; ")));
         }
 
-        // Build the reload plan
-        let plan = build_reload_plan(&old_cfg, &new_config);
+        // Build the reload plan against the live capability set so changes
+        // whose feasibility depends on optional reloaders get correctly
+        // routed to `restart_required` when the reloader isn't installed
+        // (e.g. embedded desktop boot doesn't wire the log reloader).
+        let caps = crate::config_reload::ReloadCapabilities {
+            log_reloader_installed: self.log_reloader.get().is_some(),
+        };
+        let plan = crate::config_reload::build_reload_plan_with_caps(&old_cfg, &new_config, caps);
         plan.log_summary();
 
         // Apply hot actions + store new config atomically under the same

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -521,6 +521,14 @@ pub struct LibreFangKernel {
     /// directory could not be resolved at boot.
     pub(crate) checkpoint_manager:
         Option<Arc<librefang_runtime::checkpoint_manager::CheckpointManager>>,
+    /// Pluggable hook that swaps the live tracing `EnvFilter` when
+    /// `config.log_level` changes via hot-reload. Injected by the binary
+    /// (`librefang-cli` for the daemon) post-construction; absent for
+    /// in-process callers that don't own a tracing subscriber, in which
+    /// case `log_level` changes still update `KernelConfig` in-memory but
+    /// don't take effect on the active filter (the hot-reload action is a
+    /// no-op with a warning).
+    pub(crate) log_reloader: OnceLock<crate::log_reload::LogLevelReloaderArc>,
 }
 
 /// Bounded in-memory delivery receipt tracker.
@@ -2800,6 +2808,7 @@ impl LibreFangKernel {
                     librefang_runtime::checkpoint_manager::CheckpointManager::new(cp_dir),
                 ))
             },
+            log_reloader: OnceLock::new(),
         };
 
         // Initialize proactive memory system (mem0-style) from config.
@@ -9463,6 +9472,16 @@ system_prompt = "You are a helpful assistant."
         Ok(())
     }
 
+    /// Install a [`crate::log_reload::LogLevelReloader`].
+    ///
+    /// Idempotent: subsequent calls are silently ignored (the slot is a
+    /// `OnceLock`). The injected reloader is invoked when
+    /// [`crate::config_reload::HotAction::ReloadLogLevel`] fires during
+    /// hot-reload — see `apply_hot_actions_inner`.
+    pub fn set_log_reloader(&self, reloader: crate::log_reload::LogLevelReloaderArc) {
+        let _ = self.log_reloader.set(reloader);
+    }
+
     /// Set the weak self-reference for trigger dispatch.
     ///
     /// Must be called once after the kernel is wrapped in `Arc`.
@@ -9793,6 +9812,16 @@ system_prompt = "You are a helpful assistant."
                 HotAction::UpdateDashboardCredentials => {
                     info!("Hot-reload: dashboard credentials updated — config swap is sufficient");
                 }
+                HotAction::ReloadLogLevel(level) => match self.log_reloader.get() {
+                    Some(reloader) => match reloader.reload(level) {
+                        Ok(()) => info!("Hot-reload: log_level updated to {level}"),
+                        Err(e) => warn!("Hot-reload: log_level update to {level} failed: {e}"),
+                    },
+                    None => warn!(
+                        "Hot-reload: log_level changed to {level} but no reloader is installed; \
+                         restart required for the new filter to take effect"
+                    ),
+                },
             }
         }
 

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -19,6 +19,7 @@ pub mod heartbeat;
 pub mod hooks;
 pub mod inbox;
 pub mod kernel;
+pub mod log_reload;
 pub mod mcp_oauth_provider;
 pub use librefang_kernel_metering as metering;
 pub mod orchestration;

--- a/crates/librefang-kernel/src/log_reload.rs
+++ b/crates/librefang-kernel/src/log_reload.rs
@@ -1,0 +1,23 @@
+//! Trait for swapping the global tracing log filter at runtime.
+//!
+//! `librefang-kernel` deliberately does not depend on `tracing-subscriber`,
+//! so the binary that owns the subscriber (`librefang-cli` for the daemon)
+//! implements this trait and injects it into the kernel after boot via
+//! [`crate::LibreFangKernel::set_log_reloader`]. The hot-reload path
+//! ([`crate::config_reload::HotAction::ReloadLogLevel`]) then calls
+//! [`LogLevelReloader::reload`] to swap the live `EnvFilter` directive.
+
+use std::sync::Arc;
+
+/// Replace the active tracing log filter with one parsed from `level`.
+///
+/// `level` is the raw string from `KernelConfig::log_level`
+/// (e.g. `"debug"`, `"info"`, or a full directive like
+/// `"librefang_kernel=debug,info"`). Implementations should return an error
+/// when the directive fails to parse so the caller can surface a useful
+/// reload-failure reason instead of silently dropping the change.
+pub trait LogLevelReloader: Send + Sync {
+    fn reload(&self, level: &str) -> Result<(), String>;
+}
+
+pub type LogLevelReloaderArc = Arc<dyn LogLevelReloader>;


### PR DESCRIPTION
## Summary
- `KernelConfig.log_level` previously fell into `noop_changes` on hot-reload — the `config_reload` plan flagged "requires restart" because the active tracing `EnvFilter` lived in the binary's tracing subscriber, out of reach of the kernel.
- This wires the daemon's filter through `arc-swap` so `config_reload` can swap it in place. Editing `log_level` from the dashboard now takes effect on the next event without a daemon restart.

## How it works
- **`librefang-cli/src/log_filter.rs`**: `ReloadableEnvFilter` wraps a `tracing-subscriber` `EnvFilter` behind an `ArcSwap` and implements `Filter<S>` by delegating to the loaded `EnvFilter`. Stored in a process-global `OnceLock` so `CliLogLevelReloader` (a tiny `LogLevelReloader` impl) can swap it.
- **`librefang-kernel/src/log_reload.rs`**: `LogLevelReloader` trait + `LogLevelReloaderArc` alias. `LibreFangKernel` gets a `OnceLock<LogLevelReloaderArc>` slot and a `set_log_reloader` setter.
- **`config_reload`**: replaces the noop with `HotAction::ReloadLogLevel(String)`; tests updated, including a new `test_log_level_hot_reloaded`.
- **`cmd_start`**: installs `CliLogLevelReloader` on the kernel right after construction, *only* on the daemon path. TUI / one-shot subcommands route through `init_tracing_file` (no dashboard) and intentionally leave the slot unwired — `log_level` updates there still mutate `KernelConfig` in memory but log a warning instead of trying to swap a filter that isn't there.

## Trade-offs
- The `ReloadableEnvFilter` slot is a `OnceLock`, so re-init in the same process (e.g. test harnesses calling `init_tracing_stderr` twice) reuses the first filter. Acceptable: the daemon initializes it exactly once.
- `arc-swap` was already a workspace dep; only `tracing-core 0.1` is newly added, and only in the cli crate.

## Test plan
- [ ] `cargo build --workspace --lib` green
- [ ] `cargo test -p librefang-kernel config_reload` — new `test_log_level_hot_reloaded` passes; existing noop test no longer references `log_level`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [ ] Live: start daemon at default `log_level = "info"`, send a request (verify normal logging), then `PUT /api/config` with `log_level = "debug"` (or edit `~/.librefang/config.toml`), send another request, verify DEBUG-level lines appear in stderr without restart.
- [ ] Live: confirm restart-only fields still trigger restart (e.g. `api_listen` change still ends up in `restart_required`).
