### PR TITLE
docs(byteplus_coding): align display name with registry rename

### DIFF
--- a/docs/src/app/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/configuration/providers/platforms/page.mdx
@@ -278,7 +278,7 @@ model = "seed-2-0-pro-260328"       # versioned snapshot, see byteplus.toml
 
 | | |
 |---|---|
-| **Display Name** | BytePlus ModelArk Coding Plan |
+| **Display Name** | BytePlus Coding Plan |
 | **Provider ID** | `byteplus_coding` |
 | **Driver** | Anthropic-compatible (`/v1/messages`) |
 | **Env Var** | `BYTEPLUS_CODING_API_KEY` |

--- a/docs/src/app/zh/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/zh/configuration/providers/platforms/page.mdx
@@ -278,7 +278,7 @@ model = "seed-2-0-pro-260328"       # 版本化快照 ID, 见 byteplus.toml
 
 | | |
 |---|---|
-| **显示名称** | BytePlus ModelArk Coding Plan |
+| **显示名称** | BytePlus Coding Plan |
 | **Provider ID** | `byteplus_coding` |
 | **驱动** | Anthropic 兼容(`/v1/messages`) |
 | **环境变量** | `BYTEPLUS_CODING_API_KEY` |


### PR DESCRIPTION
## Summary

Companion to librefang/librefang-registry#85 which trims `byteplus_coding`'s `display_name` from `BytePlus ModelArk Coding Plan` (29 chars) to `BytePlus Coding Plan` (20 chars). The previous wording overflowed dashboard provider cards and CLI lists.

This PR updates the matching cell in both the English and Chinese provider platform reference docs so they don't drift from what the daemon actually shows.

## Diff

Two files, one cell each:

```diff
- | **Display Name** | BytePlus ModelArk Coding Plan |
+ | **Display Name** | BytePlus Coding Plan |
```

```diff
- | **显示名称** | BytePlus ModelArk Coding Plan |
+ | **显示名称** | BytePlus Coding Plan |
```

`provider.id` (`byteplus_coding`), env var (`BYTEPLUS_CODING_API_KEY`), and base URL are unchanged on both sides.

## Test plan

- [x] Diff is +2 / -2 across two files
- [x] zh + en parity preserved
- [ ] Merge depends on librefang/librefang-registry#85 — registry change drives the actual dashboard string; this PR keeps docs aligned with that change

Refs librefang/librefang-registry#85.