### PR TITLE
feat(dashboard): push-style drawer that adapts main content width

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -41,6 +41,7 @@ import {
 } from "lucide-react";
 import { useUIStore } from "./lib/store";
 import { CommandPalette, useCommandPalette } from "./components/ui/CommandPalette";
+import { PushDrawer } from "./components/ui/PushDrawer";
 import { ShortcutsHelp } from "./components/ui/ShortcutsHelp";
 import { useKeyboardShortcuts } from "./lib/useKeyboardShortcuts";
 import { changePassword, checkDashboardAuthMode, clearApiKey, dashboardLogin, dashboardLogout, getDashboardUsername, getStatus, getVersionInfo, setApiKey, setOnUnauthorized, verifyStoredAuth, type AuthMode } from "./api";
@@ -817,6 +818,8 @@ export function App() {
           )}
         </main>
       </div>
+
+      <PushDrawer />
 
       <CommandPalette isOpen={isPaletteOpen} onClose={() => setPaletteOpen(false)} />
       <ShortcutsHelp isOpen={showShortcuts} onClose={() => setShowShortcuts(false)} />

--- a/crates/librefang-api/dashboard/src/components/TaintPolicyEditor.tsx
+++ b/crates/librefang-api/dashboard/src/components/TaintPolicyEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from "../api";
 import { useUpdateMcpTaintPolicy } from "../lib/mutations/mcp";
 import { useMcpTaintRules } from "../lib/queries/mcp";
-import { Modal } from "./ui/Modal";
+import { DrawerPanel } from "./ui/DrawerPanel";
 import { Button } from "./ui/Button";
 import { Badge } from "./ui/Badge";
 import { Input } from "./ui/Input";
@@ -160,12 +160,11 @@ export function TaintPolicyEditor({
   }, [tools, scanning, mutation, server, addToast, onClose, t]);
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={isOpen}
       onClose={onClose}
       title={t("mcp.taint_policy_title", "Taint policy — {{name}}", { name: server.name })}
       size="3xl"
-      variant="panel-right"
     >
       <div className="flex flex-col gap-4 p-4 overflow-y-auto">
         {/* Server-level scanning toggle */}
@@ -260,7 +259,7 @@ export function TaintPolicyEditor({
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useDrawerStore, type DrawerSize } from "../../lib/drawerStore";
+
+export interface DrawerPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  /** Width cap on lg+. Defaults to "md". */
+  size?: DrawerSize;
+  /** Hide the default header X button (e.g. when the body supplies its own). */
+  hideCloseButton?: boolean;
+  children: ReactNode;
+}
+
+// Drop-in replacement for `<Modal variant="panel-right">`. Pushes its
+// `children` into the global `<PushDrawer>` slot in App.tsx instead of
+// rendering as a fixed overlay, so the main content adapts (like the
+// sidebar collapse) instead of being covered.
+//
+// Sync model:
+//   1. While `isOpen`, push content (incl. children) to the store on every
+//      render — keeps the slot in sync with parent state changes.
+//   2. PushDrawer dismissals (Esc, X, mobile backdrop) call `store.close()`.
+//      The watcher below detects the external close while we still think
+//      `isOpen=true` and calls `props.onClose()` so the parent flips its
+//      own state. Single source of close-callback firing.
+//   3. Unmount while open → close the store, so a body referencing this
+//      page's local state never lingers in the global slot.
+export function DrawerPanel({
+  isOpen,
+  onClose,
+  title,
+  size = "md",
+  hideCloseButton,
+  children,
+}: DrawerPanelProps) {
+  const open = useDrawerStore((s) => s.open);
+  const close = useDrawerStore((s) => s.close);
+  const drawerOpen = useDrawerStore((s) => s.isOpen);
+
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  // Push children into the slot whenever we're open. Re-runs on every
+  // re-render that changes any of the deps — including `children`, which
+  // gets a fresh identity each render. That's intended: the body should
+  // mirror the parent's current state.
+  useEffect(() => {
+    if (!isOpen) return;
+    open({
+      title,
+      size,
+      hideCloseButton,
+      body: children,
+      onClose: () => onCloseRef.current(),
+    });
+  }, [isOpen, title, size, hideCloseButton, children, open]);
+
+  // External close → bubble up to the parent so it can flip its state.
+  useEffect(() => {
+    if (isOpen && !drawerOpen) {
+      onCloseRef.current();
+    }
+  }, [drawerOpen, isOpen]);
+
+  // Cleanup on unmount.
+  useEffect(
+    () => () => {
+      if (isOpen) close();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return null;
+}

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import { useDrawerStore, type DrawerSize } from "../../lib/drawerStore";
@@ -7,60 +7,84 @@ const DESKTOP_WIDTH: Record<DrawerSize, string> = {
   sm: "lg:w-[360px]",
   md: "lg:w-[480px]",
   lg: "lg:w-[640px]",
-  xl: "lg:w-[800px]",
+  xl: "lg:w-[720px]",
+  "2xl": "lg:w-[800px]",
+  "3xl": "lg:w-[960px]",
+  "4xl": "lg:w-[1100px]",
+  "5xl": "lg:w-[1280px]",
 };
 
-// Push-style global drawer. Renders as a flex sibling of the main column in
-// App.tsx — its width animates from 0 → target so the main content shrinks
-// instead of being overlaid (mirrors the left sidebar's collapse behaviour).
+const MIN_WIDTH: Record<DrawerSize, string> = {
+  sm: "lg:min-w-[360px]",
+  md: "lg:min-w-[480px]",
+  lg: "lg:min-w-[640px]",
+  xl: "lg:min-w-[720px]",
+  "2xl": "lg:min-w-[800px]",
+  "3xl": "lg:min-w-[960px]",
+  "4xl": "lg:min-w-[1100px]",
+  "5xl": "lg:min-w-[1280px]",
+};
+
+// Push-style global drawer host. Renders as a flex sibling of the main
+// column in App.tsx — its width animates from 0 → target so the main
+// content shrinks to make room (mirrors the left sidebar's collapse).
 //
 // Two presentations from the same store:
-//   - lg+ : push slot (animated width)
-//   - <lg : fullscreen overlay, since push doesn't fit on narrow viewports
+//   - lg+ : push slot, animated width
+//   - <lg : fullscreen overlay sheet, since push doesn't fit on narrow
+//           viewports. Backdrop click + Esc both dismiss.
 export function PushDrawer() {
   const { t } = useTranslation();
   const isOpen = useDrawerStore((s) => s.isOpen);
   const content = useDrawerStore((s) => s.content);
-  const closeDrawer = useDrawerStore((s) => s.closeDrawer);
+  const close = useDrawerStore((s) => s.close);
+
+  // Single dismissal path — DrawerPanel observes the store flip and calls
+  // its own onClose to keep parent state in sync. We don't fire content
+  // .onClose here directly; the store-flip-watcher in DrawerPanel does
+  // that, so closing twice (e.g. Esc then click X mid-frame) doesn't
+  // double-fire the callback.
+  const triggerClose = useCallback(() => close(), [close]);
 
   useEffect(() => {
     if (!isOpen) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeDrawer();
+      if (e.key === "Escape") triggerClose();
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [isOpen, closeDrawer]);
+  }, [isOpen, triggerClose]);
 
   const size: DrawerSize = content?.size ?? "md";
   const desktopWidth = isOpen ? DESKTOP_WIDTH[size] : "lg:w-0";
+  const minWidth = MIN_WIDTH[size];
 
-  const header = (
+  const header = !content?.hideCloseButton ? (
     <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
       {content?.title ? (
         <h3 className="text-sm font-bold tracking-tight truncate">{content.title}</h3>
       ) : <span />}
       <button
-        onClick={closeDrawer}
+        onClick={triggerClose}
         className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
         aria-label={t("common.close", { defaultValue: "Close" })}
       >
         <X className="h-3.5 w-3.5" />
       </button>
     </div>
-  );
+  ) : null;
 
   return (
     <>
-      {/* Desktop push slot — flex sibling of main column. The inner wrapper
-          keeps a fixed min-width so content doesn't reflow as the outer
+      {/* Desktop push slot. The aside owns the collapsing width; the inner
+          wrapper has a min-width so content doesn't reflow as the outer
           width animates between 0 and target. */}
       <aside
         className={`hidden lg:flex shrink-0 ${desktopWidth} flex-col border-l border-border-subtle bg-surface overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
         aria-hidden={!isOpen}
       >
         {content && (
-          <div className={`flex flex-col h-full ${size === "sm" ? "min-w-[360px]" : size === "md" ? "min-w-[480px]" : size === "lg" ? "min-w-[640px]" : "min-w-[800px]"}`}>
+          <div className={`flex flex-col h-full ${minWidth}`}>
             {header}
             <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">
               {content.body}
@@ -69,12 +93,11 @@ export function PushDrawer() {
         )}
       </aside>
 
-      {/* Mobile overlay fallback — push doesn't fit on narrow viewports, so
-          fall back to a fullscreen sheet. Backdrop closes on click. */}
+      {/* Mobile overlay fallback. Backdrop closes on click. */}
       {isOpen && content && (
         <div
           className="fixed inset-0 z-50 lg:hidden bg-black/40 backdrop-blur-sm flex items-stretch justify-end"
-          onClick={closeDrawer}
+          onClick={triggerClose}
         >
           <div
             className="w-full bg-surface flex flex-col"

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+import { useDrawerStore, type DrawerSize } from "../../lib/drawerStore";
+
+const DESKTOP_WIDTH: Record<DrawerSize, string> = {
+  sm: "lg:w-[360px]",
+  md: "lg:w-[480px]",
+  lg: "lg:w-[640px]",
+  xl: "lg:w-[800px]",
+};
+
+// Push-style global drawer. Renders as a flex sibling of the main column in
+// App.tsx — its width animates from 0 → target so the main content shrinks
+// instead of being overlaid (mirrors the left sidebar's collapse behaviour).
+//
+// Two presentations from the same store:
+//   - lg+ : push slot (animated width)
+//   - <lg : fullscreen overlay, since push doesn't fit on narrow viewports
+export function PushDrawer() {
+  const { t } = useTranslation();
+  const isOpen = useDrawerStore((s) => s.isOpen);
+  const content = useDrawerStore((s) => s.content);
+  const closeDrawer = useDrawerStore((s) => s.closeDrawer);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDrawer();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, closeDrawer]);
+
+  const size: DrawerSize = content?.size ?? "md";
+  const desktopWidth = isOpen ? DESKTOP_WIDTH[size] : "lg:w-0";
+
+  const header = (
+    <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
+      {content?.title ? (
+        <h3 className="text-sm font-bold tracking-tight truncate">{content.title}</h3>
+      ) : <span />}
+      <button
+        onClick={closeDrawer}
+        className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
+        aria-label={t("common.close", { defaultValue: "Close" })}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Desktop push slot — flex sibling of main column. The inner wrapper
+          keeps a fixed min-width so content doesn't reflow as the outer
+          width animates between 0 and target. */}
+      <aside
+        className={`hidden lg:flex shrink-0 ${desktopWidth} flex-col border-l border-border-subtle bg-surface overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
+        aria-hidden={!isOpen}
+      >
+        {content && (
+          <div className={`flex flex-col h-full ${size === "sm" ? "min-w-[360px]" : size === "md" ? "min-w-[480px]" : size === "lg" ? "min-w-[640px]" : "min-w-[800px]"}`}>
+            {header}
+            <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">
+              {content.body}
+            </div>
+          </div>
+        )}
+      </aside>
+
+      {/* Mobile overlay fallback — push doesn't fit on narrow viewports, so
+          fall back to a fullscreen sheet. Backdrop closes on click. */}
+      {isOpen && content && (
+        <div
+          className="fixed inset-0 z-50 lg:hidden bg-black/40 backdrop-blur-sm flex items-stretch justify-end"
+          onClick={closeDrawer}
+        >
+          <div
+            className="w-full bg-surface flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {header}
+            <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">
+              {content.body}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./Button";
-import { Modal } from "./Modal";
+import { DrawerPanel } from "./DrawerPanel";
 
 type ScheduleType = "interval_min" | "interval_hour" | "daily" | "weekday" | "weekly" | "monthly" | "custom";
 
@@ -193,7 +193,7 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} variant="panel-right" size="xl" hideCloseButton>
+    <DrawerPanel isOpen={isOpen} onClose={onClose} size="xl" hideCloseButton>
       {/* Header — kept inline so the optional subtitle line renders below
           the title; Modal's built-in title bar only takes a string. */}
       <div className="p-5 pb-3 border-b border-border-subtle">
@@ -313,6 +313,6 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
           <Button variant="primary" className="flex-1" onClick={() => onSave(previewCron, timezone)} disabled={!cronValid}>{t("common.save")}</Button>
           <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
         </div>
-    </Modal>
+    </DrawerPanel>
   );
 }

--- a/crates/librefang-api/dashboard/src/lib/drawerStore.ts
+++ b/crates/librefang-api/dashboard/src/lib/drawerStore.ts
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { create } from "zustand";
+
+export type DrawerSize = "sm" | "md" | "lg" | "xl";
+
+export interface DrawerContent {
+  title?: string;
+  size?: DrawerSize;
+  body: ReactNode;
+}
+
+interface DrawerState {
+  isOpen: boolean;
+  content: DrawerContent | null;
+  openDrawer: (content: DrawerContent) => void;
+  closeDrawer: () => void;
+}
+
+// Single global push-drawer slot. Page components call openDrawer with the
+// body to show; the slot in App.tsx is a flex sibling of the main column,
+// so its width animation pushes the main content like the sidebar collapse
+// instead of overlaying it. Only one drawer can be open at a time — opening
+// a new one replaces whatever was there. See PushDrawer.tsx for the host.
+export const useDrawerStore = create<DrawerState>((set) => ({
+  isOpen: false,
+  content: null,
+  openDrawer: (content) => set({ isOpen: true, content }),
+  closeDrawer: () => set({ isOpen: false }),
+}));

--- a/crates/librefang-api/dashboard/src/lib/drawerStore.ts
+++ b/crates/librefang-api/dashboard/src/lib/drawerStore.ts
@@ -1,29 +1,36 @@
 import type { ReactNode } from "react";
 import { create } from "zustand";
 
-export type DrawerSize = "sm" | "md" | "lg" | "xl";
+export type DrawerSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl";
 
 export interface DrawerContent {
   title?: string;
   size?: DrawerSize;
+  hideCloseButton?: boolean;
   body: ReactNode;
+  /** Called when the drawer is dismissed via Esc / X / mobile backdrop.
+   *  Parents typically use this to flip their own `isOpen` state. */
+  onClose?: () => void;
 }
 
 interface DrawerState {
   isOpen: boolean;
   content: DrawerContent | null;
-  openDrawer: (content: DrawerContent) => void;
-  closeDrawer: () => void;
+  open: (content: DrawerContent) => void;
+  close: () => void;
 }
 
-// Single global push-drawer slot. Page components call openDrawer with the
-// body to show; the slot in App.tsx is a flex sibling of the main column,
-// so its width animation pushes the main content like the sidebar collapse
-// instead of overlaying it. Only one drawer can be open at a time — opening
-// a new one replaces whatever was there. See PushDrawer.tsx for the host.
+// Single global push-drawer slot. The `<DrawerPanel>` adapter is the primary
+// caller — it pushes its `children` here on every render so the slot stays
+// in sync with parent state. The `<PushDrawer>` host in App.tsx is a flex
+// sibling of the main column, so its width animation pushes the main
+// content like the sidebar collapse instead of overlaying it.
+//
+// Only one drawer can be open at a time. Opening a new one replaces
+// whatever was there.
 export const useDrawerStore = create<DrawerState>((set) => ({
   isOpen: false,
   content: null,
-  openDrawer: (content) => set({ isOpen: true, content }),
-  closeDrawer: () => set({ isOpen: false }),
+  open: (content) => set({ isOpen: true, content }),
+  close: () => set({ isOpen: false }),
 }));

--- a/crates/librefang-api/dashboard/src/pages/A2APage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.tsx
@@ -7,7 +7,7 @@ import { useA2AAgents } from "../lib/queries/network";
 import { useDiscoverA2AAgent } from "../lib/mutations/network";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { Badge } from "../components/ui/Badge";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -208,13 +208,11 @@ export function A2APage() {
 
           {/* Send task panel */}
           {taskAgent && (
-            <Modal
+            <DrawerPanel
               isOpen
               onClose={() => setTaskAgent(null)}
-              variant="panel-right"
               size="lg"
               title={t("a2a.send_task")}
-              zIndex={200}
             >
               <div className="p-5 space-y-4">
                 <p className="text-xs text-text-dim">
@@ -244,7 +242,7 @@ export function A2APage() {
                   </button>
                 </div>
               </div>
-            </Modal>
+            </DrawerPanel>
           )}
 
           {/* Tracked tasks */}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -20,7 +20,7 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { MultiSelectCmdk } from "../components/ui/MultiSelectCmdk";
 import { Card } from "../components/ui/Card";
@@ -776,9 +776,6 @@ export function AgentsPage() {
         const activeConfigMutation = detailAgent.is_hand
           ? patchHandAgentRuntimeConfigMutation
           : patchAgentConfigMutation;
-        // Hold backdrop dismissal during edit-in-flight so a stray click
-        // doesn't close the modal mid-PATCH and still toast "Agent renamed".
-        const lockBackdropDismiss = editingName || patchAgentMutation.isPending;
         const saveModelDisabled =
           activeConfigMutation.isPending
           || !modelDraft.provider.trim()
@@ -789,13 +786,11 @@ export function AgentsPage() {
           || parseFloat(modelDraft.temperature) < 0
           || parseFloat(modelDraft.temperature) > 2;
         return (
-        <Modal
+        <DrawerPanel
           isOpen
           onClose={closeDetailModal}
-          variant="drawer-right"
           size="xl"
           hideCloseButton
-          disableBackdropClose={lockBackdropDismiss}
         >
             {/* Header — sticky, identity + state. */}
             <div className="px-6 py-4 border-b border-border-subtle sticky top-0 bg-surface z-10">
@@ -1253,13 +1248,13 @@ export function AgentsPage() {
                 {t("agents.prompts")}
               </Button>
             </div>
-        </Modal>
+        </DrawerPanel>
         );
       })()}
 
       {/* Tools Editor Modal */}
       {showToolsEditor && toolsEditorAgentId && (
-        <Modal isOpen={showToolsEditor} onClose={closeToolsEditor} title={t("agents.tools_editor_title", { defaultValue: "Agent Tools" })} size="lg" zIndex={60} overflowVisible variant="panel-right">
+        <DrawerPanel isOpen={showToolsEditor} onClose={closeToolsEditor} title={t("agents.tools_editor_title", { defaultValue: "Agent Tools" })} size="lg">
           <div className="p-6 space-y-5">
             <div>
               <p className="text-[11px] text-text-dim/70">
@@ -1403,16 +1398,15 @@ export function AgentsPage() {
               </div>
             </div>
           </div>
-        </Modal>
+        </DrawerPanel>
       )}
 
       {/* Create Agent Modal */}
-      <Modal
+      <DrawerPanel
         isOpen={showCreate}
         onClose={closeCreateModal}
         title={t("agents.create_agent")}
         size="2xl"
-        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {/* Mode tabs — switching between Form and TOML round-trips the
@@ -1670,7 +1664,7 @@ export function AgentsPage() {
             <Button variant="secondary" onClick={closeCreateModal}>{t("common.cancel")}</Button>
           </div>
         </div>
-      </Modal>
+      </DrawerPanel>
 
       {/* Prompts & Experiments Modal */}
       {showPrompts && detailAgent && (

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -52,6 +52,7 @@ import { Select } from "../components/ui/Select";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useAuditQuery } from "../lib/queries/audit";
 import { useChannels } from "../lib/queries/channels";
 import { ApiError } from "../lib/http/errors";
@@ -765,12 +766,11 @@ export function AuditPage() {
           live, the operator commits via Apply. The dim backdrop
           signals that and gives Esc / click-outside as the standard
           dismiss paths. */}
-      <Modal
+      <DrawerPanel
         isOpen={filtersOpen}
         onClose={() => setFiltersOpen(false)}
         title={t("audit.filters")}
         size="md"
-        variant="panel-right"
       >
         <form
           onSubmit={(e) => {
@@ -898,7 +898,7 @@ export function AuditPage() {
             </Button>
           </div>
         </form>
-      </Modal>
+      </DrawerPanel>
 
       {isForbidden && (
         <Card padding="lg">

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -26,7 +26,7 @@ import "@xyflow/react/dist/style.css";
 import { listAgents, listWorkflows, getWorkflow, createSchedule, type AgentItem, type WorkflowItem, type WorkflowTemplate as ApiWorkflowTemplate, type DryRunResult, type WorkflowStepResult } from "../api";
 import { Card } from "../components/ui/Card";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { InlineEmpty } from "../components/ui/InlineEmpty";
@@ -332,7 +332,7 @@ function TemplateBrowser({
   };
 
   return (
-    <Modal isOpen onClose={onClose} variant="panel-right" size="2xl" hideCloseButton>
+    <DrawerPanel isOpen onClose={onClose} size="2xl" hideCloseButton>
         {/* Header — matches the existing inline icon + custom X. */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle sticky top-0 bg-surface z-10">
           <div className="flex items-center gap-2">
@@ -447,7 +447,7 @@ function TemplateBrowser({
             )}
           </div>
         )}
-    </Modal>
+    </DrawerPanel>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -13,7 +13,7 @@ import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import {
   Network, Search, CheckCircle2, XCircle, ChevronRight, X, Grid3X3, List,
   Settings, Key, Clock, AlertCircle, CheckSquare, Square,
@@ -177,7 +177,7 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
   t: (key: string) => string
 }) {
   return (
-    <Modal isOpen onClose={onClose} variant="drawer-right" size="lg" hideCloseButton>
+    <DrawerPanel isOpen onClose={onClose} size="lg" hideCloseButton>
         {/* Coloured strip + custom header are kept inline so the
             configured/unconfigured stripe still renders. */}
         <div className={`h-2 bg-linear-to-r ${channel.configured ? "from-success via-success/60 to-success/30" : "from-brand via-brand/60 to-brand/30"}`} />
@@ -310,7 +310,7 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
         <div className="p-4 border-t border-border-subtle flex justify-end">
           <Button variant="ghost" onClick={onClose}>{t("common.close")}</Button>
         </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -369,7 +369,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
   };
 
   return (
-    <Modal isOpen onClose={onClose} variant="panel-right" size="md" hideCloseButton>
+    <DrawerPanel isOpen onClose={onClose} size="md" hideCloseButton>
         <div className="px-6 py-5 border-b border-border-subtle">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -450,7 +450,7 @@ function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () =
           </Button>
         </div>
         </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -539,7 +539,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
   useEffect(() => { startQr(); }, [startQr]);
 
   return (
-    <Modal isOpen onClose={onClose} variant="panel-right" size="md" hideCloseButton>
+    <DrawerPanel isOpen onClose={onClose} size="md" hideCloseButton>
         <div className="px-6 py-5 border-b border-border-subtle">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -587,7 +587,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
         <div className="p-4 border-t border-border-subtle flex justify-end">
           <Button variant="ghost" onClick={onClose}>{t("common.close")}</Button>
         </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -57,7 +57,7 @@ import {
 } from "../lib/mutations/hands";
 import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule } from "../lib/mutations/schedules";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useCronJobs } from "../lib/queries/runtime";
 
 
@@ -140,7 +140,7 @@ function HandDetailPanel({
 
   return (
     <>
-      <Modal isOpen onClose={onClose} variant="drawer-right" size="2xl" hideCloseButton>
+      <DrawerPanel isOpen onClose={onClose} size="2xl" hideCloseButton>
         {/* Hero header — sticky inside the drawer's single scroll container
             so identity + close stay reachable on long detail content. */}
         <div className="px-6 py-5 border-b border-border-subtle sticky top-0 bg-surface z-10">
@@ -293,7 +293,7 @@ function HandDetailPanel({
               settingsQuery={settingsQuery}
             />
         </div>
-      </Modal>
+      </DrawerPanel>
       <Suspense fallback={null}>
         <TomlViewer
           isOpen={showManifest}

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -20,7 +20,7 @@ import { Badge } from "../components/ui/Badge";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { Input } from "../components/ui/Input";
 import { useUIStore } from "../lib/store";
@@ -1131,12 +1131,11 @@ export function McpServersPage() {
       )}
 
       {/* Add / Edit Modal */}
-      <Modal
+      <DrawerPanel
         isOpen={isModalOpen}
         onClose={() => { setShowAddModal(false); setEditingServer(null); setForm(defaultForm); }}
         title={editingServer ? t("mcp.edit_server") : t("mcp.add_server")}
         size="lg"
-        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {/* Name */}
@@ -1261,15 +1260,14 @@ export function McpServersPage() {
             </Button>
           </div>
         </div>
-      </Modal>
+      </DrawerPanel>
 
       {/* Catalog env setup modal */}
-      <Modal
+      <DrawerPanel
         isOpen={!!installingTemplate}
         onClose={() => { setInstallingTemplate(null); setEnvInputs({}); }}
         title={t("mcp.env_setup_title", { name: installingTemplate?.name ?? "" })}
         size="md"
-        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           <p className="text-xs text-text-dim">{t("mcp.env_setup_desc")}</p>
@@ -1313,7 +1311,7 @@ export function McpServersPage() {
             </Button>
           </div>
         </div>
-      </Modal>
+      </DrawerPanel>
 
       {/* Delete confirmation */}
       <ConfirmDialog

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -14,7 +14,7 @@ import { Badge } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { Database, Search, Trash2, Plus, X, Sparkles, Zap, Clock, Edit2, Loader2, Settings } from "lucide-react";
@@ -36,7 +36,7 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.add_memory")} size="md" variant="panel-right">
+    <DrawerPanel isOpen={true} onClose={onClose} title={t("memory.add_memory")} size="md">
       <div className="p-4 sm:p-6">
         <div className="space-y-4">
           <div>
@@ -83,7 +83,7 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -102,7 +102,7 @@ function EditMemoryDialog({ memory, onClose }: { memory: { id: string; content?:
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.edit_memory")} size="md" variant="panel-right">
+    <DrawerPanel isOpen={true} onClose={onClose} title={t("memory.edit_memory")} size="md">
       <div className="p-4 sm:p-6">
         <div>
           <label className="text-xs font-bold text-text-dim mb-1 block">{t("memory.content")}</label>
@@ -121,7 +121,7 @@ function EditMemoryDialog({ memory, onClose }: { memory: { id: string; content?:
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -219,7 +219,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   const labelCls = "text-[10px] font-bold uppercase tracking-widest text-text-dim mb-1 block";
 
   return (
-    <Modal isOpen={true} onClose={onClose} title={t("memory.config_title", { defaultValue: "Memory Configuration" })} size="lg" variant="panel-right">
+    <DrawerPanel isOpen={true} onClose={onClose} title={t("memory.config_title", { defaultValue: "Memory Configuration" })} size="lg">
       <p className="text-xs text-text-dim -mt-2 mb-4">{t("memory.config_desc", { defaultValue: "Changes are written to config.toml. Restart required for full effect." })}</p>
 
       {configQuery.isLoading || !form ? (
@@ -307,7 +307,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
         </Button>
         <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -11,10 +11,9 @@ import { Input } from "../components/ui/Input";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { useUIStore } from "../lib/store";
-import { useDrawerStore } from "../lib/drawerStore";
 import {
   Cpu, Search, Check, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2,
   Brain, Tag, Settings,
@@ -424,51 +423,7 @@ export function ModelsPage() {
     }
   };
 
-  // Mirror detailModel into the global push-drawer slot. Two-way sync:
-  //   1. detailModel set → openDrawer with the body for that model
-  //   2. detailModel cleared → closeDrawer
-  //   3. drawer closed externally (Esc / close button) → clear detailModel
-  // The body re-renders on hiddenSet changes via the inline `hidden` prop —
-  // re-pushed each time hiddenSet flips.
-  const openDrawer = useDrawerStore((s) => s.openDrawer);
-  const closeDrawer = useDrawerStore((s) => s.closeDrawer);
-  const isDrawerOpen = useDrawerStore((s) => s.isOpen);
   const detailHidden = detailModel ? hiddenSet.has(modelKey(detailModel)) : false;
-
-  useEffect(() => {
-    if (!detailModel) {
-      closeDrawer();
-      return;
-    }
-    openDrawer({
-      title: detailModel.display_name || detailModel.id,
-      size: "md",
-      body: (
-        <ModelDetailBody
-          m={detailModel}
-          hidden={detailHidden}
-          onOpenSettings={() => {
-            setSettingsModel(detailModel);
-            setDetailModel(null);
-          }}
-          onToggleHidden={() => {
-            toggleHidden(detailModel);
-            setDetailModel(null);
-          }}
-        />
-      ),
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [detailModel, detailHidden]);
-
-  useEffect(() => {
-    if (!isDrawerOpen && detailModel) setDetailModel(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDrawerOpen]);
-
-  // Close drawer on unmount so a body referencing this page's local state
-  // never lingers in the global slot after navigating away.
-  useEffect(() => () => closeDrawer(), [closeDrawer]);
 
   const inputClass = "w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand";
 
@@ -590,12 +545,32 @@ export function ModelsPage() {
         </div>
       )}
 
-      {/* Detail drawer rendered via the global PushDrawer slot — see the
-          openDrawer effect above. The drawer pushes the main content
-          instead of overlaying it (mirrors the left sidebar). */}
+      {/* Detail drawer — pushes content via the global slot, mirroring
+          the sidebar collapse instead of overlaying the page. */}
+      <DrawerPanel
+        isOpen={!!detailModel}
+        onClose={() => setDetailModel(null)}
+        title={detailModel ? (detailModel.display_name || detailModel.id) : undefined}
+        size="md"
+      >
+        {detailModel && (
+          <ModelDetailBody
+            m={detailModel}
+            hidden={detailHidden}
+            onOpenSettings={() => {
+              setSettingsModel(detailModel);
+              setDetailModel(null);
+            }}
+            onToggleHidden={() => {
+              toggleHidden(detailModel);
+              setDetailModel(null);
+            }}
+          />
+        )}
+      </DrawerPanel>
 
       {/* Add Model Modal */}
-      <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg" variant="panel-right">
+      <DrawerPanel isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg">
         <form onSubmit={handleAdd} className="p-5 space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="sm:col-span-2">
@@ -653,7 +628,7 @@ export function ModelsPage() {
             <Button type="button" variant="secondary" onClick={() => resetForm()}>{t("common.cancel")}</Button>
           </div>
         </form>
-      </Modal>
+      </DrawerPanel>
 
       {/* Model Settings Modal */}
       {settingsModel && (
@@ -779,16 +754,16 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
 
   if (overridesQuery.isLoading) {
     return (
-      <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg" variant="panel-right">
+      <DrawerPanel isOpen onClose={onClose} title={t("models.settings_title")} size="lg">
         <div className="flex items-center justify-center p-12">
           <Loader2 className="w-6 h-6 animate-spin text-brand" />
         </div>
-      </Modal>
+      </DrawerPanel>
     );
   }
 
   return (
-    <Modal isOpen onClose={onClose} title={t("models.settings_title")} size="lg" variant="panel-right">
+    <DrawerPanel isOpen onClose={onClose} title={t("models.settings_title")} size="lg">
       <div className="p-5 space-y-5">
         {/* Model header */}
         <div className="flex items-center gap-3">
@@ -921,6 +896,6 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -14,6 +14,7 @@ import { EmptyState } from "../components/ui/EmptyState";
 import { Modal } from "../components/ui/Modal";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { useUIStore } from "../lib/store";
+import { useDrawerStore } from "../lib/drawerStore";
 import {
   Cpu, Search, Check, Eye, EyeOff, Wrench, Zap, AlertCircle, Lock, Plus, Trash2, Loader2,
   Brain, Tag, Settings,
@@ -165,6 +166,99 @@ function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pe
             </button>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ── ModelDetailBody ───────────────────────────────────────────────
+// Body rendered inside the global PushDrawer when a card is opened.
+// Reads hiddenSet from UIStore directly so the toggle button reflects
+// changes without re-pushing the whole drawer body to drawerStore.
+function ModelDetailBody({
+  m,
+  hidden,
+  onOpenSettings,
+  onToggleHidden,
+}: {
+  m: ModelItem;
+  hidden: boolean;
+  onOpenSettings: () => void;
+  onToggleHidden: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="p-5 space-y-4 text-sm">
+      <div>
+        <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_provider")}</div>
+        <div className="font-mono text-xs">{m.provider}/{m.id}</div>
+      </div>
+      {m.aliases && m.aliases.length > 0 && (
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.aliases")}</div>
+          <div className="flex flex-wrap gap-1">
+            {m.aliases.map((a) => (
+              <span key={a} className="px-2 py-0.5 rounded-md bg-main text-[10px] font-mono">{a}</span>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_tier")}</div>
+          {m.tier ? (
+            <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-bold uppercase ${tierClass(m.tier)}`}>
+              {t(`models.tier_${m.tier}`, { defaultValue: m.tier })}
+            </span>
+          ) : "—"}
+        </div>
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_context")}</div>
+          <span className="font-mono">{formatCtx(m.context_window)}</span>
+        </div>
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_input")}</div>
+          <span className="font-mono">${m.input_cost_per_m ?? 0} / M</span>
+        </div>
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_output")}</div>
+          <span className="font-mono">${m.output_cost_per_m ?? 0} / M</span>
+        </div>
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.max_output")}</div>
+          <span className="font-mono">{formatCtx(m.max_output_tokens)}</span>
+        </div>
+        <div>
+          <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.availability")}</div>
+          <span>{m.available ? <span className="text-success font-bold">●</span> : <span className="text-text-dim">○</span>} {m.available ? t("models.available") : t("models.no_key")}</span>
+        </div>
+      </div>
+      <div>
+        <div className="text-[10px] font-bold text-text-dim uppercase mb-1.5">{t("models.capabilities")}</div>
+        <div className="flex flex-wrap gap-2">
+          {([
+            ["tools", m.supports_tools, Wrench] as const,
+            ["vision", m.supports_vision, Eye] as const,
+            ["streaming", m.supports_streaming, Zap] as const,
+            ["thinking", m.supports_thinking, Brain] as const,
+          ]).map(([key, on, Icon]) => (
+            <span key={key} className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-[11px] font-bold ${
+              on ? "border-brand/30 bg-brand/10 text-brand" : "border-border-subtle text-text-dim/40"
+            }`}>
+              <Icon className="w-3 h-3" />
+              {t(`models.col_${key}`)}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-2 pt-2 border-t border-border-subtle/50">
+        <Button variant="primary" className="flex-1" onClick={onOpenSettings}>
+          <Settings className="w-4 h-4 mr-1.5" />
+          {t("models.settings_title")}
+        </Button>
+        <Button variant="secondary" onClick={onToggleHidden}>
+          {hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+        </Button>
       </div>
     </div>
   );
@@ -330,6 +424,52 @@ export function ModelsPage() {
     }
   };
 
+  // Mirror detailModel into the global push-drawer slot. Two-way sync:
+  //   1. detailModel set → openDrawer with the body for that model
+  //   2. detailModel cleared → closeDrawer
+  //   3. drawer closed externally (Esc / close button) → clear detailModel
+  // The body re-renders on hiddenSet changes via the inline `hidden` prop —
+  // re-pushed each time hiddenSet flips.
+  const openDrawer = useDrawerStore((s) => s.openDrawer);
+  const closeDrawer = useDrawerStore((s) => s.closeDrawer);
+  const isDrawerOpen = useDrawerStore((s) => s.isOpen);
+  const detailHidden = detailModel ? hiddenSet.has(modelKey(detailModel)) : false;
+
+  useEffect(() => {
+    if (!detailModel) {
+      closeDrawer();
+      return;
+    }
+    openDrawer({
+      title: detailModel.display_name || detailModel.id,
+      size: "md",
+      body: (
+        <ModelDetailBody
+          m={detailModel}
+          hidden={detailHidden}
+          onOpenSettings={() => {
+            setSettingsModel(detailModel);
+            setDetailModel(null);
+          }}
+          onToggleHidden={() => {
+            toggleHidden(detailModel);
+            setDetailModel(null);
+          }}
+        />
+      ),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailModel, detailHidden]);
+
+  useEffect(() => {
+    if (!isDrawerOpen && detailModel) setDetailModel(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDrawerOpen]);
+
+  // Close drawer on unmount so a body referencing this page's local state
+  // never lingers in the global slot after navigating away.
+  useEffect(() => () => closeDrawer(), [closeDrawer]);
+
   const inputClass = "w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm outline-none focus:border-brand";
 
   return (
@@ -450,84 +590,9 @@ export function ModelsPage() {
         </div>
       )}
 
-      {/* Detail drawer (preview before going into Settings) */}
-      {detailModel && (
-        <Modal isOpen onClose={() => setDetailModel(null)} title={detailModel.display_name || detailModel.id} size="md" variant="panel-right">
-          <div className="p-5 space-y-4 text-sm">
-            <div>
-              <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_provider")}</div>
-              <div className="font-mono text-xs">{detailModel.provider}/{detailModel.id}</div>
-            </div>
-            {detailModel.aliases && detailModel.aliases.length > 0 && (
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.aliases")}</div>
-                <div className="flex flex-wrap gap-1">
-                  {detailModel.aliases.map(a => (
-                    <span key={a} className="px-2 py-0.5 rounded-md bg-main text-[10px] font-mono">{a}</span>
-                  ))}
-                </div>
-              </div>
-            )}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_tier")}</div>
-                {detailModel.tier ? (
-                  <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-bold uppercase ${tierClass(detailModel.tier)}`}>
-                    {t(`models.tier_${detailModel.tier}`, { defaultValue: detailModel.tier })}
-                  </span>
-                ) : "—"}
-              </div>
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_context")}</div>
-                <span className="font-mono">{formatCtx(detailModel.context_window)}</span>
-              </div>
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_input")}</div>
-                <span className="font-mono">${detailModel.input_cost_per_m ?? 0} / M</span>
-              </div>
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_output")}</div>
-                <span className="font-mono">${detailModel.output_cost_per_m ?? 0} / M</span>
-              </div>
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.max_output")}</div>
-                <span className="font-mono">{formatCtx(detailModel.max_output_tokens)}</span>
-              </div>
-              <div>
-                <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.availability")}</div>
-                <span>{detailModel.available ? <span className="text-success font-bold">●</span> : <span className="text-text-dim">○</span>} {detailModel.available ? t("models.available") : t("models.no_key")}</span>
-              </div>
-            </div>
-            <div>
-              <div className="text-[10px] font-bold text-text-dim uppercase mb-1.5">{t("models.capabilities")}</div>
-              <div className="flex flex-wrap gap-2">
-                {([
-                  ["tools", detailModel.supports_tools, Wrench] as const,
-                  ["vision", detailModel.supports_vision, Eye] as const,
-                  ["streaming", detailModel.supports_streaming, Zap] as const,
-                  ["thinking", detailModel.supports_thinking, Brain] as const,
-                ]).map(([key, on, Icon]) => (
-                  <span key={key} className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-[11px] font-bold ${
-                    on ? "border-brand/30 bg-brand/10 text-brand" : "border-border-subtle text-text-dim/40"
-                  }`}>
-                    <Icon className="w-3 h-3" />
-                    {t(`models.col_${key}`)}
-                  </span>
-                ))}
-              </div>
-            </div>
-            <div className="flex gap-2 pt-2 border-t border-border-subtle/50">
-              <Button variant="primary" className="flex-1" onClick={() => { setSettingsModel(detailModel); setDetailModel(null); }}>
-                <Settings className="w-4 h-4 mr-1.5" />
-                {t("models.settings_title")}
-              </Button>
-              <Button variant="secondary" onClick={() => { toggleHidden(detailModel); setDetailModel(null); }}>
-                {hiddenSet.has(modelKey(detailModel)) ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-              </Button>
-            </div>
-          </div>
-        </Modal>
-      )}
+      {/* Detail drawer rendered via the global PushDrawer slot — see the
+          openDrawer effect above. The drawer pushes the main content
+          instead of overlaying it (mirrors the left sidebar). */}
 
       {/* Add Model Modal */}
       <Modal isOpen={showAdd} onClose={resetForm} title={t("models.add_custom_model")} size="lg" variant="panel-right">

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -15,7 +15,7 @@ import { Badge } from "../components/ui/Badge";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import {
@@ -331,7 +331,7 @@ export function PluginsPage() {
       )}
 
       {/* Install Modal */}
-      <Modal isOpen={showInstall} onClose={() => setShowInstall(false)} title={t("plugins.install_title")} size="md" variant="panel-right">
+      <DrawerPanel isOpen={showInstall} onClose={() => setShowInstall(false)} title={t("plugins.install_title")} size="md">
         <div className="p-5 space-y-4">
               {/* Source Tabs */}
               <div>
@@ -395,10 +395,10 @@ export function PluginsPage() {
                 <Button variant="secondary" onClick={() => setShowInstall(false)}>{t("common.cancel")}</Button>
               </div>
         </div>
-      </Modal>
+      </DrawerPanel>
 
       {/* Scaffold Modal */}
-      <Modal isOpen={showScaffold} onClose={() => setShowScaffold(false)} title={t("plugins.scaffold_title")} size="sm" variant="panel-right">
+      <DrawerPanel isOpen={showScaffold} onClose={() => setShowScaffold(false)} title={t("plugins.scaffold_title")} size="sm">
         <div className="p-5 space-y-4">
           <div>
             <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>
@@ -446,7 +446,7 @@ export function PluginsPage() {
             <Button variant="secondary" onClick={() => setShowScaffold(false)}>{t("common.cancel")}</Button>
           </div>
         </div>
-      </Modal>
+      </DrawerPanel>
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -17,6 +17,7 @@ import { Badge, type BadgeVariant } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
 import { Select } from "../components/ui/Select";
 import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import {
@@ -586,7 +587,7 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
   const models = modelsQuery.data?.models ?? [];
 
   return (
-    <Modal isOpen onClose={onClose} title={provider.display_name || provider.id} size="lg" variant="drawer-right">
+    <DrawerPanel isOpen onClose={onClose} title={provider.display_name || provider.id} size="lg">
       <div className="p-6 space-y-4">
         {/* Header info */}
         <div className="flex items-center gap-3">
@@ -697,7 +698,7 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -1334,7 +1335,7 @@ export function ProvidersPage() {
       )}
 
       {/* Config Modal */}
-      <Modal isOpen={!!config.provider} onClose={config.close} title={t("providers.configure_provider")} size="md" variant="panel-right">
+      <DrawerPanel isOpen={!!config.provider} onClose={config.close} title={t("providers.configure_provider")} size="md">
         {config.provider && (
           <div className="p-5 space-y-4">
             <div className="flex items-center gap-3 p-3 rounded-xl bg-main">
@@ -1421,7 +1422,7 @@ export function ProvidersPage() {
             )}
           </div>
         )}
-      </Modal>
+      </DrawerPanel>
 
       {/* Delete Confirmation Modal */}
       <Modal isOpen={!!deleteConfirmProvider} onClose={() => setDeleteConfirmProvider(null)}
@@ -1454,7 +1455,7 @@ export function ProvidersPage() {
       </Modal>
 
       {/* Create Provider Wizard */}
-      <Modal isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton variant="panel-right">
+      <DrawerPanel isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton>
         <CreateProviderWizard
           onSubmit={async (values) => {
             await createRegistryContent("provider", values);
@@ -1464,7 +1465,7 @@ export function ProvidersPage() {
           }}
           onCancel={() => setShowCreateForm(false)}
         />
-      </Modal>
+      </DrawerPanel>
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -14,7 +14,7 @@ import type { CronDeliveryTarget } from "../lib/http/client";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { DeliveryTargetsEditor } from "../components/ui/DeliveryTargetsEditor";
 import { truncateId } from "../lib/string";
 import { formatTriggerPattern } from "../lib/triggerPattern";
@@ -440,7 +440,7 @@ export function SchedulerPage() {
       </div>
 
       {/* Create Modal */}
-      <Modal isOpen={showCreate} onClose={() => setShowCreate(false)} title={t("scheduler.create_job")} size="md" variant="panel-right">
+      <DrawerPanel isOpen={showCreate} onClose={() => setShowCreate(false)} title={t("scheduler.create_job")} size="md">
         {/* Mode tabs */}
         <div className="flex gap-1 px-5 pt-4">
           <button
@@ -598,10 +598,10 @@ export function SchedulerPage() {
             </div>
           </form>
         )}
-      </Modal>
+      </DrawerPanel>
 
       {/* Edit Delivery Targets Modal */}
-      <Modal
+      <DrawerPanel
         isOpen={!!editTargetsSchedule}
         onClose={() => {
           if (setDeliveryTargetsMut.isPending) return;
@@ -610,7 +610,6 @@ export function SchedulerPage() {
         }}
         title={t("scheduler.delivery.edit_modal_title", { defaultValue: "Edit delivery targets" })}
         size="lg"
-        variant="panel-right"
       >
         <div className="p-5 space-y-4">
           {editTargetsSchedule && (
@@ -663,10 +662,10 @@ export function SchedulerPage() {
             </Button>
           </div>
         </div>
-      </Modal>
+      </DrawerPanel>
 
       {/* Edit Trigger Modal */}
-      <Modal isOpen={!!editTrigger} onClose={() => setEditTrigger(null)} title="Edit trigger" size="md" variant="panel-right">
+      <DrawerPanel isOpen={!!editTrigger} onClose={() => setEditTrigger(null)} title="Edit trigger" size="md">
         <form onSubmit={handleEditTrigger} className="p-5 space-y-4">
           {editTrigger && (
             <div className="rounded-xl bg-warning/5 border border-warning/20 px-3 py-2 text-[10px] text-text-dim/60">
@@ -731,7 +730,7 @@ export function SchedulerPage() {
             <Button type="button" variant="secondary" onClick={() => setEditTrigger(null)}>{t("common.cancel")}</Button>
           </div>
         </form>
-      </Modal>
+      </DrawerPanel>
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -35,7 +35,7 @@ import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { Input } from "../components/ui/Input";
-import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { PageHeader } from "../components/ui/PageHeader";
 import { useUIStore } from "../lib/store";
@@ -434,7 +434,7 @@ function MarketplaceDetailModal({
 }) {
   const isPending = pendingId === skill.slug;
   return (
-    <Modal isOpen onClose={onClose} title={skill.name} size="md" variant="panel-right">
+    <DrawerPanel isOpen onClose={onClose} title={skill.name} size="md">
       <div className="p-5 space-y-4">
         <div className="p-4 rounded-xl bg-surface-2">
           <p className="text-sm text-text-dim leading-relaxed">{skill.description}</p>
@@ -504,7 +504,7 @@ function MarketplaceDetailModal({
           </Button>
         )}
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -623,12 +623,11 @@ function CreateSkillModal({
   };
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={isOpen}
       onClose={onClose}
       title={t("skills.evo_create_title", { defaultValue: "Create Skill" })}
       size="xl"
-      variant="panel-right"
     >
       <div className="space-y-4 p-1">
         <div>
@@ -709,7 +708,7 @@ function CreateSkillModal({
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -1169,12 +1168,11 @@ function SkillDetailModal({
   };
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={isOpen}
       onClose={onClose}
       title={detail?.name ?? skillName ?? ""}
       size="xl"
-      variant="drawer-right"
     >
       {isLoading ? (
         <div className="flex items-center justify-center py-12">
@@ -1448,7 +1446,7 @@ function SkillDetailModal({
           {t("skills.evo_not_found", { defaultValue: "Skill not found" })}
         </p>
       )}
-    </Modal>
+    </DrawerPanel>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
@@ -53,6 +53,7 @@ import { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import { Select } from "../components/ui/Select";
 import { Modal } from "../components/ui/Modal";
+import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
@@ -840,7 +841,7 @@ function UserFormModal({
   };
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={isOpen}
       onClose={onClose}
       title={
@@ -849,7 +850,6 @@ function UserFormModal({
           : t("users.create_title", "New user")
       }
       size="lg"
-      variant="panel-right"
     >
       <div className="space-y-4">
         <Input
@@ -951,7 +951,7 @@ function UserFormModal({
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -1015,12 +1015,11 @@ function IdentityWizardModal({
   ];
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={user !== null}
       onClose={onClose}
       title={t("users.wizard_title", "Link a platform identity")}
       size="lg"
-      variant="panel-right"
     >
       {user ? (
         <div className="space-y-4">
@@ -1273,7 +1272,7 @@ function IdentityWizardModal({
           </div>
         </div>
       ) : null}
-    </Modal>
+    </DrawerPanel>
   );
 }
 
@@ -1314,7 +1313,7 @@ function BulkImportModal({
   const result = importMut.data;
 
   return (
-    <Modal
+    <DrawerPanel
       isOpen={isOpen}
       onClose={() => {
         importMut.reset();
@@ -1324,7 +1323,6 @@ function BulkImportModal({
       }}
       title={t("users.import_title", "Bulk import users")}
       size="3xl"
-      variant="panel-right"
     >
       <div className="space-y-4">
         <p className="text-xs text-text-dim">
@@ -1450,7 +1448,7 @@ function BulkImportModal({
           </Button>
         </div>
       </div>
-    </Modal>
+    </DrawerPanel>
   );
 }
 


### PR DESCRIPTION
## Why

Right-side drawers in the dashboard (the `panel-right` Modal variant) are fixed-overlay — they cover the underlying page until dismissed. The user feedback was: drawers should behave like the left sidebar collapse — when opened, the main content should adapt and make room, not get hidden behind a panel.

## What changed

A new push-drawer pattern, scoped as a **pilot on ModelsPage** before broader migration.

### New pieces

- `src/lib/drawerStore.ts` — small zustand store with `isOpen`, `content`, `openDrawer`, `closeDrawer`. Single global slot — opening a new drawer replaces whatever was there.
- `src/components/ui/PushDrawer.tsx` — host component with two presentations from the same store:
  - **lg+**: animated `width: 0 → target` in the root flex layout, so the main column shrinks (Tailwind `transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]` — same easing as the sidebar).
  - **<lg**: fullscreen overlay sheet, since push doesn't fit on narrow viewports.
- `App.tsx`: `<PushDrawer />` mounted as a flex sibling of the header+main column, mirroring `<aside>` on the left.

### ModelsPage migration

- Detail body extracted to `ModelDetailBody` (props: `m`, `hidden`, callbacks). Same JSX, no UX changes.
- Two `useEffect`s mirror local `detailModel` state into the global slot:
  1. `detailModel` set → `openDrawer({ body: <ModelDetailBody … /> })`
  2. `detailModel` cleared → `closeDrawer()`
  3. Drawer closed externally (Esc / close button) → clear `detailModel`
- Unmount cleanup so the page's local state never leaks into the global slot after navigating away.

### Out of scope

- Add Model / Settings modals stay as `Modal variant="panel-right"`. They're forms with modal blocking semantics — fitting them into the push slot would let users click around the rest of the page mid-edit, which isn't desirable.
- The other 15 `panel-right` usages (Agents / Skills / Plugins / A2A / Canvas / Scheduler / Users / etc.) are unchanged. Once the pattern is validated here, they can migrate page-by-page following the same template.

## Test plan

- [ ] `pnpm typecheck` clean (verified locally)
- [ ] Open Models page, click a model card → drawer slides in from right, main content shrinks to make room (no overlay)
- [ ] Click Esc / close button → drawer collapses, main content reclaims width
- [ ] Toggle hide/unhide from drawer → button reflects new state, drawer closes
- [ ] Click "Settings" inside drawer → drawer closes, Settings modal opens (stays modal — overlay)
- [ ] Resize to mobile (<lg) → drawer renders as fullscreen overlay with backdrop close
- [ ] Navigate away while drawer open → drawer disappears, no stale body in store
