### PR TITLE
fix(log-reload): correct max_level_hint test assertions

### DIFF
--- a/crates/librefang-cli/src/log_filter.rs
+++ b/crates/librefang-cli/src/log_filter.rs
@@ -223,9 +223,9 @@ mod tests {
             ],
         );
 
-        reload_log_level("error").expect("error reload");
-        assert_eq!(current_max_level(), Some(LevelFilter::ERROR));
-
+        // Raising the level above the baseline (debug/trace > warn) — the
+        // overall max_level_hint is dominated by the user-requested level
+        // and the baseline doesn't move it.
         reload_log_level("debug").expect("debug reload");
         assert_eq!(current_max_level(), Some(LevelFilter::DEBUG));
 
@@ -235,7 +235,7 @@ mod tests {
         // Baseline survival check (regression for Codex P2-1 #3200): even
         // though the user reloaded to `trace`, the kernel/runtime overrides
         // installed at boot must still be present in the live filter, or
-        // the dashboard "give me debug" toggle would silently flood with
+        // the dashboard "give me trace" toggle would silently flood with
         // noise that boot had specifically masked.
         let repr = current_filter_repr();
         assert!(
@@ -245,6 +245,18 @@ mod tests {
         assert!(
             repr.contains("librefang_runtime=warn"),
             "baseline directive lost after reload: {repr}"
+        );
+
+        // Lowering below the baseline — `error < warn`, but the baseline
+        // pins kernel/runtime at WARN, so the global max_level_hint is
+        // WARN (not ERROR). This is the *positive* baseline-presence test:
+        // if reload had wiped the baseline, max_level would collapse to
+        // ERROR. Asserting WARN here proves the baseline is being applied.
+        reload_log_level("error").expect("error reload");
+        assert_eq!(
+            current_max_level(),
+            Some(LevelFilter::WARN),
+            "baseline (warn) must dominate when user level (error) is lower"
         );
 
         // Invalid directives surface as `Err` and must leave the live
@@ -257,7 +269,7 @@ mod tests {
         );
         assert_eq!(
             current_max_level(),
-            Some(LevelFilter::TRACE),
+            Some(LevelFilter::WARN),
             "failed reload must not mutate the live filter"
         );
         assert!(


### PR DESCRIPTION
## Summary
PR #3200 was merged with a broken test in `crates/librefang-cli/src/log_filter.rs` — the `install_then_reload_swaps_inner_filter_and_keeps_baseline` test asserts `reload_log_level("error")` produces `max_level_hint() == ERROR`, but the baseline directives (`librefang_kernel=warn`, `librefang_runtime=warn`) remain in the live filter on every reload, and `EnvFilter::max_level_hint` returns the most permissive level any callsite could pass — so the WARN-pinned targets dominate ERROR. Net effect: `main` CI fails on every PR.

## What changed
- Reorder the asserts so the semantics are legible:
  - reload to `debug` / `trace` (above baseline) → user level dominates
  - reload to `error` (below baseline) → baseline `WARN` dominates → this is now the *positive* baseline-presence test (if the baseline had been dropped, max would collapse to ERROR)
- Update the post-failed-reload assert: prior reload was to `error` with WARN baseline → state is `WARN`, not `TRACE`
- Added comments explaining the EnvFilter `max_level_hint` semantics

No production code changes; test-only.

## Test plan
- [ ] `cargo nextest run -p librefang-cli log_filter` — passes locally
- [ ] CI Test/Ubuntu + Test/macOS green on this PR
- [ ] Once merged, downstream PRs no longer hit the same red test on main
