### PR TITLE
fix(media): close per-call billing gaps from PR #3270 review

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17017,21 +17017,22 @@ impl KernelHandle for LibreFangKernel {
             }
         };
 
-        let catalog = self.model_catalog.read().unwrap_or_else(|e| e.into_inner());
-        let cost_usd = match catalog.find_model_for_provider(provider, model) {
-            Some(entry) => {
-                let c = entry.per_call_cost_or_zero();
-                if entry.is_per_call_billed() && entry.per_call_cost.is_none() {
-                    warn_once("per_call_cost missing for per-call modality");
+        let cost_usd = {
+            let catalog = self.model_catalog.read().unwrap_or_else(|e| e.into_inner());
+            match catalog.find_model_for_provider(provider, model) {
+                Some(entry) => {
+                    let c = entry.per_call_cost_or_zero();
+                    if entry.is_per_call_billed() && entry.per_call_cost.is_none() {
+                        warn_once("per_call_cost missing for per-call modality");
+                    }
+                    c
                 }
-                c
-            }
-            None => {
-                warn_once("model not found in catalog");
-                0.0
+                None => {
+                    warn_once("model not found in catalog");
+                    0.0
+                }
             }
         };
-        drop(catalog);
 
         let Some(parsed_agent) = agent_id.and_then(|s| s.parse::<AgentId>().ok()) else {
             // No caller agent — skip the spend record. Media tools always

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17018,7 +17018,21 @@ impl KernelHandle for LibreFangKernel {
         };
 
         let cost_usd = {
-            let catalog = self.model_catalog.read().unwrap_or_else(|e| e.into_inner());
+            let catalog = self.model_catalog.read().unwrap_or_else(|e| {
+                // Lock was poisoned by a panic in another thread that
+                // held the write guard. Reading the inner data is safe
+                // for our purposes (it's a Vec lookup, no invariant we
+                // can violate by reading) and is the existing pattern
+                // elsewhere in the kernel, but the poisoning itself is
+                // an upstream bug that should surface — without this
+                // log, a panic in catalog mutation paths would silently
+                // degrade media billing forever.
+                tracing::error!(
+                    "model_catalog RwLock poisoned during media billing read; \
+                     recovering inner data — investigate the originating panic"
+                );
+                e.into_inner()
+            });
             match catalog.find_model_for_provider(provider, model) {
                 Some(entry) => {
                     let c = entry.per_call_cost_or_zero();

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -16999,30 +16999,39 @@ impl KernelHandle for LibreFangKernel {
         model: &str,
         latency_ms: u64,
     ) {
-        let cost_usd = match self.model_catalog.read() {
-            Ok(cat) => match cat.find_model_for_provider(provider, model) {
-                Some(entry) => {
-                    let c = entry.per_call_cost_or_zero();
-                    if entry.is_per_call_billed() && entry.per_call_cost.is_none() {
-                        tracing::warn!(
-                            provider = provider,
-                            model = model,
-                            "media model has no per_call_cost in catalog — billing recorded as $0"
-                        );
-                    }
-                    c
-                }
-                None => {
-                    tracing::warn!(
-                        provider = provider,
-                        model = model,
-                        "media model not found in catalog — billing recorded as $0"
-                    );
-                    0.0
-                }
-            },
-            Err(_) => 0.0,
+        // Process-wide dedup so a misconfigured catalog entry doesn't
+        // flood the log on every call. Set is unbounded but the key
+        // space is bounded by the catalog size, so it can't grow
+        // pathologically.
+        static MISSING_COST_WARNED: std::sync::OnceLock<dashmap::DashSet<(String, String)>> =
+            std::sync::OnceLock::new();
+        let warn_once = |reason: &str| {
+            let set = MISSING_COST_WARNED.get_or_init(dashmap::DashSet::new);
+            if set.insert((provider.to_string(), model.to_string())) {
+                tracing::warn!(
+                    provider = provider,
+                    model = model,
+                    reason = reason,
+                    "media model billing recorded as $0; subsequent calls suppressed"
+                );
+            }
         };
+
+        let catalog = self.model_catalog.read().unwrap_or_else(|e| e.into_inner());
+        let cost_usd = match catalog.find_model_for_provider(provider, model) {
+            Some(entry) => {
+                let c = entry.per_call_cost_or_zero();
+                if entry.is_per_call_billed() && entry.per_call_cost.is_none() {
+                    warn_once("per_call_cost missing for per-call modality");
+                }
+                c
+            }
+            None => {
+                warn_once("model not found in catalog");
+                0.0
+            }
+        };
+        drop(catalog);
 
         let Some(parsed_agent) = agent_id.and_then(|s| s.parse::<AgentId>().ok()) else {
             // No caller agent — skip the spend record. Media tools always

--- a/crates/librefang-runtime/src/media/minimax.rs
+++ b/crates/librefang-runtime/src/media/minimax.rs
@@ -376,6 +376,7 @@ impl MediaDriver for MiniMaxMediaDriver {
         Ok(MediaVideoSubmitResult {
             task_id,
             provider: "minimax".to_string(),
+            model: model.to_string(),
         })
     }
 

--- a/crates/librefang-runtime/src/media/minimax.rs
+++ b/crates/librefang-runtime/src/media/minimax.rs
@@ -322,7 +322,7 @@ impl MediaDriver for MiniMaxMediaDriver {
         request.validate().map_err(MediaError::InvalidRequest)?;
 
         let api_key = self.api_key()?;
-        let model = request.model.as_deref().unwrap_or("MiniMax-Hailuo-2.3");
+        let model = resolve_video_model(request.model.as_deref());
 
         let mut body = serde_json::json!({
             "model": model,
@@ -603,6 +603,14 @@ impl MediaDriver for MiniMaxMediaDriver {
     }
 }
 
+/// Resolve which Hailuo model handles a video request when the caller
+/// didn't pin one. The fallback **must** name a real catalog entry so
+/// downstream metering can resolve `per_call_cost`; returning
+/// `"unknown"` here would silently bill every call as $0.
+fn resolve_video_model(requested: Option<&str>) -> &str {
+    requested.unwrap_or("MiniMax-Hailuo-2.3")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -654,5 +662,26 @@ mod tests {
         });
         let err = MiniMaxMediaDriver::check_base_resp(&json).unwrap_err();
         assert!(matches!(err, MediaError::ContentFiltered(_)));
+    }
+
+    #[test]
+    fn test_resolve_video_model_default_is_real_catalog_entry() {
+        // Regression guard for PR #3270/#3272: when the caller omits a
+        // model, the fallback must name a real model id that exists in
+        // the registry catalog so per_call_cost lookup succeeds.
+        // Returning a placeholder like "unknown" here would silently
+        // bill every video call as $0.
+        let resolved = resolve_video_model(None);
+        assert!(
+            !resolved.is_empty() && resolved != "unknown",
+            "default video model must be a concrete catalog entry, got {resolved:?}"
+        );
+        assert_eq!(resolved, "MiniMax-Hailuo-2.3");
+    }
+
+    #[test]
+    fn test_resolve_video_model_explicit_wins() {
+        let resolved = resolve_video_model(Some("MiniMax-Hailuo-2.3-Fast"));
+        assert_eq!(resolved, "MiniMax-Hailuo-2.3-Fast");
     }
 }

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -4824,7 +4824,6 @@ async fn tool_video_generate(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
 ) -> Result<String, String> {
-    let started = std::time::Instant::now();
     let cache =
         media_drivers.ok_or("Media drivers not available. Ensure media drivers are configured.")?;
     let prompt = input["prompt"]
@@ -4859,20 +4858,13 @@ async fn tool_video_generate(
         .await
         .map_err(|e| e.to_string())?;
 
-    // Bill on successful submit. Video providers charge at submit time
-    // regardless of whether the caller polls to completion, so the
-    // metering record fires here rather than in `tool_video_status`.
+    // Bill on successful submit. Video providers charge once the job is
+    // accepted; if the polled job later fails the spend is still on
+    // record (conservative direction — the provider already counted it).
+    // Latency here would only cover the submit RTT, not the minutes-long
+    // generation, so we report 0 rather than mislead the dashboard.
     if let Some(k) = kernel {
-        let model_for_billing = request
-            .model
-            .clone()
-            .unwrap_or_else(|| "unknown".to_string());
-        k.record_media_usage(
-            caller_agent_id,
-            &result.provider,
-            &model_for_billing,
-            started.elapsed().as_millis() as u64,
-        );
+        k.record_media_usage(caller_agent_id, &result.provider, &result.model, 0);
     }
 
     let response = serde_json::json!({

--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -616,6 +616,12 @@ pub struct MediaVideoSubmitResult {
     pub task_id: String,
     /// Provider that accepted the task.
     pub provider: String,
+    /// Model the provider actually used to accept the job. Mirrors the
+    /// `model` field on `MediaImageResult` / `MediaTtsResult` /
+    /// `MediaMusicResult`. The metering layer needs this to look up
+    /// `per_call_cost`; without it, video calls without an explicit
+    /// caller-supplied model would bill as $0.
+    pub model: String,
 }
 
 /// Result of a completed video generation.

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -203,26 +203,6 @@ impl ModelCatalogEntry {
         self.modality == Modality::Image
     }
 
-    /// Returns true if this entry is a video-generation model.
-    pub fn is_video_generation(&self) -> bool {
-        self.modality == Modality::Video
-    }
-
-    /// Returns true if this entry is a music-generation model.
-    pub fn is_music_generation(&self) -> bool {
-        self.modality == Modality::Music
-    }
-
-    /// Returns true if this entry is a speech / audio model (TTS or STT).
-    pub fn is_audio_generation(&self) -> bool {
-        self.modality == Modality::Audio
-    }
-
-    /// Returns true if this entry is any non-text media-generation model.
-    pub fn is_media_generation(&self) -> bool {
-        !matches!(self.modality, Modality::Text)
-    }
-
     /// Map this entry's `Modality` to the `MediaCapability` that a
     /// `MediaDriver` would advertise for it. Returns `None` for
     /// `Modality::Text` (LLM models go through the regular llm-driver
@@ -280,12 +260,12 @@ impl ModelCatalogEntry {
         }
     }
 
-    /// Resolve the flat per-invocation cost in USD for this model, if
-    /// any. For video/music models the catalog SHOULD declare
-    /// `per_call_cost`; when it's missing the loader emits a WARN and
-    /// this returns 0.0 so the call still goes through (but is
-    /// recorded as $0). The kernel logs the WARN once per
-    /// (provider, model) pair to avoid log spam.
+    /// Resolve the flat per-invocation cost in USD for this model, or
+    /// `0.0` when the catalog entry omits it. Returning zero (rather
+    /// than `Option`) keeps callers from having to choose between
+    /// crashing on missing data and silently masking it — the metering
+    /// layer uses `is_per_call_billed()` to detect "should have had a
+    /// price but didn't" and emits a one-shot warn at the call site.
     pub fn per_call_cost_or_zero(&self) -> f64 {
         self.per_call_cost.unwrap_or(0.0)
     }


### PR DESCRIPTION
## Summary

Three correctness fixes from self-review of #3270, **stacked on top of `feat/media-per-call-cost`** (set base accordingly).

### 1. Video billing no longer charges $0 when caller omits `model`

`tool_video_generate` was passing `request.model.unwrap_or("unknown")` to the metering layer. The catalog lookup `find_model_for_provider("minimax", "unknown")` returned `None`, so the most common video call path (auto-detect model) silently recorded $0.

Root cause: `MediaVideoSubmitResult` was the only `Media*Result` type missing a `model` field. Fix: add `model: String`, populate it in the minimax driver from the model it actually picked, bill against `result.model`.

### 2. WARN logs are now actually de-duplicated

The doc on `per_call_cost_or_zero` claimed "kernel logs the WARN once per (provider, model) pair to avoid log spam" — but the impl logged every call. Added a `OnceLock<DashSet<(String, String)>>` in `record_media_usage` so a single misconfigured catalog entry doesn't flood the log.

### 3. Poisoned `RwLock` no longer silently bills $0

`record_media_usage` had `Err(_) => 0.0` on `model_catalog.read()`, swallowing the error. Now uses `.unwrap_or_else(|e| e.into_inner())` to recover, matching the existing kernel pattern at `kernel/mod.rs:4570`.

### Cleanup

- Drop four unused predicate helpers (`is_video_generation`, `is_music_generation`, `is_audio_generation`, `is_media_generation`) — pure YAGNI from #3270 with no consumers.
- `media_capability()` stays (has a test, is the stated `Modality` ↔ `MediaCapability` bridge).
- Video submit `latency_ms` now `0` rather than misleading submit-RTT (real generation is minutes async).

## Test plan

- [ ] `cargo check --workspace --lib`  *(deferred to CI on this branch)*
- [ ] Existing `model_catalog` unit tests still pass (no test signatures changed; added `model` field is purely additive)
- [ ] `cargo clippy --lib -- -D warnings`

## Note

Stacked PR — set base to `feat/media-per-call-cost` (#3270) rather than `main`. Once #3270 lands, GitHub will auto-retarget this to `main`.
