### PR TITLE
fix(audit): point at recovery commands when boot integrity check fails

### DIFF
--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -316,7 +316,12 @@ impl AuditLog {
                         db_tip = %current_tip,
                         "Audit anchor MISMATCH on boot — SQLite audit_entries may \
                          have been rewritten; `/api/audit/verify` will fail until \
-                         the database and anchor agree again"
+                         the database and anchor agree again. \
+                         Inspect with `librefang security verify`; if you accept the \
+                         loss of pre-break forensic value (typical in dev), \
+                         `librefang security audit-reset` truncates the chain and \
+                         re-anchors at zero. DO NOT run reset in compliance / \
+                         production environments."
                     );
                 }
             }
@@ -442,7 +447,14 @@ impl AuditLog {
         // Verify chain integrity on load
         if count > 0 {
             if let Err(e) = log.verify_integrity() {
-                tracing::error!("Audit trail integrity check FAILED on boot: {e}");
+                tracing::error!(
+                    "Audit trail integrity check FAILED on boot: {e}. \
+                     Run `librefang security verify` to inspect; if you accept the \
+                     loss of pre-break forensic value (typical in dev), \
+                     `librefang security audit-reset` truncates the chain and \
+                     re-anchors at zero. DO NOT run reset in compliance / \
+                     production environments."
+                );
             } else {
                 tracing::info!("Audit trail loaded: {count} entries, chain integrity OK");
             }


### PR DESCRIPTION
## Summary

When `verify_integrity()` or the anchor-vs-db comparison fails on daemon boot, the operator gets a single-line ERROR with the hash mismatch but no hint about what to do next. They have to grep the codebase or read source to discover that `librefang security audit-reset` exists and will clear the break.

In dev, this is the "every boot" log spam — typically caused by direct `sqlite3` editing of `audit_entries` (e.g. while debugging), which leaves a hole the chain verifier rediscovers on every restart. In compliance / production, `audit-reset` is the **wrong** answer because it destroys forensic value.

## Changes

Extends both `tracing::error!` messages in `crates/librefang-runtime/src/audit.rs` (the `Audit anchor MISMATCH` and `Audit trail integrity check FAILED` paths) to:

1. Point at `librefang security verify` for diagnostics.
2. Mention `librefang security audit-reset` as the recovery path IF the operator accepts the loss of pre-break forensic value.
3. Spell out **"DO NOT run reset in compliance / production environments"** so the recovery hint can't be cargo-culted into a bad situation.

No behavior change — message text only.

## Why

This came out of a real session where I had ~44 of these ERRORs in my dev daemon log (chain break at seq 38 caused by some past `sqlite3 DELETE`). Took a code dive to find `audit-reset`. The hint pays for itself the first time anyone else hits the same situation.

## Test plan

- [x] `cargo check -p librefang-runtime` — passed locally (3m43s, exit 0)
- [ ] CI: full workspace build
