### PR TITLE
feat(drivers): split zai api_key_env from zhipu

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -506,7 +506,7 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         name: "zai",
         aliases: &["z.ai"],
         base_url: "https://api.z.ai/api/paas/v4",
-        api_key_env: "ZHIPU_API_KEY",
+        api_key_env: "ZAI_API_KEY",
         key_required: true,
         api_format: ApiFormat::OpenAI,
         alt_api_key_env: None,
@@ -1182,6 +1182,22 @@ mod tests {
         assert_eq!(
             copilot.api_key_env, "GITHUB_TOKEN",
             "github-copilot keeps the original env (IDE-side convention)",
+        );
+    }
+
+    /// `zai` (api.z.ai, international) and `zhipu` (open.bigmodel.cn, China)
+    /// target the same Zhipu account system but are surfaced as distinct
+    /// providers in the dashboard, so they need distinct env vars to avoid
+    /// auto-activating both off a single credential.
+    #[test]
+    fn test_zai_provider_split_from_zhipu() {
+        let zai = find_provider("zai").expect("zai entry missing");
+        assert_eq!(zai.api_key_env, "ZAI_API_KEY");
+        assert_eq!(zai.base_url, "https://api.z.ai/api/paas/v4");
+        let zhipu = find_provider("zhipu").expect("zhipu entry missing");
+        assert_eq!(
+            zhipu.api_key_env, "ZHIPU_API_KEY",
+            "zhipu keeps the original env (more-established name)",
         );
     }
 


### PR DESCRIPTION
## Summary

Companion to librefang/librefang-registry#84. Updates `zai`'s `PROVIDER_REGISTRY` entry from `api_key_env = "ZHIPU_API_KEY"` to `ZAI_API_KEY`, so configuring a single Zhipu credential no longer silently activates both `zhipu` and `zai` in the dashboard model picker. Same shape as #3279 / #3281 — pure rename, no fallback.

| provider | before | after |
|---|---|---|
| `zai` (api.z.ai) | `ZHIPU_API_KEY` | `ZAI_API_KEY` |
| `zhipu` (open.bigmodel.cn) | unchanged | unchanged |

The `_coding` siblings (`zai_coding`, `zhipu_coding`) were already split in #3279.

Closes librefang/librefang#3282.

## What changes

Single-file PR, +17 / -1.

- `zai` entry's `api_key_env` field flipped to `ZAI_API_KEY`.
- New test `test_zai_provider_split_from_zhipu` asserting the env-var split (and that `zhipu` is left untouched).

## Compatibility

**BREAKING**: operators using `ZHIPU_API_KEY` to access the `zai` endpoint must also export `ZAI_API_KEY` (same key value works). Until then, the dashboard will surface `zai` as missing-credential while `zhipu` continues to work normally. Mirrors the rollout convention from #3279 / #3281 — no deprecation fallback, just a CHANGELOG-tracked breaking change (added in the registry PR).

## Test Plan

- [x] `cargo test -p librefang-llm-drivers --lib` — all 388 tests pass (added 1 new test for the split)
- [x] `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- [ ] Live integration (after this and the registry PR #84 merge):
  - daemon starts cleanly with `ZAI_API_KEY` set — `zai` available
  - daemon starts with only `ZHIPU_API_KEY` set — `zhipu` available, `zai` shown as missing-credential
  - daemon starts with both — both providers available

Refs librefang/librefang#3282, librefang/librefang-registry#84.
