### PR TITLE
fix(ci): stop bypassing needs-changes via comment inference / push

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,12 +1,16 @@
 name: PR Labels
 
+# Path-based area labels (e.g. `area/cli`, `area/dashboard`) keyed off
+# `.github/labeler.yml`. The review-state labels (`ready-for-review` ↔
+# `needs-changes`) are owned by `pr-status-labels.yml`, which queries
+# the real review state via `listReviews` instead of trying to infer
+# it from issue comments or treating every author push as
+# "all-resolved" — see librefang/librefang#3262 for the bug that
+# motivated removing the inference path.
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, closed]
-  pull_request_review:
-    types: [submitted]
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
@@ -24,94 +28,3 @@ jobs:
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true
-
-  # ── Review state tracking ─────────────────────────────────────────
-  review-state:
-    if: >-
-      (github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
-      (github.event_name != 'pull_request_target' || github.event.pull_request.user.login != 'dependabot[bot]')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update review state labels
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          LABEL_REVIEW="ready-for-review"
-          LABEL_CHANGES="needs-changes"
-
-          add_label() { gh pr edit "$PR" --repo "$REPO" --add-label "$1" 2>/dev/null || true; }
-          remove_label() { gh pr edit "$PR" --repo "$REPO" --remove-label "$1" 2>/dev/null || true; }
-
-          has_label() {
-            gh pr view "$PR" --repo "$REPO" --json labels --jq ".labels[].name" \
-              | grep -qx "$1" 2>/dev/null
-          }
-
-          is_maintainer() {
-            case "$1" in
-              OWNER|MEMBER|COLLABORATOR) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          # ── PR opened / reopened / synchronize / closed ───────────
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            PR="${{ github.event.pull_request.number }}"
-            ACTION="${{ github.event.action }}"
-
-            case "$ACTION" in
-              opened|reopened)
-                add_label "$LABEL_REVIEW"
-                remove_label "$LABEL_CHANGES"
-                ;;
-              synchronize)
-                if has_label "$LABEL_CHANGES"; then
-                  remove_label "$LABEL_CHANGES"
-                  add_label "$LABEL_REVIEW"
-                fi
-                ;;
-              closed)
-                remove_label "$LABEL_REVIEW"
-                remove_label "$LABEL_CHANGES"
-                ;;
-            esac
-
-          # ── Formal PR review ──────────────────────────────────────
-          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            PR="${{ github.event.pull_request.number }}"
-            STATE="${{ github.event.review.state }}"
-            ASSOC="${{ github.event.review.author_association }}"
-
-            if is_maintainer "$ASSOC"; then
-              case "$STATE" in
-                changes_requested)
-                  remove_label "$LABEL_REVIEW"
-                  add_label "$LABEL_CHANGES"
-                  ;;
-                approved)
-                  remove_label "$LABEL_REVIEW"
-                  remove_label "$LABEL_CHANGES"
-                  ;;
-              esac
-            fi
-
-          # ── Comment on a PR ───────────────────────────────────────
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            PR="${{ github.event.issue.number }}"
-            ASSOC="${{ github.event.comment.author_association }}"
-
-            if is_maintainer "$ASSOC"; then
-              if has_label "$LABEL_REVIEW"; then
-                remove_label "$LABEL_REVIEW"
-                add_label "$LABEL_CHANGES"
-              fi
-            else
-              if has_label "$LABEL_CHANGES"; then
-                remove_label "$LABEL_CHANGES"
-                add_label "$LABEL_REVIEW"
-              fi
-            fi
-          fi


### PR DESCRIPTION
## Summary

`pr-labels.yml`'s `review-state` job has been racing/overwriting `pr-status-labels.yml`'s correct implementation, with two failure modes that let a `needs-changes` label revert to `ready-for-review` without any actual re-review happening. Observed on #3262 (the relevant timeline excerpt is below).

This PR removes the duplicate (and buggy) `review-state` job from `pr-labels.yml`, leaving `pr-status-labels.yml` as the sole writer of `ready-for-review` ↔ `needs-changes`. Path-based area labels (`area/cli`, `area/dashboard`, etc.) — the part of `pr-labels.yml` that's unrelated to review state — stay put.

## Bug detail

In `.github/workflows/pr-labels.yml`'s removed `review-state` job, two branches inferred review state from things that aren't review state:

1. **`synchronize` (any author push)**

   ```bash
   synchronize)
     if has_label "$LABEL_CHANGES"; then
       remove_label "$LABEL_CHANGES"
       add_label "$LABEL_REVIEW"   # ← unconditional
     fi
     ;;
   ```

   Every push by the author cleared `needs-changes` and re-applied `ready-for-review`, regardless of whether the requested changes had actually been re-reviewed. GitHub's `reviewDecision` was still `CHANGES_REQUESTED`, but the label said otherwise.

2. **`issue_comment` (any comment on the PR)**

   ```bash
   elif [ "${{ github.event_name }}" = "issue_comment" ]; then
     if is_maintainer "$ASSOC"; then
       # maintainer comment → flip to needs-changes
     else
       if has_label "$LABEL_CHANGES"; then
         remove_label "$LABEL_CHANGES"
         add_label "$LABEL_REVIEW"   # ← author can self-clear
       fi
     fi
   ```

   The author replying to a review comment bounced the PR back to `ready-for-review`. The author dictating their own review state is exactly the failure mode #3262 hit.

`pr-status-labels.yml` (the file we're keeping) already owns the same label pair via a correct implementation:

- Consumes `pull_request_review` events directly (the `state` field is authoritative — `changes_requested` / `approved` / etc.).
- On `synchronize`, paginates `listReviews` and checks whether **any reviewer's latest non-comment state is still `CHANGES_REQUESTED`** before clearing `needs-changes`. See `pr-status-labels.yml` lines ~405–441.

So the duplicate job in `pr-labels.yml` was strictly worse than the existing implementation. Removing it.

## Side effects

- **Triggers dropped from `pr-labels.yml`**: `pull_request_review` and `issue_comment`. No remaining job consumes them. `pull_request_target` stays for the `area` job.
- **`area` job preserved unchanged** — path-based area labels keep working.
- **No new code added** — pure deletion (95 → 8 lines in pr-labels.yml).

## Verification

- [x] YAML still parses (no `actionlint` errors locally).
- [ ] Live: after merge, on #3262, verify (a) the existing `needs-changes` label state is honored when the author next pushes, (b) maintainer comments don't auto-flip labels.
- [ ] Live: re-test by opening any test PR, having a maintainer leave a comment with `changes_requested` review, then having the author push — `needs-changes` should stick until a formal re-review.

Closes #3262 — the label-bypass side. The PR's actual code review feedback for the OAuth state token CSPRNG patch is unaffected and still pending from @Chukwuebuka-2003.
