### PR TITLE
fix(tools): show declared tools in editor and persist to **disk**

### DIFF
--- a/crates/librefang-api/dashboard/src/api.test.ts
+++ b/crates/librefang-api/dashboard/src/api.test.ts
@@ -159,13 +159,14 @@ describe("dashboard auth helpers", () => {
   it("getAgentTools requests the agent tools endpoint", async () => {
     setApiKey("secret-token");
     fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ tool_allowlist: ["bash"], tool_blocklist: ["rm"], disabled: false }), {
+      new Response(JSON.stringify({ capabilities_tools: ["bash"], tool_allowlist: ["bash"], tool_blocklist: ["rm"], disabled: false }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
     );
 
     await expect(getAgentTools("agent-123")).resolves.toEqual({
+      capabilities_tools: ["bash"],
       tool_allowlist: ["bash"],
       tool_blocklist: ["rm"],
       disabled: false,

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1113,6 +1113,7 @@ export async function patchAgent(agentId: string, body: { name?: string; descrip
 }
 
 export interface AgentToolsResponse {
+  capabilities_tools?: string[] | null;
   tool_allowlist?: string[] | null;
   tool_blocklist?: string[] | null;
   disabled?: boolean;
@@ -1127,7 +1128,7 @@ export async function getAgentTools(agentId: string): Promise<AgentToolsResponse
   return get<AgentToolsResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`);
 }
 
-export async function updateAgentTools(agentId: string, payload: { tool_allowlist?: string[]; tool_blocklist?: string[] }): Promise<ApiActionResponse> {
+export async function updateAgentTools(agentId: string, payload: { capabilities_tools?: string[]; tool_allowlist?: string[]; tool_blocklist?: string[] }): Promise<ApiActionResponse> {
   return put<ApiActionResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`, payload);
 }
 

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -158,6 +158,7 @@ export function AgentsPage() {
   const [showHandAgents, setShowHandAgents] = useState(false);
   const [showToolsEditor, setShowToolsEditor] = useState(false);
   const [toolsEditorAgentId, setToolsEditorAgentId] = useState<string | null>(null);
+  const [capabilitiesToolsDraft, setCapabilitiesToolsDraft] = useState<string[]>([]);
   const [toolAllowlistDraft, setToolAllowlistDraft] = useState<string[]>([]);
   const [toolBlocklistDraft, setToolBlocklistDraft] = useState<string[]>([]);
   const [toolsDisabledState, setToolsDisabledState] = useState(false);
@@ -304,6 +305,7 @@ export function AgentsPage() {
     setToolsEditorLoading(false);
     setToolsEditorSaving(false);
     setAvailableToolNames([]);
+    setCapabilitiesToolsDraft([]);
     setToolAllowlistDraft([]);
     setToolBlocklistDraft([]);
     setToolsDisabledState(false);
@@ -328,6 +330,7 @@ export function AgentsPage() {
           ? allTools.map((tool: ToolDefinition) => tool.name).filter(Boolean)
           : [];
         setAvailableToolNames(names);
+        setCapabilitiesToolsDraft(Array.isArray(agentTools?.capabilities_tools) ? agentTools.capabilities_tools : []);
         setToolAllowlistDraft(Array.isArray(agentTools?.tool_allowlist) ? agentTools.tool_allowlist : []);
         setToolBlocklistDraft(Array.isArray(agentTools?.tool_blocklist) ? agentTools.tool_blocklist : []);
         setToolsDisabledState(Boolean(agentTools?.disabled));
@@ -1260,11 +1263,11 @@ export function AgentsPage() {
           <div className="p-6 space-y-5">
             <div>
               <p className="text-[11px] text-text-dim/70">
-                {t("agents.tools_editor_desc", { defaultValue: "Review the current tools state for this agent. Empty allowlist means no allow restriction; blocklist still removes selected tools." })}
+                {t("agents.tools_editor_desc", { defaultValue: "Review and manage the agent's tools. Declared tools are the primary set; allowlist/blocklist are additional filters." })}
               </p>
               {!toolsEditorLoading && (
                 <p className="mt-2 text-[10px] text-text-dim/50 font-mono">
-                  {availableToolNames.length} {t("agents.tools_available", { defaultValue: "tools available" })} · {toolAllowlistDraft.length} {t("agents.tools_allowed_count", { defaultValue: "allowed" })} · {toolBlocklistDraft.length} {t("agents.tools_blocked_count", { defaultValue: "blocked" })}
+                  {capabilitiesToolsDraft.length} {t("agents.tools_declared_count", { defaultValue: "declared" })} · {availableToolNames.length} {t("agents.tools_available", { defaultValue: "tools available" })} · {toolAllowlistDraft.length} {t("agents.tools_allowed_count", { defaultValue: "allowed" })} · {toolBlocklistDraft.length} {t("agents.tools_blocked_count", { defaultValue: "blocked" })}
                 </p>
               )}
             </div>
@@ -1295,10 +1298,28 @@ export function AgentsPage() {
                 <div className="space-y-2">
                   <div>
                     <h4 className="text-[10px] font-black text-text-dim uppercase tracking-widest mb-2">
+                      {t("agents.tools_declared_title", { defaultValue: "Declared Tools" })}
+                    </h4>
+                    <p className="text-[11px] text-text-dim/70 mb-3">
+                      {t("agents.tools_declared_desc", { defaultValue: "Tools this agent can use. Leave empty for unrestricted access to all tools." })}
+                    </p>
+                  </div>
+                  <MultiSelectCmdk
+                    options={availableToolNames}
+                    value={capabilitiesToolsDraft}
+                    onChange={setCapabilitiesToolsDraft}
+                    placeholder={t("agents.tools_search_placeholder", { defaultValue: "Search tools..." })}
+                    disabled={toolsDisabledState}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <div>
+                    <h4 className="text-[10px] font-black text-text-dim uppercase tracking-widest mb-2">
                       {t("agents.tools_allowlist_title", { defaultValue: "Allowlist" })}
                     </h4>
                     <p className="text-[11px] text-text-dim/70 mb-3">
-                      {t("agents.tools_allowlist_desc", { defaultValue: "These tools are explicitly allowed. Leave empty to allow all tools except blocked ones." })}
+                      {t("agents.tools_allowlist_desc", { defaultValue: "Additional filter: only these tools remain available. Leave empty to skip this filter." })}
                     </p>
                   </div>
                   <MultiSelectCmdk
@@ -1352,6 +1373,7 @@ export function AgentsPage() {
                 try {
                   const resolvedAllowlist = toolAllowlistDraft.filter((name) => !toolBlocklistDraft.includes(name));
                   await updateAgentTools(toolsEditorAgentId, {
+                    capabilities_tools: capabilitiesToolsDraft,
                     tool_allowlist: resolvedAllowlist,
                     tool_blocklist: toolBlocklistDraft,
                   });

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3304,11 +3304,25 @@ pub async fn get_agent_tools(
     (
         StatusCode::OK,
         Json(serde_json::json!({
+            "capabilities_tools": entry.manifest.capabilities.tools,
             "tool_allowlist": entry.manifest.tool_allowlist,
             "tool_blocklist": entry.manifest.tool_blocklist,
             "disabled": entry.manifest.tools_disabled,
         })),
     )
+}
+
+/// Request body for updating an agent's tool configuration.
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+pub struct SetAgentToolsRequest {
+    /// Declared tools (capabilities.tools). `None` = no change, `Some([])` = unrestricted.
+    pub capabilities_tools: Option<Vec<String>>,
+    /// Tool allowlist — additional filter. `None` = no change, `Some([])` = clear.
+    #[serde(default)]
+    pub tool_allowlist: Option<Vec<String>>,
+    /// Tool blocklist — exclusion filter. `None` = no change, `Some([])` = clear.
+    #[serde(default)]
+    pub tool_blocklist: Option<Vec<String>>,
 }
 
 /// PUT /api/agents/{id}/tools — Update an agent's tool allowlist/blocklist.
@@ -3317,7 +3331,7 @@ pub async fn get_agent_tools(
     path = "/api/agents/{id}/tools",
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
-    request_body(content = serde_json::Value, description = "Tool allowlist and/or blocklist arrays"),
+    request_body(content = SetAgentToolsRequest, description = "Tool configuration fields"),
     responses(
         (status = 200, description = "Update an agent's tool allowlist and blocklist", body = serde_json::Value)
     )
@@ -3326,7 +3340,7 @@ pub async fn set_agent_tools(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
-    Json(body): Json<serde_json::Value>,
+    Json(body): Json<SetAgentToolsRequest>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
@@ -3338,24 +3352,11 @@ pub async fn set_agent_tools(
             )
         }
     };
-    let allowlist = body
-        .get("tool_allowlist")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        });
-    let blocklist = body
-        .get("tool_blocklist")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        });
 
-    if allowlist.is_none() && blocklist.is_none() {
+    if body.capabilities_tools.is_none()
+        && body.tool_allowlist.is_none()
+        && body.tool_blocklist.is_none()
+    {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": t.t("api-error-agent-missing-tools")})),
@@ -3372,10 +3373,12 @@ pub async fn set_agent_tools(
         );
     }
 
-    match state
-        .kernel
-        .set_agent_tool_filters(agent_id, allowlist, blocklist)
-    {
+    match state.kernel.set_agent_tool_filters(
+        agent_id,
+        body.capabilities_tools,
+        body.tool_allowlist,
+        body.tool_blocklist,
+    ) {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8805,26 +8805,35 @@ system_prompt = "You are a helpful assistant."
     pub fn set_agent_tool_filters(
         &self,
         agent_id: AgentId,
+        capabilities_tools: Option<Vec<String>>,
         allowlist: Option<Vec<String>>,
         blocklist: Option<Vec<String>>,
     ) -> KernelResult<()> {
+        if capabilities_tools.is_none() && allowlist.is_none() && blocklist.is_none() {
+            return Ok(());
+        }
+
+        info!(
+            agent_id = %agent_id,
+            capabilities_tools = ?capabilities_tools,
+            allowlist = ?allowlist,
+            blocklist = ?blocklist,
+            "Agent tool filters updated"
+        );
+
         self.registry
-            .update_tool_filters(agent_id, allowlist.clone(), blocklist.clone())
+            .update_tool_config(agent_id, capabilities_tools, allowlist, blocklist)
             .map_err(KernelError::LibreFang)?;
 
         if let Some(entry) = self.registry.get(agent_id) {
             let _ = self.memory.save_agent(&entry);
         }
 
+        self.persist_manifest_to_disk(agent_id);
+
         // Invalidate cached tool list — tool filter change affects available tools
         self.prompt_metadata_cache.tools.remove(&agent_id);
 
-        info!(
-            agent_id = %agent_id,
-            allowlist = ?allowlist,
-            blocklist = ?blocklist,
-            "Agent tool filters updated"
-        );
         Ok(())
     }
 

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -335,10 +335,12 @@ impl AgentRegistry {
         Ok(())
     }
 
-    /// Update an agent's tool allowlist and blocklist.
-    pub fn update_tool_filters(
+    /// Update an agent's declared tools and/or allowlist/blocklist in a
+    /// single registry lock. Fields left as `None` are not modified.
+    pub fn update_tool_config(
         &self,
         id: AgentId,
+        capabilities_tools: Option<Vec<String>>,
         allowlist: Option<Vec<String>>,
         blocklist: Option<Vec<String>>,
     ) -> LibreFangResult<()> {
@@ -346,6 +348,9 @@ impl AgentRegistry {
             .agents
             .get_mut(&id)
             .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+        if let Some(ct) = capabilities_tools {
+            entry.manifest.capabilities.tools = ct;
+        }
         if let Some(al) = allowlist {
             entry.manifest.tool_allowlist = al;
         }
@@ -619,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_tool_filters_reenables_disabled_tools() {
+    fn test_update_tool_config_reenables_disabled_tools() {
         let registry = AgentRegistry::new();
         let mut entry = test_entry("tools-disabled");
         entry.manifest.tools_disabled = true;
@@ -627,7 +632,7 @@ mod tests {
         registry.register(entry).unwrap();
 
         registry
-            .update_tool_filters(id, Some(vec!["file_read".to_string()]), None)
+            .update_tool_config(id, None, Some(vec!["file_read".to_string()]), None)
             .expect("update should succeed");
 
         let updated = registry.get(id).expect("agent should exist");

--- a/openapi.json
+++ b/openapi.json
@@ -2025,10 +2025,12 @@
           }
         ],
         "requestBody": {
-          "description": "Tool allowlist and/or blocklist arrays",
+          "description": "Tool configuration fields",
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/SetAgentToolsRequest"
+              }
             }
           },
           "required": true
@@ -8739,6 +8741,42 @@
         "properties": {
           "content": {
             "type": "string"
+          }
+        }
+      },
+      "SetAgentToolsRequest": {
+        "type": "object",
+        "description": "Request body for updating an agent's tool configuration.",
+        "properties": {
+          "capabilities_tools": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Declared tools (capabilities.tools). `None` = no change, `Some([])` = unrestricted."
+          },
+          "tool_allowlist": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Tool allowlist — additional filter. `None` = no change, `Some([])` = clear."
+          },
+          "tool_blocklist": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Tool blocklist — exclusion filter. `None` = no change, `Some([])` = clear."
           }
         }
       },


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

The tools editor only managed `tool_allowlist`/`tool_blocklist` (secondary
filters) but ignored `capabilities.tools` (the primary tool set). Tools set
at agent creation never appeared in the editor, and adding tools via the
editor had no effect when `capabilities.tools` restricted the available set.
Additionally, tool filter changes were lost on restart because the boot loop
reloads from TOML on disk, which was never updated.

## Changes

- **Backend GET** `/agents/{id}/tools` now returns `capabilities_tools` alongside `tool_allowlist`/`tool_blocklist`
- **Backend PUT** `/agents/{id}/tools` accepts `capabilities_tools` via typed `SetAgentToolsRequest` struct (`Deserialize` + `ToSchema`) replacing manual JSON extraction
- **Registry**: merged `update_capabilities_tools` + `update_tool_filters` into single atomic `update_tool_config` (one DashMap lock)
- **Kernel**: `set_agent_tool_filters` calls `persist_manifest_to_disk` so changes survive restart
- **Kernel**: early return when all fields are `None` (no-op guard)
- **Frontend**: new "Declared Tools" section in the tools editor showing `capabilities.tools`
- **Frontend**: save sends `capabilities_tools` alongside allowlist/blocklist
- **Tests**: updated `api.test.ts` and registry unit test for new method

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries