### PR TITLE
ci: add Docker build + boot smoke test on PR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,91 @@
+name: Docker Build
+
+# Catches Dockerfile / runtime breakage on PR before it reaches the
+# release pipeline. Past incidents — #3058 (logs dir) and #3259 (missing
+# libdbus, blocked the entire v2026.4.27-beta6 image release) — both
+# slipped through because the docker job in release.yml only fires on
+# tag push, not on PRs.
+#
+# Build-only validation isn't enough: #3259 would still pass a pure
+# `docker build` if we only fixed the builder stage and forgot the
+# runtime SO. So we also boot the image and probe /api/health to catch
+# missing runtime libs / entrypoint regressions.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/Dockerfile'
+      - 'deploy/docker-entrypoint.sh'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**/Cargo.toml'
+      - 'crates/librefang-api/dashboard/package.json'
+      - 'crates/librefang-api/dashboard/pnpm-lock.yaml'
+      - '.github/workflows/docker-build.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/Dockerfile'
+      - 'deploy/docker-entrypoint.sh'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**/Cargo.toml'
+      - 'crates/librefang-api/dashboard/package.json'
+      - 'crates/librefang-api/dashboard/pnpm-lock.yaml'
+      - '.github/workflows/docker-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    name: docker build + smoke
+    # amd64 only — arm64 would double runtime for marginal extra coverage.
+    # The release pipeline still builds both architectures at tag time.
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (load to local daemon)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/Dockerfile
+          load: true
+          tags: librefang:ci
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Boot container and probe /api/health
+        run: |
+          set -euo pipefail
+          docker run -d --name librefang-ci -p 4545:4545 librefang:ci
+          # Poll for up to 60s — first boot does `librefang init` which
+          # writes a config and seeds the registry.
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4545/api/health >/dev/null; then
+              echo "✓ /api/health responded after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::/api/health never came up — dumping container logs"
+          docker logs librefang-ci
+          exit 1
+
+      - name: Container logs (always)
+        if: always()
+        run: docker logs librefang-ci 2>&1 || true
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f librefang-ci 2>&1 || true


### PR DESCRIPTION
## Summary

Adds a PR-level CI job that builds `deploy/Dockerfile` and boots the resulting image to probe `/api/health`, so Docker breakage is caught before the release pipeline.

## Why

Same gap that bit us with #3264 (Nix). The docker job in `release.yml` only triggers on tag push, so:
- **#3058** — entrypoint regression (missing `logs/` dir, exit 101) shipped to release before anyone noticed
- **#3259** — Dockerfile missing `libdbus-1-dev` after #3180 added the keyring crate. Blocked the entire `v2026.4.27-beta6` image release; `ghcr.io/librefang/librefang:latest` is still pinned to `v2026.4.24-beta5` as of opening this PR

Both were architecturally undetectable on PR review because no PR-level CI exercised the Docker build path.

## Design

- **Triggers**: `deploy/Dockerfile`, `deploy/docker-entrypoint.sh`, `Cargo.lock`, root `Cargo.toml`, per-crate `Cargo.toml`, dashboard `package.json` / `pnpm-lock.yaml`, or the workflow file. Touches affecting the docker layer only.
- **Build-only validation isn't enough.** #3259 had two halves — `libdbus-1-dev` for the builder, `libdbus-1-3` for the runtime SO. A pure `docker build` would have passed the half-fix and still shipped a binary that crashes at boot via dlopen failure. So the job also runs the image and polls `/api/health` (up to 60s; first boot runs `librefang init`).
- **amd64 only.** arm64 doubles runtime for marginal extra coverage; the release pipeline still builds both architectures at tag time.
- **GHA cache scoped to `docker-build`** — independent from the release pipeline's per-platform scopes so it doesn't poison their caches.
- **Action versions current as of opening**: `actions/checkout@v6`, `docker/setup-buildx-action@v4` (v4.0.0), `docker/build-push-action@v7` (v7.1.0).
- Not a required check yet — let it bake on a few PRs first.

## Test plan

- [ ] First run on this PR completes green (build + health probe)
- [ ] Cache hit on a no-op rerun is noticeably faster
- [ ] Confirm health probe actually fails when fed a deliberately broken Dockerfile (e.g. tested locally by removing `libdbus-1-3` from the runtime stage)
