### PR TITLE
feat(security): RBAC effective-permissions snapshot — wire simulator (#3054)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3689,3 +3689,63 @@ export async function updateUserPolicy(
     policy,
   );
 }
+
+// ---------------------------------------------------------------------------
+// Effective permissions snapshot (RBAC follow-up to M3/M5/M6)
+// ---------------------------------------------------------------------------
+
+// Mirrors the shape of `librefang_kernel::auth::EffectivePermissions`.
+// Per-slice fields are nullable so the simulator can distinguish "no policy
+// declared" (null) from "explicit empty allow-list" (object with empty
+// arrays). Server returns 404 for unknown users — callers handle that via
+// the query hook's error state, not by getting a synthesised default.
+
+export interface EffectiveToolPolicy {
+  allowed_tools: string[];
+  denied_tools: string[];
+}
+
+export interface EffectiveToolCategories {
+  allowed_groups: string[];
+  denied_groups: string[];
+}
+
+export interface EffectiveMemoryAccess {
+  readable_namespaces: string[];
+  writable_namespaces: string[];
+  pii_access: boolean;
+  export_allowed: boolean;
+  delete_allowed: boolean;
+}
+
+export interface EffectiveBudget {
+  max_hourly_usd: number;
+  max_daily_usd: number;
+  max_monthly_usd: number;
+  alert_threshold: number;
+}
+
+export interface EffectiveChannelToolPolicy {
+  allowed_tools: string[];
+  denied_tools: string[];
+}
+
+export interface EffectivePermissions {
+  user_id: string;
+  name: string;
+  role: string;
+  tool_policy: EffectiveToolPolicy | null;
+  tool_categories: EffectiveToolCategories | null;
+  memory_access: EffectiveMemoryAccess | null;
+  budget: EffectiveBudget | null;
+  channel_tool_rules: Record<string, EffectiveChannelToolPolicy>;
+  channel_bindings: Record<string, string>;
+}
+
+export async function getEffectivePermissions(
+  name: string,
+): Promise<EffectivePermissions> {
+  return get<EffectivePermissions>(
+    `/api/authz/effective/${encodeURIComponent(name)}`,
+  );
+}

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -136,6 +136,8 @@ export {
   // per-user budget / policy (M3+M5 stubs)
   getUserBudget,
   getUserPolicy,
+  // effective permissions snapshot (RBAC follow-up — backs the simulator)
+  getEffectivePermissions,
 } from "../../api";
 
 // ---------------------------------------------------------------------------
@@ -327,4 +329,11 @@ export type {
   UserBudgetEntry,
   UserBudgetResponse,
   PermissionPolicy,
+  // effective permissions snapshot (RBAC follow-up)
+  EffectivePermissions,
+  EffectiveToolPolicy,
+  EffectiveToolCategories,
+  EffectiveMemoryAccess,
+  EffectiveBudget,
+  EffectiveChannelToolPolicy,
 } from "../../api";

--- a/crates/librefang-api/dashboard/src/lib/queries/authz.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/authz.ts
@@ -1,0 +1,34 @@
+// Effective-permissions snapshot query — backs the permission simulator.
+//
+// Pages MUST consume this hook rather than calling `api.*` or `fetch`
+// directly. The endpoint is admin-only on the daemon side; the query
+// surfaces 404 / 403 through the standard react-query `error` channel
+// so the page can render a "user not found" or "forbidden" empty state
+// without inline fetch handling.
+
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { getEffectivePermissions } from "../http/client";
+import { authzKeys } from "./keys";
+import { withOverrides, type QueryOverrides } from "./options";
+
+const STALE_MS = 30_000;
+
+export const authzQueries = {
+  effective: (name: string) =>
+    queryOptions({
+      queryKey: authzKeys.effective(name),
+      queryFn: () => getEffectivePermissions(name),
+      enabled: !!name,
+      staleTime: STALE_MS,
+      // Don't retry 404s (unknown user) or 403s (caller not admin) — they
+      // are deterministic and a refetch storm just hides the message.
+      retry: false,
+    }),
+};
+
+export function useEffectivePermissions(
+  name: string,
+  options: QueryOverrides = {},
+) {
+  return useQuery(withOverrides(authzQueries.effective(name), options));
+}

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -315,6 +315,16 @@ export const permissionPolicyKeys = {
   detail: (name: string) => [...permissionPolicyKeys.details(), name] as const,
 };
 
+// Effective-permissions snapshot — backs the permission simulator. Read-only,
+// so only `all` and `effective(name)` are needed. Hierarchical so
+// invalidating `authzKeys.all` clears every cached snapshot at once (e.g.
+// after a config reload).
+export const authzKeys = {
+  all: ["authz"] as const,
+  effectives: () => [...authzKeys.all, "effective"] as const,
+  effective: (name: string) => [...authzKeys.effectives(), name] as const,
+};
+
 export const mediaKeys = {
   all: ["media"] as const,
   providers: () => [...mediaKeys.all, "providers"] as const,

--- a/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.tsx
@@ -1,29 +1,51 @@
-// Permission simulator (RBAC M6).
+// Permission simulator (RBAC follow-up to M3/M5/M6).
 //
-// Pick a user → render the matrix of `Action` enum variants with the
-// allow/deny decision derived locally from the kernel's role hierarchy.
-// Lives entirely on the client so it stays useful even before the M3
-// per-user-policy slice (#3205) ships its richer simulator endpoint.
+// Pick a user → call `/api/authz/effective/{name}` → render every RBAC
+// input slice that contributes to that user's permissions. The endpoint
+// returns the raw configured policy (NOT the per-call gate decision)
+// because reproducing the four-layer intersection here would silently
+// drift from the runtime gate path. Admins reading this page compose
+// the result mentally; the gate path stays the source of truth.
 
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Shield, CheckCircle2, XCircle } from "lucide-react";
+import {
+  Shield,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Wrench,
+  Layers,
+  Database,
+  DollarSign,
+  Radio,
+  Link2,
+} from "lucide-react";
 
 import { useUsers } from "../lib/queries/users";
+import { useEffectivePermissions } from "../lib/queries/authz";
+import type {
+  EffectiveBudget,
+  EffectiveChannelToolPolicy,
+  EffectiveMemoryAccess,
+  EffectiveToolCategories,
+  EffectiveToolPolicy,
+} from "../lib/http/client";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { Select } from "../components/ui/Select";
 import { EmptyState } from "../components/ui/EmptyState";
+import { Skeleton } from "../components/ui/Skeleton";
 
-// Roles ordered weakest → strongest. Indices double as the comparator we
-// use to derive allow/deny decisions, mirroring `UserRole as u8` in
-// `librefang_kernel::auth::UserRole`.
+// Roles ordered weakest → strongest, mirrors `UserRole as u8` in
+// `librefang_kernel::auth::UserRole`. The role-level allow/deny grid
+// remains useful even on top of the new effective-permissions data —
+// it answers a different question ("what can the role itself do?")
+// than the per-user-policy slices below.
 const ROLE_ORDER = ["viewer", "user", "admin", "owner"] as const;
 type Role = (typeof ROLE_ORDER)[number];
 
-// Mirrors `librefang_kernel::auth::Action` + its `required_role` map. Keep
-// in sync with the kernel: any change there must update both halves.
 const ACTIONS: Array<{
   id: string;
   label: string;
@@ -96,6 +118,17 @@ export function PermissionSimulatorPage() {
   );
   const role = (selected?.role as Role) ?? "user";
 
+  const effectiveQuery = useEffectivePermissions(selected?.name ?? "");
+  const effective = effectiveQuery.data;
+
+  // 404 from the daemon is a deterministic "user not present in
+  // AuthManager"; surface it distinctly from a generic fetch error so
+  // operators don't chase a network problem when the cause is a stale
+  // user list.
+  const notFound =
+    effectiveQuery.isError &&
+    /404|not found/i.test(String(effectiveQuery.error));
+
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
@@ -103,12 +136,12 @@ export function PermissionSimulatorPage() {
         title={t("simulator.title", "Permission simulator")}
         subtitle={t(
           "simulator.subtitle",
-          "Pick a user and see which actions their role allows. Mirrors the kernel's UserRole hierarchy.",
+          "Pick a user and see every RBAC input contributing to their permissions.",
         )}
         badge={t("simulator.badge", "Live")}
         helpText={t(
           "simulator.help",
-          "The decision is computed locally from `UserRole` ordering (Viewer < User < Admin < Owner). When M3 (#3205) lands, per-user tool/memory policy will refine these results — the dashboard hook is already wired against /api/users/{name}/policy.",
+          "Sections show RAW configured slices — not the per-call gate decision (the runtime gate intersects per-agent ToolPolicy, per-user tool_policy / tool_categories, and per-channel rules). Slices labelled \"Not configured\" defer to other layers.",
         )}
       />
 
@@ -135,46 +168,464 @@ export function PermissionSimulatorPage() {
             "Add a user from the Users page first.",
           )}
         />
-      ) : selected ? (
-        <Card padding="md">
-          <div className="flex items-center gap-2 mb-4">
-            <p className="text-sm font-bold">{selected.name}</p>
-            <Badge variant="info">{selected.role}</Badge>
+      ) : !selected ? null : (
+        <>
+          <RoleMatrixCard role={role} selectedName={selected.name} t={t} />
+
+          {effectiveQuery.isLoading ? (
+            <Card padding="md">
+              <Skeleton className="h-32 w-full" />
+            </Card>
+          ) : notFound ? (
+            <EmptyState
+              icon={<AlertTriangle className="h-8 w-8" />}
+              title={t("simulator.not_found_title", "User not found")}
+              description={t(
+                "simulator.not_found_desc",
+                "The selected user is not registered with the AuthManager. They may have been removed from config.toml since the user list cached.",
+              )}
+            />
+          ) : effectiveQuery.isError ? (
+            <EmptyState
+              icon={<AlertTriangle className="h-8 w-8" />}
+              title={t(
+                "simulator.error_title",
+                "Could not load effective permissions",
+              )}
+              description={String(effectiveQuery.error)}
+            />
+          ) : effective ? (
+            <>
+              <ToolPolicyCard policy={effective.tool_policy} t={t} />
+              <ToolCategoriesCard categories={effective.tool_categories} t={t} />
+              <MemoryAccessCard access={effective.memory_access} t={t} />
+              <BudgetCard budget={effective.budget} t={t} />
+              <ChannelRulesCard rules={effective.channel_tool_rules} t={t} />
+              <ChannelBindingsCard bindings={effective.channel_bindings} t={t} />
+            </>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------
+// Section components
+// ---------------------------------------------------------------------
+
+type Translate = (key: string, fallback: string) => string;
+
+function SectionHeader({
+  icon,
+  title,
+  configured,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  configured: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center gap-2">
+        <span className="text-text-dim">{icon}</span>
+        <p className="text-sm font-bold">{title}</p>
+      </div>
+      <Badge variant={configured ? "info" : "default"}>
+        {configured ? "Configured" : "Not configured"}
+      </Badge>
+    </div>
+  );
+}
+
+function PatternList({ items, empty }: { items: string[]; empty: string }) {
+  if (items.length === 0) {
+    return <p className="text-xs text-text-dim italic">{empty}</p>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {items.map(p => (
+        <code
+          key={p}
+          className="rounded-md border border-border-subtle bg-surface-2 px-1.5 py-0.5 text-[11px]"
+        >
+          {p}
+        </code>
+      ))}
+    </div>
+  );
+}
+
+function RoleMatrixCard({
+  role,
+  selectedName,
+  t,
+}: {
+  role: Role;
+  selectedName: string;
+  t: Translate;
+}) {
+  return (
+    <Card padding="md">
+      <div className="flex items-center gap-2 mb-4">
+        <p className="text-sm font-bold">{selectedName}</p>
+        <Badge variant="info">{role}</Badge>
+        <span className="text-[11px] text-text-dim ml-auto">
+          {t("simulator.role_matrix_caption", "Role-level coarse permissions")}
+        </span>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2">
+        {ACTIONS.map(a => {
+          const allowed = roleAllows(role, a.required);
+          return (
+            <div
+              key={a.id}
+              className={`flex items-start gap-3 rounded-xl border p-3 ${
+                allowed
+                  ? "border-success/30 bg-success/5"
+                  : "border-error/30 bg-error/5"
+              }`}
+            >
+              <div className="shrink-0 pt-0.5">
+                {allowed ? (
+                  <CheckCircle2 className="h-4 w-4 text-success" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-error" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-bold">{a.label}</p>
+                <p className="mt-0.5 text-[11px] text-text-dim">
+                  {a.description}
+                </p>
+                <p className="mt-1 text-[10px] uppercase tracking-widest text-text-dim">
+                  {t("simulator.requires", "Requires")}: {a.required}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+function ToolPolicyCard({
+  policy,
+  t,
+}: {
+  policy: EffectiveToolPolicy | null;
+  t: Translate;
+}) {
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<Wrench className="h-4 w-4" />}
+        title={t("simulator.tool_policy_title", "Tool policy (per-user)")}
+        configured={!!policy}
+      />
+      {policy ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-success mb-1.5">
+              {t("simulator.allowed_tools", "Allowed")}
+            </p>
+            <PatternList
+              items={policy.allowed_tools}
+              empty={t("simulator.no_allow_list", "No allow-list set")}
+            />
           </div>
-          <div className="grid gap-2 md:grid-cols-2">
-            {ACTIONS.map(a => {
-              const allowed = roleAllows(role, a.required);
-              return (
-                <div
-                  key={a.id}
-                  className={`flex items-start gap-3 rounded-xl border p-3 ${
-                    allowed
-                      ? "border-success/30 bg-success/5"
-                      : "border-error/30 bg-error/5"
-                  }`}
-                >
-                  <div className="shrink-0 pt-0.5">
-                    {allowed ? (
-                      <CheckCircle2 className="h-4 w-4 text-success" />
-                    ) : (
-                      <XCircle className="h-4 w-4 text-error" />
-                    )}
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-bold">{a.label}</p>
-                    <p className="mt-0.5 text-[11px] text-text-dim">
-                      {a.description}
-                    </p>
-                    <p className="mt-1 text-[10px] uppercase tracking-widest text-text-dim">
-                      {t("simulator.requires", "Requires")}: {a.required}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-error mb-1.5">
+              {t("simulator.denied_tools", "Denied")}
+            </p>
+            <PatternList
+              items={policy.denied_tools}
+              empty={t("simulator.no_deny_list", "No deny-list set")}
+            />
           </div>
-        </Card>
+        </div>
+      ) : (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.tool_policy_unset",
+            "Defers to per-agent ToolPolicy and channel rules.",
+          )}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function ToolCategoriesCard({
+  categories,
+  t,
+}: {
+  categories: EffectiveToolCategories | null;
+  t: Translate;
+}) {
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<Layers className="h-4 w-4" />}
+        title={t(
+          "simulator.tool_categories_title",
+          "Tool categories (bulk by ToolGroup)",
+        )}
+        configured={!!categories}
+      />
+      {categories ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-success mb-1.5">
+              {t("simulator.allowed_groups", "Allowed groups")}
+            </p>
+            <PatternList
+              items={categories.allowed_groups}
+              empty={t("simulator.no_allow_list", "No allow-list set")}
+            />
+          </div>
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-error mb-1.5">
+              {t("simulator.denied_groups", "Denied groups")}
+            </p>
+            <PatternList
+              items={categories.denied_groups}
+              empty={t("simulator.no_deny_list", "No deny-list set")}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.tool_categories_unset",
+            "No category-level overrides for this user.",
+          )}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function MemoryAccessCard({
+  access,
+  t,
+}: {
+  access: EffectiveMemoryAccess | null;
+  t: Translate;
+}) {
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<Database className="h-4 w-4" />}
+        title={t("simulator.memory_title", "Memory access")}
+        configured={!!access}
+      />
+      {access ? (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={access.pii_access ? "warning" : "default"}>
+              {access.pii_access
+                ? t("simulator.pii_access_on", "PII access ON")
+                : t("simulator.pii_access_off", "PII redacted")}
+            </Badge>
+            <Badge variant={access.export_allowed ? "info" : "default"}>
+              {access.export_allowed
+                ? t("simulator.export_on", "Export allowed")
+                : t("simulator.export_off", "No export")}
+            </Badge>
+            <Badge variant={access.delete_allowed ? "warning" : "default"}>
+              {access.delete_allowed
+                ? t("simulator.delete_on", "Delete allowed")
+                : t("simulator.delete_off", "No delete")}
+            </Badge>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <p className="text-[11px] uppercase tracking-widest text-text-dim mb-1.5">
+                {t("simulator.readable_namespaces", "Readable namespaces")}
+              </p>
+              <PatternList
+                items={access.readable_namespaces}
+                empty={t("simulator.no_namespaces", "No namespaces")}
+              />
+            </div>
+            <div>
+              <p className="text-[11px] uppercase tracking-widest text-text-dim mb-1.5">
+                {t("simulator.writable_namespaces", "Writable namespaces")}
+              </p>
+              <PatternList
+                items={access.writable_namespaces}
+                empty={t("simulator.no_namespaces", "No namespaces")}
+              />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.memory_unset",
+            "Falls back to the role-default ACL (Owner/Admin = full, User = proactive + kv:*, Viewer = proactive read-only).",
+          )}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function BudgetCard({
+  budget,
+  t,
+}: {
+  budget: EffectiveBudget | null;
+  t: Translate;
+}) {
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<DollarSign className="h-4 w-4" />}
+        title={t("simulator.budget_title", "Per-user budget caps")}
+        configured={!!budget}
+      />
+      {budget ? (
+        <div className="grid gap-3 md:grid-cols-3">
+          <BudgetRow
+            label={t("simulator.budget_hourly", "Hourly")}
+            value={budget.max_hourly_usd}
+          />
+          <BudgetRow
+            label={t("simulator.budget_daily", "Daily")}
+            value={budget.max_daily_usd}
+          />
+          <BudgetRow
+            label={t("simulator.budget_monthly", "Monthly")}
+            value={budget.max_monthly_usd}
+          />
+          <div className="md:col-span-3 text-[11px] text-text-dim">
+            {t("simulator.alert_threshold_label", "Alert threshold")}:{" "}
+            {(budget.alert_threshold * 100).toFixed(0)}%
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.budget_unset",
+            "No per-user cap. Bounded by global / per-agent / per-provider budgets only.",
+          )}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function BudgetRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-border-subtle p-3">
+      <p className="text-[11px] uppercase tracking-widest text-text-dim">
+        {label}
+      </p>
+      <p className="text-sm font-bold mt-1">
+        {value > 0 ? `$${value.toFixed(2)}` : "—"}
+      </p>
+      {value === 0 ? (
+        <p className="text-[10px] text-text-dim mt-0.5">unlimited on window</p>
       ) : null}
     </div>
+  );
+}
+
+function ChannelRulesCard({
+  rules,
+  t,
+}: {
+  rules: Record<string, EffectiveChannelToolPolicy>;
+  t: Translate;
+}) {
+  const entries = Object.entries(rules);
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<Radio className="h-4 w-4" />}
+        title={t("simulator.channel_rules_title", "Per-channel tool overrides")}
+        configured={entries.length > 0}
+      />
+      {entries.length === 0 ? (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.channel_rules_unset",
+            "No per-channel overrides. The global ApprovalPolicy.channel_rules still applies.",
+          )}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {entries.map(([channel, rule]) => (
+            <div
+              key={channel}
+              className="rounded-xl border border-border-subtle p-3"
+            >
+              <p className="text-xs font-bold mb-2">{channel}</p>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div>
+                  <p className="text-[10px] uppercase tracking-widest text-success mb-1">
+                    {t("simulator.allowed_tools", "Allowed")}
+                  </p>
+                  <PatternList
+                    items={rule.allowed_tools}
+                    empty={t("simulator.no_allow_list", "No allow-list set")}
+                  />
+                </div>
+                <div>
+                  <p className="text-[10px] uppercase tracking-widest text-error mb-1">
+                    {t("simulator.denied_tools", "Denied")}
+                  </p>
+                  <PatternList
+                    items={rule.denied_tools}
+                    empty={t("simulator.no_deny_list", "No deny-list set")}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ChannelBindingsCard({
+  bindings,
+  t,
+}: {
+  bindings: Record<string, string>;
+  t: Translate;
+}) {
+  const entries = Object.entries(bindings);
+  return (
+    <Card padding="md">
+      <SectionHeader
+        icon={<Link2 className="h-4 w-4" />}
+        title={t("simulator.channel_bindings_title", "Channel bindings")}
+        configured={entries.length > 0}
+      />
+      {entries.length === 0 ? (
+        <p className="text-xs text-text-dim italic">
+          {t(
+            "simulator.bindings_unset",
+            "No platform IDs bound. Inbound from any channel will be unrecognised.",
+          )}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {entries.map(([channel, platformId]) => (
+            <div key={channel} className="flex items-center gap-2 text-xs">
+              <Badge variant="info">{channel}</Badge>
+              <code className="rounded-md border border-border-subtle bg-surface-2 px-1.5 py-0.5 text-[11px]">
+                {platformId}
+              </code>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
   );
 }

--- a/crates/librefang-api/src/routes/authz.rs
+++ b/crates/librefang-api/src/routes/authz.rs
@@ -1,0 +1,130 @@
+//! RBAC follow-up — admin-only effective-permissions snapshot endpoint.
+//!
+//! Backs the dashboard's permission simulator (RBAC M6, #3209). Returns
+//! the raw RBAC inputs configured for one user across all four layers
+//! (per-user `tool_policy` + `tool_categories` from M3, `memory_access`
+//! from M3, `budget` from M5, `channel_tool_rules` from M3 + channel
+//! bindings) so an admin debugging a denial can see every contributing
+//! slice in one place without mentally walking the gate path.
+//!
+//! The endpoint is deliberately a **getter / serializer** — it does NOT
+//! recompute the four-layer intersection that decides per-call tool
+//! gates. That decision lives in the runtime + kernel gate path
+//! (`AuthManager::resolve_user_tool_decision` + per-agent
+//! `ToolPolicy::check_tool` + global `ApprovalPolicy.channel_rules`)
+//! and is the single source of truth; reproducing it here would
+//! silently drift on every gate-logic change.
+//!
+//! Gating mirrors the M5 `/api/audit/*` and `/api/budget/users/*`
+//! endpoints: anonymous callers and Viewer/User roles are denied with a
+//! `PermissionDenied` audit entry, only `Admin+` proceeds. The
+//! diagnostic surfaces the same identity / policy data those endpoints
+//! already expose, so the trust ceiling is identical.
+
+use super::AppState;
+use crate::middleware::AuthenticatedApiUser;
+use crate::types::ApiErrorResponse;
+use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use librefang_kernel::auth::UserRole;
+use librefang_types::agent::UserId;
+use std::sync::Arc;
+
+/// Build admin-gated authz / effective-permissions routes.
+pub fn router() -> axum::Router<Arc<AppState>> {
+    axum::Router::new().route(
+        "/authz/effective/{user_id}",
+        axum::routing::get(effective_permissions),
+    )
+}
+
+/// Reject the request unless the caller is an authenticated `Admin`+.
+///
+/// Anonymous callers (loopback / `LIBREFANG_ALLOW_NO_AUTH=1`) are
+/// denied for the same reason as `/api/audit/*`: the snapshot exposes
+/// per-user policy and channel bindings — sensitive enough that we
+/// don't blanket-trust an unauthenticated origin even on loopback. To
+/// use this endpoint in a no-auth deployment, configure at least one
+/// user with an admin api_key.
+fn require_admin(state: &AppState, api_user: Option<&AuthenticatedApiUser>) -> Option<Response> {
+    match api_user {
+        Some(u) if u.role >= UserRole::Admin => None,
+        Some(u) => {
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_runtime::audit::AuditAction::PermissionDenied,
+                format!("authz/effective endpoint denied for role {}", u.role),
+                "denied",
+                Some(u.user_id),
+                Some("api".to_string()),
+            );
+            Some(
+                ApiErrorResponse::forbidden("Admin role required for effective-permissions access")
+                    .into_response(),
+            )
+        }
+        None => {
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_runtime::audit::AuditAction::PermissionDenied,
+                "authz/effective endpoint denied for anonymous caller",
+                "denied",
+                None,
+                Some("api".to_string()),
+            );
+            Some(
+                ApiErrorResponse::forbidden(
+                    "Authenticated Admin role required for effective-permissions access \
+                     (configure an admin api_key)",
+                )
+                .into_response(),
+            )
+        }
+    }
+}
+
+/// GET /api/authz/effective/{user_id} — admin-only effective-permissions snapshot.
+///
+/// `user_id` accepts either a UUID (the canonical `UserId` form) or the
+/// raw configured name (re-derived via `UserId::from_name`) so operators
+/// can paste a name from `config.toml` directly into the URL — same
+/// semantics as `/api/budget/users/{user_id}`.
+///
+/// Returns 404 when no user matches; we intentionally do NOT synthesize
+/// "guest defaults" because the simulator's value is showing the operator
+/// what they configured, not inventing inputs.
+#[utoipa::path(
+    get,
+    path = "/api/authz/effective/{user_id}",
+    tag = "system",
+    params(("user_id" = String, Path, description = "User UUID or configured name")),
+    responses(
+        (status = 200, description = "Effective permissions snapshot", body = serde_json::Value),
+        (status = 404, description = "Unknown user"),
+    )
+)]
+pub async fn effective_permissions(
+    State(state): State<Arc<AppState>>,
+    Path(user_id_param): Path<String>,
+    api_user: Option<axum::Extension<AuthenticatedApiUser>>,
+) -> Response {
+    let api_user_ref = api_user.as_ref().map(|e| &e.0);
+    if let Some(deny) = require_admin(&state, api_user_ref) {
+        return deny;
+    }
+
+    // Resolve to a canonical UserId. Try parse-as-uuid first; if that
+    // fails fall back to from_name, which always succeeds.
+    let user_id: UserId = user_id_param
+        .parse()
+        .unwrap_or_else(|_| UserId::from_name(&user_id_param));
+
+    match state.kernel.auth_manager().effective_permissions(user_id) {
+        Some(snapshot) => Json(snapshot).into_response(),
+        None => ApiErrorResponse::not_found(format!(
+            "no user matches '{user_id_param}' (try a configured name or canonical UUID)"
+        ))
+        .into_response(),
+    }
+}

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod agents;
 pub mod audit;
+pub mod authz;
 pub mod auto_dream;
 pub mod budget;
 pub mod channels;
@@ -46,6 +47,7 @@ pub mod workflows;
 // `routes::agents::router()`), so there is no actual conflict.
 pub use agents::*;
 pub use audit::*;
+pub use authz::*;
 pub use auto_dream::*;
 pub use budget::*;
 pub use channels::*;

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -48,6 +48,7 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
         .merge(routes::config::router())
         .merge(routes::agents::router())
         .merge(routes::audit::router())
+        .merge(routes::authz::router())
         .merge(routes::channels::router())
         .merge(routes::system::router())
         .merge(routes::memory::router())

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3184,17 +3184,11 @@ async fn test_effective_permissions_admin_returns_200_with_full_payload() {
         channel_tool_rules: alice_channel_rules,
     };
 
-    let server = start_test_server_with_full_user_configs(
-        "any-key",
-        vec![(alice, "alice-admin-key")],
-    )
-    .await;
+    let server =
+        start_test_server_with_full_user_configs("any-key", vec![(alice, "alice-admin-key")]).await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!(
-            "{}/api/authz/effective/Alice",
-            server.base_url
-        ))
+        .get(format!("{}/api/authz/effective/Alice", server.base_url))
         .header("authorization", "Bearer alice-admin-key")
         .send()
         .await
@@ -3300,10 +3294,7 @@ async fn test_effective_permissions_viewer_rejected_403() {
     .await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!(
-            "{}/api/authz/effective/Alice",
-            server.base_url
-        ))
+        .get(format!("{}/api/authz/effective/Alice", server.base_url))
         .header("authorization", "Bearer eve-viewer-key")
         .send()
         .await
@@ -3326,17 +3317,11 @@ async fn test_effective_permissions_unknown_user_404() {
         role: "admin".to_string(),
         ..Default::default()
     };
-    let server = start_test_server_with_full_user_configs(
-        "any-key",
-        vec![(alice, "alice-admin-key")],
-    )
-    .await;
+    let server =
+        start_test_server_with_full_user_configs("any-key", vec![(alice, "alice-admin-key")]).await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!(
-            "{}/api/authz/effective/Nobody",
-            server.base_url
-        ))
+        .get(format!("{}/api/authz/effective/Nobody", server.base_url))
         .header("authorization", "Bearer alice-admin-key")
         .send()
         .await
@@ -3361,17 +3346,11 @@ async fn test_effective_permissions_rejects_anonymous() {
         role: "admin".to_string(),
         ..Default::default()
     };
-    let server = start_test_server_with_full_user_configs(
-        "any-key",
-        vec![(alice, "alice-admin-key")],
-    )
-    .await;
+    let server =
+        start_test_server_with_full_user_configs("any-key", vec![(alice, "alice-admin-key")]).await;
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!(
-            "{}/api/authz/effective/Alice",
-            server.base_url
-        ))
+        .get(format!("{}/api/authz/effective/Alice", server.base_url))
         .send()
         .await
         .unwrap();

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2815,11 +2815,14 @@ async fn start_test_server_with_rbac_users(
     };
 
     let app = Router::new()
-        // Wire ONLY the M5 routes under `/api/` — sufficient for these
-        // tests. Other RBAC layers (channel bindings, tool policy) are
-        // exercised by the kernel-level tests.
+        // Wire the admin-gated RBAC routes under `/api/` — sufficient for
+        // these tests. Other RBAC layers (channel bindings, tool policy)
+        // are exercised by the kernel-level tests. The authz router is
+        // mounted alongside audit/budget so the effective-permissions
+        // tests can hit it through the same auth middleware.
         .nest("/api", routes::audit::router())
         .nest("/api", routes::budget::router())
+        .nest("/api", routes::authz::router())
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             middleware::auth,
@@ -2991,4 +2994,390 @@ async fn test_user_budget_detail_includes_enforced_true() {
     assert!(body["daily"]["spend"].is_number());
     assert!(body["monthly"]["spend"].is_number());
     assert!(body["alert_breach"].is_boolean());
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Effective-permissions snapshot — `/api/authz/effective/{user_id}`
+//
+// Pins:
+//   1. Admin GET returns 200 with every documented section populated for
+//      a user that was seeded with non-default tool_policy / memory_access
+//      / budget. Catches a regression where the kernel-side getter starts
+//      collapsing slices to None or the route serialiser drops fields.
+//   2. Viewer GET is rejected at the in-handler `require_admin` gate
+//      (403). The middleware lets Viewer through GETs by default — only
+//      the handler stops them.
+//   3. Unknown user IDs return 404 (NOT a synthesised "guest defaults"
+//      payload — the simulator's job is to show what's configured).
+//   4. Anonymous (no Bearer header) is rejected — same model as audit.
+// ───────────────────────────────────────────────────────────────────────
+
+use librefang_types::user_policy::{
+    ChannelToolPolicy, UserMemoryAccess, UserToolCategories, UserToolPolicy,
+};
+
+/// Variant of `start_test_server_with_rbac_users` that lets the caller
+/// inject pre-built `UserConfig` rows so per-user policy fields
+/// (`tool_policy`, `memory_access`, `budget`, …) can be seeded for
+/// the effective-permissions tests.
+async fn start_test_server_with_full_user_configs(
+    api_key: &str,
+    users: Vec<(UserConfig, &str)>,
+) -> TestServer {
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let mut user_configs: Vec<UserConfig> = Vec::with_capacity(users.len());
+    let mut api_user_records: Vec<middleware::ApiUserAuth> = Vec::with_capacity(users.len());
+    for (cfg, key) in &users {
+        let hash =
+            librefang_api::password_hash::hash_password(key).expect("password hash should succeed");
+        let mut cfg = cfg.clone();
+        cfg.api_key_hash = Some(hash.clone());
+        api_user_records.push(middleware::ApiUserAuth {
+            name: cfg.name.clone(),
+            role: KernelUserRole::from_str_role(&cfg.role),
+            api_key_hash: hash,
+            user_id: librefang_types::agent::UserId::from_name(&cfg.name),
+        });
+        user_configs.push(cfg);
+    }
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        api_key: api_key.to_string(),
+        users: user_configs,
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+    let config_path = tmp.path().join("config.toml");
+    std::fs::write(&config_path, toml::to_string_pretty(&config).unwrap())
+        .expect("Failed to write test config");
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+
+    let api_key_lock = std::sync::Arc::new(tokio::sync::RwLock::new(
+        kernel.config_ref().api_key.clone(),
+    ));
+
+    let audit_log = kernel.audit().clone();
+
+    let state = Arc::new(AppState {
+        kernel,
+        started_at: Instant::now(),
+        peer_registry: None,
+        bridge_manager: tokio::sync::Mutex::new(None),
+        channels_config: tokio::sync::RwLock::new(Default::default()),
+        shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_cache: dashmap::DashMap::new(),
+        skillhub_cache: dashmap::DashMap::new(),
+        provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+        webhook_store: librefang_api::webhook_store::WebhookStore::load(std::env::temp_dir().join(
+            format!("librefang-test-webhooks-{}.json", uuid::Uuid::new_v4()),
+        )),
+        active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+        #[cfg(feature = "telemetry")]
+        prometheus_handle: None,
+        media_drivers: librefang_runtime::media::MediaDriverCache::new(),
+        webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+        api_key_lock: api_key_lock.clone(),
+        provider_test_cache: dashmap::DashMap::new(),
+        config_write_lock: tokio::sync::Mutex::new(()),
+    });
+
+    let api_key_state = middleware::AuthState {
+        api_key_lock,
+        active_sessions: state.active_sessions.clone(),
+        dashboard_auth_enabled: false,
+        user_api_keys: Arc::new(api_user_records),
+        require_auth_for_reads: false,
+        allow_no_auth: true,
+        audit_log: Some(audit_log),
+    };
+
+    let app = Router::new()
+        .nest("/api", routes::audit::router())
+        .nest("/api", routes::budget::router())
+        .nest("/api", routes::authz::router())
+        .layer(axum::middleware::from_fn_with_state(
+            api_key_state,
+            middleware::auth,
+        ))
+        .layer(axum::middleware::from_fn(middleware::request_logging))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind test server");
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    TestServer {
+        base_url: format!("http://{}", addr),
+        config_path,
+        state,
+        _tmp: tmp,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_effective_permissions_admin_returns_200_with_full_payload() {
+    // Seed Alice with non-default values for every per-user RBAC slice
+    // so the snapshot must surface each one. A regression that drops a
+    // slice from the response (e.g. forgetting to expose `budget` or
+    // collapsing `memory_access` to `None`) will fail one of the
+    // assertions below.
+    let mut alice_bindings = std::collections::HashMap::new();
+    alice_bindings.insert("telegram".to_string(), "555111".to_string());
+    alice_bindings.insert("discord".to_string(), "8001".to_string());
+
+    let mut alice_channel_rules = std::collections::HashMap::new();
+    alice_channel_rules.insert(
+        "telegram".to_string(),
+        ChannelToolPolicy {
+            allowed_tools: vec!["web_*".to_string()],
+            denied_tools: vec!["shell_*".to_string()],
+        },
+    );
+
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        channel_bindings: alice_bindings,
+        api_key_hash: None,
+        budget: Some(librefang_types::config::UserBudgetConfig {
+            max_hourly_usd: 1.0,
+            max_daily_usd: 10.0,
+            max_monthly_usd: 100.0,
+            alert_threshold: 0.75,
+        }),
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["read_*".to_string(), "list_*".to_string()],
+            denied_tools: vec!["dangerous_tool".to_string()],
+        }),
+        tool_categories: Some(UserToolCategories {
+            allowed_groups: vec!["safe".to_string()],
+            denied_groups: vec!["destructive".to_string()],
+        }),
+        memory_access: Some(UserMemoryAccess {
+            readable_namespaces: vec!["proactive".to_string(), "kv:*".to_string()],
+            writable_namespaces: vec!["kv:*".to_string()],
+            pii_access: true,
+            export_allowed: false,
+            delete_allowed: true,
+        }),
+        channel_tool_rules: alice_channel_rules,
+    };
+
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "{}/api/authz/effective/Alice",
+            server.base_url
+        ))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "Admin must receive 200");
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    // Identity fields
+    assert_eq!(body["name"], "Alice");
+    assert_eq!(body["role"], "admin");
+    assert!(
+        body["user_id"].is_string() && !body["user_id"].as_str().unwrap().is_empty(),
+        "user_id must be a non-empty stringified UUID"
+    );
+
+    // Per-user tool policy round-trip
+    assert_eq!(
+        body["tool_policy"]["allowed_tools"],
+        serde_json::json!(["read_*", "list_*"])
+    );
+    assert_eq!(
+        body["tool_policy"]["denied_tools"],
+        serde_json::json!(["dangerous_tool"])
+    );
+
+    // Tool categories
+    assert_eq!(
+        body["tool_categories"]["allowed_groups"],
+        serde_json::json!(["safe"])
+    );
+    assert_eq!(
+        body["tool_categories"]["denied_groups"],
+        serde_json::json!(["destructive"])
+    );
+
+    // Memory access (PII flag is the load-bearing one for the dashboard
+    // badge — pin it)
+    assert_eq!(body["memory_access"]["pii_access"], serde_json::json!(true));
+    assert_eq!(
+        body["memory_access"]["readable_namespaces"],
+        serde_json::json!(["proactive", "kv:*"])
+    );
+    assert_eq!(
+        body["memory_access"]["writable_namespaces"],
+        serde_json::json!(["kv:*"])
+    );
+    assert_eq!(
+        body["memory_access"]["export_allowed"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        body["memory_access"]["delete_allowed"],
+        serde_json::json!(true)
+    );
+
+    // Budget
+    assert_eq!(body["budget"]["max_hourly_usd"], serde_json::json!(1.0));
+    assert_eq!(body["budget"]["max_daily_usd"], serde_json::json!(10.0));
+    assert_eq!(body["budget"]["max_monthly_usd"], serde_json::json!(100.0));
+    assert_eq!(body["budget"]["alert_threshold"], serde_json::json!(0.75));
+
+    // Channel rules
+    assert_eq!(
+        body["channel_tool_rules"]["telegram"]["allowed_tools"],
+        serde_json::json!(["web_*"])
+    );
+    assert_eq!(
+        body["channel_tool_rules"]["telegram"]["denied_tools"],
+        serde_json::json!(["shell_*"])
+    );
+
+    // Channel bindings (cross-platform identity)
+    assert_eq!(
+        body["channel_bindings"]["telegram"],
+        serde_json::json!("555111")
+    );
+    assert_eq!(
+        body["channel_bindings"]["discord"],
+        serde_json::json!("8001")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_effective_permissions_viewer_rejected_403() {
+    // Pins the in-handler `require_admin` gate. The middleware lets
+    // Viewer GET through; only the handler stops them with 403. A
+    // refactor that drops that gate must surface here, not in
+    // production where the leak would be silent.
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        ..Default::default()
+    };
+    let eve = UserConfig {
+        name: "Eve".to_string(),
+        role: "viewer".to_string(),
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key"), (eve, "eve-viewer-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "{}/api/authz/effective/Alice",
+            server.base_url
+        ))
+        .header("authorization", "Bearer eve-viewer-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "Viewer must be denied by the in-handler require_admin gate"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_effective_permissions_unknown_user_404() {
+    // Unknown user → 404 with a useful message. We deliberately do NOT
+    // synthesise "guest defaults" — the simulator's job is to show what
+    // an admin configured, not to invent inputs that no AuthManager
+    // entry actually carries.
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "{}/api/authz/effective/Nobody",
+            server.base_url
+        ))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "Unknown user must be 404, not a synthesised guest payload"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_effective_permissions_rejects_anonymous() {
+    // Anonymous (no Bearer header) callers MUST be denied. Same
+    // contract as `/api/audit/query` — the snapshot exposes per-user
+    // policy and channel bindings, which is too sensitive to leak even
+    // on loopback. With both `api_key` and `user_api_keys` configured,
+    // the middleware short-circuits to 401 before reaching the handler;
+    // either status code (401 / 403) is an acceptable rejection.
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "{}/api/authz/effective/Alice",
+            server.base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "anonymous /api/authz/effective must be rejected at the middleware (401)"
+    );
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3360,3 +3360,97 @@ async fn test_effective_permissions_rejects_anonymous() {
         "anonymous /api/authz/effective must be rejected at the middleware (401)"
     );
 }
+
+/// Pins the "raw Option" discrimination on the snapshot. A user that
+/// declared `tool_policy: None` (omitted in TOML) and a user that
+/// declared `tool_policy: Some(UserToolPolicy::default())` (explicit
+/// empty allow/deny lists) MUST surface distinctly in the JSON:
+/// `null` vs `{"allowed_tools": [], "denied_tools": []}`. Same for
+/// `tool_categories` and `memory_access`.
+///
+/// Regression: an earlier draft collapsed both shapes to `None` by
+/// comparing the resolved struct to its `Default::default()` after
+/// `populate`'s `unwrap_or_default()`. That made the "Configured /
+/// Not configured" badge in the simulator silently lie about
+/// explicit-empty configs. This test fails closed if `populate`
+/// drops the raw `Option<...>` again.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_effective_permissions_distinguishes_none_from_empty() {
+    let bare = UserConfig {
+        name: "Bare".to_string(),
+        role: "user".to_string(),
+        // tool_policy / tool_categories / memory_access default to None.
+        ..Default::default()
+    };
+    let explicit_empty = UserConfig {
+        name: "Empty".to_string(),
+        role: "user".to_string(),
+        tool_policy: Some(UserToolPolicy::default()),
+        tool_categories: Some(UserToolCategories::default()),
+        memory_access: Some(UserMemoryAccess::default()),
+        ..Default::default()
+    };
+    let admin = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![
+            (admin, "alice-admin-key"),
+            (bare, "bare-key"),
+            (explicit_empty, "empty-key"),
+        ],
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    let bare_body: serde_json::Value = client
+        .get(format!("{}/api/authz/effective/Bare", server.base_url))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        bare_body["tool_policy"].is_null(),
+        "tool_policy must be null when UserConfig.tool_policy = None, got {:?}",
+        bare_body["tool_policy"]
+    );
+    assert!(
+        bare_body["tool_categories"].is_null(),
+        "tool_categories must be null when omitted"
+    );
+    assert!(
+        bare_body["memory_access"].is_null(),
+        "memory_access must be null when omitted"
+    );
+
+    let empty_body: serde_json::Value = client
+        .get(format!("{}/api/authz/effective/Empty", server.base_url))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        empty_body["tool_policy"].is_object(),
+        "tool_policy must be an object (not null) when UserConfig.tool_policy = Some(default), got {:?}",
+        empty_body["tool_policy"]
+    );
+    assert_eq!(
+        empty_body["tool_policy"]["allowed_tools"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        empty_body["tool_policy"]["denied_tools"],
+        serde_json::json!([])
+    );
+    assert!(empty_body["tool_categories"].is_object());
+    assert!(empty_body["memory_access"].is_object());
+}

--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -137,6 +137,22 @@ pub struct UserIdentity {
     /// budgets. When `Some`, [`MeteringEngine::check_user_budget`]
     /// enforces the listed windows after every LLM call.
     pub budget: Option<librefang_types::config::UserBudgetConfig>,
+    /// Raw `Option<UserToolPolicy>` as declared in `UserConfig`, preserved
+    /// for the diagnostic snapshot path
+    /// ([`AuthManager::effective_permissions`]). The gate path reads
+    /// `policy.tool_policy` (default-filled); this field exists so the
+    /// simulator can faithfully report "no per-user policy declared" vs
+    /// "explicit empty allow-list" — `populate`'s `unwrap_or_default()`
+    /// would otherwise collapse those two cases together.
+    pub raw_tool_policy: Option<UserToolPolicy>,
+    /// Raw `Option<UserToolCategories>` as declared in `UserConfig`. Same
+    /// rationale as [`Self::raw_tool_policy`].
+    pub raw_tool_categories: Option<UserToolCategories>,
+    /// Raw `Option<UserMemoryAccess>` as declared in `UserConfig`. Same
+    /// rationale as [`Self::raw_tool_policy`]; the simulator surfaces
+    /// `None` distinctly from "configured-but-empty" so admins can spot
+    /// users still on the role-default ACL.
+    pub raw_memory_access: Option<UserMemoryAccess>,
 }
 
 /// Diagnostic snapshot of every RBAC input that contributes to a user's
@@ -263,6 +279,13 @@ impl AuthManager {
             // Build the per-user policy snapshot. Optional fields fall
             // back to default (no opinion) so `evaluate` returns
             // NeedsRoleEscalation everywhere — i.e. existing behaviour.
+            //
+            // We also keep the *raw* `Option<...>` from `UserConfig`
+            // alongside the resolved struct. The gate path reads the
+            // resolved (default-filled) form; the diagnostic /
+            // simulator path reads the raw form so it can faithfully
+            // report "not declared" vs "configured-but-empty" without
+            // having to guess from default-equality.
             let policy = ResolvedUserPolicy {
                 tool_policy: config.tool_policy.clone().unwrap_or_default(),
                 channel_tool_rules: config.channel_tool_rules.clone(),
@@ -276,6 +299,9 @@ impl AuthManager {
                 role,
                 policy,
                 budget: config.budget.clone(),
+                raw_tool_policy: config.tool_policy.clone(),
+                raw_tool_categories: config.tool_categories.clone(),
+                raw_memory_access: config.memory_access.clone(),
             };
 
             self.users.insert(user_id, identity);
@@ -579,20 +605,14 @@ impl AuthManager {
     pub fn effective_permissions(&self, user_id: UserId) -> Option<EffectivePermissions> {
         let identity = self.users.get(&user_id)?.value().clone();
 
-        // The raw `UserConfig` was consumed at boot/reload (see
-        // `populate`); reconstruct the per-slice `Option<...>` shape
-        // by treating the resolved policy's defaults as "unset". A
-        // user that explicitly declared an empty allow-list still
-        // reaches here as default-equal — that's fine for the
-        // simulator's purpose (tell the operator they have no opinion
-        // configured), and matches the `serde(skip_serializing_if =
-        // "Option::is_none")` round-trip on `UserConfig`.
-        let tool_policy = (identity.policy.tool_policy != UserToolPolicy::default())
-            .then(|| identity.policy.tool_policy.clone());
-        let tool_categories = (identity.policy.tool_categories != UserToolCategories::default())
-            .then(|| identity.policy.tool_categories.clone());
-        let memory_access = (!identity.policy.memory_access.is_unconfigured())
-            .then(|| identity.policy.memory_access.clone());
+        // Read the raw `Option<...>` slices preserved on `UserIdentity`
+        // by `populate`. This is the only way to faithfully report
+        // "not declared" vs "configured-but-empty": the resolved
+        // policy on `identity.policy.*` was default-filled at boot, so
+        // those two cases would be indistinguishable from there.
+        let tool_policy = identity.raw_tool_policy.clone();
+        let tool_categories = identity.raw_tool_categories.clone();
+        let memory_access = identity.raw_memory_access.clone();
 
         // `channel_index` is a flat key→user_id map; rebuild the per-
         // user bindings by filtering entries that point at us. Cost

--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -6,12 +6,15 @@
 use dashmap::DashMap;
 use librefang_channels::types::{ChannelRoleQuery, SenderContext};
 use librefang_types::agent::UserId;
-use librefang_types::config::{ChannelRoleMapping, UserConfig};
+use librefang_types::config::{ChannelRoleMapping, UserBudgetConfig, UserConfig};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::tool_policy::ToolGroup;
 use librefang_types::user_policy::{
-    ResolvedUserPolicy, UserMemoryAccess, UserToolDecision, UserToolGate,
+    ChannelToolPolicy, ResolvedUserPolicy, UserMemoryAccess, UserToolCategories, UserToolDecision,
+    UserToolGate, UserToolPolicy,
 };
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use tracing::{debug, info, warn};
 
@@ -134,6 +137,49 @@ pub struct UserIdentity {
     /// budgets. When `Some`, [`MeteringEngine::check_user_budget`]
     /// enforces the listed windows after every LLM call.
     pub budget: Option<librefang_types::config::UserBudgetConfig>,
+}
+
+/// Diagnostic snapshot of every RBAC input that contributes to a user's
+/// effective permissions, returned by [`AuthManager::effective_permissions`].
+///
+/// This is a **read-only dump of the configured policy slices** — not a
+/// recomputation of the per-call gate decision. The four-layer
+/// intersection (per-agent `ToolPolicy` ⋂ per-user `tool_policy` ⋂
+/// per-user `tool_categories` ⋂ per-channel `ChannelToolPolicy`) lives
+/// inside the runtime / kernel gate path; reproducing it here would
+/// duplicate that logic and silently drift from production. The
+/// permission simulator UI shows operators each input separately so they
+/// can mentally compose the result, with the gate-path code remaining
+/// the single source of truth.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffectivePermissions {
+    /// Canonical UUID-form `UserId` for this user, stringified.
+    pub user_id: String,
+    /// Configured display name (matches `[users.x] name = "..."`).
+    pub name: String,
+    /// Resolved role string, lowercase (`viewer` / `user` / `admin` / `owner`).
+    pub role: String,
+    /// Raw per-user `tool_policy` from `UserConfig` (RBAC M3). `None`
+    /// when the user has no per-user policy declared — gate calls fall
+    /// through to per-agent / role layers in that case.
+    pub tool_policy: Option<UserToolPolicy>,
+    /// Raw per-user `tool_categories` from `UserConfig` (RBAC M3).
+    pub tool_categories: Option<UserToolCategories>,
+    /// Raw per-user `memory_access` from `UserConfig` (RBAC M3). `None`
+    /// signals "use the role-default ACL"; the resolved default lives
+    /// in [`AuthManager::memory_acl_for`] and is intentionally NOT
+    /// folded in here — the simulator surfaces "no opinion" so admins
+    /// can spot users still on defaults.
+    pub memory_access: Option<UserMemoryAccess>,
+    /// Raw per-user spending cap from `UserConfig` (RBAC M5).
+    pub budget: Option<UserBudgetConfig>,
+    /// Per-channel tool overrides, keyed by channel adapter name (RBAC M3).
+    /// Empty map = no channel overrides configured.
+    pub channel_tool_rules: HashMap<String, ChannelToolPolicy>,
+    /// Configured channel bindings (RBAC M3) so admins can see the
+    /// cross-platform identity at a glance — same shape as
+    /// `UserConfig.channel_bindings`.
+    pub channel_bindings: HashMap<String, String>,
 }
 
 /// Cache key for resolved channel roles.
@@ -507,6 +553,72 @@ impl AuthManager {
     /// per-agent / per-provider budgets only.
     pub fn budget_for(&self, user_id: UserId) -> Option<librefang_types::config::UserBudgetConfig> {
         self.users.get(&user_id)?.value().budget.clone()
+    }
+
+    /// Read-only diagnostic snapshot of every RBAC input that contributes
+    /// to a user's permissions — backs the permission simulator UI.
+    ///
+    /// Returns `None` when `user_id` doesn't match any registered user;
+    /// callers (e.g. `/api/authz/effective/{user_id}`) surface that as a
+    /// 404 rather than synthesising "guest defaults", since the
+    /// simulator's job is to show the operator what they configured,
+    /// not to invent inputs.
+    ///
+    /// Per-user policy slices that an operator left unset are returned
+    /// as `None` (not as `Default::default()`) so the UI can distinguish
+    /// "explicitly empty allow-list" from "no policy declared — defer
+    /// to other layers". For the same reason, [`UserMemoryAccess`] is
+    /// surfaced as the raw configured value rather than the role-default
+    /// ACL — admins need to see which users are still on defaults.
+    ///
+    /// **This is NOT the per-call gate decision.** The four-layer
+    /// intersection happens at the runtime tool-gate site
+    /// ([`AuthManager::resolve_user_tool_decision`] + per-agent
+    /// `ToolPolicy::check_tool` + global `ApprovalPolicy.channel_rules`)
+    /// and is intentionally not duplicated here.
+    pub fn effective_permissions(&self, user_id: UserId) -> Option<EffectivePermissions> {
+        let identity = self.users.get(&user_id)?.value().clone();
+
+        // The raw `UserConfig` was consumed at boot/reload (see
+        // `populate`); reconstruct the per-slice `Option<...>` shape
+        // by treating the resolved policy's defaults as "unset". A
+        // user that explicitly declared an empty allow-list still
+        // reaches here as default-equal — that's fine for the
+        // simulator's purpose (tell the operator they have no opinion
+        // configured), and matches the `serde(skip_serializing_if =
+        // "Option::is_none")` round-trip on `UserConfig`.
+        let tool_policy = (identity.policy.tool_policy != UserToolPolicy::default())
+            .then(|| identity.policy.tool_policy.clone());
+        let tool_categories = (identity.policy.tool_categories != UserToolCategories::default())
+            .then(|| identity.policy.tool_categories.clone());
+        let memory_access = (!identity.policy.memory_access.is_unconfigured())
+            .then(|| identity.policy.memory_access.clone());
+
+        // `channel_index` is a flat key→user_id map; rebuild the per-
+        // user bindings by filtering entries that point at us. Cost
+        // is O(N_bindings_total), bounded by the number of configured
+        // users * 3-4 platforms — cheap and avoids carrying a parallel
+        // copy on `UserIdentity`.
+        let mut channel_bindings: HashMap<String, String> = HashMap::new();
+        for entry in self.channel_index.iter() {
+            if *entry.value() == user_id {
+                if let Some((channel, platform_id)) = entry.key().split_once(':') {
+                    channel_bindings.insert(channel.to_string(), platform_id.to_string());
+                }
+            }
+        }
+
+        Some(EffectivePermissions {
+            user_id: user_id.to_string(),
+            name: identity.name,
+            role: identity.role.to_string(),
+            tool_policy,
+            tool_categories,
+            memory_access,
+            budget: identity.budget,
+            channel_tool_rules: identity.policy.channel_tool_rules,
+            channel_bindings,
+        })
     }
 
     /// Get the memory namespace ACL for a user (if registered) merged


### PR DESCRIPTION
## Summary

Activates `PermissionSimulatorPage` by adding the missing `GET /api/authz/effective/{user_id}` endpoint. Today the page is a stub linking to "after RBAC ships" — RBAC has shipped (M2-M6 all merged today), so this connects the diagnostic plane.

This is the **read** side of the RBAC management surface — "what does this user actually have?". The 4-layer intersection (per-agent ToolPolicy ∩ per-user policy ∩ tool categories ∩ channel rules) is a runtime decision that happens at every gated operation; the simulator just dumps the **inputs** to that decision so a human can read them in one place. Without the simulator, an admin debugging an RBAC denial has to mentally evaluate the AuthManager's resolution logic, which is error-prone.

## Surface

- **`GET /api/authz/effective/{user_id}`** — admin-only. Path param accepts UUID or configured name (same parse-as-uuid-then-from_name fallback as the existing user budget endpoint).
- New `EffectivePermissions` struct on `AuthManager` returns the **raw** per-user config slices: `tool_policy`, `tool_categories`, `memory_access`, `budget`, `channel_tool_rules`, `channel_bindings`, plus `name` / `role`.
- Returns 404 with a useful message when user is unknown — the simulator surfaces "user not found" rather than synthesising guest defaults.
- Audit-tags `PermissionDenied` for under-privileged callers, same pattern as `require_admin_for_user_budget`.

## Why "raw config" not "computed intersection"

The simulator deliberately does NOT pre-compute the 4-layer intersection. If it did, every authorization gate's logic would have a second source of truth that could drift. Instead we return the inputs — the dashboard renders them in clear sections so a human can answer "is the deny coming from the per-user `denied_tools`, the channel rule, or the per-agent policy?" by reading them side by side.

## Dashboard

- `PermissionSimulatorPage` rewritten from stub to a full read view: 7 sections (role badge, tool policy, tool categories, memory access with PII flag, budget windows, channel rules per-platform, channel bindings).
- `useEffectivePermissions(name)` hook with `retry: false` so a 404 doesn't bounce.
- New hierarchical `authzKeys` factory in `lib/queries/keys.ts` (`all` / `effectives()` / `effective(name)`).

## Deviations from the original spec (worth flagging)

1. **Page selects user via dropdown, not URL `:name` param.** The existing TanStack route is `/users/simulator` with no path param — adding a `/users/$name/simulator` route is out of scope and would change the router shape. The dropdown is fine for the diagnostic use case.
2. **Anonymous test asserts 401, not 403.** The middleware short-circuits to 401 before reaching the in-handler `require_admin` (same as `test_audit_query_rejects_anonymous`). Safety property "anonymous cannot access" still holds, just at an earlier layer.

## Out of scope (follow-ups noted)

- `UserUpsertPayload` in `dashboard/src/api.ts` doesn't expose `tool_policy` / `tool_categories` / `memory_access` / `budget`. The simulator surfaces the read side; the matrix-editor UI in `UserPolicyPage.tsx` is a separate PR (the write side is being addressed in a parallel branch).
- `/api/authz/check` (single-permission query for external callers) is the natural follow-up to this read surface — covered by the `effective_permissions` getter, ~30 lines.

## Test plan

- [x] `test_effective_permissions_admin_returns_200_with_full_payload` — seed Alice with non-default tool_policy + memory_access + budget, GET, all sections present.
- [x] `test_effective_permissions_viewer_rejected_403`
- [x] `test_effective_permissions_unknown_user_404`
- [x] `test_effective_permissions_rejects_anonymous` — 401 from middleware
- [x] 4/4 pass locally; `cargo clippy -p librefang-kernel -p librefang-api -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib auth::` — 42 passed (no regressions)

Refs #3054.
