### PR TITLE
fix(dashboard/audit): wire missing applyDatePreset for quick-pick buttons

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -503,6 +503,15 @@ export function AuditPage() {
     setActive(reset);
   };
 
+  // Apply a quick-pick: snap `from` to `now − N`, clear `to`, and push
+  // the change into `active` so the query re-runs without the operator
+  // pressing Apply (matches the comment on DATE_PRESETS above).
+  const applyDatePreset = (preset: DatePreset) => {
+    const next: AuditQueryFilters = { ...draft, from: preset.since(), to: undefined };
+    setDraft(next);
+    setActive(next);
+  };
+
   // Active-filter → URL sync. `replace: true` so each filter tweak
   // doesn't pollute browser history (back button feels broken
   // otherwise — every chip click would be its own entry). `seq` is


### PR DESCRIPTION
## Summary

`AuditPage.tsx:786` calls `applyDatePreset(p)` but the function was never defined — `pnpm typecheck` failed with `Cannot find name 'applyDatePreset'`, and the 1h / 24h / today / 7d / 30d quick-pick buttons in the right-docked filter drawer crashed at runtime when clicked.

The spec is already in the file: a comment at line 297-303 documents what `applyDatePreset` should do — *"sets `draft.from` to `now − N` and clears `draft.to`"* — and notes that the change should propagate to the active query so the operator sees the filtered result without an extra Apply click.

This PR adds the function next to `onClearAll`:

```ts
const applyDatePreset = (preset: DatePreset) => {
  const next: AuditQueryFilters = { ...draft, from: preset.since(), to: undefined };
  setDraft(next);
  setActive(next);
};
```

Regression introduced when audit filters moved into a right-docked drawer (#3254). The function existed in the inline-form variant but was dropped during the drawer refactor.

## Test plan

- [x] `pnpm typecheck` — clean (was failing on `Cannot find name 'applyDatePreset'`)
- [ ] Manual: open Audit page → filter drawer → click `24h` → drawer closes, audit list refetches with `from = now − 24h`, no `to`. Confirm via Network tab + URL.