### PR TITLE
chore: regenerate Cargo.lock for librefang-llm-drivers dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,7 @@ dependencies = [
  "librefang-extensions",
  "librefang-hands",
  "librefang-kernel",
+ "librefang-llm-drivers",
  "librefang-memory",
  "librefang-migrate",
  "librefang-runtime",


### PR DESCRIPTION
## Summary

#3294 added `librefang-llm-drivers` as a path dep of `librefang-api` in `crates/librefang-api/Cargo.toml`, but didn't refresh `Cargo.lock`. The `librefang-api` entry in the lock is missing the corresponding `librefang-llm-drivers` line, so `Cargo.lock` is out of sync with `Cargo.toml` on `main`.

Effect:

- Any `cargo build --locked` / `cargo metadata --locked` fails (lock asserts staleness).
- Non-`--locked` local builds silently auto-add the line on every invocation, leaving a permanent dirty `Cargo.lock` in every contributor's working tree.

This PR is the one-line lock refresh. Generated with `cargo metadata` against the unchanged `Cargo.toml` — no source or dep version changes.

```diff
  "librefang-extensions",
  "librefang-hands",
  "librefang-kernel",
+ "librefang-llm-drivers",
  "librefang-memory",
  "librefang-migrate",
  "librefang-runtime",
```

## Test plan

- [x] `cargo metadata` produces no further changes after applying.
- [ ] CI green on workspace build / clippy / test jobs.
