### PR TITLE
fix(authz/check): mark scope as user_policy_only to match implementation (#3231 follow-up)

### DIFF
--- a/crates/librefang-api/src/routes/authz.rs
+++ b/crates/librefang-api/src/routes/authz.rs
@@ -30,8 +30,9 @@ use axum::Json;
 use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::user_policy::UserToolGate;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 /// Build admin-gated authz / effective-permissions routes.
 pub fn router() -> axum::Router<Arc<AppState>> {
@@ -145,13 +146,63 @@ pub struct CheckQuery {
     pub channel: Option<String>,
 }
 
-/// GET /api/authz/check — admin-only single-decision permission query.
+/// Response body for `GET /api/authz/check`.
 ///
-/// Answers "can user X invoke tool Y on channel Z right now?" by calling
-/// the same `AuthManager::resolve_user_tool_decision` the runtime gate
-/// path uses. **Production single source of truth** — this endpoint
-/// returns whatever the dispatcher would return, no parallel
-/// re-implementation that could drift.
+/// Dashboard surfaces (when added) MUST display the disclaimer that
+/// goes with `scope = "user_policy_only"`: "User-policy decision only —
+/// runtime gate may differ" because per-agent `ToolPolicy` and global
+/// `ApprovalPolicy.channel_rules` are not consulted by this endpoint.
+/// Today no dashboard page consumes this endpoint; new consumers must
+/// honour that contract before shipping.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthzCheckResponse {
+    /// Echoes the `user` query parameter (UUID or name as supplied).
+    pub user: String,
+    /// Echoes the `action` query parameter.
+    pub action: String,
+    /// Echoes the `channel` query parameter, or `null` when omitted.
+    pub channel: Option<String>,
+    /// Decision label: `"allow"`, `"deny"`, or `"needs_approval"`.
+    pub decision: String,
+    /// Convenience flag — true only when `decision == "allow"`.
+    pub allowed: bool,
+    /// Human-readable reason when the decision is not `allow`. `None`
+    /// for `allow`.
+    pub reason: Option<String>,
+    /// **Always** `"user_policy_only"`. Marker that this decision is
+    /// computed from the user's RBAC slice alone (Layer A + Layer B in
+    /// [`AuthManager::resolve_decision_for_user`]) and does NOT include
+    /// per-agent `ToolPolicy::check_tool`, global
+    /// `ApprovalPolicy.channel_rules`, or the per-call approval gate.
+    /// The runtime tool-gate may therefore deny or require approval for
+    /// a tool that this endpoint reports as allowed.
+    pub scope: &'static str,
+}
+
+/// GET /api/authz/check — admin-only **user-policy-only** decision query.
+///
+/// Answers "would user X's per-user RBAC policy permit tool Y on channel
+/// Z?" by calling [`AuthManager::resolve_decision_for_user`], which walks
+/// Layer A (the user's own `tool_policy` / `tool_categories` /
+/// `channel_tool_rules`) and Layer B (role-escalation: would an admin
+/// have allowed it?).
+///
+/// **Scope is intentionally narrow — this is NOT the full runtime gate
+/// decision.** The production tool-gate path additionally intersects with:
+/// - per-agent [`ToolPolicy::check_tool`] (allow/blocklist from
+///   `agent.toml` — varies per agent),
+/// - global `ApprovalPolicy.channel_rules` (e.g. `shell_*` always
+///   requires approval regardless of user policy),
+/// - the existing per-call approval / capability gates.
+///
+/// Those layers depend on which agent is invoking the tool and the
+/// runtime context, neither of which this query carries. So an `Allow`
+/// here can still surface as `NeedsApproval` or `Deny` at runtime if a
+/// per-agent ToolPolicy or channel rule says so. The response always
+/// carries `scope: "user_policy_only"` to make this contract explicit
+/// to operators debugging gate mismatches; widening to the full gate
+/// path is a future RFC (would require an `agent_id` query param —
+/// breaking API change).
 ///
 /// Returns 404 when the user can't be matched, so external callers can
 /// distinguish "not registered" from "registered but denied". The
@@ -167,7 +218,7 @@ pub struct CheckQuery {
         ("channel" = Option<String>, Query, description = "Channel context (telegram, slack, api, ...)"),
     ),
     responses(
-        (status = 200, description = "Decision payload", body = serde_json::Value),
+        (status = 200, description = "User-policy decision payload (scope = user_policy_only)", body = AuthzCheckResponse),
         (status = 404, description = "Unknown user"),
     )
 )]
@@ -204,21 +255,34 @@ pub async fn check(
     // surface doesn't have, and would silently fall back to the guest
     // gate (returning `needs_approval`) for users whose policy actually
     // hard-denies the action.
+    //
+    // SCOPE NOTE: `resolve_decision_for_user` walks Layer A (user's
+    // own policy) + Layer B (role escalation) ONLY. The runtime
+    // tool-gate also intersects per-agent `ToolPolicy::check_tool` (from
+    // `agent.toml`) and global `ApprovalPolicy.channel_rules`
+    // (e.g. `shell_*` always-approve), neither of which is consulted
+    // here — both depend on an `agent_id` the caller doesn't supply.
+    // The response sets `scope: "user_policy_only"` to advertise this;
+    // future widening to the full gate is tracked as an API-breaking
+    // RFC (M6/M7).
     let gate = auth.resolve_decision_for_user(user_id, &q.action, q.channel.as_deref());
 
     let (decision, allowed, reason) = match gate {
-        UserToolGate::Allow => ("allow", true, None),
-        UserToolGate::Deny { reason } => ("deny", false, Some(reason)),
-        UserToolGate::NeedsApproval { reason } => ("needs_approval", false, Some(reason)),
+        UserToolGate::Allow => ("allow".to_string(), true, None),
+        UserToolGate::Deny { reason } => ("deny".to_string(), false, Some(reason)),
+        UserToolGate::NeedsApproval { reason } => {
+            ("needs_approval".to_string(), false, Some(reason))
+        }
     };
 
-    Json(serde_json::json!({
-        "user": q.user,
-        "action": q.action,
-        "channel": q.channel,
-        "decision": decision,
-        "allowed": allowed,
-        "reason": reason,
-    }))
+    Json(AuthzCheckResponse {
+        user: q.user,
+        action: q.action,
+        channel: q.channel,
+        decision,
+        allowed,
+        reason,
+        scope: "user_policy_only",
+    })
     .into_response()
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3496,6 +3496,81 @@ async fn test_authz_check_returns_allow_for_permitted_tool() {
     assert_eq!(body["decision"], "allow");
     assert_eq!(body["allowed"], true);
     assert!(body["reason"].is_null());
+    // `scope` advertises that this is a user-policy-only decision and
+    // does NOT consult per-agent ToolPolicy or channel_rules. Operators
+    // and any future dashboard consumer rely on this marker to display
+    // the "runtime gate may differ" disclaimer.
+    assert_eq!(
+        body["scope"], "user_policy_only",
+        "scope must mark the decision as user-policy-only — see authz.rs::check docstring"
+    );
+}
+
+/// Regression for #3231 follow-up: a typical query must always carry
+/// `scope: "user_policy_only"` so callers can render the disclaimer
+/// that the runtime gate may still deny or require approval (per-agent
+/// ToolPolicy + ApprovalPolicy.channel_rules are not consulted by this
+/// endpoint).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_authz_check_response_advertises_user_policy_only_scope() {
+    let alice = UserConfig {
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        ..Default::default()
+    };
+    let bob = UserConfig {
+        name: "Bob".to_string(),
+        role: "user".to_string(),
+        tool_policy: Some(UserToolPolicy {
+            allowed_tools: vec!["web_search".to_string()],
+            denied_tools: vec!["shell_exec".to_string()],
+        }),
+        ..Default::default()
+    };
+    let server = start_test_server_with_full_user_configs(
+        "any-key",
+        vec![(alice, "alice-admin-key"), (bob, "bob-key")],
+    )
+    .await;
+    let client = reqwest::Client::new();
+
+    // Allow case.
+    let allow: serde_json::Value = client
+        .get(format!(
+            "{}/api/authz/check?user=Bob&action=web_search&channel=api",
+            server.base_url
+        ))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(allow["decision"], "allow");
+    assert_eq!(
+        allow["scope"], "user_policy_only",
+        "allow path must carry scope marker"
+    );
+
+    // Deny case — scope marker must travel with every decision class.
+    let deny: serde_json::Value = client
+        .get(format!(
+            "{}/api/authz/check?user=Bob&action=shell_exec",
+            server.base_url
+        ))
+        .header("authorization", "Bearer alice-admin-key")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(deny["decision"], "deny");
+    assert_eq!(
+        deny["scope"], "user_policy_only",
+        "deny path must carry scope marker"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -3536,6 +3611,7 @@ async fn test_authz_check_returns_deny_for_blocked_tool() {
     assert_eq!(body["decision"], "deny");
     assert_eq!(body["allowed"], false);
     assert!(body["reason"].as_str().unwrap_or("").contains("shell_exec"));
+    assert_eq!(body["scope"], "user_policy_only");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Follow-up to MERGED #3231. The `/api/authz/check` endpoint advertised itself as the **runtime gate's source of truth**, but it only walks `AuthManager::resolve_decision_for_user` (Layer A: user policy + Layer B: role escalation). It does **not** consult:

- per-agent `ToolPolicy::check_tool` (the per-agent allow/block list from `agent.toml`)
- global `ApprovalPolicy.channel_rules` (e.g. `shell_*` always-approve regardless of user policy)

Both depend on an `agent_id` the endpoint doesn't accept. So an `Allow` here can still surface as `NeedsApproval` or `Deny` at runtime, leading operators to chase phantom RBAC bugs.

## Approach

Document-of-truth fix — **don't change the decision logic** (callers depend on it), but advertise the scope honestly. The full-gate widening would require an `agent_id` query param (API-breaking) and is tracked as a future RFC.

## Changes

- Replace ad-hoc `serde_json::json!` body with typed `AuthzCheckResponse` (`utoipa::ToSchema`) carrying `scope: "user_policy_only"`.
- Long docstring on both the handler and the response struct enumerating exactly which layers are NOT consulted.
- OpenAPI 200 response points at `AuthzCheckResponse`.

## Tests

- `test_authz_check_returns_allow_for_permitted_tool` extended to assert `body["scope"] == "user_policy_only"`.
- New `test_authz_check_response_advertises_user_policy_only_scope` pins the marker on both Allow and Deny paths.

## Heads-up: OpenAPI drift

This change tightens the response schema (Value → typed struct), so CI's "OpenAPI Drift" check will flag it. I'll regen `openapi.json` + the 4 SDK clients in a chained commit on this branch once CI confirms the failure scope.

Refs #3231 review item #14.
