### PR TITLE
fix(dashboard/simulator): invalidate effective-permissions on policy/budget mutations (#3228 follow-up)

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
@@ -3,7 +3,10 @@
 // Both writes invalidate the matching `userBudgetKeys.detail(name)` so any
 // open detail panel re-fetches against the now-persisted config.toml. We
 // also kick `userKeys.detail(name)` because `UserConfig.budget` is part of
-// the `UserItem` payload (the M6 dashboard surfaces it on the user row).
+// the `UserItem` payload (the M6 dashboard surfaces it on the user row),
+// and `authzKeys.effective(name)` because the permission simulator reads
+// `EffectivePermissions.budget` from the same `UserConfig` row (#3228
+// follow-up).
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -11,7 +14,7 @@ import {
   deleteUserBudget,
   type UserBudgetPayload,
 } from "../http/client";
-import { userBudgetKeys, userKeys } from "../queries/keys";
+import { authzKeys, userBudgetKeys, userKeys } from "../queries/keys";
 
 export function useUpdateUserBudget() {
   const qc = useQueryClient();
@@ -22,6 +25,9 @@ export function useUpdateUserBudget() {
       qc.invalidateQueries({ queryKey: userBudgetKeys.detail(variables.name) });
       qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
       qc.invalidateQueries({ queryKey: userKeys.lists() });
+      qc.invalidateQueries({
+        queryKey: authzKeys.effective(variables.name),
+      });
     },
   });
 }
@@ -34,6 +40,7 @@ export function useDeleteUserBudget() {
       qc.invalidateQueries({ queryKey: userBudgetKeys.detail(name) });
       qc.invalidateQueries({ queryKey: userKeys.detail(name) });
       qc.invalidateQueries({ queryKey: userKeys.lists() });
+      qc.invalidateQueries({ queryKey: authzKeys.effective(name) });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/mutations/users.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/users.ts
@@ -4,6 +4,12 @@
 // the affected detail cache. Bulk import dirties the whole `userKeys.all`
 // subtree because the import can touch arbitrary rows; that's the exact
 // "bulk reset" case AGENTS.md calls out as a legitimate `all` invalidation.
+//
+// `authzKeys.effective(name)` is also invalidated on every user-touching
+// write because the permission simulator's snapshot is derived from the
+// same `UserConfig` row (#3228 follow-up). Without these invalidations the
+// simulator pane shows stale data for up to `STALE_MS` (30s) after an
+// admin saves a policy / role / channel-binding / budget edit.
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -19,14 +25,18 @@ import {
 import {
   userKeys,
   permissionPolicyKeys,
+  authzKeys,
 } from "../queries/keys";
 
 export function useCreateUser() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (payload: UserUpsertPayload) => createUser(payload),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: userKeys.lists() });
+      // The new user is immediately simulatable — drop any cached
+      // "user not found" 404 from a prior lookup of the same name.
+      qc.invalidateQueries({ queryKey: authzKeys.effective(variables.name) });
     },
   });
 }
@@ -39,10 +49,19 @@ export function useUpdateUser() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: userKeys.lists() });
       qc.invalidateQueries({ queryKey: userKeys.detail(variables.originalName) });
+      // `updateUser` can change `role` and `channel_bindings`, both of
+      // which feed the effective-permissions snapshot; invalidate the
+      // simulator cache for both old and (renamed) new identities.
+      qc.invalidateQueries({
+        queryKey: authzKeys.effective(variables.originalName),
+      });
       // If the user renamed, also invalidate the new-name detail cache so
       // any open detail view falls through to a fresh fetch.
       if (variables.payload.name !== variables.originalName) {
         qc.invalidateQueries({ queryKey: userKeys.detail(variables.payload.name) });
+        qc.invalidateQueries({
+          queryKey: authzKeys.effective(variables.payload.name),
+        });
       }
     },
   });
@@ -55,6 +74,10 @@ export function useDeleteUser() {
     onSuccess: (_data, name) => {
       qc.invalidateQueries({ queryKey: userKeys.lists() });
       qc.removeQueries({ queryKey: userKeys.detail(name) });
+      // The simulator should stop showing the deleted user immediately;
+      // remove the snapshot rather than invalidate so a refetch doesn't
+      // race a now-404 endpoint.
+      qc.removeQueries({ queryKey: authzKeys.effective(name) });
     },
   });
 }
@@ -71,6 +94,9 @@ export function useImportUsers() {
       // Dry run never mutates state — keep the cache as-is.
       if (data.dry_run) return;
       qc.invalidateQueries({ queryKey: userKeys.all });
+      // Bulk import can rewrite roles, policies, and channel bindings on
+      // arbitrary users — sweep the entire effective-permissions subtree.
+      qc.invalidateQueries({ queryKey: authzKeys.all });
     },
   });
 }
@@ -90,6 +116,11 @@ export function useUpdateUserPolicy() {
       });
       qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
       qc.invalidateQueries({ queryKey: userKeys.lists() });
+      // Policy edits change every per-user slice the simulator surfaces:
+      // tool_policy, tool_categories, memory_access, channel_tool_rules.
+      qc.invalidateQueries({
+        queryKey: authzKeys.effective(variables.name),
+      });
     },
   });
 }


### PR DESCRIPTION
Follow-up to #3228 (RBAC effective-permissions snapshot).

## Bug

`useEffectivePermissions` (`crates/librefang-api/dashboard/src/lib/queries/authz.ts`) caches with `staleTime: 30_000` and no dashboard mutation invalidated `authzKeys.effective(name)`. After an admin saved a policy / role / channel-binding / budget edit through the dashboard, the permission simulator pane kept showing the pre-edit snapshot for up to 30 s.

The `staleTime` itself is fine — staleness is the right default for a read-only diagnostic page. The bug was specifically the missing invalidation on user-driven writes.

## Invalidation chain added

Every mutation whose write feeds into `EffectivePermissions` (in `librefang-kernel/src/auth.rs`) now invalidates the simulator cache:

| Mutation | What it touches in `EffectivePermissions` | Invalidation |
| --- | --- | --- |
| `useCreateUser` | new identity (clears stale 404) | `authzKeys.effective(name)` |
| `useUpdateUser` | `role`, `channel_bindings` | `authzKeys.effective(originalName)` + new name on rename |
| `useDeleteUser` | identity removed | `removeQueries(authzKeys.effective(name))` (avoids refetch racing the 404) |
| `useImportUsers` | arbitrary rows | `authzKeys.all` (bulk sweep) |
| `useUpdateUserPolicy` | `tool_policy`, `tool_categories`, `memory_access`, `channel_tool_rules` | `authzKeys.effective(name)` |
| `useUpdateUserBudget` / `useDeleteUserBudget` | `budget` | `authzKeys.effective(name)` |

## `channel_role_mapping` decision — NOT added

The reviewer's claim that `EffectivePermissions` is missing M4's `channel_role_mapping` was re-verified and is **incorrect**. The two M4 outputs that ARE per-user — `channel_tool_rules` and `channel_bindings` — are already present in the struct (`auth.rs:194,198`) and rendered in the simulator (`PermissionSimulatorPage.tsx:203-204`).

`channel_role_mapping` itself is **global kernel config**, not per-user data. It translates platform-native admin roles (Telegram supergroup admin, Discord guild admin, Slack workspace admin) into LibreFang roles for inbound senders **without** an explicit `[users.x]` row. By the time we're simulating a registered user, the explicit `channel_bindings` path applies and the global mapping is irrelevant for that user — adding it to a per-user snapshot would be misleading because the value doesn't depend on the selected user.

If a future need arises to surface global RBAC config, it belongs on a separate "RBAC overview" page, not on the per-user simulator.

## Verification

- `pnpm typecheck` produces only pre-existing errors on `client.ts` / `UserBudgetPage.tsx` that also reproduce on a clean `origin/main` checkout (unrelated to this fix).
- No Rust changes were made (decision above), so `cargo` checks were skipped.
- `staleTime: 30_000` is unchanged — only invalidation handlers were added.

## Test plan

- [ ] Open the permission simulator, select user A.
- [ ] In another tab, edit A's policy / role / channel binding / budget.
- [ ] Save and switch back to the simulator — the snapshot should refresh on next focus / mount instead of waiting up to 30 s.
- [ ] Repeat for `useImportUsers` (bulk sweep) and `useDeleteUser` (snapshot disappears immediately).
