### PR TITLE
feat(wizard): backfill providers missing from TUI first-run setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Added
 
+- TUI setup wizard now offers `microsoft`, `zai`, `zai_coding`, `volcengine`, `volcengine_coding`, `byteplus`, `byteplus_coding` alongside the existing first-run options. The wizard's PROVIDERS list had drifted from `PROVIDER_REGISTRY` and silently hid these from new installs; a unit test now pins these entries against future regressions. (@houko)
 - Treat CLI logins as first-class default providers (#3061) (@houko)
 - Grafana Tempo + business-level span instrumentation (#3064) (@houko)
 - /new creates a new session instead of resetting the current one (#3071) (@neo-wanderer)

--- a/crates/librefang-cli/src/tui/screens/wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/wizard.rs
@@ -144,6 +144,48 @@ const PROVIDERS: &[ProviderInfo] = &[
         needs_key: true,
     },
     ProviderInfo {
+        name: "zai",
+        env_var: "ZAI_API_KEY",
+        default_model: "zai/glm-4.7",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "zai_coding",
+        env_var: "ZAI_CODING_API_KEY",
+        default_model: "glm-4.7-coding",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "volcengine",
+        env_var: "VOLCENGINE_API_KEY",
+        default_model: "doubao-seed-2-0-pro-260215",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "volcengine_coding",
+        env_var: "VOLCENGINE_CODING_API_KEY",
+        default_model: "doubao-seed-2-0-code",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "byteplus",
+        env_var: "BYTEPLUS_API_KEY",
+        default_model: "seed-2-0-pro-260328",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "byteplus_coding",
+        env_var: "BYTEPLUS_CODING_API_KEY",
+        default_model: "ark-code-latest",
+        needs_key: true,
+    },
+    ProviderInfo {
+        name: "microsoft",
+        env_var: "GITHUB_MODELS_TOKEN",
+        default_model: "phi-4",
+        needs_key: true,
+    },
+    ProviderInfo {
         name: "claude-code",
         env_var: "",
         default_model: "claude-code/sonnet",
@@ -694,5 +736,42 @@ fn draw_done(f: &mut Frame, area: Rect, state: &WizardState) {
             theme::dim_style(),
         )]));
         f.render_widget(cont, chunks[1]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// The wizard's `PROVIDERS` array is hand-maintained alongside the driver
+    /// registry's `PROVIDER_REGISTRY`. Whenever a provider was added to the
+    /// driver registry without a matching wizard entry, first-run users would
+    /// silently miss it. This test pins the providers wired up alongside the
+    /// recent env-var splits (#3279 / #3281 / #3285) so they can't regress;
+    /// extending the assertion list when adding new providers is easier than
+    /// rediscovering the drift in user reports.
+    #[test]
+    fn test_wizard_includes_recently_added_providers() {
+        let names: HashSet<&str> = PROVIDERS.iter().map(|p| p.name).collect();
+        let env_vars: HashSet<&str> = PROVIDERS.iter().map(|p| p.env_var).collect();
+        for (name, env_var) in [
+            ("zai", "ZAI_API_KEY"),
+            ("zai_coding", "ZAI_CODING_API_KEY"),
+            ("volcengine", "VOLCENGINE_API_KEY"),
+            ("volcengine_coding", "VOLCENGINE_CODING_API_KEY"),
+            ("byteplus", "BYTEPLUS_API_KEY"),
+            ("byteplus_coding", "BYTEPLUS_CODING_API_KEY"),
+            ("microsoft", "GITHUB_MODELS_TOKEN"),
+        ] {
+            assert!(
+                names.contains(name),
+                "wizard PROVIDERS missing entry for `{name}`",
+            );
+            assert!(
+                env_vars.contains(env_var),
+                "wizard PROVIDERS missing env_var `{env_var}` (expected on `{name}`)",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Backfills 7 providers that the recent env-var splits (#3279, #3281, #3285) added to `PROVIDER_REGISTRY` but never wired into the TUI first-run wizard's `PROVIDERS` array. New installs running `librefang setup` (or the auto-launched wizard on a fresh `LIBREFANG_HOME`) now see all of them as selectable options:

| name | env var | default model |
|---|---|---|
| `zai` | `ZAI_API_KEY` | `zai/glm-4.7` |
| `zai_coding` | `ZAI_CODING_API_KEY` | `glm-4.7-coding` |
| `volcengine` | `VOLCENGINE_API_KEY` | `doubao-seed-2-0-pro-260215` |
| `volcengine_coding` | `VOLCENGINE_CODING_API_KEY` | `doubao-seed-2-0-code` |
| `byteplus` | `BYTEPLUS_API_KEY` | `seed-2-0-pro-260328` |
| `byteplus_coding` | `BYTEPLUS_CODING_API_KEY` | `ark-code-latest` |
| `microsoft` | `GITHUB_MODELS_TOKEN` | `phi-4` |

Each `default_model` is verified to exist in the corresponding catalog file, so the wizard's pre-fill matches what the daemon actually loads at boot.

## Drift prevention

Adds a unit test pinning the seven `(name, env_var)` pairs:

```rust
test tui::screens::wizard::tests::test_wizard_includes_recently_added_providers ... ok
```

A future env-var rename or accidental removal will trip this in CI rather than reaching users via a missing wizard option.

## Out of Scope

There's a deeper drift between `wizard::PROVIDERS` and `PROVIDER_REGISTRY` predating the recent env splits — `deepinfra`, `huggingface`, `replicate`, `bedrock`, `azure-openai`, `vertex-ai`, `nvidia-nim`, etc. are all in the driver registry but missing from the wizard. Cleaning those up properly probably wants a refactor that derives the wizard list off `cloud_provider_key_specs()` rather than maintaining a parallel array (the same way `librefang doctor` was rewritten in #3275). That belongs in a separate PR — this one is scoped to closing the gaps the recent env splits opened.

## Test Plan

- [x] `cargo test -p librefang-cli tui::screens::wizard` — new test passes
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings` — clean
- [ ] Live: launch wizard against an empty `LIBREFANG_HOME`, confirm all seven new entries appear (and that detection-order placement works when the env var is set)

Refs librefang/librefang#3279, librefang/librefang#3281, librefang/librefang#3285.
