### PR TITLE
fix(channels/telegram): prefix sender_chat ids so they can't collide with user namespace (#3215 follow-up)

### DIFF
--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -2447,14 +2447,33 @@ fn parse_telegram_callback_query(
     })
 }
 
+/// Source of a Telegram message's sender id.
+///
+/// `From` means the id came from `message.from.id` and is a real user id
+/// (positive integer per Telegram API). `SenderChat` means the id came from
+/// `message.sender_chat.id` (anonymous channel admins, channel-on-behalf
+/// posts) and is a NEGATIVE chat id — semantically a channel, not a user.
+///
+/// Downstream consumers (RBAC, per-user rate limiting) key off
+/// `metadata[SENDER_USER_ID_KEY]`. Callers must prefix `SenderChat` ids
+/// with `tg_channel:` before writing them so they cannot collide with — or
+/// be mistaken for — a real user identity in the same key namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TelegramSenderSource {
+    From,
+    SenderChat,
+}
+
 /// Extract sender identity from a Telegram message.
 ///
 /// Tries `from` (user) first, then falls back to `sender_chat` (channel/group).
-/// Returns `(user_id, display_name, Option<username>)`.
+/// Returns `(user_id, display_name, Option<username>, source)`. Callers must
+/// inspect `source` before writing `user_id` into `SENDER_USER_ID_KEY` — see
+/// `TelegramSenderSource` for the namespace prefix rule.
 fn extract_telegram_sender(
     message: &serde_json::Value,
     update_id: i64,
-) -> Result<(i64, String, Option<String>), DropReason> {
+) -> Result<(i64, String, Option<String>, TelegramSenderSource), DropReason> {
     if let Some(from) = message.get("from") {
         let uid = match from["id"].as_i64() {
             Some(id) => id,
@@ -2472,7 +2491,7 @@ fn extract_telegram_sender(
             format!("{first_name} {last_name}")
         };
         let username = from["username"].as_str().map(String::from);
-        Ok((uid, name, username))
+        Ok((uid, name, username, TelegramSenderSource::From))
     } else if let Some(sender_chat) = message.get("sender_chat") {
         // Messages sent on behalf of a channel or group have `sender_chat` instead of `from`.
         let uid = match sender_chat["id"].as_i64() {
@@ -2484,7 +2503,12 @@ fn extract_telegram_sender(
             }
         };
         let title = sender_chat["title"].as_str().unwrap_or("Unknown Channel");
-        Ok((uid, title.to_string(), None))
+        Ok((
+            uid,
+            title.to_string(),
+            None,
+            TelegramSenderSource::SenderChat,
+        ))
     } else {
         Err(DropReason::ParseError(format!(
             "update {update_id} has no from or sender_chat field"
@@ -2778,7 +2802,8 @@ async fn parse_telegram_update(
         }
     };
 
-    let (user_id, display_name, username) = extract_telegram_sender(message, update_id)?;
+    let (user_id, display_name, username, sender_source) =
+        extract_telegram_sender(message, update_id)?;
 
     // Security: check allowed_users (supports user ID and username)
     if !telegram_user_allowed(allowed_users, user_id, username.as_deref()) {
@@ -2816,9 +2841,19 @@ async fn parse_telegram_update(
     // sender's user id, so without this entry `bridge::sender_user_id()` would
     // fall back to the chat_id and `auth_manager.identify("telegram", chat_id)`
     // would reject every group message as "Unrecognized user".
+    //
+    // For `sender_chat` (anonymous channel admins / channel-on-behalf posts)
+    // the id is a NEGATIVE chat id, not a user id. Prefix it with
+    // `tg_channel:` so it cannot be mistaken for — or collide with — a real
+    // user identity in the shared SENDER_USER_ID_KEY namespace consumed by
+    // RBAC and per-user rate limiting.
+    let sender_user_id_value = match sender_source {
+        TelegramSenderSource::From => user_id.to_string(),
+        TelegramSenderSource::SenderChat => format!("tg_channel:{user_id}"),
+    };
     metadata.insert(
         SENDER_USER_ID_KEY.to_string(),
-        serde_json::json!(user_id.to_string()),
+        serde_json::json!(sender_user_id_value),
     );
 
     // Store reply-to-message metadata for downstream consumers.
@@ -3593,15 +3628,50 @@ mod tests {
         );
         // sender_chat fallback yields the *channel id*, not a user id. We
         // still write it into SENDER_USER_ID_KEY for shape consistency, but
-        // it is not a real user identity — RBAC will (correctly) reject it
-        // because no `[[users]]` entry maps to a negative channel id.
-        // Documenting the value here so a future change can't silently flip
-        // anonymous-admin / channel-on-behalf posts into authorized users.
+        // it MUST be prefixed with `tg_channel:` so it cannot collide with
+        // — or be mistaken for — a real user identity in the shared
+        // namespace consumed by RBAC and per-user rate limiting. RBAC will
+        // (correctly) reject it because no `[[users]]` entry maps to a
+        // `tg_channel:` prefixed key.
         assert_eq!(
             msg.metadata
                 .get(crate::bridge::SENDER_USER_ID_KEY)
                 .and_then(|v| v.as_str()),
-            Some("-1001999888777"),
+            Some("tg_channel:-1001999888777"),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_from_user_no_prefix() {
+        // Regression: ensure normal `from`-sourced messages write the bare
+        // integer string into SENDER_USER_ID_KEY (no `tg_channel:` prefix).
+        // The prefix is reserved exclusively for the sender_chat fallback
+        // path; applying it to real users would break RBAC lookups.
+        let update = serde_json::json!({
+            "update_id": 502,
+            "message": {
+                "message_id": 82,
+                "from": {
+                    "id": 12345_i64,
+                    "first_name": "Alice",
+                    "username": "alice"
+                },
+                "chat": { "id": 12345_i64, "type": "private" },
+                "date": 1700000000,
+                "text": "hi"
+            }
+        });
+
+        let client = test_client();
+        let msg = parse_telegram_update(&update, &[], &test_ctx(&client), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            msg.metadata
+                .get(crate::bridge::SENDER_USER_ID_KEY)
+                .and_then(|v| v.as_str()),
+            Some("12345"),
+            "from-sourced sender id must be the bare integer, no `tg_channel:` prefix",
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #3215. The Telegram sender extraction added in that PR
falls back to `message.sender_chat.id` when `from` is absent — the
case for anonymous channel admins and channel-on-behalf posts. The
resulting NEGATIVE chat id (per Telegram API) was being written
verbatim into `metadata[SENDER_USER_ID_KEY]`, which is the shared
key namespace consumed by RBAC and per-user rate limiting.

A negative chat id can never collide with a real user id (Telegram
user ids are positive integers), but it still:
- pollutes the per-user rate-limit bucket map with fake "users"
  (each anonymous-admin-posting channel becomes its own bucket)
- creates semantic confusion in audit logs and any downstream
  consumer that does `if id starts with "-": treat as channel`-style
  heuristics

This PR makes the channel-vs-user distinction structural rather
than relying on sign conventions.

## Fix

- New private enum `TelegramSenderSource { From, SenderChat }`
  threaded through `extract_telegram_sender`'s return tuple
- At the single SENDER_USER_ID_KEY write site that observes the
  fallback (`parse_telegram_update`), branch on the source:
  - `From` → bare integer string (unchanged: `"12345"`)
  - `SenderChat` → prefixed: `"tg_channel:-1001999888777"`

The other two SENDER_USER_ID_KEY write sites in this file
(poll_answer, callback_query) both require a real `from` field
upstream and are intentionally untouched.

## Why `tg_channel:` prefix

- Cannot lex as a positive integer string, so it can never be
  confused with a real user id by any downstream consumer
- Self-documenting in audit logs and rate-limit metrics
- Reserves the `tg_channel:` namespace for any future
  channel-as-sender shapes Telegram introduces

## Repro (before this PR)

Send a Telegram message from a user posting "as the channel"
into a supergroup the bot is in. The metadata recorded for that
message would contain:

```
SENDER_USER_ID_KEY = "-1001999888777"
```

After this PR:

```
SENDER_USER_ID_KEY = "tg_channel:-1001999888777"
```

## Test plan

- [x] `cargo test -p librefang-channels --lib telegram::tests::` (116 passed)
- [x] `cargo clippy -p librefang-channels --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --all` (clean)
- [x] Updated `test_parse_sender_chat_fallback` (originally added in
      #3215 to pin the prior verbatim-negative-id behavior) now asserts
      the prefixed form
- [x] Added `test_parse_from_user_no_prefix` regression so a future
      change cannot silently apply the prefix to real `from`-sourced
      messages and break RBAC lookups
- [x] Existing `test_sender_chat_allowed_users_id_only`,
      `test_group_message_carries_sender_user_id_metadata`, and
      `test_private_message_also_carries_sender_user_id_metadata`
      still pass — `allowed_users` matching still operates on the raw
      i64 and is unchanged
