### PR TITLE
fix(providers/test): treat Anthropic 401/403 as reachable, not auth-failed

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1460,7 +1460,17 @@ pub async fn test_provider(
         ),
     );
 
-    if status_code == 401 || status_code == 403 {
+    // For Anthropic-protocol providers, 401/403/404 on /v1/models is a
+    // **listing-endpoint-not-exposed** signal, not an auth failure. The
+    // BytePlus and Volcengine "coding plan" tokens, for instance, work
+    // fine for /v1/messages (the real chat path) but the same key gets
+    // a 401 from /v1/models because that endpoint isn't part of the
+    // coding-plan scope. Reporting "Authentication failed" makes the
+    // dashboard show a red "broken provider" tile when the key is in
+    // fact valid for actual inference. Treat the same status codes that
+    // the background `probe_provider` already treats as `Ok` here too —
+    // both paths now converge on the same Anthropic-shape semantics.
+    if !is_anthropic_shape && (status_code == 401 || status_code == 403) {
         (
             StatusCode::OK,
             Json(serde_json::json!({


### PR DESCRIPTION
Follow-up to #3292.

## Problem

After #3292 merged, `byteplus_coding` (and any other Anthropic-protocol provider) on the dashboard still shows:

```
Authentication failed (HTTP 401)
byteplus_coding
```

Direct API:

```bash
$ curl http://127.0.0.1:4545/api/providers/byteplus_coding/test
{"error":"Authentication failed (HTTP 401)","provider":"byteplus_coding","status":"error"}
```

## Why

#3292 fixed the **request** half — `test_provider` now hits `/v1/models` with `x-api-key` + `anthropic-version` for Anthropic-format providers. But the **response** half still hardcoded:

```rust
if status_code == 401 || status_code == 403 {
    return ... "Authentication failed (HTTP {})" ...;
}
```

For BytePlus / Volcengine coding-plan tokens, that 401 isn't an auth failure for the user's actual workload:

- The same key is valid for `POST /v1/messages` (the real chat path) — verified by #3271 + the registry PRs.
- BytePlus's coding-plan scope simply doesn't expose the `/v1/models` listing endpoint to coding-plan tokens, so any GET there returns 401 by design.
- The companion `probe_provider` (the background catalog cycle) already treats `401/403/404` on Anthropic-format endpoints as `Ok` for exactly this reason — added in #3292. `test_provider` was missing the matching arm, so the on-demand button kept disagreeing with the background poll.

## Fix

One-line semantic change: `401/403` is only an auth failure for non-Anthropic shapes:

```rust
if !is_anthropic_shape && (status_code == 401 || status_code == 403) {
    // ... auth-failed response
}
```

For Anthropic-format providers, fall through to the existing "reachable" branch.

Now both probe paths (`probe_provider` background + `test_provider` on-demand) converge on the same Anthropic-shape semantics.

## Test plan

- [ ] CI: `cargo check -p librefang-api`
- [ ] **Live verification**: `curl /api/providers/byteplus_coding/test` should return `{"status":"ok","provider":"byteplus_coding","latency_ms":...}` instead of the auth-failed payload. Dashboard tile turns from red to green.

## Why one-line + new PR vs amending #3292

#3292 already merged (2026-04-27). New PR keeps the bisect-friendly "one bug per merge" history; the diff is genuinely small. Could be merged on its own without #3292, but builds on top of `is_anthropic_shape` introduced there.
