### PR TITLE
refactor(skills): tidy env_passthrough nits from #3219 review

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1901,8 +1901,10 @@ fn load_update_channel_from_config() -> Option<librefang_types::config::UpdateCh
 /// otherwise `librefang skill test` would silently allow vars that
 /// production strips. Errors during read/parse degrade to default; this is
 /// a dev-time gate, not a security boundary, but its job is to mirror
-/// what prod will do.
-fn load_skill_env_policy_from_config() -> librefang_types::config::EnvPassthroughPolicy {
+/// what prod will do. Returns `None` only when the operator has explicitly
+/// cleared both `env_passthrough_denied_patterns` and
+/// `env_passthrough_per_skill` — matching the kernel-side semantics.
+fn load_skill_env_policy_from_config() -> Option<librefang_types::config::EnvPassthroughPolicy> {
     let cfg = (|| -> Option<librefang_types::config::SkillsConfig> {
         let config_path = dirs::home_dir()?.join(".librefang").join("config.toml");
         let content = std::fs::read_to_string(&config_path).ok()?;
@@ -6944,7 +6946,7 @@ fn cmd_skill_test(path: Option<PathBuf>, tool: Option<String>, input: Option<Str
         &prepared.source_dir,
         &tool_name,
         &input_json,
-        Some(&env_policy),
+        env_policy.as_ref(),
     ));
     match result {
         Ok(result) => {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -16997,7 +16997,7 @@ impl KernelHandle for LibreFangKernel {
         &self,
     ) -> Option<librefang_types::config::EnvPassthroughPolicy> {
         let cfg = self.config.load();
-        Some(librefang_types::config::EnvPassthroughPolicy::from_skills_config(&cfg.skills))
+        librefang_types::config::EnvPassthroughPolicy::from_skills_config(&cfg.skills)
     }
 
     fn fire_agent_step(&self, agent_id: &str, step: u32) {

--- a/crates/librefang-skills/src/loader.rs
+++ b/crates/librefang-skills/src/loader.rs
@@ -42,10 +42,6 @@ const KERNEL_RESERVED_ENV: &[&str] = &[
     "TERM",
 ];
 
-fn name_matches(haystack: &str, needle: &str) -> bool {
-    haystack.eq_ignore_ascii_case(needle)
-}
-
 /// Validate that a resolved script path stays within the skill directory.
 /// Prevents path traversal attacks via `../` in entry names.
 fn validate_script_path(skill_dir: &Path, entry: &str) -> Result<std::path::PathBuf, SkillError> {
@@ -102,7 +98,10 @@ pub fn resolve_effective_passthrough(
     manifest_list
         .iter()
         .filter(|name| {
-            if FORBIDDEN_PASSTHROUGH.iter().any(|f| name_matches(f, name)) {
+            if FORBIDDEN_PASSTHROUGH
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(name))
+            {
                 warn!(
                     skill = skill_name,
                     var = %name,
@@ -111,7 +110,10 @@ pub fn resolve_effective_passthrough(
                 );
                 return false;
             }
-            if KERNEL_RESERVED_ENV.iter().any(|r| name_matches(r, name)) {
+            if KERNEL_RESERVED_ENV
+                .iter()
+                .any(|r| r.eq_ignore_ascii_case(name))
+            {
                 warn!(
                     skill = skill_name,
                     var = %name,
@@ -134,7 +136,7 @@ pub fn resolve_effective_passthrough(
             });
             if blocked_by_deny {
                 let allowed_by_override = overrides
-                    .map(|v| v.iter().any(|n| name_matches(n, name)))
+                    .map(|v| v.iter().any(|n| n.eq_ignore_ascii_case(name)))
                     .unwrap_or(false);
                 if !allowed_by_override {
                     warn!(
@@ -606,10 +608,10 @@ fn apply_env_passthrough(cmd: &mut tokio::process::Command, allowlist: &[String]
     for var_name in allowlist {
         if FORBIDDEN_PASSTHROUGH
             .iter()
-            .any(|f| name_matches(f, var_name))
+            .any(|f| f.eq_ignore_ascii_case(var_name))
             || KERNEL_RESERVED_ENV
                 .iter()
-                .any(|r| name_matches(r, var_name))
+                .any(|r| r.eq_ignore_ascii_case(var_name))
         {
             warn!(
                 var = %var_name,
@@ -1166,7 +1168,14 @@ echo '{"greeting": "hello from shell"}'
 
     #[tokio::test]
     #[cfg(unix)]
-    #[serial_test::serial(skill_env_passthrough)]
+    // Serialize against any other env-mutating test in the workspace, not
+    // just other env_passthrough tests. `std::env::set_var` is process-wide
+    // and (on Rust 2024 edition) `unsafe` because concurrent readers in
+    // other threads — including the tokio worker pool — can observe torn
+    // state. Using the conventional `env` key is a partial mitigation; the
+    // proper fix is to inject an env-getter into `apply_env_passthrough`
+    // so the test never touches process state. Tracked for the edition bump.
+    #[serial_test::serial(env)]
     async fn test_env_passthrough_allowlist_injects_var() {
         use crate::{
             SkillManifest, SkillMeta, SkillRequirements, SkillRuntimeConfig, SkillToolDef,
@@ -1182,8 +1191,9 @@ echo '{"greeting": "hello from shell"}'
         // or the host environment.
         let allowed_var = "LIBREFANG_TEST_PASSTHROUGH_ALLOWED";
         let blocked_var = "LIBREFANG_TEST_PASSTHROUGH_BLOCKED";
-        // SAFETY: tests in this module run serially-enough; the values
-        // are scoped to this test's subprocess.
+        // SAFETY: serialized via `serial_test::serial(env)` against the
+        // workspace-wide `env` key; values are scoped to this test's
+        // subprocess and removed before assertions run.
         std::env::set_var(allowed_var, "hello-from-host");
         std::env::set_var(blocked_var, "should-not-leak");
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1269,17 +1269,24 @@ pub struct EnvPassthroughPolicy {
 }
 
 impl EnvPassthroughPolicy {
-    /// Construct a policy from a `[skills]` config block. Always returns a
-    /// populated `Self`; callers that want to skip applying the operator
-    /// gate entirely (e.g. an operator with empty deny patterns and no
-    /// per-skill overrides) should drop down to passing `None` for the
-    /// `env_policy` argument instead — that's `KernelHandle::skill_env_passthrough_policy`'s
-    /// job, not this constructor's.
-    pub fn from_skills_config(cfg: &SkillsConfig) -> Self {
-        Self {
+    /// Construct a policy from a `[skills]` config block, or `None` when the
+    /// config carries neither deny patterns nor per-skill overrides. Returning
+    /// `None` lets the caller (and `KernelHandle::skill_env_passthrough_policy`)
+    /// skip the operator-gate plumbing entirely — only the built-in
+    /// `FORBIDDEN_PASSTHROUGH` and kernel-reserved hard blocks apply in that
+    /// case. Note that `SkillsConfig::default()` ships with a non-empty deny
+    /// list, so the default config still produces `Some(...)`; `None` only
+    /// arises when an operator has explicitly cleared both fields.
+    pub fn from_skills_config(cfg: &SkillsConfig) -> Option<Self> {
+        if cfg.env_passthrough_denied_patterns.is_empty()
+            && cfg.env_passthrough_per_skill.is_empty()
+        {
+            return None;
+        }
+        Some(Self {
             denied_patterns: cfg.env_passthrough_denied_patterns.clone(),
             per_skill_overrides: cfg.env_passthrough_per_skill.clone(),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Three nits from the #3219 review, none of which blocked the merge:

1. **Drop `name_matches` wrapper.** It was a single-line wrapper for `str::eq_ignore_ascii_case` and added a jump on every read. Inlined at the four call sites in `loader.rs`.

2. **`EnvPassthroughPolicy::from_skills_config` now returns `Option<Self>`.** Previously it always returned `Some(...)`, including for the empty-config case, which made the `Option<&EnvPassthroughPolicy>` parameter on `execute_skill_tool` semantically dead — the `None` branch existed only for the trait default in `KernelHandle`. Returning `None` when both `denied_patterns` and `per_skill_overrides` are empty makes "no operator gate" representable end-to-end. Note: `SkillsConfig::default()` ships with a non-empty deny list, so this only changes behavior for operators who have explicitly cleared both fields.

3. **Tighten `serial_test` key on the env-mutating test.** `test_env_passthrough_allowlist_injects_var` calls `std::env::set_var`, which is process-global — `serial(skill_env_passthrough)` only serialized against other tests using the same key, not against any other test in the workspace that reads env. Switched to the conventional `serial(env)` key. The deeper fix (inject an env-getter into `apply_env_passthrough` so the test never touches process state) is left as a TODO in a code comment, to be done before the Rust 2024 edition bump that marks `set_var` as `unsafe`.

## Test plan

- [ ] `cargo build --workspace --lib`
- [ ] `cargo test -p librefang-skills` (passthrough tests still pass)
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`

Follow-up to #3219.
