### PR TITLE
fix(security): RBAC M3 follow-up — namespace traversal + case-insensitive deny + memory audit emit (#3205)

### DIFF
--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -216,11 +216,50 @@ fn anonymous_fallback_acl() -> librefang_types::user_policy::UserMemoryAccess {
     }
 }
 
-/// Convert an `AuthDenied` error to a 403 JSON response.
-fn auth_denied(reason: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+/// Convert an `AuthDenied` error to a 403 JSON response **and** record a
+/// `PermissionDenied` audit row.
+///
+/// The reviewer of PR #3205 flagged that memory ACL denials at the API
+/// layer were silently dropped from the audit chain, while the parallel
+/// `routes/audit.rs`, `routes/budget.rs`, `routes/authz.rs`, and the
+/// global auth middleware all emit a `PermissionDenied` row. This helper
+/// closes that gap so a privilege probe against `/api/memory*` shows up
+/// in `/api/audit` and the `audit.log` chain.
+///
+/// Anonymous (loopback / no-auth mode) callers are recorded with
+/// `user_id = None` and the reason string in the detail field — same
+/// shape as `routes/audit.rs::require_admin`.
+fn auth_denied(
+    state: &AppState,
+    extensions: &axum::http::Extensions,
+    reason: impl std::fmt::Display,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let reason_str = reason.to_string();
+    let api_user = extensions.get::<crate::middleware::AuthenticatedApiUser>();
+    let (user_id, detail) = match api_user {
+        Some(u) => (
+            Some(u.user_id),
+            format!(
+                "memory denied for {} (role={}): {reason_str}",
+                u.name, u.role
+            ),
+        ),
+        None => (
+            None,
+            format!("memory denied for anonymous caller: {reason_str}"),
+        ),
+    };
+    state.kernel.audit().record_with_context(
+        "system",
+        librefang_runtime::audit::AuditAction::PermissionDenied,
+        detail,
+        "denied",
+        user_id,
+        Some("api".to_string()),
+    );
     (
         StatusCode::FORBIDDEN,
-        Json(serde_json::json!({"error": reason.to_string()})),
+        Json(serde_json::json!({"error": reason_str})),
     )
 }
 
@@ -257,7 +296,9 @@ pub async fn memory_search(
             StatusCode::OK,
             Json(serde_json::json!({ "memories": items })),
         ),
-        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => auth_denied(reason),
+        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => {
+            auth_denied(&state, request.extensions(), reason)
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -324,7 +365,9 @@ pub async fn memory_list(
                 })),
             )
         }
-        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => auth_denied(reason),
+        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => {
+            auth_denied(&state, request.extensions(), reason)
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -357,7 +400,9 @@ pub async fn memory_get_user(
             StatusCode::OK,
             Json(serde_json::json!({ "memories": items })),
         ),
-        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => auth_denied(reason),
+        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => {
+            auth_denied(&state, request.extensions(), reason)
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -728,7 +773,9 @@ pub async fn memory_list_agent(
                 })),
             )
         }
-        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => auth_denied(reason),
+        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => {
+            auth_denied(&state, request.extensions(), reason)
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -770,7 +817,9 @@ pub async fn memory_search_agent(
             StatusCode::OK,
             Json(serde_json::json!({ "memories": items })),
         ),
-        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => auth_denied(reason),
+        Err(librefang_types::error::LibreFangError::AuthDenied(reason)) => {
+            auth_denied(&state, request.extensions(), reason)
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -1331,23 +1380,26 @@ pub async fn memory_config_patch(
 
 #[cfg(test)]
 mod tests {
-    //! Regression tests for PR #3205 follow-up — Issue #6 fail-open fix.
+    //! Regression tests for PR #3205 follow-ups.
     //!
-    //! Pin the contract that an anonymous request (no
-    //! `AuthenticatedApiUser` extension) gets a Viewer-equivalent ACL,
-    //! NOT the previous owner-equivalent fallback. The owner-equivalent
-    //! fallback (`readable=["*"]`, `pii_access=true`,
-    //! `export_allowed=true`, `delete_allowed=true`) was a fail-open bug
-    //! that let any loopback / `LIBREFANG_ALLOW_NO_AUTH=1` caller
-    //! exfiltrate every memory fragment including PII and bulk-delete
-    //! across agents.
+    //! - **Issue #6 (fail-open)**: anonymous request (no
+    //!   `AuthenticatedApiUser` extension) must get a Viewer-equivalent
+    //!   ACL, NOT the historical owner-equivalent fallback.
+    //!   `anonymous_fallback_*` tests pin that contract.
+    //! - **Issue #8b (missing audit emit)**: a memory ACL denial at the
+    //!   API layer must record a `PermissionDenied` audit row, matching
+    //!   `routes/audit.rs`, `routes/budget.rs`, `routes/authz.rs`, and
+    //!   the global auth middleware. `auth_denied_emits_audit_*` tests
+    //!   pin that contract.
     //!
-    //! These tests exercise [`anonymous_fallback_acl`] directly because
+    //! `anonymous_fallback_*` tests exercise the helper directly because
     //! constructing a real [`AppState`] requires booting an entire
-    //! kernel; the integration test in `api_integration_test.rs`
-    //! covers the wiring through the HTTP stack.
+    //! kernel; `auth_denied_*` tests do boot a kernel because we need to
+    //! observe the audit chain.
     use super::*;
     use librefang_memory::namespace_acl::{MemoryNamespaceGuard, NamespaceGate};
+    use librefang_runtime::audit::AuditAction;
+    use librefang_types::config::KernelConfig;
 
     #[test]
     fn anonymous_fallback_denies_pii_export_and_delete() {
@@ -1369,9 +1421,6 @@ mod tests {
             "anonymous fallback must NOT permit writes, got {:?}",
             acl.writable_namespaces
         );
-        // Reads are scoped to `proactive` only — `kv:*` / `shared:*` /
-        // `kg` must all fail closed. We assert on the namespace list
-        // here AND on the guard semantics below.
         assert_eq!(
             acl.readable_namespaces,
             vec!["proactive".to_string()],
@@ -1383,16 +1432,11 @@ mod tests {
     fn anonymous_fallback_guard_gates_match_acl_intent() {
         let guard = MemoryNamespaceGuard::new(anonymous_fallback_acl());
 
-        // Allowed: reading the `proactive` namespace so the loopback
-        // dashboard list/search keeps working (with PII redacted).
         assert!(matches!(
             guard.check_read("proactive"),
             NamespaceGate::Allow
         ));
 
-        // Denied: every other namespace, all writes, all exports, all
-        // deletes — the four channels through which the pre-fix
-        // fallback leaked sensitive data.
         assert!(matches!(
             guard.check_read("kv:secrets"),
             NamespaceGate::Deny(_)
@@ -1417,6 +1461,128 @@ mod tests {
         assert!(
             !guard.pii_access_allowed(),
             "fallback guard must redact PII"
+        );
+    }
+
+    /// Minimal `AppState` for unit-testing the audit-emit path of
+    /// [`auth_denied`]. Mirrors the fixture in `routes/agents.rs` but
+    /// keeps fields to the bare minimum we touch here.
+    fn audit_test_app_state() -> (Arc<AppState>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let home_dir = tmp.path().join("librefang-memory-audit-test");
+        std::fs::create_dir_all(&home_dir).unwrap();
+
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+
+        let kernel = Arc::new(librefang_kernel::LibreFangKernel::boot_with_config(config).unwrap());
+        let state = Arc::new(AppState {
+            kernel,
+            started_at: std::time::Instant::now(),
+            peer_registry: None,
+            bridge_manager: tokio::sync::Mutex::new(None),
+            channels_config: tokio::sync::RwLock::new(Default::default()),
+            shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+            clawhub_cache: dashmap::DashMap::new(),
+            skillhub_cache: dashmap::DashMap::new(),
+            provider_probe_cache: librefang_runtime::provider_health::ProbeCache::new(),
+            provider_test_cache: dashmap::DashMap::new(),
+            webhook_store: crate::webhook_store::WebhookStore::load(
+                home_dir.join("data").join("webhooks.json"),
+            ),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+            #[cfg(feature = "telemetry")]
+            prometheus_handle: None,
+            media_drivers: librefang_runtime::media::MediaDriverCache::new(),
+            webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
+            api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+            config_write_lock: tokio::sync::Mutex::new(()),
+        });
+        (state, tmp)
+    }
+
+    /// Reviewer claim (PR #3205 follow-up #8b): a memory ACL denial at
+    /// the API layer must emit a `PermissionDenied` audit row, matching
+    /// `routes/audit.rs`, `routes/budget.rs`, `routes/authz.rs`, and the
+    /// global auth middleware. Without this, a privilege probe against
+    /// `/api/memory*` was silently dropped from the chain.
+    ///
+    /// Anonymous (loopback / no-auth) variant — the row is recorded with
+    /// `user_id = None`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn auth_denied_emits_audit_row_for_anonymous() {
+        let (state, _tmp) = audit_test_app_state();
+        let extensions = axum::http::Extensions::new();
+
+        let before = state.kernel.audit().len();
+        let (status, _body) = auth_denied(
+            &state,
+            &extensions,
+            "namespace 'kv:secrets' is not readable for the current user",
+        );
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let entries = state.kernel.audit().recent(8);
+        assert!(
+            state.kernel.audit().len() > before,
+            "auth_denied must append at least one audit entry"
+        );
+        let last = entries.last().expect("audit log must have a tail entry");
+        assert!(matches!(last.action, AuditAction::PermissionDenied));
+        assert_eq!(last.outcome, "denied");
+        assert!(
+            last.detail.contains("anonymous"),
+            "anonymous detail should mark the caller: got {:?}",
+            last.detail
+        );
+        assert!(
+            last.detail.contains("kv:secrets"),
+            "detail should carry the rejected namespace reason: got {:?}",
+            last.detail
+        );
+        assert!(
+            last.user_id.is_none(),
+            "anonymous denial must not attribute a user_id"
+        );
+        assert_eq!(last.channel.as_deref(), Some("api"));
+    }
+
+    /// Authenticated-but-denied variant — the row carries the attributed
+    /// `user_id` so an admin can see *who* tried to read what.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn auth_denied_emits_audit_row_for_authenticated_user() {
+        use crate::middleware::AuthenticatedApiUser;
+        use librefang_kernel::auth::UserRole;
+        use librefang_types::agent::UserId;
+
+        let (state, _tmp) = audit_test_app_state();
+        let mut extensions = axum::http::Extensions::new();
+        let user_id = UserId::from_name("alice");
+        extensions.insert(AuthenticatedApiUser {
+            name: "alice".to_string(),
+            role: UserRole::User,
+            user_id,
+        });
+
+        let (status, _body) = auth_denied(&state, &extensions, "kv:secrets not readable");
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let last = state
+            .kernel
+            .audit()
+            .recent(4)
+            .into_iter()
+            .last()
+            .expect("audit must have a tail entry");
+        assert!(matches!(last.action, AuditAction::PermissionDenied));
+        assert_eq!(last.user_id, Some(user_id));
+        assert!(
+            last.detail.contains("alice"),
+            "authenticated detail should name the user: got {:?}",
+            last.detail
         );
     }
 }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1499,6 +1499,7 @@ mod tests {
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
         });
         (state, tmp)

--- a/crates/librefang-types/src/user_policy.rs
+++ b/crates/librefang-types/src/user_policy.rs
@@ -108,15 +108,27 @@ impl ChannelToolPolicy {
     /// * `Some(false)` — explicitly denied
     /// * `Some(true)`  — explicitly allowed
     /// * `None`        — no opinion (rule does not apply)
+    ///
+    /// Matching is **case-insensitive** (ASCII): `denied_tools = ["shell_exec"]`
+    /// catches a hallucinated invocation of `SHELL_EXEC` or `Shell_Exec`.
+    /// Tool registries today store canonical lowercase identifiers, but
+    /// LLM output is unreliable and downstream MCP / skill providers may
+    /// accept their own case-insensitive aliases, so we normalise here
+    /// rather than trusting every dispatcher to canonicalise upstream.
     pub fn check_tool(&self, tool_name: &str) -> Option<bool> {
-        if self.denied_tools.iter().any(|p| glob_matches(p, tool_name)) {
+        let needle = tool_name.to_ascii_lowercase();
+        if self
+            .denied_tools
+            .iter()
+            .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle))
+        {
             return Some(false);
         }
         if !self.allowed_tools.is_empty() {
             return Some(
                 self.allowed_tools
                     .iter()
-                    .any(|p| glob_matches(p, tool_name)),
+                    .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle)),
             );
         }
         None
@@ -148,15 +160,25 @@ impl UserToolPolicy {
     /// Order: `denied_tools` first (deny-wins), then `allowed_tools`. If
     /// neither has an opinion, returns [`UserToolDecision::NeedsRoleEscalation`]
     /// so the caller can decide whether to escalate.
+    ///
+    /// Matching is **case-insensitive** (ASCII) so that a deny rule for
+    /// `shell_exec` still bites when the LLM emits `SHELL_EXEC` or any
+    /// other case variant. See [`ChannelToolPolicy::check_tool`] for the
+    /// rationale.
     pub fn check_tool(&self, tool_name: &str) -> UserToolDecision {
-        if self.denied_tools.iter().any(|p| glob_matches(p, tool_name)) {
+        let needle = tool_name.to_ascii_lowercase();
+        if self
+            .denied_tools
+            .iter()
+            .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle))
+        {
             return UserToolDecision::Deny;
         }
         if !self.allowed_tools.is_empty() {
             if self
                 .allowed_tools
                 .iter()
-                .any(|p| glob_matches(p, tool_name))
+                .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle))
             {
                 return UserToolDecision::Allow;
             }
@@ -192,11 +214,19 @@ impl UserToolCategories {
     /// * `Some(false)` — tool belongs to a denied group
     /// * `Some(true)`  — tool belongs to an allowed group (when allow-list is set)
     /// * `None`        — categories have no opinion
+    ///
+    /// Tool name matching is **case-insensitive** (ASCII); see
+    /// [`UserToolPolicy::check_tool`] for rationale.
     pub fn check_tool(&self, tool_name: &str, groups: &[ToolGroup]) -> Option<bool> {
+        let needle = tool_name.to_ascii_lowercase();
         // denied_groups wins: any group match denies.
         for group_name in &self.denied_groups {
             if let Some(group) = groups.iter().find(|g| &g.name == group_name) {
-                if group.tools.iter().any(|p| glob_matches(p, tool_name)) {
+                if group
+                    .tools
+                    .iter()
+                    .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle))
+                {
                     return Some(false);
                 }
             }
@@ -204,7 +234,11 @@ impl UserToolCategories {
         if !self.allowed_groups.is_empty() {
             for group_name in &self.allowed_groups {
                 if let Some(group) = groups.iter().find(|g| &g.name == group_name) {
-                    if group.tools.iter().any(|p| glob_matches(p, tool_name)) {
+                    if group
+                        .tools
+                        .iter()
+                        .any(|p| glob_matches(&p.to_ascii_lowercase(), &needle))
+                    {
                         return Some(true);
                     }
                 }
@@ -251,11 +285,98 @@ pub struct UserMemoryAccess {
     pub delete_allowed: bool,
 }
 
+/// Memory namespaces are colon- and slash-delimited identifiers
+/// (`kv:user_alice`, `shared:scope/foo`). A `..` segment in a candidate
+/// namespace is a path-traversal attempt and is rejected before any glob
+/// pattern is consulted — the LLM-facing memory tools never need it, and
+/// allowing it would let `kv:user_*` admit `kv:user_../admin`.
+fn has_path_traversal(namespace: &str) -> bool {
+    namespace
+        .split(|c: char| c == '/' || c == ':' || c.is_whitespace())
+        .any(|seg| seg == "..")
+}
+
+/// Namespace-aware variant of [`crate::capability::glob_matches`].
+///
+/// Differences from the generic matcher:
+///
+/// - `"*"` still matches anything (subject to the traversal guard the
+///   caller applies separately). This preserves the "owner / admin
+///   sees everything" UX.
+/// - A `*` embedded in a longer pattern (e.g. `kv:user_*`, `shared:*:foo`)
+///   may NOT cross a namespace separator (`:` or `/`). So `kv:user_*`
+///   matches `kv:user_alice` but not `kv:user_evil/etc/passwd` and not
+///   `kv:user_../admin` (the candidate is rejected before reaching this
+///   matcher anyway, but the separator constraint is the structural
+///   property; the traversal check is defense in depth).
+///
+/// This is intentionally separate from [`crate::capability::glob_matches`]
+/// because that one is used for tool names and capability strings where
+/// `*` collapsing across separators is desirable (e.g. `file_*` matching
+/// `file_read`). Don't unify them — namespace ACL is the only place where
+/// the strict semantics belong.
+fn namespace_glob_matches(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if pattern == value {
+        return true;
+    }
+
+    let component = |s: &str| !s.contains(':') && !s.contains('/');
+
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        // "*foo" — `value` must end with `foo` and the prefix it captures
+        // must not span a separator.
+        if !value.ends_with(suffix) {
+            return false;
+        }
+        let head = &value[..value.len() - suffix.len()];
+        return component(head);
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        // "foo*" — `value` must start with `foo` and the suffix it
+        // captures must not span a separator.
+        if !value.starts_with(prefix) {
+            return false;
+        }
+        let tail = &value[prefix.len()..];
+        return component(tail);
+    }
+    if let Some(star_pos) = pattern.find('*') {
+        // "foo*bar" — middle wildcard, captured middle must not span a
+        // separator.
+        let prefix = &pattern[..star_pos];
+        let suffix = &pattern[star_pos + 1..];
+        if !value.starts_with(prefix) || !value.ends_with(suffix) {
+            return false;
+        }
+        if value.len() < prefix.len() + suffix.len() {
+            return false;
+        }
+        let mid = &value[prefix.len()..value.len() - suffix.len()];
+        return component(mid);
+    }
+    false
+}
+
 impl UserMemoryAccess {
-    /// Wildcard pattern matching against `readable_namespaces`. The
-    /// special pattern `"*"` allows any namespace; otherwise an exact
-    /// match or single-`*` glob is required (see
-    /// [`crate::capability::glob_matches`] for the semantics).
+    /// Wildcard pattern matching against `readable_namespaces`.
+    ///
+    /// Uses [`namespace_glob_matches`] — a stricter variant of the generic
+    /// [`crate::capability::glob_matches`] that:
+    ///
+    /// 1. **Rejects path-traversal candidates outright.** Any namespace
+    ///    containing a `..` segment (delimited by `/`, `:`, or whitespace)
+    ///    is denied — even if a configured pattern would otherwise match.
+    ///    Without this, `kv:user_*` would match `kv:user_../admin` because
+    ///    `*` greedily eats `../admin` as plain text.
+    /// 2. **Bounds `*` to a single namespace component.** A pattern like
+    ///    `kv:user_*` only matches strings whose substring after `kv:user_`
+    ///    contains no `/` or `:` — so `kv:user_alice` matches but
+    ///    `kv:user_../admin` and `kv:user_/etc/passwd` do not.
+    ///
+    /// `"*"` still matches any non-traversing namespace as before.
     ///
     /// An empty `readable_namespaces` deny-all by default, **except**
     /// when no other restriction is configured at all (`pii_access=false`,
@@ -263,16 +384,25 @@ impl UserMemoryAccess {
     /// — that's an "unconfigured" sentinel and the caller (kernel) treats
     /// it as "no opinion, defer to role-default".
     pub fn can_read(&self, namespace: &str) -> bool {
+        if has_path_traversal(namespace) {
+            return false;
+        }
         self.readable_namespaces
             .iter()
-            .any(|p| glob_matches(p, namespace))
+            .any(|p| namespace_glob_matches(p, namespace))
     }
 
     /// Wildcard match against `writable_namespaces`.
+    ///
+    /// Uses the same separator-aware, traversal-rejecting matcher as
+    /// [`Self::can_read`] — see that method's docs for details.
     pub fn can_write(&self, namespace: &str) -> bool {
+        if has_path_traversal(namespace) {
+            return false;
+        }
         self.writable_namespaces
             .iter()
-            .any(|p| glob_matches(p, namespace))
+            .any(|p| namespace_glob_matches(p, namespace))
     }
 
     /// Returns true when no fields have been customised — i.e. the
@@ -477,6 +607,73 @@ mod tests {
         assert!(!acl.can_write("kv:internal"));
     }
 
+    /// Reviewer claim (PR #3205 follow-up #7): the namespace matcher
+    /// uses the generic [`crate::capability::glob_matches`] which lets
+    /// `*` greedily eat path separators, so `kv:user_*` would match
+    /// `kv:user_../admin` or `kv:user_evil/etc/passwd` and let a memory
+    /// tool cross into another user's bucket. The fix:
+    ///
+    /// 1. Reject any namespace candidate containing a `..` segment
+    ///    (delimited by `/`, `:`, or whitespace).
+    /// 2. Require `*` in patterns to stay within a single namespace
+    ///    component — no `/` or `:` allowed inside the captured span.
+    ///
+    /// Both legs are exercised here so a regression on either is caught.
+    #[test]
+    fn memory_access_namespace_blocks_path_traversal() {
+        let acl = UserMemoryAccess {
+            readable_namespaces: vec!["kv:user_*".into()],
+            writable_namespaces: vec!["kv:user_*".into()],
+            pii_access: false,
+            export_allowed: false,
+            delete_allowed: false,
+        };
+
+        // Positive control: legitimate per-user namespace still matches.
+        assert!(acl.can_read("kv:user_alice"));
+        assert!(acl.can_write("kv:user_alice"));
+
+        // Path-traversal candidates rejected.
+        assert!(
+            !acl.can_read("kv:user_../admin"),
+            "`..` segment must be rejected even when the prefix matches"
+        );
+        assert!(!acl.can_write("kv:user_../admin"));
+        assert!(
+            !acl.can_read("kv:user_alice/../bob"),
+            "embedded `..` between separators must be rejected"
+        );
+
+        // Separator-crossing wildcards rejected.
+        assert!(
+            !acl.can_read("kv:user_evil/etc/passwd"),
+            "`*` must not match across `/` separators"
+        );
+        assert!(
+            !acl.can_read("kv:user_a:b"),
+            "`*` must not match across `:` separators"
+        );
+    }
+
+    /// `"*"` retains its "match anything" semantics for the
+    /// owner / admin role, but still rejects traversal candidates so
+    /// even a maximally-permissive ACL can't be tricked into reading a
+    /// `..`-bearing namespace.
+    #[test]
+    fn memory_access_star_pattern_still_rejects_traversal() {
+        let acl = UserMemoryAccess {
+            readable_namespaces: vec!["*".into()],
+            writable_namespaces: vec!["*".into()],
+            pii_access: false,
+            export_allowed: false,
+            delete_allowed: false,
+        };
+        assert!(acl.can_read("kv:anything"));
+        assert!(acl.can_read("shared:scope/foo"));
+        assert!(!acl.can_read("kv:user_../admin"));
+        assert!(!acl.can_write("kv:user_alice/../bob"));
+    }
+
     #[test]
     fn memory_access_unconfigured_sentinel() {
         assert!(UserMemoryAccess::default().is_unconfigured());
@@ -549,6 +746,50 @@ mod tests {
             policy.evaluate("anything", None, &[]),
             UserToolDecision::NeedsRoleEscalation
         );
+    }
+
+    // ---- #3205 follow-up: ASCII case-insensitive deny matching ----
+
+    /// Reviewer claim (PR #3205 follow-up #8a): a deny rule for
+    /// `shell_exec` would be silently bypassed by a different-case
+    /// invocation like `SHELL_EXEC`. Built-in tool dispatch matches case
+    /// exactly so the call would have failed downstream anyway, but
+    /// MCP / skill providers may accept their own case variants — and
+    /// the deny list is supposed to be the authoritative gate. Pin
+    /// case-insensitive matching so a future refactor can't quietly flip
+    /// us back to case-sensitive.
+    #[test]
+    fn user_deny_is_case_insensitive() {
+        let p = UserToolPolicy {
+            allowed_tools: vec![],
+            denied_tools: vec!["shell_exec".into()],
+        };
+        assert_eq!(p.check_tool("shell_exec"), UserToolDecision::Deny);
+        assert_eq!(p.check_tool("SHELL_EXEC"), UserToolDecision::Deny);
+        assert_eq!(p.check_tool("Shell_Exec"), UserToolDecision::Deny);
+    }
+
+    #[test]
+    fn channel_deny_is_case_insensitive() {
+        let p = ChannelToolPolicy {
+            allowed_tools: vec!["*".into()],
+            denied_tools: vec!["shell_exec".into()],
+        };
+        assert_eq!(p.check_tool("SHELL_EXEC"), Some(false));
+        assert_eq!(p.check_tool("shell_exec"), Some(false));
+        // Allow-list still matches non-denied tools regardless of case.
+        assert_eq!(p.check_tool("FILE_READ"), Some(true));
+    }
+
+    #[test]
+    fn categories_deny_is_case_insensitive() {
+        let groups = vec![group("shell_tools", &["shell_exec"])];
+        let cats = UserToolCategories {
+            allowed_groups: vec![],
+            denied_groups: vec!["shell_tools".into()],
+        };
+        assert_eq!(cats.check_tool("SHELL_EXEC", &groups), Some(false));
+        assert_eq!(cats.check_tool("shell_exec", &groups), Some(false));
     }
 
     /// Precedence regression (PR #3205 review feedback): when the user-level


### PR DESCRIPTION
## Summary

Three reviewer-flagged bugs from merged PR #3205 (RBAC M3 — per-user tool policy + memory namespace ACL). Each was re-verified against current main before fixing; verdicts and concrete evidence below.

### Item #7 — Namespace glob path traversal — **REAL**

`UserMemoryAccess::can_read/can_write` (`crates/librefang-types/src/user_policy.rs`) deferred to `capability::glob_matches`, where `*` greedily matches any text including `/` and `:`. So:

- `glob_matches("kv:user_*", "kv:user_../admin")` -> `true` (the `*` swallows `../admin`)
- `glob_matches("kv:user_*", "kv:user_evil/etc/passwd")` -> `true`
- `glob_matches("kv:*", "kv:user_../admin")` -> `true`

A memory tool that constructs the namespace from user input could therefore cross into another user's bucket — even though the per-user pattern was supposed to scope them to `kv:user_<their-name>`.

**Fix.** Introduce `namespace_glob_matches` with two stricter rules:
1. Reject any candidate containing a `..` segment (delimited by `/`, `:`, or whitespace) outright.
2. `*` may not span `/` or `:` separators inside a longer pattern — `kv:user_*` only matches a single component after the prefix.

`*` standalone still matches any non-traversing namespace so the owner/admin "see everything" UX is preserved. Kept separate from the generic `glob_matches` (which is used for tool-name and capability matching where collapsing across separators is intentional).

### Item #8a — Case-sensitive deny lists — **PARTIAL -> fixed**

`UserToolPolicy`, `ChannelToolPolicy`, and `UserToolCategories` matched tool names case-sensitively (`crates/librefang-types/src/user_policy.rs:151,111,195`):
- `glob_matches("shell_exec", "SHELL_EXEC")` -> `false`

Built-in tools dispatch by exact-case match (`tool_runner.rs:1041`) so a `SHELL_EXEC` invocation would not have executed; the call would have hit the "Unknown tool" arm. But MCP and skill tool providers may accept their own case variants, and the deny list is supposed to be the authoritative gate regardless of the dispatcher's tolerance. Defense in depth: ASCII-lowercase both pattern and tool name at every per-user check site.

Scope kept tight — only the three per-user `check_tool` methods. Rate-limit buckets and capability matchers stay exact-case (tool identities there are content-addressed).

### Item #8b — Memory ACL denial silently dropped from audit — **REAL**

`routes/memory.rs::auth_denied` (the helper called on every `LibreFangError::AuthDenied` from the namespace guard) returned a 403 without recording a `PermissionDenied` audit row. Meanwhile every other admin-gated RBAC endpoint emits one:
- `routes/audit.rs::require_admin` — emits PermissionDenied
- `routes/budget.rs:468,482` — emits PermissionDenied
- `routes/authz.rs:60,74` — emits PermissionDenied
- `middleware.rs:435,765` — emits PermissionDenied

So a privilege probe against `/api/memory*` was invisible to admins reading `/api/audit`.

**Fix.** `auth_denied` now takes `&AppState` + `&Extensions` and writes a `PermissionDenied` row via `state.kernel.audit().record_with_context(...)` before returning 403. Anonymous callers -> `user_id = None`; authenticated-but-denied callers -> attributed `user_id` plus user / role in the detail string.

### Files changed

- `crates/librefang-types/src/user_policy.rs` — `namespace_glob_matches` + `has_path_traversal` + case-insensitive `check_tool` on `UserToolPolicy` / `ChannelToolPolicy` / `UserToolCategories` + tests
- `crates/librefang-api/src/routes/memory.rs` — `auth_denied` audit emit + tests

## Test plan

- [x] `memory_access_namespace_blocks_path_traversal` — `kv:user_../admin`, `kv:user_alice/../bob`, and separator-crossing globs all denied; `kv:user_alice` still allowed (positive control)
- [x] `memory_access_star_pattern_still_rejects_traversal` — even `["*"]` rejects `..` candidates while still matching legitimate `kv:anything` / `shared:scope/foo`
- [x] `user_deny_is_case_insensitive`, `channel_deny_is_case_insensitive`, `categories_deny_is_case_insensitive` — pin lowercase normalisation
- [x] `auth_denied_emits_audit_row_for_anonymous` — boots a real kernel, calls `auth_denied(&state, &extensions, ..)`, asserts a `PermissionDenied` row appears with `outcome="denied"`, `channel="api"`, `user_id=None`, and the namespace reason in `detail`
- [x] `auth_denied_emits_audit_row_for_authenticated_user` — same but with `AuthenticatedApiUser` extension; asserts attribution to `user_id`
- [x] Existing `anonymous_fallback_*` tests (from #3239) still pass — kept verbatim alongside the new ones
- [ ] CI verifies `cargo build --workspace --lib` / `cargo test --workspace` / `cargo clippy -- -D warnings`

Refs: PR #3205 (RBAC M3), follow-up to #3239 (memory ACL fail-closed).
