### PR TITLE
fix(doctor): recognize BYTEPLUS_API_KEY in provider key checks

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -5372,6 +5372,7 @@ fn cmd_doctor(json: bool, repair: bool) {
         ("TOGETHER_API_KEY", "Together", "together"),
         ("MISTRAL_API_KEY", "Mistral", "mistral"),
         ("FIREWORKS_API_KEY", "Fireworks", "fireworks"),
+        ("BYTEPLUS_API_KEY", "BytePlus", "byteplus"),
     ];
 
     let mut any_key_set = false;
@@ -8431,6 +8432,10 @@ pub(crate) fn test_api_key(provider: &str, key: &str) -> bool {
             .send(),
         "openrouter" => client
             .get("https://openrouter.ai/api/v1/models")
+            .bearer_auth(key)
+            .send(),
+        "byteplus" => client
+            .get("https://ark.ap-southeast.bytepluses.com/api/v3/models")
             .bearer_auth(key)
             .send(),
         "elevenlabs" => client


### PR DESCRIPTION
## Summary

Follow-up to **PR #3271** which added the `byteplus` and `byteplus_coding` driver entries. The `librefang doctor` command's provider-key check loop is hardcoded against a 10-entry whitelist that wasn't updated, so users with only `BYTEPLUS_API_KEY` set get this misleading failure even though the daemon recognizes and uses the key correctly:

```
✘ No LLM provider API keys found!
```

## Changes

- Add `BYTEPLUS_API_KEY` to the doctor `provider_keys` array (`crates/librefang-cli/src/main.rs`).
- Add a `byteplus` arm to `test_api_key()` that performs a live `GET /api/v3/models` Bearer-auth probe — same shape as the existing OpenAI / DeepSeek / OpenRouter checks.

## Underlying issue

The `provider_keys` whitelist drifts from `PROVIDER_REGISTRY` (in `librefang-llm-drivers`) whenever a new provider is added. A proper fix is to drive doctor off the registry directly so it can never drift again — but that's a wider refactor. This PR closes the specific gap that's actively misleading users today; the registry-driven cleanup should be a separate issue.

Other providers in `PROVIDER_REGISTRY` that are similarly missing from doctor's whitelist (left to that follow-up): `minimax`, `volcengine`, `zhipu`, `zai`, `moonshot`, `kimi-coding`, `qianfan`, `qwen`, `alibaba-coding-plan`, `xai`, `cerebras`, `sambanova`, `nvidia-nim`, `xiaomi`, `arcee`, etc.

## Test plan

- [x] Local: `BYTEPLUS_API_KEY=ark-... librefang doctor` now reports the key (was failing before).
- [ ] CI: `cargo check --workspace --lib`
