### PR TITLE
fix(log-reload): correct max_level_hint test assertions

### DIFF
--- a/crates/librefang-cli/src/log_filter.rs
+++ b/crates/librefang-cli/src/log_filter.rs
@@ -223,9 +223,9 @@ mod tests {
             ],
         );
 
-        reload_log_level("error").expect("error reload");
-        assert_eq!(current_max_level(), Some(LevelFilter::ERROR));
-
+        // Raising the level above the baseline (debug/trace > warn) — the
+        // overall max_level_hint is dominated by the user-requested level
+        // and the baseline doesn't move it.
         reload_log_level("debug").expect("debug reload");
         assert_eq!(current_max_level(), Some(LevelFilter::DEBUG));
 
@@ -235,7 +235,7 @@ mod tests {
         // Baseline survival check (regression for Codex P2-1 #3200): even
         // though the user reloaded to `trace`, the kernel/runtime overrides
         // installed at boot must still be present in the live filter, or
-        // the dashboard "give me debug" toggle would silently flood with
+        // the dashboard "give me trace" toggle would silently flood with
         // noise that boot had specifically masked.
         let repr = current_filter_repr();
         assert!(
@@ -245,6 +245,18 @@ mod tests {
         assert!(
             repr.contains("librefang_runtime=warn"),
             "baseline directive lost after reload: {repr}"
+        );
+
+        // Lowering below the baseline — `error < warn`, but the baseline
+        // pins kernel/runtime at WARN, so the global max_level_hint is
+        // WARN (not ERROR). This is the *positive* baseline-presence test:
+        // if reload had wiped the baseline, max_level would collapse to
+        // ERROR. Asserting WARN here proves the baseline is being applied.
+        reload_log_level("error").expect("error reload");
+        assert_eq!(
+            current_max_level(),
+            Some(LevelFilter::WARN),
+            "baseline (warn) must dominate when user level (error) is lower"
         );
 
         // Invalid directives surface as `Err` and must leave the live
@@ -257,7 +269,7 @@ mod tests {
         );
         assert_eq!(
             current_max_level(),
-            Some(LevelFilter::TRACE),
+            Some(LevelFilter::WARN),
             "failed reload must not mutate the live filter"
         );
         assert!(


### PR DESCRIPTION
Follow-up to PR #3200 — fixes a broken test assertion that landed in main alongside the Codex review fix.

## What's wrong on `main` right now

`crates/librefang-cli/src/log_filter.rs::install_then_reload_swaps_inner_filter_and_keeps_baseline` asserts that `reload_log_level("error")` produces `max_level_hint() == ERROR`. With the baseline-preserving reload behaviour added in the same PR (`librefang_kernel=warn`, `librefang_runtime=warn` are reapplied on every reload), the live filter's `max_level_hint` is the most permissive level any callsite could pass — so the WARN-pinned baseline targets dominate the user's ERROR. The next `cargo test -p librefang-cli` on main fails:

```
assertion `left == right` failed
  left: Some(LevelFilter::WARN)
 right: Some(LevelFilter::ERROR)
```

I caught this locally after #3200 was merged. No production code is wrong — only the test expectations.

## Fix

Reorder the assertions so the semantics actually match what the reload does:

- Reload to `debug` / `trace` (above baseline `warn`) → user level dominates → `max_level_hint == DEBUG / TRACE`.
- Reload to `error` (below baseline `warn`) → baseline pins kernel/runtime at WARN → `max_level_hint == WARN`. This becomes the *positive* baseline-presence assertion: if reload had silently dropped the baseline, `max` would have collapsed to `ERROR`.
- Failed reload after the prior `error` reload → state stays at WARN (not TRACE as before, since the prior successful reload was now to ERROR).

## Test plan

- [x] `cargo test -p librefang-cli --bin librefang log_filter` — passes locally with the fix; fails on plain `main`.
- [x] No production code touched; only `#[cfg(test)]` assertions and their inline comments.
