### PR TITLE
fix(dashboard/audit): channel dropdown uses /api/channels for full 44-adapter list

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -53,6 +53,7 @@ import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { Modal } from "../components/ui/Modal";
 import { useAuditQuery } from "../lib/queries/audit";
+import { useChannels } from "../lib/queries/channels";
 import { ApiError } from "../lib/http/errors";
 import { formatRelativeTime } from "../lib/datetime";
 import type { AuditQueryFilters } from "../lib/http/client";
@@ -444,16 +445,24 @@ export function AuditPage() {
     [t],
   );
 
-  // Channel Select options: a fixed seed of well-known adapter names +
-  // any other channel value actually present in the current result set,
-  // so the operator can both pick from common ones up-front AND drill
-  // into a one-off channel that showed up in the log (e.g. a webhook
-  // adapter the seed doesn't list). "(any)" stays the empty-value
-  // first option; "Custom…" reveals a free-text input for channels
-  // that haven't been recorded yet.
+  // Channel Select options: every adapter the daemon ships
+  // (`/api/channels` returns all 44 — telegram, discord, feishu, voice,
+  // wechat, mastodon, …) UNION the kernel-internal channel identifiers
+  // the audit log uses (`api / dashboard / cli / system / cron`) UNION
+  // any channel value actually present in the current result set, so
+  // even a webhook-style channel name we don't know about up front
+  // appears once it shows up in the log. The hardcoded seed of 8 was
+  // visibly incomplete — operators couldn't pick `feishu`, `wechat`,
+  // `voice`, etc until they had data for them. "(any)" stays the
+  // empty-value first option; "Custom…" reveals a free-text input
+  // for channels that don't exist anywhere yet.
+  const channelsQuery = useChannels();
   const channelOptions = useMemo(() => {
-    const seed = ["api", "dashboard", "cli", "telegram", "discord", "slack", "matrix", "feishu"];
-    const seen = new Set<string>(seed);
+    const internal = ["api", "dashboard", "cli", "system", "cron"];
+    const seen = new Set<string>(internal);
+    for (const c of channelsQuery.data ?? []) {
+      seen.add(c.name);
+    }
     for (const e of query.data?.entries ?? []) {
       if (e.channel) seen.add(e.channel);
     }
@@ -463,7 +472,7 @@ export function AuditPage() {
       ...list.map((c) => ({ value: c, label: c })),
       { value: "__custom__", label: t("audit.range_custom") },
     ];
-  }, [query.data?.entries, t]);
+  }, [channelsQuery.data, query.data?.entries, t]);
 
   // True when the active channel filter doesn't match any known option
   // (operator typed something custom, or filtered via row-click for a


### PR DESCRIPTION
## Summary

The audit page's Channel filter dropdown shipped with a hardcoded seed of 8 names — `api / dashboard / cli / telegram / discord / slack / matrix / feishu`. The daemon ships **44** channel adapters; the operator couldn't pick `feishu`, `wechat`, `voice`, `mastodon`, `webhook`, or any of the other 36 shipping adapters until a row with that channel happened to appear in the result set. The dropdown failed exactly when it was needed: filtering to a channel you've **never used yet**.

## Fix

Replace the 8-name seed with the union of:

1. `useChannels()` — the existing `/api/channels` hook the Channels page already consumes, returning all 44 adapters with metadata.
2. Kernel-internal channels — `api / dashboard / cli / system / cron` — these aren't user-configurable adapters but they appear as `channel` values in audit entries (HTTP API calls, dashboard reads, CLI commands, scheduler / system events).
3. Channels seen in the current result set — covers any one-off channel name we don't know about up front (e.g. webhook adapters with custom routes).

`Custom…` still covers the rare case where none of the three sources knows about the channel yet.

## Test plan

- [ ] Open `/dashboard/audit`, expand Filters, open the Channel dropdown.
- [ ] Confirm the list now shows all 44 adapters (alphabetical) plus the 5 internal channel identifiers.
- [ ] Pick a channel you've never used (e.g. `wechat`) and Apply → server returns empty result set, no longer "you can't even ask the question".
