### PR TITLE
fix(probe): use correct path + auth for Anthropic-protocol providers

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1349,20 +1349,16 @@ pub async fn test_provider(
         return ApiErrorResponse::bad_request("Provider API key not configured").into_json_tuple();
     }
 
-    let start = std::time::Instant::now();
     let api_key_val = api_key.unwrap_or_default();
-    let client = match librefang_runtime::http_client::proxied_client_builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return ApiErrorResponse::internal(format!(
-                "Failed to build HTTP client for provider test: {e}"
-            ))
-            .into_json_tuple();
-        }
-    };
+    // Reuse the shared probe HTTP client instead of building a fresh
+    // `reqwest::Client` per request. Each rebuild paid a TLS-config init +
+    // root-cert-chain load (~50–100 ms) on top of the actual handshake,
+    // and that cost was being **counted as provider latency** below — so
+    // a single `byteplus_coding 230 ms` round-trip surfaced on the
+    // dashboard as `~500 ms` purely from the rebuilt client. Sharing the
+    // pool also lets the second click reuse the warm TLS session.
+    let client = librefang_runtime::provider_health::probe_client();
+    let start = std::time::Instant::now();
 
     // ── Bedrock: AWS Signature auth — can't test with simple HTTP ──
     if name == "bedrock" || name == "aws-bedrock" {
@@ -1382,38 +1378,52 @@ pub async fn test_provider(
     }
 
     // ── Provider-specific test URL ──
-    let test_url_str = match name.as_str() {
-        "anthropic" => format!("{}/v1/models", base_url.trim_end_matches('/')),
-        "gemini" | "google" => format!(
-            "{}/v1beta/models?key={}",
-            base_url.trim_end_matches('/'),
-            api_key_val
-        ),
-        "chatgpt" => format!("{}/me", base_url.trim_end_matches('/')),
-        "github-copilot" => format!("{}/models", base_url.trim_end_matches('/')),
-        "elevenlabs" => format!("{}/user", base_url.trim_end_matches('/')),
-        _ => format!("{}/models", base_url.trim_end_matches('/')),
+    // Anthropic-format providers (anthropic + byteplus_coding +
+    // volcengine_coding + …) all probe via `/v1/models` with x-api-key
+    // headers. Look up the registered ApiFormat instead of duplicating
+    // the registry's name list here, so future Anthropic-protocol
+    // providers don't need a parallel edit in this file.
+    let api_format = librefang_llm_drivers::drivers::provider_api_format(&name);
+    let is_anthropic_shape = matches!(
+        api_format,
+        Some(librefang_llm_drivers::drivers::ApiFormat::Anthropic)
+    );
+    let test_url_str = if is_anthropic_shape {
+        format!("{}/v1/models", base_url.trim_end_matches('/'))
+    } else {
+        match name.as_str() {
+            "gemini" | "google" => format!(
+                "{}/v1beta/models?key={}",
+                base_url.trim_end_matches('/'),
+                api_key_val
+            ),
+            "chatgpt" => format!("{}/me", base_url.trim_end_matches('/')),
+            "github-copilot" => format!("{}/models", base_url.trim_end_matches('/')),
+            "elevenlabs" => format!("{}/user", base_url.trim_end_matches('/')),
+            _ => format!("{}/models", base_url.trim_end_matches('/')),
+        }
     };
 
     let mut req = client.get(&test_url_str);
-    match name.as_str() {
-        "anthropic" => {
-            req = req
-                .header("x-api-key", &api_key_val)
-                .header("anthropic-version", "2023-06-01");
-        }
-        "gemini" | "google" => {
-            // Key is in query param, no header needed
-        }
-        "github-copilot" => {
-            req = req.header("Authorization", format!("token {}", api_key_val));
-        }
-        "elevenlabs" => {
-            req = req.header("xi-api-key", &api_key_val);
-        }
-        _ => {
-            if !api_key_val.is_empty() {
-                req = req.header("Authorization", format!("Bearer {}", api_key_val));
+    if is_anthropic_shape {
+        req = req
+            .header("x-api-key", &api_key_val)
+            .header("anthropic-version", "2023-06-01");
+    } else {
+        match name.as_str() {
+            "gemini" | "google" => {
+                // Key is in query param, no header needed
+            }
+            "github-copilot" => {
+                req = req.header("Authorization", format!("token {}", api_key_val));
+            }
+            "elevenlabs" => {
+                req = req.header("xi-api-key", &api_key_val);
+            }
+            _ => {
+                if !api_key_val.is_empty() {
+                    req = req.header("Authorization", format!("Bearer {}", api_key_val));
+                }
             }
         }
     }

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -952,6 +952,20 @@ pub fn known_providers() -> Vec<&'static str> {
         .collect()
 }
 
+/// Look up the wire-format an arbitrary provider speaks, by canonical name
+/// or alias. Returns `None` if the name doesn't match any registered
+/// provider, in which case callers should default to `OpenAI` (the most
+/// common shape). This lets out-of-tree probes pick correct endpoint paths
+/// (`/models` vs `/v1/models`) and auth headers (`Authorization: Bearer`
+/// vs `x-api-key` + `anthropic-version`) without hardcoding per-provider
+/// branches at every call site.
+pub fn provider_api_format(name: &str) -> Option<ApiFormat> {
+    PROVIDER_REGISTRY
+        .iter()
+        .find(|p| p.name == name || p.aliases.contains(&name))
+        .map(|p| p.api_format)
+}
+
 /// `(env_var, provider_id)` pairs for every cloud provider in the registry
 /// that requires an API key. Both the canonical `api_key_env` and the
 /// optional `alt_api_key_env` (e.g. `GOOGLE_API_KEY` for `gemini`) are

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -352,16 +352,27 @@ pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str
         }
     }
 
-    // Non-ollama: single OpenAI-compatible probe.
-    let openai_url = format!("{}/models", base_url.trim_end_matches('/'));
-    match try_probe_endpoint(
-        &openai_url,
-        EndpointShape::OpenAiModels,
-        api_key,
-        is_loopback,
-    )
-    .await
-    {
+    // Non-ollama: dispatch on the registered API format. Anthropic-protocol
+    // providers (anthropic, byteplus_coding, volcengine_coding, …) don't
+    // serve `{base}/models` and answer requests with `Authorization: Bearer`
+    // with a 4xx — which the old probe reported as "unreachable" while
+    // *also* counting the 4xx round-trip in `latency_ms`, doubly misleading
+    // the dashboard. Pick the right path + auth headers per format.
+    let shape = match librefang_llm_drivers::drivers::provider_api_format(provider) {
+        Some(librefang_llm_drivers::drivers::ApiFormat::Anthropic) => {
+            EndpointShape::AnthropicModels
+        }
+        // OpenAI-compat is the historical default for everything else and
+        // remains correct for OpenAI/Groq/DeepSeek/Mistral/etc. Unknown
+        // providers also fall through here (matches pre-PR behaviour).
+        _ => EndpointShape::OpenAiModels,
+    };
+    let probe_path = match shape {
+        EndpointShape::AnthropicModels => "/v1/models",
+        _ => "/models",
+    };
+    let probe_url = format!("{}{}", base_url.trim_end_matches('/'), probe_path);
+    match try_probe_endpoint(&probe_url, shape, api_key, is_loopback).await {
         EndpointOutcome::Ok { models, model_info } => ProbeResult {
             reachable: true,
             latency_ms: start.elapsed().as_millis() as u64,
@@ -383,8 +394,17 @@ pub async fn probe_provider(provider: &str, base_url: &str, api_key: Option<&str
 enum EndpointShape {
     /// Ollama native: `{ "models": [{ "name": "...", "details": {...} }, ...] }`
     OllamaTags,
-    /// OpenAI-compatible: `{ "data": [{ "id": "...", ... }, ...] }`
+    /// OpenAI-compatible: `{ "data": [{ "id": "...", ... }, ...] }`. Auth via
+    /// `Authorization: Bearer <key>`.
     OpenAiModels,
+    /// Anthropic-compatible `/v1/models`. Same response shape as OpenAI
+    /// (`{ "data": [...] }`) but auth is `x-api-key` + `anthropic-version`.
+    /// 401/403 here is treated as reachable: it's a positive signal that
+    /// the server speaks the Anthropic wire protocol — only the key is
+    /// rejected, which is a *configured-but-unauthenticated* state, not
+    /// network failure. Otherwise a misconfigured provider would burn ~RTT
+    /// on every probe and report inflated latency to the dashboard.
+    AnthropicModels,
 }
 
 /// Internal result of one probe attempt — used to drive the ollama→openai
@@ -419,7 +439,14 @@ async fn try_probe_endpoint(
     if let Some(key) = api_key {
         let trimmed = key.trim();
         if !trimmed.is_empty() {
-            req = req.header("Authorization", format!("Bearer {trimmed}"));
+            req = match shape {
+                EndpointShape::AnthropicModels => req
+                    .header("x-api-key", trimmed)
+                    .header("anthropic-version", "2023-06-01"),
+                EndpointShape::OllamaTags | EndpointShape::OpenAiModels => {
+                    req.header("Authorization", format!("Bearer {trimmed}"))
+                }
+            };
         }
     }
 
@@ -432,9 +459,25 @@ async fn try_probe_endpoint(
         }
     };
 
-    if !resp.status().is_success() {
+    let status = resp.status();
+    if !status.is_success() {
+        // Anthropic-protocol endpoints often answer GET /v1/models with 401
+        // ("API key invalid for this scope") or 404 ("listing not exposed
+        // for this plan") even when the chat path works fine. Treat those
+        // as *reachable but no model list* rather than failing the probe —
+        // a fail flips the dashboard provider tile to "broken" and reports
+        // the round-trip latency on a path nobody actually uses for
+        // inference. Real outages still surface as 5xx / connection errors.
+        if matches!(shape, EndpointShape::AnthropicModels)
+            && (status.as_u16() == 401 || status.as_u16() == 403 || status.as_u16() == 404)
+        {
+            return EndpointOutcome::Ok {
+                models: Vec::new(),
+                model_info: Vec::new(),
+            };
+        }
         return EndpointOutcome::Failed {
-            error: format!("HTTP {}", resp.status()),
+            error: format!("HTTP {status}"),
         };
     }
 
@@ -449,7 +492,9 @@ async fn try_probe_endpoint(
 
     match shape {
         EndpointShape::OllamaTags => parse_ollama_tags(&body),
-        EndpointShape::OpenAiModels => parse_openai_models(&body),
+        // Anthropic /v1/models returns the same `{ "data": [{ "id": ... }] }`
+        // shape OpenAI does, so the OpenAI parser handles both.
+        EndpointShape::OpenAiModels | EndpointShape::AnthropicModels => parse_openai_models(&body),
     }
 }
 

--- a/crates/librefang-runtime/src/provider_health.rs
+++ b/crates/librefang-runtime/src/provider_health.rs
@@ -179,7 +179,15 @@ fn format_request_error(err: &reqwest::Error) -> String {
 static PROBE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 /// Return the shared probe HTTP client, building it on first call.
-fn probe_client() -> &'static reqwest::Client {
+///
+/// Exposed publicly so on-demand `/api/providers/{name}/test` handlers
+/// can reuse the same connection-pooled client instead of paying a fresh
+/// TLS handshake (~80 ms over the Pacific) on every dashboard click.
+/// Before this was public, that endpoint was rebuilding a `reqwest::Client`
+/// per call and reporting the rebuilt-client + cold-handshake cost as the
+/// "provider latency", roughly doubling what operators saw vs. the steady-
+/// state probe cycle.
+pub fn probe_client() -> &'static reqwest::Client {
     PROBE_CLIENT.get_or_init(|| {
         crate::http_client::proxied_client_builder()
             .connect_timeout(Duration::from_secs(PROBE_REMOTE_CONNECT_TIMEOUT_SECS))


### PR DESCRIPTION
## Summary

Both probe paths in librefang were broken for Anthropic-protocol providers (`anthropic`, `byteplus_coding`, `volcengine_coding`, …). The dashboard latency tile reported numbers that were a mix of (a) the wrong probe URL's round-trip and (b) per-call HTTP-client rebuild overhead — operators saw `byteplus_coding 495 ms` when the actual chat path is ~230 ms. This PR fixes both paths.

## What was wrong

Two independent paths probe providers, both broken in similar ways:

| Path | Caller | Bugs |
|---|---|---|
| `provider_health::probe_provider` | Background 60-second catalog health cycle | Hardcoded `{base}/models` + `Authorization: Bearer` for non-Ollama. For Anthropic-format providers: wrong URL (often 404) or wrong auth (401), and 4xx round-trip on a useless path got counted as "latency". |
| `routes::providers::test_provider` | Dashboard "测试" button (`POST /api/providers/{name}/test`) | Same wrong-URL bug for Anthropic-format providers (only literal `"anthropic"` was special-cased; `byteplus_coding`/`volcengine_coding` fell through to the OpenAI default). **Plus** rebuilt a fresh `reqwest::Client` per call — TLS config + root cert chain init (~50–100 ms over Pacific paths) was *inside* the `start..send` measurement window. |

## Changes

### Commit 1: `probe_provider` (background cycle)

1. New helper `librefang_llm_drivers::drivers::provider_api_format(name)` exposes the registered `ApiFormat` so out-of-tree probes can dispatch correctly without duplicating the registry.
2. `probe_provider` picks path + headers per format:
   - **OpenAI shape**: `GET {base}/models` with `Authorization: Bearer`
   - **Anthropic shape**: `GET {base}/v1/models` with `x-api-key` + `anthropic-version: 2023-06-01`
3. For Anthropic shape, 401/403/404 are treated as **reachable but no model list exposed** — coding-plan endpoints (BytePlus / Volcengine) deliberately don't serve `/v1/models` to coding-plan tokens but `/v1/messages` works fine; flipping their dashboard tile to "broken" on every poll was wrong.

### Commit 2: `test_provider` (dashboard button)

1. Reuse `provider_health::probe_client()` — the OnceLock-cached client from the background cycle. Made `probe_client` public for cross-crate access. The second click on the same provider now reuses the warm TLS session.
2. Replace the literal `"anthropic"` special case with a `provider_api_format(&name) == Anthropic` check, so all Anthropic-format providers (anthropic + byteplus_coding + volcengine_coding + future ones) share one branch.

Both probe paths now agree on what URL + auth to use per `ApiFormat`, and share one HTTP client pool.

## Test plan

- [ ] CI: `cargo check -p librefang-runtime`, `cargo check -p librefang-api`, `cargo check -p librefang-llm-drivers`
- [ ] **Live verification deferred to post-merge**. Expected: dashboard "测试 byteplus_coding" first click drops from ~495 ms to ~230 ms (cold TLS handshake to Singapore), second click drops further (warm session reuse). The Tokyo↔Singapore physical RTT (~80 ms × 3) is the floor and not solvable here.

## Out of scope

- Pacific-RTT physical floor: BytePlus has no Tokyo region. Latency below ~230 ms requires a CDN PoP closer to JP, which is BytePlus's roadmap not librefang's.
- Refactoring `test_provider` to delegate to `probe_provider` entirely (DRY): the named special cases (`chatgpt /me`, `gemini ?key=`, `elevenlabs /user`, `github-copilot token`) don't fit the format-based dispatch and need their own home. Left for a focused follow-up.
