### PR TITLE
fix: unbreak main — namespace traversal substring + openapi.json bump

### DIFF
--- a/crates/librefang-types/src/user_policy.rs
+++ b/crates/librefang-types/src/user_policy.rs
@@ -286,14 +286,18 @@ pub struct UserMemoryAccess {
 }
 
 /// Memory namespaces are colon- and slash-delimited identifiers
-/// (`kv:user_alice`, `shared:scope/foo`). A `..` segment in a candidate
-/// namespace is a path-traversal attempt and is rejected before any glob
-/// pattern is consulted — the LLM-facing memory tools never need it, and
-/// allowing it would let `kv:user_*` admit `kv:user_../admin`.
+/// (`kv:user_alice`, `shared:scope/foo`). Any segment containing `..`
+/// is a path-traversal candidate and is rejected before any glob pattern
+/// is consulted — the LLM-facing memory tools never need `..` for
+/// legitimate purposes, and a substring check defends against both the
+/// canonical `kv:user_alice/../bob` form (segment is exactly `..`) and
+/// the prefix-bypass form `kv:user_../admin` where the `..` is glued to
+/// a longer segment (`user_..`) and would slip past a `seg == ".."`
+/// check.
 fn has_path_traversal(namespace: &str) -> bool {
     namespace
         .split(|c: char| c == '/' || c == ':' || c.is_whitespace())
-        .any(|seg| seg == "..")
+        .any(|seg| seg.contains(".."))
 }
 
 /// Namespace-aware variant of [`crate::capability::glob_matches`].

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "2026.4.24-beta5"
+    "version": "2026.4.27-beta6"
   },
   "paths": {
     "/.well-known/agent.json": {


### PR DESCRIPTION
## Summary

Unbreak `main` — two independent failures since the `v2026.4.27-beta6` cut, both blocking CI on every push.

### 1. Test failure (security regression)

`librefang-types::user_policy::tests::memory_access_star_pattern_still_rejects_traversal` from #3249 asserts that the memory-namespace ACL guard rejects `kv:user_../admin`, but the implementation only catches `..` when it's a **standalone segment** (`seg == ".."`). The test correctly identifies a real attack: `kv:user_../admin` splits into `["kv", "user_..", "admin"]` — `user_..` slips past the equality check but any naive resolver still normalizes the string to `kv:admin`, jumping out of the `kv:user_*` (or `*` owner-all) ACL.

**Fix:** widen the check from equality to substring (`seg.contains("..")`). Memory namespaces have no legitimate use for `..` anywhere.

| Input | Before | After |
|---|---|---|
| `kv:user_alice/../bob` | rejected ✓ | rejected ✓ |
| `kv:user_../admin` | **allowed** | rejected ✓ |
| `..foo`, `foo..bar` | allowed | rejected ✓ |

### 2. OpenAPI drift (stale generated file)

The version bump in #3255 didn't regenerate `openapi.json`. The file still carried `"version": "2026.4.24-beta5"` while Cargo had moved to `beta6`, so every PR was failing the `OpenAPI Drift` job on the same one-line diff. Re-ran `cargo xtask codegen --openapi`; only the version string changed.

## Test plan

- [x] `cargo test -p librefang-types --lib user_policy` — all 25 tests pass locally including the previously failing one.
- [x] `cargo clippy -p librefang-types --all-targets -- -D warnings` — clean.
- [x] `python3 scripts/codegen-sdks.py` — SDKs unchanged (no API version field).
- [ ] CI green on Ubuntu / macOS / Windows + OpenAPI Drift.
