### PR TITLE
fix(audit/export): include prev_hash so verifiers can replay the chain (#3203 follow-up)

### DIFF
--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -370,6 +370,7 @@ fn stream_json(entries: Vec<AuditEntry>) -> Response {
             "user_id": e.user_id.map(|u| u.to_string()),
             "channel": e.channel,
             "hash": e.hash,
+            "prev_hash": e.prev_hash,
         });
         let mut buf = Vec::with_capacity(256);
         if !first {
@@ -392,7 +393,7 @@ fn stream_json(entries: Vec<AuditEntry>) -> Response {
         })
 }
 
-/// Emit CSV with a fixed schema: `seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash`.
+/// Emit CSV with a fixed schema: `seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash,prev_hash`.
 /// Header row is first; every cell is wrapped in `"…"` if it contains a
 /// comma, quote, CR, or LF (RFC 4180). Existing quotes inside a cell are
 /// doubled. This pins the format so downstream parsers (Excel, csv-rs,
@@ -402,11 +403,15 @@ pub(crate) fn stream_csv(entries: Vec<AuditEntry>) -> Response {
 
     let mut chunks: Vec<Result<Vec<u8>, std::io::Error>> = Vec::with_capacity(entries.len() + 1);
     chunks.push(Ok(
-        b"seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash\n".to_vec(),
+        b"seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash,prev_hash\n".to_vec(),
     ));
     for e in entries {
+        // `prev_hash` is appended as the last column so a downstream
+        // verifier can replay the SHA-256 chain off the dump alone (see
+        // `librefang-runtime::audit::compute_hash`). Without it, the
+        // export is unverifiable — the whole point of the hash chain.
         let line = format!(
-            "{},{},{},{},{},{},{},{},{}\n",
+            "{},{},{},{},{},{},{},{},{},{}\n",
             e.seq,
             csv_escape(&e.timestamp),
             csv_escape(&e.agent_id),
@@ -416,6 +421,7 @@ pub(crate) fn stream_csv(entries: Vec<AuditEntry>) -> Response {
             csv_escape(&e.user_id.map(|u| u.to_string()).unwrap_or_default()),
             csv_escape(e.channel.as_deref().unwrap_or("")),
             csv_escape(&e.hash),
+            csv_escape(&e.prev_hash),
         );
         chunks.push(Ok(line.into_bytes()));
     }
@@ -659,6 +665,65 @@ mod tests {
         // Inner-position formula sentinels are NOT prefixed (only first char).
         assert_eq!(csv_escape("a=b"), "a=b");
         assert_eq!(csv_escape("foo+bar"), "foo+bar");
+    }
+
+    /// Drain a streaming `Response` body to a UTF-8 `String`. Used by the
+    /// export-roundtrip tests below — `Body::from_stream` doesn't expose a
+    /// sync `to_bytes`, so we go through `http_body_util::BodyExt::collect`.
+    async fn body_to_string(resp: Response) -> String {
+        use http_body_util::BodyExt;
+        let bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .expect("collect streaming body")
+            .to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("UTF-8")
+    }
+
+    /// JSON export must include `prev_hash` for every entry. Without it,
+    /// a downstream verifier can't replay the SHA-256 chain off the dump
+    /// — defeating the integrity guarantee the chain exists for.
+    #[tokio::test]
+    async fn test_stream_json_includes_prev_hash() {
+        let mut e = entry(7, "agent-1", AuditAction::ToolInvoke, "x", None, None);
+        e.prev_hash = "a".repeat(64);
+        e.hash = "b".repeat(64);
+
+        let resp = stream_json(vec![e]);
+        let body = body_to_string(resp).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON array");
+        let first = &parsed[0];
+        assert_eq!(
+            first["prev_hash"],
+            serde_json::Value::String("a".repeat(64)),
+            "prev_hash must round-trip on the JSON export so verifiers can replay the chain"
+        );
+        assert_eq!(first["hash"], serde_json::Value::String("b".repeat(64)));
+    }
+
+    /// CSV export must carry `prev_hash` as the last column. The header
+    /// row schema is part of the public download contract — pin both the
+    /// header and the per-row value here.
+    #[tokio::test]
+    async fn test_stream_csv_includes_prev_hash_column() {
+        let mut e = entry(7, "agent-1", AuditAction::ToolInvoke, "x", None, None);
+        e.prev_hash = "a".repeat(64);
+        e.hash = "b".repeat(64);
+
+        let resp = stream_csv(vec![e]);
+        let body = body_to_string(resp).await;
+        let mut lines = body.lines();
+        let header = lines.next().unwrap_or("");
+        assert_eq!(
+            header, "seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash,prev_hash",
+            "CSV header must end with `prev_hash` so the chain is verifiable"
+        );
+        let row = lines.next().unwrap_or("");
+        assert!(
+            row.ends_with(&format!(",{},{}", "b".repeat(64), "a".repeat(64))),
+            "CSV row must end with `…,hash,prev_hash`; got {row:?}"
+        );
     }
 
     #[test]

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2962,8 +2962,9 @@ async fn test_audit_export_csv_emits_documented_headers() {
     let text = resp.text().await.unwrap();
     let first_line = text.lines().next().unwrap_or("");
     assert_eq!(
-        first_line, "seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash",
-        "CSV header row schema must remain stable for downstream parsers"
+        first_line, "seq,timestamp,agent_id,action,detail,outcome,user_id,channel,hash,prev_hash",
+        "CSV header row schema must remain stable for downstream parsers; \
+         `prev_hash` is the last column so a verifier can replay the chain"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #3203 (RBAC M5 audit query/export + per-user budget API). The shipped `/api/audit/export` JSON and CSV emitters in `routes/audit.rs` drop `prev_hash` from the output. `AuditEntry` carries it (it's the predecessor pointer in the SHA-256 hash chain), but the export only emits `hash`. Without `prev_hash` on the dump, a downstream verifier cannot replay the chain — they can hash a row's content but have no way to bind it to the chain anchor. That defeats the whole reason the audit log is a hash chain in the first place.

## Changes

- `stream_json` (`routes/audit.rs:363`): append `"prev_hash": e.prev_hash` to the per-entry object after `hash`.
- `stream_csv` (`routes/audit.rs:400`): append `prev_hash` as the last column on both the header row and the per-entry format string. Routed through the existing `csv_escape` for consistency, even though hex SHA-256 won't trip the RFC-4180 escape paths.
- Existing column order is preserved exactly — `prev_hash` is appended at the tail so any downstream parser keyed off the documented schema only needs to add one new tail column.

## Tests

- `audit::tests::test_stream_json_includes_prev_hash` — calls `stream_json`, drains the streamed body via `http_body_util::BodyExt::collect`, parses the JSON array, and asserts `prev_hash` round-trips for one entry.
- `audit::tests::test_stream_csv_includes_prev_hash_column` — pins the new header row literal and asserts the per-entry row ends with `,{hash},{prev_hash}`.
- `test_audit_export_csv_emits_documented_headers` (integration) — updated to expect the new header schema.

All run green:

```
cargo check -p librefang-api --tests
cargo test  -p librefang-api --lib --tests audit   # 9 unit + 8 integration, all pass
cargo clippy -p librefang-api --tests -- -D warnings
cargo fmt --all
```

## Out of scope

The same review also flagged that `audit_export` materialises the filtered `Vec<AuditEntry>` in memory before streaming, so the `Body::from_stream` chunking is cosmetic and a 50K-row export still costs ~50K rows of RAM. That is a real concern but is a separate, larger change (true row-by-row streaming from SQLite, with a different cursor strategy). This PR fixes only the integrity/verifiability bug; the buffering optimisation is left for a follow-up.

## Test plan

- [ ] CI build + unit tests + clippy on this branch
- [ ] Live: hit `/api/audit/export?format=json` after a few real audited actions and confirm every entry has `prev_hash`.
- [ ] Live: hit `/api/audit/export?format=csv` and confirm header is `…,hash,prev_hash` and every row ends with the SHA-256 of the previous row's hash field.
- [ ] Replay: write a tiny script that consumes the JSON export, recomputes `compute_hash` from `librefang-runtime::audit`, and asserts the chain links — should now be possible end-to-end.
