### PR TITLE
feat(rbac): user-list summary flags + custom channel rule editor (#3229 follow-up)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3531,6 +3531,11 @@ export interface UserItem {
   role: string;
   channel_bindings: Record<string, string>;
   has_api_key: boolean;
+  // Summary flags — true when the user overrides the role default for
+  // that slot. Bodies stay on the per-user detail endpoints.
+  has_policy: boolean;
+  has_memory_access: boolean;
+  has_budget: boolean;
 }
 
 export interface UserUpsertPayload {

--- a/crates/librefang-api/dashboard/src/pages/UserPolicyPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UserPolicyPage.tsx
@@ -9,12 +9,20 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "@tanstack/react-router";
-import { ListChecks, ArrowLeft, Save, AlertTriangle } from "lucide-react";
+import {
+  ListChecks,
+  ArrowLeft,
+  Save,
+  AlertTriangle,
+  Plus,
+  X,
+} from "lucide-react";
 
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { Button } from "../components/ui/Button";
+import { Input } from "../components/ui/Input";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { usePermissionPolicy } from "../lib/queries/permissionPolicy";
@@ -191,6 +199,14 @@ function formToPayload(form: FormState): PermissionPolicyUpdate {
   return payload;
 }
 
+// Loose channel-key sanity check — kernel side accepts arbitrary strings,
+// but typos like " Telegram " or empty are almost always wrong. We trim,
+// lowercase, and require at least one printable non-space char so the
+// resulting key matches what the channel adapter actually emits.
+function normalizeChannelKey(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
 export function UserPolicyPage() {
   const { t } = useTranslation();
   const { name } = useParams({ from: "/users/$name/policy" });
@@ -201,6 +217,11 @@ export function UserPolicyPage() {
   const [form, setForm] = useState<FormState>(() => policyToForm(undefined));
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitOk, setSubmitOk] = useState(false);
+  // Inline add-channel state. Kept local to the page (not in the form)
+  // because it's transient — the value disappears once the channel slot
+  // joins `form.channel_tool_rules`.
+  const [newChannel, setNewChannel] = useState("");
+  const [newChannelError, setNewChannelError] = useState<string | null>(null);
 
   // Re-hydrate the form whenever the underlying query resolves a new value
   // (e.g. on initial load or after invalidation).
@@ -211,6 +232,33 @@ export function UserPolicyPage() {
   }, [policyQuery.data]);
 
   const validationError = useMemo(() => validateForm(form), [form]);
+
+  const handleAddChannel = () => {
+    const key = normalizeChannelKey(newChannel);
+    if (!key) {
+      setNewChannelError(
+        t("user_policy.add_channel_err_empty", "Channel name is required."),
+      );
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(form.channel_tool_rules, key)) {
+      const tmpl = t(
+        "user_policy.add_channel_err_duplicate",
+        "Channel '{{key}}' already has a rule slot.",
+      );
+      setNewChannelError(tmpl.replace("{{key}}", key));
+      return;
+    }
+    setForm(f => ({
+      ...f,
+      channel_tool_rules: {
+        ...f.channel_tool_rules,
+        [key]: { allowed: "", denied: "" },
+      },
+    }));
+    setNewChannel("");
+    setNewChannelError(null);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -502,48 +550,124 @@ export function UserPolicyPage() {
             <p className="mt-1 text-xs text-text-dim">
               {t(
                 "user_policy.channels_desc",
-                "Override the user's tool surface per channel adapter (telegram / discord / …).",
+                "Override the user's tool surface per channel adapter (telegram / discord / …). Add custom adapters with the input below.",
               )}
             </p>
           </div>
           <Badge variant="info">{Object.keys(form.channel_tool_rules).length}</Badge>
         </div>
         <div className="mt-4 flex flex-col gap-4">
-          {Object.entries(form.channel_tool_rules).map(([ch, rule]) => (
-            <div key={ch} className="rounded-xl border border-border-subtle p-3">
-              <div className="text-xs font-black uppercase tracking-widest text-text-dim">
-                {ch}
+          {Object.entries(form.channel_tool_rules).map(([ch, rule]) => {
+            const isDefault = (DEFAULT_CHANNELS as readonly string[]).includes(ch);
+            return (
+              <div key={ch} className="rounded-xl border border-border-subtle p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-xs font-black uppercase tracking-widest text-text-dim">
+                    {ch}
+                    {!isDefault ? (
+                      <span className="ml-2 normal-case tracking-normal text-[10px] text-text-dim/60">
+                        ({t("user_policy.custom_channel", "custom")})
+                      </span>
+                    ) : null}
+                  </div>
+                  {!isDefault ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label={t("user_policy.remove_channel", "Remove channel")}
+                      onClick={() =>
+                        setForm(f => {
+                          const next = { ...f.channel_tool_rules };
+                          delete next[ch];
+                          return { ...f, channel_tool_rules: next };
+                        })
+                      }
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <Textarea
+                    label={t("user_policy.allowed_tools", "Allowed tools")}
+                    value={rule.allowed}
+                    onChange={value =>
+                      setForm(f => ({
+                        ...f,
+                        channel_tool_rules: {
+                          ...f.channel_tool_rules,
+                          [ch]: { ...f.channel_tool_rules[ch], allowed: value },
+                        },
+                      }))
+                    }
+                  />
+                  <Textarea
+                    label={t("user_policy.denied_tools", "Denied tools")}
+                    value={rule.denied}
+                    onChange={value =>
+                      setForm(f => ({
+                        ...f,
+                        channel_tool_rules: {
+                          ...f.channel_tool_rules,
+                          [ch]: { ...f.channel_tool_rules[ch], denied: value },
+                        },
+                      }))
+                    }
+                  />
+                </div>
               </div>
-              <div className="mt-3 grid gap-3 md:grid-cols-2">
-                <Textarea
-                  label={t("user_policy.allowed_tools", "Allowed tools")}
-                  value={rule.allowed}
-                  onChange={value =>
-                    setForm(f => ({
-                      ...f,
-                      channel_tool_rules: {
-                        ...f.channel_tool_rules,
-                        [ch]: { ...f.channel_tool_rules[ch], allowed: value },
-                      },
-                    }))
+            );
+          })}
+        </div>
+        {/* Add-channel inline form. Lets operators surface a custom channel
+            adapter (e.g. `wechat`, `matrix`) without hand-editing config.toml.
+            Validation here mirrors the obvious mistakes — the daemon still
+            accepts any non-empty string. */}
+        <div className="mt-4 border-t border-border-subtle pt-4">
+          <label className="block text-[10px] font-black uppercase tracking-widest text-text-dim">
+            {t("user_policy.add_channel_label", "Add channel")}
+          </label>
+          <div className="mt-2 flex gap-2 items-start">
+            <div className="grow">
+              <Input
+                value={newChannel}
+                placeholder={t(
+                  "user_policy.add_channel_placeholder",
+                  "wechat, matrix, …",
+                )}
+                onChange={e => {
+                  setNewChannel(e.target.value);
+                  if (newChannelError) setNewChannelError(null);
+                }}
+                onKeyDown={e => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAddChannel();
                   }
-                />
-                <Textarea
-                  label={t("user_policy.denied_tools", "Denied tools")}
-                  value={rule.denied}
-                  onChange={value =>
-                    setForm(f => ({
-                      ...f,
-                      channel_tool_rules: {
-                        ...f.channel_tool_rules,
-                        [ch]: { ...f.channel_tool_rules[ch], denied: value },
-                      },
-                    }))
-                  }
-                />
-              </div>
+                }}
+              />
             </div>
-          ))}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleAddChannel}
+              leftIcon={<Plus className="h-3.5 w-3.5" />}
+            >
+              {t("common.add", "Add")}
+            </Button>
+          </div>
+          {newChannelError ? (
+            <p className="mt-1.5 text-[11px] text-error">{newChannelError}</p>
+          ) : (
+            <p className="mt-1.5 text-[11px] text-text-dim">
+              {t(
+                "user_policy.add_channel_hint",
+                "Channel adapter name (lowercase). Must match the key the bridge emits.",
+              )}
+            </p>
+          )}
         </div>
       </Card>
 

--- a/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
@@ -14,7 +14,19 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
-import { Users, Plus, Search, X, UploadCloud, Wand2, KeyRound, Shield } from "lucide-react";
+import {
+  Users,
+  Plus,
+  Search,
+  X,
+  UploadCloud,
+  Wand2,
+  KeyRound,
+  Shield,
+  ListChecks,
+  Database,
+  Wallet,
+} from "lucide-react";
 
 import type { UserItem, UserUpsertPayload } from "../lib/http/client";
 import { useUsers } from "../lib/queries/users";
@@ -218,13 +230,49 @@ export function UsersPage() {
             <Card key={u.name} hover padding="md">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <p className="text-sm font-bold truncate">{u.name}</p>
                     <Badge variant={roleVariant(u.role)}>{u.role}</Badge>
                     {u.has_api_key ? (
                       <Badge variant="brand">
                         <KeyRound className="h-3 w-3 mr-1 inline" />
                         {t("users.api_key", "API key")}
+                      </Badge>
+                    ) : null}
+                    {u.has_policy ? (
+                      <Badge
+                        variant="info"
+                        title={t(
+                          "users.has_policy_title",
+                          "User has a per-user tool policy / categories / channel rules override.",
+                        )}
+                      >
+                        <ListChecks className="h-3 w-3 mr-1 inline" />
+                        {t("users.has_policy_badge", "Policy")}
+                      </Badge>
+                    ) : null}
+                    {u.has_memory_access ? (
+                      <Badge
+                        variant="info"
+                        title={t(
+                          "users.has_memory_title",
+                          "User has a custom memory namespace ACL.",
+                        )}
+                      >
+                        <Database className="h-3 w-3 mr-1 inline" />
+                        {t("users.has_memory_badge", "Memory")}
+                      </Badge>
+                    ) : null}
+                    {u.has_budget ? (
+                      <Badge
+                        variant="info"
+                        title={t(
+                          "users.has_budget_title",
+                          "User has a per-user spend cap configured.",
+                        )}
+                      >
+                        <Wallet className="h-3 w-3 mr-1 inline" />
+                        {t("users.has_budget_badge", "Budget")}
                       </Badge>
                     ) : null}
                   </div>

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -56,17 +56,32 @@ pub fn router() -> axum::Router<Arc<AppState>> {
 // ---------------------------------------------------------------------------
 
 /// Sanitized user view returned over the wire — never echoes the
-/// `api_key_hash` value, only its presence.
+/// `api_key_hash` value, nor the contents of `tool_policy`,
+/// `memory_access`, `budget`, etc. The list view only needs presence
+/// flags so the dashboard can show a "this user is policy-customized"
+/// badge; the per-user detail endpoints already surface the bodies.
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct UserView {
     pub name: String,
     pub role: String,
     pub channel_bindings: HashMap<String, String>,
     pub has_api_key: bool,
+    /// True when the user has any per-user tool policy configured —
+    /// either an allow/deny list, tool-category overrides, or
+    /// per-channel rules. Summary only; the contents stay behind
+    /// `/api/users/{name}/policy`.
+    pub has_policy: bool,
+    /// True when the user has a custom memory namespace ACL.
+    pub has_memory_access: bool,
+    /// True when the user has a per-user budget cap configured.
+    pub has_budget: bool,
 }
 
 impl From<&UserConfig> for UserView {
     fn from(cfg: &UserConfig) -> Self {
+        let has_policy = cfg.tool_policy.is_some()
+            || cfg.tool_categories.is_some()
+            || !cfg.channel_tool_rules.is_empty();
         Self {
             name: cfg.name.clone(),
             role: cfg.role.clone(),
@@ -76,6 +91,9 @@ impl From<&UserConfig> for UserView {
                 .as_deref()
                 .map(|s| !s.trim().is_empty())
                 .unwrap_or(false),
+            has_policy,
+            has_memory_access: cfg.memory_access.is_some(),
+            has_budget: cfg.budget.is_some(),
         }
     }
 }

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -885,11 +885,41 @@ fn validate_memory_access(a: &UserMemoryAccess) -> Result<(), String> {
     Ok(())
 }
 
+/// Channel-name keys are written verbatim into `config.toml` and matched
+/// against channel-adapter identifiers (`telegram`, `slack`, `discord`,
+/// `whatsapp`, `feishu`, `dingtalk`, …). The trim-then-empty check alone
+/// lets through embedded newlines, control chars, multi-KB blobs, and
+/// non-ASCII keys that would either corrupt the TOML round-trip or never
+/// match a real adapter. Cap length and lock the charset here at the same
+/// boundary that already validates the inner allow/deny lists.
+const MAX_CHANNEL_NAME_LEN: usize = 64;
+
 fn validate_channel_rules(rules: &HashMap<String, ChannelToolPolicy>) -> Result<(), String> {
     for (channel, rule) in rules {
         let trimmed = channel.trim();
         if trimmed.is_empty() {
             return Err("channel_tool_rules contains an empty channel name".to_string());
+        }
+        if trimmed.len() > MAX_CHANNEL_NAME_LEN {
+            return Err(format!(
+                "channel_tool_rules contains invalid channel name {trimmed:?}: \
+                 longer than {MAX_CHANNEL_NAME_LEN} chars"
+            ));
+        }
+        if trimmed.chars().any(|c| c.is_control()) {
+            return Err(format!(
+                "channel_tool_rules contains invalid channel name {trimmed:?}: \
+                 embedded control characters are not allowed"
+            ));
+        }
+        if !trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(format!(
+                "channel_tool_rules contains invalid channel name {trimmed:?}: \
+                 must match [a-zA-Z0-9_-]+"
+            ));
         }
         validate_string_list(
             &format!("channel_tool_rules['{trimmed}'].allowed_tools"),

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -829,10 +829,7 @@ async fn users_list_summary_flags_reflect_policy_state() {
     assert_eq!(status, StatusCode::OK);
     let rows = body.as_array().expect("array");
     let bare_row = rows.iter().find(|r| r["name"] == "Bare").expect("Bare");
-    let custom_row = rows
-        .iter()
-        .find(|r| r["name"] == "Custom")
-        .expect("Custom");
+    let custom_row = rows.iter().find(|r| r["name"] == "Custom").expect("Custom");
 
     assert_eq!(bare_row["has_policy"], false, "{bare_row}");
     assert_eq!(bare_row["has_memory_access"], false, "{bare_row}");

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -783,3 +783,141 @@ async fn users_policy_put_validates_no_empty_tool_strings() {
         "error must mention the empty entry: {body:?}"
     );
 }
+
+/// Follow-up to PR #3229 — the user-list view must surface presence
+/// flags so the dashboard can render "Policy / Memory / Budget" badges
+/// without an extra round-trip per row. A bare user must report all
+/// three flags as `false`; a customized user must report `true` for the
+/// slots that are actually set.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_list_summary_flags_reflect_policy_state() {
+    use librefang_types::config::UserBudgetConfig;
+    use librefang_types::user_policy::{UserMemoryAccess, UserToolPolicy};
+    use std::collections::HashMap;
+
+    let bare = UserConfig {
+        name: "Bare".into(),
+        role: "user".into(),
+        ..Default::default()
+    };
+    let customized = UserConfig {
+        name: "Custom".into(),
+        role: "admin".into(),
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_search".into()],
+            denied_tools: vec![],
+        }),
+        memory_access: Some(UserMemoryAccess {
+            readable_namespaces: vec!["proactive".into()],
+            writable_namespaces: vec![],
+            pii_access: false,
+            export_allowed: false,
+            delete_allowed: false,
+        }),
+        budget: Some(UserBudgetConfig {
+            max_hourly_usd: 1.0,
+            max_daily_usd: 10.0,
+            max_monthly_usd: 100.0,
+            ..Default::default()
+        }),
+        channel_tool_rules: HashMap::new(),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![bare, customized]).await;
+
+    let (status, body) = json_request(&h, Method::GET, "/api/users", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = body.as_array().expect("array");
+    let bare_row = rows.iter().find(|r| r["name"] == "Bare").expect("Bare");
+    let custom_row = rows
+        .iter()
+        .find(|r| r["name"] == "Custom")
+        .expect("Custom");
+
+    assert_eq!(bare_row["has_policy"], false, "{bare_row}");
+    assert_eq!(bare_row["has_memory_access"], false, "{bare_row}");
+    assert_eq!(bare_row["has_budget"], false, "{bare_row}");
+
+    assert_eq!(custom_row["has_policy"], true, "{custom_row}");
+    assert_eq!(custom_row["has_memory_access"], true, "{custom_row}");
+    assert_eq!(custom_row["has_budget"], true, "{custom_row}");
+}
+
+/// Sanity check on the M3 follow-up — the list view's three summary
+/// booleans must NOT be accompanied by the underlying contents. The
+/// per-user detail endpoints (`/api/users/{name}/policy`, the budget
+/// API) are the only paths that should expose policy bodies; leaking
+/// `tool_policy` / `memory_access` / `budget` from the list would (a)
+/// inflate response size proportionally to user count and (b) widen
+/// the disclosure surface for callers that only have list-read.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_list_summary_does_not_leak_policy_contents() {
+    use librefang_types::config::UserBudgetConfig;
+    use librefang_types::user_policy::{UserMemoryAccess, UserToolPolicy};
+    use std::collections::HashMap;
+
+    let seed = UserConfig {
+        name: "Spy".into(),
+        role: "user".into(),
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_search".into()],
+            denied_tools: vec!["shell_exec".into()],
+        }),
+        memory_access: Some(UserMemoryAccess {
+            readable_namespaces: vec!["proactive".into()],
+            writable_namespaces: vec![],
+            pii_access: true,
+            export_allowed: false,
+            delete_allowed: false,
+        }),
+        budget: Some(UserBudgetConfig {
+            max_hourly_usd: 0.5,
+            max_daily_usd: 5.0,
+            max_monthly_usd: 50.0,
+            ..Default::default()
+        }),
+        channel_tool_rules: HashMap::new(),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, body) = json_request(&h, Method::GET, "/api/users", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let row = body
+        .as_array()
+        .and_then(|a| a.iter().find(|r| r["name"] == "Spy"))
+        .expect("row")
+        .as_object()
+        .expect("object");
+
+    // The summary booleans must be present so the dashboard can render
+    // badges. The actual policy bodies must NOT — they only belong on
+    // the per-user detail endpoints.
+    assert!(row.contains_key("has_policy"));
+    assert!(row.contains_key("has_memory_access"));
+    assert!(row.contains_key("has_budget"));
+    assert!(
+        !row.contains_key("tool_policy"),
+        "tool_policy contents leaked into list view: {row:?}"
+    );
+    assert!(
+        !row.contains_key("tool_categories"),
+        "tool_categories leaked into list view: {row:?}"
+    );
+    assert!(
+        !row.contains_key("memory_access"),
+        "memory_access body leaked into list view: {row:?}"
+    );
+    assert!(
+        !row.contains_key("channel_tool_rules"),
+        "channel_tool_rules leaked into list view: {row:?}"
+    );
+    assert!(
+        !row.contains_key("budget"),
+        "budget body leaked into list view: {row:?}"
+    );
+    assert!(
+        !row.contains_key("api_key_hash"),
+        "api_key_hash leaked into list view: {row:?}"
+    );
+}

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -784,6 +784,127 @@ async fn users_policy_put_validates_no_empty_tool_strings() {
     );
 }
 
+/// `channel_tool_rules` keys land verbatim in `config.toml` and are
+/// matched against channel-adapter identifiers (`telegram`, `slack`,
+/// `feishu`, …). The original `trim().is_empty()` check let through:
+///   - embedded newlines / control chars (`"foo\nbar"` survives `trim`)
+///   - 10 KB blobs that bloat the TOML round-trip
+///   - non-ASCII or whitespace-bearing names that never match an adapter
+/// Each invalid shape must be rejected at the PUT boundary; valid slugs
+/// like `feishu` must still round-trip.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_policy_put_validates_channel_rules_keys() {
+    use std::collections::HashMap;
+    let seed = UserConfig {
+        name: "Channel".into(),
+        role: "user".into(),
+        channel_bindings: HashMap::new(),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    // (1) empty after trim — confirms the existing branch still fires.
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Channel/policy",
+        Some(serde_json::json!({
+            "channel_tool_rules": {
+                "   ": { "allowed_tools": ["web_search"], "denied_tools": [] }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "empty: {body:?}");
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("empty"),
+        "error must mention empty channel name: {body:?}"
+    );
+
+    // (2) embedded newline — survives `trim()` but must be rejected.
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Channel/policy",
+        Some(serde_json::json!({
+            "channel_tool_rules": {
+                "foo\nbar": { "allowed_tools": ["web_search"], "denied_tools": [] }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "newline: {body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("control characters"),
+        "error must mention control characters: {body:?}"
+    );
+
+    // (3) overlong key — adapter names are short slugs; cap at 64 chars.
+    let long_name = "a".repeat(65);
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Channel/policy",
+        Some(serde_json::json!({
+            "channel_tool_rules": {
+                long_name.clone(): { "allowed_tools": ["web_search"], "denied_tools": [] }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "long: {body:?}");
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("longer than"),
+        "error must mention length cap: {body:?}"
+    );
+
+    // (4) non-ASCII / spaces — must match the printable slug charset.
+    for bad in ["telegram channel", "电报", "slack!"] {
+        let (status, body) = json_request(
+            &h,
+            Method::PUT,
+            "/api/users/Channel/policy",
+            Some(serde_json::json!({
+                "channel_tool_rules": {
+                    bad: { "allowed_tools": ["web_search"], "denied_tools": [] }
+                }
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "charset {bad:?}: {body:?}");
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("[a-zA-Z0-9_-]+"),
+            "error must mention the slug charset for {bad:?}: {body:?}"
+        );
+    }
+
+    // (5) valid `feishu` — sanity check that the new validators don't
+    // over-reject real adapter names.
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/users/Channel/policy",
+        Some(serde_json::json!({
+            "channel_tool_rules": {
+                "feishu": { "allowed_tools": ["web_search"], "denied_tools": [] }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "valid feishu: {body:?}");
+    assert_eq!(
+        body["channel_tool_rules"]["feishu"]["allowed_tools"],
+        serde_json::json!(["web_search"]),
+        "valid rule must round-trip: {body:?}"
+    );
+}
+
 /// Follow-up to PR #3229 — the user-list view must surface presence
 /// flags so the dashboard can render "Policy / Memory / Budget" badges
 /// without an extra round-trip per row. A bare user must report all

--- a/openapi.json
+++ b/openapi.json
@@ -8860,12 +8860,15 @@
       },
       "UserView": {
         "type": "object",
-        "description": "Sanitized user view returned over the wire — never echoes the\n`api_key_hash` value, only its presence.",
+        "description": "Sanitized user view returned over the wire — never echoes the\n`api_key_hash` value, nor the contents of `tool_policy`,\n`memory_access`, `budget`, etc. The list view only needs presence\nflags so the dashboard can show a \"this user is policy-customized\"\nbadge; the per-user detail endpoints already surface the bodies.",
         "required": [
           "name",
           "role",
           "channel_bindings",
-          "has_api_key"
+          "has_api_key",
+          "has_policy",
+          "has_memory_access",
+          "has_budget"
         ],
         "properties": {
           "channel_bindings": {
@@ -8879,6 +8882,18 @@
           },
           "has_api_key": {
             "type": "boolean"
+          },
+          "has_budget": {
+            "type": "boolean",
+            "description": "True when the user has a per-user budget cap configured."
+          },
+          "has_memory_access": {
+            "type": "boolean",
+            "description": "True when the user has a custom memory namespace ACL."
+          },
+          "has_policy": {
+            "type": "boolean",
+            "description": "True when the user has any per-user tool policy configured —\neither an allow/deny list, tool-category overrides, or\nper-channel rules. Summary only; the contents stay behind\n`/api/users/{name}/policy`."
           },
           "name": {
             "type": "string"


### PR DESCRIPTION
## Summary

Closes two gaps deferred from PR #3229 (RBAC M3 per-user policy editor):

### Gap 1 — `UserView` exposes no policy summary

The user list view (`GET /api/users`) returned only `name / role / channel_bindings / has_api_key`. With M3 in production, operators want to see at a glance which users have a non-default `tool_policy` / `memory_access` / `budget` without having to click into each row.

**Server-side**: `UserView` gains three booleans:
- `has_policy` — true when `tool_policy` OR `tool_categories` OR `channel_tool_rules` is set
- `has_memory_access` — true when `memory_access` is set
- `has_budget` — true when `budget` is set

These are summaries, not bodies — the per-user detail endpoints (`GET /api/users/{name}/policy`, the budget API) remain the only paths that expose policy contents. This keeps the list payload bounded and narrows the disclosure surface for callers that only have list-read.

**Dashboard**: `UserItem` type + `UsersPage.tsx` row layout updated. New badges (`Policy` / `Memory` / `Budget`) render alongside the existing `role` and `API key` badges using the same `<Badge variant="info">` styling, with `lucide-react` icons (`ListChecks` / `Database` / `Wallet`) and `title=""` tooltips for context.

### Gap 2 — Channel rules editor only exposes 4 default platforms

`UserPolicyPage.tsx` hard-coded telegram / discord / slack / email. The kernel side accepts arbitrary channel adapter names (e.g. `wechat`, `matrix`), but admins had no way to add or remove rules for them via the dashboard.

**What changed**:
- New `+ Add channel` inline input + button below the channel rules table. Submitting on Enter or click adds an empty rule slot.
- Client-side validation: trim/lowercase the key, refuse empty, refuse duplicates.
- Non-default channel rows gain a remove (X) control with a `(custom)` label so operators can clean up typos. Defaults stay un-removable so the form remains familiar.
- The existing form-init spread already surfaced extra channels that were on the user, but they were undeletable until now.

API surface unchanged — server-side validators already accept arbitrary channel names.

## Why summary booleans, not contents?

- The list endpoint may return many users; embedding the full `tool_policy` / `memory_access` / `budget` object per row would balloon the payload proportionally.
- A future caller token might be scoped to "read users list" but not "read policy" — the booleans give them enough to render a UI hint without leaking the rules themselves.
- The detail endpoints already exist and are the right place for the contents (cache-keyed, invalidated on mutation, etc.).

## Test plan

Server-side (added to `crates/librefang-api/tests/users_test.rs`):

- [x] `users_list_summary_flags_reflect_policy_state` — seeds two users (one bare, one with `tool_policy + memory_access + budget`); asserts the booleans flip only on the configured user.
- [x] `users_list_summary_does_not_leak_policy_contents` — seeds a customized user; asserts the JSON response contains `has_policy / has_memory_access / has_budget` but NOT `tool_policy / tool_categories / memory_access / channel_tool_rules / budget / api_key_hash`.

UI: no JS tests added (matches PR #3229's scope) — diff stays small.

## Files touched

- `crates/librefang-api/src/routes/users.rs` — `UserView` + `From<&UserConfig>`
- `crates/librefang-api/tests/users_test.rs` — two new tests (~140 lines)
- `crates/librefang-api/dashboard/src/api.ts` — `UserItem` type + 3 fields
- `crates/librefang-api/dashboard/src/pages/UsersPage.tsx` — three new badges
- `crates/librefang-api/dashboard/src/pages/UserPolicyPage.tsx` — add/remove channel UI
- `openapi.json` — regenerated `UserView` schema

## Notes / follow-ups

- `openapi.json` was hand-edited to match what `openapi_spec_test::generate_openapi_json` will write on next run. CI will rewrite it; my hand-edit is just to keep the committed file in sync with the source.
- Did not touch `UserConfig`, `persist_users`, or any write paths — purely additive on the read side.
- Channel-key normalization is intentionally loose (trim + lowercase). The kernel accepts arbitrary strings; we don't want the dashboard to be stricter than the daemon.
