### PR TITLE
feat(approval): include agent name in approval notifications

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -16082,7 +16082,8 @@ impl KernelHandle for LibreFangKernel {
 
         let policy = self.approval_manager.policy();
         let risk_level = crate::approval::ApprovalManager::classify_risk(tool_name);
-        let description = format!("Agent {} requests to execute {}", agent_id, tool_name);
+        let agent_display = self.approval_agent_display(agent_id);
+        let description = format!("Agent {} requests to execute {}", agent_display, tool_name);
         let request_id = uuid::Uuid::new_v4();
         let req = TypedRequest {
             id: request_id,
@@ -16165,9 +16166,9 @@ impl KernelHandle for LibreFangKernel {
                 };
 
             let msg = format!(
-                "{} Approval needed: agent \"{}\" wants to run `{}` — {}",
+                "{} Approval needed: agent {} wants to run `{}` — {}",
                 risk_level.emoji(),
-                agent_id,
+                agent_display,
                 tool_name,
                 description,
             );
@@ -16236,7 +16237,8 @@ impl KernelHandle for LibreFangKernel {
 
         let policy = self.approval_manager.policy();
         let risk_level = crate::approval::ApprovalManager::classify_risk(tool_name);
-        let description = format!("Agent {} requests to execute {}", agent_id, tool_name);
+        let agent_display = self.approval_agent_display(agent_id);
+        let description = format!("Agent {} requests to execute {}", agent_display, tool_name);
         let request_id = uuid::Uuid::new_v4();
         let req = TypedRequest {
             id: request_id,
@@ -16310,9 +16312,9 @@ impl KernelHandle for LibreFangKernel {
                 }
             };
             let msg = format!(
-                "{} Approval needed: agent \"{}\" wants to run `{}` — {}",
+                "{} Approval needed: agent {} wants to run `{}` — {}",
                 risk_level.emoji(),
-                agent_id,
+                agent_display,
                 tool_name,
                 description,
             );
@@ -17137,6 +17139,18 @@ impl KernelHandle for LibreFangKernel {
 // ---------------------------------------------------------------------------
 
 impl LibreFangKernel {
+    /// Render an agent identifier for human-facing messages: `"name" (short-id)`
+    /// when the agent is in the registry, otherwise the raw id verbatim.
+    fn approval_agent_display(&self, agent_id: &str) -> String {
+        if let Ok(aid) = agent_id.parse::<AgentId>() {
+            if let Some(entry) = self.registry.get(aid) {
+                let short = agent_id.get(..8).unwrap_or(agent_id);
+                return format!("\"{}\" ({})", entry.name, short);
+            }
+        }
+        format!("\"{}\"", agent_id)
+    }
+
     async fn notify_escalated_approval(
         &self,
         req: &librefang_types::approval::ApprovalRequest,
@@ -17178,10 +17192,10 @@ impl LibreFangKernel {
             };
 
         let msg = format!(
-            "{} ESCALATION #{}: Approval still needed: agent \"{}\" wants to run `{}` - {}",
+            "{} ESCALATION #{}: Approval still needed: agent {} wants to run `{}` - {}",
             req.risk_level.emoji(),
             req.escalation_count,
-            req.agent_id,
+            self.approval_agent_display(&req.agent_id),
             req.tool_name,
             req.description,
         );

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17141,11 +17141,23 @@ impl KernelHandle for LibreFangKernel {
 impl LibreFangKernel {
     /// Render an agent identifier for human-facing messages: `"name" (short-id)`
     /// when the agent is in the registry, otherwise the raw id verbatim.
+    ///
+    /// Do not use this for audit detail strings or any field that downstream
+    /// queries filter on — those need the canonical UUID so that
+    /// `/api/audit/query?agent=<uuid>` keeps working. This helper is for
+    /// operator-facing copy (push notifications, channel messages,
+    /// human-readable descriptions) only.
     fn approval_agent_display(&self, agent_id: &str) -> String {
         if let Ok(aid) = agent_id.parse::<AgentId>() {
             if let Some(entry) = self.registry.get(aid) {
                 let short = agent_id.get(..8).unwrap_or(agent_id);
-                return format!("\"{}\" ({})", entry.name, short);
+                // Names are user-configured free text. Escape embedded `"` so
+                // adapters that interpret the surrounding context (Telegram
+                // MarkdownV2, Discord, etc.) don't see a malformed message
+                // that fails to render — operators can't approve what they
+                // can't see.
+                let safe_name = entry.name.replace('"', "\\\"");
+                return format!("\"{}\" ({})", safe_name, short);
             }
         }
         format!("\"{}\"", agent_id)

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4332,3 +4332,99 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
 
     kernel.shutdown();
 }
+
+// ---------------------------------------------------------------------------
+// approval_agent_display
+// ---------------------------------------------------------------------------
+
+fn boot_kernel_for_display_tests() -> LibreFangKernel {
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    // Leak the tempdir so the kernel keeps a valid home for the rest of the
+    // test — the kernel is shut down before the test returns, but we don't
+    // need to delete files between assertions.
+    std::mem::forget(dir);
+    LibreFangKernel::boot_with_config(config).expect("Kernel should boot")
+}
+
+fn register_test_agent(kernel: &LibreFangKernel, name: &str) -> AgentId {
+    let id = AgentId::new();
+    let entry = AgentEntry {
+        id,
+        name: name.to_string(),
+        manifest: test_manifest(name, "test agent", vec![]),
+        state: AgentState::Running,
+        mode: AgentMode::default(),
+        created_at: chrono::Utc::now(),
+        last_active: chrono::Utc::now(),
+        parent: None,
+        children: vec![],
+        session_id: SessionId::new(),
+        tags: vec![],
+        identity: Default::default(),
+        onboarding_completed: false,
+        onboarding_completed_at: None,
+        source_toml_path: None,
+        is_hand: false,
+        ..Default::default()
+    };
+    kernel.registry.register(entry).unwrap();
+    id
+}
+
+#[test]
+fn approval_display_registered_agent_returns_name_and_short_id() {
+    let kernel = boot_kernel_for_display_tests();
+    let id = register_test_agent(&kernel, "jarvis");
+    let id_str = id.to_string();
+
+    let rendered = kernel.approval_agent_display(&id_str);
+
+    let expected_short = &id_str[..8];
+    assert_eq!(rendered, format!("\"jarvis\" ({})", expected_short));
+
+    kernel.shutdown();
+}
+
+#[test]
+fn approval_display_unknown_uuid_falls_back_to_raw_quoted() {
+    let kernel = boot_kernel_for_display_tests();
+    let unknown = AgentId::new().to_string();
+
+    let rendered = kernel.approval_agent_display(&unknown);
+
+    assert_eq!(rendered, format!("\"{}\"", unknown));
+
+    kernel.shutdown();
+}
+
+#[test]
+fn approval_display_non_uuid_string_falls_back_verbatim() {
+    let kernel = boot_kernel_for_display_tests();
+
+    let rendered = kernel.approval_agent_display("not-a-uuid");
+
+    assert_eq!(rendered, "\"not-a-uuid\"");
+
+    kernel.shutdown();
+}
+
+#[test]
+fn approval_display_escapes_quote_in_agent_name() {
+    let kernel = boot_kernel_for_display_tests();
+    let id = register_test_agent(&kernel, "jar\"vis");
+    let id_str = id.to_string();
+
+    let rendered = kernel.approval_agent_display(&id_str);
+
+    let expected_short = &id_str[..8];
+    assert_eq!(rendered, format!("\"jar\\\"vis\" ({})", expected_short));
+
+    kernel.shutdown();
+}


### PR DESCRIPTION
## Summary
- Approval push notifications (Telegram, etc.) previously rendered the bare agent UUID, e.g. `agent "144dee90-c98b-5f25-bec5-a75537d77298" wants to run mcp_filesystem_list_directory`, making it nearly impossible to tell which agent was asking from a phone screen.
- Add a small `approval_agent_display()` helper on `LibreFangKernel` that looks the id up in the registry and returns `"<name>" (<short-id>)`, falling back to the raw id when the agent isn't registered. Embedded `"` in the registry name is escaped so adapters that interpret the surrounding context (Telegram MarkdownV2, Discord, etc.) don't see a malformed message.
- Wire it into all three notification paths in `crates/librefang-kernel/src/kernel/mod.rs`: blocking `request_approval`, non-blocking `submit_tool_approval`, and `notify_escalated_approval`. Both the human-facing `description` field and the channel `msg` use the display form.

After:
```
⚠️ Approval needed: agent "jarvis" (144dee90) wants to run `mcp_filesystem_list_directory` — Agent "jarvis" (144dee90) requests to execute mcp_filesystem_list_directory
```

> **Format note for log scrapers:** the `ApprovalRequest.description` string changed from `Agent <uuid> requests to execute <tool>` to `Agent "<name>" (<short>) requests to execute <tool>`. It's free-form text (no schema break), but anyone matching that field with a regex will need to update their pattern.

## Test plan
- [x] `cargo build -p librefang-kernel --lib`
- [x] `cargo test -p librefang-kernel --lib approval_display` — 4/4 pass (registered agent / unknown UUID / non-UUID string / quote-in-name escape)
- [x] `cargo clippy -p librefang-kernel --lib --tests -- -D warnings`
- [ ] Trigger a tool that requires approval from a registered agent and verify the Telegram/notification target shows the agent name + short id
- [ ] Trigger an approval for an agent_id that isn't in the registry (e.g. stale or external) and verify the message gracefully falls back to the raw id
- [ ] Let an approval escalate and verify the escalation message also carries the name