### PR TITLE
fix(docker): install libdbus-1 so image builds and starts (closes #3259)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,10 +12,15 @@ RUN corepack enable \
 # Stage 2: Build Rust binary
 FROM rust:1-slim-bookworm AS builder
 WORKDIR /build
+# libdbus-1-dev is required by libdbus-sys (transitive dep of keyring's
+# sync-secret-service feature, added in #3180). Without it the cargo build
+# panics with exit 101 in the build script — same root cause as #3259, and
+# why the v2026.4.27-beta6 docker image was never published.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     pkg-config \
     libssl-dev \
+    libdbus-1-dev \
     perl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -33,11 +38,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/librefang /usr/local/bin/librefang
 
 FROM node:lts-bookworm-slim
+# libdbus-1-3 = runtime SO that libdbus-sys links against. Without it the
+# binary fails to start (the keyring init path runs early in boot and
+# exits 101 if the .so can't be resolved).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     python3 \
     python3-venv \
     libicu72 \
+    libdbus-1-3 \
     gosu \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/librefang /usr/local/bin/


### PR DESCRIPTION
Closes #3259

## Root cause

PR #3180 added the `keyring` crate with the `sync-secret-service` feature, which transitively pulls `libdbus-sys` (a C-FFI binding to libdbus). The Dockerfile was never updated, so:

```
#28 149.9 error: failed to run custom build command for `libdbus-sys v0.2.7`
#28 149.9   pkg_config failed
#28 149.9   The system library `dbus-1` required by crate `libdbus-sys` was not found.
#28 ERROR: process "/bin/sh -c cargo build --release ..." did not complete successfully: exit code: 101
```

Both `Docker / linux/amd64` and `Docker / linux/arm64` jobs failed in the v2026.4.27-beta6 release run ([24960196009](https://github.com/librefang/librefang/actions/runs/24960196009)). Because the docker job failed, the manifest job never ran, and `ghcr.io/librefang/librefang:latest` is still pinned to v2026.4.24-beta5 — the version that has the boot-time crash #3060 was supposed to fix. That's exactly what the user is hitting in #3259: they pull `latest`, get beta5, and watch it exit 101.

## Fix

- Builder stage: add `libdbus-1-dev` so `pkg_config` finds `dbus-1.pc`.
- Runtime stage: add `libdbus-1-3` so the linked binary's `libdbus-1.so.3` resolves at startup.

## Out of scope (explicit)

The same `libdbus-sys` failure also broke `CLI / x86_64-unknown-linux-gnu`, `CLI / x86_64-unknown-linux-gnu (mini)`, the musl-static cross builds, and the android cross build in the same release run. The native CLI fix is a one-line apt change in `release.yml`, but the cross/musl/android builds need a different approach (proper feature gating, since shipping libdbus into a static or android binary doesn't make sense). Splitting those out keeps this PR narrowly focused on unblocking the user's bug.

## Test plan

- [ ] CI builds both `Docker / linux/amd64` and `Docker / linux/arm64`
- [ ] After merge + next release, `docker pull ghcr.io/librefang/librefang:latest` produces a runnable container that starts the daemon (no exit 101)
- [ ] `docker run -p 4545:4545 ghcr.io/librefang/librefang:latest` serves `/api/health`
