### PR TITLE
fix(release): install libdbus-1-dev for glibc Linux CLI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install build deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+        # libdbus-1-dev is required by libdbus-sys, pulled in transitively
+        # by the keyring crate's secret-service backend on glibc Linux
+        # (see crates/librefang-extensions/Cargo.toml target gate).
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --locked
@@ -510,7 +513,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install build deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+        # libdbus-1-dev is required by libdbus-sys, pulled in transitively
+        # by the keyring crate's secret-service backend on glibc Linux.
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
       - uses: Swatinem/rust-cache@v2
         with:
           key: cli-mini-${{ matrix.target }}-${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1133,6 +1133,12 @@ jobs:
 
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
+        # libdbus-1-dev is required by libdbus-sys, pulled in transitively
+        # by the keyring crate's secret-service backend on glibc Linux
+        # (librefang-desktop -> librefang-extensions). webkit2gtk has
+        # historically pulled libdbus-1-dev as a transitive system dep,
+        # but make it explicit so the build doesn't break the day apt
+        # changes its package metadata.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -1140,6 +1146,7 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
+            libdbus-1-dev \
             patchelf
 
       - uses: dtolnay/rust-toolchain@stable

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
-  "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"
+  "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH"
 ]
 
 [target.aarch64-linux-android]


### PR DESCRIPTION
## Summary

Beta 6 (`v2026.4.27-beta6`) shipped missing **all 10 Linux CLI assets** because the release workflow's `apt-get install` line never picked up `libdbus-1-dev` after the keyring wiring landed.

**Timeline of the regression**

- #3180 (commit 42fd29bb) wired the keyring crate with `sync-secret-service` → pulls `libdbus-sys` transitively on glibc Linux.
- Beta 6 was cut hours later. `cli_linux` (×2), `cli_linux_mini`, `cli_musl` (×2) all failed with:
  ```
  The system library `dbus-1` required by crate `libdbus-sys` was not found.
  ```
- #3265 added `libdbus-1-dev` to the **Dockerfile** → unblocked Docker images.
- #3267 made keyring target-conditional → unblocked **musl** and **android** cross builds.
- `release.yml` and `Cross.toml` were never updated, so the **four glibc CLI tarballs** would still fail on the next release.

The 10 missing assets in Beta 6:

```
librefang-{x86_64,aarch64}-unknown-linux-gnu.tar.gz{,.sha256}    # 4 (cli_linux)
librefang-x86_64-unknown-linux-gnu-mini.tar.gz{,.sha256}          # 2 (cli_linux_mini)
librefang-{x86_64,aarch64}-unknown-linux-musl.tar.gz{,.sha256}    # 4 (cli_musl)
```

After this PR + #3267, all 10 should reappear.

## Changes

- `release.yml` `cli_linux` job: add `libdbus-1-dev` to apt deps (covers x86_64 native build).
- `release.yml` `cli_linux_mini` job: same.
- `Cross.toml` `[target.aarch64-unknown-linux-gnu]` pre-build: add `libdbus-1-dev:$CROSS_DEB_ARCH` so the cross sysroot has it for the aarch64 build.

`cli_musl` and `cli_android` are intentionally untouched — after #3267 the keyring crate is no longer compiled for those targets, so libdbus-sys is not pulled in.

## Test plan

- [ ] Next release tag triggers `cli_linux` (gnu, both archs), `cli_linux_mini`, `cli_musl` (both archs), and `cli_android` to all succeed.
- [ ] Resulting GitHub Release contains all 10 Linux CLI assets again.
- [ ] No change to macOS / Windows asset set.
