### PR TITLE
fix: silence three sources of routine WARN log spam

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -5361,19 +5361,51 @@ fn cmd_doctor(json: bool, repair: bool) {
     if !json {
         println!("\n  LLM Providers:");
     }
-    let provider_keys = [
-        ("GROQ_API_KEY", "Groq", "groq"),
-        ("OPENROUTER_API_KEY", "OpenRouter", "openrouter"),
-        ("ANTHROPIC_API_KEY", "Anthropic", "anthropic"),
-        ("OPENAI_API_KEY", "OpenAI", "openai"),
-        ("DEEPSEEK_API_KEY", "DeepSeek", "deepseek"),
-        ("GEMINI_API_KEY", "Gemini", "gemini"),
-        ("GOOGLE_API_KEY", "Google", "google"),
-        ("TOGETHER_API_KEY", "Together", "together"),
-        ("MISTRAL_API_KEY", "Mistral", "mistral"),
-        ("FIREWORKS_API_KEY", "Fireworks", "fireworks"),
-        ("BYTEPLUS_API_KEY", "BytePlus", "byteplus"),
-    ];
+    // Pretty display names for known provider IDs. Anything not listed
+    // here falls back to a Title-Case derivation of the raw provider id
+    // (e.g. `xiaomi` → `Xiaomi`). Adding a new provider to
+    // `PROVIDER_REGISTRY` automatically picks up the fallback so the
+    // check loop never silently misses a key — only the cosmetic name
+    // needs editing here, not the list of providers checked.
+    fn display_name(provider_id: &str) -> String {
+        match provider_id {
+            "openai" => "OpenAI".to_string(),
+            "openrouter" => "OpenRouter".to_string(),
+            "deepseek" => "DeepSeek".to_string(),
+            "deepinfra" => "DeepInfra".to_string(),
+            "byteplus" => "BytePlus".to_string(),
+            "azure-openai" => "Azure OpenAI".to_string(),
+            "github-copilot" => "GitHub Copilot".to_string(),
+            "huggingface" => "Hugging Face".to_string(),
+            "openai-codex" => "OpenAI Codex".to_string(),
+            "claude-code" => "Claude Code".to_string(),
+            "vertex-ai" => "Vertex AI".to_string(),
+            "nvidia-nim" => "NVIDIA NIM".to_string(),
+            "z.ai" | "zai" => "Z.ai".to_string(),
+            "kimi-coding" | "kimi_coding" => "Kimi Coding".to_string(),
+            "alibaba-coding-plan" => "Alibaba Coding Plan".to_string(),
+            other => {
+                // Title-case fallback for unlisted providers so `xiaomi` →
+                // `Xiaomi` instead of leaking the raw lowercase id.
+                let mut chars = other.chars();
+                match chars.next() {
+                    Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+        }
+    }
+
+    // Drive doctor off PROVIDER_REGISTRY so adding a provider to the
+    // driver layer never requires a parallel edit here. `GOOGLE_API_KEY`
+    // (gemini's alt env) and similar aliases come through automatically.
+    // This subsumes the previous hardcoded array (including the byteplus
+    // entry from #3274 — now provided automatically by the registry).
+    let provider_specs = librefang_runtime::drivers::cloud_provider_key_specs();
+    let provider_keys: Vec<(&str, String, &str)> = provider_specs
+        .iter()
+        .map(|(env_var, provider_id)| (*env_var, display_name(provider_id), *provider_id))
+        .collect();
 
     let mut any_key_set = false;
     for (env_var, name, provider_id) in &provider_keys {

--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -126,7 +126,12 @@ pub fn parse_hand_toml_with_agents_dir(
         // resolved during agent construction (before AgentManifest parsing).
         crate::parse_hand_definition(toml_content, agents_dir)
             .or_else(|flat_err| {
-                tracing::warn!("Flat parse failed for hand: {flat_err}");
+                // Flat-vs-wrapped is a try/fallback dispatch, not a fault:
+                // a HAND.toml authored in the wrapped `[hand] base = ...`
+                // form will always fail flat parsing first. Demote to debug
+                // so the only WARN reaches operators when BOTH formats
+                // fail (the .map_err on the outer `?` below).
+                tracing::debug!("Flat parse failed for hand (trying wrapped): {flat_err}");
                 // Try wrapped format: fields under [hand] section.
                 // Extract the [hand] sub-table and re-serialize so that
                 // parse_hand_definition can resolve `base` templates with agents_dir.
@@ -145,7 +150,9 @@ pub fn parse_hand_toml_with_agents_dir(
         // No agents_dir — use standard serde path (no base resolution).
         toml::from_str::<HandDefinition>(toml_content)
             .or_else(|flat_err| {
-                tracing::warn!("Flat parse failed for hand: {flat_err}");
+                // See note above: flat-vs-wrapped is a normal dispatch, not
+                // an error — only the final outer `?` should surface to ops.
+                tracing::debug!("Flat parse failed for hand (trying wrapped): {flat_err}");
                 toml::from_str::<HandTomlWrapper>(toml_content).map(|w| w.hand)
             })
             .map_err(|e| HandError::TomlParse(e.to_string()))?

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -364,6 +364,13 @@ pub(super) fn generate_identity_files(
     use std::io::Write;
 
     let identity_dir = workspace.join(".identity");
+    // Ensure `.identity/` exists before any of the per-file opens below;
+    // without this, every TOOLS.md write from a fresh agent boot warns
+    // "No such file or directory" (and SOUL/USER/MEMORY silently skip
+    // creation because they use create_new). The mirror cleanup helper
+    // at the bottom of this file already does the same — keep them in
+    // sync.
+    let _ = std::fs::create_dir_all(&identity_dir);
 
     let soul_content = format!(
         "# Soul\n\

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -942,6 +942,34 @@ pub fn known_providers() -> Vec<&'static str> {
         .collect()
 }
 
+/// `(env_var, provider_id)` pairs for every cloud provider in the registry
+/// that requires an API key. Both the canonical `api_key_env` and the
+/// optional `alt_api_key_env` (e.g. `GOOGLE_API_KEY` for `gemini`) are
+/// returned as separate entries so callers like `doctor` can probe each
+/// independently without losing the alias mapping.
+///
+/// Hidden providers (alternate-protocol variants like `*_coding`) are
+/// excluded — they share an env var with their parent and listing them
+/// would double-count.
+///
+/// This is the single source of truth so adding a new provider to
+/// `PROVIDER_REGISTRY` automatically surfaces it everywhere that
+/// enumerates cloud keys, instead of silently drifting from a hardcoded
+/// whitelist.
+pub fn cloud_provider_key_specs() -> Vec<(&'static str, &'static str)> {
+    let mut out: Vec<(&'static str, &'static str)> = Vec::new();
+    for p in PROVIDER_REGISTRY {
+        if !p.key_required || p.hidden {
+            continue;
+        }
+        out.push((p.api_key_env, p.name));
+        if let Some(alt) = p.alt_api_key_env {
+            out.push((alt, p.name));
+        }
+    }
+    out
+}
+
 /// Check if a CLI-based provider is available (binary on PATH or credentials exist).
 pub fn cli_provider_available(name: &str) -> bool {
     match name {


### PR DESCRIPTION
## Summary

Three log-noise issues were spamming every daemon boot / agent turn even after the operator had nothing to fix. Each one trains operators to tune out WARN entirely, masking the next real problem. Found via a full audit of `daemon-*.log` after a routine session — bundled into one PR because they all came out of the same audit pass.

## What this PR does

### 1. doctor missed BYTEPLUS_API_KEY (and ~40 other registered providers)

Continuation of [#3274](https://github.com/librefang/librefang/pull/3274). That PR added BYTEPLUS to the hardcoded `provider_keys` array, but the array itself drifts from `PROVIDER_REGISTRY` every time a new provider lands — minimax, volcengine, zhipu, zai, kimi-coding, qianfan, qwen, alibaba-coding-plan, xai, cerebras, sambanova, nvidia-nim, xiaomi, arcee, etc. all silently absent.

Rewritten to pull straight from the registry via a new `cloud_provider_key_specs()` helper in `librefang-llm-drivers`. Adds a `display_name()` map for the camel-cased ones (OpenAI, DeepSeek, etc.) with a Title-Case fallback for the rest. New providers now surface in doctor automatically; the BYTEPLUS line from #3274 is subsumed by the helper.

### 2. `Failed to write TOOLS.md ... No such file or directory` (≈20×/boot per agent)

`generate_identity_files()` in `workspace_setup.rs` computes `workspace.join(".identity")` but never creates it before the per-file opens. The mirror cleanup helper at the bottom of the same file already does `create_dir_all` — added the matching call up front so they stay in sync.

### 3. `WARN Flat parse failed for hand: ...` on every wrapped HAND.toml

`parse_hand_toml_with_agents_dir` tries flat parsing first and falls back to wrapped on failure. That's normal dispatch — not a fault — but the intermediate failure was logged at WARN. Demoted to debug on both arms (with and without `agents_dir`) so only the final "both formats failed" path actually surfaces.

## Why bundle them

All three:
- spammed the same logs every boot,
- have no behavior change beyond log level / auto-create-missing-dir,
- were found in the same audit pass.

Splitting would mean three near-identical PRs through the same review queue.

## Test plan

- [x] **#1 doctor** — verified locally: pre-PR `librefang doctor` reported `✘ No LLM provider API keys found!` despite `BYTEPLUS_API_KEY` being set; the missing-from-whitelist root cause was confirmed before writing the helper.
- [ ] **#2 TOOLS.md** — code-reviewed only. The fix mirrors the existing `create_dir_all` pattern at the bottom of the same file (line 555). Not re-validated against a fresh agent boot in this branch.
- [ ] **#3 hand parse** — code-reviewed only. The original WARN was confirmed against `registry/hands/devteam/HAND.toml` (`base = "coder"` triggers flat-parse fail → wrapped success). Not re-validated against a fresh hand load in this branch.
- [ ] CI: `cargo check --workspace --lib`
