### PR TITLE
feat(runtime): aux LLM client for cheap-tier side tasks (#3314)

### DIFF
--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -4099,6 +4099,23 @@
       },
       "type": "object"
     },
+    "LlmConfig": {
+      "description": "Top-level `[llm]` section. Currently only carries `auxiliary` — primary driver configuration still lives in `[default_model]` / `[[fallback_providers]]` so this struct exists purely to namespace future LLM-routing knobs.",
+      "properties": {
+        "auxiliary": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Per-task auxiliary fallback chains. See [`AuxiliaryConfig`].",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "MastodonConfig": {
       "description": "Mastodon Streaming API channel adapter configuration.",
       "properties": {
@@ -14231,6 +14248,17 @@
         "timeout_secs": 10
       },
       "description": "Link understanding configuration."
+    },
+    "llm": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/LlmConfig"
+        }
+      ],
+      "default": {
+        "auxiliary": {}
+      },
+      "description": "`[llm]` section — currently carries the auxiliary side-task chain configuration. See [`LlmConfig`] / [`AuxiliaryConfig`]."
     },
     "local_probe_interval_secs": {
       "default": 60,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -367,6 +367,12 @@ pub struct LibreFangKernel {
     pub(crate) metering: Arc<MeteringEngine>,
     /// Default LLM driver (from kernel config).
     default_driver: Arc<dyn LlmDriver>,
+    /// Auxiliary LLM client — resolves cheap-tier fallback chains for side
+    /// tasks (context compression, title generation, search summarisation,
+    /// vision captioning). Wrapped in `ArcSwap` so config hot-reload can
+    /// rebuild the chains without restarting the kernel. See issue #3314
+    /// and `librefang_runtime::aux_client`.
+    aux_client: arc_swap::ArcSwap<librefang_runtime::aux_client::AuxClient>,
     /// WASM sandbox engine (shared across all WASM agent executions).
     wasm_sandbox: WasmSandbox,
     /// RBAC authentication manager.
@@ -2897,6 +2903,14 @@ impl LibreFangKernel {
         // restarting servers.
         let initial_taint_rules =
             std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(config.taint_rules.clone()));
+        // Build the aux client BEFORE moving `config` into the struct so we
+        // can clone the snapshot without re-loading from the swap. The
+        // primary driver is shared by `Arc::clone` so failover behaviour
+        // matches the kernel's main `default_driver`.
+        let initial_aux_client = librefang_runtime::aux_client::AuxClient::new(
+            std::sync::Arc::new(config.clone()),
+            Arc::clone(&driver),
+        );
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),
@@ -2923,6 +2937,9 @@ impl LibreFangKernel {
                 audit_anchor_path,
             )),
             metering,
+            // ArcSwap lets config_reload rebuild on `[llm.auxiliary]` edits
+            // without invalidating any long-lived `Arc<Kernel>` handle.
+            aux_client: arc_swap::ArcSwap::from_pointee(initial_aux_client),
             default_driver: driver,
             wasm_sandbox,
             auth,
@@ -4552,6 +4569,7 @@ system_prompt = "You are a helpful assistant."
                 interrupt: Some(librefang_runtime::interrupt::SessionInterrupt::new()),
                 max_iterations: self.config.load().agent_max_iterations,
                 max_history_messages: self.config.load().max_history_messages,
+                aux_client: Some(self.aux_client.load_full()),
             },
         )
         .await
@@ -5276,6 +5294,7 @@ system_prompt = "You are a helpful assistant."
             interrupt: Some(interrupt),
             max_iterations: self.config.load().agent_max_iterations,
             max_history_messages: self.config.load().max_history_messages,
+            aux_client: Some(self.aux_client.load_full()),
         };
         // INVARIANT: forks must use the canonical session so the parent turn's
         // prompt-cache prefix is reused. Do NOT pass a `session_id_override`
@@ -5346,6 +5365,7 @@ system_prompt = "You are a helpful assistant."
             interrupt: Some(session_interrupt),
             max_iterations: self.config.load().agent_max_iterations,
             max_history_messages: self.config.load().max_history_messages,
+            aux_client: Some(self.aux_client.load_full()),
         };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
@@ -7491,6 +7511,7 @@ system_prompt = "You are a helpful assistant."
             interrupt: Some(session_interrupt),
             max_iterations: cfg.agent_max_iterations,
             max_history_messages: cfg.max_history_messages,
+            aux_client: Some(self.aux_client.load_full()),
         };
 
         // Build a per-execution MCP pool that includes the agent workspace as
@@ -9111,7 +9132,6 @@ system_prompt = "You are a helpful assistant."
             ));
         }
 
-        let driver = self.resolve_driver(&entry.manifest)?;
         // Strip provider prefix so the model name is valid for the upstream API.
         let model = librefang_runtime::agent_loop::strip_provider_prefix(
             &entry.manifest.model.model,
@@ -9131,6 +9151,18 @@ system_prompt = "You are a helpful assistant."
                     .filter(|w| *w > 0)
             })
             .unwrap_or(200_000);
+
+        // Compaction is a side task — route through the auxiliary chain when
+        // configured (issue #3314) so users with `[llm.auxiliary] compression`
+        // pay cheap-tier rates rather than the agent's primary model. When no
+        // aux entry can be initialised, the resolver returns a driver
+        // equivalent to `resolve_driver(&entry.manifest)` (the kernel's
+        // default driver chain), so behaviour matches the pre-issue-#3314
+        // baseline.
+        let driver = self
+            .aux_client
+            .load()
+            .driver_for(librefang_types::config::AuxTask::Compression);
 
         // Delegate to the context engine when available (and allowed for this agent),
         // otherwise fall back to the built-in compactor directly.
@@ -10377,7 +10409,19 @@ system_prompt = "You are a helpful assistant."
             // edits even when no other hot action fires.
             self.taint_rules_swap
                 .store(std::sync::Arc::new(new_config.taint_rules.clone()));
-            self.config.store(std::sync::Arc::new(new_config));
+            let new_config_arc = std::sync::Arc::new(new_config);
+            self.config.store(std::sync::Arc::clone(&new_config_arc));
+            // Rebuild the auxiliary LLM client so `[llm.auxiliary]` edits
+            // take effect on the next side-task call. ArcSwap atomically
+            // replaces the live snapshot — concurrent callers that already
+            // resolved a chain keep using their `Arc<dyn LlmDriver>` until
+            // the call completes.
+            self.aux_client.store(std::sync::Arc::new(
+                librefang_runtime::aux_client::AuxClient::new(
+                    new_config_arc,
+                    Arc::clone(&self.default_driver),
+                ),
+            ));
         }
 
         Ok(plan)

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1478,6 +1478,14 @@ pub struct LoopOptions {
     /// manifest. `None` → use the library fallback. Values below
     /// `MIN_HISTORY_MESSAGES` are clamped up at resolution time.
     pub max_history_messages: Option<usize>,
+    /// Auxiliary LLM client used for cheap-tier side tasks
+    /// (context compression, title generation, search summarisation,
+    /// vision captioning). When `None`, side tasks fall back to the
+    /// primary `driver` — preserving pre-issue-#3314 behaviour.
+    ///
+    /// Kernel populates this from the boot-time-built [`AuxClient`].
+    /// Tests typically leave it as `None`.
+    pub aux_client: Option<std::sync::Arc<crate::aux_client::AuxClient>>,
 }
 
 /// Result of an agent loop execution.
@@ -3200,14 +3208,20 @@ pub async fn run_agent_loop(
         } else {
             // Inline fallback: LLM-based context compression (soft), then
             // overflow recovery (hard trim), then context guard.
+            //
+            // When the kernel wired an [`AuxClient`] through `opts.aux_client`,
+            // summarisation routes to the cheap-tier auxiliary chain
+            // (issue #3314); otherwise the primary `driver` is used —
+            // preserving baseline behaviour.
             let (compressed, compression_events) = context_compressor
-                .compress_if_needed(
+                .compress_if_needed_with_aux(
                     messages.clone(),
                     &system_prompt,
                     available_tools,
                     ctx_window,
                     &manifest.model.model,
                     driver.clone(),
+                    opts.aux_client.as_deref(),
                 )
                 .await;
             if !compression_events.is_empty() {
@@ -4533,14 +4547,16 @@ pub async fn run_agent_loop_streaming(
             result.recovery
         } else {
             // LLM-based soft compression first, then hard overflow recovery.
+            // Routes through the aux client when one is wired (issue #3314).
             let (compressed, compression_events) = context_compressor
-                .compress_if_needed(
+                .compress_if_needed_with_aux(
                     messages.clone(),
                     &system_prompt,
                     available_tools,
                     ctx_window,
                     &manifest.model.model,
                     driver.clone(),
+                    opts.aux_client.as_deref(),
                 )
                 .await;
             if !compression_events.is_empty() {

--- a/crates/librefang-runtime/src/aux_client.rs
+++ b/crates/librefang-runtime/src/aux_client.rs
@@ -214,7 +214,11 @@ impl AuxClient {
             skip_permissions: true,
             message_timeout_secs: self.kernel_config.default_model.message_timeout_secs,
             mcp_bridge: None,
-            proxy_url: self.kernel_config.provider_proxy_urls.get(provider).cloned(),
+            proxy_url: self
+                .kernel_config
+                .provider_proxy_urls
+                .get(provider)
+                .cloned(),
             request_timeout_secs: self
                 .kernel_config
                 .provider_request_timeout_secs
@@ -242,7 +246,10 @@ impl AuxClient {
 impl std::fmt::Debug for AuxClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AuxClient")
-            .field("configured_tasks", &self.config.tasks.keys().collect::<Vec<_>>())
+            .field(
+                "configured_tasks",
+                &self.config.tasks.keys().collect::<Vec<_>>(),
+            )
             .finish()
     }
 }
@@ -317,10 +324,7 @@ mod tests {
 
     #[async_trait]
     impl LlmDriverTrait for MarkerDriver {
-        async fn complete(
-            &self,
-            _req: CompletionRequest,
-        ) -> Result<CompletionResponse, LlmError> {
+        async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
             self.1.fetch_add(1, Ordering::SeqCst);
             Ok(CompletionResponse {
                 content: vec![ContentBlock::Text {
@@ -417,10 +421,19 @@ mod tests {
 
     #[test]
     fn alias_resolution_expands_known_aliases() {
-        assert_eq!(resolve_model_alias("anthropic", "sonnet"), "claude-3-5-sonnet-latest");
-        assert_eq!(resolve_model_alias("anthropic", "haiku"), "claude-3-5-haiku-latest");
+        assert_eq!(
+            resolve_model_alias("anthropic", "sonnet"),
+            "claude-3-5-sonnet-latest"
+        );
+        assert_eq!(
+            resolve_model_alias("anthropic", "haiku"),
+            "claude-3-5-haiku-latest"
+        );
         // Unknown aliases pass through unchanged.
-        assert_eq!(resolve_model_alias("anthropic", "claude-9001"), "claude-9001");
+        assert_eq!(
+            resolve_model_alias("anthropic", "claude-9001"),
+            "claude-9001"
+        );
         // Unknown provider passes through unchanged.
         assert_eq!(resolve_model_alias("nvidia", "nemotron"), "nemotron");
     }

--- a/crates/librefang-runtime/src/aux_client.rs
+++ b/crates/librefang-runtime/src/aux_client.rs
@@ -1,0 +1,461 @@
+//! Auxiliary LLM client — cheap-tier fallback chains for side tasks.
+//!
+//! This module addresses issue #3314: side tasks in LibreFang (context
+//! compression, session-title generation, search summarisation, vision
+//! captioning, browser-vision page understanding) historically run on the
+//! same model the agent is configured with. That means a user running
+//! Opus pays Opus rates to summarise their conversation history into a
+//! 4 k-token blurb, and a user running a tiny local model has no fallback
+//! when compression demands more capability than `qwen:0.5b` can provide.
+//!
+//! [`AuxClient`] resolves a per-task [`FallbackChain`] composed of cheap-
+//! tier providers declared in `[llm.auxiliary]`. The same `FallbackChain`
+//! engine that powers the primary path (rate-limit retries, credit-
+//! exhaustion failover, auth-error skip) is reused here — there is **no
+//! new fallback engine**, only a new chain composition rule.
+//!
+//! # Resolution algorithm
+//!
+//! 1. Look up `[llm.auxiliary]` for `task` in [`AuxiliaryConfig`].
+//! 2. If empty, fall back to a built-in published default chain.
+//! 3. For each `provider:model` reference, attempt to construct a driver
+//!    using the user's already-configured credentials (env vars or
+//!    `[provider_api_keys]` overrides). Skip silently when credentials are
+//!    missing — exactly the same way [`crate::drivers::create_driver`]
+//!    behaves elsewhere.
+//! 4. If every entry was skipped, fall through to the caller-supplied
+//!    primary driver. The aux client is a routing optimisation, never a
+//!    permission gate.
+//!
+//! # Cost accounting
+//!
+//! All aux calls still flow through the same driver objects the kernel
+//! constructed via [`librefang_llm_drivers::drivers::create_driver`], which
+//! means the metering layer sees them. The aux client never bypasses the
+//! billing pipeline — it just picks a cheaper model.
+
+use librefang_llm_driver::{DriverConfig, LlmDriver};
+use librefang_llm_drivers::drivers::{
+    create_driver,
+    fallback_chain::{ChainEntry, FallbackChain},
+};
+use librefang_types::config::{AuxTask, AuxiliaryConfig, KernelConfig};
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+/// Auxiliary LLM client: resolves a [`FallbackChain`] per [`AuxTask`].
+///
+/// Construct once at kernel boot and share via `Arc<AuxClient>`. The struct
+/// is `Send + Sync`; resolution is cheap (driver instances are cached on
+/// the kernel-supplied [`librefang_llm_drivers::drivers::DriverCache`]
+/// when one is wired through, or built ad-hoc otherwise).
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
+pub struct AuxClient {
+    /// User-supplied per-task chain configuration.
+    config: AuxiliaryConfig,
+    /// Snapshot of the kernel config — needed to resolve provider env-var
+    /// names, base URL overrides, proxy settings, and provider-specific
+    /// auth (Vertex AI, Azure OpenAI). Cloned at construction time; if the
+    /// kernel hot-reloads its config it must rebuild the [`AuxClient`].
+    kernel_config: Arc<KernelConfig>,
+    /// Fallback driver used when no aux entry could be initialised. This
+    /// is normally the primary driver chain so callers see no change in
+    /// behaviour relative to the pre-aux baseline.
+    primary: Arc<dyn LlmDriver>,
+}
+
+impl AuxClient {
+    /// Build a new auxiliary client from a kernel config snapshot.
+    ///
+    /// `primary` is the driver returned to callers when no auxiliary entry
+    /// can be initialised for the requested task. Pass the kernel's
+    /// already-constructed primary fallback driver so behaviour matches
+    /// the pre-aux baseline.
+    pub fn new(config: Arc<KernelConfig>, primary: Arc<dyn LlmDriver>) -> Self {
+        Self {
+            config: config.llm.auxiliary.clone(),
+            kernel_config: config,
+            primary,
+        }
+    }
+
+    /// Build an aux client without a kernel config — used by tests and the
+    /// fallback path inside the context compressor when the surrounding
+    /// component was constructed before kernel boot completed.
+    ///
+    /// Every task resolves directly to `primary`.
+    pub fn with_primary_only(primary: Arc<dyn LlmDriver>) -> Self {
+        Self {
+            config: AuxiliaryConfig::empty(),
+            kernel_config: Arc::new(KernelConfig::default()),
+            primary,
+        }
+    }
+
+    /// Resolve the chain for `task`.
+    ///
+    /// Returns an `Arc<dyn LlmDriver>` that callers invoke exactly like the
+    /// primary driver. The returned object is either a [`FallbackChain`]
+    /// composed of cheap providers, or — when no aux entry could be
+    /// initialised — a clone of the primary driver `Arc`.
+    ///
+    /// Also returns a slice of `(provider, model)` pairs describing the
+    /// resolved chain for logging / debugging. When the slice is empty the
+    /// caller is talking to the primary driver, not an aux chain.
+    pub fn resolve(&self, task: AuxTask) -> AuxResolution {
+        let raw = match self.config.chain_for(task) {
+            Some(chain) if !chain.is_empty() => chain.to_vec(),
+            _ => self.default_chain(task),
+        };
+
+        if raw.is_empty() {
+            debug!(task = %task, "AuxClient: no chain configured, using primary driver");
+            return AuxResolution {
+                driver: Arc::clone(&self.primary),
+                resolved: Vec::new(),
+                used_primary: true,
+            };
+        }
+
+        let mut entries: Vec<ChainEntry> = Vec::with_capacity(raw.len());
+        let mut resolved_pairs: Vec<(String, String)> = Vec::with_capacity(raw.len());
+
+        for spec in &raw {
+            let Some((provider, model)) = parse_spec(spec) else {
+                warn!(spec, "AuxClient: malformed entry, skipping");
+                continue;
+            };
+
+            match self.build_driver(&provider) {
+                Ok(driver) => {
+                    let model_resolved = resolve_model_alias(&provider, &model);
+                    debug!(task = %task, %provider, model = %model_resolved, "AuxClient: chain entry resolved");
+                    entries.push(ChainEntry {
+                        driver,
+                        model_override: model_resolved.clone(),
+                        provider_name: provider.clone(),
+                    });
+                    resolved_pairs.push((provider, model_resolved));
+                }
+                Err(reason) => {
+                    debug!(task = %task, %provider, %reason, "AuxClient: chain entry skipped");
+                }
+            }
+        }
+
+        if entries.is_empty() {
+            debug!(task = %task, "AuxClient: every aux entry skipped, falling back to primary");
+            return AuxResolution {
+                driver: Arc::clone(&self.primary),
+                resolved: Vec::new(),
+                used_primary: true,
+            };
+        }
+
+        let chain: Arc<dyn LlmDriver> = Arc::new(FallbackChain::new(entries));
+        AuxResolution {
+            driver: chain,
+            resolved: resolved_pairs,
+            used_primary: false,
+        }
+    }
+
+    /// Convenience: return just the driver. Most call sites only need this.
+    pub fn driver_for(&self, task: AuxTask) -> Arc<dyn LlmDriver> {
+        self.resolve(task).driver
+    }
+
+    /// Default chain for `task` when the user has not configured `[llm.auxiliary]`.
+    ///
+    /// These defaults are intentionally conservative — the aux client only
+    /// engages when the named provider has its API key set in the user's
+    /// environment, otherwise the entry is silently skipped and we fall
+    /// through to the primary driver. That preserves behaviour for users
+    /// who haven't opted in (no `OPENROUTER_API_KEY` set → no aux call).
+    ///
+    /// Aliases (`sonnet`, `haiku`, `gpt-4o`) are used rather than concrete
+    /// model IDs so catalog drift in the model registry doesn't break this
+    /// list. Provider drivers expand the alias before sending the request.
+    fn default_chain(&self, task: AuxTask) -> Vec<String> {
+        match task {
+            // Compression is a high-volume side task. Cheap haiku-class
+            // models are good enough; OpenRouter is preferred because most
+            // adopters of "auxiliary cheap tier" already have a key there.
+            AuxTask::Compression | AuxTask::Title | AuxTask::Search => vec![
+                "openrouter:anthropic/claude-3-5-haiku".to_string(),
+                "anthropic:haiku".to_string(),
+                "openai:gpt-4o-mini".to_string(),
+            ],
+            // Vision-capable models are scarce; only providers with
+            // first-class multimodal support are listed.
+            AuxTask::Vision | AuxTask::BrowserVision => vec![
+                "anthropic:sonnet".to_string(),
+                "openai:gpt-4o-mini".to_string(),
+                "openrouter:anthropic/claude-3-5-sonnet".to_string(),
+            ],
+        }
+    }
+
+    /// Construct a driver for `provider` using the user's existing config.
+    ///
+    /// Returns `Err` when the provider has no API key in the user's env or
+    /// `[provider_api_keys]` mapping (and isn't a local provider) — the
+    /// caller treats that as "skip this slot, try the next one".
+    fn build_driver(&self, provider: &str) -> Result<Arc<dyn LlmDriver>, String> {
+        let api_key = self.resolve_api_key(provider);
+
+        let driver_cfg = DriverConfig {
+            provider: provider.to_string(),
+            api_key,
+            base_url: self.kernel_config.provider_urls.get(provider).cloned(),
+            vertex_ai: self.kernel_config.vertex_ai.clone(),
+            azure_openai: self.kernel_config.azure_openai.clone(),
+            skip_permissions: true,
+            message_timeout_secs: self.kernel_config.default_model.message_timeout_secs,
+            mcp_bridge: None,
+            proxy_url: self.kernel_config.provider_proxy_urls.get(provider).cloned(),
+            request_timeout_secs: self
+                .kernel_config
+                .provider_request_timeout_secs
+                .get(provider)
+                .copied(),
+        };
+
+        create_driver(&driver_cfg).map_err(|e| e.to_string())
+    }
+
+    /// Resolve the API key for `provider`. `None` for local providers
+    /// (ollama, vllm, lmstudio) is fine — `create_driver` accepts an empty
+    /// key for those. For cloud providers, returning `None` here means
+    /// `create_driver` will see no key and most likely fail; the caller
+    /// then skips the slot.
+    fn resolve_api_key(&self, provider: &str) -> Option<String> {
+        let env_var = self.kernel_config.resolve_api_key_env(provider);
+        if env_var.is_empty() {
+            return None;
+        }
+        std::env::var(&env_var).ok().filter(|v| !v.is_empty())
+    }
+}
+
+impl std::fmt::Debug for AuxClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuxClient")
+            .field("configured_tasks", &self.config.tasks.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Outcome of [`AuxClient::resolve`].
+#[derive(Clone)]
+pub struct AuxResolution {
+    /// Driver to call for this side task.
+    pub driver: Arc<dyn LlmDriver>,
+    /// `(provider, model)` pairs in chain order. Empty when `used_primary`
+    /// is true.
+    pub resolved: Vec<(String, String)>,
+    /// True when no aux entry could be initialised and the primary driver
+    /// is being used as the chain.
+    pub used_primary: bool,
+}
+
+/// Parse a `provider:model` spec.  Returns `None` on malformed input.
+///
+/// Supports models that themselves contain `/` (e.g.
+/// `openrouter:anthropic/claude-3-5-haiku`) — only the first `:` is the
+/// provider/model separator.
+fn parse_spec(spec: &str) -> Option<(String, String)> {
+    let (provider, model) = spec.split_once(':')?;
+    let provider = provider.trim();
+    let model = model.trim();
+    if provider.is_empty() || model.is_empty() {
+        return None;
+    }
+    Some((provider.to_string(), model.to_string()))
+}
+
+/// Expand short aliases to a canonical model slug per provider so users can
+/// write `anthropic:sonnet` without pinning a specific dated revision.
+///
+/// Unknown aliases are returned unchanged — the underlying driver will
+/// either accept the model name as-is or surface a `ModelUnavailable`
+/// error that triggers chain failover.
+fn resolve_model_alias(provider: &str, model: &str) -> String {
+    match (provider, model) {
+        ("anthropic", "sonnet") => "claude-3-5-sonnet-latest".to_string(),
+        ("anthropic", "haiku") => "claude-3-5-haiku-latest".to_string(),
+        ("anthropic", "opus") => "claude-3-opus-latest".to_string(),
+        ("openai", "gpt-4o") => "gpt-4o".to_string(),
+        ("openai", "gpt-4o-mini") => "gpt-4o-mini".to_string(),
+        _ => model.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_driver::{
+        CompletionRequest, CompletionResponse, LlmDriver as LlmDriverTrait, LlmError, StreamEvent,
+    };
+    use async_trait::async_trait;
+    use librefang_types::config::AuxiliaryConfig;
+    use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MarkerDriver(&'static str, AtomicUsize);
+
+    impl MarkerDriver {
+        fn new(label: &'static str) -> Arc<Self> {
+            Arc::new(Self(label, AtomicUsize::new(0)))
+        }
+    }
+
+    #[async_trait]
+    impl LlmDriverTrait for MarkerDriver {
+        async fn complete(
+            &self,
+            _req: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.1.fetch_add(1, Ordering::SeqCst);
+            Ok(CompletionResponse {
+                content: vec![ContentBlock::Text {
+                    text: self.0.to_string(),
+                    provider_metadata: None,
+                }],
+                stop_reason: StopReason::EndTurn,
+                tool_calls: vec![],
+                usage: TokenUsage::default(),
+            })
+        }
+
+        async fn stream(
+            &self,
+            req: CompletionRequest,
+            _tx: tokio::sync::mpsc::Sender<StreamEvent>,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.complete(req).await
+        }
+    }
+
+    /// Empty config + a primary driver → every task hits the primary.
+    #[tokio::test]
+    async fn empty_config_falls_through_to_primary() {
+        let primary = MarkerDriver::new("primary");
+        let primary_calls = Arc::clone(&primary);
+
+        let mut cfg = KernelConfig::default();
+        cfg.llm.auxiliary = AuxiliaryConfig::empty();
+
+        let aux = AuxClient::new(Arc::new(cfg), primary);
+        let resolution = aux.resolve(AuxTask::Compression);
+        // No env keys are set in CI for OpenRouter / Anthropic / OpenAI, so
+        // the default chain entries get skipped and we fall through to the
+        // primary driver. `used_primary` is the load-bearing assertion.
+        assert!(
+            resolution.used_primary,
+            "no aux entries should be initialised in a clean test env"
+        );
+
+        let req = CompletionRequest {
+            model: "test".to_string(),
+            messages: vec![],
+            tools: vec![],
+            max_tokens: 32,
+            temperature: 0.0,
+            system: None,
+            thinking: None,
+            prompt_caching: false,
+            cache_ttl: None,
+            response_format: None,
+            timeout_secs: None,
+            extra_body: None,
+            agent_id: None,
+        };
+        resolution.driver.complete(req).await.unwrap();
+        assert_eq!(primary_calls.1.load(Ordering::SeqCst), 1);
+    }
+
+    /// Misconfigured aux entries (unknown provider, no base_url) get
+    /// skipped silently and resolution falls back to the primary driver.
+    #[test]
+    fn malformed_chain_falls_back_to_primary() {
+        let primary = MarkerDriver::new("primary");
+        let mut cfg = KernelConfig::default();
+        cfg.llm.auxiliary.tasks.insert(
+            AuxTask::Title,
+            vec![
+                "definitely-not-a-real-provider:foo".to_string(),
+                "another-bogus:bar".to_string(),
+            ],
+        );
+
+        let aux = AuxClient::new(Arc::new(cfg), primary);
+        let resolution = aux.resolve(AuxTask::Title);
+        assert!(resolution.used_primary, "all entries should fail to init");
+        assert!(resolution.resolved.is_empty());
+    }
+
+    /// `provider:model` parser handles model strings containing `/`.
+    #[test]
+    fn parse_spec_handles_slashed_model() {
+        let (p, m) = parse_spec("openrouter:anthropic/claude-3-5-haiku").unwrap();
+        assert_eq!(p, "openrouter");
+        assert_eq!(m, "anthropic/claude-3-5-haiku");
+    }
+
+    #[test]
+    fn parse_spec_rejects_empty_sides() {
+        assert!(parse_spec(":foo").is_none());
+        assert!(parse_spec("foo:").is_none());
+        assert!(parse_spec("noproto").is_none());
+    }
+
+    #[test]
+    fn alias_resolution_expands_known_aliases() {
+        assert_eq!(resolve_model_alias("anthropic", "sonnet"), "claude-3-5-sonnet-latest");
+        assert_eq!(resolve_model_alias("anthropic", "haiku"), "claude-3-5-haiku-latest");
+        // Unknown aliases pass through unchanged.
+        assert_eq!(resolve_model_alias("anthropic", "claude-9001"), "claude-9001");
+        // Unknown provider passes through unchanged.
+        assert_eq!(resolve_model_alias("nvidia", "nemotron"), "nemotron");
+    }
+
+    #[test]
+    fn config_default_chain_covers_all_tasks() {
+        let cfg = KernelConfig::default();
+        let primary = MarkerDriver::new("primary");
+        let aux = AuxClient::new(Arc::new(cfg), primary);
+        // None of the default-chain providers should be present in CI env,
+        // but the resolver must still produce a non-panicking result for
+        // every task variant.
+        for task in [
+            AuxTask::Compression,
+            AuxTask::Title,
+            AuxTask::Search,
+            AuxTask::Vision,
+            AuxTask::BrowserVision,
+        ] {
+            let res = aux.resolve(task);
+            assert!(
+                res.used_primary,
+                "task {task} should have fallen through to primary in CI env"
+            );
+        }
+    }
+
+    #[test]
+    fn with_primary_only_always_returns_primary() {
+        let primary = MarkerDriver::new("primary");
+        let aux = AuxClient::with_primary_only(primary);
+        for task in [AuxTask::Compression, AuxTask::Vision, AuxTask::Title] {
+            let res = aux.resolve(task);
+            assert!(res.used_primary);
+            assert!(res.resolved.is_empty());
+        }
+    }
+}

--- a/crates/librefang-runtime/src/context_compressor.rs
+++ b/crates/librefang-runtime/src/context_compressor.rs
@@ -191,6 +191,7 @@ impl ContextCompressor {
     /// `model` is still threaded through but is overridden per-entry by
     /// the chain's `model_override` so the cheap providers send their own
     /// model slug rather than the agent's primary model.
+    #[allow(clippy::too_many_arguments)] // mirrors `compress_if_needed` plus an `aux_client`
     pub async fn compress_if_needed_with_aux(
         &self,
         messages: Vec<Message>,

--- a/crates/librefang-runtime/src/context_compressor.rs
+++ b/crates/librefang-runtime/src/context_compressor.rs
@@ -26,10 +26,12 @@
 //!   that persists in the message list across turns.
 //! - System-prompt messages (`Role::System`) in the head are preserved unchanged.
 
+use crate::aux_client::AuxClient;
 use crate::compactor::{self, CompactionConfig};
 use crate::llm_driver::LlmDriver;
 use librefang_memory::session::Session;
 use librefang_types::agent::{AgentId, SessionId};
+use librefang_types::config::AuxTask;
 use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
 use librefang_types::tool::ToolDefinition;
 use std::sync::Arc;
@@ -142,6 +144,12 @@ impl ContextCompressor {
     /// one. Session state is NOT persisted here — that remains the agent
     /// loop's responsibility.
     ///
+    /// This is the legacy entrypoint that always summarises with the
+    /// caller-supplied primary `driver`. Callers wired up to the auxiliary
+    /// LLM client should prefer [`Self::compress_if_needed_with_aux`] which
+    /// routes summarisation through a cheap-tier chain when one is
+    /// configured (see issue #3314).
+    ///
     /// # Parameters
     ///
     /// - `messages` — current LLM working copy of the conversation
@@ -160,6 +168,58 @@ impl ContextCompressor {
         model: &str,
         driver: Arc<dyn LlmDriver>,
     ) -> (Vec<Message>, Vec<CompressionEvent>) {
+        self.compress_if_needed_with_aux(
+            messages,
+            system_prompt,
+            tools,
+            context_window,
+            model,
+            driver,
+            None,
+        )
+        .await
+    }
+
+    /// Aux-aware variant of [`Self::compress_if_needed`].
+    ///
+    /// When `aux_client` is `Some`, summarisation routes through
+    /// [`AuxClient::driver_for(AuxTask::Compression)`] — a cheap-tier
+    /// fallback chain. When the chain has no usable entries the resolver
+    /// hands back the primary `driver`, so behaviour is identical for
+    /// users who haven't configured `[llm.auxiliary]`.
+    ///
+    /// `model` is still threaded through but is overridden per-entry by
+    /// the chain's `model_override` so the cheap providers send their own
+    /// model slug rather than the agent's primary model.
+    pub async fn compress_if_needed_with_aux(
+        &self,
+        messages: Vec<Message>,
+        system_prompt: &str,
+        tools: &[ToolDefinition],
+        context_window: usize,
+        model: &str,
+        driver: Arc<dyn LlmDriver>,
+        aux_client: Option<&AuxClient>,
+    ) -> (Vec<Message>, Vec<CompressionEvent>) {
+        // Resolve the summariser driver: aux chain when configured, else
+        // the caller-supplied primary driver. Build it once outside the
+        // iteration loop so we don't re-resolve on every pass.
+        let summariser_driver: Arc<dyn LlmDriver> = match aux_client {
+            Some(aux) => {
+                let resolution = aux.resolve(AuxTask::Compression);
+                if !resolution.used_primary {
+                    debug!(
+                        chain = ?resolution.resolved,
+                        "ContextCompressor: using auxiliary chain for summarisation"
+                    );
+                    resolution.driver
+                } else {
+                    driver.clone()
+                }
+            }
+            None => driver.clone(),
+        };
+        let driver = summariser_driver;
         let mut current = messages;
         let mut events = Vec::new();
 

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -13,6 +13,7 @@ pub mod agent_loop;
 pub mod apply_patch;
 pub mod audit;
 pub mod auth_cooldown;
+pub mod aux_client;
 pub mod browser;
 pub mod catalog_sync;
 pub mod channel_registry;

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -988,7 +988,17 @@ pub struct FallbackProviderConfig {
 /// agent's provider list. See `librefang_runtime::aux_client` for the
 /// resolution algorithm and the published default chains.
 #[derive(
-    Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, schemars::JsonSchema,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum AuxTask {

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -1,7 +1,7 @@
 //! All configuration struct and enum type definitions, including Default impls and associated helper functions.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use super::serde_helpers::{deserialize_string_or_int_vec, OneOrMany};
@@ -979,6 +979,104 @@ pub struct FallbackProviderConfig {
     /// Base URL override (uses catalog default if None).
     #[serde(default)]
     pub base_url: Option<String>,
+}
+
+/// Side-task category for the auxiliary LLM client.
+///
+/// Each variant maps to a separate fallback chain in `[llm.auxiliary]` so
+/// users can pick a cheap model per task without polluting the primary
+/// agent's provider list. See `librefang_runtime::aux_client` for the
+/// resolution algorithm and the published default chains.
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum AuxTask {
+    /// LLM-driven context compression (history summarisation).
+    Compression,
+    /// Session / trajectory title generation.
+    Title,
+    /// Search-result summarisation.
+    Search,
+    /// Image / video / vision-capable description.
+    Vision,
+    /// Browser-tool vision-driven page understanding.
+    BrowserVision,
+}
+
+impl AuxTask {
+    /// Stable string slug used in TOML and logs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AuxTask::Compression => "compression",
+            AuxTask::Title => "title",
+            AuxTask::Search => "search",
+            AuxTask::Vision => "vision",
+            AuxTask::BrowserVision => "browser_vision",
+        }
+    }
+}
+
+impl std::fmt::Display for AuxTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Auxiliary LLM client configuration — one cheap-tier fallback chain per
+/// side task.
+///
+/// Each entry is a list of `provider:model` references resolved in order
+/// against the user's already-configured credentials. A task with no entries
+/// (or whose entries cannot be initialised because the relevant API keys are
+/// missing) silently falls back to the primary driver — the auxiliary client
+/// is purely a routing optimisation, never a permission gate.
+///
+/// ```toml
+/// [llm.auxiliary]
+/// compression    = ["openrouter:anthropic/claude-3-5-haiku", "anthropic:haiku"]
+/// title          = ["openrouter:meta-llama/llama-3.1-8b-instruct", "groq:llama-3.1-8b-instant"]
+/// search         = ["openrouter:anthropic/claude-3-5-haiku", "openai:gpt-4o-mini"]
+/// vision         = ["anthropic:sonnet", "openai:gpt-4o-mini"]
+/// browser_vision = ["anthropic:sonnet", "openai:gpt-4o-mini"]
+/// ```
+///
+/// Uses `BTreeMap` rather than `HashMap` so serialised output is
+/// deterministic (see issue #3298).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct AuxiliaryConfig {
+    /// Per-task ordered chain of `provider:model` references.
+    pub tasks: BTreeMap<AuxTask, Vec<String>>,
+}
+
+impl AuxiliaryConfig {
+    /// Build an empty config (every task falls back to the primary driver).
+    pub fn empty() -> Self {
+        Self {
+            tasks: BTreeMap::new(),
+        }
+    }
+
+    /// Lookup the configured chain for `task`, if any.
+    pub fn chain_for(&self, task: AuxTask) -> Option<&[String]> {
+        self.tasks.get(&task).map(|v| v.as_slice())
+    }
+
+    /// Whether this config has any user-supplied entries.
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+}
+
+/// Top-level `[llm]` section. Currently only carries `auxiliary` — primary
+/// driver configuration still lives in `[default_model]` / `[[fallback_providers]]`
+/// so this struct exists purely to namespace future LLM-routing knobs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct LlmConfig {
+    /// Per-task auxiliary fallback chains. See [`AuxiliaryConfig`].
+    pub auxiliary: AuxiliaryConfig,
 }
 
 /// Text-to-speech configuration.
@@ -2506,6 +2604,10 @@ pub struct KernelConfig {
     /// Configure in config.toml as `[[fallback_providers]]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fallback_providers: Vec<FallbackProviderConfig>,
+    /// `[llm]` section — currently carries the auxiliary side-task chain
+    /// configuration. See [`LlmConfig`] / [`AuxiliaryConfig`].
+    #[serde(default)]
+    pub llm: LlmConfig,
     /// Browser automation configuration.
     #[serde(default)]
     pub browser: BrowserConfig,
@@ -4513,6 +4615,7 @@ impl Default for KernelConfig {
             stable_prefix_mode: false,
             web: WebConfig::default(),
             fallback_providers: Vec::new(),
+            llm: LlmConfig::default(),
             browser: BrowserConfig::default(),
             extensions: ExtensionsConfig::default(),
             skills: SkillsConfig::default(),


### PR DESCRIPTION
## Summary

Closes #3314.

Side tasks in LibreFang (context compression, session-title generation, search summarisation, vision captioning, browser-vision page understanding) historically run on the **same model the agent is configured with**. Two pain points:

- A user running Opus pays Opus rates to summarise their conversation history into a 4 k blurb.
- A user running a tiny local model has no fallback when compression demands more capability than `qwen:0.5b` can provide.

This PR introduces an **auxiliary LLM client** that resolves a per-task `FallbackChain` composed of cheap-tier providers declared in `[llm.auxiliary]`. The same `FallbackChain` engine that powers the primary path (rate-limit retries, credit-exhaustion failover, auth-error skip) is reused — there is **no new fallback engine**, only a new chain composition rule.

### Resolution algorithm

1. Look up `[llm.auxiliary]` for `task` in `AuxiliaryConfig`.
2. If empty, fall back to a built-in published default chain.
3. For each `provider:model` reference, attempt to construct a driver against the user's already-configured credentials. Skip silently when credentials are missing — same behaviour as `create_driver` elsewhere.
4. If every entry was skipped, fall through to the primary driver. **The aux client is a routing optimisation, never a permission gate.**

### Wiring

- `LoopOptions.aux_client: Option<Arc<AuxClient>>` plumbs the resolver into the agent loop.
- `ContextCompressor::compress_if_needed_with_aux` is the new aux-aware entrypoint; legacy `compress_if_needed` is preserved as a thin wrapper passing `None`, keeping baseline behaviour for callers that haven't updated.
- Kernel stores the `AuxClient` in an `ArcSwap` so `config_reload` can rebuild on `[llm.auxiliary]` edits without invalidating long-lived `Arc<Kernel>` handles.
- All 4 `LoopOptions` builders in `kernel/mod.rs` (the central `execute_llm_agent`, fork path, channel path, ephemeral migrate path) wire the field.

### Cost accounting

Aux calls flow through the same driver objects the kernel constructed via `create_driver` — the metering layer sees them. The aux client never bypasses the billing pipeline, it just picks a cheaper model.

### New types

- `AuxTask` enum: `Compression` / `Title` / `Search` / `Vision` / `BrowserVision` (snake_case in TOML).
- `AuxiliaryConfig`: cheap-tier fallback chain per task.

## Test plan

- [x] `cargo build --workspace --lib` (local)
- [ ] `cargo test --workspace` (CI)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (CI)
- [ ] Live integration: start daemon with `[llm.auxiliary]` configured, send long message, confirm compression hits aux chain via tracing.
- [ ] Live integration: start daemon **without** `[llm.auxiliary]`, confirm summarisation still works via primary driver (baseline preserved).
