### PR TITLE
feat(dashboard): activate AuditPage now that M5 audit endpoints shipped

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3592,36 +3592,37 @@ export async function importUsers(
 }
 
 // ---------------------------------------------------------------------------
-// Audit query (M5 / #3203 — endpoint stubbed; the hook stays wired so the
-// dashboard layer is ready when the daemon ships the route).
+// Audit query (RBAC M5 / #3203). Shape mirrors `routes/audit.rs::audit_query`
+// — keep field names in lockstep, the server returns raw `serde_json::Value`
+// so a drift here is silently wrong wire-format on the page.
 // ---------------------------------------------------------------------------
 
 export interface AuditQueryFilters {
-  limit?: number;
-  offset?: number;
-  user?: string;
-  action?: string;
-  status?: string;
-  since?: string;
-  until?: string;
+  user?: string; // UUID or configured name
+  action?: string; // AuditAction variant name, case-insensitive
+  agent?: string;
+  channel?: string;
+  from?: string; // ISO-8601 lower bound (inclusive)
+  to?: string; // ISO-8601 upper bound (inclusive)
+  limit?: number; // default 200, hard cap 5000
 }
 
-// Distinct from `AuditEntry` (recent-tail / hash-chain shape) — the M5
-// `/api/audit/query` endpoint returns a flatter, search-friendly shape with
-// the user dimension promoted to a first-class field.
 export interface AuditQueryEntry {
+  seq: number;
   timestamp: string;
-  agent: string;
-  user?: string | null;
+  agent_id: string;
   action: string;
-  status: string;
-  details?: string | null;
+  detail: string;
+  outcome: string;
+  user_id: string | null;
+  channel: string | null;
+  hash: string;
 }
 
 export interface AuditQueryResponse {
   entries: AuditQueryEntry[];
-  total: number;
-  has_more: boolean;
+  count: number;
+  limit: number;
 }
 
 export async function queryAudit(

--- a/crates/librefang-api/dashboard/src/lib/queries/audit.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/audit.ts
@@ -1,9 +1,5 @@
-// Audit-trail queries.
-//
-// `useAuditQuery` wires the dashboard layer to the searchable `/api/audit/query`
-// endpoint that ships with M5 / #3203. Until that endpoint exists the daemon
-// returns 404; the AuditPage component renders a placeholder rather than
-// surfacing the failure. When M5 lands, only the placeholder swap is needed.
+// Audit-trail queries — wires the dashboard layer to the searchable
+// `/api/audit/query` endpoint shipped in M5.
 
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { queryAudit, type AuditQueryFilters } from "../http/client";

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -1,29 +1,55 @@
-// Audit query viewer (RBAC M6 — stub).
+// Audit-trail viewer (RBAC M5 + M6).
 //
-// The dashboard data layer (`useAuditQuery` in `lib/queries/audit.ts`) is
-// already wired against `/api/audit/query` so when M5 / #3203 ships the
-// daemon endpoint, only this placeholder body needs to be replaced with
-// the table. The hook is intentionally NOT enabled here so the page
-// doesn't 404-spam the daemon while M5 is in flight.
+// Admin-only. Filters narrow the in-memory window (server hard cap 5000
+// rows, default 200) — for deeper history use the export button which hits
+// /api/audit/export with the same filter set.
 
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ScrollText, ExternalLink } from "lucide-react";
+import { ScrollText, Download, AlertTriangle, Search } from "lucide-react";
+
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
-import { Badge } from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
 import { useAuditQuery } from "../lib/queries/audit";
+import type { AuditQueryFilters } from "../lib/http/client";
+
+function buildExportUrl(
+  filters: AuditQueryFilters,
+  format: "csv" | "json",
+): string {
+  const params = new URLSearchParams({ format });
+  for (const [k, v] of Object.entries(filters)) {
+    if (v === undefined || v === null || v === "") continue;
+    params.set(k, String(v));
+  }
+  return `/api/audit/export?${params.toString()}`;
+}
+
+const ACTION_OPTIONS = [
+  "",
+  "ToolInvoke",
+  "ShellExec",
+  "UserLogin",
+  "RoleChange",
+  "PermissionDenied",
+  "BudgetExceeded",
+  "ConfigChange",
+];
 
 export function AuditPage() {
   const { t } = useTranslation();
+  const [draft, setDraft] = useState<AuditQueryFilters>({ limit: 200 });
+  const [active, setActive] = useState<AuditQueryFilters>({ limit: 200 });
+  const query = useAuditQuery(active);
 
-  // Wire the hook in `enabled: false` mode so:
-  //   1. The query layer is exercised by typecheck + tests (factory key
-  //      stays anchored, types match the M5 endpoint shape we're committing
-  //      to).
-  //   2. We don't actually fire the request against a daemon that hasn't
-  //      shipped #3203 yet, which would just return 404 noise.
-  // The very moment M5 lands, drop `enabled: false` and render `data`.
-  void useAuditQuery({ limit: 50 }, { enabled: false });
+  const onApply = (e: React.FormEvent) => {
+    e.preventDefault();
+    setActive(draft);
+  };
+
+  const isForbidden =
+    query.error instanceof Error && /403|admin/i.test(query.error.message);
 
   return (
     <div className="flex flex-col gap-6">
@@ -34,39 +60,212 @@ export function AuditPage() {
           "audit.subtitle",
           "Searchable, filterable audit log across users / actions / agents.",
         )}
-        badge={t("audit.badge_pending", "Pending M5")}
+        actions={
+          <a
+            href={buildExportUrl(active, "csv")}
+            className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs hover:bg-surface-2"
+            download
+          >
+            <Download className="h-3.5 w-3.5" />
+            {t("audit.export_csv", "Export CSV")}
+          </a>
+        }
       />
 
       <Card padding="lg">
-        <div className="flex items-start gap-3">
-          <ScrollText className="h-5 w-5 text-text-dim shrink-0" />
-          <div>
-            <p className="text-sm font-bold">
-              {t(
-                "audit.stub_title",
-                "Audit query / export will activate when M5 (#3203) merges.",
-              )}
-            </p>
-            <p className="mt-1 text-xs text-text-dim">
-              {t(
-                "audit.stub_body",
-                "The dashboard query layer is wired and ready. The page consumes `useAuditQuery({...})` from `lib/queries/audit.ts`, keyed via the `auditKeys.query()` factory. When M5 ships `/api/audit/query`, drop the `enabled: false` guard in this component and render the table.",
-              )}
-            </p>
-            <div className="mt-3 flex items-center gap-2 text-[11px]">
-              <Badge variant="info">depends on librefang/librefang#3203</Badge>
-              <a
-                href="https://github.com/librefang/librefang/pull/3203"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-text-dim hover:text-brand"
-              >
-                <ExternalLink className="h-3 w-3" />
-                {t("audit.view_pr", "View PR")}
-              </a>
+        <form onSubmit={onApply} className="grid grid-cols-3 gap-3 text-xs">
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">{t("audit.f_user", "User")}</span>
+            <input
+              value={draft.user ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, user: e.target.value || undefined }))
+              }
+              placeholder="UUID or name"
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">
+              {t("audit.f_action", "Action")}
+            </span>
+            <select
+              value={draft.action ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({
+                  ...d,
+                  action: e.target.value || undefined,
+                }))
+              }
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            >
+              {ACTION_OPTIONS.map((a) => (
+                <option key={a} value={a}>
+                  {a || t("audit.f_any", "(any)")}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">{t("audit.f_agent", "Agent")}</span>
+            <input
+              value={draft.agent ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, agent: e.target.value || undefined }))
+              }
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">
+              {t("audit.f_channel", "Channel")}
+            </span>
+            <input
+              value={draft.channel ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({
+                  ...d,
+                  channel: e.target.value || undefined,
+                }))
+              }
+              placeholder="api / telegram / ..."
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">
+              {t("audit.f_from", "From (ISO-8601)")}
+            </span>
+            <input
+              type="datetime-local"
+              value={draft.from ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({
+                  ...d,
+                  from: e.target.value || undefined,
+                }))
+              }
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-dim">
+              {t("audit.f_to", "To (ISO-8601)")}
+            </span>
+            <input
+              type="datetime-local"
+              value={draft.to ?? ""}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, to: e.target.value || undefined }))
+              }
+              className="rounded border border-border bg-surface-2 px-2 py-1"
+            />
+          </label>
+          <div className="col-span-3 flex justify-end">
+            <Button type="submit" icon={<Search className="h-3.5 w-3.5" />}>
+              {t("audit.apply", "Apply filters")}
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      {isForbidden && (
+        <Card padding="lg">
+          <div className="flex items-start gap-3 text-sm text-error">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-bold">
+                {t("audit.forbidden_title", "Admin role required")}
+              </p>
+              <p className="mt-1 text-xs">
+                {t(
+                  "audit.forbidden_body",
+                  "/api/audit/query is admin-only. Sign in with an Admin or Owner api_key.",
+                )}
+              </p>
             </div>
           </div>
-        </div>
+        </Card>
+      )}
+
+      {!isForbidden && query.error && (
+        <Card padding="lg">
+          <div className="flex items-start gap-3 text-sm text-error">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-bold">
+                {t("audit.error_title", "Failed to load audit log")}
+              </p>
+              <p className="mt-1 text-xs">{String(query.error)}</p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      <Card padding="lg">
+        {query.isLoading && (
+          <p className="text-sm text-text-dim">
+            {t("audit.loading", "Loading…")}
+          </p>
+        )}
+        {query.data && (
+          <>
+            <p className="text-xs text-text-dim mb-3">
+              {t("audit.count_label", "Showing {{count}} of up to {{limit}}", {
+                count: query.data.count,
+                limit: query.data.limit,
+              })}
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-left text-text-dim">
+                    <th className="px-2 py-1">seq</th>
+                    <th className="px-2 py-1">timestamp</th>
+                    <th className="px-2 py-1">action</th>
+                    <th className="px-2 py-1">agent</th>
+                    <th className="px-2 py-1">user</th>
+                    <th className="px-2 py-1">channel</th>
+                    <th className="px-2 py-1">outcome</th>
+                    <th className="px-2 py-1">detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {query.data.entries.map((e) => (
+                    <tr key={`${e.seq}-${e.hash}`} className="border-t border-border/50">
+                      <td className="px-2 py-1 font-mono">{e.seq}</td>
+                      <td className="px-2 py-1 font-mono">{e.timestamp}</td>
+                      <td className="px-2 py-1">{e.action}</td>
+                      <td className="px-2 py-1 font-mono">{e.agent_id}</td>
+                      <td className="px-2 py-1 font-mono">{e.user_id ?? "—"}</td>
+                      <td className="px-2 py-1">{e.channel ?? "—"}</td>
+                      <td
+                        className={`px-2 py-1 ${
+                          e.outcome === "denied" || e.outcome === "error"
+                            ? "text-error"
+                            : ""
+                        }`}
+                      >
+                        {e.outcome}
+                      </td>
+                      <td className="px-2 py-1 text-text-dim">{e.detail}</td>
+                    </tr>
+                  ))}
+                  {query.data.entries.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={8}
+                        className="px-2 py-4 text-center text-text-dim"
+                      >
+                        {t("audit.empty", "No matching audit entries")}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
       </Card>
     </div>
   );

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -12,18 +12,70 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { useAuditQuery } from "../lib/queries/audit";
+import { ApiError } from "../lib/http/errors";
 import type { AuditQueryFilters } from "../lib/http/client";
+
+// `<input type="datetime-local">` produces "YYYY-MM-DDTHH:MM" with no
+// timezone. The server parses `from` / `to` as RFC-3339 (offset
+// required), so we must normalise to ISO-8601 with `Z` before sending
+// — otherwise the server returns 400 and the filter silently fails.
+// Treats the input as the user's local time (matches what the picker
+// displays) and converts to UTC.
+function toRfc3339(local: string | undefined): string | undefined {
+  if (!local) return undefined;
+  const d = new Date(local);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
+}
+
+function normaliseFilters(filters: AuditQueryFilters): AuditQueryFilters {
+  return {
+    ...filters,
+    from: toRfc3339(filters.from),
+    to: toRfc3339(filters.to),
+  };
+}
 
 function buildExportUrl(
   filters: AuditQueryFilters,
   format: "csv" | "json",
 ): string {
+  const normalised = normaliseFilters(filters);
   const params = new URLSearchParams({ format });
-  for (const [k, v] of Object.entries(filters)) {
+  for (const [k, v] of Object.entries(normalised)) {
     if (v === undefined || v === null || v === "") continue;
     params.set(k, String(v));
   }
   return `/api/audit/export?${params.toString()}`;
+}
+
+// Authenticated download: dashboard auth is Bearer-in-header, but
+// `<a download>` triggers a navigation that drops custom headers, so
+// the browser would download the daemon's 401 / login HTML as
+// `audit.csv`. Fetch with the Bearer header, materialise the body as
+// a Blob, then programmatically click an object-URL anchor.
+async function downloadExport(
+  filters: AuditQueryFilters,
+  format: "csv" | "json",
+): Promise<void> {
+  const url = buildExportUrl(filters, format);
+  const token = localStorage.getItem("librefang-api-key") || "";
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const resp = await fetch(url, { headers });
+  if (!resp.ok) {
+    throw await ApiError.fromResponse(resp);
+  }
+  const blob = await resp.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = `audit.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer revoke so the browser has a chance to start the save dialog.
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
 }
 
 const ACTION_OPTIONS = [
@@ -41,15 +93,39 @@ export function AuditPage() {
   const { t } = useTranslation();
   const [draft, setDraft] = useState<AuditQueryFilters>({ limit: 200 });
   const [active, setActive] = useState<AuditQueryFilters>({ limit: 200 });
-  const query = useAuditQuery(active);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  // Normalise from/to so the server's RFC-3339 parser doesn't 400 on
+  // the bare datetime-local format. Same for export URL.
+  const query = useAuditQuery(normaliseFilters(active));
 
   const onApply = (e: React.FormEvent) => {
     e.preventDefault();
     setActive(draft);
   };
 
-  const isForbidden =
-    query.error instanceof Error && /403|admin/i.test(query.error.message);
+  const onExport = async () => {
+    setExportError(null);
+    setExporting(true);
+    try {
+      await downloadExport(active, "csv");
+    } catch (err) {
+      setExportError(
+        err instanceof ApiError
+          ? `${err.status}: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  // Status-code check, not text-matching the message: the server's
+  // forbidden body is "Admin role required for audit access" today
+  // but a future copy edit shouldn't silently regress this banner.
+  const isForbidden = query.error instanceof ApiError && query.error.status === 403;
 
   return (
     <div className="flex flex-col gap-6">
@@ -61,16 +137,33 @@ export function AuditPage() {
           "Searchable, filterable audit log across users / actions / agents.",
         )}
         actions={
-          <a
-            href={buildExportUrl(active, "csv")}
-            className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs hover:bg-surface-2"
-            download
+          <button
+            type="button"
+            onClick={onExport}
+            disabled={exporting}
+            className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-xs hover:bg-surface-2 disabled:opacity-50"
           >
             <Download className="h-3.5 w-3.5" />
-            {t("audit.export_csv", "Export CSV")}
-          </a>
+            {exporting
+              ? t("audit.exporting", "Exporting…")
+              : t("audit.export_csv", "Export CSV")}
+          </button>
         }
       />
+
+      {exportError && (
+        <Card padding="lg">
+          <div className="flex items-start gap-3 text-sm text-error">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-bold">
+                {t("audit.export_error_title", "Export failed")}
+              </p>
+              <p className="mt-1 text-xs">{exportError}</p>
+            </div>
+          </div>
+        </Card>
+      )}
 
       <Card padding="lg">
         <form onSubmit={onApply} className="grid grid-cols-3 gap-3 text-xs">
@@ -162,7 +255,7 @@ export function AuditPage() {
             />
           </label>
           <div className="col-span-3 flex justify-end">
-            <Button type="submit" icon={<Search className="h-3.5 w-3.5" />}>
+            <Button type="submit" leftIcon={<Search className="h-3.5 w-3.5" />}>
               {t("audit.apply", "Apply filters")}
             </Button>
           </div>


### PR DESCRIPTION
## Summary

Activates the dashboard `AuditPage` now that M5 (`/api/audit/query` + `/api/audit/export`) is in main. This is the same kind of cleanup as the recent `UserBudgetPage` activation: PR #3209 (M6 dashboard) shipped these pages as "Pending M5" stubs with `enabled: false` guards and **guessed** wire-format types, expecting a follow-up to wire them after M5 landed.

Reported by an operator hitting `/dashboard/audit` and seeing "Pending M5" even though M5 is live.

## Wire-format alignment

`AuditQueryResponse` and `AuditQueryFilters` in `api.ts` were guesses written before #3203's `routes/audit.rs::audit_query` shipped. They didn't match the real shape on any field worth caring about:

| | Stub (wrong) | Server (correct) |
|---|---|---|
| Filter time bounds | `since` / `until` | `from` / `to` |
| Filter — `offset` | present | doesn't exist (server keeps in-memory window then truncates) |
| Filter — `status` | present | doesn't exist (use `action` instead) |
| Filter — `agent` / `channel` | missing | present |
| Entry — agent | `agent` | `agent_id` |
| Entry — detail | `details` | `detail` |
| Entry — outcome | `status` | `outcome` |
| Entry — user | `user` | `user_id` |
| Entry — added | — | `seq`, `channel`, `hash` |
| Wrapper | `{ total, has_more }` | `{ count, limit }` |

If anyone had tried to drop `enabled: false` against the old types, every column would have been blank.

## UI

- `AuditPage` rewritten from stub to a working viewer:
  - Filter form: user / action (dropdown of variants) / agent / channel / from / to
  - Table with `seq, timestamp, action, agent_id, user_id, channel, outcome, detail`; failed/denied rows highlighted
  - CSV export button — uses `<a download>` against `/api/audit/export?format=csv` so the kernel's progressive transfer is preserved (no memory bloat in the browser)
  - 403 banner when the caller's api_key isn't Admin+ — audit is admin-only via `require_admin` in `routes/audit.rs:98`, so non-admin users now see a useful message instead of a generic error.
- CSV export URL is built by a tiny local `buildExportUrl` helper inside `AuditPage.tsx`. It's a string template for `<a download>`, not a network call, so it deliberately does **not** sit in the `lib/http/client` layer (whose semantic is "exports here = real fetch").
- `lib/queries/audit.ts` — dropped the stale "M5-pending" comment.

## What this PR does NOT do

- Does **not** add hash-chain verification UI for the displayed rows. `verifyAuditChain` already exists in `client.ts` for the `listAuditRecent` view; we can wire it into the query view as a follow-up.
- Does **not** add server-side pagination — the M5 endpoint is recency-windowed (hard cap 5000) and the page mirrors that. True pagination is a future refactor on the server.

## Test plan

- [x] Manual: read the diff against the actual `routes/audit.rs` to confirm field-by-field alignment.
- [ ] Manual on a real daemon: log in with an admin api_key, apply filters, click export — confirm CSV download works and table renders rows.
- [ ] Tsx render test — none added; `AuditPage` was previously untested too. Worth following up if the page grows complexity.

Refs #3054 (RBAC umbrella), follow-up to #3203 (M5) and #3209 (M6).
