### PR TITLE
feat(release): auto-Highlights + collapse boilerplate + contributor roll-up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,12 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
 
           {
-            echo "## What's New"
+            echo "## Full Changelog"
             echo ""
             cat /tmp/changelog.md
             echo ""
-            echo "## Installation"
+            echo "<details>"
+            echo "<summary>📦 Install / Upgrade</summary>"
             echo ""
             echo '**Homebrew (macOS):**'
             echo '```bash'
@@ -194,44 +195,17 @@ jobs:
             echo 'brew install --cask librefang-rc    # Desktop (rc channel)'
             echo '```'
             echo ""
-            echo '**CLI (Linux/macOS):**'
-            echo '```bash'
-            echo 'curl -fsSL https://librefang.ai/install.sh | sh'
-            echo '```'
+            echo '**CLI (Linux/macOS):** `curl -fsSL https://librefang.ai/install.sh | sh`'
             echo ""
-            echo '**npm:**'
-            echo '```bash'
-            echo 'npm install -g @librefang/cli'
-            echo '```'
+            echo '**npm:** `npm install -g @librefang/cli` &nbsp;·&nbsp; **pip:** `pip install librefang` &nbsp;·&nbsp; **cargo:** `cargo install librefang`'
             echo ""
-            echo '**pip:**'
-            echo '```bash'
-            echo 'pip install librefang'
-            echo '```'
+            echo '**Docker:** `docker pull ghcr.io/librefang/librefang:latest`'
             echo ""
-            echo '**Cargo:**'
-            echo '```bash'
-            echo 'cargo install librefang'
-            echo '```'
+            echo '**Coming from OpenClaw / OpenFang?** `librefang migrate --from openclaw` (or `--from openfang`)'
             echo ""
-            echo '**Docker:**'
-            echo '```bash'
-            echo 'docker pull ghcr.io/librefang/librefang:latest'
-            echo '```'
+            echo "</details>"
             echo ""
-            echo "## Migration"
-            echo ""
-            echo '**Coming from OpenClaw or OpenFang?**'
-            echo '```bash'
-            echo 'librefang migrate --from openclaw'
-            echo 'librefang migrate --from openfang'
-            echo '```'
-            echo ""
-            echo "## Links"
-            echo ""
-            echo "- [Documentation](https://librefang.ai)"
-            echo "- [Discord](https://discord.gg/DzTYqAZZmc)"
-            echo "- [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)"
+            echo "[Documentation](https://librefang.ai) &nbsp;·&nbsp; [Discord](https://discord.gg/DzTYqAZZmc) &nbsp;·&nbsp; [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)"
             echo ""
             PREV=$(git tag --sort=-creatordate | grep -E '^v[0-9]' | grep -v "$TAG" | head -1)
             if [ -n "$PREV" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
             cat /tmp/changelog.md
             echo ""
             echo "<details>"
-            echo "<summary>📦 Install / Upgrade</summary>"
+            echo "<summary>Install / Upgrade</summary>"
             echo ""
             echo '**Homebrew (macOS):**'
             echo '```bash'

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -119,10 +119,16 @@ const CATEGORY_ORDER: &[&str] = &[
     "Other",
 ];
 
+/// Categories visible above the fold. Everything else (Documentation,
+/// Maintenance, Other, Reverted) is folded into a `<details>` block at the
+/// bottom of the section to keep the user-facing view scannable.
+const PRIMARY_CATEGORIES: &[&str] = &["Added", "Fixed", "Changed", "Performance"];
+
 fn generate_classified_output(prs: &[PrInfo]) -> String {
     let conv_re = Regex::new(r"^(\w+)(?:\([^)]*\))?[!]?:\s*(.*)").unwrap();
     let mut categories: std::collections::HashMap<&str, Vec<String>> =
         std::collections::HashMap::new();
+    let mut authors: Vec<String> = Vec::new();
 
     for pr in prs {
         let title = pr.title.trim();
@@ -130,11 +136,9 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
             continue;
         }
 
-        let credit = if pr.author.is_empty() {
-            String::new()
-        } else {
-            format!(" (@{})", pr.author)
-        };
+        if !pr.author.is_empty() && !authors.iter().any(|a| a == &pr.author) {
+            authors.push(pr.author.clone());
+        }
 
         let (category, desc) = if let Some(caps) = conv_re.captures(title) {
             let prefix = caps.get(1).unwrap().as_str().to_lowercase();
@@ -159,21 +163,44 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
         categories
             .entry(category)
             .or_default()
-            .push(format!("{} (#{}){}", desc, pr.number, credit));
+            .push(format!("{} (#{})", desc, pr.number));
     }
 
     let mut output = String::new();
+    let mut secondary = String::new();
     for &cat in CATEGORY_ORDER {
-        if let Some(items) = categories.get(cat) {
-            if !items.is_empty() {
-                output.push_str(&format!("### {}\n\n", cat));
-                for item in items {
-                    output.push_str(&format!("- {}\n", item));
-                }
-                output.push('\n');
-            }
+        let Some(items) = categories.get(cat) else {
+            continue;
+        };
+        if items.is_empty() {
+            continue;
         }
+        let target = if PRIMARY_CATEGORIES.contains(&cat) {
+            &mut output
+        } else {
+            &mut secondary
+        };
+        target.push_str(&format!("### {}\n\n", cat));
+        for item in items {
+            target.push_str(&format!("- {}\n", item));
+        }
+        target.push('\n');
     }
+
+    if !secondary.is_empty() {
+        output.push_str("<details>\n<summary>Documentation, maintenance, and other internal changes</summary>\n\n");
+        output.push_str(&secondary);
+        output.push_str("</details>\n\n");
+    }
+
+    if !authors.is_empty() {
+        output.push_str("### Contributors\n\n");
+        output.push_str("Thanks to ");
+        let mentions: Vec<String> = authors.iter().map(|a| format!("@{}", a)).collect();
+        output.push_str(&mentions.join(", "));
+        output.push_str(" for the contributions in this release.\n\n");
+    }
+
     output
 }
 

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -128,7 +128,6 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
     let conv_re = Regex::new(r"^(\w+)(?:\([^)]*\))?[!]?:\s*(.*)").unwrap();
     let mut categories: std::collections::HashMap<&str, Vec<String>> =
         std::collections::HashMap::new();
-    let mut authors: Vec<String> = Vec::new();
 
     for pr in prs {
         let title = pr.title.trim();
@@ -136,9 +135,11 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
             continue;
         }
 
-        if !pr.author.is_empty() && !authors.iter().any(|a| a == &pr.author) {
-            authors.push(pr.author.clone());
-        }
+        let credit = if pr.author.is_empty() {
+            String::new()
+        } else {
+            format!(" (@{})", pr.author)
+        };
 
         let (category, desc) = if let Some(caps) = conv_re.captures(title) {
             let prefix = caps.get(1).unwrap().as_str().to_lowercase();
@@ -163,7 +164,7 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
         categories
             .entry(category)
             .or_default()
-            .push(format!("{} (#{})", desc, pr.number));
+            .push(format!("{} (#{}){}", desc, pr.number, credit));
     }
 
     let mut output = String::new();
@@ -191,14 +192,6 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
         output.push_str("<details>\n<summary>Documentation, maintenance, and other internal changes</summary>\n\n");
         output.push_str(&secondary);
         output.push_str("</details>\n\n");
-    }
-
-    if !authors.is_empty() {
-        output.push_str("### Contributors\n\n");
-        output.push_str("Thanks to ");
-        let mentions: Vec<String> = authors.iter().map(|a| format!("@{}", a)).collect();
-        output.push_str(&mentions.join(", "));
-        output.push_str(" for the contributions in this release.\n\n");
     }
 
     output

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -62,6 +62,8 @@ struct PrInfo {
     number: u64,
     title: String,
     author: String,
+    /// Conventional-commits breaking-change marker: `feat!:`, `fix(scope)!:`, etc.
+    breaking: bool,
 }
 
 fn fetch_pr_info(num: u64) -> Option<PrInfo> {
@@ -79,9 +81,12 @@ fn fetch_pr_info(num: u64) -> Option<PrInfo> {
         return None;
     }
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let title = json["title"].as_str()?.to_string();
+    let breaking_re = Regex::new(r"^\w+(?:\([^)]*\))?!:").unwrap();
     Some(PrInfo {
         number: json["number"].as_u64()?,
-        title: json["title"].as_str()?.to_string(),
+        breaking: breaking_re.is_match(&title),
+        title,
         author: json["author"]["login"].as_str().unwrap_or("").to_string(),
     })
 }
@@ -195,6 +200,81 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
     }
 
     output
+}
+
+/// Build a `### Breaking Changes` block from PRs whose conventional-commit
+/// title carries the `!` marker (`feat!:`, `fix(scope)!:`, etc.). Returns
+/// `None` when there are none — the section is omitted entirely.
+fn generate_breaking_changes(prs: &[PrInfo]) -> Option<String> {
+    let conv_re = Regex::new(r"^(\w+)(?:\([^)]*\))?!:\s*(.*)").unwrap();
+    let mut bullets = Vec::new();
+    for pr in prs {
+        if !pr.breaking || should_skip(pr.title.trim()) {
+            continue;
+        }
+        let credit = if pr.author.is_empty() {
+            String::new()
+        } else {
+            format!(" (@{})", pr.author)
+        };
+        let desc = conv_re
+            .captures(pr.title.trim())
+            .and_then(|c| c.get(2).map(|m| m.as_str().trim().to_string()))
+            .unwrap_or_else(|| pr.title.trim().to_string());
+        let desc = {
+            let mut chars = desc.chars();
+            match chars.next() {
+                None => desc,
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+            }
+        };
+        bullets.push(format!("- {} (#{}){}", desc, pr.number, credit));
+    }
+    if bullets.is_empty() {
+        return None;
+    }
+    let mut block = String::from("### Breaking Changes\n\n");
+    for b in bullets {
+        block.push_str(&b);
+        block.push('\n');
+    }
+    block.push('\n');
+    Some(block)
+}
+
+/// One-line stats prefix: `_N PRs from M contributors since vBASE._`
+/// `base_tag` is the version we're comparing from; `None` when unknown.
+fn generate_stats_line(prs: &[PrInfo], base_tag: Option<&str>) -> Option<String> {
+    let included: Vec<&PrInfo> = prs
+        .iter()
+        .filter(|p| !should_skip(p.title.trim()))
+        .collect();
+    if included.is_empty() {
+        return None;
+    }
+    let pr_count = included.len();
+    let mut authors: Vec<&str> = included
+        .iter()
+        .map(|p| p.author.as_str())
+        .filter(|a| !a.is_empty())
+        .collect();
+    authors.sort_unstable();
+    authors.dedup();
+    let author_count = authors.len();
+    let pr_word = if pr_count == 1 { "PR" } else { "PRs" };
+    let contrib_word = if author_count == 1 {
+        "contributor"
+    } else {
+        "contributors"
+    };
+    let suffix = match base_tag {
+        Some(t) => format!(" since {}", t),
+        None => String::new(),
+    };
+    Some(format!(
+        "_{} {} from {} {}{}._\n\n",
+        pr_count, pr_word, author_count, contrib_word, suffix
+    ))
 }
 
 /// Summarize the classified changelog into a `### Highlights` block via local
@@ -360,11 +440,14 @@ pub fn run(args: ChangelogArgs) -> Result<(), Box<dyn std::error::Error>> {
         .collect();
 
     let classified = generate_classified_output(&prs);
+    let breaking = generate_breaking_changes(&prs).unwrap_or_default();
+    let stats = generate_stats_line(&prs, base_tag.as_deref()).unwrap_or_default();
 
-    let final_output = match generate_highlights(&classified) {
-        Some(highlights) => format!("{}{}", highlights, classified),
-        None => classified,
-    };
+    // Feed breaking + classified to claude so highlights can flag breaking items.
+    let highlights_input = format!("{}{}", breaking, classified);
+    let highlights = generate_highlights(&highlights_input).unwrap_or_default();
+
+    let final_output = format!("{}{}{}{}", stats, breaking, highlights, classified);
 
     write_changelog(&changelog_path, &args.version, &final_output)?;
 

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -177,6 +177,61 @@ fn generate_classified_output(prs: &[PrInfo]) -> String {
     output
 }
 
+/// Summarize the classified changelog into a `### Highlights` block via local
+/// `claude` CLI. Returns `None` if claude isn't installed, the call fails, or
+/// the response is empty — never propagates errors to gate the release.
+fn generate_highlights(classified: &str) -> Option<String> {
+    if classified.trim().is_empty() {
+        return None;
+    }
+
+    if Command::new("claude").arg("--version").output().is_err() {
+        println!("  claude CLI not available, skipping Highlights generation");
+        return None;
+    }
+
+    let prompt = format!(
+        "Summarize this LibreFang release changelog into 3-5 user-facing highlights as a markdown bullet list under a `### Highlights` heading. \
+        Lead each bullet with the headline feature name in **bold**, followed by an em dash and a short clause. \
+        Pick the most impactful user-visible changes; group related items into one bullet. \
+        Skip internal milestone names (M2, M3, etc.), test/CI/typecheck fixes, refactors, and pure maintenance. \
+        Output ONLY the `### Highlights` section and its bullets — no preamble, no trailing prose.\n\n\
+        Changelog:\n{}",
+        classified
+    );
+
+    let output = Command::new("claude")
+        .args([
+            "-p",
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "text",
+            &prompt,
+        ])
+        .env_remove("CLAUDECODE")
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        println!("  claude call failed, skipping Highlights generation");
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        return None;
+    }
+
+    let block = if text.starts_with("### Highlights") {
+        format!("{}\n\n", text)
+    } else {
+        format!("### Highlights\n\n{}\n\n", text)
+    };
+    println!("  Generated Highlights via claude");
+    Some(block)
+}
+
 fn write_changelog(
     changelog_path: &Path,
     version: &str,
@@ -286,7 +341,12 @@ pub fn run(args: ChangelogArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let classified = generate_classified_output(&prs);
 
-    write_changelog(&changelog_path, &args.version, &classified)?;
+    let final_output = match generate_highlights(&classified) {
+        Some(highlights) => format!("{}{}", highlights, classified),
+        None => classified,
+    };
+
+    write_changelog(&changelog_path, &args.version, &final_output)?;
 
     println!("Updated {}", changelog_path.display());
 


### PR DESCRIPTION
## Summary

End-to-end overhaul of the release-notes pipeline so each published GitHub release lands with a scannable, human-friendly layout instead of a wall of repeated boilerplate. Three coordinated changes:

1. **Auto-generated Highlights** (`xtask/src/changelog.rs`) — local `claude` CLI summarizes the classified PR list into a 3-5 bullet `### Highlights` block, prepended to each new CHANGELOG section. Soft dependency: skipped silently if `claude` isn't on PATH or the call fails.
2. **Format optimizations** for the rendered release body:
   - **Collapse Install/Migration boilerplate** into a `<details>` block — the brew/npm/pip/cargo/docker section was repeated identically every release.
   - **Fold internal categories** (Documentation, Maintenance, Other, Reverted) into a `<details>` block; only Added / Fixed / Changed / Performance stay above the fold.
   - Rename `## What's New` → `## Full Changelog` (Highlights now carries the news headline).
   - Inline the Links row as `Documentation · Discord · Contributing Guide`.

Inline `(@author)` attribution on every PR bullet is preserved.

Motivated by the manual highlights I added to [v2026.4.27-beta6](https://github.com/librefang/librefang/releases/tag/v2026.4.27-beta6) — instead of doing that by hand each release, automate it and clean up the surrounding noise at the same time.

## Trade-offs

- Highlights only generated when `cargo xtask release` runs locally. The `bump_version` job in CI doesn't have `claude` installed, so workflow-dispatched releases will skip highlights. Acceptable since `just release` is the primary path.
- Adds a few seconds of latency to `cargo xtask changelog`.
- Categories below the fold need an extra click — intentional; users who care can always hit "Full diff".

## Test plan

- [ ] Run `cargo xtask changelog 2026.4.27` locally, verify `### Highlights` appears at the top, every bullet still ends with `(#NNNN) (@author)`, and Documentation/Maintenance/Other are wrapped in `<details>`.
- [ ] Temporarily rename `claude` on PATH, re-run, verify highlights step skips silently and the rest of the format still applies.
- [ ] Tag a throwaway pre-release through the workflow, verify the GitHub release body shows: Highlights at top → Full Changelog (with author credits) → folded internal categories → folded Install/Upgrade → Links → Full diff link.
