### PR TITLE
fix(telemetry): skip OTLP exporter when no collector is reachable

### DIFF
--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1100,25 +1100,75 @@ pub async fn run_daemon(
     kernel.set_self_handle();
     kernel.start_background_agents().await;
 
+    // Auto-start observability stack (OTLP collector + Prometheus + Grafana)
+    // ONLY when the operator has opted in via `telemetry.auto_start_observability_stack`.
+    // Default is off because spinning four containers on every `librefang
+    // start` is a strong implicit side effect; users who only want OTel export
+    // to an existing collector should keep this off and just configure
+    // `otlp_endpoint`. Issue #3136.
+    //
+    // Done before OTLP exporter init so the exporter gate can observe the
+    // actual startup outcome — if `auto_start = true` but Docker is missing
+    // or a port conflict kills compose, we must NOT init the exporter at the
+    // default localhost:4317, otherwise the BatchSpanProcessor spams
+    // ConnectionRefused on every export interval (issue #3136 follow-up).
+    let mut observability_guard: Option<ObservabilityHandle> = if kernel
+        .config_ref()
+        .telemetry
+        .enabled
+        && kernel.config_ref().telemetry.auto_start_observability_stack
+    {
+        let project = derive_compose_project_name(kernel.home_dir());
+        match start_observability_stack(kernel.home_dir(), &project) {
+            Ok(ObservabilityStartup::Started) => {
+                info!(
+                    "Observability stack started ({project}: OTLP :4317/:4318, Tempo :3200, Prometheus :9090, Grafana :3000)"
+                );
+                Some(ObservabilityHandle::new(
+                    kernel.home_dir().to_path_buf(),
+                    project,
+                ))
+            }
+            Ok(ObservabilityStartup::DockerUnavailable) => {
+                info!("Docker not available, skipping observability stack");
+                None
+            }
+            Ok(ObservabilityStartup::ComposeFailed { stderr }) => {
+                tracing::warn!(
+                    "Observability stack failed to start (likely a port conflict on 3000/3200/4317/9090 or an existing stack): {}",
+                    stderr.trim()
+                );
+                None
+            }
+            Err(e) => {
+                tracing::warn!("Failed to start observability stack: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Initialize OpenTelemetry OTLP tracing when telemetry feature is compiled
     // in and the config has `telemetry.enabled = true`. Skip the exporter when
-    // no collector is reachable (default localhost endpoint without daemon-
-    // managed stack, or explicit empty endpoint) — issue #3136 follow-up:
-    // PR #3170 made the bundled stack opt-in but left the exporter pointing
-    // at localhost:4317 by default, so the BatchSpanProcessor would spam
-    // ConnectionRefused on every default install.
+    // no collector is reachable: explicit empty endpoint, or default localhost
+    // endpoint without a running bundled stack (auto_start off, OR auto_start
+    // on but startup failed above).
     #[cfg(feature = "telemetry")]
     {
         let cfg = kernel.config_ref();
         if cfg.telemetry.enabled {
-            if cfg.telemetry.otlp_export_disabled() {
+            let stack_running = observability_guard.is_some();
+            if cfg.telemetry.otlp_export_disabled(stack_running) {
                 tracing::info!(
                     otlp_endpoint = %cfg.telemetry.otlp_endpoint,
                     auto_start_observability_stack =
                         cfg.telemetry.auto_start_observability_stack,
-                    "Telemetry OTLP exporter skipped: no collector configured. \
-                     Set telemetry.auto_start_observability_stack = true or \
-                     override telemetry.otlp_endpoint to enable trace export."
+                    stack_running,
+                    "Telemetry OTLP exporter skipped: no collector reachable. \
+                     Set telemetry.auto_start_observability_stack = true (and \
+                     ensure Docker is available) or override \
+                     telemetry.otlp_endpoint to point at a running collector."
                 );
             } else if let Err(e) = crate::telemetry::init_otel_tracing(
                 &cfg.telemetry.otlp_endpoint,
@@ -1258,49 +1308,6 @@ pub async fn run_daemon(
     info!("LibreFang API server listening on http://{addr}");
     info!("WebChat UI available at http://{addr}/",);
     info!("WebSocket endpoint: ws://{addr}/api/agents/{{id}}/ws",);
-
-    // Auto-start observability stack (OTLP collector + Prometheus + Grafana)
-    // ONLY when the operator has opted in via `telemetry.auto_start_observability_stack`.
-    // Default is off because spinning four containers on every `librefang
-    // start` is a strong implicit side effect; users who only want OTel export
-    // to an existing collector should keep this off and just configure
-    // `otlp_endpoint`. Issue #3136.
-    let mut observability_guard: Option<ObservabilityHandle> = if kernel
-        .config_ref()
-        .telemetry
-        .enabled
-        && kernel.config_ref().telemetry.auto_start_observability_stack
-    {
-        let project = derive_compose_project_name(kernel.home_dir());
-        match start_observability_stack(kernel.home_dir(), &project) {
-            Ok(ObservabilityStartup::Started) => {
-                info!(
-                    "Observability stack started ({project}: OTLP :4317/:4318, Tempo :3200, Prometheus :9090, Grafana :3000)"
-                );
-                Some(ObservabilityHandle::new(
-                    kernel.home_dir().to_path_buf(),
-                    project,
-                ))
-            }
-            Ok(ObservabilityStartup::DockerUnavailable) => {
-                info!("Docker not available, skipping observability stack");
-                None
-            }
-            Ok(ObservabilityStartup::ComposeFailed { stderr }) => {
-                tracing::warn!(
-                    "Observability stack failed to start (likely a port conflict on 3000/3200/4317/9090 or an existing stack): {}",
-                    stderr.trim()
-                );
-                None
-            }
-            Err(e) => {
-                tracing::warn!("Failed to start observability stack: {e}");
-                None
-            }
-        }
-    } else {
-        None
-    };
 
     // Background: sync model catalog from community repo on startup, then every 24 hours
     {

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1101,12 +1101,26 @@ pub async fn run_daemon(
     kernel.start_background_agents().await;
 
     // Initialize OpenTelemetry OTLP tracing when telemetry feature is compiled
-    // in and the config has `telemetry.enabled = true`.
+    // in and the config has `telemetry.enabled = true`. Skip the exporter when
+    // no collector is reachable (default localhost endpoint without daemon-
+    // managed stack, or explicit empty endpoint) — issue #3136 follow-up:
+    // PR #3170 made the bundled stack opt-in but left the exporter pointing
+    // at localhost:4317 by default, so the BatchSpanProcessor would spam
+    // ConnectionRefused on every default install.
     #[cfg(feature = "telemetry")]
     {
         let cfg = kernel.config_ref();
         if cfg.telemetry.enabled {
-            if let Err(e) = crate::telemetry::init_otel_tracing(
+            if cfg.telemetry.otlp_export_disabled() {
+                tracing::info!(
+                    otlp_endpoint = %cfg.telemetry.otlp_endpoint,
+                    auto_start_observability_stack =
+                        cfg.telemetry.auto_start_observability_stack,
+                    "Telemetry OTLP exporter skipped: no collector configured. \
+                     Set telemetry.auto_start_observability_stack = true or \
+                     override telemetry.otlp_endpoint to enable trace export."
+                );
+            } else if let Err(e) = crate::telemetry::init_otel_tracing(
                 &cfg.telemetry.otlp_endpoint,
                 &cfg.telemetry.service_name,
                 cfg.telemetry.sample_rate,

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1530,19 +1530,24 @@ impl TelemetryConfig {
     /// reachable. Returns `true` when:
     ///
     /// - `otlp_endpoint` is empty (operator opted out), OR
-    /// - `otlp_endpoint` is the default `http://localhost:4317` AND the daemon
-    ///   isn't auto-starting the bundled stack — i.e. nobody is listening on
-    ///   that port and the BatchSpanProcessor would just spam
-    ///   `ConnectionRefused` every export interval.
+    /// - `otlp_endpoint` is the default `http://localhost:4317` AND the bundled
+    ///   observability stack is not actually running — either the operator
+    ///   didn't opt in (`auto_start_observability_stack = false`), or they
+    ///   opted in but startup failed (Docker missing, port conflict, compose
+    ///   error). In both cases nothing listens on 4317 and the
+    ///   `BatchSpanProcessor` would spam `ConnectionRefused` every export
+    ///   interval.
     ///
-    /// Operators with an external collector on the default port should either
-    /// flip `auto_start_observability_stack = true` (if they want our stack)
-    /// or set `otlp_endpoint` to the collector's address to opt back in.
-    pub fn otlp_export_disabled(&self) -> bool {
+    /// `stack_running` reflects the runtime fact, not the config intent — call
+    /// sites pass `Some(handle).is_some()` (or equivalent) after attempting
+    /// startup. Operators with an external collector on the default port
+    /// should set `otlp_endpoint` to the collector's address to opt back in;
+    /// the bundled-stack opt-in only helps when the stack actually comes up.
+    pub fn otlp_export_disabled(&self, stack_running: bool) -> bool {
         if self.otlp_endpoint.is_empty() {
             return true;
         }
-        self.otlp_endpoint == DEFAULT_OTLP_ENDPOINT && !self.auto_start_observability_stack
+        self.otlp_endpoint == DEFAULT_OTLP_ENDPOINT && !stack_running
     }
 }
 
@@ -7628,14 +7633,17 @@ rule_sets = ["browser_handles", "pii_baseline"]
     // Issue #3136 follow-up: PR #3170 made the bundled observability stack
     // opt-in but left `otlp_endpoint` defaulting to localhost:4317, so default
     // installs spammed `ConnectionRefused`. `otlp_export_disabled()` is the
-    // gate that suppresses the exporter when no collector is reachable.
+    // gate that suppresses the exporter when no collector is reachable. The
+    // gate takes the runtime fact `stack_running` rather than just the config
+    // intent — `auto_start_observability_stack = true` only matters when the
+    // stack actually came up, otherwise we'd still spam.
     #[test]
     fn otlp_export_disabled_for_default_localhost_without_managed_stack() {
         let cfg = TelemetryConfig::default();
         assert!(cfg.enabled, "default still enables tracing wiring");
         assert!(
-            cfg.otlp_export_disabled(),
-            "default localhost endpoint + auto_start=false must skip exporter"
+            cfg.otlp_export_disabled(false),
+            "default localhost endpoint with no running stack must skip exporter"
         );
     }
 
@@ -7646,8 +7654,23 @@ rule_sets = ["browser_handles", "pii_baseline"]
             ..TelemetryConfig::default()
         };
         assert!(
-            !cfg.otlp_export_disabled(),
-            "daemon-managed stack listens on default endpoint; export must run"
+            !cfg.otlp_export_disabled(true),
+            "running stack on default endpoint; export must run"
+        );
+    }
+
+    // Regression: operator opts in to auto_start but Docker is missing /
+    // compose fails / port conflicts — without this gate, exporter would
+    // still init and spam ConnectionRefused on every export interval.
+    #[test]
+    fn otlp_export_disabled_when_managed_stack_failed_to_start() {
+        let cfg = TelemetryConfig {
+            auto_start_observability_stack: true,
+            ..TelemetryConfig::default()
+        };
+        assert!(
+            cfg.otlp_export_disabled(false),
+            "auto_start=true but stack startup failed; default endpoint is dead"
         );
     }
 
@@ -7658,8 +7681,8 @@ rule_sets = ["browser_handles", "pii_baseline"]
             ..TelemetryConfig::default()
         };
         assert!(
-            !cfg.otlp_export_disabled(),
-            "explicit non-default endpoint signals operator intent"
+            !cfg.otlp_export_disabled(false),
+            "explicit non-default endpoint signals operator intent regardless of stack"
         );
     }
 
@@ -7670,8 +7693,8 @@ rule_sets = ["browser_handles", "pii_baseline"]
             ..TelemetryConfig::default()
         };
         assert!(
-            cfg.otlp_export_disabled(),
-            "empty endpoint is the explicit opt-out path"
+            cfg.otlp_export_disabled(true),
+            "empty endpoint is the explicit opt-out path even when stack is up"
         );
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1484,6 +1484,11 @@ impl Default for InboxConfig {
     }
 }
 
+/// Default OTLP gRPC endpoint — matches the port the bundled observability
+/// stack (Tempo / OTel collector) binds when
+/// `auto_start_observability_stack = true`.
+pub const DEFAULT_OTLP_ENDPOINT: &str = "http://localhost:4317";
+
 /// Telemetry / observability configuration.
 ///
 /// ```toml
@@ -1520,11 +1525,33 @@ pub struct TelemetryConfig {
     pub auto_start_observability_stack: bool,
 }
 
+impl TelemetryConfig {
+    /// Whether OTLP exporter init should be skipped because no collector is
+    /// reachable. Returns `true` when:
+    ///
+    /// - `otlp_endpoint` is empty (operator opted out), OR
+    /// - `otlp_endpoint` is the default `http://localhost:4317` AND the daemon
+    ///   isn't auto-starting the bundled stack — i.e. nobody is listening on
+    ///   that port and the BatchSpanProcessor would just spam
+    ///   `ConnectionRefused` every export interval.
+    ///
+    /// Operators with an external collector on the default port should either
+    /// flip `auto_start_observability_stack = true` (if they want our stack)
+    /// or set `otlp_endpoint` explicitly (e.g. `http://127.0.0.1:4317`) to opt
+    /// back in.
+    pub fn otlp_export_disabled(&self) -> bool {
+        if self.otlp_endpoint.is_empty() {
+            return true;
+        }
+        self.otlp_endpoint == DEFAULT_OTLP_ENDPOINT && !self.auto_start_observability_stack
+    }
+}
+
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            otlp_endpoint: "http://localhost:4317".to_string(),
+            otlp_endpoint: DEFAULT_OTLP_ENDPOINT.to_string(),
             service_name: "librefang".to_string(),
             sample_rate: 1.0,
             prometheus_enabled: true,
@@ -7597,5 +7624,55 @@ rule_sets = ["browser_handles", "pii_baseline"]
         assert_eq!(nav.default, McpTaintToolAction::Scan);
         assert!(nav.rule_sets.is_empty());
         assert_eq!(nav.paths.len(), 1);
+    }
+
+    // Issue #3136 follow-up: PR #3170 made the bundled observability stack
+    // opt-in but left `otlp_endpoint` defaulting to localhost:4317, so default
+    // installs spammed `ConnectionRefused`. `otlp_export_disabled()` is the
+    // gate that suppresses the exporter when no collector is reachable.
+    #[test]
+    fn otlp_export_disabled_for_default_localhost_without_managed_stack() {
+        let cfg = TelemetryConfig::default();
+        assert!(cfg.enabled, "default still enables tracing wiring");
+        assert!(
+            cfg.otlp_export_disabled(),
+            "default localhost endpoint + auto_start=false must skip exporter"
+        );
+    }
+
+    #[test]
+    fn otlp_export_enabled_when_managed_stack_runs() {
+        let cfg = TelemetryConfig {
+            auto_start_observability_stack: true,
+            ..TelemetryConfig::default()
+        };
+        assert!(
+            !cfg.otlp_export_disabled(),
+            "daemon-managed stack listens on default endpoint; export must run"
+        );
+    }
+
+    #[test]
+    fn otlp_export_enabled_for_custom_endpoint() {
+        let cfg = TelemetryConfig {
+            otlp_endpoint: "http://otel.internal:4317".to_string(),
+            ..TelemetryConfig::default()
+        };
+        assert!(
+            !cfg.otlp_export_disabled(),
+            "explicit non-default endpoint signals operator intent"
+        );
+    }
+
+    #[test]
+    fn otlp_export_disabled_for_empty_endpoint() {
+        let cfg = TelemetryConfig {
+            otlp_endpoint: String::new(),
+            ..TelemetryConfig::default()
+        };
+        assert!(
+            cfg.otlp_export_disabled(),
+            "empty endpoint is the explicit opt-out path"
+        );
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1537,8 +1537,7 @@ impl TelemetryConfig {
     ///
     /// Operators with an external collector on the default port should either
     /// flip `auto_start_observability_stack = true` (if they want our stack)
-    /// or set `otlp_endpoint` explicitly (e.g. `http://127.0.0.1:4317`) to opt
-    /// back in.
+    /// or set `otlp_endpoint` to the collector's address to opt back in.
     pub fn otlp_export_disabled(&self) -> bool {
         if self.otlp_endpoint.is_empty() {
             return true;


### PR DESCRIPTION
## Summary
- After PR #3170 (issue #3136) made the bundled observability docker stack opt-in via `auto_start_observability_stack = false`, the OTLP exporter was still pointed at the default `http://localhost:4317`. A clean `librefang start` with default config now runs a `BatchSpanProcessor` that spams `BatchSpanProcessor.ExportError: tcp connect error ... ConnectionRefused` on every export interval, because nobody listens on 4317 by default anymore.
- Add `TelemetryConfig::otlp_export_disabled()` and gate exporter init behind it. Exporter is skipped when `otlp_endpoint` is empty (explicit opt-out) or when it equals the default `http://localhost:4317` AND `auto_start_observability_stack = false`.
- Operators with an external collector at the default address can either flip `auto_start_observability_stack = true` or set `otlp_endpoint` to their collector's address. The skip path emits one info log explaining both options.

## Why this design
- Symmetric with PR #3170: that PR said "don't auto-start the stack at default endpoint"; this PR says "don't push to the default endpoint when nothing is auto-started there."
- Doesn't change `enabled` default (which would silently disable telemetry for users who already rely on the default and have a collector running).
- A more thorough fix would model `otlp_endpoint` as `Option<String>` to distinguish "field absent" vs "field equals literal default", but that's a wider schema change. Happy to do it as a follow-up if reviewers prefer it.

## Edge case
An operator running a manually-started external collector on `localhost:4317` with `auto_start_observability_stack = false` will see their exporter silently skipped. The info log on startup describes both opt-in paths (flip `auto_start_observability_stack = true` or set `otlp_endpoint` to their collector's address).

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test --workspace` — only failure is the pre-existing `test_estimate_cost_with_catalog` in `librefang-kernel-metering` which also fails on `origin/main` and is unrelated to this PR.
- [x] 4 new unit tests in `librefang-types` cover all `otlp_export_disabled()` branches (default localhost / managed stack / custom endpoint / empty endpoint).
- [x] **Live smoke test 1**: default config (`enabled=true`, default endpoint, `auto_start=false`) → emits `Telemetry OTLP exporter skipped: no collector configured. ...`, no `OpenTelemetry OTLP tracing initialized`, **no `ConnectionRefused` over 8s of boot**. ✅
- [x] **Live smoke test 2**: `otlp_endpoint=""` → emits skip log with `otlp_endpoint=` (empty), no init. ✅
- [x] **Live smoke test 3**: `otlp_endpoint="http://otel.example.invalid:4317"` → no skip log, emits `OpenTelemetry OTLP tracing initialized endpoint="http://otel.example.invalid:4317"` — confirms the non-skip path still wires up the exporter. ✅

Issue #3136 follow-up.