### PR TITLE
feat(kernel): include session_id in agent-loop-failure warn log

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -304,6 +304,46 @@ fn collect_rotation_key_specs(
     specs
 }
 
+/// Resolve the effective session id used by the dispatch site in
+/// `send_message_full_with_upstream`. Mirrors the resolution that
+/// `execute_llm_agent` performs internally so the kernel and any failure /
+/// supervisor logs agree on which session id was actually used — including
+/// when `session_mode = "new"` would otherwise mint a fresh id deeper in
+/// the stack. Returns `None` for module types that do not carry a session
+/// (wasm, python).
+fn resolve_dispatch_session_id(
+    module: &str,
+    agent_id: AgentId,
+    entry_session_id: SessionId,
+    manifest_session_mode: librefang_types::agent::SessionMode,
+    sender_context: Option<&SenderContext>,
+    session_mode_override: Option<librefang_types::agent::SessionMode>,
+    session_id_override: Option<SessionId>,
+) -> Option<SessionId> {
+    if module.starts_with("wasm:") || module.starts_with("python:") {
+        return None;
+    }
+    if let Some(sid) = session_id_override {
+        return Some(sid);
+    }
+    Some(match sender_context {
+        Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
+            let scope = match &ctx.chat_id {
+                Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
+                _ => ctx.channel.clone(),
+            };
+            SessionId::for_channel(agent_id, &scope)
+        }
+        _ => {
+            let mode = session_mode_override.unwrap_or(manifest_session_mode);
+            match mode {
+                librefang_types::agent::SessionMode::Persistent => entry_session_id,
+                librefang_types::agent::SessionMode::New => SessionId::new(),
+            }
+        }
+    })
+}
+
 /// One in-flight `(agent, session)` loop. Stored in
 /// `LibreFangKernel.running_tasks` to support per-session cancellation
 /// (`stop_session_run`) and runtime introspection
@@ -4752,6 +4792,21 @@ system_prompt = "You are a helpful assistant."
             return Ok(AgentLoopResult::default());
         }
 
+        // Resolve the effective session id up front for the LLM path so we
+        // can include it in supervisor / failure logs below, then pass it
+        // back down as the explicit override so the kernel and the log line
+        // agree on the id even when `session_mode = "new"` would otherwise
+        // mint a fresh session inside `execute_llm_agent`.
+        let resolved_session_id: Option<SessionId> = resolve_dispatch_session_id(
+            &entry.manifest.module,
+            agent_id,
+            entry.session_id,
+            entry.manifest.session_mode,
+            sender_context,
+            session_mode_override,
+            session_id_override,
+        );
+
         // Dispatch based on module type
         let result = match entry.manifest.module.as_str() {
             module if module.starts_with("wasm:") => {
@@ -4772,7 +4827,7 @@ system_prompt = "You are a helpful assistant."
                     sender_context,
                     session_mode_override,
                     thinking_override,
-                    session_id_override,
+                    resolved_session_id.or(session_id_override),
                     upstream_interrupt,
                 )
                 .await
@@ -5075,7 +5130,15 @@ system_prompt = "You are a helpful assistant."
 
                 // Record the failure in supervisor for health reporting
                 self.supervisor.record_panic();
-                warn!(agent_id = %agent_id, error = %e, "Agent loop failed — recorded in supervisor");
+                let session_id_for_log = resolved_session_id
+                    .map(|s| s.0.to_string())
+                    .unwrap_or_else(|| "<none>".to_string());
+                warn!(
+                    agent_id = %agent_id,
+                    session_id = %session_id_for_log,
+                    error = %e,
+                    "Agent loop failed — recorded in supervisor"
+                );
 
                 // Push failure notification to alert_channels
                 let agent_name = self

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4621,3 +4621,177 @@ fn mcp_summary_inner_tool_list_is_sorted() {
         "Inner tool list must be sorted; got: {summary}"
     );
 }
+
+// ─── resolve_dispatch_session_id ──────────────────────────────────────────
+//
+// Backstop for the session-id-in-failure-log change: ensures the kernel
+// dispatch site and the warn log line always agree on which session id was
+// used, including the `session_mode = "new"` path that would otherwise mint
+// a different fresh id deeper inside `execute_llm_agent`. Tests target the
+// pure helper directly so they don't need a live kernel + driver setup.
+
+fn dummy_sender(channel: &str, chat_id: Option<&str>) -> SenderContext {
+    SenderContext {
+        channel: channel.to_string(),
+        chat_id: chat_id.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn resolve_dispatch_session_id_returns_none_for_wasm_module() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let got = resolve_dispatch_session_id(
+        "wasm:foo",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        None,
+        None,
+        None,
+    );
+    assert_eq!(got, None);
+}
+
+#[test]
+fn resolve_dispatch_session_id_returns_none_for_python_module() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let got = resolve_dispatch_session_id(
+        "python:foo",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        None,
+        None,
+        None,
+    );
+    assert_eq!(got, None);
+}
+
+#[test]
+fn resolve_dispatch_session_id_explicit_override_wins() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let override_sid = SessionId::new();
+    let sender = dummy_sender("telegram", Some("chat-1"));
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::New,
+        Some(&sender),
+        Some(librefang_types::agent::SessionMode::Persistent),
+        Some(override_sid),
+    );
+    assert_eq!(got, Some(override_sid));
+}
+
+#[test]
+fn resolve_dispatch_session_id_uses_channel_scope_with_chat_id() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let sender = dummy_sender("telegram", Some("chat-42"));
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        Some(&sender),
+        None,
+        None,
+    );
+    let expected = SessionId::for_channel(agent_id, "telegram:chat-42");
+    assert_eq!(got, Some(expected));
+}
+
+#[test]
+fn resolve_dispatch_session_id_uses_channel_only_when_no_chat_id() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let sender = dummy_sender("slack", None);
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        Some(&sender),
+        None,
+        None,
+    );
+    let expected = SessionId::for_channel(agent_id, "slack");
+    assert_eq!(got, Some(expected));
+}
+
+#[test]
+fn resolve_dispatch_session_id_canonical_session_bypasses_channel_scope() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let sender = SenderContext {
+        channel: "telegram".to_string(),
+        chat_id: Some("chat-7".to_string()),
+        use_canonical_session: true,
+        ..Default::default()
+    };
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        Some(&sender),
+        None,
+        None,
+    );
+    assert_eq!(got, Some(entry_sid));
+}
+
+#[test]
+fn resolve_dispatch_session_id_persistent_mode_returns_entry_session() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::Persistent,
+        None,
+        None,
+        None,
+    );
+    assert_eq!(got, Some(entry_sid));
+}
+
+#[test]
+fn resolve_dispatch_session_id_new_mode_mints_fresh_session() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::New,
+        None,
+        None,
+        None,
+    );
+    let sid = got.expect("expected Some session id");
+    assert_ne!(sid, entry_sid, "New mode must mint a fresh session id");
+}
+
+#[test]
+fn resolve_dispatch_session_id_session_mode_override_beats_manifest() {
+    let agent_id = AgentId::new();
+    let entry_sid = SessionId::new();
+    // Manifest says New, override says Persistent → must return entry id.
+    let got = resolve_dispatch_session_id(
+        "builtin:chat",
+        agent_id,
+        entry_sid,
+        librefang_types::agent::SessionMode::New,
+        None,
+        Some(librefang_types::agent::SessionMode::Persistent),
+        None,
+    );
+    assert_eq!(got, Some(entry_sid));
+}


### PR DESCRIPTION
## Summary

The `Agent loop failed — recorded in supervisor` warn line previously logged only `agent_id`, which makes it hard to correlate a failure (e.g. `Repeated tool failures`) with the specific session whose history caused it. This adds `session_id` to that log line.

To make the dispatch site and the log agree on the id even when `session_mode = \"new\"` would otherwise mint a fresh id deeper inside `execute_llm_agent`, the effective session id is resolved once at the dispatch site (`send_message_full_with_upstream`) via a new pure helper `resolve_dispatch_session_id` and passed back down as the explicit `session_id_override`.

Resolution mirrors the existing precedence inside `execute_llm_agent`:

- `None` for wasm/python modules (no session)
- explicit `session_id_override` if supplied
- channel-derived scope (`SessionId::for_channel(agent_id, \"<channel>[:<chat_id>]\")`) when `sender_context` has a non-empty channel and `use_canonical_session` is false
- session-mode fallback: `Persistent` → `entry.session_id`, `New` → `SessionId::new()` (per-trigger override beats manifest)

Example log change:

```
WARN Agent loop failed — recorded in supervisor agent_id=635cf1da-… session_id=8f1c…-… error=Repeated tool failures: 3 consecutive iterations with 1 errors
```

## Test plan

- [x] `cargo build -p librefang-kernel --lib`
- [x] `cargo test -p librefang-kernel --lib resolve_dispatch_session_id` — 9 new unit tests pass:
  - returns `None` for wasm / python modules
  - explicit `session_id_override` wins over channel + manifest mode
  - channel scope uses `\"channel:chat_id\"` when chat_id present
  - channel scope falls back to bare `\"channel\"` when chat_id absent
  - `use_canonical_session` bypasses channel scope and returns `entry.session_id`
  - `Persistent` mode returns `entry.session_id`
  - `New` mode mints a fresh id distinct from `entry.session_id`
  - per-call `session_mode_override` beats manifest `session_mode`
- [ ] Verify in a live daemon that the warn line now shows `session_id=…` on a `Repeated tool failures` exit