### PR TITLE
docs: drop HTML comment that broke Deploy Docs on main

### DIFF
--- a/docs/src/app/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/configuration/providers/platforms/page.mdx
@@ -64,10 +64,6 @@ This page covers providers that route through a platform-specific gateway, enter
 
 ---
 
-<!-- Voyage AI / Anyscale removed: no driver implementation in code,
-     no env var wiring, no model catalog entries. Re-add when a
-     real driver lands. -->
-
 ## DeepInfra
 
 | | |

--- a/docs/src/app/zh/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/zh/configuration/providers/platforms/page.mdx
@@ -64,9 +64,6 @@
 
 ---
 
-<!-- Voyage AI / Anyscale 已移除:代码里没有驱动实现、没有 env var 接线、没有
-     model catalog 条目。等真实驱动落地再加回来。 -->
-
 ## DeepInfra
 
 | | |


### PR DESCRIPTION
Hot-fix for the broken **Deploy Docs** workflow on `main` (run [24945355937](https://github.com/librefang/librefang/actions/runs/24945355937), introduced by #3201).

## Failure

```
page.mdx:67:2: Unexpected character `!` (U+0021) before name, expected a
character that can start a name, such as a letter, `$`, or `_` (note: to
create a comment in MDX, use `{/* text */}`)
```

MDX v3 (Next.js 15 docs build) treats `<!` as the start of a JSX tag and chokes. The offending HTML comment lived in `docs/src/app/configuration/providers/platforms/page.mdx` and its zh mirror.

## Fix

Delete the comment outright rather than convert it to `{/* … */}`. The note was a build-only TODO ("Voyage AI / Anyscale removed: no driver impl, re-add when one lands") — that's exactly the kind of context that belongs in `git log`/PR descriptions, not in a long-lived rendered docs page. Git history (#3201 and earlier) already records the why; removing the note also avoids leaving an attractive nuisance for similar non-rendered annotations.

## Test plan
- [x] Both files contain no `<!--` markers any more (`grep -rn "<!--" docs/src/`).
- [ ] **Deploy Docs** turns green on this PR / `main` after merge.
