### PR TITLE
fix(dashboard/workflows): align useDeleteWorkflow test with removeQueries semantics

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
@@ -86,7 +86,11 @@ describe.each([
     name: "useDeleteWorkflow",
     hook: useDeleteWorkflow,
     arg: "wf-1",
-    expectedKeys: [workflowKeys.lists(), workflowKeys.detail("wf-1"), workflowKeys.runs("wf-1")],
+    // detail(workflowId) is evicted via removeQueries (see separate test
+    // below) — the deleted workflow has no row to refetch, so an
+    // invalidate would just trigger a 404 on next read. Only lists()
+    // and runs() go through invalidateQueries here.
+    expectedKeys: [workflowKeys.lists(), workflowKeys.runs("wf-1")],
   },
   {
     name: "useCreateWorkflow",
@@ -124,5 +128,20 @@ describe.each([
     for (const queryKey of expectedKeys) {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
     }
+  });
+});
+
+describe("useDeleteWorkflow detail eviction", () => {
+  it("removes the deleted workflow's detail query instead of refetching", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+
+    const { result } = renderHook(() => useDeleteWorkflow(), { wrapper });
+
+    await result.current.mutateAsync("wf-1");
+
+    expect(removeSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.detail("wf-1"),
+    });
   });
 });


### PR DESCRIPTION
## Summary

The `useDeleteWorkflow` mutation evicts `workflowKeys.detail(workflowId)` via `qc.removeQueries` rather than `invalidateQueries`, because the deleted workflow has no row to refetch — an `invalidateQueries` would just trigger a 404 on next access. The `describe.each` parametric test in `workflows.test.tsx` was asserting that the detail key went through the `invalidateSpy`, so the suite failed on every CI run with:

```
× useDeleteWorkflow > invalidates the expected workflow keys
```

Production behavior is correct; the test was checking the wrong contract.

## Changes

- Drop `detail("wf-1")` from `useDeleteWorkflow`'s `expectedKeys` and add a comment explaining why detail sits outside the parametric loop.
- Add a focused test `useDeleteWorkflow detail eviction > removes the deleted workflow's detail query instead of refetching` that spies on `removeQueries` so the eviction contract is locked in.

`useUpdateWorkflow`'s entry still expects `detail("wf-1")` in `expectedKeys` — that's correct since update goes through `invalidateQueries` (the row still exists).

## Test plan

- [x] `pnpm test src/lib/mutations/workflows.test.tsx` — 9/9 pass (was 7/8 before; +1 new removeQueries assertion).
- [x] No production code changed — `useDeleteWorkflow` itself is untouched.