### PR TITLE
fix(api): add missing librefang-llm-drivers dep to unbreak main

### DIFF
--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -10,6 +10,7 @@ librefang-types = { path = "../librefang-types" }
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 librefang-kernel = { path = "../librefang-kernel" }
 librefang-runtime = { path = "../librefang-runtime" }
+librefang-llm-drivers = { path = "../librefang-llm-drivers" }
 librefang-memory = { path = "../librefang-memory" }
 librefang-channels = { path = "../librefang-channels", default-features = false }
 librefang-wire = { path = "../librefang-wire" }


### PR DESCRIPTION
## Summary

🚨 **Main is red.** Every CI run since #3292 merged is failing with:

```
error[E0433]: cannot find module or crate `librefang_llm_drivers`
   --> crates/librefang-api/src/routes/providers.rs:1386:22
   |
1386 |     let api_format = librefang_llm_drivers::drivers::provider_api_format(&name);
   |                      ^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate
```

The two call sites at `routes/providers.rs:1386,1389` (introduced by #3292's Anthropic-probe fix) reference `librefang_llm_drivers::drivers::provider_api_format` + `::ApiFormat::Anthropic`, but `crates/librefang-api/Cargo.toml` never picked up the new path-dep.

Affected jobs (last 3 main commits — #3292, #3291, #3287):
- Test / Ubuntu — FAIL
- Test / macOS — FAIL
- Test / Windows — FAIL
- Quality — FAIL
- OpenAPI Drift — FAIL

## Fix

One-line addition to `crates/librefang-api/Cargo.toml`:

```diff
 librefang-runtime = { path = "../librefang-runtime" }
+librefang-llm-drivers = { path = "../librefang-llm-drivers" }
 librefang-memory = { path = "../librefang-memory" }
```

Both symbols are already `pub` and live at the expected import path:

- `pub mod drivers;` — `librefang-llm-drivers/src/lib.rs:11`
- `pub fn provider_api_format(name: &str) -> Option<ApiFormat>` — `drivers/mod.rs:962`
- `pub enum ApiFormat` — `drivers/mod.rs:110` (with `Anthropic` variant)

So no source code change is needed beyond the manifest.

## Test plan

- [x] `cargo build -p librefang-api --lib` — local build clean (was failing on E0433 before this change).
- [ ] CI: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, OpenAPI Drift — should all flip from red to green once this lands.

## Why a separate PR

Independent one-line manifest fix — fastest path to unblocking main; merging this first lets every queued PR re-run CI on a green base. No risk of conflict with the source-code fix in #3292 itself.