### PR TITLE
fix(rbac): autonomous-loop tool calls bypass user gate (closes #3243)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -42,6 +42,18 @@ use librefang_types::tool::{AgentLoopSignal, ToolApprovalSubmission, ToolDefinit
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use librefang_channels::types::SenderContext;
+
+/// Synthetic `SenderContext.channel` value the cron dispatcher uses for
+/// `[[cron_jobs]]` fires. Matched in [`KernelHandle::resolve_user_tool_decision`]
+/// to bypass per-user RBAC the same way the `system_call=true` flag does
+/// — daemon-driven calls have no user to attribute to.
+pub(crate) const SYSTEM_CHANNEL_CRON: &str = "cron";
+
+/// Synthetic `SenderContext.channel` value the autonomous-loop dispatcher
+/// uses for agents whose manifest declares `[autonomous]`. Same RBAC
+/// carve-out as [`SYSTEM_CHANNEL_CRON`] — both are kernel-internal and
+/// have no user to attribute to. Issue #3243.
+pub(crate) const SYSTEM_CHANNEL_AUTONOMOUS: &str = "autonomous";
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -11948,9 +11960,9 @@ system_prompt = "You are a helpful assistant."
                                 let wants_new_session = job.session_mode
                                     == Some(librefang_types::agent::SessionMode::New);
                                 let cron_sender = SenderContext {
-                                    channel: "cron".to_string(),
+                                    channel: SYSTEM_CHANNEL_CRON.to_string(),
                                     user_id: job.peer_id.clone().unwrap_or_default(),
-                                    display_name: "cron".to_string(),
+                                    display_name: SYSTEM_CHANNEL_CRON.to_string(),
                                     is_group: false,
                                     was_mentioned: false,
                                     thread_id: None,
@@ -12422,9 +12434,9 @@ system_prompt = "You are a helpful assistant."
                 let k = Arc::clone(&kernel);
                 tokio::spawn(async move {
                     let sender = SenderContext {
-                        channel: "autonomous".to_string(),
+                        channel: SYSTEM_CHANNEL_AUTONOMOUS.to_string(),
                         user_id: aid.to_string(),
-                        display_name: "autonomous".to_string(),
+                        display_name: SYSTEM_CHANNEL_AUTONOMOUS.to_string(),
                         is_group: false,
                         was_mentioned: false,
                         thread_id: None,
@@ -16040,7 +16052,10 @@ impl KernelHandle for LibreFangKernel {
         // (PR #3205 review item #1). Both have been removed: an
         // unattributed inbound now goes through the guest gate so
         // RBAC fails closed end-to-end.
-        let system_call = matches!(channel, Some("cron") | Some("autonomous"));
+        let system_call = matches!(
+            channel,
+            Some(c) if c == SYSTEM_CHANNEL_CRON || c == SYSTEM_CHANNEL_AUTONOMOUS
+        );
         self.auth
             .resolve_user_tool_decision(tool_name, sender_id, channel, system_call)
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -42,6 +42,12 @@ use librefang_types::tool::{AgentLoopSignal, ToolApprovalSubmission, ToolDefinit
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use librefang_channels::types::SenderContext;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock, Weak};
+use tracing::{debug, info, instrument, warn};
 
 /// Synthetic `SenderContext.channel` value the cron dispatcher uses for
 /// `[[cron_jobs]]` fires. Matched in [`KernelHandle::resolve_user_tool_decision`]
@@ -54,12 +60,6 @@ pub(crate) const SYSTEM_CHANNEL_CRON: &str = "cron";
 /// carve-out as [`SYSTEM_CHANNEL_CRON`] — both are kernel-internal and
 /// have no user to attribute to. Issue #3243.
 pub(crate) const SYSTEM_CHANNEL_AUTONOMOUS: &str = "autonomous";
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock, Weak};
-use tracing::{debug, info, instrument, warn};
 
 /// Build the MCP bridge config that lets CLI-based drivers (Claude Code)
 /// reach back into the daemon's own `/mcp` endpoint. Uses loopback when the

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12406,13 +12406,33 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Start continuous/periodic loops
+        // Start continuous/periodic loops.
+        //
+        // RBAC carve-out (issue #3243): autonomous ticks have no inbound
+        // user. Without a synthetic `SenderContext { channel:"autonomous" }`
+        // the runtime would call `resolve_user_tool_decision(.., None, None)`
+        // → `guest_gate` → `NeedsApproval` for any non-safe-list tool, and
+        // every tick would flood the approval queue when `[[users]]` is
+        // configured. The `"autonomous"` channel sentinel matches the same
+        // `system_call=true` carve-out as cron (see
+        // `resolve_user_tool_decision` in this file).
         let kernel = Arc::clone(self);
         self.background
             .start_agent(agent_id, name, schedule, move |aid, msg| {
                 let k = Arc::clone(&kernel);
                 tokio::spawn(async move {
-                    match k.send_message(aid, &msg).await {
+                    let sender = SenderContext {
+                        channel: "autonomous".to_string(),
+                        user_id: aid.to_string(),
+                        display_name: "autonomous".to_string(),
+                        is_group: false,
+                        was_mentioned: false,
+                        thread_id: None,
+                        account_id: None,
+                        is_internal_cron: false,
+                        ..Default::default()
+                    };
+                    match k.send_message_with_sender_context(aid, &msg, &sender).await {
                         Ok(_) => {}
                         Err(e) => {
                             // send_message already records the panic in supervisor,
@@ -15997,11 +16017,20 @@ impl KernelHandle for LibreFangKernel {
         sender_id: Option<&str>,
         channel: Option<&str>,
     ) -> librefang_types::user_policy::UserToolGate {
-        // Only the synthetic `"cron"` channel is treated as a system-
-        // internal call. The cron dispatcher synthesises
-        // `SenderContext{channel:"cron"}` (see kernel/mod.rs ~10876)
-        // before fanning out to agents; everything else MUST carry a
-        // real `(channel, sender_id)` tuple.
+        // The synthetic `"cron"` and `"autonomous"` channels are the only
+        // two the kernel treats as system-internal. Both are synthesised
+        // by the kernel itself for daemon-driven calls that have no
+        // user-facing sender:
+        //   - `"cron"` — `kernel/mod.rs::start_periodic_loops` cron tick
+        //     (~line 11950) for `[[cron_jobs]]` fires.
+        //   - `"autonomous"` — `start_continuous_autonomous_loop`
+        //     (~line 12412) for autonomous-tick prompts on agents whose
+        //     manifest declares `[autonomous]`.
+        // Both fan out the agent's own loop with a synthetic
+        // `SenderContext { channel: "cron" | "autonomous" }`. Issue #3243
+        // tracks the autonomous case: without this carve-out, every
+        // autonomous tool call falls into `guest_gate` → NeedsApproval
+        // and floods the approval queue when RBAC is enabled.
         //
         // Earlier drafts also matched `"system"` / `"internal"` and
         // treated `(None, None)` as system, but neither sentinel is
@@ -16011,7 +16040,7 @@ impl KernelHandle for LibreFangKernel {
         // (PR #3205 review item #1). Both have been removed: an
         // unattributed inbound now goes through the guest gate so
         // RBAC fails closed end-to-end.
-        let system_call = matches!(channel, Some("cron"));
+        let system_call = matches!(channel, Some("cron") | Some("autonomous"));
         self.auth
             .resolve_user_tool_decision(tool_name, sender_id, channel, system_call)
     }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4251,3 +4251,84 @@ async fn test_push_notification_unknown_event_type_yields_no_targets() {
 
     kernel.shutdown();
 }
+
+/// Issue #3243 regression — RBAC enabled (`[[users]]` configured) must
+/// not gate **autonomous-loop tool calls** through the user policy /
+/// approval queue. Without the carve-out, every autonomous tick that
+/// invoked a non-safe-list tool (e.g. `shell_exec`) would fall into
+/// `guest_gate` → `NeedsApproval` because autonomous calls have no
+/// inbound `(sender_id, channel)` tuple to resolve a user from. The
+/// kernel synthesises `SenderContext { channel: "autonomous", .. }` at
+/// the dispatch site (`start_continuous_autonomous_loop`) and
+/// [`KernelHandle::resolve_user_tool_decision`] matches that sentinel
+/// alongside the existing `"cron"` carve-out.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
+    use kernel_handle::KernelHandle;
+    use librefang_types::config::UserConfig;
+    use librefang_types::user_policy::UserToolGate;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    // Configure a single Owner user with NO `tool_policy` allowlist.
+    // The mere presence of `[[users]]` enables RBAC; without the
+    // carve-out, every autonomous tool call would be denied because
+    // the autonomous loop carries no sender_id to resolve to "Owner".
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        users: vec![UserConfig {
+            name: "Owner".to_string(),
+            role: "owner".to_string(),
+            ..Default::default()
+        }],
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+
+    // Cron channel — the existing carve-out (must remain Allow).
+    assert_eq!(
+        KernelHandle::resolve_user_tool_decision(
+            kernel.as_ref(),
+            "shell_exec",
+            None,
+            Some("cron"),
+        ),
+        UserToolGate::Allow,
+        "cron carve-out must continue to bypass RBAC for autonomous-class calls"
+    );
+
+    // Autonomous channel — the new carve-out (issue #3243).
+    assert_eq!(
+        KernelHandle::resolve_user_tool_decision(
+            kernel.as_ref(),
+            "shell_exec",
+            None,
+            Some("autonomous"),
+        ),
+        UserToolGate::Allow,
+        "autonomous-tick tool calls must bypass RBAC — without this, RBAC + autonomous \
+         hand agents are unusable (issue #3243)"
+    );
+
+    // A real inbound channel WITHOUT a registered sender must still
+    // hit the guest gate — proves the carve-out is targeted, not a
+    // blanket fail-open.
+    let guest_decision = KernelHandle::resolve_user_tool_decision(
+        kernel.as_ref(),
+        "shell_exec",
+        Some("999999"),
+        Some("telegram"),
+    );
+    assert!(
+        !matches!(guest_decision, UserToolGate::Allow),
+        "unknown sender on a real channel must NOT bypass RBAC: got {guest_decision:?}"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4297,7 +4297,7 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
             kernel.as_ref(),
             "shell_exec",
             None,
-            Some("cron"),
+            Some(super::SYSTEM_CHANNEL_CRON),
         ),
         UserToolGate::Allow,
         "cron carve-out must continue to bypass RBAC for autonomous-class calls"
@@ -4309,7 +4309,7 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
             kernel.as_ref(),
             "shell_exec",
             None,
-            Some("autonomous"),
+            Some(super::SYSTEM_CHANNEL_AUTONOMOUS),
         ),
         UserToolGate::Allow,
         "autonomous-tick tool calls must bypass RBAC — without this, RBAC + autonomous \


### PR DESCRIPTION
## Summary

Closes [#3243](https://github.com/librefang/librefang/issues/3243). When `[[users]]` is configured (RBAC enabled) but a tool call has no inbound `(sender_id, channel)` — autonomous loops, scheduled triggers without a synthesized SenderContext — `AuthManager::resolve_user` short-circuits to `None`, the call falls into `guest_gate()`, and any tool not on the read-only safe list returns `UserToolGate::NeedsApproval`. The hand-agent auto-approval carve-out in `submit_tool_approval` is explicitly skipped under `force_human=true`, so every autonomous tool call gets queued for human approval and either times out or floods the queue, killing the loop.

This is the regression neo-wanderer reported: enable RBAC and your background browser hand stops functioning the moment its first autonomous tick fires.

## Fix

Mirror the existing **cron** carve-out — synthesize a `SenderContext { channel: "autonomous", .. }` at the autonomous-loop dispatch site (`start_continuous_autonomous_loop`), and extend `KernelHandle::resolve_user_tool_decision` to treat the `"autonomous"` sentinel the same as `"cron"`: `system_call=true`, RBAC bypassed.

```rust
// Before
let system_call = matches!(channel, Some("cron"));
// After
let system_call = matches!(channel, Some("cron") | Some("autonomous"));
```

This is suggestion (1) from the issue body. The autonomous loop runs under the agent's own identity (the manifest declares it; the daemon spawns it), not on behalf of any user — so the "system call" classification is the correct semantic model. The risk noted in the issue ("a malicious manifest could mark itself autonomous") is bounded by the same trust boundary as the manifest itself: anyone who can edit `[autonomous]` in `agent.toml` has direct access to `config.toml` and could grant themselves Owner anyway.

## Surface

- `crates/librefang-kernel/src/kernel/mod.rs::start_continuous_autonomous_loop` (~line 12412): autonomous tick now uses `send_message_with_sender_context(.., SenderContext { channel: "autonomous", .. })` instead of the bare `send_message`.
- `crates/librefang-kernel/src/kernel/mod.rs::resolve_user_tool_decision` (~line 16014): `system_call` matcher widened to accept both `"cron"` and `"autonomous"`. Doc-comment updated to document both carve-outs and the issue trail.

## What this PR does NOT do

- ❌ Does **not** fall open for `(sender_id=None, channel=None)`. That path still hits the guest gate. The fix is targeted at the synthetic autonomous channel only.
- ❌ Does **not** change cron behavior; it only joins it.
- ❌ Does **not** add a per-agent `[autonomous].rbac_bypass` toggle. The carve-out is unconditional because per-agent toggles for security carve-outs invite the misconfiguration this PR exists to fix.

## Test plan

- [x] `test_resolve_user_tool_decision_autonomous_bypasses_rbac` in `kernel/tests.rs` — boots a kernel with `[[users]]` configured, asserts:
    - cron carve-out still allows `shell_exec` (regression guard for the existing path)
    - the new `"autonomous"` channel does the same
    - an unknown sender on a real channel (`telegram`, sender_id `999999`) still hits the guest gate, so the carve-out remains targeted

Per project policy I'm not running local builds; CI validates.

## Reviewer notes

- The doc-comment on `resolve_user_tool_decision` was rewritten to enumerate both carve-outs and reference the issue numbers. That comment is now the canonical place to look when adding a third sentinel — please update it rather than introducing a new one.
- `is_internal_cron` stays `false` for autonomous because the `[SILENT]` message handling at `kernel/mod.rs:7405` is cron-specific and the autonomous prompt format is `[AUTONOMOUS TICK] ...`.

Closes #3243.
