### PR TITLE
hotfix(api/auth): unbreak main — use local user_api_keys snapshot

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -425,8 +425,12 @@ pub async fn auth(
                     }
                     return next.run(request).await;
                 }
-                if let Some(user) = auth_state
-                    .user_api_keys
+                // Use the local `user_api_keys` snapshot taken at the top
+                // of `auth()` (line ~363) — `auth_state.user_api_keys` is
+                // an `Arc<RwLock<Vec<…>>>` since the rotate-key fix and
+                // does not expose `iter()` directly. The snapshot is the
+                // single source of truth for this request.
+                if let Some(user) = user_api_keys
                     .iter()
                     .find(|user| {
                         crate::password_hash::verify_password(&token_str, &user.api_key_hash)


### PR DESCRIPTION
## Summary

Merge race between #3236 (loopback attribution) and #3233 (rotate-key race lock).

#3233 changed `AuthState.user_api_keys` from `Arc<Vec<ApiUserAuth>>` to `Arc<tokio::sync::RwLock<Vec<ApiUserAuth>>>` so the rotate handler could hold the write lock across persist + reload + snapshot swap. #3236 was authored against the old type and uses `auth_state.user_api_keys.iter()` directly. Once they both landed in main the trunk no longer compiles:

```
error[E0599]: no method named `iter` found for struct `Arc<RwLock<Vec<ApiUserAuth>>>`
   --> crates/librefang-api/src/middleware.rs:430
```

## Fix

`auth()` already snapshots the lock at line ~363 into a local `user_api_keys: Vec<ApiUserAuth>` for exactly this reason — every other downstream read uses it. The new loopback-attribution path needs to do the same. One-line rename.

## Test plan

CI compile alone is the regression gate. No behavior change.