### PR TITLE
chore(dashboard): unbreak typecheck on sessions-stream test

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
@@ -5,7 +5,15 @@ import { useSessionStream } from "./sessions";
 // Minimal in-test EventSource fake. Native EventSource exists in jsdom only
 // as a no-op stub; we drive our own so we can deterministically assert
 // open / message / error transitions.
-class FakeEventSource implements Partial<EventSource> {
+//
+// Intentionally NOT `implements Partial<EventSource>`: the real interface
+// declares add/removeEventListener with overloaded signatures that pin
+// MessageEvent on typed channels, which a plain `EventListener` arg cannot
+// satisfy (TS2416). The hook only depends on duck-typed access through
+// the `as unknown as typeof EventSource` cast at the call sites, so
+// formal interface conformance buys us nothing and just fights the
+// type checker.
+class FakeEventSource {
   static instances: FakeEventSource[] = [];
   url: string;
   withCredentials: boolean;
@@ -100,7 +108,11 @@ describe("useSessionStream", () => {
 
     act(() => es.emit("done", "{}"));
     expect(result.current.isAttached).toBe(false);
-    expect(result.current.events.at(-1)?.type).toBe("done");
+    // Indexed access instead of `.at(-1)` — tsconfig targets ES2020,
+    // and `Array.prototype.at` is ES2022.
+    expect(
+      result.current.events[result.current.events.length - 1]?.type,
+    ).toBe("done");
   });
 
   it("treats error-before-any-data as a silent no-op (404 / not-deployed)", () => {


### PR DESCRIPTION
## Summary

Three pre-existing `tsc --noEmit` errors in `src/lib/queries/sessions-stream.test.tsx` that have been silent since #3087 because nothing in CI gated on `pnpm typecheck` for the dashboard. Surfaced while reviewing #3225 — fixing them as a separate chore PR so #3225's diff stays focused on the audit page.

## Changes

1. **TS2416 × 2** on `addEventListener` / `removeEventListener`. The class declares `implements Partial<EventSource>`, which forces conformance to the real interface's overloaded signatures (typed `MessageEventMap` channels). A plain `(type: string, fn: EventListener)` parameter can't satisfy those overloads. The hook already duck-types through `as unknown as typeof EventSource` at every call site, so formal interface conformance buys nothing — dropped `implements Partial<EventSource>` and added a comment explaining why.

2. **TS2550** on `events.at(-1)?.type`. `tsconfig.json` targets ES2020 and `Array.prototype.at` is ES2022. Replaced with indexed access `events[events.length - 1]?.type`. Lower blast radius than bumping the target lib.

## Verification

- `pnpm typecheck` — clean (was: 3 errors).
- `pnpm vitest run src/lib/queries/sessions-stream.test.tsx` — 10/10 pass (no runtime behavior change).

## Follow-up worth tracking

Dashboard `typecheck` should be wired into CI's Quality job — same shape as the existing `cargo xtask fmt` / `cargo clippy` gates — so future drift is caught at PR time instead of accumulating silently. Out of scope here; a one-line addition to the workflow file.
