### PR TITLE
fix(dashboard): refresh provider list after Test button so latency shows

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -8,10 +8,18 @@ import {
 } from "../http/client";
 import { modelKeys, providerKeys, runtimeKeys } from "../queries/keys";
 
-// Fire-and-forget: one-shot probe, test result returned to caller, no cache to invalidate.
+// Probes the provider and persists `latency_ms` + `last_tested` on the
+// kernel side, so callers must refetch the provider list to see the new
+// values. Use `onSettled` (not `onSuccess`) because the backend records the
+// timestamp even on probe failure (`result.ok === false` with HTTP 200) and
+// the dashboard surfaces that "last attempted" timing too.
 export function useTestProvider() {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: testProvider,
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: providerKeys.all });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Bug report: clicking the **Test** button on a provider card shows the success/failure pill but the latency cell stays at the pre-test value (or `-`). Refreshing the page reveals the new latency.

Root cause: `useTestProvider` (`src/lib/mutations/providers.ts:11`) was annotated as

```ts
// Fire-and-forget: one-shot probe, test result returned to caller, no cache to invalidate.
```

…but the kernel-side `testProvider` does persist `latency_ms` and `last_tested` on the provider state — they're served on the next `/api/providers` GET. Since the mutation didn't invalidate the providers query, React Query kept serving the cached snapshot.

Fix: add `onSettled` invalidation so the list refetches after every probe — succeed or fail. `onSettled` (not `onSuccess`) because the backend records the timestamp on probe failure too, and the dashboard's "last test" badge surfaces that.

```ts
export function useTestProvider() {
  const qc = useQueryClient();
  return useMutation({
    mutationFn: testProvider,
    onSettled: () => {
      qc.invalidateQueries({ queryKey: providerKeys.all });
    },
  });
}
```

This aligns with CLAUDE.md's dashboard-mutation rule:
> each mutation with side-effects must call `invalidateQueries` with factory keys in `onSuccess` (or `onSettled`).

## Test plan

- [x] `pnpm typecheck` — only failure is the pre-existing `applyDatePreset` issue in `AuditPage.tsx` (`origin/main` fails the same way), unrelated to this PR.
- [x] `pnpm test src/lib` — only failure is `workflows.test.tsx > useDeleteWorkflow > invalidates the expected workflow keys` which also fails on `origin/main`, unrelated.
- [ ] Manual: click **Test** on a provider card → latency cell + "last test" timestamp now refresh in place without a page reload.

## Diff

`crates/librefang-api/dashboard/src/lib/mutations/providers.ts`: +9 / -1 (added `useQueryClient` invocation, `onSettled` invalidator, and a corrected leading comment explaining why `onSettled` and not `onSuccess`).