### PR TITLE
feat(drivers): add microsoft provider entry with own env var

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -393,6 +393,16 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         hidden: false,
     },
     ProviderEntry {
+        name: "microsoft",
+        aliases: &["github-models"],
+        base_url: "https://models.inference.ai.azure.com",
+        api_key_env: "GITHUB_MODELS_TOKEN",
+        key_required: true,
+        api_format: ApiFormat::OpenAI,
+        alt_api_key_env: None,
+        hidden: false,
+    },
+    ProviderEntry {
         name: "claude-code",
         aliases: &[],
         base_url: "",
@@ -1155,7 +1165,24 @@ mod tests {
         assert!(providers.contains(&"nvidia-nim"));
         assert!(providers.contains(&"novita"));
         assert!(providers.contains(&"bedrock"));
-        assert_eq!(providers.len(), 42);
+        assert!(providers.contains(&"microsoft"));
+        assert_eq!(providers.len(), 43);
+    }
+
+    /// `microsoft` (GitHub Models / Azure AI Inference) must declare its own
+    /// env var rather than reusing `GITHUB_TOKEN`, since that token is also
+    /// accepted by the IDE-side `github-copilot` provider — sharing the env
+    /// var made one credential silently activate two distinct products.
+    #[test]
+    fn test_microsoft_provider_split_from_github_copilot() {
+        let microsoft = find_provider("microsoft").expect("microsoft entry missing");
+        assert_eq!(microsoft.api_key_env, "GITHUB_MODELS_TOKEN");
+        assert_eq!(microsoft.base_url, "https://models.inference.ai.azure.com");
+        let copilot = find_provider("github-copilot").expect("github-copilot entry missing");
+        assert_eq!(
+            copilot.api_key_env, "GITHUB_TOKEN",
+            "github-copilot keeps the original env (IDE-side convention)",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Companion to librefang/librefang-registry#83. Adds an explicit `microsoft` entry to `PROVIDER_REGISTRY` with `api_key_env = "GITHUB_MODELS_TOKEN"` so the GitHub Models / Azure AI Inference endpoint no longer shares an env var with the IDE-side `github-copilot` provider. `github-copilot` keeps `GITHUB_TOKEN` — that's the established convention for the IDE side.

The driver registry previously had no entry for `microsoft` (it was catalog-only, falling through to a generic OpenAI-compatible code path).

| provider | env var | base URL |
|---|---|---|
| `microsoft` (new entry, alias `github-models`) | `GITHUB_MODELS_TOKEN` | `https://models.inference.ai.azure.com` |
| `github-copilot` (unchanged) | `GITHUB_TOKEN` | `https://api.githubcopilot.com` |

Background and design discussion: librefang/librefang#3278.

## What changes

- New `microsoft` entry in `PROVIDER_REGISTRY` (`ApiFormat::OpenAI`, alias `github-models`).
- `known_providers().len()` assertion bumps 42 → 43, with a new `contains(&"microsoft")` check.
- New `test_microsoft_provider_split_from_github_copilot` test asserting the env-var split and base URL, and that `github-copilot` is left alone.

Single-file PR, +28 / -1.

## Compatibility

**BREAKING**: operators using `GITHUB_TOKEN` to authenticate the `microsoft` provider need to also export `GITHUB_MODELS_TOKEN` (same key value works). Until they do, the dashboard will show `microsoft` as missing-credential. Mirrors the approach taken in #3279 for the `_coding` providers.

## Test Plan

- [x] `cargo test -p librefang-llm-drivers --lib` — passes (added 1 new test for the microsoft split)
- [x] `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- [ ] Live integration (after this and the registry PR #83 merge):
  - daemon starts cleanly with `GITHUB_MODELS_TOKEN` set — `microsoft` available
  - daemon starts with only `GITHUB_TOKEN` set — `microsoft` shown as missing-credential
  - `github-copilot` behavior unchanged in all cases (still uses `GITHUB_TOKEN`)

## Out of Scope

Tracked under #3278 for separate follow-up:
- `zai`/`zhipu` cross-region key sharing (independent providers vs `[provider.regions.china]` pattern — design decision pending)
- Driving `librefang doctor`'s provider whitelist off `PROVIDER_REGISTRY` so it can't drift again

Refs librefang/librefang#3278, librefang/librefang-registry#83.
