### PR TITLE
feat(security): owner-only API key rotation with live session kill

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3592,6 +3592,26 @@ export async function importUsers(
 }
 
 // ---------------------------------------------------------------------------
+// API-key rotation (RBAC follow-up to #3054 / M3 / M6)
+//
+// Owner-only. Returns the new plaintext key in the response — that is the
+// only time the server exposes it; we never log, persist, or re-derive it.
+// ---------------------------------------------------------------------------
+
+export interface RotateUserKeyResponse {
+  status: string;
+  new_api_key: string;
+  sessions_invalidated: number;
+}
+
+export async function rotateUserKey(name: string): Promise<RotateUserKeyResponse> {
+  return post<RotateUserKeyResponse>(
+    `/api/users/${encodeURIComponent(name)}/rotate-key`,
+    {},
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Audit query (M5 / #3203 — endpoint stubbed; the hook stays wired so the
 // dashboard layer is ready when the daemon ships the route).
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -277,6 +277,7 @@ export {
   updateUser,
   deleteUser,
   importUsers,
+  rotateUserKey,
   // per-user policy (M3 stub)
   updateUserPolicy,
 } from "../../api";
@@ -322,6 +323,7 @@ export type {
   UserRoleName,
   BulkImportRow,
   BulkImportResult,
+  RotateUserKeyResponse,
   // audit / per-user budget / policy
   AuditQueryEntry,
   AuditQueryFilters,

--- a/crates/librefang-api/dashboard/src/lib/mutations/users.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/users.ts
@@ -11,10 +11,12 @@ import {
   updateUser,
   deleteUser,
   importUsers,
+  rotateUserKey,
   updateUserPolicy,
   type UserUpsertPayload,
   type PermissionPolicy,
   type BulkImportResult,
+  type RotateUserKeyResponse,
 } from "../http/client";
 import {
   userKeys,
@@ -71,6 +73,28 @@ export function useImportUsers() {
       // Dry run never mutates state — keep the cache as-is.
       if (data.dry_run) return;
       qc.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+
+// API-key rotation (RBAC follow-up to #3054 / M3 / M6). Owner-only on
+// the daemon — non-Owner callers get a 403 surfaced through the mutation
+// error path. The response contains the new plaintext key, which the UI
+// must show exactly once (server can't reproduce it later); the dashboard
+// itself never persists the value.
+//
+// Server-side, a successful rotation also swaps the live `user_api_keys`
+// snapshot the auth middleware reads from, so any other tab still
+// authenticated with the OLD key will start getting 401s on the next
+// request. The dashboard doesn't track sessions independently — refreshing
+// the user list is enough to surface the change.
+export function useRotateUserKey() {
+  const qc = useQueryClient();
+  return useMutation<RotateUserKeyResponse, Error, string>({
+    mutationFn: (name: string) => rotateUserKey(name),
+    onSuccess: (_data, name) => {
+      qc.invalidateQueries({ queryKey: userKeys.lists() });
+      qc.invalidateQueries({ queryKey: userKeys.detail(name) });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
@@ -14,7 +14,18 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
-import { Users, Plus, Search, X, UploadCloud, Wand2, KeyRound, Shield } from "lucide-react";
+import {
+  Users,
+  Plus,
+  Search,
+  X,
+  UploadCloud,
+  Wand2,
+  KeyRound,
+  Shield,
+  RefreshCw,
+  Copy,
+} from "lucide-react";
 
 import type { UserItem, UserUpsertPayload } from "../lib/http/client";
 import { useUsers } from "../lib/queries/users";
@@ -22,6 +33,7 @@ import {
   useCreateUser,
   useDeleteUser,
   useImportUsers,
+  useRotateUserKey,
   useUpdateUser,
 } from "../lib/mutations/users";
 
@@ -91,6 +103,13 @@ export function UsersPage() {
   const [confirmDelete, setConfirmDelete] = useState<UserItem | null>(null);
   const [wizardUser, setWizardUser] = useState<UserItem | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+  // Rotation flow holds two pieces of state: the user the operator is
+  // confirming a rotate against (pre-confirm), and the freshly-rotated
+  // plaintext key (post-confirm, copy-once display). They are separate so
+  // closing the post-rotate modal does not re-open the confirm.
+  const [confirmRotate, setConfirmRotate] = useState<UserItem | null>(null);
+  const [rotatedKey, setRotatedKey] =
+    useState<{ name: string; plaintext: string } | null>(null);
 
   // ── data ─────────────────────────────────────────────────────────────
   const usersQuery = useUsers({
@@ -101,6 +120,7 @@ export function UsersPage() {
   const createMut = useCreateUser();
   const updateMut = useUpdateUser();
   const deleteMut = useDeleteUser();
+  const rotateMut = useRotateUserKey();
 
   const users = usersQuery.data ?? [];
 
@@ -264,6 +284,16 @@ export function UsersPage() {
                   >
                     {t("common.edit", "Edit")}
                   </Button>
+                  {u.has_api_key ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      leftIcon={<RefreshCw className="h-3 w-3" />}
+                      onClick={() => setConfirmRotate(u)}
+                    >
+                      {t("users.rotate_key", "Rotate API key")}
+                    </Button>
+                  ) : null}
                   <Button
                     variant="ghost"
                     size="sm"
@@ -377,6 +407,127 @@ export function UsersPage() {
               </Button>
             </div>
           </div>
+        ) : null}
+      </Modal>
+
+      {/* Rotate-key confirm */}
+      <Modal
+        isOpen={confirmRotate !== null}
+        onClose={() => setConfirmRotate(null)}
+        title={t("users.confirm_rotate_title", "Rotate API key?")}
+        size="sm"
+      >
+        {confirmRotate ? (
+          <div className="space-y-4">
+            <p className="text-sm text-text-dim">
+              {t(
+                "users.confirm_rotate_body",
+                "Generates a fresh API key for this user. The old key stops working immediately — any client still using it will start receiving 401 errors on the next request. The new plaintext key will be shown ONCE on the next screen; the server cannot reproduce it later.",
+              )}
+            </p>
+            <p className="text-sm font-mono">{confirmRotate.name}</p>
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="secondary"
+                onClick={() => setConfirmRotate(null)}
+              >
+                {t("common.cancel", "Cancel")}
+              </Button>
+              <Button
+                variant="primary"
+                leftIcon={<RefreshCw className="h-3.5 w-3.5" />}
+                isLoading={rotateMut.isPending}
+                onClick={async () => {
+                  const target = confirmRotate;
+                  setConfirmRotate(null);
+                  try {
+                    const res = await rotateMut.mutateAsync(target.name);
+                    setRotatedKey({
+                      name: target.name,
+                      plaintext: res.new_api_key,
+                    });
+                  } catch (e) {
+                    // Surface failure inline in the same spot — no silent
+                    // swallow. Common cause: caller is Admin, not Owner.
+                    setRotatedKey({
+                      name: target.name,
+                      plaintext: `__ERROR__:${
+                        e instanceof Error ? e.message : String(e)
+                      }`,
+                    });
+                  }
+                }}
+              >
+                {t("users.rotate_key_confirm", "Rotate now")}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+
+      {/* Post-rotation: copy-once display of the new plaintext key */}
+      <Modal
+        isOpen={rotatedKey !== null}
+        onClose={() => setRotatedKey(null)}
+        title={
+          rotatedKey?.plaintext.startsWith("__ERROR__:")
+            ? t("users.rotate_key_error_title", "Rotation failed")
+            : t("users.rotate_key_done_title", "New API key — copy now")
+        }
+        size="md"
+      >
+        {rotatedKey ? (
+          rotatedKey.plaintext.startsWith("__ERROR__:") ? (
+            <div className="space-y-3">
+              <p className="text-sm text-error">
+                {rotatedKey.plaintext.slice("__ERROR__:".length)}
+              </p>
+              <div className="flex justify-end">
+                <Button
+                  variant="secondary"
+                  onClick={() => setRotatedKey(null)}
+                >
+                  {t("common.close", "Close")}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-warning font-medium">
+                {t(
+                  "users.rotate_key_done_warning",
+                  "This is the ONLY time the plaintext key will be shown. Copy and store it now — the server cannot reproduce it later.",
+                )}
+              </p>
+              <p className="text-xs text-text-dim">
+                {t("users.rotate_key_done_user", "User")}:{" "}
+                <span className="font-mono">{rotatedKey.name}</span>
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="grow rounded bg-main/40 px-3 py-2 font-mono text-xs break-all">
+                  {rotatedKey.plaintext}
+                </code>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leftIcon={<Copy className="h-3.5 w-3.5" />}
+                  onClick={() => {
+                    void navigator.clipboard.writeText(rotatedKey.plaintext);
+                  }}
+                >
+                  {t("common.copy", "Copy")}
+                </Button>
+              </div>
+              <div className="flex justify-end">
+                <Button
+                  variant="primary"
+                  onClick={() => setRotatedKey(null)}
+                >
+                  {t("users.rotate_key_done_close", "I've copied the key")}
+                </Button>
+              </div>
+            </div>
+          )
         ) : null}
       </Modal>
     </div>

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -509,10 +509,7 @@ pub async fn auth(
     // Loopback already short-circuits above for the single-user dev UX, so
     // reaching this branch means the caller is on the LAN/WAN.
     let api_key = api_key.trim();
-    if api_key.is_empty()
-        && user_api_keys.is_empty()
-        && !auth_state.dashboard_auth_enabled
-    {
+    if api_key.is_empty() && user_api_keys.is_empty() && !auth_state.dashboard_auth_enabled {
         // Re-check ConnectInfo defensively — if it is missing for any reason
         // we MUST treat the origin as non-loopback (fail closed, never open).
         let is_loopback = request

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -35,7 +35,12 @@ pub struct AuthState {
     /// Whether dashboard username/password auth is configured.
     pub dashboard_auth_enabled: bool,
     /// Optional per-user API-key hashes used for role-based API access.
-    pub user_api_keys: Arc<Vec<ApiUserAuth>>,
+    ///
+    /// Wrapped in a `RwLock` (mirroring `api_key_lock`) so the rotate-key
+    /// endpoint can swap the in-memory snapshot atomically. Without a live
+    /// swap, a leaked per-user bearer token could only be revoked by
+    /// restarting the daemon — defeating the point of rotation.
+    pub user_api_keys: Arc<tokio::sync::RwLock<Vec<ApiUserAuth>>>,
     /// When `true` and an `api_key` is configured, GET endpoints that are
     /// otherwise on the dashboard public-read allowlist (agents, config,
     /// budget, sessions, approvals, hands, skills, workflows, …) are forced
@@ -320,6 +325,12 @@ pub async fn auth(
     next: Next,
 ) -> Response<Body> {
     let api_key = auth_state.api_key_lock.read().await.clone();
+    // Snapshot the per-user API key list once per request — `user_api_keys`
+    // is now an `Arc<RwLock<Vec<…>>>` so the rotate-key endpoint can swap
+    // entries live. The snapshot is cheap (small Vec of role records, no
+    // hash work) and lets every downstream read avoid re-acquiring the
+    // lock, including the constant-time `verify_password` loop below.
+    let user_api_keys: Vec<ApiUserAuth> = auth_state.user_api_keys.read().await.clone();
     // SECURITY: Capture method early for method-aware public endpoint checks.
     let method = request.method().clone();
 
@@ -414,7 +425,7 @@ pub async fn auth(
     // (see the 401 handler below). When no auth is configured the shell
     // stays public so the out-of-the-box dev experience still works.
     let auth_configured = !api_key.trim().is_empty()
-        || !auth_state.user_api_keys.is_empty()
+        || !user_api_keys.is_empty()
         || auth_state.dashboard_auth_enabled;
     // The inline login page (`login_page.html`) only speaks username/password,
     // so only gate the shell when *that* mode is actually enabled. API-key-only
@@ -499,7 +510,7 @@ pub async fn auth(
     // reaching this branch means the caller is on the LAN/WAN.
     let api_key = api_key.trim();
     if api_key.is_empty()
-        && auth_state.user_api_keys.is_empty()
+        && user_api_keys.is_empty()
         && !auth_state.dashboard_auth_enabled
     {
         // Re-check ConnectInfo defensively — if it is missing for any reason
@@ -615,8 +626,7 @@ pub async fn auth(
         }
         drop(sessions);
 
-        if let Some(user) = auth_state
-            .user_api_keys
+        if let Some(user) = user_api_keys
             .iter()
             .find(|user| crate::password_hash::verify_password(token_str, &user.api_key_hash))
             .cloned()
@@ -981,7 +991,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1011,12 +1021,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "Guest".to_string(),
                 role: UserRole::User,
                 api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
                 user_id: UserId::from_name("Guest"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1049,12 +1059,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "Guest".to_string(),
                 role: UserRole::User,
                 api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
                 user_id: UserId::from_name("Guest"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1087,12 +1097,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "ReadOnly".to_string(),
                 role: UserRole::Viewer,
                 api_key_hash: crate::password_hash::hash_password("viewer-key").unwrap(),
                 user_id: UserId::from_name("ReadOnly"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1125,12 +1135,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "ReadOnly".to_string(),
                 role: UserRole::Viewer,
                 api_key_hash: crate::password_hash::hash_password("viewer-key").unwrap(),
                 user_id: UserId::from_name("ReadOnly"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1162,12 +1172,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "Guest".to_string(),
                 role: UserRole::User,
                 api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
                 user_id: UserId::from_name("Guest"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1210,7 +1220,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("somekey".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![]),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1243,12 +1253,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "Guest".to_string(),
                 role: UserRole::User,
                 api_key_hash: crate::password_hash::hash_password("user-key").unwrap(),
                 user_id: UserId::from_name("Guest"),
-            }]),
+            }])),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1285,7 +1295,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1320,7 +1330,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1352,7 +1362,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1383,7 +1393,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1421,7 +1431,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1468,7 +1478,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1499,7 +1509,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1535,12 +1545,12 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(vec![ApiUserAuth {
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(vec![ApiUserAuth {
                 name: "alice".into(),
                 role: UserRole::User,
                 api_key_hash: crate::password_hash::hash_password("alice-key").unwrap(),
                 user_id: UserId::from_name("alice"),
-            }]),
+            }])),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1590,7 +1600,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: true,
             allow_no_auth: false,
             audit_log: None,
@@ -1632,7 +1642,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,
@@ -1644,7 +1654,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(key.to_string())),
             active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             dashboard_auth_enabled: false,
-            user_api_keys: Arc::new(Vec::new()),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             require_auth_for_reads: false,
             allow_no_auth: false,
             audit_log: None,

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -240,6 +240,7 @@ use crate::types;
         routes::users::update_user,
         routes::users::delete_user,
         routes::users::import_users,
+        routes::users::rotate_user_key,
 
         // ── Memory (KV) ──
         routes::get_agent_kv,
@@ -368,6 +369,7 @@ use crate::types;
         routes::users::BulkImportRequest,
         routes::users::BulkImportResult,
         routes::users::BulkImportRow,
+        routes::users::RotateKeyResponse,
     )),
     tags(
         (name = "system", description = "Health checks, status, version, config, and system management"),

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6273,6 +6273,7 @@ mod monitoring_tests {
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
         });
         (state, tmp)

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -134,8 +134,7 @@ pub struct AppState {
     /// reads from, so swapping the inner Vec via `rotate_user_key` (or any
     /// future user-mutation endpoint) makes the change visible to the very
     /// next request without a daemon restart.
-    pub user_api_keys:
-        Arc<tokio::sync::RwLock<Vec<crate::middleware::ApiUserAuth>>>,
+    pub user_api_keys: Arc<tokio::sync::RwLock<Vec<crate::middleware::ApiUserAuth>>>,
     /// Media generation driver cache for image/TTS/video/music.
     pub media_drivers: librefang_runtime::media::MediaDriverCache,
     /// Dynamic webhook router for channel webhook endpoints.

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -130,6 +130,12 @@ pub struct AppState {
     /// Shared api_key_lock from the auth middleware — updated on password/api_key change
     /// so the new credentials take effect immediately without restart.
     pub api_key_lock: Arc<tokio::sync::RwLock<String>>,
+    /// Shared per-user API key snapshot — same Arc the auth middleware
+    /// reads from, so swapping the inner Vec via `rotate_user_key` (or any
+    /// future user-mutation endpoint) makes the change visible to the very
+    /// next request without a daemon restart.
+    pub user_api_keys:
+        Arc<tokio::sync::RwLock<Vec<crate::middleware::ApiUserAuth>>>,
     /// Media generation driver cache for image/TTS/video/music.
     pub media_drivers: librefang_runtime::media::MediaDriverCache,
     /// Dynamic webhook router for channel webhook endpoints.

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -23,14 +23,17 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use librefang_kernel::auth::UserRole;
+use librefang_types::agent::UserId;
 use librefang_types::config::UserConfig;
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
+use crate::middleware::{ApiUserAuth, AuthenticatedApiUser};
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
@@ -42,6 +45,10 @@ pub fn router() -> axum::Router<Arc<AppState>> {
                 .delete(delete_user),
         )
         .route("/users/import", axum::routing::post(import_users))
+        .route(
+            "/users/{name}/rotate-key",
+            axum::routing::post(rotate_user_key),
+        )
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +123,23 @@ pub struct BulkImportResult {
     pub failed: usize,
     pub dry_run: bool,
     pub rows: Vec<BulkImportRow>,
+}
+
+/// Response payload for `POST /api/users/{name}/rotate-key`.
+///
+/// `new_api_key` is the **plaintext** rotated key — this is the only time
+/// the server will surface it. Operators must copy and store it now;
+/// nothing else (audit log included) records the plaintext.
+///
+/// `sessions_invalidated` reports how many in-memory per-user API key
+/// records were swapped — typically `1`. See the doc-comment on
+/// [`rotate_user_key`] for why dashboard sessions are NOT included in
+/// this count.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct RotateKeyResponse {
+    pub status: String,
+    pub new_api_key: String,
+    pub sessions_invalidated: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -620,6 +644,166 @@ pub async fn import_users(
     }
 }
 
+/// Rotate a user's API key.
+///
+/// Generates a fresh 32-byte random plaintext key, hashes it with Argon2id,
+/// stores the hash in `config.toml`, and **swaps the live in-memory snapshot
+/// the auth middleware reads from** so the next request that presents the
+/// old plaintext token immediately fails authentication. Without the live
+/// swap a leaked key could only be revoked by restarting the daemon — which
+/// defeats the point of rotation. See the `user_api_keys` field on
+/// [`AppState`] for the shared `Arc<RwLock<…>>` that makes this work.
+///
+/// Owner-only, gated by `is_owner_only_write` in `middleware.rs` — same
+/// blast radius as user create/delete. The request takes no body; the new
+/// plaintext key is returned in the response and is **never written to the
+/// audit log or echoed again**.
+///
+/// Dashboard sessions (`AppState.active_sessions`) are intentionally NOT
+/// invalidated here. The active-sessions store is keyed by an opaque token
+/// and the stored [`crate::password_hash::SessionToken`] does not carry a
+/// `user_id` — it tracks the single shared dashboard credential pair
+/// (`dashboard_user` / `dashboard_pass`), not the per-user API keys this
+/// endpoint rotates. The two auth surfaces are independent: a per-user
+/// bearer-token caller never lands in `active_sessions` at all (see
+/// `middleware.rs:618`), so the per-user key swap completes the kill on
+/// its own. If a future change ties dashboard sessions to a `UserId`, we
+/// can extend `sessions_invalidated` to include those evictions; today
+/// the count reflects the per-user-bearer-token kill, which is the actual
+/// revocation that matters for this surface.
+#[utoipa::path(
+    post,
+    path = "/api/users/{name}/rotate-key",
+    tag = "users",
+    params(("name" = String, Path, description = "User name (case-sensitive)")),
+    responses(
+        (status = 200, description = "Key rotated. `new_api_key` is the only time the plaintext is exposed — the server cannot reproduce it later.", body = RotateKeyResponse),
+        (status = 404, description = "Not found"),
+    )
+)]
+pub async fn rotate_user_key(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    caller: Option<Extension<AuthenticatedApiUser>>,
+) -> impl IntoResponse {
+    // 32-byte random plaintext token, hex-encoded (64 chars). Mirrors the
+    // shape of `password_hash::generate_session_token` so operator tooling
+    // that already knows how to handle session tokens accepts these too.
+    let new_plaintext = generate_api_key_plaintext();
+    let new_hash = match crate::password_hash::hash_password(&new_plaintext) {
+        Ok(h) => h,
+        Err(e) => {
+            return err_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("hash failed: {e}"),
+            );
+        }
+    };
+
+    let target = name.clone();
+    let result = persist_users(&state, move |users| -> Result<(), PersistError> {
+        let idx = users
+            .iter()
+            .position(|u| u.name == target)
+            .ok_or_else(|| PersistError::NotFound(format!("user '{target}' not found")))?;
+        // Preserve every other field — rotation only swaps `api_key_hash`,
+        // it must not zero out budget / RBAC M3 policy / channel bindings.
+        users[idx].api_key_hash = Some(new_hash);
+        Ok(())
+    })
+    .await;
+
+    // The post-rotation `UserConfig` isn't part of the response shape (no
+    // leakage of the new hash) but we still need to drive `persist_users`
+    // through the on-disk write + reload + middleware-snapshot refresh
+    // before serializing the success body. Discard the captured value.
+    if let Err(e) = result {
+        return match e {
+            PersistError::NotFound(m) => err_response(StatusCode::NOT_FOUND, m),
+            PersistError::BadRequest(m) => err_response(StatusCode::BAD_REQUEST, m),
+            PersistError::Conflict(m) => err_response(StatusCode::CONFLICT, m),
+            PersistError::Internal(m) => err_response(StatusCode::INTERNAL_SERVER_ERROR, m),
+        };
+    }
+
+    // `persist_users` already refreshed `state.user_api_keys` after the
+    // kernel reload — count the swapped entry for the wire response so
+    // operators can see the kill happened in the same hop. We resolve the
+    // count by inspecting the live snapshot for the rotated user instead
+    // of trusting `persist_users` to return it (the in-place refresh is
+    // best-effort with respect to ordering).
+    let sessions_invalidated = state
+        .user_api_keys
+        .read()
+        .await
+        .iter()
+        .filter(|u| u.name == name)
+        .count();
+
+    // Audit-record the rotation. Detail names the actor (caller) so the
+    // hash-chained log answers "who rotated whose key" without echoing
+    // the plaintext — that stays in the response body only.
+    let actor = caller
+        .as_ref()
+        .map(|c| c.0.name.clone())
+        .unwrap_or_else(|| "system".to_string());
+    let actor_user_id = caller.as_ref().map(|c| c.0.user_id);
+    state.kernel.audit().record_with_context(
+        "system",
+        librefang_runtime::audit::AuditAction::RoleChange,
+        format!("api_key rotated by {actor} for user {name}"),
+        "completed",
+        actor_user_id,
+        Some("api".to_string()),
+    );
+
+    Json(RotateKeyResponse {
+        status: "ok".to_string(),
+        new_api_key: new_plaintext,
+        sessions_invalidated,
+    })
+    .into_response()
+}
+
+/// Generate a 32-byte (256-bit) random API key plaintext.
+///
+/// Hex-encoded so the result is URL-safe and matches the existing
+/// `generate_session_token` shape (64 chars). We don't reuse
+/// `generate_session_token` directly because that returns a
+/// [`crate::password_hash::SessionToken`] with a creation timestamp, which
+/// is the wrong type — API keys don't carry a TTL.
+fn generate_api_key_plaintext() -> String {
+    use argon2::password_hash::rand_core::{OsRng, RngCore};
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Rebuild the `ApiUserAuth` records from the kernel's current `[[users]]`
+/// table. Mirrors `server.rs::configured_user_api_keys`, kept private to
+/// `users.rs` so the persistence path can call it without exposing
+/// `server.rs` internals across the route boundary.
+fn rebuild_api_user_records(state: &AppState) -> Vec<ApiUserAuth> {
+    state
+        .kernel
+        .config_ref()
+        .users
+        .iter()
+        .filter_map(|user| {
+            let api_key_hash = user.api_key_hash.as_deref()?.trim();
+            if api_key_hash.is_empty() {
+                return None;
+            }
+            Some(ApiUserAuth {
+                name: user.name.clone(),
+                role: UserRole::from_str_role(&user.role),
+                api_key_hash: api_key_hash.to_string(),
+                user_id: UserId::from_name(&user.name),
+            })
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Persistence helpers
 // ---------------------------------------------------------------------------
@@ -738,6 +922,17 @@ where
         // restart) will pick it up.
         tracing::warn!(error = %e, "user config reload failed after write");
         return Err(PersistError::Internal(format!("reload failed: {e}")));
+    }
+
+    // Refresh the in-memory `ApiUserAuth` snapshot the auth middleware
+    // reads from. Without this swap, mutations to `users[].api_key_hash`
+    // (rotate-key, update_user, import_users) only become effective after
+    // a daemon restart — the bug rotate-key exists to fix. Done in the
+    // shared helper so every user-mutation path benefits, not only the
+    // rotation endpoint.
+    {
+        let refreshed = rebuild_api_user_records(state.as_ref());
+        *state.user_api_keys.write().await = refreshed;
     }
 
     state.kernel.audit().record(

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -708,30 +708,44 @@ pub async fn rotate_user_key(
     };
 
     let target = name.clone();
-    let result = persist_users(&state, move |users| -> Result<(), PersistError> {
-        let idx = users
-            .iter()
-            .position(|u| u.name == target)
-            .ok_or_else(|| PersistError::NotFound(format!("user '{target}' not found")))?;
-        // Preserve every other field — rotation only swaps `api_key_hash`,
-        // it must not zero out budget / RBAC M3 policy / channel bindings.
-        users[idx].api_key_hash = Some(new_hash);
-        Ok(())
-    })
-    .await;
+    // Capture the OLD `api_key_hash` (pre-rotation) so we can compute a
+    // short audit fingerprint AFTER the persist succeeds — without it
+    // an audit entry like `"api_key rotated by alice for user bob"`
+    // is forensically useless when correlating with an authentication
+    // log line "auth failed with leaked key X". The fingerprint is the
+    // first 8 hex chars of `sha256(old_argon2_hash)` — a hash-of-hash —
+    // so we never write any plaintext or any reversibly-related material
+    // into the audit log; the operator just gets a stable correlation
+    // ID for the just-revoked credential.
+    let result =
+        persist_users(&state, move |users| -> Result<Option<String>, PersistError> {
+            let idx = users
+                .iter()
+                .position(|u| u.name == target)
+                .ok_or_else(|| PersistError::NotFound(format!("user '{target}' not found")))?;
+            let old_hash = users[idx].api_key_hash.clone();
+            // Preserve every other field — rotation only swaps `api_key_hash`,
+            // it must not zero out budget / RBAC M3 policy / channel bindings.
+            users[idx].api_key_hash = Some(new_hash);
+            Ok(old_hash)
+        })
+        .await;
 
     // The post-rotation `UserConfig` isn't part of the response shape (no
     // leakage of the new hash) but we still need to drive `persist_users`
     // through the on-disk write + reload + middleware-snapshot refresh
-    // before serializing the success body. Discard the captured value.
-    if let Err(e) = result {
-        return match e {
-            PersistError::NotFound(m) => err_response(StatusCode::NOT_FOUND, m),
-            PersistError::BadRequest(m) => err_response(StatusCode::BAD_REQUEST, m),
-            PersistError::Conflict(m) => err_response(StatusCode::CONFLICT, m),
-            PersistError::Internal(m) => err_response(StatusCode::INTERNAL_SERVER_ERROR, m),
-        };
-    }
+    // before serializing the success body.
+    let old_hash = match result {
+        Ok(h) => h,
+        Err(e) => {
+            return match e {
+                PersistError::NotFound(m) => err_response(StatusCode::NOT_FOUND, m),
+                PersistError::BadRequest(m) => err_response(StatusCode::BAD_REQUEST, m),
+                PersistError::Conflict(m) => err_response(StatusCode::CONFLICT, m),
+                PersistError::Internal(m) => err_response(StatusCode::INTERNAL_SERVER_ERROR, m),
+            };
+        }
+    };
 
     // `persist_users` already refreshed `state.user_api_keys` after the
     // kernel reload — count the swapped entry for the wire response so
@@ -920,13 +934,35 @@ where
         }
     }
 
+    // Acquire the auth-snapshot write lock BEFORE the disk write so the
+    // middleware can never observe an intermediate state where the new
+    // hash is already on disk (and reachable through `kernel.config_ref()`)
+    // but the `state.user_api_keys` Vec the middleware actually verifies
+    // against still holds the OLD record. Earlier ordering was
+    // `write file → reload → acquire lock → swap`, which left a small
+    // race window: any request landing between the file write and the
+    // snapshot swap would hit the stale `Vec<ApiUserAuth>` and pass auth
+    // with the just-rotated plaintext — bounded by `reload_config`
+    // latency (a few ms under load) but exploitable. Holding the lock
+    // across persist + reload + swap means every concurrent auth check
+    // either sees the pre-rotation snapshot OR blocks on this writer
+    // until the swap completes; never an in-between read where the
+    // on-disk hash and the live `Vec` disagree. Auth blocking during
+    // rotation is the correct behavior (the operator just rotated;
+    // concurrent requests with the old key SHOULD fail).
+    let mut user_keys_guard = state.user_api_keys.write().await;
+
     std::fs::write(&config_path, &new_toml)
         .map_err(|e| PersistError::Internal(format!("write failed: {e}")))?;
 
     if let Err(e) = state.kernel.reload_config().await {
         // The file is on disk; surface a soft error so the dashboard can
         // show the reason without rolling back. The next manual reload (or
-        // restart) will pick it up.
+        // restart) will pick it up. Drop the guard so subsequent reads
+        // aren't blocked on a failed-write path — the on-disk state has
+        // moved forward, and a stale `Vec<ApiUserAuth>` is no worse than
+        // pre-fix behaviour for this failure mode.
+        drop(user_keys_guard);
         tracing::warn!(error = %e, "user config reload failed after write");
         return Err(PersistError::Internal(format!("reload failed: {e}")));
     }
@@ -936,11 +972,10 @@ where
     // (rotate-key, update_user, import_users) only become effective after
     // a daemon restart — the bug rotate-key exists to fix. Done in the
     // shared helper so every user-mutation path benefits, not only the
-    // rotation endpoint.
-    {
-        let refreshed = rebuild_api_user_records(state.as_ref());
-        *state.user_api_keys.write().await = refreshed;
-    }
+    // rotation endpoint. Still holding `user_keys_guard` here so the swap
+    // is atomic with the persist + reload above.
+    *user_keys_guard = rebuild_api_user_records(state.as_ref());
+    drop(user_keys_guard);
 
     state.kernel.audit().record(
         "system",

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -717,8 +717,9 @@ pub async fn rotate_user_key(
     // so we never write any plaintext or any reversibly-related material
     // into the audit log; the operator just gets a stable correlation
     // ID for the just-revoked credential.
-    let result =
-        persist_users(&state, move |users| -> Result<Option<String>, PersistError> {
+    let result = persist_users(
+        &state,
+        move |users| -> Result<Option<String>, PersistError> {
             let idx = users
                 .iter()
                 .position(|u| u.name == target)
@@ -728,8 +729,9 @@ pub async fn rotate_user_key(
             // it must not zero out budget / RBAC M3 policy / channel bindings.
             users[idx].api_key_hash = Some(new_hash);
             Ok(old_hash)
-        })
-        .await;
+        },
+    )
+    .await;
 
     // The post-rotation `UserConfig` isn't part of the response shape (no
     // leakage of the new hash) but we still need to drive `persist_users`
@@ -763,7 +765,20 @@ pub async fn rotate_user_key(
 
     // Audit-record the rotation. Detail names the actor (caller) so the
     // hash-chained log answers "who rotated whose key" without echoing
-    // the plaintext — that stays in the response body only.
+    // the plaintext — that stays in the response body only. The
+    // `(old: <fp>)` fragment is the first 8 hex chars of
+    // `sha256(old_argon2_hash)` so operators can correlate this audit
+    // entry with prior authentication-failure log lines mentioning the
+    // same fingerprint after a leaked key is reported. The fingerprint
+    // is a hash-of-hash, so it leaks no key material — the underlying
+    // value is already an Argon2id PHC string, and the truncated SHA-256
+    // is one-way over that. If the user had no prior key (first-time
+    // assignment via rotate) we record `(old: none)` so the field is
+    // always present and parseable downstream.
+    let old_fp = old_hash
+        .as_deref()
+        .map(api_key_hash_fingerprint)
+        .unwrap_or_else(|| "none".to_string());
     let actor = caller
         .as_ref()
         .map(|c| c.0.name.clone())
@@ -772,7 +787,7 @@ pub async fn rotate_user_key(
     state.kernel.audit().record_with_context(
         "system",
         librefang_runtime::audit::AuditAction::RoleChange,
-        format!("api_key rotated by {actor} for user {name}"),
+        format!("api_key rotated by {actor} for user {name} (old: {old_fp})"),
         "completed",
         actor_user_id,
         Some("api".to_string()),
@@ -798,6 +813,30 @@ fn generate_api_key_plaintext() -> String {
     let mut bytes = [0u8; 32];
     OsRng.fill_bytes(&mut bytes);
     bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Short forensic fingerprint of an Argon2 PHC `api_key_hash` string.
+///
+/// Returns the first 8 hex chars of `sha256(input)` — a hash-of-hash so
+/// nothing key-related is reversible from the result, even with the
+/// rotated key in hand. Used by the rotate-key audit detail to tag the
+/// just-revoked credential, so an operator chasing a "leaked key"
+/// authentication-failure line can correlate the failed token's
+/// fingerprint (computed the same way at the auth layer when a future
+/// telemetry change adds it) against the rotation entry that revoked it.
+///
+/// Length is 8 hex chars (32 bits) — enough to distinguish individual
+/// rotations within a normal-sized user table without making the audit
+/// detail noisy. Truncation is safe here because the value is for human
+/// pattern-matching, not a cryptographic identifier.
+fn api_key_hash_fingerprint(api_key_hash: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(api_key_hash.as_bytes());
+    let mut s = String::with_capacity(8);
+    for b in digest.iter().take(4) {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }
 
 /// Rebuild the `ApiUserAuth` records from the kernel's current `[[users]]`

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -796,6 +796,14 @@ pub async fn build_router(
     // Create api_key_lock before AppState so both AppState and AuthState share the same Arc.
     let api_key = valid_api_tokens(kernel.as_ref()).join("\n");
     let api_key_lock = Arc::new(tokio::sync::RwLock::new(api_key));
+    // Per-user API key snapshot is wrapped in a `RwLock` so the rotate-key
+    // endpoint (`POST /api/users/{name}/rotate-key`) can swap entries live —
+    // both AppState (mutator) and AuthState (reader) share the same Arc, so
+    // the next request after rotation sees the new hash and the old plaintext
+    // bearer token immediately fails authentication.
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(configured_user_api_keys(
+        kernel.as_ref(),
+    )));
 
     let state = Arc::new(AppState {
         kernel: kernel.clone(),
@@ -813,6 +821,7 @@ pub async fn build_router(
         ),
         active_sessions: active_sessions.clone(),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         media_drivers: librefang_runtime::media::MediaDriverCache::new_with_urls(
             kernel.config_ref().provider_urls.clone(),
         ),
@@ -856,11 +865,13 @@ pub async fn build_router(
             .allow_headers(tower_http::cors::Any)
     };
 
-    // AuthState shares api_key_lock with AppState so change_password can update it live.
-    let user_api_keys_vec = configured_user_api_keys(state.kernel.as_ref());
+    // AuthState shares api_key_lock + user_api_keys with AppState so
+    // change_password / rotate-key can update them live without a daemon
+    // restart.
+    let user_api_keys_initial_len = state.user_api_keys.read().await.len();
     let dashboard_auth_enabled = has_dashboard_credentials(state.kernel.as_ref());
     let api_key_set = !state.kernel.config_ref().api_key.trim().is_empty();
-    let any_auth = api_key_set || !user_api_keys_vec.is_empty() || dashboard_auth_enabled;
+    let any_auth = api_key_set || user_api_keys_initial_len > 0 || dashboard_auth_enabled;
 
     // Resolve the effective value of `require_auth_for_reads`.
     // - Explicit `Some(true)`  → operators are forcing the allowlist
@@ -927,7 +938,7 @@ pub async fn build_router(
         api_key_lock: api_key_lock.clone(),
         active_sessions: active_sessions.clone(),
         dashboard_auth_enabled,
-        user_api_keys: Arc::new(user_api_keys_vec),
+        user_api_keys: state.user_api_keys.clone(),
         require_auth_for_reads,
         allow_no_auth,
         // RBAC M5: hand the audit log to the auth layer so role-denial

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -114,6 +114,7 @@ async fn start_test_server_with_provider(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1608,6 +1609,8 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         kernel.config_ref().api_key.clone(),
     ));
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(Vec::new()));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -1627,6 +1630,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1635,7 +1639,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(Vec::new()),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         // Tests synthesize requests without ConnectInfo, so opt in to the
         // open-server path to keep them green.
@@ -2777,6 +2781,8 @@ async fn start_test_server_with_rbac_users(
 
     let audit_log = kernel.audit().clone();
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(api_user_records));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -2796,6 +2802,7 @@ async fn start_test_server_with_rbac_users(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -2804,7 +2811,7 @@ async fn start_test_server_with_rbac_users(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         // Anonymous-rejection tests rely on this — we synthesize requests
         // without a Bearer header and need them to flow through to the
@@ -3075,6 +3082,8 @@ async fn start_test_server_with_full_user_configs(
 
     let audit_log = kernel.audit().clone();
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(api_user_records));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -3094,6 +3103,7 @@ async fn start_test_server_with_full_user_configs(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -3102,7 +3112,7 @@ async fn start_test_server_with_full_user_configs(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         allow_no_auth: true,
         audit_log: Some(audit_log),

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -114,6 +114,7 @@ async fn start_test_server_with_provider(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1607,6 +1608,9 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
     let api_key_lock = std::sync::Arc::new(tokio::sync::RwLock::new(
         kernel.config_ref().api_key.clone(),
     ));
+    let user_api_keys_lock: std::sync::Arc<
+        tokio::sync::RwLock<Vec<middleware::ApiUserAuth>>,
+    > = std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new()));
 
     let state = Arc::new(AppState {
         kernel,
@@ -1627,6 +1631,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1635,7 +1640,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(Vec::new()),
+        user_api_keys: state.user_api_keys.clone(),
         require_auth_for_reads: false,
         // Tests synthesize requests without ConnectInfo, so opt in to the
         // open-server path to keep them green.
@@ -2774,6 +2779,9 @@ async fn start_test_server_with_rbac_users(
     let api_key_lock = std::sync::Arc::new(tokio::sync::RwLock::new(
         kernel.config_ref().api_key.clone(),
     ));
+    let user_api_keys_lock: std::sync::Arc<
+        tokio::sync::RwLock<Vec<middleware::ApiUserAuth>>,
+    > = std::sync::Arc::new(tokio::sync::RwLock::new(api_user_records));
 
     let audit_log = kernel.audit().clone();
 
@@ -2796,6 +2804,7 @@ async fn start_test_server_with_rbac_users(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -2804,7 +2813,7 @@ async fn start_test_server_with_rbac_users(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock,
         require_auth_for_reads: false,
         // Anonymous-rejection tests rely on this — we synthesize requests
         // without a Bearer header and need them to flow through to the
@@ -3069,6 +3078,9 @@ async fn start_test_server_with_full_user_configs(
     let api_key_lock = std::sync::Arc::new(tokio::sync::RwLock::new(
         kernel.config_ref().api_key.clone(),
     ));
+    let user_api_keys_lock: std::sync::Arc<
+        tokio::sync::RwLock<Vec<middleware::ApiUserAuth>>,
+    > = std::sync::Arc::new(tokio::sync::RwLock::new(api_user_records));
 
     let audit_log = kernel.audit().clone();
 
@@ -3091,6 +3103,7 @@ async fn start_test_server_with_full_user_configs(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -3099,7 +3112,7 @@ async fn start_test_server_with_full_user_configs(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock,
         require_auth_for_reads: false,
         allow_no_auth: true,
         audit_log: Some(audit_log),
@@ -3109,6 +3122,11 @@ async fn start_test_server_with_full_user_configs(
         .nest("/api", routes::audit::router())
         .nest("/api", routes::budget::router())
         .nest("/api", routes::authz::router())
+        // Mounted so the owner-only gate on `/api/users/{name}/rotate-key`
+        // and other RBAC-M6 routes can be exercised end-to-end through
+        // the real auth middleware. Same router as `server.rs` mounts in
+        // production.
+        .nest("/api", routes::users::router())
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             middleware::auth,
@@ -3453,4 +3471,69 @@ async fn test_effective_permissions_distinguishes_none_from_empty() {
     );
     assert!(empty_body["tool_categories"].is_object());
     assert!(empty_body["memory_access"].is_object());
+}
+
+// ---------------------------------------------------------------------------
+// API-key rotation owner-only gate (RBAC follow-up to #3054 / M3 / M6)
+// ---------------------------------------------------------------------------
+
+/// Pins the owner-only gate on `POST /api/users/{name}/rotate-key`.
+/// Without `is_owner_only_write` covering the rotation path, an Admin
+/// per-user API key could rotate any other user's key — including the
+/// Owner's — and lock everyone else out. This is the same blast radius
+/// as user create/delete, which is why all of `/api/users/*` non-GET goes
+/// through the `Owner` gate at `middleware.rs:109`.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_admin_returns_403() {
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: None, // populated by helper
+        ..Default::default()
+    };
+    let bob = UserConfig {
+        name: "Bob".to_string(),
+        role: "user".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: None,
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key"), (bob, "bob-user-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // Admin attempting to rotate Bob's key — must be rejected by the
+    // middleware's owner-only gate before the handler is even invoked.
+    let resp = client
+        .post(format!("{}/api/users/Bob/rotate-key", server.base_url))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "Admin must NOT be able to rotate another user's key — only Owner. \
+         If this returns 200, an admin can self-promote by rotating the owner's key."
+    );
+
+    // Bob attempting to self-rotate is also rejected — same gate. The
+    // self-service "rotate my own key" workflow is intentionally NOT
+    // supported through this endpoint; users should ask an Owner. This
+    // matches the kernel's `Action::ManageUsers` posture.
+    let resp = client
+        .post(format!("{}/api/users/Bob/rotate-key", server.base_url))
+        .header("authorization", "Bearer bob-user-key")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "Non-Owner users (incl. self-rotate) must be rejected"
+    );
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -114,6 +114,7 @@ async fn start_test_server_with_provider(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1608,6 +1609,8 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         kernel.config_ref().api_key.clone(),
     ));
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(Vec::new()));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -1627,6 +1630,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -1635,7 +1639,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(Vec::new()),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         // Tests synthesize requests without ConnectInfo, so opt in to the
         // open-server path to keep them green.
@@ -2777,6 +2781,8 @@ async fn start_test_server_with_rbac_users(
 
     let audit_log = kernel.audit().clone();
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(api_user_records));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -2796,6 +2802,7 @@ async fn start_test_server_with_rbac_users(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -2804,7 +2811,7 @@ async fn start_test_server_with_rbac_users(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         // Anonymous-rejection tests rely on this — we synthesize requests
         // without a Bearer header and need them to flow through to the
@@ -3072,6 +3079,8 @@ async fn start_test_server_with_full_user_configs(
 
     let audit_log = kernel.audit().clone();
 
+    let user_api_keys_lock = Arc::new(tokio::sync::RwLock::new(api_user_records));
+
     let state = Arc::new(AppState {
         kernel,
         started_at: Instant::now(),
@@ -3091,6 +3100,7 @@ async fn start_test_server_with_full_user_configs(
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: api_key_lock.clone(),
+        user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -3099,7 +3109,7 @@ async fn start_test_server_with_full_user_configs(
         api_key_lock,
         active_sessions: state.active_sessions.clone(),
         dashboard_auth_enabled: false,
-        user_api_keys: Arc::new(api_user_records),
+        user_api_keys: user_api_keys_lock.clone(),
         require_auth_for_reads: false,
         allow_no_auth: true,
         audit_log: Some(audit_log),

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -127,6 +127,7 @@ async fn test_full_daemon_lifecycle() {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -268,6 +269,7 @@ async fn test_server_immediate_responsiveness() {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -71,6 +71,7 @@ async fn start_test_server() -> TestServer {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });

--- a/crates/librefang-api/tests/tools_invoke_test.rs
+++ b/crates/librefang-api/tests/tools_invoke_test.rs
@@ -74,6 +74,7 @@ async fn build_harness(tool_invoke: ToolInvokeConfig) -> Harness {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -70,6 +70,7 @@ async fn boot_with_seed_users(seed: Vec<UserConfig>) -> Harness {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });
@@ -587,5 +588,262 @@ async fn users_create_refuses_to_overwrite_corrupt_config_toml() {
     assert!(
         on_disk.contains("this is not [[ valid TOML"),
         "config.toml was overwritten despite parse failure: {on_disk}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// API-key rotation (RBAC follow-up to #3054 / M3 / M6)
+// ---------------------------------------------------------------------------
+
+/// Seed a single user with an Argon2id hash of `plaintext_key` so the
+/// auth-state snapshot the rotation endpoint mutates has something to swap.
+fn seed_user_with_key(name: &str, plaintext_key: &str) -> UserConfig {
+    let hash =
+        librefang_api::password_hash::hash_password(plaintext_key).expect("seed hash should succeed");
+    UserConfig {
+        name: name.to_string(),
+        role: "admin".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: Some(hash),
+        ..Default::default()
+    }
+}
+
+/// Happy path — rotation returns a non-empty plaintext token in the response
+/// body. The plaintext is the only place the new credential exists; if this
+/// test ever asserts an empty string, operators have lost the rotated key
+/// with no way to recover it.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_returns_new_plaintext() {
+    let h = boot_with_seed_users(vec![seed_user_with_key("Alice", "old-plaintext")]).await;
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/users/Alice/rotate-key",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "rotate failed: {body:?}");
+    assert_eq!(body["status"], "ok");
+    let new_key = body["new_api_key"].as_str().unwrap_or("");
+    assert!(
+        !new_key.is_empty(),
+        "rotation must return a non-empty plaintext key: {body:?}"
+    );
+    assert_eq!(
+        new_key.len(),
+        64,
+        "expected 32-byte hex (64 chars), got {}: {body:?}",
+        new_key.len()
+    );
+    assert_eq!(body["sessions_invalidated"], 1);
+}
+
+/// Persisting the new hash is what closes the rotation loop — without it,
+/// the next daemon restart would silently revive the old plaintext key.
+/// We assert the hash on disk (and in the live kernel snapshot) is no
+/// longer the seeded one.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_persists_new_hash() {
+    let original_hash =
+        librefang_api::password_hash::hash_password("old-plaintext").expect("seed hash");
+    let seed = UserConfig {
+        name: "Bob".to_string(),
+        role: "admin".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: Some(original_hash.clone()),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, _) = json_request(&h, Method::POST, "/api/users/Bob/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let after = h
+        ._state
+        .kernel
+        .config_ref()
+        .users
+        .iter()
+        .find(|u| u.name == "Bob")
+        .cloned()
+        .expect("user must still exist");
+    let after_hash = after.api_key_hash.expect("rotation must leave a hash");
+    assert_ne!(
+        after_hash, original_hash,
+        "api_key_hash unchanged after rotate — persist path is dead"
+    );
+    assert!(
+        after_hash.starts_with("$argon2id$"),
+        "post-rotation hash is not Argon2id PHC: {after_hash}"
+    );
+}
+
+/// The actual session kill: `state.user_api_keys` is the in-memory snapshot
+/// the auth middleware consults on every per-user bearer-token request.
+/// After rotation, the OLD plaintext token must NOT verify against any
+/// entry in the snapshot — the new hash has replaced it. This is the
+/// integration point that distinguishes "rotated, but the leaked token
+/// still authenticates until restart" from a real revocation.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_invalidates_existing_session() {
+    let h = boot_with_seed_users(vec![seed_user_with_key("Carol", "carol-plaintext")]).await;
+
+    // Pre-populate the live AppState snapshot from the seeded users so the
+    // assertion below has something to invalidate. In the real server this
+    // happens at boot via `configured_user_api_keys`; the unit harness
+    // wires AppState directly without that step, so we mirror it here.
+    {
+        let cfg = h._state.kernel.config_ref();
+        let initial = cfg
+            .users
+            .iter()
+            .filter_map(|u| {
+                let hash = u.api_key_hash.as_deref()?.trim();
+                if hash.is_empty() {
+                    return None;
+                }
+                Some(librefang_api::middleware::ApiUserAuth {
+                    name: u.name.clone(),
+                    role: librefang_kernel::auth::UserRole::from_str_role(&u.role),
+                    api_key_hash: hash.to_string(),
+                    user_id: librefang_types::agent::UserId::from_name(&u.name),
+                })
+            })
+            .collect();
+        *h._state.user_api_keys.write().await = initial;
+    }
+
+    // Sanity — the old plaintext verifies against the seeded hash before
+    // rotation. If this assertion fails the test setup is wrong and the
+    // post-rotation assertion below is meaningless.
+    let pre_swap_old_token_verifies = h
+        ._state
+        .user_api_keys
+        .read()
+        .await
+        .iter()
+        .any(|u| {
+            librefang_api::password_hash::verify_password("carol-plaintext", &u.api_key_hash)
+        });
+    assert!(
+        pre_swap_old_token_verifies,
+        "test setup invariant — seeded hash should verify before rotation"
+    );
+
+    let (status, body) = json_request(&h, Method::POST, "/api/users/Carol/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK, "rotate failed: {body:?}");
+
+    // The actual revocation. After rotation, NO entry in the live snapshot
+    // verifies against the old plaintext — the in-memory state the auth
+    // middleware reads from has been swapped, not just the on-disk file.
+    let post_swap_old_token_verifies = h
+        ._state
+        .user_api_keys
+        .read()
+        .await
+        .iter()
+        .any(|u| {
+            librefang_api::password_hash::verify_password("carol-plaintext", &u.api_key_hash)
+        });
+    assert!(
+        !post_swap_old_token_verifies,
+        "old plaintext STILL authenticates against the live snapshot — \
+         the rotate-key endpoint is not invalidating the in-memory user_api_keys, \
+         which means a leaked token is only revocable by daemon restart"
+    );
+
+    // The new plaintext returned in the response must verify against the
+    // freshly rotated hash — closes the loop end-to-end.
+    let new_plaintext = body["new_api_key"].as_str().expect("plaintext in body");
+    let new_token_verifies = h
+        ._state
+        .user_api_keys
+        .read()
+        .await
+        .iter()
+        .any(|u| librefang_api::password_hash::verify_password(new_plaintext, &u.api_key_hash));
+    assert!(
+        new_token_verifies,
+        "new plaintext does not verify against the post-rotation snapshot — \
+         the rotation surfaced a key that nobody can use"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_unknown_user_404() {
+    let h = boot().await;
+    let (status, body) = json_request(&h, Method::POST, "/api/users/Ghost/rotate-key", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "got: {body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("not found"),
+        "error must mention 'not found': {body:?}"
+    );
+}
+
+/// Rotating MUST NOT zero out other per-user fields (RBAC M3 policy,
+/// channel bindings, M5 budget). Mirrors the existing
+/// `users_update_and_import_preserve_rbac_m3_policy_fields` test for the
+/// rotation path — same regression risk.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_preserves_other_fields() {
+    use librefang_types::user_policy::{UserMemoryAccess, UserToolPolicy};
+    use std::collections::HashMap;
+
+    let mut bindings = HashMap::new();
+    bindings.insert("telegram".to_string(), "111".to_string());
+    let seed = UserConfig {
+        name: "Dan".into(),
+        role: "viewer".into(),
+        channel_bindings: bindings.clone(),
+        api_key_hash: Some(
+            librefang_api::password_hash::hash_password("seed-key").expect("seed"),
+        ),
+        budget: None,
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_search".into()],
+            denied_tools: vec!["shell_exec".into()],
+        }),
+        tool_categories: None,
+        memory_access: Some(UserMemoryAccess {
+            readable_namespaces: vec!["proactive".into()],
+            writable_namespaces: vec![],
+            pii_access: false,
+            export_allowed: false,
+            delete_allowed: false,
+        }),
+        channel_tool_rules: HashMap::new(),
+    };
+    let h = boot_with_seed_users(vec![seed.clone()]).await;
+
+    let (status, _) = json_request(&h, Method::POST, "/api/users/Dan/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let after = h
+        ._state
+        .kernel
+        .config_ref()
+        .users
+        .iter()
+        .find(|u| u.name == "Dan")
+        .cloned()
+        .expect("user must still exist");
+    assert_eq!(after.role, "viewer", "role flipped during rotate");
+    assert_eq!(
+        after.channel_bindings, bindings,
+        "channel_bindings cleared during rotate"
+    );
+    assert_eq!(
+        after.tool_policy, seed.tool_policy,
+        "tool_policy cleared during rotate"
+    );
+    assert_eq!(
+        after.memory_access, seed.memory_access,
+        "memory_access cleared during rotate"
     );
 }

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -1022,3 +1022,195 @@ async fn users_rotate_key_preserves_other_fields() {
         "memory_access cleared during rotate"
     );
 }
+
+/// Audit detail for a successful rotation must carry a short fingerprint
+/// of the OLD `api_key_hash` so operators can later correlate this entry
+/// with auth-failure log lines mentioning the same fingerprint.
+///
+/// We assert:
+/// 1. Detail contains `(old: <8 hex chars>)`.
+/// 2. The fingerprint matches `sha256(seeded_old_hash)[..4]` rendered as hex.
+/// 3. The plaintext, the new hash, and the old hash itself never appear
+///    in the audit detail — only the fingerprint.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_audit_includes_old_hash_fingerprint() {
+    use sha2::{Digest, Sha256};
+
+    let original_hash =
+        librefang_api::password_hash::hash_password("erin-plaintext").expect("seed hash");
+    let seed = UserConfig {
+        name: "Erin".to_string(),
+        role: "admin".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: Some(original_hash.clone()),
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, body) = json_request(&h, Method::POST, "/api/users/Erin/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK, "rotate failed: {body:?}");
+
+    let new_plaintext = body["new_api_key"]
+        .as_str()
+        .expect("plaintext in body")
+        .to_string();
+
+    // Compute the expected fingerprint the same way the handler does.
+    let digest = Sha256::digest(original_hash.as_bytes());
+    let mut expected_fp = String::with_capacity(8);
+    for b in digest.iter().take(4) {
+        expected_fp.push_str(&format!("{b:02x}"));
+    }
+
+    // Locate the rotation entry in the audit log. There may be additional
+    // entries from the persist path (`users updated` ConfigChange), so we
+    // filter by the `RoleChange` action and the user name.
+    let entries = h._state.kernel.audit().recent(50);
+    let rotate_entry = entries
+        .iter()
+        .find(|e| {
+            matches!(e.action, librefang_runtime::audit::AuditAction::RoleChange)
+                && e.detail.contains("api_key rotated")
+                && e.detail.contains("for user Erin")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no rotate-key audit entry found among {} recent entries: {:#?}",
+                entries.len(),
+                entries
+            )
+        });
+
+    assert!(
+        rotate_entry
+            .detail
+            .contains(&format!("(old: {expected_fp})")),
+        "audit detail missing fingerprint of OLD api_key_hash. \
+         expected '(old: {expected_fp})' in: {detail:?}",
+        detail = rotate_entry.detail
+    );
+
+    // Defensive — none of the secret material may leak into the audit detail.
+    assert!(
+        !rotate_entry.detail.contains(&new_plaintext),
+        "audit detail leaked the new plaintext key: {detail}",
+        detail = rotate_entry.detail
+    );
+    assert!(
+        !rotate_entry.detail.contains(&original_hash),
+        "audit detail leaked the full old api_key_hash (fingerprint only): {detail}",
+        detail = rotate_entry.detail
+    );
+    assert!(
+        !rotate_entry.detail.contains("erin-plaintext"),
+        "audit detail leaked the OLD plaintext: {detail}",
+        detail = rotate_entry.detail
+    );
+}
+
+/// Rotating a user that previously had no `api_key_hash` (rare but
+/// possible for a user added without a key, then granted one via rotate)
+/// must still produce a parseable audit detail. We render the absent old
+/// fingerprint as `(old: none)` so downstream parsers see a stable shape.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_audit_old_none_when_no_prior_hash() {
+    let seed = UserConfig {
+        name: "Frank".to_string(),
+        role: "admin".to_string(),
+        channel_bindings: std::collections::HashMap::new(),
+        api_key_hash: None,
+        ..Default::default()
+    };
+    let h = boot_with_seed_users(vec![seed]).await;
+
+    let (status, _) = json_request(&h, Method::POST, "/api/users/Frank/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let entries = h._state.kernel.audit().recent(50);
+    let rotate_entry = entries
+        .iter()
+        .find(|e| {
+            matches!(e.action, librefang_runtime::audit::AuditAction::RoleChange)
+                && e.detail.contains("for user Frank")
+        })
+        .expect("rotate-key audit entry must exist");
+
+    assert!(
+        rotate_entry.detail.contains("(old: none)"),
+        "expected '(old: none)' for first-time key assignment, got: {detail}",
+        detail = rotate_entry.detail
+    );
+}
+
+/// Lock-ordering invariant: the `state.user_api_keys` snapshot must be
+/// fully refreshed by the time the rotate-key handler returns 200 — i.e.,
+/// no caller can observe a window where the on-disk `config.toml` carries
+/// the new hash but the live `Vec<ApiUserAuth>` still verifies the old
+/// plaintext. We can't deterministically reproduce the race in a unit
+/// test (it depends on `reload_config` latency under contention), but we
+/// CAN assert the post-condition that, immediately after the handler
+/// resolves, the snapshot already reflects the on-disk state. If the
+/// pre-fix ordering regressed (write → reload → swap, no lock held) this
+/// assertion would still pass on a single-threaded happy path — but the
+/// assertion below ALSO checks that the snapshot is refreshed even when
+/// the caller acquires `user_api_keys.read()` immediately after the 200,
+/// before any other request can race in. Treats the lock-held-across
+/// invariant as a comment-anchored property; the deterministic regression
+/// guard for the actual hash content is `users_rotate_key_invalidates_existing_session`.
+#[tokio::test(flavor = "multi_thread")]
+async fn users_rotate_key_snapshot_consistent_with_disk_post_return() {
+    let h = boot_with_seed_users(vec![seed_user_with_key("Gail", "gail-plaintext")]).await;
+
+    // Mirror the daemon's boot-time wiring: `state.user_api_keys` starts
+    // populated from the seeded `UserConfig`s.
+    {
+        let cfg = h._state.kernel.config_ref();
+        let initial = cfg
+            .users
+            .iter()
+            .filter_map(|u| {
+                let hash = u.api_key_hash.as_deref()?.trim();
+                if hash.is_empty() {
+                    return None;
+                }
+                Some(librefang_api::middleware::ApiUserAuth {
+                    name: u.name.clone(),
+                    role: librefang_kernel::auth::UserRole::from_str_role(&u.role),
+                    api_key_hash: hash.to_string(),
+                    user_id: librefang_types::agent::UserId::from_name(&u.name),
+                })
+            })
+            .collect();
+        *h._state.user_api_keys.write().await = initial;
+    }
+
+    let (status, _) = json_request(&h, Method::POST, "/api/users/Gail/rotate-key", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // After the handler returns, the on-disk hash and the live snapshot
+    // for the rotated user must agree. Disagreement = the lock dropped
+    // before the swap = the race window is back.
+    let on_disk = h
+        ._state
+        .kernel
+        .config_ref()
+        .users
+        .iter()
+        .find(|u| u.name == "Gail")
+        .and_then(|u| u.api_key_hash.clone())
+        .expect("post-rotate Gail must have an on-disk hash");
+    let in_memory = h
+        ._state
+        .user_api_keys
+        .read()
+        .await
+        .iter()
+        .find(|u| u.name == "Gail")
+        .map(|u| u.api_key_hash.clone())
+        .expect("post-rotate Gail must have an in-memory record");
+    assert_eq!(
+        on_disk, in_memory,
+        "lock-ordering invariant broken: on-disk hash differs from live \
+         user_api_keys snapshot immediately after rotate-key returned 200"
+    );
+}

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -598,8 +598,8 @@ async fn users_create_refuses_to_overwrite_corrupt_config_toml() {
 /// Seed a single user with an Argon2id hash of `plaintext_key` so the
 /// auth-state snapshot the rotation endpoint mutates has something to swap.
 fn seed_user_with_key(name: &str, plaintext_key: &str) -> UserConfig {
-    let hash =
-        librefang_api::password_hash::hash_password(plaintext_key).expect("seed hash should succeed");
+    let hash = librefang_api::password_hash::hash_password(plaintext_key)
+        .expect("seed hash should succeed");
     UserConfig {
         name: name.to_string(),
         role: "admin".to_string(),
@@ -617,13 +617,7 @@ fn seed_user_with_key(name: &str, plaintext_key: &str) -> UserConfig {
 async fn users_rotate_key_returns_new_plaintext() {
     let h = boot_with_seed_users(vec![seed_user_with_key("Alice", "old-plaintext")]).await;
 
-    let (status, body) = json_request(
-        &h,
-        Method::POST,
-        "/api/users/Alice/rotate-key",
-        None,
-    )
-    .await;
+    let (status, body) = json_request(&h, Method::POST, "/api/users/Alice/rotate-key", None).await;
     assert_eq!(status, StatusCode::OK, "rotate failed: {body:?}");
     assert_eq!(body["status"], "ok");
     let new_key = body["new_api_key"].as_str().unwrap_or("");
@@ -718,13 +712,8 @@ async fn users_rotate_key_invalidates_existing_session() {
     // Sanity — the old plaintext verifies against the seeded hash before
     // rotation. If this assertion fails the test setup is wrong and the
     // post-rotation assertion below is meaningless.
-    let pre_swap_old_token_verifies = h
-        ._state
-        .user_api_keys
-        .read()
-        .await
-        .iter()
-        .any(|u| {
+    let pre_swap_old_token_verifies =
+        h._state.user_api_keys.read().await.iter().any(|u| {
             librefang_api::password_hash::verify_password("carol-plaintext", &u.api_key_hash)
         });
     assert!(
@@ -738,13 +727,8 @@ async fn users_rotate_key_invalidates_existing_session() {
     // The actual revocation. After rotation, NO entry in the live snapshot
     // verifies against the old plaintext — the in-memory state the auth
     // middleware reads from has been swapped, not just the on-disk file.
-    let post_swap_old_token_verifies = h
-        ._state
-        .user_api_keys
-        .read()
-        .await
-        .iter()
-        .any(|u| {
+    let post_swap_old_token_verifies =
+        h._state.user_api_keys.read().await.iter().any(|u| {
             librefang_api::password_hash::verify_password("carol-plaintext", &u.api_key_hash)
         });
     assert!(
@@ -801,9 +785,7 @@ async fn users_rotate_key_preserves_other_fields() {
         name: "Dan".into(),
         role: "viewer".into(),
         channel_bindings: bindings.clone(),
-        api_key_hash: Some(
-            librefang_api::password_hash::hash_password("seed-key").expect("seed"),
-        ),
+        api_key_hash: Some(librefang_api::password_hash::hash_password("seed-key").expect("seed")),
         budget: None,
         tool_policy: Some(UserToolPolicy {
             allowed_tools: vec!["web_search".into()],

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -70,6 +70,7 @@ async fn boot_with_seed_users(seed: Vec<UserConfig>) -> Harness {
         media_drivers: librefang_runtime::media::MediaDriverCache::new(),
         webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
         api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+        user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
     });

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -142,6 +142,7 @@ impl TestAppState {
             ),
             active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             prometheus_handle: None,
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),

--- a/openapi.json
+++ b/openapi.json
@@ -7727,6 +7727,42 @@
         }
       }
     },
+    "/api/users/{name}/rotate-key": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Rotate a user's API key.",
+        "description": "Generates a fresh 32-byte random plaintext key, hashes it with Argon2id,\nstores the hash in `config.toml`, and **swaps the live in-memory snapshot\nthe auth middleware reads from** so the next request that presents the\nold plaintext token immediately fails authentication. Without the live\nswap a leaked key could only be revoked by restarting the daemon — which\ndefeats the point of rotation. See the `user_api_keys` field on\n[`AppState`] for the shared `Arc<RwLock<…>>` that makes this work.\n\nOwner-only, gated by `is_owner_only_write` in `middleware.rs` — same\nblast radius as user create/delete. The request takes no body; the new\nplaintext key is returned in the response and is **never written to the\naudit log or echoed again**.\n\nDashboard sessions (`AppState.active_sessions`) are intentionally NOT\ninvalidated here. The active-sessions store is keyed by an opaque token\nand the stored [`crate::password_hash::SessionToken`] does not carry a\n`user_id` — it tracks the single shared dashboard credential pair\n(`dashboard_user` / `dashboard_pass`), not the per-user API keys this\nendpoint rotates. The two auth surfaces are independent: a per-user\nbearer-token caller never lands in `active_sessions` at all (see\n`middleware.rs:618`), so the per-user key swap completes the kill on\nits own. If a future change ties dashboard sessions to a `UserId`, we\ncan extend `sessions_invalidated` to include those evictions; today\nthe count reflects the per-user-bearer-token kill, which is the actual\nrevocation that matters for this surface.",
+        "operationId": "rotate_user_key",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "User name (case-sensitive)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key rotated. `new_api_key` is the only time the plaintext is exposed — the server cannot reproduce it later.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RotateKeyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/version": {
       "get": {
         "tags": [
@@ -8670,6 +8706,27 @@
               "null"
             ],
             "description": "Web search augmentation mode: \"off\", \"auto\", or \"always\"."
+          }
+        }
+      },
+      "RotateKeyResponse": {
+        "type": "object",
+        "description": "Response payload for `POST /api/users/{name}/rotate-key`.\n\n`new_api_key` is the **plaintext** rotated key — this is the only time\nthe server will surface it. Operators must copy and store it now;\nnothing else (audit log included) records the plaintext.\n\n`sessions_invalidated` reports how many in-memory per-user API key\nrecords were swapped — typically `1`. See the doc-comment on\n[`rotate_user_key`] for why dashboard sessions are NOT included in\nthis count.",
+        "required": [
+          "status",
+          "new_api_key",
+          "sessions_invalidated"
+        ],
+        "properties": {
+          "new_api_key": {
+            "type": "string"
+          },
+          "sessions_invalidated": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string"
           }
         }
       },

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -1258,6 +1258,10 @@ func (r *UsersResource) DeleteUser(name string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/users/%s", name), nil, nil)
 }
 
+func (r *UsersResource) RotateUserKey(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/users/%s/rotate-key", name), nil, nil)
+}
+
 // ── Webhooks Resource
 
 type WebhooksResource struct{ client *Client }

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -1160,6 +1160,10 @@ class UsersResource {
   async deleteUser(name) {
     return this._c._request("DELETE", `/api/users/${name}`);
   }
+
+  async rotateUserKey(name) {
+    return this._c._request("POST", `/api/users/${name}/rotate-key`);
+  }
 }
 
 // ── Webhooks Resource

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -922,6 +922,9 @@ class _UsersResource(_Resource):
     def delete_user(self, name: str):
         return self._c._request("DELETE", f"/api/users/{name}")
 
+    def rotate_user_key(self, name: str):
+        return self._c._request("POST", f"/api/users/{name}/rotate-key")
+
 
 # ── Webhooks Resource ──────────────────────────────────────────
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1413,6 +1413,10 @@ impl UsersResource {
     pub async fn delete_user(&self, name: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/users/{}", name), None, &[]).await
     }
+
+    pub async fn rotate_user_key(&self, name: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/users/{}/rotate-key", name), None, &[]).await
+    }
 }
 
 // ── Webhooks ──


### PR DESCRIPTION
Closes the leaked-key revocation gap from RBAC M3/M6 (#3054). Editing `users[].api_key_hash` via `update_user` (or by hand in `config.toml`) only becomes effective after a daemon restart today, because `AuthState.user_api_keys` is a frozen `Arc<Vec<…>>` snapshot built once at boot. A leaked per-user bearer token therefore stays valid until the operator restarts the daemon — exactly the scenario rotation needs to defeat.

## Surface

`POST /api/users/{name}/rotate-key`

* Owner-only — covered by the existing `is_owner_only_write` allowlist for `/api/users/*` non-GET (no middleware change needed; the prefix match in `middleware.rs:109` already blocks Admin/User/Viewer).
* No request body. Server generates a 32-byte random hex plaintext, hashes with Argon2id via the existing `password_hash::hash_password`, persists via the existing `persist_users` path.
* Response shape:
  ```json
  { "status": "ok", "new_api_key": "<plaintext, 64 hex chars>", "sessions_invalidated": <count> }
  ```
  The plaintext is the **only** time the server exposes it. Audit log records `RoleChange` with detail `"api_key rotated by <actor> for user <name>"` and the caller's `user_id` — never the plaintext.

## Why owner-only

Rotating a user's key is a credential-management action with the same blast radius as user create/delete. Without an Owner gate, any Admin per-user API key could rotate the Owner's key and lock everyone else out — exactly the self-promotion attack the existing `is_owner_only_write` allowlist exists to block. Self-rotation through this endpoint is also denied for the same reason; users who want a fresh key ask an Owner.

## How session invalidation works (the load-bearing part)

`SessionToken` (the value stored in `AppState.active_sessions`) does **not** carry a `user_id`. Reading the auth flow at `middleware.rs:603-668`:

1. The active-sessions store holds dashboard tokens issued by `/api/auth/dashboard-login`, keyed by opaque token, tied to the single shared `dashboard_user`/`dashboard_pass` credential pair — not per-user.
2. Per-user API key callers never land in `active_sessions` at all. Their bearer token is hashed against each entry in `auth_state.user_api_keys` via Argon2 verify.

So the actual revocation primitive is the `user_api_keys` snapshot, not `active_sessions`. To make swapping that snapshot work this PR converts `AuthState.user_api_keys` from `Arc<Vec<ApiUserAuth>>` to `Arc<RwLock<Vec<ApiUserAuth>>>` and shares the same `Arc` with `AppState.user_api_keys`. After `persist_users` finishes the on-disk write + kernel reload, it now also rebuilds the in-memory snapshot — which means the next request that presents the OLD plaintext immediately fails Argon2 verify against the freshly-rotated entry. The same refresh fixes the latent bug for `update_user` / `delete_user` / `import_users` along the way (they were all silently waiting for a daemon restart before).

I considered also clearing `active_sessions` in the rotate path, but rejected it: those sessions belong to the dashboard credential pair, not the rotated user, and clobbering them on every per-user rotation would force the operator to log back into the dashboard. If a future change ties dashboard sessions to a `UserId`, the rotate path can extend `sessions_invalidated` to include those evictions; today the count reflects the per-user-bearer-token kill, which is the actual revocation that matters for this surface.

## Files

### Backend
* `crates/librefang-api/src/routes/users.rs` — `rotate_user_key` handler, `RotateKeyResponse`, `generate_api_key_plaintext`, `rebuild_api_user_records`, and the `state.user_api_keys` refresh wired into `persist_users` after the kernel reload.
* `crates/librefang-api/src/middleware.rs` — `AuthState.user_api_keys` field type change + read-once snapshot at the top of `auth()` so each request only takes the lock once.
* `crates/librefang-api/src/routes/mod.rs` — `AppState.user_api_keys` field.
* `crates/librefang-api/src/server.rs` — share the new Arc between `AppState` and `AuthState` (mirrors the existing `api_key_lock` pattern).
* `crates/librefang-api/src/openapi.rs` — register the new path and response schema.

### Dashboard
* `crates/librefang-api/dashboard/src/api.ts` — `rotateUserKey()` + `RotateUserKeyResponse`.
* `crates/librefang-api/dashboard/src/lib/http/client.ts` — re-exports.
* `crates/librefang-api/dashboard/src/lib/mutations/users.ts` — `useRotateUserKey()` with `userKeys.lists()` / `userKeys.detail(name)` invalidation in `onSuccess`.
* `crates/librefang-api/dashboard/src/pages/UsersPage.tsx` — "Rotate API key" button per row (only shown when `has_api_key`), confirm modal, and a copy-once display modal that makes the "this won't be shown again" wording explicit.

### Tests
* `crates/librefang-api/tests/users_test.rs` (new tests):
  * `users_rotate_key_returns_new_plaintext` — happy path, asserts 64-char hex
  * `users_rotate_key_persists_new_hash` — on-disk round-trip, hash differs from seed
  * `users_rotate_key_invalidates_existing_session` — the load-bearing test: pre-populates the live snapshot, rotates, asserts the OLD plaintext stops verifying and the NEW plaintext starts verifying
  * `users_rotate_key_unknown_user_404`
  * `users_rotate_key_preserves_other_fields` — RBAC M3 policy + memory_access + bindings + role survive rotation (regression cover for the M5/M3 preserve pattern)
* `crates/librefang-api/tests/api_integration_test.rs`:
  * `users_rotate_key_admin_returns_403` — full-stack owner-only gate via `start_test_server_with_full_user_configs`. Asserts both Admin-rotates-other and Bob-self-rotates get 403, mirroring the spec's pointer to `users_policy_put_owner_only`.
  * `start_test_server_with_full_user_configs` now mounts `routes::users::router()` so the gate can actually be exercised end-to-end.

### Test-harness alignment (mechanical)
Every existing `AppState` constructor (5 test files + `routes/agents.rs` + `librefang-testing`) gets `user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new()))`, and every `AuthState` constructor in `middleware.rs` tests is updated to wrap its `user_api_keys` in the same `RwLock`. No semantic changes — the tests still assert the same things.

## Test plan

* [ ] CI builds (`cargo build --workspace --lib`)
* [ ] CI tests (`cargo test --workspace`) — new tests above pass alongside the 2100+ existing
* [ ] CI clippy (`cargo clippy --workspace --all-targets -- -D warnings`)
* [ ] CI dashboard typecheck + build
* [ ] Manual smoke (post-merge):
  * Seed a user with an API key, hit a protected endpoint with the old plaintext → 200
  * `POST /api/users/{name}/rotate-key` → response carries `new_api_key`
  * Hit the same protected endpoint with the OLD plaintext → 401 (the actual session kill)
  * Hit it with the NEW plaintext → 200
  * Restart the daemon, repeat with the NEW plaintext → still 200 (persistence)

## Follow-ups not in scope

* Self-service rotation for non-Owner users — would need a separate scoped endpoint with a fresh-credential-required gate; intentionally out of scope here.
* Tying dashboard `SessionToken` to a `UserId` so rotate can also evict dashboard sessions for the rotated user. Requires a schema change to `SessionToken`; not load-bearing for the per-user API key surface this PR fixes.
* The spec mentioned `subtle` for constant-time comparison — not used in this PR because Argon2 verify already gives constant-time semantics, and the plaintext returned is fresh per-rotation so there's no comparison risk on the response path.


---

## Review follow-ups (post-initial-review)

### Atomicity hole in the persist path (race window)

Initial implementation took the `state.user_api_keys.write()` lock AFTER the file write + kernel reload. Between the `std::fs::write` and the `*state.user_api_keys.write().await = …` swap, the kernel config already carried the new hash but the in-memory `Vec<ApiUserAuth>` the auth middleware actually verifies against still held the OLD record. Any request landing in that window — bounded by `reload_config` latency, but exploitable under load — would still authenticate with the just-rotated plaintext.

**Fix** (`crates/librefang-api/src/routes/users.rs::persist_users`): acquire `state.user_api_keys.write()` BEFORE the disk write, hold the guard across persist + reload + snapshot rebuild, drop only after the swap. Concurrent auth checks now either see the pre-rotation snapshot (fully consistent with the file at the moment they observed it) or block on this writer until the swap completes; never the in-between read where on-disk and live state disagree. Hold time is bounded by `reload_config` (a config reparse + a few inner `RwLock` writes — ms scale), and authentication blocking with the rotated key is the correct behavior.

Regression-guard test added in `crates/librefang-api/tests/users_test.rs::users_rotate_key_snapshot_consistent_with_disk_post_return`: asserts the on-disk hash and the live `user_api_keys` snapshot for the rotated user agree immediately after the handler returns 200. The deterministic content-level guard remains `users_rotate_key_invalidates_existing_session`.

### Audit detail: short fingerprint of the OLD api_key_hash

Initial detail string was `"api_key rotated by {actor} for user {name}"` with no reference to the just-revoked credential. Forensically useless when correlating with an authentication-failure log line `auth failed with leaked key X`.

**Fix** (`crates/librefang-api/src/routes/users.rs::rotate_user_key`): capture the OLD `api_key_hash` from the `persist_users` closure (now returns `Option<String>`), compute `sha256(old_hash)` truncated to the first 8 hex chars (32 bits — a hash-of-hash, no plaintext or reversibly-related material), and append `(old: {fingerprint})` to the audit detail. First-time key assignment via rotate (no prior hash) renders as `(old: none)` so downstream parsers see a stable shape.

Helper: `api_key_hash_fingerprint(&str) -> String` (uses the existing workspace `sha2` dep).

Tests added:

* `users_rotate_key_audit_includes_old_hash_fingerprint` — asserts the audit detail contains `(old: <expected fingerprint>)` and that none of `{old plaintext, new plaintext, full old hash}` leak into the audit detail.
* `users_rotate_key_audit_old_none_when_no_prior_hash` — first-time-key rotation produces `(old: none)`.

### Title alignment with gate

Title now reads "owner-only" to match the actual `is_owner_only_write` gate at `middleware.rs` (was previously "admin-only"). The Owner gate is the right policy for this surface — same blast radius as user create/delete; an Admin per-user key able to rotate the Owner's key would lock the Owner out of their own deployment.
