### PR TITLE
ci: add Nix build workflow to catch flake breakage on PR

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,68 @@
+name: Nix Build
+
+# Catches NixOS build breakage on flake.nix or workspace changes before
+# they reach main. Past incidents (#2937, #2974, #3052, #3156, #3197) all
+# slipped through because regular CI doesn't exercise the Nix path.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**/Cargo.toml'
+      - '.github/workflows/nix-build.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**/Cargo.toml'
+      - '.github/workflows/nix-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  nix-build:
+    name: nix build (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - librefang-cli
+          - librefang-desktop
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Cache /nix/store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ matrix.package }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ matrix.package }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-${{ matrix.package }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+
+      - name: Build .#${{ matrix.package }}
+        run: nix build --print-build-logs .#${{ matrix.package }}


### PR DESCRIPTION
## Summary

Adds a dedicated CI workflow that runs `nix build .#librefang-cli` and `nix build .#librefang-desktop` so flake breakage is caught on PR review instead of after merge.

## Why

The Nix build path has broken at least six times — #2937, #2974, #3052, #3156, #3197, #3263 — and every one shipped to `main` because no CI job exercises `flake.nix`. NixOS users have to wait for a follow-up fix PR each time.

## Design

- **Triggers**: `flake.nix`, `flake.lock`, root `Cargo.lock`, root `Cargo.toml`, any per-crate `Cargo.toml`, or the workflow file itself. Rust-only PRs don't pay the cost.
- **Matrix**: builds `librefang-cli` and `librefang-desktop` in parallel with `fail-fast: false` — historically both paths have broken independently (CLI in #2937, desktop tray icon in #3052/#3197).
- **Cache**: `nix-community/cache-nix-action@v7` keyed on `flake.lock` + `Cargo.lock`; cold build ~30–40 min, warm hit much faster.
- **Actions versions**: `actions/checkout@v6`, `cachix/install-nix-action@v31`, `nix-community/cache-nix-action@v7` — all current major versions as of opening this PR.
- **Timeout**: 60 min, generous for the cold path.

Not making this a required check yet — let it bake on a few PRs first to confirm the cache behaviour and runtime are sane.

## Test plan

- [ ] Workflow file parses (GitHub will reject malformed YAML on push)
- [ ] First run on this PR completes both matrix legs green
- [ ] Confirm cache hit on a no-op rerun is materially faster than the cold run
