### PR TITLE
feat(runtime): stream plugin / python stderr per-line to tracing (#3256)

### DIFF
--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -69,6 +69,7 @@ pub mod session_repair;
 pub mod silent_response;
 pub use silent_response::{is_silent_response, SilentReason};
 pub mod shell_bleed;
+pub mod stderr_log;
 pub mod str_utils;
 pub mod subprocess_sandbox;
 pub mod tool_budget;

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -1324,7 +1324,22 @@ pub async fn run_hook_json(
                 err_line.clear();
                 match stderr_reader.read_line(&mut err_line).await {
                     Ok(0) => break,
-                    Ok(_) => text.push_str(&err_line),
+                    Ok(_) => {
+                        // Stream each line to tracing as it arrives so operators
+                        // can monitor long-running hooks live (issue #3256).
+                        // Filter via `RUST_LOG=plugin_stderr=info`. The post-exit
+                        // summary below is preserved for backwards compatibility.
+                        let trimmed = err_line.trim_end();
+                        if !trimmed.is_empty() {
+                            tracing::info!(
+                                target: "plugin_stderr",
+                                hook = %hook_name,
+                                script = %script_path,
+                                "{trimmed}"
+                            );
+                        }
+                        text.push_str(&err_line);
+                    }
                     Err(_) => break,
                 }
             }

--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -37,6 +37,15 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tracing::{debug, warn};
 
+use crate::stderr_log::trim_for_log;
+
+/// `tracing` target for per-line plugin-hook stderr (issue #3256). Filter
+/// in operator logs via `RUST_LOG=plugin_stderr=info`. Stable wire-format
+/// — changing this string breaks downstream log filters and journalctl
+/// pipelines, and is pinned by the `plugin_stderr_target_is_stable` unit
+/// test.
+pub const PLUGIN_STDERR_TARGET: &str = "plugin_stderr";
+
 /// Classify a process exit status into a human-readable label.
 ///
 /// Returns a short string like `"OOM-killed (exit 137)"`, `"SIGSEGV (exit 139)"`,
@@ -1325,14 +1334,13 @@ pub async fn run_hook_json(
                 match stderr_reader.read_line(&mut err_line).await {
                     Ok(0) => break,
                     Ok(_) => {
-                        // Stream each line to tracing as it arrives so operators
-                        // can monitor long-running hooks live (issue #3256).
-                        // Filter via `RUST_LOG=plugin_stderr=info`. The post-exit
-                        // summary below is preserved for backwards compatibility.
-                        let trimmed = err_line.trim_end();
-                        if !trimmed.is_empty() {
+                        // Stream each non-empty line to tracing as it arrives so
+                        // operators can monitor long-running hooks live (#3256).
+                        // The full line stays in `text` either way — the
+                        // post-exit `debug!` summary below is independent.
+                        if let Some(trimmed) = trim_for_log(&err_line) {
                             tracing::info!(
-                                target: "plugin_stderr",
+                                target: PLUGIN_STDERR_TARGET,
                                 hook = %hook_name,
                                 script = %script_path,
                                 "{trimmed}"
@@ -1905,6 +1913,14 @@ mod tests {
         assert_eq!(PluginRuntime::Python.version_args(), &["--version"]);
         assert_eq!(PluginRuntime::Node.version_args(), &["--version"]);
         assert_eq!(PluginRuntime::Ruby.version_args(), &["--version"]);
+    }
+
+    #[test]
+    fn plugin_stderr_target_is_stable() {
+        // Operator log filters and journalctl pipelines key off this
+        // string. Changing it is a breaking change — bump the docs and
+        // CHANGELOG together if you ever do.
+        assert_eq!(PLUGIN_STDERR_TARGET, "plugin_stderr");
     }
 
     #[test]

--- a/crates/librefang-runtime/src/python_runtime.rs
+++ b/crates/librefang-runtime/src/python_runtime.rs
@@ -302,6 +302,23 @@ async fn run_python_with_stdin(
             match stderr_reader.read_line(&mut stderr_line).await {
                 Ok(0) => break,
                 Ok(_) => {
+                    // Stream each line to tracing as it arrives so operators
+                    // can monitor long-running Python tools live (issue #3256).
+                    // Filter via `RUST_LOG=python_stderr=info`. The post-exit
+                    // summary below is preserved for backwards compatibility.
+                    // Reminder for tool authors: Python buffers stdout/stderr
+                    // by default — pass `flush=True` to `print()` or run with
+                    // `python -u` for line-buffered output to actually see
+                    // progress in real time.
+                    let trimmed = stderr_line.trim_end();
+                    if !trimmed.is_empty() {
+                        tracing::info!(
+                            target: "python_stderr",
+                            agent_id = %agent_id,
+                            script = %script_path,
+                            "{trimmed}"
+                        );
+                    }
                     stderr_text.push_str(&stderr_line);
                 }
                 Err(_) => break,

--- a/crates/librefang-runtime/src/python_runtime.rs
+++ b/crates/librefang-runtime/src/python_runtime.rs
@@ -24,6 +24,14 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tracing::{debug, error, warn};
 
+use crate::stderr_log::trim_for_log;
+
+/// `tracing` target for per-line Python tool stderr (issue #3256). Filter
+/// in operator logs via `RUST_LOG=python_stderr=info`. Stable wire-format
+/// — changing this string breaks downstream log filters and is pinned by
+/// the `python_stderr_target_is_stable` unit test.
+pub const PYTHON_STDERR_TARGET: &str = "python_stderr";
+
 /// Error type for Python runtime operations.
 #[derive(Debug, thiserror::Error)]
 pub enum PythonError {
@@ -302,18 +310,18 @@ async fn run_python_with_stdin(
             match stderr_reader.read_line(&mut stderr_line).await {
                 Ok(0) => break,
                 Ok(_) => {
-                    // Stream each line to tracing as it arrives so operators
-                    // can monitor long-running Python tools live (issue #3256).
-                    // Filter via `RUST_LOG=python_stderr=info`. The post-exit
-                    // summary below is preserved for backwards compatibility.
-                    // Reminder for tool authors: Python buffers stdout/stderr
-                    // by default — pass `flush=True` to `print()` or run with
-                    // `python -u` for line-buffered output to actually see
-                    // progress in real time.
-                    let trimmed = stderr_line.trim_end();
-                    if !trimmed.is_empty() {
+                    // Stream each non-empty line to tracing as it arrives so
+                    // operators can monitor long-running Python tools live
+                    // (#3256). The full line stays in `stderr_text` either way
+                    // — the post-exit `debug!` summary below is independent.
+                    //
+                    // Reminder for tool authors: Python block-buffers
+                    // stdout/stderr by default — pass `flush=True` to
+                    // `print()` or run with `python -u` for line-buffered
+                    // output to actually see progress in real time.
+                    if let Some(trimmed) = trim_for_log(&stderr_line) {
                         tracing::info!(
-                            target: "python_stderr",
+                            target: PYTHON_STDERR_TARGET,
                             agent_id = %agent_id,
                             script = %script_path,
                             "{trimmed}"
@@ -403,6 +411,14 @@ pub fn is_python_module(module: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn python_stderr_target_is_stable() {
+        // Operator log filters and journalctl pipelines key off this
+        // string. Changing it is a breaking change — bump the docs and
+        // CHANGELOG together if you ever do.
+        assert_eq!(PYTHON_STDERR_TARGET, "python_stderr");
+    }
 
     #[test]
     fn test_parse_python_module() {

--- a/crates/librefang-runtime/src/stderr_log.rs
+++ b/crates/librefang-runtime/src/stderr_log.rs
@@ -1,0 +1,53 @@
+//! Live-streaming helpers for child-process stderr.
+//!
+//! `plugin_runtime` (hooks) and `python_runtime` (Python tool calls) both
+//! tail child stderr line-by-line to give operators a "still working"
+//! signal during long runs (issue #3256). Each call site exposes a
+//! `pub const _STDERR_TARGET` so log filters / journalctl pipelines can
+//! key off a stable string; this module owns the trim-and-skip predicate
+//! they share.
+//!
+//! The full line (including the trailing newline) is *always* appended
+//! to the post-exit summary buffer regardless of what this helper
+//! returns — `info!` streaming and the `debug!` summary are independent
+//! channels by design.
+
+/// Trim trailing whitespace from a raw `read_line` chunk. Returns `None`
+/// for empty / whitespace-only inputs so callers can skip the
+/// `tracing::info!` emission without affecting the post-exit summary
+/// buffer.
+pub(crate) fn trim_for_log(line: &str) -> Option<&str> {
+    let trimmed = line.trim_end();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_empty_and_whitespace_only_lines() {
+        // `read_line` regularly hands us a bare `\n` between log
+        // statements. Streaming those would just spam the operator.
+        assert_eq!(trim_for_log(""), None);
+        assert_eq!(trim_for_log("\n"), None);
+        assert_eq!(trim_for_log("\r\n"), None);
+        assert_eq!(trim_for_log("   \t\n"), None);
+    }
+
+    #[test]
+    fn strips_trailing_newline_keeps_leading_whitespace() {
+        // Indentation-as-structure (e.g. tracebacks) must survive — only
+        // the trailing newline gets eaten by the streaming layer.
+        assert_eq!(trim_for_log("hello\n"), Some("hello"));
+        assert_eq!(trim_for_log("step 3/5\r\n"), Some("step 3/5"));
+        assert_eq!(
+            trim_for_log("    File \"x.py\", line 1\n"),
+            Some("    File \"x.py\", line 1")
+        );
+    }
+}

--- a/docs/src/app/agent/plugins/page.mdx
+++ b/docs/src/app/agent/plugins/page.mdx
@@ -736,7 +736,9 @@ Call this whenever a plugin mysteriously does nothing — `runtime_available: fa
 - **Path traversal**: script paths may not contain `..` components — rejected at every invocation, not just load time.
 - **Env scrubbing**: every inherited env var is wiped (`env_clear`) before the subprocess spawns. LibreFang then sets `LIBREFANG_AGENT_ID`, `LIBREFANG_MESSAGE`, `LIBREFANG_RUNTIME`, forwards `PATH` and `HOME` from the parent process, adds the runtime's passthrough set (e.g. `PYTHONPATH`/`VIRTUAL_ENV` for Python, `GEM_HOME`/`GEM_PATH` for Ruby — see `runtime_passthrough_vars`), and finally forwards anything listed in the agent's `allowed_env_vars`. Your hook can read `LIBREFANG_AGENT_ID` / `LIBREFANG_MESSAGE` from the environment as an alternative to parsing stdin JSON.
 
-Hook stderr is captured and printed to LibreFang's own logs — use it liberally for debug logging from inside your hook.
+Hook stderr is captured and printed to LibreFang's own logs — use it liberally for debug logging from inside your hook. Each line is forwarded to tracing **as it arrives** under the `plugin_stderr` target (Python tools get `python_stderr`), so long-running hooks can stream progress to `journalctl` / `docker logs` instead of going silent until they exit. Filter with `RUST_LOG=plugin_stderr=info` (or `python_stderr=info`).
+
+> **Buffering caveat (especially Python)** — most language runtimes block-buffer stderr by default, so progress lines won't reach the daemon until the buffer fills or the process exits. For live streaming, flush after each line: `print(..., file=sys.stderr, flush=True)` in Python, `STDERR.sync = true` in Ruby, `process.stderr.write(...)` is unbuffered in Node, etc. Or run interpreters in line-buffered mode (`python -u`).
 
 ---
 

--- a/docs/src/app/agent/plugins/page.mdx
+++ b/docs/src/app/agent/plugins/page.mdx
@@ -738,7 +738,11 @@ Call this whenever a plugin mysteriously does nothing — `runtime_available: fa
 
 Hook stderr is captured and printed to LibreFang's own logs — use it liberally for debug logging from inside your hook. Each line is forwarded to tracing **as it arrives** under the `plugin_stderr` target (Python tools get `python_stderr`), so long-running hooks can stream progress to `journalctl` / `docker logs` instead of going silent until they exit. Filter with `RUST_LOG=plugin_stderr=info` (or `python_stderr=info`).
 
-> **Buffering caveat (especially Python)** — most language runtimes block-buffer stderr by default, so progress lines won't reach the daemon until the buffer fills or the process exits. For live streaming, flush after each line: `print(..., file=sys.stderr, flush=True)` in Python, `STDERR.sync = true` in Ruby, `process.stderr.write(...)` is unbuffered in Node, etc. Or run interpreters in line-buffered mode (`python -u`).
+After the hook exits, the full captured stderr is *also* emitted as a single `debug!`-level summary so existing tooling that scrapes `"hook stderr:"` keeps working. The two channels are independent — operators that enable both will see each line streamed live AND once more in the post-exit summary.
+
+> **Buffering caveat (especially Python)** — most language runtimes block-buffer stderr by default, so progress lines won't reach the daemon until the buffer fills or the process exits. For live streaming, flush after each line: `print(..., file=sys.stderr, flush=True)` in Python, `STDERR.sync = true` in Ruby. Node has no userspace stdio buffer of its own, so `process.stderr.write(...)` reaches the daemon as soon as the kernel pipe drains. Or run the interpreter in line-buffered mode (`python -u`).
+
+> **Don't put secrets on stderr.** Once an operator enables `RUST_LOG=plugin_stderr=info` (or `python_stderr=info`), every stderr line from every hook lands in the daemon log — and from there into `journalctl`, `docker logs`, or whatever sink ships logs off-host. Tokens, API keys, PII, and anything else you don't want persisted by the platform's log retention should never be `print`-ed to stderr. Use `debug` framing (gated by the same `RUST_LOG`) only when you've audited the content.
 
 ---
 

--- a/docs/src/app/zh/agent/plugins/page.mdx
+++ b/docs/src/app/zh/agent/plugins/page.mdx
@@ -736,7 +736,9 @@ curl http://127.0.0.1:4545/api/plugins/doctor
 - **路径穿越**：脚本路径里不能带 `..` 组件 —— 每次调用都会检查，不只是加载时。
 - **环境变量洗白**：子进程启动前所有继承的环境变量会被 `env_clear` 清空。LibreFang 然后设置 `LIBREFANG_AGENT_ID`、`LIBREFANG_MESSAGE`、`LIBREFANG_RUNTIME`，从父进程透传 `PATH` 和 `HOME`，加上 runtime 自己的透传集合（Python 的 `PYTHONPATH`/`VIRTUAL_ENV`、Ruby 的 `GEM_HOME`/`GEM_PATH` 等 —— 见 `runtime_passthrough_vars`），最后透传 agent 的 `allowed_env_vars` 里列出的变量。你的 hook 可以从环境变量读 `LIBREFANG_AGENT_ID` / `LIBREFANG_MESSAGE`，这是解析 stdin JSON 之外的另一种方式。
 
-Hook 的 stderr 会被捕获后打印到 LibreFang 自己的日志里 —— 想打 debug log 直接往 stderr 写就行。
+Hook 的 stderr 会被捕获后打印到 LibreFang 自己的日志里 —— 想打 debug log 直接往 stderr 写就行。每行 stderr 都会**实时**通过 tracing 转发出来（target 为 `plugin_stderr`，Python 工具是 `python_stderr`），所以长时间运行的 hook 可以把进度流到 `journalctl` / `docker logs`，不用等到退出才一口气吐出。用 `RUST_LOG=plugin_stderr=info`(或 `python_stderr=info`) 过滤。
+
+> **缓冲注意（尤其 Python）** —— 大多数语言 runtime 默认按块缓冲 stderr，进度行要等缓冲填满或进程退出才会到 daemon。要实时流式输出，每行后 flush：Python 用 `print(..., file=sys.stderr, flush=True)`，Ruby 加 `STDERR.sync = true`，Node 的 `process.stderr.write(...)` 本身就是无缓冲。或者直接让解释器跑行缓冲模式 (`python -u`)。
 
 ---
 

--- a/docs/src/app/zh/agent/plugins/page.mdx
+++ b/docs/src/app/zh/agent/plugins/page.mdx
@@ -738,7 +738,11 @@ curl http://127.0.0.1:4545/api/plugins/doctor
 
 Hook 的 stderr 会被捕获后打印到 LibreFang 自己的日志里 —— 想打 debug log 直接往 stderr 写就行。每行 stderr 都会**实时**通过 tracing 转发出来（target 为 `plugin_stderr`，Python 工具是 `python_stderr`），所以长时间运行的 hook 可以把进度流到 `journalctl` / `docker logs`，不用等到退出才一口气吐出。用 `RUST_LOG=plugin_stderr=info`(或 `python_stderr=info`) 过滤。
 
-> **缓冲注意（尤其 Python）** —— 大多数语言 runtime 默认按块缓冲 stderr，进度行要等缓冲填满或进程退出才会到 daemon。要实时流式输出，每行后 flush：Python 用 `print(..., file=sys.stderr, flush=True)`，Ruby 加 `STDERR.sync = true`，Node 的 `process.stderr.write(...)` 本身就是无缓冲。或者直接让解释器跑行缓冲模式 (`python -u`)。
+hook 退出后，完整的 stderr **还会再以一条 `debug!` 级别的汇总日志发出来**，原本依赖 `"hook stderr:"` 这个串做抓取的工具不会失效。两个通道相互独立 —— 同时开启的话，每行先实时出现一次、退出后又在汇总里出现一次。
+
+> **缓冲注意（尤其 Python）** —— 大多数语言 runtime 默认按块缓冲 stderr，进度行要等缓冲填满或进程退出才会到 daemon。要实时流式输出，每行后 flush：Python 用 `print(..., file=sys.stderr, flush=True)`，Ruby 加 `STDERR.sync = true`。Node 在用户态没有自己的 stdio buffer，`process.stderr.write(...)` 一旦内核 pipe 排空就到 daemon。或者直接让解释器跑行缓冲模式 (`python -u`)。
+
+> **不要把 secret 打到 stderr。** 一旦运维开启 `RUST_LOG=plugin_stderr=info`(或 `python_stderr=info`)，所有 hook 的每行 stderr 都会进 daemon 日志 —— 然后被 `journalctl`、`docker logs` 或任何把日志运出主机的 sink 持久化。Token、API key、PII，以及任何你不想被平台日志保留策略沉淀下来的内容，**都不要** `print` 到 stderr。用 `debug` 通道（同样受 `RUST_LOG` 控制）发的内容也得先确认无敏感字段。
 
 ---
 

--- a/sdk/python/librefang/librefang_sdk.py
+++ b/sdk/python/librefang/librefang_sdk.py
@@ -20,6 +20,26 @@ Or for simple scripts without the decorator pattern:
     data = read_input()
     result = f"Echo: {data['message']}"
     respond(result)
+
+Live progress logging
+---------------------
+The LibreFang daemon streams every line your script writes to stderr to
+its own tracing subsystem under the ``python_stderr`` target — visible
+with ``RUST_LOG=python_stderr=info`` (or filtered through ``journalctl``
+/ ``docker logs`` when the daemon runs as a service). This is the
+recommended channel for "still working" / progress heartbeats from
+long-running tools.
+
+**Python buffers stderr by default**, so for the daemon to actually
+see lines as they happen, either:
+
+- pass ``flush=True`` to ``print(..., file=sys.stderr, flush=True)``,
+- run the interpreter line-buffered with ``python -u``, or
+- call ``sys.stderr.reconfigure(line_buffering=True)`` once at startup.
+
+Without one of these, stderr is block-buffered (~4–8 KiB) and the
+daemon will only log lines once the buffer fills or the process exits,
+defeating the purpose of live streaming.
 """
 
 import json


### PR DESCRIPTION
Closes #3256.

## Summary

Both `plugin_runtime::run_hook_json` and `python_runtime::run_python_with_stdin` previously buffered the entire child stderr into a `String` and emitted a single `tracing::debug!` summary only after `child.wait().await`. For long-running hooks / Python tools (large file processing, batched API calls, ML inference, etc.) operators saw nothing in the daemon log until the tool finished — no way to tell "still working" from "hung".

The `read_line` loops were already real-time; only the logging was batched.

## What this PR does

### 1. Per-line streaming to tracing

Logs each stderr line as it arrives:

- `plugin_runtime.rs`: `tracing::info!(target: "plugin_stderr", hook = %hook_name, script = %script_path, "{line}")`
- `python_runtime.rs`: `tracing::info!(target: "python_stderr", agent_id = %agent_id, script = %script_path, "{line}")`

Filter via:
```bash
RUST_LOG=plugin_stderr=info,python_stderr=info librefang start
```

The existing post-exit summary at `debug!` level is preserved so existing `grep "hook stderr:"` operator practice keeps working.

### 2. Document the Python buffering caveat

Issue called out that without docs people will hit silent buffering. Two doc surfaces updated:

- **`sdk/python/librefang/librefang_sdk.py`** — module docstring gets a "Live progress logging" section explaining the `flush=True` / `python -u` / `sys.stderr.reconfigure(line_buffering=True)` options.
- **`docs/agent/plugins/page.mdx`** (en + zh) — existing "Error Handling, Timeouts, and Logs" section gets a callout about per-line streaming + buffering caveats for Python / Ruby / Node.

## What this PR doesn't do (deliberate, out of scope)

- **Issue point (2) — structured event channel.** The dashboard-event side-channel is a bigger lift requiring an opt-in `streaming = true` manifest flag and event-bus wiring. Issue author noted (1) "covers the operator/log use case on its own" and that's all this PR claims.
- **`python_runtime` deadlock latent bug.** That fn reads stdout-then-stderr serially (`plugin_runtime` already uses `tokio::join!`). A Python tool that fills its 64 KiB stderr pipe before closing stdout will hang. Real bug but distinct from this issue's scope and would change the fn's read semantics — leave to a focused follow-up.

## Test plan

- [x] CI: `cargo check` (passed locally, 3m43s)
- [x] **Live verified** end-to-end against the running daemon. Steps:
  1. Cherry-picked this PR onto main worktree, `just dev` rebuilt the binary, restarted daemon with `RUST_LOG=plugin_stderr=info`.
  2. Created throwaway plugin at `~/.librefang/plugins/test-stderr-stream/hooks/ingest.py` that loops `for i in range(5): print(f"step {i+1}/5 t={time.time()}", file=sys.stderr, flush=True); time.sleep(0.5)`.
  3. `POST /api/plugins/test-stderr-stream/test-hook` with `{"hook":"ingest","input":{}}`.
  4. **All 5 lines streamed to `~/.librefang/logs/daemon.log` with target `plugin_stderr`, ~510ms apart** — confirming live arrival vs. post-exit batch dump:
     ```
     INFO request: [smoke] step 1/5 t=1777276511.168 hook=ingest script=…/ingest.py
     INFO request: [smoke] step 2/5 t=1777276511.678 hook=ingest …  (+510ms)
     INFO request: [smoke] step 3/5 t=1777276512.188 hook=ingest …  (+510ms)
     INFO request: [smoke] step 4/5 t=1777276512.694 hook=ingest …  (+506ms)
     INFO request: [smoke] step 5/5 t=1777276513.204 hook=ingest …  (+510ms)
     ```
  5. Without `flush=True` in the script, all 5 lines arrived simultaneously at process exit — confirming the documented buffering caveat is real and necessary.
