### PR TITLE
feat(api): per-user budget write/clear endpoints + dashboard editor

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3639,26 +3639,64 @@ export async function queryAudit(
 }
 
 // ---------------------------------------------------------------------------
-// Per-user budget (M5 / #3203 — endpoint stubbed)
+// Per-user budget (RBAC M5)
 // ---------------------------------------------------------------------------
 
-export interface UserBudgetEntry {
-  user: string;
-  spend_usd: number;
-  budget_usd: number | null;
-  tokens_in: number;
-  tokens_out: number;
-  requests: number;
-  period_start?: string;
-  period_end?: string;
+/// Per-window spend + cap pair returned by GET /api/budget/users/{user_id}.
+export interface UserBudgetWindow {
+  spend: number;
+  limit: number;
+  pct: number;
 }
 
-export interface UserBudgetResponse extends UserBudgetEntry {
-  daily?: Array<{ date: string; spend_usd: number; tokens: number }>;
+/// Shape returned by GET /api/budget/users/{user_id} — see
+/// `routes/budget.rs::user_budget_detail`.
+export interface UserBudgetResponse {
+  user_id: string;
+  name: string | null;
+  role: string | null;
+  hourly: UserBudgetWindow;
+  daily: UserBudgetWindow;
+  monthly: UserBudgetWindow;
+  alert_threshold: number;
+  alert_breach: boolean;
+  /// True once the M5 enforcement arm is wired (commit 4a00a646). Kept
+  /// in the payload so the dashboard can surface a "deferred" notice
+  /// against older daemons that may still report `false`.
+  enforced: boolean;
+}
+
+/// Body shape for PUT /api/budget/users/{user_id}. Mirrors
+/// `librefang_types::config::UserBudgetConfig`. Any window left at 0
+/// means "unlimited on that window"; same semantics as the kernel
+/// metering check.
+export interface UserBudgetPayload {
+  max_hourly_usd: number;
+  max_daily_usd: number;
+  max_monthly_usd: number;
+  alert_threshold: number;
 }
 
 export async function getUserBudget(name: string): Promise<UserBudgetResponse> {
   return get<UserBudgetResponse>(
+    `/api/budget/users/${encodeURIComponent(name)}`,
+  );
+}
+
+export async function updateUserBudget(
+  name: string,
+  payload: UserBudgetPayload,
+): Promise<{ status: string; budget: UserBudgetPayload }> {
+  return put(
+    `/api/budget/users/${encodeURIComponent(name)}`,
+    payload,
+  );
+}
+
+export async function deleteUserBudget(
+  name: string,
+): Promise<ApiActionResponse> {
+  return del<ApiActionResponse>(
     `/api/budget/users/${encodeURIComponent(name)}`,
   );
 }

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -133,9 +133,15 @@ export {
   // users (RBAC M6)
   listUsers,
   getUser,
-  // per-user budget / policy (M3+M5 stubs)
+  // per-user budget (M5) / policy (M3 stub)
   getUserBudget,
   getUserPolicy,
+} from "../../api";
+
+export type {
+  UserBudgetResponse,
+  UserBudgetWindow,
+  UserBudgetPayload,
 } from "../../api";
 
 // ---------------------------------------------------------------------------
@@ -277,6 +283,9 @@ export {
   importUsers,
   // per-user policy (M3 stub)
   updateUserPolicy,
+  // per-user budget (RBAC M5)
+  updateUserBudget,
+  deleteUserBudget,
 } from "../../api";
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
@@ -1,0 +1,39 @@
+// Per-user budget mutations (RBAC M5).
+//
+// Both writes invalidate the matching `userBudgetKeys.detail(name)` so any
+// open detail panel re-fetches against the now-persisted config.toml. We
+// also kick `userKeys.detail(name)` because `UserConfig.budget` is part of
+// the `UserItem` payload (the M6 dashboard surfaces it on the user row).
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  updateUserBudget,
+  deleteUserBudget,
+  type UserBudgetPayload,
+} from "../http/client";
+import { userBudgetKeys, userKeys } from "../queries/keys";
+
+export function useUpdateUserBudget() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { name: string; payload: UserBudgetPayload }) =>
+      updateUserBudget(vars.name, vars.payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: userBudgetKeys.detail(variables.name) });
+      qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
+      qc.invalidateQueries({ queryKey: userKeys.lists() });
+    },
+  });
+}
+
+export function useDeleteUserBudget() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => deleteUserBudget(name),
+    onSuccess: (_data, name) => {
+      qc.invalidateQueries({ queryKey: userBudgetKeys.detail(name) });
+      qc.invalidateQueries({ queryKey: userKeys.detail(name) });
+      qc.invalidateQueries({ queryKey: userKeys.lists() });
+    },
+  });
+}

--- a/crates/librefang-api/dashboard/src/lib/queries/userBudget.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/userBudget.ts
@@ -1,8 +1,4 @@
-// Per-user budget queries (M5 / #3203 stub).
-//
-// The endpoint `/api/budget/users/{name}` ships with M5. Until then the
-// hook is wired to the same shape; the consuming page renders a placeholder
-// instead of relying on the network call.
+// Per-user budget queries (RBAC M5).
 
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { getUserBudget } from "../http/client";

--- a/crates/librefang-api/dashboard/src/pages/UserBudgetPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UserBudgetPage.tsx
@@ -1,25 +1,103 @@
-// Per-user budget detail (RBAC M6 — stub for M5 / #3203).
+// Per-user budget detail (RBAC M5).
 //
-// Reads the route param `name` and pre-wires `useUserBudget` against
-// `/api/budget/users/{name}`. Activates after M5 merges; until then the
-// component renders a placeholder so visitors don't see a perpetual
-// loading spinner.
+// Shows the user's current spend vs cap across the three windows the
+// metering pipeline enforces (hourly / daily / monthly), and lets an admin
+// upsert or clear the cap. The page assumes Admin+ — anything below gets
+// 403'd by the in-handler `require_admin_for_user_budget` gate before this
+// loads.
 
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "@tanstack/react-router";
-import { Wallet, ExternalLink, ArrowLeft } from "lucide-react";
+import { Wallet, ArrowLeft, AlertTriangle, Check } from "lucide-react";
 
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
 import { useUserBudget } from "../lib/queries/userBudget";
+import {
+  useUpdateUserBudget,
+  useDeleteUserBudget,
+} from "../lib/mutations/userBudget";
+
+interface FormState {
+  max_hourly_usd: string;
+  max_daily_usd: string;
+  max_monthly_usd: string;
+  alert_threshold: string;
+}
+
+const ZERO_FORM: FormState = {
+  max_hourly_usd: "0",
+  max_daily_usd: "0",
+  max_monthly_usd: "0",
+  alert_threshold: "0.8",
+};
 
 export function UserBudgetPage() {
   const { t } = useTranslation();
   const { name } = useParams({ from: "/users/$name/budget" });
+  const query = useUserBudget(name);
+  const updateMut = useUpdateUserBudget();
+  const deleteMut = useDeleteUserBudget();
 
-  // Disabled until M5 lands — see AuditPage for the same pattern.
-  void useUserBudget(name, { enabled: false });
+  const [form, setForm] = useState<FormState>(ZERO_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the form from the current limits whenever they refresh. Spend
+  // values are display-only; we only ever sync `limit` / `alert_threshold`.
+  useEffect(() => {
+    if (!query.data) return;
+    setForm({
+      max_hourly_usd: String(query.data.hourly.limit),
+      max_daily_usd: String(query.data.daily.limit),
+      max_monthly_usd: String(query.data.monthly.limit),
+      alert_threshold: String(query.data.alert_threshold),
+    });
+  }, [query.data]);
+
+  const isLoading = query.isLoading;
+  const fetchError = query.error;
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const payload = {
+      max_hourly_usd: parseFloat(form.max_hourly_usd),
+      max_daily_usd: parseFloat(form.max_daily_usd),
+      max_monthly_usd: parseFloat(form.max_monthly_usd),
+      alert_threshold: parseFloat(form.alert_threshold),
+    };
+
+    for (const [k, v] of Object.entries(payload)) {
+      if (Number.isNaN(v) || !Number.isFinite(v) || v < 0) {
+        setError(`${k} must be a finite, non-negative number`);
+        return;
+      }
+    }
+    if (payload.alert_threshold > 1) {
+      setError("alert_threshold must be in 0.0..=1.0");
+      return;
+    }
+
+    try {
+      await updateMut.mutateAsync({ name, payload });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onClear = async () => {
+    setError(null);
+    try {
+      await deleteMut.mutateAsync(name);
+      setForm(ZERO_FORM);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -27,7 +105,21 @@ export function UserBudgetPage() {
         icon={<Wallet className="h-4 w-4" />}
         title={t("user_budget.title", "User budget")}
         subtitle={name}
-        badge={t("user_budget.badge_pending", "Pending M5")}
+        badge={
+          query.data?.alert_breach ? (
+            <Badge variant="warn">
+              {t("user_budget.alert_breach", "alert breach")}
+            </Badge>
+          ) : query.data?.enforced ? (
+            <Badge variant="success">
+              {t("user_budget.enforced", "enforced")}
+            </Badge>
+          ) : (
+            <Badge variant="info">
+              {t("user_budget.deferred", "enforcement deferred")}
+            </Badge>
+          )
+        }
         actions={
           <Link
             to="/users"
@@ -39,36 +131,133 @@ export function UserBudgetPage() {
         }
       />
 
-      <Card padding="lg">
-        <div className="flex items-start gap-3">
-          <Wallet className="h-5 w-5 text-text-dim shrink-0" />
-          <div>
-            <p className="text-sm font-bold">
-              {t(
-                "user_budget.stub_title",
-                "Per-user budget charts will activate when M5 merges.",
-              )}
-            </p>
-            <p className="mt-1 text-xs text-text-dim">
-              {t(
-                "user_budget.stub_body",
-                "Hook ready: `useUserBudget(name)` in `lib/queries/userBudget.ts`, keyed via `userBudgetKeys.detail(name)`. Once M5 ships `/api/budget/users/{name}`, drop `enabled: false` and render the daily-spend chart + alert thresholds.",
-              )}
-            </p>
-            <div className="mt-3 flex items-center gap-2 text-[11px]">
-              <Badge variant="info">depends on librefang/librefang#3203</Badge>
-              <a
-                href="https://github.com/librefang/librefang/pull/3203"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-text-dim hover:text-brand"
-              >
-                <ExternalLink className="h-3 w-3" />
-                {t("user_budget.view_pr", "View PR")}
-              </a>
+      {fetchError && (
+        <Card padding="lg">
+          <div className="flex items-start gap-3 text-sm text-error">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-bold">
+                {t("user_budget.fetch_error", "Failed to load budget")}
+              </p>
+              <p className="mt-1 text-xs">{String(fetchError)}</p>
             </div>
           </div>
-        </div>
+        </Card>
+      )}
+
+      {isLoading && (
+        <Card padding="lg">
+          <p className="text-sm text-text-dim">
+            {t("user_budget.loading", "Loading…")}
+          </p>
+        </Card>
+      )}
+
+      {query.data && (
+        <Card padding="lg">
+          <h2 className="text-sm font-bold mb-3">
+            {t("user_budget.current_spend", "Current spend (USD)")}
+          </h2>
+          <div className="grid grid-cols-3 gap-4">
+            {(["hourly", "daily", "monthly"] as const).map((w) => {
+              const win = query.data![w];
+              const breached =
+                win.limit > 0 && win.pct >= query.data!.alert_threshold;
+              return (
+                <div key={w} className="text-sm">
+                  <div className="text-xs text-text-dim uppercase">
+                    {t(`user_budget.window_${w}`, w)}
+                  </div>
+                  <div
+                    className={`mt-1 font-mono ${
+                      breached ? "text-error" : ""
+                    }`}
+                  >
+                    ${win.spend.toFixed(4)}{" "}
+                    <span className="text-text-dim">
+                      / {win.limit > 0 ? `$${win.limit.toFixed(2)}` : "∞"}
+                    </span>
+                  </div>
+                  {win.limit > 0 && (
+                    <div className="mt-1 h-1 w-full bg-surface-2 rounded">
+                      <div
+                        className={`h-1 rounded ${
+                          breached ? "bg-error" : "bg-brand"
+                        }`}
+                        style={{
+                          width: `${Math.min(100, win.pct * 100).toFixed(1)}%`,
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
+
+      <Card padding="lg">
+        <h2 className="text-sm font-bold mb-3">
+          {t("user_budget.set_limits", "Set spend limits")}
+        </h2>
+        <p className="text-xs text-text-dim mb-4">
+          {t(
+            "user_budget.zero_means_unlimited",
+            "Set any window to 0 for unlimited on that window. Threshold is the fraction of any limit at which a BudgetExceeded audit fires.",
+          )}
+        </p>
+        <form onSubmit={onSubmit} className="grid grid-cols-2 gap-4">
+          {(
+            [
+              ["max_hourly_usd", "Max hourly USD"],
+              ["max_daily_usd", "Max daily USD"],
+              ["max_monthly_usd", "Max monthly USD"],
+              ["alert_threshold", "Alert threshold (0–1)"],
+            ] as const
+          ).map(([key, label]) => (
+            <label key={key} className="flex flex-col gap-1 text-xs">
+              <span className="text-text-dim">{label}</span>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={form[key]}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, [key]: e.target.value }))
+                }
+                className="rounded border border-border bg-surface-2 px-2 py-1 font-mono"
+              />
+            </label>
+          ))}
+          {error && (
+            <div className="col-span-2 text-xs text-error flex items-center gap-2">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              {error}
+            </div>
+          )}
+          <div className="col-span-2 flex items-center gap-2 mt-2">
+            <Button
+              type="submit"
+              disabled={updateMut.isPending}
+              icon={<Check className="h-3.5 w-3.5" />}
+            >
+              {updateMut.isPending
+                ? t("user_budget.saving", "Saving…")
+                : t("user_budget.save", "Save")}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClear}
+              disabled={deleteMut.isPending}
+            >
+              {deleteMut.isPending
+                ? t("user_budget.clearing", "Clearing…")
+                : t("user_budget.clear", "Clear cap")}
+            </Button>
+          </div>
+        </form>
       </Card>
     </div>
   );

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -680,14 +680,21 @@ pub async fn user_budget_detail(
 /// PUT /api/budget/users/{user_id} — admin-only per-user budget upsert.
 ///
 /// `user_id` accepts the same forms as the GET sibling (UUID or configured
-/// name). The request body mirrors `UserBudgetConfig`:
+/// name). The request body mirrors `UserBudgetConfig` and is a **full
+/// replacement** of the user's budget — all four keys are required, any
+/// missing key returns 400. Set a window to `0.0` to mean "unlimited on
+/// that window" (same semantics as the kernel-side metering check); this
+/// is **not** the same as omitting the key.
+///
 /// ```json
 /// { "max_hourly_usd": 1.0, "max_daily_usd": 10.0, "max_monthly_usd": 100.0,
 ///   "alert_threshold": 0.8 }
 /// ```
-/// Any window set to `0.0` is "unlimited on that window" (same semantics as
-/// the kernel-side metering check). Missing fields default to `0.0` /
-/// `0.8` so a partial payload upgrades cleanly.
+///
+/// Full-replace was chosen over PATCH semantics so `curl -X PUT` with a
+/// partial body cannot silently zero out other windows (`UserBudgetConfig`
+/// derives `#[serde(default)]`, which would otherwise default any omitted
+/// field to `0.0` / `0.8` and clear an existing cap).
 ///
 /// On success the cap takes effect on the **next** LLM call — already-
 /// billed responses are returned unchanged. Persists to `config.toml` via
@@ -700,7 +707,7 @@ pub async fn user_budget_detail(
     params(("user_id" = String, Path, description = "User UUID or configured name")),
     responses(
         (status = 200, description = "Budget written and reloaded", body = serde_json::Value),
-        (status = 400, description = "Invalid budget payload (negative limit, threshold out of range)"),
+        (status = 400, description = "Invalid or partial budget payload"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "No user matches the given id/name"),
     )
@@ -716,13 +723,37 @@ pub async fn update_user_budget(
         return deny;
     }
 
-    // Parse + validate. Anything that would make `MeteringEngine::
-    // check_user_budget` behave surprisingly is rejected here so the
-    // operator sees a 400 instead of a silently-wrong cap.
-    let max_hourly_usd = body["max_hourly_usd"].as_f64().unwrap_or(0.0);
-    let max_daily_usd = body["max_daily_usd"].as_f64().unwrap_or(0.0);
-    let max_monthly_usd = body["max_monthly_usd"].as_f64().unwrap_or(0.0);
-    let alert_threshold = body["alert_threshold"].as_f64().unwrap_or(0.8);
+    // Full replacement: every field is required. Reject missing or wrong-
+    // typed keys before disk so a partial body cannot silently zero out
+    // existing caps via `UserBudgetConfig`'s `#[serde(default)]`. A typo
+    // (`"max_hourly_usd": "1.0"` as a string) returns 400 instead of being
+    // coerced to 0.0.
+    let extract_f64 = |key: &str| -> Result<f64, ApiErrorResponse> {
+        match body.get(key) {
+            Some(v) => v.as_f64().ok_or_else(|| {
+                ApiErrorResponse::bad_request(format!("{key} must be a JSON number (got {v})"))
+            }),
+            None => Err(ApiErrorResponse::bad_request(format!(
+                "{key} is required (PUT is a full replacement, not a patch)"
+            ))),
+        }
+    };
+    let max_hourly_usd = match extract_f64("max_hourly_usd") {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+    let max_daily_usd = match extract_f64("max_daily_usd") {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+    let max_monthly_usd = match extract_f64("max_monthly_usd") {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+    let alert_threshold = match extract_f64("alert_threshold") {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
 
     for (label, v) in [
         ("max_hourly_usd", max_hourly_usd),
@@ -761,13 +792,14 @@ pub async fn update_user_budget(
         .unwrap_or_else(|_| UserId::from_name(&user_id_param));
 
     let new_budget_for_closure = new_budget.clone();
+    let user_id_param_for_closure = user_id_param.clone();
     let result = super::users::persist_users(&state, move |users| {
         let idx = users
             .iter()
             .position(|u| UserId::from_name(&u.name) == target_user_id)
             .ok_or_else(|| {
                 super::users::PersistError::NotFound(format!(
-                    "no user matches '{user_id_param}'"
+                    "no user matches '{user_id_param_for_closure}'"
                 ))
             })?;
         users[idx].budget = Some(new_budget_for_closure);
@@ -779,9 +811,9 @@ pub async fn update_user_budget(
         Ok(()) => {
             state.kernel.audit().record_with_context(
                 "system",
-                librefang_runtime::audit::AuditAction::RoleChange,
+                librefang_runtime::audit::AuditAction::ConfigChange,
                 format!(
-                    "user budget updated: hourly={max_hourly_usd} daily={max_daily_usd} monthly={max_monthly_usd} alert={alert_threshold}"
+                    "user_budget updated for {user_id_param}: hourly={max_hourly_usd} daily={max_daily_usd} monthly={max_monthly_usd} alert={alert_threshold}"
                 ),
                 "ok",
                 api_user_ref.map(|u| u.user_id),
@@ -842,13 +874,14 @@ pub async fn delete_user_budget(
         .parse()
         .unwrap_or_else(|_| UserId::from_name(&user_id_param));
 
+    let user_id_param_for_closure = user_id_param.clone();
     let result = super::users::persist_users(&state, move |users| {
         let idx = users
             .iter()
             .position(|u| UserId::from_name(&u.name) == target_user_id)
             .ok_or_else(|| {
                 super::users::PersistError::NotFound(format!(
-                    "no user matches '{user_id_param}'"
+                    "no user matches '{user_id_param_for_closure}'"
                 ))
             })?;
         users[idx].budget = None;
@@ -860,8 +893,8 @@ pub async fn delete_user_budget(
         Ok(()) => {
             state.kernel.audit().record_with_context(
                 "system",
-                librefang_runtime::audit::AuditAction::RoleChange,
-                "user budget cleared",
+                librefang_runtime::audit::AuditAction::ConfigChange,
+                format!("user_budget cleared for {user_id_param}"),
                 "ok",
                 api_user_ref.map(|u| u.user_id),
                 Some("api".to_string()),

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -27,7 +27,9 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         .route("/budget/users", axum::routing::get(user_budget_ranking))
         .route(
             "/budget/users/{user_id}",
-            axum::routing::get(user_budget_detail),
+            axum::routing::get(user_budget_detail)
+                .put(update_user_budget)
+                .delete(delete_user_budget),
         )
 }
 use axum::extract::{Path, Query, State};
@@ -673,4 +675,214 @@ pub async fn user_budget_detail(
         "enforced": true,
     }))
     .into_response()
+}
+
+/// PUT /api/budget/users/{user_id} — admin-only per-user budget upsert.
+///
+/// `user_id` accepts the same forms as the GET sibling (UUID or configured
+/// name). The request body mirrors `UserBudgetConfig`:
+/// ```json
+/// { "max_hourly_usd": 1.0, "max_daily_usd": 10.0, "max_monthly_usd": 100.0,
+///   "alert_threshold": 0.8 }
+/// ```
+/// Any window set to `0.0` is "unlimited on that window" (same semantics as
+/// the kernel-side metering check). Missing fields default to `0.0` /
+/// `0.8` so a partial payload upgrades cleanly.
+///
+/// On success the cap takes effect on the **next** LLM call — already-
+/// billed responses are returned unchanged. Persists to `config.toml` via
+/// `users::persist_users` and triggers a kernel reload (auth manager picks
+/// up the new `UserConfig.budget`).
+#[utoipa::path(
+    put,
+    path = "/api/budget/users/{user_id}",
+    tag = "budget",
+    params(("user_id" = String, Path, description = "User UUID or configured name")),
+    responses(
+        (status = 200, description = "Budget written and reloaded", body = serde_json::Value),
+        (status = 400, description = "Invalid budget payload (negative limit, threshold out of range)"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "No user matches the given id/name"),
+    )
+)]
+pub async fn update_user_budget(
+    State(state): State<Arc<AppState>>,
+    Path(user_id_param): Path<String>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    let api_user_ref = api_user.as_ref().map(|e| &e.0);
+    if let Some(deny) = require_admin_for_user_budget(&state, api_user_ref) {
+        return deny;
+    }
+
+    // Parse + validate. Anything that would make `MeteringEngine::
+    // check_user_budget` behave surprisingly is rejected here so the
+    // operator sees a 400 instead of a silently-wrong cap.
+    let max_hourly_usd = body["max_hourly_usd"].as_f64().unwrap_or(0.0);
+    let max_daily_usd = body["max_daily_usd"].as_f64().unwrap_or(0.0);
+    let max_monthly_usd = body["max_monthly_usd"].as_f64().unwrap_or(0.0);
+    let alert_threshold = body["alert_threshold"].as_f64().unwrap_or(0.8);
+
+    for (label, v) in [
+        ("max_hourly_usd", max_hourly_usd),
+        ("max_daily_usd", max_daily_usd),
+        ("max_monthly_usd", max_monthly_usd),
+    ] {
+        if v.is_nan() || v.is_infinite() || v < 0.0 {
+            return ApiErrorResponse::bad_request(format!(
+                "{label} must be a finite, non-negative number (got {v})"
+            ))
+            .into_response();
+        }
+    }
+    if !(0.0..=1.0).contains(&alert_threshold)
+        || alert_threshold.is_nan()
+        || alert_threshold.is_infinite()
+    {
+        return ApiErrorResponse::bad_request(format!(
+            "alert_threshold must be in 0.0..=1.0 (got {alert_threshold})"
+        ))
+        .into_response();
+    }
+
+    let new_budget = librefang_types::config::UserBudgetConfig {
+        max_hourly_usd,
+        max_daily_usd,
+        max_monthly_usd,
+        alert_threshold,
+    };
+
+    // Resolve the path param to a name we can match in the on-disk
+    // `[[users]]` array. Same parse-as-uuid-then-from_name shape as
+    // `user_budget_detail`.
+    let target_user_id: UserId = user_id_param
+        .parse()
+        .unwrap_or_else(|_| UserId::from_name(&user_id_param));
+
+    let new_budget_for_closure = new_budget.clone();
+    let result = super::users::persist_users(&state, move |users| {
+        let idx = users
+            .iter()
+            .position(|u| UserId::from_name(&u.name) == target_user_id)
+            .ok_or_else(|| {
+                super::users::PersistError::NotFound(format!(
+                    "no user matches '{user_id_param}'"
+                ))
+            })?;
+        users[idx].budget = Some(new_budget_for_closure);
+        Ok(())
+    })
+    .await;
+
+    match result {
+        Ok(()) => {
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_runtime::audit::AuditAction::RoleChange,
+                format!(
+                    "user budget updated: hourly={max_hourly_usd} daily={max_daily_usd} monthly={max_monthly_usd} alert={alert_threshold}"
+                ),
+                "ok",
+                api_user_ref.map(|u| u.user_id),
+                Some("api".to_string()),
+            );
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "ok",
+                    "budget": new_budget,
+                })),
+            )
+                .into_response()
+        }
+        Err(super::users::PersistError::NotFound(m)) => {
+            ApiErrorResponse::not_found(m).into_response()
+        }
+        Err(super::users::PersistError::BadRequest(m)) => {
+            ApiErrorResponse::bad_request(m).into_response()
+        }
+        Err(super::users::PersistError::Conflict(m)) => {
+            ApiErrorResponse::conflict(m).into_response()
+        }
+        Err(super::users::PersistError::Internal(m)) => {
+            ApiErrorResponse::internal(m).into_response()
+        }
+    }
+}
+
+/// DELETE /api/budget/users/{user_id} — clear the per-user budget.
+///
+/// Sets `UserConfig.budget` back to `None` and persists. Subsequent LLM
+/// calls from this user are bounded only by global / per-agent /
+/// per-provider caps. Returns 200 even when the user had no budget set
+/// (idempotent — same shape as `delete_agent_budget`'s sibling pattern).
+#[utoipa::path(
+    delete,
+    path = "/api/budget/users/{user_id}",
+    tag = "budget",
+    params(("user_id" = String, Path, description = "User UUID or configured name")),
+    responses(
+        (status = 200, description = "Budget cleared (or already absent)"),
+        (status = 403, description = "Caller is not an admin"),
+        (status = 404, description = "No user matches the given id/name"),
+    )
+)]
+pub async fn delete_user_budget(
+    State(state): State<Arc<AppState>>,
+    Path(user_id_param): Path<String>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
+) -> Response {
+    let api_user_ref = api_user.as_ref().map(|e| &e.0);
+    if let Some(deny) = require_admin_for_user_budget(&state, api_user_ref) {
+        return deny;
+    }
+
+    let target_user_id: UserId = user_id_param
+        .parse()
+        .unwrap_or_else(|_| UserId::from_name(&user_id_param));
+
+    let result = super::users::persist_users(&state, move |users| {
+        let idx = users
+            .iter()
+            .position(|u| UserId::from_name(&u.name) == target_user_id)
+            .ok_or_else(|| {
+                super::users::PersistError::NotFound(format!(
+                    "no user matches '{user_id_param}'"
+                ))
+            })?;
+        users[idx].budget = None;
+        Ok(())
+    })
+    .await;
+
+    match result {
+        Ok(()) => {
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_runtime::audit::AuditAction::RoleChange,
+                "user budget cleared",
+                "ok",
+                api_user_ref.map(|u| u.user_id),
+                Some("api".to_string()),
+            );
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "ok", "message": "budget cleared"})),
+            )
+                .into_response()
+        }
+        Err(super::users::PersistError::NotFound(m)) => {
+            ApiErrorResponse::not_found(m).into_response()
+        }
+        Err(super::users::PersistError::BadRequest(m)) => {
+            ApiErrorResponse::bad_request(m).into_response()
+        }
+        Err(super::users::PersistError::Conflict(m)) => {
+            ApiErrorResponse::conflict(m).into_response()
+        }
+        Err(super::users::PersistError::Internal(m)) => {
+            ApiErrorResponse::internal(m).into_response()
+        }
+    }
 }

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -624,7 +624,7 @@ pub async fn import_users(
 // Persistence helpers
 // ---------------------------------------------------------------------------
 
-enum PersistError {
+pub(crate) enum PersistError {
     BadRequest(String),
     Conflict(String),
     NotFound(String),
@@ -638,7 +638,7 @@ enum PersistError {
 /// `update_user` uses this to surface the post-merge `UserConfig`
 /// (including preserved RBAC M3 policy fields) without an out-of-band
 /// `Arc<Mutex>` capture.
-async fn persist_users<F, R>(state: &Arc<AppState>, mutate: F) -> Result<R, PersistError>
+pub(crate) async fn persist_users<F, R>(state: &Arc<AppState>, mutate: F) -> Result<R, PersistError>
 where
     F: FnOnce(&mut Vec<UserConfig>) -> Result<R, PersistError>,
 {

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3072,7 +3072,9 @@ async fn test_user_budget_put_get_delete_round_trip() {
 }
 
 /// Validation: PUT with negative or out-of-range values is rejected
-/// before touching disk.
+/// before touching disk. Each case is a full-shape payload with exactly
+/// one offending field — proves the per-field validators fire, not just
+/// the "missing key" gate.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_budget_put_rejects_invalid_payload() {
     let server =
@@ -3081,11 +3083,24 @@ async fn test_user_budget_put_rejects_invalid_payload() {
     let client = reqwest::Client::new();
     let url = format!("{}/api/budget/users/Alice", server.base_url);
 
-    for bad in [
-        serde_json::json!({"max_hourly_usd": -1.0}),
-        serde_json::json!({"alert_threshold": 1.5}),
-        serde_json::json!({"alert_threshold": -0.1}),
+    let base = serde_json::json!({
+        "max_hourly_usd": 1.0,
+        "max_daily_usd": 10.0,
+        "max_monthly_usd": 100.0,
+        "alert_threshold": 0.8,
+    });
+    let mut cases = Vec::new();
+    for (field, value) in [
+        ("max_hourly_usd", serde_json::json!(-1.0)),
+        ("alert_threshold", serde_json::json!(1.5)),
+        ("alert_threshold", serde_json::json!(-0.1)),
     ] {
+        let mut body = base.clone();
+        body[field] = value;
+        cases.push(body);
+    }
+
+    for bad in cases {
         let resp = client
             .put(&url)
             .header("authorization", "Bearer alice-admin-key")
@@ -3101,7 +3116,81 @@ async fn test_user_budget_put_rejects_invalid_payload() {
     }
 }
 
+/// Regression: a partial body must NOT be accepted as an upsert. Without
+/// this guard, `UserBudgetConfig`'s `#[serde(default)]` would silently
+/// fill missing fields with `0.0` / `0.8` and clear an existing cap on
+/// the windows the caller didn't mention.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_budget_put_rejects_partial_payload() {
+    let server =
+        start_test_server_with_rbac_users("any-key", vec![("Alice", "admin", "alice-admin-key")])
+            .await;
+    let client = reqwest::Client::new();
+    let url = format!("{}/api/budget/users/Alice", server.base_url);
+
+    // Seed a real cap so we can confirm it stays put when a partial PUT
+    // gets rejected.
+    let put_full = client
+        .put(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .json(&serde_json::json!({
+            "max_hourly_usd": 2.0,
+            "max_daily_usd": 20.0,
+            "max_monthly_usd": 200.0,
+            "alert_threshold": 0.6,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put_full.status(), 200);
+
+    // Each partial body omits at least one required key and must be
+    // rejected with 400.
+    for partial in [
+        serde_json::json!({"max_hourly_usd": 5.0}),
+        serde_json::json!({"max_daily_usd": 50.0, "max_monthly_usd": 500.0}),
+        serde_json::json!({}),
+        // Wrong type should also 400, not be coerced to 0.
+        serde_json::json!({
+            "max_hourly_usd": "1.0",
+            "max_daily_usd": 10.0,
+            "max_monthly_usd": 100.0,
+            "alert_threshold": 0.8,
+        }),
+    ] {
+        let resp = client
+            .put(&url)
+            .header("authorization", "Bearer alice-admin-key")
+            .json(&partial)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            400,
+            "expected 400 for partial / wrong-typed payload {partial:?}"
+        );
+    }
+
+    // Original cap survived all rejected partials.
+    let after: serde_json::Value = client
+        .get(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(after["hourly"]["limit"], serde_json::json!(2.0));
+    assert_eq!(after["daily"]["limit"], serde_json::json!(20.0));
+    assert_eq!(after["monthly"]["limit"], serde_json::json!(200.0));
+    assert_eq!(after["alert_threshold"], serde_json::json!(0.6));
+}
+
 /// Authz: a non-admin caller is rejected even when the URL is well-formed.
+/// The body is intentionally partial — the admin gate must fire before
+/// body validation, so a viewer's request never reaches the parser.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_budget_put_rejects_viewer_with_403() {
     let server = start_test_server_with_rbac_users(
@@ -3124,7 +3213,8 @@ async fn test_user_budget_put_rejects_viewer_with_403() {
 }
 
 /// 404 path: PUT against an unknown user surfaces a real error (not a
-/// silent insert).
+/// silent insert). Requires a full-shape body so the request reaches the
+/// persist step (a partial body would be 400'd earlier).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_budget_put_unknown_user_returns_404() {
     let server =
@@ -3134,7 +3224,12 @@ async fn test_user_budget_put_unknown_user_returns_404() {
     let resp = client
         .put(format!("{}/api/budget/users/NonExistent", server.base_url))
         .header("authorization", "Bearer alice-admin-key")
-        .json(&serde_json::json!({"max_hourly_usd": 1.0}))
+        .json(&serde_json::json!({
+            "max_hourly_usd": 1.0,
+            "max_daily_usd": 10.0,
+            "max_monthly_usd": 100.0,
+            "alert_threshold": 0.8,
+        }))
         .send()
         .await
         .unwrap();

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2992,3 +2992,151 @@ async fn test_user_budget_detail_includes_enforced_true() {
     assert!(body["monthly"]["spend"].is_number());
     assert!(body["alert_breach"].is_boolean());
 }
+
+/// Round-trip: PUT a budget, GET reflects the new limits, DELETE clears
+/// it back to "no cap" (limit = 0 in the response).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_budget_put_get_delete_round_trip() {
+    let server =
+        start_test_server_with_rbac_users("any-key", vec![("Alice", "admin", "alice-admin-key")])
+            .await;
+    let client = reqwest::Client::new();
+    let url = format!("{}/api/budget/users/Alice", server.base_url);
+
+    // Initial GET — no cap configured, all limits are 0.
+    let initial: serde_json::Value = client
+        .get(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(initial["hourly"]["limit"], serde_json::json!(0.0));
+
+    // PUT a real cap.
+    let put_resp = client
+        .put(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .json(&serde_json::json!({
+            "max_hourly_usd": 1.5,
+            "max_daily_usd": 12.0,
+            "max_monthly_usd": 100.0,
+            "alert_threshold": 0.75,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put_resp.status(), 200, "PUT should accept the upsert");
+
+    // GET should reflect the new caps.
+    let after_put: serde_json::Value = client
+        .get(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(after_put["hourly"]["limit"], serde_json::json!(1.5));
+    assert_eq!(after_put["daily"]["limit"], serde_json::json!(12.0));
+    assert_eq!(after_put["monthly"]["limit"], serde_json::json!(100.0));
+    assert_eq!(after_put["alert_threshold"], serde_json::json!(0.75));
+
+    // DELETE clears.
+    let del_resp = client
+        .delete(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(del_resp.status(), 200, "DELETE should clear the cap");
+
+    // GET again — back to limit = 0.
+    let after_delete: serde_json::Value = client
+        .get(&url)
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        after_delete["hourly"]["limit"],
+        serde_json::json!(0.0),
+        "DELETE must reset limit back to 0 (no cap)"
+    );
+}
+
+/// Validation: PUT with negative or out-of-range values is rejected
+/// before touching disk.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_budget_put_rejects_invalid_payload() {
+    let server =
+        start_test_server_with_rbac_users("any-key", vec![("Alice", "admin", "alice-admin-key")])
+            .await;
+    let client = reqwest::Client::new();
+    let url = format!("{}/api/budget/users/Alice", server.base_url);
+
+    for bad in [
+        serde_json::json!({"max_hourly_usd": -1.0}),
+        serde_json::json!({"alert_threshold": 1.5}),
+        serde_json::json!({"alert_threshold": -0.1}),
+    ] {
+        let resp = client
+            .put(&url)
+            .header("authorization", "Bearer alice-admin-key")
+            .json(&bad)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            400,
+            "expected 400 for invalid payload {bad:?}"
+        );
+    }
+}
+
+/// Authz: a non-admin caller is rejected even when the URL is well-formed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_budget_put_rejects_viewer_with_403() {
+    let server = start_test_server_with_rbac_users(
+        "any-key",
+        vec![
+            ("Alice", "admin", "alice-admin-key"),
+            ("Bob", "viewer", "bob-viewer-key"),
+        ],
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .put(format!("{}/api/budget/users/Alice", server.base_url))
+        .header("authorization", "Bearer bob-viewer-key")
+        .json(&serde_json::json!({"max_hourly_usd": 1.0}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403, "Viewer must not write user budget");
+}
+
+/// 404 path: PUT against an unknown user surfaces a real error (not a
+/// silent insert).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_budget_put_unknown_user_returns_404() {
+    let server =
+        start_test_server_with_rbac_users("any-key", vec![("Alice", "admin", "alice-admin-key")])
+            .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .put(format!("{}/api/budget/users/NonExistent", server.base_url))
+        .header("authorization", "Bearer alice-admin-key")
+        .json(&serde_json::json!({"max_hourly_usd": 1.0}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}


### PR DESCRIPTION
## Summary

Closes the M5 follow-up gap: `UserConfig.budget` was settable only by editing `config.toml` directly. PR #3209 (M6 dashboard) shipped a `UserBudgetPage` stub linking to PR #3203 with "wire up after M5 lands". M5 has landed (per-user enforcement is real — `MeteringEngine::check_user_budget` denies over-budget calls, audit fires `BudgetExceeded`), so this connects the management plane.

## Surface

- **`PUT /api/budget/users/{user_id}`** — admin-only upsert. Body mirrors `UserBudgetConfig`:
  ```json
  { "max_hourly_usd": 1.5, "max_daily_usd": 12.0,
    "max_monthly_usd": 100.0, "alert_threshold": 0.75 }
  ```
  Any window at `0.0` = "unlimited on that window" (same semantics as the kernel-side check). Validates negatives / NaN / Infinity / threshold range before touching disk → 400 if bad.
- **`DELETE /api/budget/users/{user_id}`** — admin-only clear. Sets `UserConfig.budget = None`. Idempotent.
- Both persist via `users::persist_users` (toml_edit round-trip + kernel reload), so the new cap is in effect on the next LLM call. Both record a `RoleChange` audit event with the caller's `user_id`.

## Plumbing

- `users::persist_users` + `PersistError` lifted from module-private to `pub(crate)` so the budget handler shares the same write path. No semantic change.
- `UserBudgetResponse` in `api.ts` retyped from M5-stub guess to the real server shape (`{user_id, name, role, hourly{spend,limit,pct}, daily, monthly, alert_threshold, alert_breach, enforced}`).
- `UserBudgetPage` rewritten from "Pending M5" placeholder to a live editor with spend bars + limit form + clear button.

## Why admin (not owner)?

Mirrors `update_agent_budget` and the existing `/api/budget/users` GET ranking — budget management is an admin operation, not the same blast radius as `/api/users` CRUD which is owner-only. Same `require_admin_for_user_budget` gate as the GET sibling.

## Test plan

- [x] `cargo check -p librefang-api` — clean.
- [x] `cargo test -p librefang-api --test api_integration_test -- test_user_budget` — 4 new tests + 2 pre-existing ones, all green:
  - `test_user_budget_put_get_delete_round_trip`
  - `test_user_budget_put_rejects_invalid_payload`
  - `test_user_budget_put_rejects_viewer_with_403`
  - `test_user_budget_put_unknown_user_returns_404`
- [ ] Live integration test on a real daemon — deferred to CI / reviewer.

Refs #3054 (RBAC umbrella), follow-up to #3203 (M5).
