### PR TITLE
fix(tests): align model_catalog/routing tests with current registry

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1252,8 +1252,8 @@ id = "acme"
     #[test]
     fn test_find_model_by_id() {
         let catalog = test_catalog();
-        let entry = catalog.find_model("claude-sonnet-4-20250514").unwrap();
-        assert_eq!(entry.display_name, "Claude Sonnet 4");
+        let entry = catalog.find_model("claude-sonnet-4-6").unwrap();
+        assert_eq!(entry.display_name, "Claude Sonnet 4.6");
         assert_eq!(entry.provider, "anthropic");
         assert_eq!(entry.tier, ModelTier::Smart);
     }
@@ -1268,7 +1268,7 @@ id = "acme"
     #[test]
     fn test_find_model_case_insensitive() {
         let catalog = test_catalog();
-        assert!(catalog.find_model("Claude-Sonnet-4-20250514").is_some());
+        assert!(catalog.find_model("Claude-Sonnet-4-6").is_some());
         assert!(catalog.find_model("SONNET").is_some());
     }
 
@@ -1281,20 +1281,20 @@ id = "acme"
     /// `find_model_for_provider` must filter by provider so the same model
     /// id under different providers (which can differ in `context_window`)
     /// resolves to the right entry. The test catalog has
-    /// `claude-sonnet-4-20250514` only under `anthropic`, so a copilot
+    /// `claude-sonnet-4-6` only under `anthropic`, so a copilot
     /// lookup of the same id must miss.
     #[test]
     fn test_find_model_for_provider_filters_by_provider() {
         let catalog = test_catalog();
         assert!(
             catalog
-                .find_model_for_provider("anthropic", "claude-sonnet-4-20250514")
+                .find_model_for_provider("anthropic", "claude-sonnet-4-6")
                 .is_some(),
             "anthropic catalog hit expected"
         );
         assert!(
             catalog
-                .find_model_for_provider("copilot", "claude-sonnet-4-20250514")
+                .find_model_for_provider("copilot", "claude-sonnet-4-6")
                 .is_none(),
             "no copilot entry for the anthropic id should exist",
         );
@@ -1307,10 +1307,10 @@ id = "acme"
     fn test_find_model_for_provider_empty_provider_falls_back() {
         let catalog = test_catalog();
         let via_filtered = catalog
-            .find_model_for_provider("", "claude-sonnet-4-20250514")
+            .find_model_for_provider("", "claude-sonnet-4-6")
             .expect("empty provider should match anyway");
         let via_unfiltered = catalog
-            .find_model("claude-sonnet-4-20250514")
+            .find_model("claude-sonnet-4-6")
             .expect("unfiltered match");
         assert_eq!(via_filtered.id, via_unfiltered.id);
     }
@@ -1321,7 +1321,7 @@ id = "acme"
     fn test_find_model_for_provider_case_insensitive_provider() {
         let catalog = test_catalog();
         assert!(catalog
-            .find_model_for_provider("ANTHROPIC", "claude-sonnet-4-20250514")
+            .find_model_for_provider("ANTHROPIC", "claude-sonnet-4-6")
             .is_some(),);
     }
 
@@ -1373,7 +1373,7 @@ id = "acme"
     #[test]
     fn test_pricing_lookup() {
         let catalog = test_catalog();
-        let (input, output) = catalog.pricing("claude-sonnet-4-20250514").unwrap();
+        let (input, output) = catalog.pricing("claude-sonnet-4-6").unwrap();
         assert!((input - 3.0).abs() < 0.001);
         assert!((output - 15.0).abs() < 0.001);
     }
@@ -1526,7 +1526,6 @@ id = "acme"
         assert_eq!(aliases.get("sonnet").unwrap(), "claude-sonnet-4-6");
         // New aliases
         assert_eq!(aliases.get("grok").unwrap(), "grok-4-0709");
-        assert_eq!(aliases.get("jamba").unwrap(), "jamba-1.5-large");
     }
 
     #[test]
@@ -1586,8 +1585,6 @@ id = "acme"
         assert!(xai.iter().any(|m| m.id == "grok-4-fast-non-reasoning"));
         assert!(xai.iter().any(|m| m.id == "grok-4-1-fast-reasoning"));
         assert!(xai.iter().any(|m| m.id == "grok-4-1-fast-non-reasoning"));
-        assert!(xai.iter().any(|m| m.id == "grok-3"));
-        assert!(xai.iter().any(|m| m.id == "grok-3-mini"));
     }
 
     #[test]
@@ -1814,13 +1811,13 @@ id = "acme"
         let mut catalog = test_catalog();
 
         // Pick a known builtin xai model and verify it exists
-        let builtin = catalog.find_model("grok-3").unwrap();
+        let builtin = catalog.find_model("grok-4-fast-reasoning").unwrap();
         assert_eq!(builtin.provider, "xai");
 
         // Add a custom model with the same ID but a different provider
         assert!(catalog.add_custom_model(ModelCatalogEntry {
-            id: "grok-3".to_string(),
-            display_name: "Grok 3 via OpenRouter".to_string(),
+            id: "grok-4-fast-reasoning".to_string(),
+            display_name: "Grok 4 Fast via OpenRouter".to_string(),
             provider: "openrouter".to_string(),
             tier: ModelTier::Custom,
             context_window: 131_072,
@@ -1836,7 +1833,7 @@ id = "acme"
         }));
 
         // find_model should now return the custom entry, not the builtin
-        let found = catalog.find_model("grok-3").unwrap();
+        let found = catalog.find_model("grok-4-fast-reasoning").unwrap();
         assert_eq!(found.provider, "openrouter");
         assert_eq!(found.tier, ModelTier::Custom);
     }
@@ -1882,11 +1879,17 @@ id = "acme"
     #[test]
     fn test_kimi2_models() {
         let catalog = test_catalog();
-        // Kimi K2 and K2.5 models
-        let k2 = catalog.find_model("kimi-k2").unwrap();
+        // Kimi K2 and K2.5 models — use provider-scoped lookup because
+        // byteplus_coding also exposes kimi-k2.5 and the unscoped find_model
+        // does not guarantee a particular provider when IDs collide.
+        let k2 = catalog
+            .find_model_for_provider("moonshot", "kimi-k2")
+            .unwrap();
         assert_eq!(k2.provider, "moonshot");
         assert_eq!(k2.tier, ModelTier::Frontier);
-        let k25 = catalog.find_model("kimi-k2.5").unwrap();
+        let k25 = catalog
+            .find_model_for_provider("moonshot", "kimi-k2.5")
+            .unwrap();
         assert_eq!(k25.provider, "moonshot");
         assert_eq!(k25.tier, ModelTier::Frontier);
         // Alias resolution
@@ -1925,14 +1928,6 @@ id = "acme"
             hs.provider
         );
         assert!(catalog.find_model("minimax-m2.7-highspeed").is_some());
-        // abab7-chat
-        let abab7 = catalog.find_model("abab7-chat").unwrap();
-        assert!(
-            abab7.provider == "minimax" || abab7.provider == "minimax-cn",
-            "unexpected provider: {}",
-            abab7.provider
-        );
-        assert!(abab7.supports_vision);
     }
 
     #[test]
@@ -2269,8 +2264,8 @@ aliases = []
     fn test_merge_catalog_skips_duplicate_models() {
         let toml_content = r#"
 [[models]]
-id = "claude-sonnet-4-20250514"
-display_name = "Claude Sonnet 4"
+id = "claude-sonnet-4-6"
+display_name = "Claude Sonnet 4.6"
 provider = "anthropic"
 tier = "smart"
 context_window = 200000
@@ -2501,11 +2496,6 @@ supports_streaming = true
     #[test]
     fn test_alibaba_coding_plan_zero_cost() {
         let catalog = test_catalog();
-        let qwen35plus = catalog
-            .find_model("alibaba-coding-plan/qwen3.5-plus")
-            .expect("qwen3.5-plus model should be registered");
-        assert_eq!(qwen35plus.input_cost_per_m, 0.0);
-        assert_eq!(qwen35plus.output_cost_per_m, 0.0);
         let qwen36plus = catalog
             .find_model("alibaba-coding-plan/qwen3.6-plus")
             .expect("qwen3.6-plus model should be registered");
@@ -2516,25 +2506,12 @@ supports_streaming = true
     #[test]
     fn test_alibaba_coding_plan_vision_models() {
         let catalog = test_catalog();
-        let qwen35plus = catalog
-            .find_model("alibaba-coding-plan/qwen3.5-plus")
-            .expect("qwen3.5-plus model should be registered");
-        assert!(qwen35plus.supports_vision);
-        assert_eq!(qwen35plus.tier, ModelTier::Smart);
-        assert_eq!(qwen35plus.context_window, 1_000_000);
-
         let qwen36plus = catalog
             .find_model("alibaba-coding-plan/qwen3.6-plus")
             .expect("qwen3.6-plus model should be registered");
         assert!(qwen36plus.supports_vision);
         assert_eq!(qwen36plus.tier, ModelTier::Smart);
         assert_eq!(qwen36plus.context_window, 1_000_000);
-
-        let kimi = catalog
-            .find_model("alibaba-coding-plan/kimi-k2.5")
-            .expect("kimi-k2.5 model should be registered");
-        assert!(kimi.supports_vision);
-        assert_eq!(kimi.tier, ModelTier::Smart);
     }
 
     #[test]

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -361,7 +361,7 @@ mod tests {
         );
         assert_eq!(
             router.model_for_complexity(TaskComplexity::Complex),
-            "claude-opus-4-6"
+            "claude-opus-4-7"
         );
     }
 


### PR DESCRIPTION
## Summary

CI on `main` (and every open PR) has been failing 15 tests in `librefang-runtime` across Ubuntu / Windows / macOS because the upstream `librefang-registry` has renamed and dropped a number of model IDs and aliases since these tests were written. PRs touching unrelated code (#3271, #3273, #3274, #3275, #3277) are all blocked by red CI for the same reason.

This PR is **test-only** — it realigns the assertions with what the current registry actually exposes. No production code changes.

## Changes

- `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (display name `"Claude Sonnet 4.6"`) — across `find_model`, `find_model_for_provider`, `pricing`, and the `merge_catalog_skips_duplicate_models` fixture.
- `grok-3` / `grok-3-mini` — removed from registry. Dropped the two `xai` model-set assertions; rewired `test_find_model_prefers_custom_over_builtin` to use `grok-4-fast-reasoning` (xai-only ID, no alias collisions).
- `jamba` alias — gone since the ai21 provider was removed in #3023. Dropped the assertion in `test_list_aliases`.
- `abab7-chat` — removed from minimax. Dropped the assertion in `test_chinese_model_aliases`.
- `alibaba-coding-plan/qwen3.5-plus` and `alibaba-coding-plan/kimi-k2.5` — removed from the alibaba-coding-plan catalog. The two tests now cover only the surviving `qwen3.6-plus`.
- `routing::test_resolve_aliases` — `opus` alias resolves to `claude-opus-4-7` (the current Anthropic flagship), not `claude-opus-4-6`.
- `test_kimi2_models` — the new `byteplus_coding` provider (added in #3271) also exposes `kimi-k2.5`, so the unscoped `find_model("kimi-k2.5")` is non-deterministic. Switched to `find_model_for_provider("moonshot", "kimi-k2.5")` so the test asserts what it actually means. Left a comment explaining the collision so future readers don't undo it.

## Why

The catalog tests pull the live registry at test time (via `registry_sync` cloning `github.com/librefang/librefang-registry`). When the registry repo changes, these assertions go red on the next CI run regardless of what any individual PR is doing — and `main` has been red for several days.

## Test plan

- [x] `cargo test -p librefang-runtime --lib` → 1397 passed, 0 failed (was 15 failed)
- [x] `cargo test -p librefang-runtime --lib model_catalog::` → 75 passed
- [x] `cargo test -p librefang-runtime --lib routing::` → 10 passed
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings` → clean
- [ ] CI on Ubuntu / Windows / macOS

