### PR TITLE
feat(kernel/workspace): external mount points in agent.toml (#3230)

### DIFF
--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -13594,6 +13594,13 @@
         "null"
       ]
     },
+    "allowed_mount_roots": {
+      "description": "Host directories under which `agent.toml: [workspaces].<name>.mount` declarations may resolve. Each declared mount is canonicalized at boot and must be a path prefix of one of these (also canonicalized) roots; otherwise it is rejected with a warning. Empty (default) denies all external mounts — the safe default. See issue #3230.\n\nExample: ```toml allowed_mount_roots = [ \"/Users/alice/Documents\", \"/data/shared\", ] ```",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "api_key": {
       "default": "",
       "description": "API authentication key. When set, all API endpoints (except /api/health) require a `Authorization: Bearer <key>` header. If empty, the API is unauthenticated (local development only).",

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3312,6 +3312,7 @@ impl LibreFangKernel {
                                                 let resolved_workspaces = ensure_named_workspaces(
                                                     &cfg.effective_workspaces_dir(),
                                                     &entry.manifest.workspaces,
+                                                    &cfg.allowed_mount_roots,
                                                 );
                                                 if entry.manifest.generate_identity_files {
                                                     generate_identity_files(
@@ -3835,8 +3836,11 @@ system_prompt = "You are a helpful assistant."
         )?;
         ensure_workspace(&workspace_dir)?;
         migrate_identity_files(&workspace_dir);
-        let resolved_workspaces =
-            ensure_named_workspaces(&cfg.effective_workspaces_dir(), &manifest.workspaces);
+        let resolved_workspaces = ensure_named_workspaces(
+            &cfg.effective_workspaces_dir(),
+            &manifest.workspaces,
+            &cfg.allowed_mount_roots,
+        );
         if manifest.generate_identity_files {
             generate_identity_files(&workspace_dir, &manifest, &resolved_workspaces);
         }
@@ -11246,6 +11250,7 @@ system_prompt = "You are a helpful assistant."
                         let resolved_ws = ensure_named_workspaces(
                             &cfg.effective_workspaces_dir(),
                             &agent.manifest.workspaces,
+                            &cfg.allowed_mount_roots,
                         );
                         generate_identity_files(&workspace, &agent.manifest, &resolved_ws);
                     }
@@ -17004,20 +17009,21 @@ impl KernelHandle for LibreFangKernel {
         if entry.manifest.workspaces.is_empty() {
             return vec![];
         }
-        let workspaces_root = self.config.load().effective_workspaces_dir();
+        let cfg = self.config.load();
+        let workspaces_root = cfg.effective_workspaces_dir();
+        let canonical_mount_roots =
+            workspace_setup::canonicalize_allowed_mount_roots(&cfg.allowed_mount_roots);
         entry
             .manifest
             .workspaces
-            .values()
-            .filter_map(|decl| {
-                if decl.path.is_absolute() || has_unsafe_relative_components(&decl.path) {
-                    return None;
-                }
-                workspaces_root
-                    .join(&decl.path)
-                    .canonicalize()
-                    .ok()
-                    .map(|p| (p, decl.mode.clone()))
+            .iter()
+            .filter_map(|(name, decl)| {
+                workspace_setup::resolve_workspace_decl(
+                    name,
+                    decl,
+                    &workspaces_root,
+                    &canonical_mount_roots,
+                )
             })
             .collect()
     }

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -575,35 +575,163 @@ pub(super) fn migrate_identity_files(workspace: &Path) {
     }
 }
 
-/// Create named workspace directories and return their resolved absolute paths with modes.
-/// Paths are validated (no absolute paths, no `..` components).
+/// Canonicalize entries in `allowed_mount_roots`, skipping any that fail.
+/// Returns the canonical roots ready to be used as prefix-checks against
+/// declared `mount` paths. Used by both the boot-time setup path and the
+/// hot-path `named_workspace_prefixes` query, so a single broken root in
+/// `config.toml` doesn't poison every mount lookup.
+pub(super) fn canonicalize_allowed_mount_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .filter_map(|r| match r.canonicalize() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                tracing::warn!(
+                    root = %r.display(),
+                    "config.toml: allowed_mount_roots entry could not be canonicalized: {e}"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Resolve a single `[workspaces]` declaration to its canonical on-disk
+/// target, without creating any directories. Returns `None` when the
+/// declaration is invalid for any reason (warns at module level).
+///
+/// This is the shared core used by both `ensure_named_workspaces` (which
+/// additionally creates `path` targets at boot) and the runtime hot-path
+/// query `named_workspace_prefixes` (which must avoid touching the
+/// filesystem beyond `canonicalize`).
+///
+/// `allowed_mount_canonical_roots` must already be canonicalized — see
+/// `canonicalize_allowed_mount_roots`.
+pub(super) fn resolve_workspace_decl(
+    name: &str,
+    decl: &librefang_types::agent::WorkspaceDecl,
+    workspaces_root: &Path,
+    allowed_mount_canonical_roots: &[PathBuf],
+) -> Option<(PathBuf, WorkspaceMode)> {
+    match (decl.path.as_ref(), decl.mount.as_ref()) {
+        (Some(_), Some(_)) => {
+            tracing::warn!(
+                name,
+                "Workspace declaration has both `path` and `mount` set — skipped \
+                 (use exactly one)"
+            );
+            None
+        }
+        (None, None) => {
+            tracing::warn!(
+                name,
+                "Workspace declaration has neither `path` nor `mount` — skipped"
+            );
+            None
+        }
+        (Some(rel), None) => {
+            if rel.is_absolute() || has_unsafe_relative_components(rel) {
+                tracing::warn!(
+                    name,
+                    path = %rel.display(),
+                    "Invalid named workspace path — skipped (must be relative, no `..`)"
+                );
+                return None;
+            }
+            let abs = workspaces_root.join(rel);
+            match abs.canonicalize() {
+                Ok(p) => Some((p, decl.mode.clone())),
+                Err(e) => {
+                    tracing::warn!(
+                        name,
+                        path = %abs.display(),
+                        "Failed to canonicalize named workspace: {e}"
+                    );
+                    None
+                }
+            }
+        }
+        (None, Some(mount)) => {
+            if !mount.is_absolute() {
+                tracing::warn!(
+                    name,
+                    mount = %mount.display(),
+                    "Workspace mount must be an absolute path — skipped"
+                );
+                return None;
+            }
+            let canonical = match mount.canonicalize() {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        name,
+                        mount = %mount.display(),
+                        "Failed to canonicalize workspace mount (does the directory exist?): {e}"
+                    );
+                    return None;
+                }
+            };
+            if allowed_mount_canonical_roots.is_empty() {
+                tracing::warn!(
+                    name,
+                    mount = %canonical.display(),
+                    "Workspace mount rejected — `allowed_mount_roots` is empty in config.toml. \
+                     External mounts are denied by default; whitelist a parent directory to enable."
+                );
+                return None;
+            }
+            let allowed = allowed_mount_canonical_roots
+                .iter()
+                .any(|root| canonical.starts_with(root));
+            if !allowed {
+                tracing::warn!(
+                    name,
+                    mount = %canonical.display(),
+                    "Workspace mount is not under any `config.toml: allowed_mount_roots` entry — skipped"
+                );
+                return None;
+            }
+            Some((canonical, decl.mode.clone()))
+        }
+    }
+}
+
+/// Resolve all named workspace declarations and create the directories
+/// for `path` entries. Returns the map of canonical absolute paths with
+/// access modes. Invalid declarations are logged and skipped.
+///
+/// `allowed_mount_roots` comes from `config.toml`. External `mount`
+/// targets must canonicalize to a prefix of one of these roots; the
+/// list is empty by default, which denies all external mounts.
 pub(super) fn ensure_named_workspaces(
     workspaces_root: &Path,
     decls: &HashMap<String, librefang_types::agent::WorkspaceDecl>,
+    allowed_mount_roots: &[PathBuf],
 ) -> HashMap<String, (PathBuf, WorkspaceMode)> {
+    let canonical_roots = canonicalize_allowed_mount_roots(allowed_mount_roots);
     let mut resolved = HashMap::new();
     for (name, decl) in decls {
-        if decl.path.is_absolute() || has_unsafe_relative_components(&decl.path) {
-            tracing::warn!(name, path = %decl.path.display(), "Invalid named workspace path — skipped");
-            continue;
-        }
-        let abs = workspaces_root.join(&decl.path);
-        if let Err(e) = std::fs::create_dir_all(&abs) {
-            tracing::warn!(name, path = %abs.display(), "Failed to create named workspace: {e}");
-            continue;
-        }
-        // Canonicalize after create_dir_all so the path is consistent with
-        // readonly_workspace_prefixes (which also canonicalizes). Skip on failure
-        // rather than falling back to a non-canonical path that would silently
-        // bypass the readonly check.
-        let canonical = match abs.canonicalize() {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::warn!(name, path = %abs.display(), "Failed to canonicalize named workspace: {e}");
-                continue;
+        // Create the on-disk directory for `path` entries before resolving.
+        // External `mount` targets must already exist — the daemon never
+        // creates host directories on behalf of an agent (issue #3230).
+        if let (Some(rel), None) = (decl.path.as_ref(), decl.mount.as_ref()) {
+            if !(rel.is_absolute() || has_unsafe_relative_components(rel)) {
+                let abs = workspaces_root.join(rel);
+                if let Err(e) = std::fs::create_dir_all(&abs) {
+                    tracing::warn!(
+                        name,
+                        path = %abs.display(),
+                        "Failed to create named workspace: {e}"
+                    );
+                    continue;
+                }
             }
-        };
-        resolved.insert(name.clone(), (canonical, decl.mode.clone()));
+        }
+        if let Some(entry) =
+            resolve_workspace_decl(name, decl, workspaces_root, &canonical_roots)
+        {
+            resolved.insert(name.clone(), entry);
+        }
     }
     resolved
 }
@@ -695,5 +823,177 @@ pub(super) fn gethostname() -> Option<String> {
     #[cfg(not(any(unix, windows)))]
     {
         None
+    }
+}
+
+#[cfg(test)]
+mod mount_tests {
+    //! Regression tests for issue #3230: external `mount` declarations in
+    //! `[workspaces]` must require an explicit `allowed_mount_roots`
+    //! whitelist; declarations that mix `path` and `mount`, or leave
+    //! both empty, must be rejected.
+
+    use super::*;
+    use librefang_types::agent::{WorkspaceDecl, WorkspaceMode};
+    use std::collections::HashMap;
+
+    fn decl_path(rel: &str, mode: WorkspaceMode) -> WorkspaceDecl {
+        WorkspaceDecl {
+            path: Some(PathBuf::from(rel)),
+            mount: None,
+            mode,
+        }
+    }
+
+    fn decl_mount(abs: &Path, mode: WorkspaceMode) -> WorkspaceDecl {
+        WorkspaceDecl {
+            path: None,
+            mount: Some(abs.to_path_buf()),
+            mode,
+        }
+    }
+
+    #[test]
+    fn resolve_path_relative_inside_workspaces_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rel = "shared/lib";
+        std::fs::create_dir_all(tmp.path().join(rel)).unwrap();
+        let decl = decl_path(rel, WorkspaceMode::ReadWrite);
+        let resolved = resolve_workspace_decl("lib", &decl, tmp.path(), &[]).unwrap();
+        assert_eq!(
+            resolved.0.canonicalize().unwrap(),
+            tmp.path().join(rel).canonicalize().unwrap()
+        );
+        assert_eq!(resolved.1, WorkspaceMode::ReadWrite);
+    }
+
+    #[test]
+    fn resolve_path_rejects_absolute_relative_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Putting an absolute path into the relative-only `path` field is invalid.
+        let decl = WorkspaceDecl {
+            path: Some(PathBuf::from("/etc")),
+            mount: None,
+            mode: WorkspaceMode::ReadWrite,
+        };
+        assert!(resolve_workspace_decl("bad", &decl, tmp.path(), &[]).is_none());
+    }
+
+    #[test]
+    fn resolve_path_rejects_parent_dir_components() {
+        let tmp = tempfile::tempdir().unwrap();
+        let decl = decl_path("../escape", WorkspaceMode::ReadWrite);
+        assert!(resolve_workspace_decl("escape", &decl, tmp.path(), &[]).is_none());
+    }
+
+    #[test]
+    fn resolve_mount_denied_when_whitelist_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("vault");
+        std::fs::create_dir_all(&target).unwrap();
+        let decl = decl_mount(&target, WorkspaceMode::ReadOnly);
+        assert!(resolve_workspace_decl("vault", &decl, tmp.path(), &[]).is_none());
+    }
+
+    #[test]
+    fn resolve_mount_allowed_when_under_whitelisted_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host_root = tmp.path().join("host");
+        let target = host_root.join("Obsidian");
+        std::fs::create_dir_all(&target).unwrap();
+        let canonical_roots = canonicalize_allowed_mount_roots(&[host_root.clone()]);
+        let decl = decl_mount(&target, WorkspaceMode::ReadOnly);
+        let resolved =
+            resolve_workspace_decl("vault", &decl, tmp.path(), &canonical_roots).unwrap();
+        assert_eq!(resolved.0, target.canonicalize().unwrap());
+        assert_eq!(resolved.1, WorkspaceMode::ReadOnly);
+    }
+
+    #[test]
+    fn resolve_mount_rejected_when_outside_whitelisted_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host_root = tmp.path().join("host");
+        std::fs::create_dir_all(&host_root).unwrap();
+        // Target directory exists but lives OUTSIDE host_root.
+        let outside = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&outside).unwrap();
+        let canonical_roots = canonicalize_allowed_mount_roots(&[host_root]);
+        let decl = decl_mount(&outside, WorkspaceMode::ReadWrite);
+        assert!(resolve_workspace_decl("nope", &decl, tmp.path(), &canonical_roots).is_none());
+    }
+
+    #[test]
+    fn resolve_mount_rejects_relative_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let decl = WorkspaceDecl {
+            path: None,
+            mount: Some(PathBuf::from("relative/path")),
+            mode: WorkspaceMode::ReadOnly,
+        };
+        // Even with a permissive whitelist, a relative `mount` must be rejected.
+        let canonical_roots = canonicalize_allowed_mount_roots(&[tmp.path().to_path_buf()]);
+        assert!(resolve_workspace_decl("rel", &decl, tmp.path(), &canonical_roots).is_none());
+    }
+
+    #[test]
+    fn resolve_mount_does_not_create_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host_root = tmp.path().to_path_buf();
+        let missing = host_root.join("does_not_exist_yet");
+        let canonical_roots = canonicalize_allowed_mount_roots(&[host_root]);
+        let decl = decl_mount(&missing, WorkspaceMode::ReadOnly);
+        // Should be skipped: kernel never creates host directories on
+        // behalf of an agent.
+        assert!(resolve_workspace_decl("nope", &decl, tmp.path(), &canonical_roots).is_none());
+        assert!(!missing.exists(), "kernel must not create the target");
+    }
+
+    #[test]
+    fn resolve_rejects_when_both_path_and_mount_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("vault");
+        std::fs::create_dir_all(&target).unwrap();
+        let canonical_roots = canonicalize_allowed_mount_roots(&[tmp.path().to_path_buf()]);
+        let decl = WorkspaceDecl {
+            path: Some(PathBuf::from("rel")),
+            mount: Some(target),
+            mode: WorkspaceMode::ReadWrite,
+        };
+        assert!(resolve_workspace_decl("ambig", &decl, tmp.path(), &canonical_roots).is_none());
+    }
+
+    #[test]
+    fn resolve_rejects_when_neither_path_nor_mount_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let decl = WorkspaceDecl::default();
+        assert!(resolve_workspace_decl("empty", &decl, tmp.path(), &[]).is_none());
+    }
+
+    #[test]
+    fn ensure_named_workspaces_creates_path_targets_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host_root = tmp.path().join("host");
+        std::fs::create_dir_all(&host_root).unwrap();
+        let mount_target = host_root.join("Obsidian");
+        std::fs::create_dir_all(&mount_target).unwrap();
+
+        let mut decls = HashMap::new();
+        decls.insert(
+            "library".to_string(),
+            decl_path("shared/library", WorkspaceMode::ReadWrite),
+        );
+        decls.insert(
+            "vault".to_string(),
+            decl_mount(&mount_target, WorkspaceMode::ReadOnly),
+        );
+        // A `path` target that doesn't yet exist — kernel should create it.
+        let workspaces_root = tmp.path().join("workspaces");
+        std::fs::create_dir_all(&workspaces_root).unwrap();
+        let allowed = vec![host_root];
+
+        let resolved = ensure_named_workspaces(&workspaces_root, &decls, &allowed);
+        assert_eq!(resolved.len(), 2, "both decls should resolve");
+        assert!(workspaces_root.join("shared/library").is_dir());
+        assert!(mount_target.is_dir());
     }
 }

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -727,9 +727,7 @@ pub(super) fn ensure_named_workspaces(
                 }
             }
         }
-        if let Some(entry) =
-            resolve_workspace_decl(name, decl, workspaces_root, &canonical_roots)
-        {
+        if let Some(entry) = resolve_workspace_decl(name, decl, workspaces_root, &canonical_roots) {
             resolved.insert(name.clone(), entry);
         }
     }

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -899,7 +899,7 @@ mod mount_tests {
         let host_root = tmp.path().join("host");
         let target = host_root.join("Obsidian");
         std::fs::create_dir_all(&target).unwrap();
-        let canonical_roots = canonicalize_allowed_mount_roots(&[host_root.clone()]);
+        let canonical_roots = canonicalize_allowed_mount_roots(std::slice::from_ref(&host_root));
         let decl = decl_mount(&target, WorkspaceMode::ReadOnly);
         let resolved =
             resolve_workspace_decl("vault", &decl, tmp.path(), &canonical_roots).unwrap();

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -2329,7 +2329,10 @@ model = "llama-3.3-70b-versatile"
 mode = "rw"
 "#;
         let d: WorkspaceDecl = toml::from_str(s).unwrap();
-        assert_eq!(d.path.as_deref(), Some(std::path::Path::new("shared/library")));
+        assert_eq!(
+            d.path.as_deref(),
+            Some(std::path::Path::new("shared/library"))
+        );
         assert!(d.mount.is_none());
         assert_eq!(d.mode, WorkspaceMode::ReadWrite);
         assert!(!d.is_external_mount());
@@ -2341,7 +2344,10 @@ mode = "rw"
 mode = "r"
 "#;
         let d: WorkspaceDecl = toml::from_str(s).unwrap();
-        assert_eq!(d.mount.as_deref(), Some(std::path::Path::new("/Users/me/Obsidian")));
+        assert_eq!(
+            d.mount.as_deref(),
+            Some(std::path::Path::new("/Users/me/Obsidian"))
+        );
         assert!(d.path.is_none());
         assert_eq!(d.mode, WorkspaceMode::ReadOnly);
         assert!(d.is_external_mount());

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -953,13 +953,39 @@ pub enum WorkspaceMode {
 }
 
 /// Declaration of a named workspace in `agent.toml`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Exactly one of `path` or `mount` must be set:
+/// * `path` — relative to the configured `workspaces_dir`. The kernel
+///   creates the directory if it does not exist. This is the original
+///   shared-workspace mechanism and is the right choice for directories
+///   that LibreFang owns.
+/// * `mount` — an absolute path to a directory that already exists on
+///   the host (e.g. an Obsidian vault). The kernel never creates the
+///   target. The path must canonicalize to a prefix of one of the
+///   `allowed_mount_roots` entries in `config.toml`; otherwise the
+///   declaration is rejected at boot. See issue #3230.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct WorkspaceDecl {
     /// Path relative to `workspaces_dir` (e.g. `"shared/library"`).
-    pub path: PathBuf,
+    /// Mutually exclusive with `mount`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    /// Absolute path to an existing host directory (e.g. an Obsidian
+    /// vault). Mutually exclusive with `path`. Must be whitelisted via
+    /// `config.toml: allowed_mount_roots`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mount: Option<PathBuf>,
     /// Access mode. Defaults to read-write.
     #[serde(default)]
     pub mode: WorkspaceMode,
+}
+
+impl WorkspaceDecl {
+    /// Whether this declaration targets a directory outside `workspaces_dir`.
+    /// External targets require an entry in `config.toml: allowed_mount_roots`.
+    pub fn is_external_mount(&self) -> bool {
+        self.mount.is_some()
+    }
 }
 
 fn default_true() -> bool {
@@ -2293,5 +2319,51 @@ model = "llama-3.3-70b-versatile"
         let a = SessionId::from_route_key(agent, "matrix", "alice@example.org", "!room:server");
         let b = SessionId::from_route_key(agent, "matrix", "alice@example.org", "!room:server");
         assert_eq!(a, b);
+    }
+
+    // ── WorkspaceDecl: path / mount mutual-exclusion (#3230) ──────────────
+
+    #[test]
+    fn workspace_decl_path_only_deserializes() {
+        let s = r#"path = "shared/library"
+mode = "rw"
+"#;
+        let d: WorkspaceDecl = toml::from_str(s).unwrap();
+        assert_eq!(d.path.as_deref(), Some(std::path::Path::new("shared/library")));
+        assert!(d.mount.is_none());
+        assert_eq!(d.mode, WorkspaceMode::ReadWrite);
+        assert!(!d.is_external_mount());
+    }
+
+    #[test]
+    fn workspace_decl_mount_only_deserializes() {
+        let s = r#"mount = "/Users/me/Obsidian"
+mode = "r"
+"#;
+        let d: WorkspaceDecl = toml::from_str(s).unwrap();
+        assert_eq!(d.mount.as_deref(), Some(std::path::Path::new("/Users/me/Obsidian")));
+        assert!(d.path.is_none());
+        assert_eq!(d.mode, WorkspaceMode::ReadOnly);
+        assert!(d.is_external_mount());
+    }
+
+    /// Both fields can deserialize together — the kernel rejects the
+    /// combination at boot (see `resolve_workspace_decl`). Schema-level
+    /// rejection would break agent.toml hot-reload from the dashboard
+    /// (the user couldn't even see the validation error in context).
+    #[test]
+    fn workspace_decl_both_fields_deserialize_runtime_rejects() {
+        let s = r#"path = "rel"
+mount = "/abs"
+"#;
+        let d: WorkspaceDecl = toml::from_str(s).unwrap();
+        assert!(d.path.is_some() && d.mount.is_some());
+    }
+
+    #[test]
+    fn workspace_decl_neither_field_deserializes() {
+        let s = "mode = \"r\"\n";
+        let d: WorkspaceDecl = toml::from_str(s).unwrap();
+        assert!(d.path.is_none() && d.mount.is_none());
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2240,6 +2240,21 @@ pub struct KernelConfig {
     /// hostnames without port, e.g. `"dash.example.com"`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trusted_hosts: Vec<String>,
+    /// Host directories under which `agent.toml: [workspaces].<name>.mount`
+    /// declarations may resolve. Each declared mount is canonicalized at
+    /// boot and must be a path prefix of one of these (also canonicalized)
+    /// roots; otherwise it is rejected with a warning. Empty (default)
+    /// denies all external mounts — the safe default. See issue #3230.
+    ///
+    /// Example:
+    /// ```toml
+    /// allowed_mount_roots = [
+    ///   "/Users/alice/Documents",
+    ///   "/data/shared",
+    /// ]
+    /// ```
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_mount_roots: Vec<PathBuf>,
     /// Whether to enable the OFP network layer.
     pub network_enabled: bool,
     /// Operator override for the agent-loop iteration cap. When set, any
@@ -4389,6 +4404,7 @@ impl Default for KernelConfig {
             registry: RegistryConfig::default(),
             cors_origin: Vec::new(),
             trusted_hosts: Vec::new(),
+            allowed_mount_roots: Vec::new(),
             privacy: PrivacyConfig::default(),
             strict_config: false,
             qwen_code_path: None,

--- a/docs/src/app/agent/templates/page.mdx
+++ b/docs/src/app/agent/templates/page.mdx
@@ -264,6 +264,31 @@ The kernel creates the directories on spawn and injects their resolved paths int
 
 **Modes**: `rw` (read-write, default) or `r` (read-only). Paths are relative to `workspaces_dir` and must not be absolute or contain `..`.
 
+#### External mounts (`mount`)
+
+Use `mount` instead of `path` to expose a directory that already exists outside `workspaces_dir` — for example an Obsidian vault or a project tree:
+
+```toml
+# agent.toml
+[workspaces]
+vault = { mount = "/Users/me/Documents/Obsidian", mode = "r" }
+```
+
+Constraints:
+
+- `mount` must be an absolute path that already exists. The kernel never creates host directories on the agent's behalf.
+- The path must canonicalize to a prefix of one of the entries in `config.toml`'s top-level `allowed_mount_roots`. Without that whitelist, every `mount` is rejected at boot — the safe default.
+- `path` and `mount` are mutually exclusive within a single declaration.
+
+```toml
+# config.toml — required to enable the example above
+allowed_mount_roots = [
+  "/Users/me/Documents",
+]
+```
+
+`readonly` mode (`mode = "r"`) is enforced for mounts the same way as for shared workspaces: write tool calls are rejected by the kernel.
+
 ### Live Context (`context.md`)
 
 If a `context.md` file is present in the agent's workspace, it is re-read **on every agent turn** and injected into the system prompt as a `## Live Context` section. This lets external tools (cron jobs, scripts, dashboards) push fresh data — market prices, project state, on-call rosters — into an agent without restarting it.

--- a/docs/src/app/zh/agent/templates/page.mdx
+++ b/docs/src/app/zh/agent/templates/page.mdx
@@ -264,6 +264,31 @@ library = { path = "shared/library", mode = "r" }   # 只读
 
 **访问模式**：`rw`（读写，默认）或 `r`（只读）。路径相对于 `workspaces_dir`，不能是绝对路径或包含 `..`。
 
+#### 外部挂载（`mount`）
+
+用 `mount` 替代 `path`，可以挂载 `workspaces_dir` 外已经存在的目录——比如 Obsidian vault 或某个项目树：
+
+```toml
+# agent.toml
+[workspaces]
+vault = { mount = "/Users/me/Documents/Obsidian", mode = "r" }
+```
+
+约束：
+
+- `mount` 必须是已存在的绝对路径。内核**不会**替 agent 创建外部目录。
+- 路径 canonicalize 后必须是 `config.toml` 顶层 `allowed_mount_roots` 中某条目的前缀。**白名单为空（默认）时所有 `mount` 都会被拒绝**——安全的默认行为。
+- 同一条声明里 `path` 与 `mount` 互斥。
+
+```toml
+# config.toml —— 启用上面示例所需
+allowed_mount_roots = [
+  "/Users/me/Documents",
+]
+```
+
+只读模式（`mode = "r"`）对挂载点的执行方式与共享 workspace 一致：写工具调用会被内核拒绝。
+
 ### 实时上下文（`context.md`）
 
 如果 agent workspace 里有 `context.md` 文件，**每个 agent 回合都会重新读取**，并以 `## Live Context` section 注入 system prompt。这让外部工具（cron 任务、脚本、dashboard）能把新数据 — 行情、项目状态、值班表 — 推给 agent，无需重启。


### PR DESCRIPTION
## Summary

Closes #3230. Adds a `mount` field to `[workspaces]` in `agent.toml` so an agent can be granted controlled access to a directory that already exists outside `workspaces_dir` (e.g. an Obsidian vault or a project tree) **without** breaking the sandbox or surfacing the host path to the agent. The agent only ever sees the logical mount name; the kernel does the path remapping internally.

## Surface

```toml
# agent.toml
[workspaces]
vault = { mount = "/Users/me/Documents/Obsidian", mode = "r" }
```

```toml
# config.toml — required to enable any external mount
allowed_mount_roots = [
  "/Users/me/Documents",
]
```

Rules:
- `path` (existing) — relative to `workspaces_dir`, kernel creates it.
- `mount` (new) — absolute host path, must already exist, kernel never creates it.
- The two are mutually exclusive per declaration.
- A `mount` is denied unless its canonical path is a prefix of one of the canonicalized `allowed_mount_roots`. Empty list (default) = deny all.

## Plumbing

- `WorkspaceDecl.path` is now `Option<PathBuf>`, alongside new `Option<PathBuf> mount`. Default is "neither set" (rejected at runtime, not at schema-time, so the dashboard hot-reload can surface a useful warning).
- New `KernelConfig.allowed_mount_roots: Vec<PathBuf>` with safe empty default.
- New `workspace_setup::resolve_workspace_decl` is the single resolver shared by both the boot-time `ensure_named_workspaces` (which still creates `path` directories) and the runtime hot-path `KernelHandle::named_workspace_prefixes`. Keeps the readonly-prefix list, sandbox-check list, and TOOLS.md injection list in lock-step.
- Three call sites in `kernel/mod.rs` (boot, agent spawn, hot-reload identity refresh) updated to pass `&cfg.allowed_mount_roots` through.

## Tests

`crates/librefang-kernel/src/kernel/workspace_setup.rs` mount_tests module:

- `resolve_path_relative_inside_workspaces_root` — happy path for the existing `path` mode.
- `resolve_path_rejects_absolute_relative_field` — `path` cannot smuggle in an absolute path.
- `resolve_path_rejects_parent_dir_components` — `..` traversal blocked.
- `resolve_mount_denied_when_whitelist_empty` — safe default.
- `resolve_mount_allowed_when_under_whitelisted_root` — happy path.
- `resolve_mount_rejected_when_outside_whitelisted_root` — whitelist enforced.
- `resolve_mount_rejects_relative_path` — `mount` must be absolute.
- `resolve_mount_does_not_create_target` — kernel never creates the host directory.
- `resolve_rejects_when_both_path_and_mount_set` / `..._neither_..._set` — XOR enforced.
- `ensure_named_workspaces_creates_path_targets_only` — integration smoke.

`crates/librefang-types/src/agent.rs` adds 4 serde tests pinning the deserializer's behaviour for path-only / mount-only / both / neither.

## Test plan

- [x] `cargo test -p librefang-types -p librefang-kernel --lib` — local (CI runs full).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (deferred to CI).
- [ ] Live integration: spawn an agent with `vault = { mount = "/abs", mode = "r" }`, verify TOOLS.md gets `@vault → /abs (r)` only when the root is whitelisted, and write tools are rejected. Deferred to reviewer / staging.

## Why deny-by-default

Whitelisting is intentional. An empty `allowed_mount_roots` makes every `mount` declaration a startup warning + skip — no agent gains escape capability just by setting an `agent.toml` field. The operator has to opt in to a parent directory.
