### PR TITLE
docs(providers): align Z.ai env + add Microsoft (GitHub Models) section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 - Merge duplicate type definitions across crates (#3185) (@houko)
 - Rename Action enums to disambiguate from domain types (#3188) (@houko)
 - **BREAKING**: Split coding-provider API keys onto dedicated env vars — `byteplus_coding` now reads `BYTEPLUS_CODING_API_KEY` (was `BYTEPLUS_API_KEY`), `volcengine_coding` reads `VOLCENGINE_CODING_API_KEY` (was `VOLCENGINE_API_KEY`), `zai_coding` reads `ZAI_CODING_API_KEY` (was `ZHIPU_API_KEY`), `zhipu_coding` reads `ZHIPU_CODING_API_KEY` (was `ZHIPU_API_KEY`). Per-token siblings (`byteplus`, `volcengine`, `zai`, `zhipu`) keep their original env vars. Set the new env var if you use any `_coding` provider. (#3279) (@houko)
+- **BREAKING**: Register `microsoft` (GitHub Models / Azure AI Inference) as an explicit driver-registry entry with its own `GITHUB_MODELS_TOKEN` env var, distinct from `github-copilot`'s `GITHUB_TOKEN`. Same PAT works for both, but the env vars are now separate so configuring one product no longer auto-activates the other in the model picker. Set `GITHUB_MODELS_TOKEN` if you use the `microsoft` provider. (#3281) (@houko)
+- **BREAKING**: Split `zai` from sharing `ZHIPU_API_KEY` with `zhipu` — `zai` (api.z.ai) now reads `ZAI_API_KEY` while `zhipu` (open.bigmodel.cn) keeps `ZHIPU_API_KEY`. Same Zhipu credential value works for both, but the env vars are now separate so configuring one no longer auto-activates the other. Set `ZAI_API_KEY` if you use the `zai` provider. (#3285) (@houko)
 
 ### Documentation
 

--- a/docs/src/app/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/configuration/providers/platforms/page.mdx
@@ -8,6 +8,7 @@ This page covers providers that route through a platform-specific gateway, enter
 - NVIDIA NIM
 - DeepInfra
 - Azure OpenAI
+- GitHub Models (Azure AI Inference)
 - Qwen (DashScope)
 - MiniMax
 - Qianfan (Baidu)
@@ -106,6 +107,36 @@ This page covers providers that route through a platform-specific gateway, enter
    export AZURE_OPENAI_API_KEY="..."
    export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
    ```
+
+---
+
+## GitHub Models (Azure AI Inference)
+
+| | |
+|---|---|
+| **Display Name** | Microsoft |
+| **Provider ID** | `microsoft` (alias: `github-models`) |
+| **Driver** | OpenAI-compatible |
+| **Env Var** | `GITHUB_MODELS_TOKEN` |
+| **Base URL** | `https://models.inference.ai.azure.com` |
+| **Key Required** | Yes |
+| **Free Tier** | Yes (rate-limited per GitHub plan) |
+| **Auth** | `Authorization: Bearer` header |
+
+**Setup:**
+1. Sign in to [github.com/marketplace/models](https://github.com/marketplace/models)
+2. Generate a fine-grained Personal Access Token (no repository scopes are required for the Models endpoint)
+3. `export GITHUB_MODELS_TOKEN="ghp_..."` (the same PAT works as `GITHUB_TOKEN` for `github-copilot`, but the env vars are kept separate so configuring one product doesn't auto-activate the other)
+
+**Minimal `config.toml`:**
+
+```toml
+[default_model]
+provider = "microsoft"
+model = "phi-4"
+```
+
+**Notes:** Despite the `microsoft` provider id, this is the GitHub Models / Azure AI Inference endpoint, distinct from `azure-openai` (which addresses your own Azure OpenAI deployments via `AZURE_OPENAI_ENDPOINT`) and from `github-copilot` (which is the IDE-side Copilot subscription). Models are catalog-driven and include third-party hosts like `meta-llama-3-70b-instruct`, `mistral-large`, `phi-4`, etc.
 
 ---
 

--- a/docs/src/app/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/configuration/providers/platforms/page.mdx
@@ -328,7 +328,7 @@ provider = "zhipu"
 model = "glm-4-plus"
 ```
 
-**Notes:** Zhipu develops the GLM (General Language Model) family. Tools, vision, and embeddings supported. `z.ai` (below) is the international-region front-end of the same backend and shares `ZHIPU_API_KEY`. The Coding Plan endpoints (`zhipu_coding`, `zai_coding`) now use `ZHIPU_CODING_API_KEY` and `ZAI_CODING_API_KEY` respectively — register once at Zhipu and re-export the same value under each name you actually use.
+**Notes:** Zhipu develops the GLM (General Language Model) family. Tools, vision, and embeddings supported. `z.ai` (below) is the international-region front-end of the same backend but is registered as its own provider with its own `ZAI_API_KEY`. The Coding Plan endpoints (`zhipu_coding`, `zai_coding`) similarly use their own `ZHIPU_CODING_API_KEY` and `ZAI_CODING_API_KEY`. Register once at Zhipu and re-export the same key value under each env var you actually use.
 
 ---
 
@@ -368,15 +368,15 @@ model = "codegeex-4"
 | **Display Name** | Z.ai |
 | **Provider ID** | `z.ai` |
 | **Driver** | OpenAI-compatible |
-| **Env Var** | `ZHIPU_API_KEY` (shares key with Zhipu) |
+| **Env Var** | `ZAI_API_KEY` |
 | **Base URL** | `https://api.z.ai/api/paas/v4` |
 | **Key Required** | Yes |
 | **Free Tier** | Yes (counted against the same Zhipu quota) |
 | **Auth** | `Authorization: Bearer` header |
 
 **Setup:**
-1. Use the same Zhipu API key
-2. `export ZHIPU_API_KEY="..."`
+1. Use the same Zhipu API key (register once on the Zhipu open platform)
+2. `export ZAI_API_KEY="..."` (same value as `ZHIPU_API_KEY`, separate env so configuring Zhipu chat doesn't auto-activate this endpoint)
 
 **Minimal `config.toml`:**
 

--- a/docs/src/app/zh/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/zh/configuration/providers/platforms/page.mdx
@@ -8,6 +8,7 @@
 - NVIDIA NIM
 - DeepInfra
 - Azure OpenAI
+- GitHub Models(Azure AI Inference)
 - Qwen (DashScope)
 - MiniMax
 - Qianfan(百度)
@@ -106,6 +107,36 @@
    export AZURE_OPENAI_API_KEY="..."
    export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
    ```
+
+---
+
+## GitHub Models(Azure AI Inference)
+
+| | |
+|---|---|
+| **显示名称** | Microsoft |
+| **Provider ID** | `microsoft`(别名 `github-models`) |
+| **驱动** | OpenAI 兼容 |
+| **环境变量** | `GITHUB_MODELS_TOKEN` |
+| **基础 URL** | `https://models.inference.ai.azure.com` |
+| **需要密钥** | 是 |
+| **免费额度** | 是(按 GitHub 套餐限速) |
+| **认证方式** | `Authorization: Bearer` 请求头 |
+
+**设置：**
+1. 登录 [github.com/marketplace/models](https://github.com/marketplace/models)
+2. 生成一个 fine-grained Personal Access Token(Models 端点不需要 repository scope)
+3. `export GITHUB_MODELS_TOKEN="ghp_..."`(同一把 PAT 也是 `github-copilot` 用的 `GITHUB_TOKEN`,但环境变量保持独立,这样配置一个产品不会顺带激活另一个)
+
+**最小 `config.toml`：**
+
+```toml
+[default_model]
+provider = "microsoft"
+model = "phi-4"
+```
+
+**说明:** 虽然 provider id 叫 `microsoft`,但实际是 GitHub Models / Azure AI Inference 端点,与 `azure-openai`(指向你自有 Azure OpenAI 部署,通过 `AZURE_OPENAI_ENDPOINT` 路由)以及 `github-copilot`(IDE 端的 Copilot 订阅)都不同。模型通过 catalog 加载,包含第三方托管模型如 `meta-llama-3-70b-instruct`、`mistral-large`、`phi-4` 等。
 
 ---
 

--- a/docs/src/app/zh/configuration/providers/platforms/page.mdx
+++ b/docs/src/app/zh/configuration/providers/platforms/page.mdx
@@ -328,7 +328,7 @@ provider = "zhipu"
 model = "glm-4-plus"
 ```
 
-**说明:** 智谱开发 GLM(General Language Model)系列。支持工具、vision、embedding。`z.ai`(下面)是同一后端的国际区域前端,与本 provider 共用 `ZHIPU_API_KEY`。Coding Plan 端点(`zhipu_coding`、`zai_coding`)现在分别使用 `ZHIPU_CODING_API_KEY` 与 `ZAI_CODING_API_KEY` —— 在智谱注册一次,把同一个值按需导出到对应的环境变量名下。
+**说明:** 智谱开发 GLM(General Language Model)系列。支持工具、vision、embedding。`z.ai`(下面)是同一后端的国际区域前端,但注册为独立 provider,使用独立的 `ZAI_API_KEY`。Coding Plan 端点(`zhipu_coding`、`zai_coding`)同样使用独立的 `ZHIPU_CODING_API_KEY` 与 `ZAI_CODING_API_KEY`。在智谱注册一次,把同一个 key 值按需导出到对应的环境变量名下。
 
 ---
 
@@ -368,15 +368,15 @@ model = "codegeex-4"
 | **显示名称** | Z.ai |
 | **Provider ID** | `z.ai` |
 | **驱动** | OpenAI 兼容 |
-| **环境变量** | `ZHIPU_API_KEY`(与 Zhipu 共享 key) |
+| **环境变量** | `ZAI_API_KEY` |
 | **基础 URL** | `https://api.z.ai/api/paas/v4` |
 | **需要密钥** | 是 |
 | **免费额度** | 是(算在同一个智谱配额里) |
 | **认证方式** | `Authorization: Bearer` 请求头 |
 
 **设置：**
-1. 复用智谱 API key
-2. `export ZHIPU_API_KEY="..."`
+1. 复用智谱 API key(在智谱开放平台注册一次)
+2. `export ZAI_API_KEY="..."`(与 `ZHIPU_API_KEY` 同值;独立环境变量,避免配置 Zhipu chat 时把 z.ai 端点也自动激活)
 
 **最小 `config.toml`：**
 


### PR DESCRIPTION
## Summary

Two related docs follow-ups landing together:

1. **Align Z.ai env var with #3285** — that PR renamed `zai`'s `api_key_env` to `ZAI_API_KEY` but the Platforms reference (en + zh) still claimed `ZHIPU_API_KEY (shares key with Zhipu)`. Brings both pages in sync.
2. **Add a Microsoft (GitHub Models) section** — the `microsoft` provider entry shipped in #3281 / librefang-registry#83 with `GITHUB_MODELS_TOKEN`, but this catalog-only provider has never had an entry on the Platforms page. Adding it now gives users a canonical place to look up the new env var and to disambiguate `microsoft` from `azure-openai` and `github-copilot`, which live in adjacent territory.

en + zh kept in sync.

## Changes

### Commit 1 — `docs(providers): align Z.ai env var with #3285`

- Z.ai section's Env Var row: `ZHIPU_API_KEY (shares key with Zhipu)` → `ZAI_API_KEY`
- Z.ai setup step: `export ZHIPU_API_KEY` → `export ZAI_API_KEY` (with the same-value-as-Zhipu note carried over from the `zhipu_coding` section style)
- Parent Zhipu section's Notes: drop the "z.ai shares ZHIPU_API_KEY" claim, update the cross-link to mention zai uses its own env

### Commit 2 — `docs(providers): add Microsoft (GitHub Models) section`

- New section between **Azure OpenAI** and **Qwen (DashScope)** in both Included Providers list and the body
- Documents `microsoft` (alias `github-models`), `GITHUB_MODELS_TOKEN`, base URL `https://models.inference.ai.azure.com`
- Notes block disambiguates from `azure-openai` (own deployments) and `github-copilot` (IDE subscription)

Refs librefang/librefang#3281, librefang/librefang#3285, librefang/librefang-registry#83, librefang/librefang-registry#84.
