### PR TITLE
fix(docker): copy deploy/ into builder so include_str! observability assets resolve (closes #3259)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -29,6 +29,12 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
 COPY packages ./packages
+# librefang-api uses include_str!("../../../deploy/...") to embed the
+# observability stack (prometheus / tempo / otel-collector / grafana
+# configs) at compile time — added in #3062. Without this COPY the
+# build fails with "couldn't read deploy/grafana/...". flake.nix
+# already lists the same paths in its source fileset.
+COPY deploy ./deploy
 COPY --from=dashboard-builder /build/static/react ./crates/librefang-api/static/react
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
Closes #3259 (for real this time).

## Summary

Adds `COPY deploy ./deploy` to the Dockerfile builder stage so the `include_str!("../../../deploy/...")` macros in `librefang-api` can resolve at compile time.

## Why this is a separate PR

#3265 fixed the **first** thing blocking the docker image build — `libdbus-1-dev` / `libdbus-1-3` for the keyring crate. After it merged, the docker-build CI from #3266 ran on main and immediately surfaced a **second** independent bug:

```
error: couldn't read crates/librefang-api/src/../../../deploy/grafana/provisioning/datasources/prometheus.yml
error: couldn't read crates/librefang-api/src/../../../deploy/grafana/dashboards/librefang.json
... (12 errors total)
error: could not compile `librefang-api`
```

Root cause: PR #3062 (Apr 25) added `include_str!("../../../deploy/grafana/…", "deploy/prometheus/…", "deploy/otel-collector/…", "deploy/tempo/…", "deploy/docker-compose.observability.yml")` to embed the local observability stack into the binary. The Dockerfile builder stage only copies `crates / xtask / packages` — `deploy/` was never added, so cargo couldn't read those paths from `/build/deploy/...`.

This was hidden behind the libdbus-sys panic for two days. Removing one error revealed the other. The docker-build CI added in #3266 was specifically designed to catch exactly this kind of layered breakage on PR — its first run on main caught it.

## Why `COPY deploy ./deploy` instead of selective copies

Five subdirs are referenced today (`docker-compose.observability.yml`, `prometheus`, `otel-collector`, `tempo`, `grafana`). Selective copies would be five lines and would silently break the next time someone adds an `include_str!("../../../deploy/...")`. The whole `deploy/` dir is a few hundred KB and exists only in the builder stage (thrown away in the runtime image), so a single `COPY deploy ./deploy` is both simpler and more future-proof. `flake.nix` already takes the same approach in its source fileset.

## Test plan

- [ ] docker-build CI on this PR completes green (build + `/api/health` smoke)
- [ ] After merge, `docker pull ghcr.io/librefang/librefang:latest` produces a runnable image (requires next release tag to be cut to actually publish)
