### PR TITLE
feat(security): RBAC M3 — per-user policy GET/PUT + dashboard editor

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3664,14 +3664,50 @@ export async function getUserBudget(name: string): Promise<UserBudgetResponse> {
 }
 
 // ---------------------------------------------------------------------------
-// Per-user permission policy (M3 / #3205 — endpoint stubbed)
+// Per-user permission policy (RBAC M3 / #3205 — wired to the real daemon)
 // ---------------------------------------------------------------------------
 
+export interface UserToolPolicy {
+  allowed_tools: string[];
+  denied_tools: string[];
+}
+
+export interface UserToolCategories {
+  allowed_groups: string[];
+  denied_groups: string[];
+}
+
+export interface UserMemoryAccess {
+  readable_namespaces: string[];
+  writable_namespaces: string[];
+  pii_access: boolean;
+  export_allowed: boolean;
+  delete_allowed: boolean;
+}
+
+export interface ChannelToolPolicy {
+  allowed_tools: string[];
+  denied_tools: string[];
+}
+
+// Mirrors the `UserPolicyView` returned by `GET /api/users/{name}/policy`.
+// `null` on a top-level slot = "no opinion configured" (kernel falls back
+// to role-default). Empty `channel_tool_rules` map = no per-channel rules.
 export interface PermissionPolicy {
-  tool_allowlist: string[] | null;
-  tool_blocklist: string[] | null;
-  memory_read: string[] | null;
-  memory_write: string[] | null;
+  tool_policy: UserToolPolicy | null;
+  tool_categories: UserToolCategories | null;
+  memory_access: UserMemoryAccess | null;
+  channel_tool_rules: Record<string, ChannelToolPolicy>;
+}
+
+// PUT body shape: every key independently nullable. `undefined` = preserve
+// existing, `null` = clear. `channel_tool_rules` collapses absent/null to
+// "preserve"; pass `{}` to clear.
+export interface PermissionPolicyUpdate {
+  tool_policy?: UserToolPolicy | null;
+  tool_categories?: UserToolCategories | null;
+  memory_access?: UserMemoryAccess | null;
+  channel_tool_rules?: Record<string, ChannelToolPolicy>;
 }
 
 export async function getUserPolicy(name: string): Promise<PermissionPolicy> {
@@ -3682,9 +3718,9 @@ export async function getUserPolicy(name: string): Promise<PermissionPolicy> {
 
 export async function updateUserPolicy(
   name: string,
-  policy: PermissionPolicy,
-): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(
+  policy: PermissionPolicyUpdate,
+): Promise<PermissionPolicy> {
+  return put<PermissionPolicy>(
     `/api/users/${encodeURIComponent(name)}/policy`,
     policy,
   );

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -133,7 +133,7 @@ export {
   // users (RBAC M6)
   listUsers,
   getUser,
-  // per-user budget / policy (M3+M5 stubs)
+  // per-user budget (M5 stub) / policy (M3 #3205 — wired)
   getUserBudget,
   getUserPolicy,
 } from "../../api";
@@ -275,7 +275,7 @@ export {
   updateUser,
   deleteUser,
   importUsers,
-  // per-user policy (M3 stub)
+  // per-user policy (M3 #3205)
   updateUserPolicy,
 } from "../../api";
 
@@ -327,4 +327,9 @@ export type {
   UserBudgetEntry,
   UserBudgetResponse,
   PermissionPolicy,
+  PermissionPolicyUpdate,
+  UserToolPolicy,
+  UserToolCategories,
+  UserMemoryAccess,
+  ChannelToolPolicy,
 } from "../../api";

--- a/crates/librefang-api/dashboard/src/lib/mutations/users.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/users.ts
@@ -13,7 +13,7 @@ import {
   importUsers,
   updateUserPolicy,
   type UserUpsertPayload,
-  type PermissionPolicy,
+  type PermissionPolicyUpdate,
   type BulkImportResult,
 } from "../http/client";
 import {
@@ -75,18 +75,21 @@ export function useImportUsers() {
   });
 }
 
-// M3 / #3205 stub. Wired to the future endpoint via `updateUserPolicy`;
-// callers that try to invoke this against pre-M3 daemons will get a 404
-// from the daemon, which the consuming page surfaces as "feature pending".
+// RBAC M3 (#3205) — per-user policy upsert. Invalidates the policy detail
+// AND the user detail/list caches because policy fields are part of the
+// `UserConfig` row and could surface in any user-listing widget that grows
+// to render policy badges.
 export function useUpdateUserPolicy() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: { name: string; policy: PermissionPolicy }) =>
+    mutationFn: (vars: { name: string; policy: PermissionPolicyUpdate }) =>
       updateUserPolicy(vars.name, vars.policy),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({
         queryKey: permissionPolicyKeys.detail(variables.name),
       });
+      qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
+      qc.invalidateQueries({ queryKey: userKeys.lists() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -307,8 +307,9 @@ export const userBudgetKeys = {
   detail: (name: string) => [...userBudgetKeys.details(), name] as const,
 };
 
-// M3 / #3205 — per-user tool/memory policy. Endpoint stubbed; the matrix
-// editor consumes it once M3 ships.
+// RBAC M3 (#3205) — per-user tool/memory policy. Lives at
+// `/api/users/{name}/policy`; the matrix editor in `UserPolicyPage`
+// consumes this hierarchy.
 export const permissionPolicyKeys = {
   all: ["permissionPolicy"] as const,
   details: () => [...permissionPolicyKeys.all, "detail"] as const,

--- a/crates/librefang-api/dashboard/src/lib/queries/permissionPolicy.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/permissionPolicy.ts
@@ -1,8 +1,8 @@
-// Per-user policy queries (M3 / #3205 stub).
+// Per-user policy queries (RBAC M3 / #3205, wired to the live daemon).
 //
-// The endpoint `/api/users/{name}/policy` is owned by RBAC M3. The hook
-// ships now so the matrix-editor page only needs the placeholder swap when
-// M3 lands.
+// `GET /api/users/{name}/policy` returns the per-user `tool_policy` /
+// `tool_categories` / `memory_access` / `channel_tool_rules` slice. The
+// matrix editor in `UserPolicyPage` reads this to populate the form.
 
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { getUserPolicy } from "../http/client";

--- a/crates/librefang-api/dashboard/src/pages/UserPolicyPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UserPolicyPage.tsx
@@ -1,74 +1,627 @@
-// Per-user permission matrix editor (RBAC M6 — stub for M3 / #3205).
+// Per-user permission matrix editor (RBAC M3 / #3205, M6 follow-up).
 //
-// The dashboard query / mutation hooks for `/api/users/{name}/policy` ship
-// alongside this slice. The interactive matrix renders as a placeholder
-// until M3 lands the daemon endpoint.
+// Reads `/api/users/{name}/policy` via `usePermissionPolicy`, edits the
+// four slots independently (tool allow/deny, tool categories, memory
+// access, channel rules), and PUTs the whole sheet back through
+// `useUpdateUserPolicy`. Validation mirrors the daemon's checks so the
+// user sees errors inline before a round-trip.
 
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "@tanstack/react-router";
-import { ListChecks, ExternalLink, ArrowLeft } from "lucide-react";
+import { ListChecks, ArrowLeft, Save, AlertTriangle } from "lucide-react";
 
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
+import { EmptyState } from "../components/ui/EmptyState";
+import { CardSkeleton } from "../components/ui/Skeleton";
 import { usePermissionPolicy } from "../lib/queries/permissionPolicy";
+import { useUpdateUserPolicy } from "../lib/mutations/users";
+import type {
+  PermissionPolicy,
+  PermissionPolicyUpdate,
+  ChannelToolPolicy,
+} from "../lib/http/client";
+
+// Channels we expose by default in the per-channel rules table. Operators
+// can still PUT additional keys via the API; this just keeps the form
+// approachable.
+const DEFAULT_CHANNELS = ["telegram", "discord", "slack", "email"] as const;
+
+interface FormState {
+  tool_policy: { allowed: string; denied: string; enabled: boolean };
+  tool_categories: { allowed: string; denied: string; enabled: boolean };
+  memory_access: {
+    enabled: boolean;
+    readable: string;
+    writable: string;
+    pii_access: boolean;
+    export_allowed: boolean;
+    delete_allowed: boolean;
+  };
+  channel_tool_rules: Record<string, { allowed: string; denied: string }>;
+}
+
+// Newline-separated textarea contents <-> string[]. Trim each line; drop
+// blanks. Mirrors the server's `validate_string_list` behaviour so the
+// preview the user types matches what the server will accept.
+function parseList(raw: string): string[] {
+  return raw
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}
+
+function formatList(items: string[] | undefined): string {
+  if (!items || items.length === 0) return "";
+  return items.join("\n");
+}
+
+function policyToForm(policy: PermissionPolicy | undefined): FormState {
+  return {
+    tool_policy: {
+      enabled: !!policy?.tool_policy,
+      allowed: formatList(policy?.tool_policy?.allowed_tools),
+      denied: formatList(policy?.tool_policy?.denied_tools),
+    },
+    tool_categories: {
+      enabled: !!policy?.tool_categories,
+      allowed: formatList(policy?.tool_categories?.allowed_groups),
+      denied: formatList(policy?.tool_categories?.denied_groups),
+    },
+    memory_access: {
+      enabled: !!policy?.memory_access,
+      readable: formatList(policy?.memory_access?.readable_namespaces),
+      writable: formatList(policy?.memory_access?.writable_namespaces),
+      pii_access: policy?.memory_access?.pii_access ?? false,
+      export_allowed: policy?.memory_access?.export_allowed ?? false,
+      delete_allowed: policy?.memory_access?.delete_allowed ?? false,
+    },
+    channel_tool_rules: (() => {
+      const out: Record<string, { allowed: string; denied: string }> = {};
+      for (const ch of DEFAULT_CHANNELS) {
+        out[ch] = { allowed: "", denied: "" };
+      }
+      for (const [ch, rule] of Object.entries(policy?.channel_tool_rules ?? {})) {
+        out[ch] = {
+          allowed: formatList(rule.allowed_tools),
+          denied: formatList(rule.denied_tools),
+        };
+      }
+      return out;
+    })(),
+  };
+}
+
+// Mirror of the daemon's validators in `routes/users.rs`. We surface
+// errors inline before the PUT round-trip so a typo doesn't waste a
+// request, but the daemon revalidates so this layer is convenience only.
+function validateForm(form: FormState): string | null {
+  const checkList = (label: string, items: string[]): string | null => {
+    const seen = new Set<string>();
+    for (const item of items) {
+      if (item.length === 0) {
+        return `${label} contains an empty entry`;
+      }
+      if (seen.has(item)) {
+        return `${label} contains duplicate entry '${item}'`;
+      }
+      seen.add(item);
+    }
+    return null;
+  };
+
+  if (form.tool_policy.enabled) {
+    const allowed = parseList(form.tool_policy.allowed);
+    const denied = parseList(form.tool_policy.denied);
+    const e =
+      checkList("tool_policy.allowed_tools", allowed) ??
+      checkList("tool_policy.denied_tools", denied);
+    if (e) return e;
+  }
+  if (form.tool_categories.enabled) {
+    const allowed = parseList(form.tool_categories.allowed);
+    const denied = parseList(form.tool_categories.denied);
+    const e =
+      checkList("tool_categories.allowed_groups", allowed) ??
+      checkList("tool_categories.denied_groups", denied);
+    if (e) return e;
+  }
+  if (form.memory_access.enabled) {
+    const readable = parseList(form.memory_access.readable);
+    const writable = parseList(form.memory_access.writable);
+    const e =
+      checkList("memory_access.readable_namespaces", readable) ??
+      checkList("memory_access.writable_namespaces", writable);
+    if (e) return e;
+    for (const w of writable) {
+      if (!readable.includes(w)) {
+        return `memory_access.writable_namespaces['${w}'] is not in readable_namespaces (writable must be a subset of readable)`;
+      }
+    }
+  }
+  for (const [ch, rule] of Object.entries(form.channel_tool_rules)) {
+    const allowed = parseList(rule.allowed);
+    const denied = parseList(rule.denied);
+    const e =
+      checkList(`channel_tool_rules['${ch}'].allowed_tools`, allowed) ??
+      checkList(`channel_tool_rules['${ch}'].denied_tools`, denied);
+    if (e) return e;
+  }
+  return null;
+}
+
+function formToPayload(form: FormState): PermissionPolicyUpdate {
+  const payload: PermissionPolicyUpdate = {};
+  payload.tool_policy = form.tool_policy.enabled
+    ? {
+        allowed_tools: parseList(form.tool_policy.allowed),
+        denied_tools: parseList(form.tool_policy.denied),
+      }
+    : null;
+  payload.tool_categories = form.tool_categories.enabled
+    ? {
+        allowed_groups: parseList(form.tool_categories.allowed),
+        denied_groups: parseList(form.tool_categories.denied),
+      }
+    : null;
+  payload.memory_access = form.memory_access.enabled
+    ? {
+        readable_namespaces: parseList(form.memory_access.readable),
+        writable_namespaces: parseList(form.memory_access.writable),
+        pii_access: form.memory_access.pii_access,
+        export_allowed: form.memory_access.export_allowed,
+        delete_allowed: form.memory_access.delete_allowed,
+      }
+    : null;
+  // Build the channel map: omit channels that have no rules, so the
+  // server-side empty-map = "preserve" semantic doesn't kick in. We pass
+  // an explicit object so PUT becomes a full replace of the channel slot.
+  const channelRules: Record<string, ChannelToolPolicy> = {};
+  for (const [ch, rule] of Object.entries(form.channel_tool_rules)) {
+    const allowed = parseList(rule.allowed);
+    const denied = parseList(rule.denied);
+    if (allowed.length > 0 || denied.length > 0) {
+      channelRules[ch] = { allowed_tools: allowed, denied_tools: denied };
+    }
+  }
+  payload.channel_tool_rules = channelRules;
+  return payload;
+}
 
 export function UserPolicyPage() {
   const { t } = useTranslation();
   const { name } = useParams({ from: "/users/$name/policy" });
 
-  // Hook is wired and disabled — see AuditPage for the rationale.
-  void usePermissionPolicy(name, { enabled: false });
+  const policyQuery = usePermissionPolicy(name);
+  const updateMutation = useUpdateUserPolicy();
+
+  const [form, setForm] = useState<FormState>(() => policyToForm(undefined));
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitOk, setSubmitOk] = useState(false);
+
+  // Re-hydrate the form whenever the underlying query resolves a new value
+  // (e.g. on initial load or after invalidation).
+  useEffect(() => {
+    if (policyQuery.data) {
+      setForm(policyToForm(policyQuery.data));
+    }
+  }, [policyQuery.data]);
+
+  const validationError = useMemo(() => validateForm(form), [form]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+    setSubmitOk(false);
+    if (validationError) {
+      setSubmitError(validationError);
+      return;
+    }
+    try {
+      await updateMutation.mutateAsync({
+        name,
+        policy: formToPayload(form),
+      });
+      setSubmitOk(true);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (policyQuery.isLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <PageHeader
+          icon={<ListChecks className="h-4 w-4" />}
+          title={t("user_policy.title", "Permission matrix")}
+          subtitle={name}
+        />
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  if (policyQuery.isError) {
+    return (
+      <div className="flex flex-col gap-6">
+        <PageHeader
+          icon={<ListChecks className="h-4 w-4" />}
+          title={t("user_policy.title", "Permission matrix")}
+          subtitle={name}
+        />
+        <EmptyState
+          icon={<AlertTriangle className="h-6 w-6" />}
+          title={t("user_policy.load_error_title", "Failed to load policy")}
+          description={
+            policyQuery.error instanceof Error
+              ? policyQuery.error.message
+              : t(
+                  "user_policy.load_error_body",
+                  "The daemon returned an error fetching the per-user policy slice.",
+                )
+          }
+        />
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-6">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
       <PageHeader
         icon={<ListChecks className="h-4 w-4" />}
         title={t("user_policy.title", "Permission matrix")}
         subtitle={name}
-        badge={t("user_policy.badge_pending", "Pending M3")}
         actions={
-          <Link
-            to="/users"
-            className="inline-flex items-center gap-1.5 text-xs text-text-dim hover:text-brand"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            {t("user_policy.back", "Back to users")}
-          </Link>
+          <div className="flex items-center gap-3">
+            <Link
+              to="/users"
+              className="inline-flex items-center gap-1.5 text-xs text-text-dim hover:text-brand"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              {t("user_policy.back", "Back to users")}
+            </Link>
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              disabled={updateMutation.isPending || !!validationError}
+            >
+              <Save className="h-3.5 w-3.5" />
+              {t("user_policy.save", "Save")}
+            </Button>
+          </div>
         }
       />
 
+      {submitError && (
+        <Card padding="md">
+          <div className="flex items-start gap-2 text-sm text-red-500">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{submitError}</span>
+          </div>
+        </Card>
+      )}
+      {submitOk && !submitError && (
+        <Card padding="md">
+          <div className="text-sm font-bold text-emerald-500">
+            {t("user_policy.saved", "Policy saved.")}
+          </div>
+        </Card>
+      )}
+
       <Card padding="lg">
-        <div className="flex items-start gap-3">
-          <ListChecks className="h-5 w-5 text-text-dim shrink-0" />
+        <SectionHeader
+          title={t("user_policy.section_tool_policy", "Tool allow / deny")}
+          description={t(
+            "user_policy.tool_policy_desc",
+            "Per-user allow + deny patterns. Layered ON TOP of agent + channel rules. Deny wins.",
+          )}
+          enabled={form.tool_policy.enabled}
+          onToggle={enabled =>
+            setForm(f => ({
+              ...f,
+              tool_policy: { ...f.tool_policy, enabled },
+            }))
+          }
+        />
+        {form.tool_policy.enabled && (
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <Textarea
+              label={t("user_policy.allowed_tools", "Allowed tools")}
+              hint={t(
+                "user_policy.glob_hint",
+                "One pattern per line. Glob with `*` allowed.",
+              )}
+              value={form.tool_policy.allowed}
+              onChange={value =>
+                setForm(f => ({
+                  ...f,
+                  tool_policy: { ...f.tool_policy, allowed: value },
+                }))
+              }
+            />
+            <Textarea
+              label={t("user_policy.denied_tools", "Denied tools")}
+              hint={t("user_policy.glob_hint_deny", "Always wins over allow.")}
+              value={form.tool_policy.denied}
+              onChange={value =>
+                setForm(f => ({
+                  ...f,
+                  tool_policy: { ...f.tool_policy, denied: value },
+                }))
+              }
+            />
+          </div>
+        )}
+      </Card>
+
+      <Card padding="lg">
+        <SectionHeader
+          title={t("user_policy.section_categories", "Tool categories")}
+          description={t(
+            "user_policy.categories_desc",
+            "Bulk allow / deny by tool group name (defined in `KernelConfig.tool_policy.groups`).",
+          )}
+          enabled={form.tool_categories.enabled}
+          onToggle={enabled =>
+            setForm(f => ({
+              ...f,
+              tool_categories: { ...f.tool_categories, enabled },
+            }))
+          }
+        />
+        {form.tool_categories.enabled && (
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <Textarea
+              label={t("user_policy.allowed_groups", "Allowed groups")}
+              hint={t(
+                "user_policy.group_hint",
+                "One group name per line (e.g. `web_tools`).",
+              )}
+              value={form.tool_categories.allowed}
+              onChange={value =>
+                setForm(f => ({
+                  ...f,
+                  tool_categories: { ...f.tool_categories, allowed: value },
+                }))
+              }
+            />
+            <Textarea
+              label={t("user_policy.denied_groups", "Denied groups")}
+              hint={t("user_policy.glob_hint_deny", "Always wins over allow.")}
+              value={form.tool_categories.denied}
+              onChange={value =>
+                setForm(f => ({
+                  ...f,
+                  tool_categories: { ...f.tool_categories, denied: value },
+                }))
+              }
+            />
+          </div>
+        )}
+      </Card>
+
+      <Card padding="lg">
+        <SectionHeader
+          title={t("user_policy.section_memory", "Memory access")}
+          description={t(
+            "user_policy.memory_desc",
+            "Namespace ACL + PII redaction toggles. Writable must be a subset of readable.",
+          )}
+          enabled={form.memory_access.enabled}
+          onToggle={enabled =>
+            setForm(f => ({
+              ...f,
+              memory_access: { ...f.memory_access, enabled },
+            }))
+          }
+        />
+        {form.memory_access.enabled && (
+          <div className="mt-4 flex flex-col gap-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <Textarea
+                label={t("user_policy.readable_ns", "Readable namespaces")}
+                hint={t(
+                  "user_policy.ns_hint",
+                  "One namespace per line. `*` matches all.",
+                )}
+                value={form.memory_access.readable}
+                onChange={value =>
+                  setForm(f => ({
+                    ...f,
+                    memory_access: { ...f.memory_access, readable: value },
+                  }))
+                }
+              />
+              <Textarea
+                label={t("user_policy.writable_ns", "Writable namespaces")}
+                hint={t(
+                  "user_policy.writable_hint",
+                  "Must be a subset of readable.",
+                )}
+                value={form.memory_access.writable}
+                onChange={value =>
+                  setForm(f => ({
+                    ...f,
+                    memory_access: { ...f.memory_access, writable: value },
+                  }))
+                }
+              />
+            </div>
+            <div className="flex flex-wrap gap-4">
+              <CheckboxLabel
+                label={t("user_policy.pii_access", "PII access")}
+                checked={form.memory_access.pii_access}
+                onChange={checked =>
+                  setForm(f => ({
+                    ...f,
+                    memory_access: { ...f.memory_access, pii_access: checked },
+                  }))
+                }
+              />
+              <CheckboxLabel
+                label={t("user_policy.export_allowed", "Export allowed")}
+                checked={form.memory_access.export_allowed}
+                onChange={checked =>
+                  setForm(f => ({
+                    ...f,
+                    memory_access: {
+                      ...f.memory_access,
+                      export_allowed: checked,
+                    },
+                  }))
+                }
+              />
+              <CheckboxLabel
+                label={t("user_policy.delete_allowed", "Delete allowed")}
+                checked={form.memory_access.delete_allowed}
+                onChange={checked =>
+                  setForm(f => ({
+                    ...f,
+                    memory_access: {
+                      ...f.memory_access,
+                      delete_allowed: checked,
+                    },
+                  }))
+                }
+              />
+            </div>
+          </div>
+        )}
+      </Card>
+
+      <Card padding="lg">
+        <div className="flex items-center justify-between">
           <div>
             <p className="text-sm font-bold">
-              {t(
-                "user_policy.stub_title",
-                "Per-user tool policy editor activates when M3 (#3205) merges.",
-              )}
+              {t("user_policy.section_channels", "Per-channel tool rules")}
             </p>
             <p className="mt-1 text-xs text-text-dim">
               {t(
-                "user_policy.stub_body",
-                "Wired: `usePermissionPolicy(name)` query + `useUpdateUserPolicy()` mutation, keyed via `permissionPolicyKeys.detail(name)`. The mutation invalidates the detail subtree on success. The simulator already exposes role-level decisions; once M3 ships the per-user override surface, the matrix renders here.",
+                "user_policy.channels_desc",
+                "Override the user's tool surface per channel adapter (telegram / discord / …).",
               )}
             </p>
-            <div className="mt-3 flex items-center gap-2 text-[11px]">
-              <Badge variant="info">depends on librefang/librefang#3205</Badge>
-              <a
-                href="https://github.com/librefang/librefang/pull/3205"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-text-dim hover:text-brand"
-              >
-                <ExternalLink className="h-3 w-3" />
-                {t("user_policy.view_pr", "View PR")}
-              </a>
-            </div>
           </div>
+          <Badge variant="info">{Object.keys(form.channel_tool_rules).length}</Badge>
+        </div>
+        <div className="mt-4 flex flex-col gap-4">
+          {Object.entries(form.channel_tool_rules).map(([ch, rule]) => (
+            <div key={ch} className="rounded-xl border border-border-subtle p-3">
+              <div className="text-xs font-black uppercase tracking-widest text-text-dim">
+                {ch}
+              </div>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <Textarea
+                  label={t("user_policy.allowed_tools", "Allowed tools")}
+                  value={rule.allowed}
+                  onChange={value =>
+                    setForm(f => ({
+                      ...f,
+                      channel_tool_rules: {
+                        ...f.channel_tool_rules,
+                        [ch]: { ...f.channel_tool_rules[ch], allowed: value },
+                      },
+                    }))
+                  }
+                />
+                <Textarea
+                  label={t("user_policy.denied_tools", "Denied tools")}
+                  value={rule.denied}
+                  onChange={value =>
+                    setForm(f => ({
+                      ...f,
+                      channel_tool_rules: {
+                        ...f.channel_tool_rules,
+                        [ch]: { ...f.channel_tool_rules[ch], denied: value },
+                      },
+                    }))
+                  }
+                />
+              </div>
+            </div>
+          ))}
         </div>
       </Card>
+
+      {validationError && (
+        <Card padding="md">
+          <div className="flex items-start gap-2 text-sm text-amber-500">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{validationError}</span>
+          </div>
+        </Card>
+      )}
+    </form>
+  );
+}
+
+interface SectionHeaderProps {
+  title: string;
+  description: string;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+}
+
+function SectionHeader({ title, description, enabled, onToggle }: SectionHeaderProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="text-sm font-bold">{title}</p>
+        <p className="mt-1 text-xs text-text-dim">{description}</p>
+      </div>
+      <CheckboxLabel
+        label={enabled ? "Configured" : "Not set"}
+        checked={enabled}
+        onChange={onToggle}
+      />
     </div>
   );
 }
+
+interface TextareaProps {
+  label: string;
+  hint?: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function Textarea({ label, hint, value, onChange }: TextareaProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+        {label}
+      </label>
+      <textarea
+        className="w-full min-h-[100px] rounded-xl border border-border-subtle bg-surface px-4 py-2.5 text-sm font-mono text-text-main placeholder:text-text-dim/40 focus:outline-none focus:ring-2 focus:ring-brand/40"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
+      {hint && <p className="text-[11px] text-text-dim">{hint}</p>}
+    </div>
+  );
+}
+
+interface CheckboxLabelProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function CheckboxLabel({ label, checked, onChange }: CheckboxLabelProps) {
+  return (
+    <label className="inline-flex items-center gap-2 text-xs font-medium text-text-main cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={e => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-border-subtle accent-brand"
+      />
+      {label}
+    </label>
+  );
+}
+

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -28,6 +28,9 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use librefang_types::config::UserConfig;
+use librefang_types::user_policy::{
+    ChannelToolPolicy, UserMemoryAccess, UserToolCategories, UserToolPolicy,
+};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
@@ -42,6 +45,10 @@ pub fn router() -> axum::Router<Arc<AppState>> {
                 .delete(delete_user),
         )
         .route("/users/import", axum::routing::post(import_users))
+        .route(
+            "/users/{name}/policy",
+            axum::routing::get(get_user_policy).put(update_user_policy),
+        )
 }
 
 // ---------------------------------------------------------------------------
@@ -748,4 +755,318 @@ where
     );
 
     Ok(captured)
+}
+
+// ---------------------------------------------------------------------------
+// RBAC M3 — per-user policy GET / PUT (#3054 Phase 2 wiring)
+// ---------------------------------------------------------------------------
+
+/// View / wire shape for the per-user RBAC M3 policy slice.
+///
+/// Each top-level field is independently nullable so the dashboard can edit
+/// one section at a time without restating the others. On PUT a `None`
+/// clears that field; a missing key preserves the existing value (see
+/// [`update_user_policy`]). On GET every field is always present (`null`
+/// when the user has no opinion configured) so the client can render a
+/// stable form.
+// `utoipa::ToSchema` is intentionally NOT derived: the inner types
+// (`UserToolPolicy`, `UserMemoryAccess`, `ChannelToolPolicy`, …) live in
+// `librefang-types` and don't implement `ToSchema` to keep that crate
+// free of OpenAPI deps. The handler attribute below points utoipa at
+// `serde_json::Value` for documentation; the wire shape is still pinned
+// by serde so callers see the real JSON.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UserPolicyView {
+    #[serde(default)]
+    pub tool_policy: Option<UserToolPolicy>,
+    #[serde(default)]
+    pub tool_categories: Option<UserToolCategories>,
+    #[serde(default)]
+    pub memory_access: Option<UserMemoryAccess>,
+    #[serde(default)]
+    pub channel_tool_rules: HashMap<String, ChannelToolPolicy>,
+}
+
+impl From<&UserConfig> for UserPolicyView {
+    fn from(cfg: &UserConfig) -> Self {
+        Self {
+            tool_policy: cfg.tool_policy.clone(),
+            tool_categories: cfg.tool_categories.clone(),
+            memory_access: cfg.memory_access.clone(),
+            channel_tool_rules: cfg.channel_tool_rules.clone(),
+        }
+    }
+}
+
+/// PUT body decoder. We accept the request as a raw JSON object so we can
+/// distinguish three states per key:
+///   * key absent       → preserve existing value
+///   * key present null → clear
+///   * key present obj  → replace
+///
+/// `Option<serde_json::Value>` would collapse `null` to `None` (serde's
+/// default behaviour for `Option<T>`), making absent and explicit-null
+/// indistinguishable. Using `serde_json::Map` directly preserves both via
+/// `Map::contains_key` + `Value::is_null`.
+const KNOWN_POLICY_KEYS: &[&str] = &[
+    "tool_policy",
+    "tool_categories",
+    "memory_access",
+    "channel_tool_rules",
+];
+
+/// Reject lists with empty/whitespace-only entries or duplicates so the
+/// resolver can never trip over a `""` glob (matches every tool) or a
+/// duplicate-as-typo that silently shadows the user's intended pattern.
+fn validate_string_list(label: &str, items: &[String]) -> Result<(), String> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for item in items {
+        let trimmed = item.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "{label} contains an empty or whitespace-only entry"
+            ));
+        }
+        if !seen.insert(trimmed) {
+            return Err(format!("{label} contains duplicate entry '{trimmed}'"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_tool_policy(p: &UserToolPolicy) -> Result<(), String> {
+    validate_string_list("tool_policy.allowed_tools", &p.allowed_tools)?;
+    validate_string_list("tool_policy.denied_tools", &p.denied_tools)?;
+    Ok(())
+}
+
+fn validate_tool_categories(c: &UserToolCategories) -> Result<(), String> {
+    validate_string_list("tool_categories.allowed_groups", &c.allowed_groups)?;
+    validate_string_list("tool_categories.denied_groups", &c.denied_groups)?;
+    Ok(())
+}
+
+fn validate_memory_access(a: &UserMemoryAccess) -> Result<(), String> {
+    validate_string_list("memory_access.readable_namespaces", &a.readable_namespaces)?;
+    validate_string_list("memory_access.writable_namespaces", &a.writable_namespaces)?;
+    // RBAC invariant: a user can only write where they can read. Without
+    // this check an admin could grant `writable=["proactive"]` while
+    // leaving `readable=[]`, producing a write-only ACL the kernel's
+    // `can_read`/`can_write` paths can't reason about consistently
+    // (writes succeed, but the same user can't read the entry back).
+    // Enforced newly here — there is no upstream validation today; the
+    // kernel resolver assumes the config is well-formed.
+    for w in &a.writable_namespaces {
+        if !a.readable_namespaces.iter().any(|r| r == w) {
+            return Err(format!(
+                "memory_access.writable_namespaces['{w}'] is not in readable_namespaces \
+                 (writable must be a subset of readable)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_channel_rules(rules: &HashMap<String, ChannelToolPolicy>) -> Result<(), String> {
+    for (channel, rule) in rules {
+        let trimmed = channel.trim();
+        if trimmed.is_empty() {
+            return Err("channel_tool_rules contains an empty channel name".to_string());
+        }
+        validate_string_list(
+            &format!("channel_tool_rules['{trimmed}'].allowed_tools"),
+            &rule.allowed_tools,
+        )?;
+        validate_string_list(
+            &format!("channel_tool_rules['{trimmed}'].denied_tools"),
+            &rule.denied_tools,
+        )?;
+    }
+    Ok(())
+}
+
+/// Decode a single key out of the raw PUT body into one of three states.
+enum FieldUpdate<T> {
+    Absent,
+    Clear,
+    Set(T),
+}
+
+fn decode_field<T: serde::de::DeserializeOwned>(
+    label: &str,
+    body: &serde_json::Map<String, serde_json::Value>,
+) -> Result<FieldUpdate<T>, String> {
+    match body.get(label) {
+        None => Ok(FieldUpdate::Absent),
+        Some(serde_json::Value::Null) => Ok(FieldUpdate::Clear),
+        Some(v) => serde_json::from_value::<T>(v.clone())
+            .map(FieldUpdate::Set)
+            .map_err(|e| format!("{label} payload is invalid: {e}")),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/users/{name}/policy",
+    tag = "users",
+    params(("name" = String, Path, description = "User name (case-sensitive)")),
+    responses(
+        (status = 200, description = "Per-user policy slice", body = serde_json::Value),
+        (status = 404, description = "Not found"),
+    )
+)]
+pub async fn get_user_policy(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let cfg = state.kernel.config_ref();
+    match cfg.users.iter().find(|u| u.name == name) {
+        Some(u) => Json(UserPolicyView::from(u)).into_response(),
+        None => err_response(StatusCode::NOT_FOUND, format!("user '{name}' not found")),
+    }
+}
+
+/// PUT /api/users/{name}/policy — upsert the per-user RBAC M3 policy slice.
+///
+/// Body shape:
+/// ```json
+/// {
+///   "tool_policy":        {...} | null,
+///   "tool_categories":    {...} | null,
+///   "memory_access":      {...} | null,
+///   "channel_tool_rules": {"telegram": {...}, ...}
+/// }
+/// ```
+///
+/// Each top-level key is independently optional:
+///   * key absent       → preserve existing value (so a partial edit
+///                        from the dashboard never clobbers a section
+///                        the form didn't expose),
+///   * key present null → clear the field,
+///   * key present obj  → replace.
+///
+/// `channel_tool_rules` collapses absent/null to "preserve" (use an empty
+/// object `{}` to clear all rules), since a `null` map is rarely what an
+/// operator means.
+///
+/// Owner-only — covered by `middleware::is_owner_only_write` which gates
+/// every mutating call under `/api/users*`. Per-user policy edits change
+/// someone's authorization surface, which is unambiguously an Owner action.
+#[utoipa::path(
+    put,
+    path = "/api/users/{name}/policy",
+    tag = "users",
+    params(("name" = String, Path, description = "User name (case-sensitive)")),
+    request_body = serde_json::Value,
+    responses(
+        (status = 200, description = "Updated user policy slice", body = serde_json::Value),
+        (status = 400, description = "Validation error"),
+        (status = 404, description = "Not found"),
+    )
+)]
+pub async fn update_user_policy(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Json(raw): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let body = match raw {
+        serde_json::Value::Object(map) => map,
+        _ => {
+            return err_response(
+                StatusCode::BAD_REQUEST,
+                "request body must be a JSON object",
+            )
+        }
+    };
+
+    // Reject unknown top-level keys early so a typo (e.g. `tool_polices`)
+    // doesn't silently no-op — without this the absent/null distinction
+    // turns every typo into "preserve existing".
+    for k in body.keys() {
+        if !KNOWN_POLICY_KEYS.iter().any(|known| known == k) {
+            return err_response(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "unknown field '{k}' (expected one of: {})",
+                    KNOWN_POLICY_KEYS.join(", ")
+                ),
+            );
+        }
+    }
+
+    let tool_policy_update = match decode_field::<UserToolPolicy>("tool_policy", &body) {
+        Ok(v) => v,
+        Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
+    };
+    let tool_categories_update =
+        match decode_field::<UserToolCategories>("tool_categories", &body) {
+            Ok(v) => v,
+            Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
+        };
+    let memory_access_update = match decode_field::<UserMemoryAccess>("memory_access", &body) {
+        Ok(v) => v,
+        Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
+    };
+    let channel_rules_update =
+        match decode_field::<HashMap<String, ChannelToolPolicy>>("channel_tool_rules", &body) {
+            Ok(v) => v,
+            Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
+        };
+
+    if let FieldUpdate::Set(p) = &tool_policy_update {
+        if let Err(e) = validate_tool_policy(p) {
+            return err_response(StatusCode::BAD_REQUEST, e);
+        }
+    }
+    if let FieldUpdate::Set(c) = &tool_categories_update {
+        if let Err(e) = validate_tool_categories(c) {
+            return err_response(StatusCode::BAD_REQUEST, e);
+        }
+    }
+    if let FieldUpdate::Set(a) = &memory_access_update {
+        if let Err(e) = validate_memory_access(a) {
+            return err_response(StatusCode::BAD_REQUEST, e);
+        }
+    }
+    if let FieldUpdate::Set(r) = &channel_rules_update {
+        if let Err(e) = validate_channel_rules(r) {
+            return err_response(StatusCode::BAD_REQUEST, e);
+        }
+    }
+
+    let target = name.clone();
+    match persist_users(&state, move |users| -> Result<UserConfig, PersistError> {
+        let idx = users
+            .iter()
+            .position(|u| u.name == target)
+            .ok_or_else(|| PersistError::NotFound(format!("user '{target}' not found")))?;
+        match tool_policy_update {
+            FieldUpdate::Absent => {}
+            FieldUpdate::Clear => users[idx].tool_policy = None,
+            FieldUpdate::Set(p) => users[idx].tool_policy = Some(p),
+        }
+        match tool_categories_update {
+            FieldUpdate::Absent => {}
+            FieldUpdate::Clear => users[idx].tool_categories = None,
+            FieldUpdate::Set(c) => users[idx].tool_categories = Some(c),
+        }
+        match memory_access_update {
+            FieldUpdate::Absent => {}
+            FieldUpdate::Clear => users[idx].memory_access = None,
+            FieldUpdate::Set(a) => users[idx].memory_access = Some(a),
+        }
+        match channel_rules_update {
+            FieldUpdate::Absent | FieldUpdate::Clear => {}
+            FieldUpdate::Set(r) => users[idx].channel_tool_rules = r,
+        }
+        Ok(users[idx].clone())
+    })
+    .await
+    {
+        Ok(final_cfg) => (StatusCode::OK, Json(UserPolicyView::from(&final_cfg))).into_response(),
+        Err(PersistError::NotFound(m)) => err_response(StatusCode::NOT_FOUND, m),
+        Err(PersistError::BadRequest(m)) => err_response(StatusCode::BAD_REQUEST, m),
+        Err(PersistError::Conflict(m)) => err_response(StatusCode::CONFLICT, m),
+        Err(PersistError::Internal(m)) => err_response(StatusCode::INTERNAL_SERVER_ERROR, m),
+    }
 }

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -998,11 +998,11 @@ pub async fn update_user_policy(
         Ok(v) => v,
         Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
     };
-    let tool_categories_update =
-        match decode_field::<UserToolCategories>("tool_categories", &body) {
-            Ok(v) => v,
-            Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
-        };
+    let tool_categories_update = match decode_field::<UserToolCategories>("tool_categories", &body)
+    {
+        Ok(v) => v,
+        Err(e) => return err_response(StatusCode::BAD_REQUEST, e),
+    };
     let memory_access_update = match decode_field::<UserMemoryAccess>("memory_access", &body) {
         Ok(v) => v,
         Err(e) => return err_response(StatusCode::BAD_REQUEST, e),

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3670,4 +3670,3 @@ async fn users_policy_put_owner_only() {
         "Owner must be allowed to upsert per-user policy"
     );
 }
-

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2815,11 +2815,13 @@ async fn start_test_server_with_rbac_users(
     };
 
     let app = Router::new()
-        // Wire ONLY the M5 routes under `/api/` — sufficient for these
-        // tests. Other RBAC layers (channel bindings, tool policy) are
+        // Wire the M5 routes plus the users router so M3 (#3205) policy
+        // PUT/GET tests run the full middleware stack (owner-only gate).
+        // Other RBAC layers (channel bindings, tool policy resolution) are
         // exercised by the kernel-level tests.
         .nest("/api", routes::audit::router())
         .nest("/api", routes::budget::router())
+        .nest("/api", routes::users::router())
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             middleware::auth,
@@ -2991,4 +2993,57 @@ async fn test_user_budget_detail_includes_enforced_true() {
     assert!(body["daily"]["spend"].is_number());
     assert!(body["monthly"]["spend"].is_number());
     assert!(body["alert_breach"].is_boolean());
+}
+
+/// RBAC M3 (#3205) follow-up — `PUT /api/users/{name}/policy` rewrites the
+/// caller's authorization surface, so it must travel through the same
+/// owner-only gate as `POST /api/users` and `DELETE /api/users/{name}`.
+/// An Admin api key has to be 403'd here; otherwise an Admin could
+/// silently grant themselves `denied_tools = []` and bypass downstream
+/// per-user denials.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_put_owner_only() {
+    let server = start_test_server_with_rbac_users(
+        "any-key",
+        vec![
+            ("Owner1", "owner", "owner-key"),
+            ("Alice", "admin", "alice-admin-key"),
+        ],
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // Admin is denied at the middleware before reaching the handler.
+    let resp = client
+        .put(format!("{}/api/users/Alice/policy", server.base_url))
+        .header("authorization", "Bearer alice-admin-key")
+        .json(&serde_json::json!({
+            "tool_policy": { "allowed_tools": ["web_*"], "denied_tools": [] }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "Admin must be denied PUT /api/users/{{name}}/policy by the owner-only middleware gate"
+    );
+
+    // Owner sails through. Used to confirm the route IS wired — without
+    // this assertion a 404 from a missing route would also produce a 4xx
+    // and pretend the gate was working.
+    let resp = client
+        .put(format!("{}/api/users/Alice/policy", server.base_url))
+        .header("authorization", "Bearer owner-key")
+        .json(&serde_json::json!({
+            "tool_policy": { "allowed_tools": ["web_*"], "denied_tools": [] }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "Owner must be allowed to upsert per-user policy"
+    );
 }

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -779,10 +779,7 @@ async fn users_policy_put_validates_no_empty_tool_strings() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"]
-            .as_str()
-            .unwrap_or("")
-            .contains("empty"),
+        body["error"].as_str().unwrap_or("").contains("empty"),
         "error must mention the empty entry: {body:?}"
     );
 }

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -589,3 +589,200 @@ async fn users_create_refuses_to_overwrite_corrupt_config_toml() {
         "config.toml was overwritten despite parse failure: {on_disk}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// RBAC M3 (#3205) per-user policy GET / PUT — exercises the M6 follow-up
+// that wires the dashboard's matrix editor to the real daemon endpoint.
+// ---------------------------------------------------------------------------
+
+/// Seed a user with non-default `tool_policy` + `memory_access`. GET must
+/// surface every field verbatim so the dashboard can render the editor
+/// without a second round-trip.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_get_round_trip() {
+    use librefang_types::user_policy::{UserMemoryAccess, UserToolPolicy};
+    use std::collections::HashMap;
+
+    let seed = UserConfig {
+        name: "Bob".into(),
+        role: "user".into(),
+        channel_bindings: HashMap::new(),
+        api_key_hash: None,
+        budget: None,
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_*".into()],
+            denied_tools: vec!["shell_exec".into()],
+        }),
+        tool_categories: None,
+        memory_access: Some(UserMemoryAccess {
+            readable_namespaces: vec!["proactive".into(), "kv:bob".into()],
+            writable_namespaces: vec!["kv:bob".into()],
+            pii_access: true,
+            export_allowed: false,
+            delete_allowed: true,
+        }),
+        channel_tool_rules: HashMap::new(),
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, body) = json_request(&h, Method::GET, "/api/users/Bob/policy", None).await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(
+        body["tool_policy"]["allowed_tools"],
+        serde_json::json!(["web_*"])
+    );
+    assert_eq!(
+        body["tool_policy"]["denied_tools"],
+        serde_json::json!(["shell_exec"])
+    );
+    assert_eq!(
+        body["memory_access"]["readable_namespaces"],
+        serde_json::json!(["proactive", "kv:bob"])
+    );
+    assert_eq!(
+        body["memory_access"]["writable_namespaces"],
+        serde_json::json!(["kv:bob"])
+    );
+    assert_eq!(body["memory_access"]["pii_access"], true);
+    assert_eq!(body["memory_access"]["delete_allowed"], true);
+    assert_eq!(body["memory_access"]["export_allowed"], false);
+    assert!(body["tool_categories"].is_null(), "{body:?}");
+    assert_eq!(body["channel_tool_rules"], serde_json::json!({}));
+}
+
+/// PUT with `tool_policy: null` must clear that slot but leave
+/// `memory_access` (which the request body never mentioned) untouched.
+/// Pins the absent-vs-null distinction the handler relies on.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_put_replaces_only_specified_fields() {
+    use librefang_types::user_policy::{UserMemoryAccess, UserToolPolicy};
+    use std::collections::HashMap;
+
+    let seed_memory = UserMemoryAccess {
+        readable_namespaces: vec!["proactive".into()],
+        writable_namespaces: vec![],
+        pii_access: false,
+        export_allowed: false,
+        delete_allowed: false,
+    };
+    let seed = UserConfig {
+        name: "Carol".into(),
+        role: "user".into(),
+        channel_bindings: HashMap::new(),
+        api_key_hash: None,
+        budget: None,
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_*".into()],
+            denied_tools: vec![],
+        }),
+        tool_categories: None,
+        memory_access: Some(seed_memory.clone()),
+        channel_tool_rules: HashMap::new(),
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    // PUT clears tool_policy, leaves memory_access alone (key absent).
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Carol/policy",
+        Some(serde_json::json!({ "tool_policy": null })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert!(body["tool_policy"].is_null(), "tool_policy must be cleared");
+
+    // Verify in-kernel state — memory_access must still match the seed.
+    let after = h
+        ._state
+        .kernel
+        .config_ref()
+        .users
+        .iter()
+        .find(|u| u.name == "Carol")
+        .cloned()
+        .expect("Carol must still exist");
+    assert!(
+        after.tool_policy.is_none(),
+        "tool_policy was not cleared: {:?}",
+        after.tool_policy
+    );
+    assert_eq!(
+        after.memory_access,
+        Some(seed_memory),
+        "memory_access was clobbered despite being absent from PUT body"
+    );
+}
+
+/// `writable_namespaces` MUST be a subset of `readable_namespaces`. There
+/// is no upstream enforcement for this invariant today; the handler is the
+/// first gate. Pins the new validation so a refactor doesn't silently drop it.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_put_validates_writable_subset_of_readable() {
+    use std::collections::HashMap;
+    let seed = UserConfig {
+        name: "Dan".into(),
+        role: "user".into(),
+        channel_bindings: HashMap::new(),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Dan/policy",
+        Some(serde_json::json!({
+            "memory_access": {
+                "readable_namespaces": [],
+                "writable_namespaces": ["proactive"],
+                "pii_access": false,
+                "export_allowed": false,
+                "delete_allowed": false
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    let err = body["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("subset") || err.contains("readable"),
+        "error must mention the readable/writable subset rule: {err}"
+    );
+}
+
+/// Empty / whitespace-only tool entries are rejected — without this an
+/// operator can paste a stray newline into the matrix editor and grant
+/// `""` (matches every tool via the glob layer).
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_put_validates_no_empty_tool_strings() {
+    use std::collections::HashMap;
+    let seed = UserConfig {
+        name: "Eve".into(),
+        role: "user".into(),
+        channel_bindings: HashMap::new(),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Eve/policy",
+        Some(serde_json::json!({
+            "tool_policy": {
+                "allowed_tools": ["", "web_search"],
+                "denied_tools": []
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("empty"),
+        "error must mention the empty entry: {body:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Activates `UserPolicyPage` by adding `GET` + `PUT /api/users/{name}/policy` — the **write** side of the RBAC management surface, complementing the read-side simulator (#3228). Today the page is a stub linking to "after M3 ships". M3 (`feat(security): RBAC M3 — per-user tool policy + memory namespace ACL`) is merged in main; this PR connects the management plane.

## Surface

- **`GET /api/users/{name}/policy`** — owner-only. Returns the user's current `tool_policy`, `tool_categories`, `memory_access`, `channel_tool_rules` from `UserConfig`.
- **`PUT /api/users/{name}/policy`** — owner-only. Body shape:
  ```json
  {
    "tool_policy": { "allowed_tools": [...], "denied_tools": [...] } | null | <omitted>,
    "tool_categories": { ... } | null | <omitted>,
    "memory_access": { ... } | null | <omitted>,
    "channel_tool_rules": { "telegram": {...}, ... } | <omitted>
  }
  ```
  Each field is independently nullable. **`null` clears, omitted preserves** — this distinction is critical and required deserializing the body as `serde_json::Map` rather than the typed struct (`Option<T>` collapses both into `None`).
- Owner-only inherited from existing `is_owner_only_write` middleware allowlist (`/api/users/*` with non-GET method) — no new gate code, just a new route under the existing umbrella.

## Validation

- Tool / namespace strings: nonempty, no whitespace-only entries
- No duplicate entries within a single list
- `memory_access.writable_namespaces ⊆ readable_namespaces` — newly enforced at this layer with a comment noting there's no upstream check today and the kernel resolver assumes well-formed config
- **Unknown top-level keys rejected** so a typo (`tool_polices`) can't silently no-op into "preserve everything"

## Dashboard

- `UserPolicyPage` rewritten from stub to a 4-section editor: tool allow/deny lists, tool categories, memory access (with PII checkbox), per-channel rules. Client-side validation mirrors server.
- `useUpdateUserPolicy` invalidates `permissionPolicyKeys.detail(name)` + `userKeys.detail(name)` + `userKeys.lists()` on success.
- `PermissionPolicy` type rewritten to match the real wire shape (the previous one was an M3-stub guess written before the endpoint shipped — same root cause as #3225 / #3224 / #3228).

## Test plan

- [x] Unit-style: `users_policy_get_round_trip`, `users_policy_put_replaces_only_specified_fields`, `users_policy_put_validates_writable_subset_of_readable`, `users_policy_put_validates_no_empty_tool_strings` — 4/4 pass.
- [x] Full-stack through the auth middleware: `users_policy_put_owner_only` — Admin caller (not Owner) blocked at the middleware → 403.
- [x] No regressions in surrounding tests: `users_test` 16/16, `api_integration_test -- test_audit test_user_budget` 4/4 (all M5 surface still passes).
- [x] `cargo check -p librefang-api -p librefang-kernel -p librefang-types` clean; `cargo clippy -p librefang-api --tests -- -D warnings` clean.
- [x] Dashboard `pnpm build` + `pnpm typecheck` clean (no new errors; pre-existing errors in `sessions-stream.test.tsx` unrelated).
- [ ] Live: not run against a real daemon. The integration test goes through the full middleware + handler + persist_users + reload chain on a real axum server, which is the meaningful end-to-end coverage; spinning up the daemon is operator-validation rather than CI.

## Out-of-scope follow-ups noted

- `UserItem` doesn't yet expose policy fields, so the `userKeys` invalidation is defensive — no UI today reads policy off `UserItem`. Costs nothing to leave in.
- Channel rules editor only exposes 4 default platforms (telegram/discord/slack/email); arbitrary channel names work in the API but the UI needs a "+ add channel" button to surface them. Not in this slice.
- `update_user_policy` doesn't add its own `RoleChange` audit row — `persist_users` emits a generic config-change row. Could add a finer-grained record like `update_user_budget` does; stylistic, not a bug.

Refs #3054.
