### PR TITLE
feat(dashboard): unify all custom animations on motion

### DIFF
--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -27,6 +27,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "katex": "^0.16.22",
     "lucide-react": "^0.577.0",
+    "motion": "^12.38.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/crates/librefang-api/dashboard/pnpm-lock.yaml
+++ b/crates/librefang-api/dashboard/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.5)
+      motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1454,6 +1457,20 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1871,6 +1888,26 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3664,6 +3701,15 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   fsevents@2.3.2:
     optional: true
 
@@ -4310,6 +4356,20 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.2
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   ms@2.1.3: {}
 

--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -1,6 +1,8 @@
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
+import { fadeInScale, pageTransition } from "./lib/motion";
 import {
   Globe,
   Sun,
@@ -137,7 +139,7 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
 
   return (
     <div className="fixed inset-0 z-200 flex items-center justify-center bg-black/70 backdrop-blur-md">
-      <div className="w-full max-w-md mx-4 animate-fade-in-scale">
+      <motion.div className="w-full max-w-md mx-4" variants={fadeInScale} initial="initial" animate="animate">
         <div className="rounded-2xl border border-border-subtle bg-surface shadow-2xl p-8">
           <div className="flex flex-col items-center mb-6">
             <div className="w-14 h-14 rounded-2xl bg-brand/10 flex items-center justify-center mb-4 ring-2 ring-brand/20">
@@ -240,7 +242,7 @@ function AuthDialog({ mode, onAuthenticated }: { mode: AuthMode; onAuthenticated
             </button>
           </form>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }
@@ -311,7 +313,7 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="fixed inset-0 z-200 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="w-full max-w-md mx-4 animate-fade-in-scale">
+      <motion.div className="w-full max-w-md mx-4" variants={fadeInScale} initial="initial" animate="animate">
         <div className="rounded-2xl border border-border-subtle bg-surface shadow-2xl">
           <div className="flex items-center justify-between px-6 pt-6 pb-4">
             <h2 className="text-base font-black tracking-tight">{t("settings.change_credentials")}</h2>
@@ -402,7 +404,7 @@ function ChangePasswordModal({ onClose }: { onClose: () => void }) {
             </div>
           </form>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }
@@ -806,15 +808,31 @@ export function App() {
           className={`bg-main ${isFullHeightPage ? "flex flex-col flex-1 overflow-hidden" : "flex-1 overflow-y-auto overflow-x-hidden"}`}
           tabIndex={-1}
         >
-          {isFullHeightPage ? (
-            <div className="flex flex-col flex-1 min-h-0">
-              <Outlet />
-            </div>
-          ) : (
-            <div className="w-full p-3 sm:p-4 lg:p-8">
-              <Outlet />
-            </div>
-          )}
+          <AnimatePresence mode="wait" initial={false}>
+            {isFullHeightPage ? (
+              <motion.div
+                key={`full:${location.pathname}`}
+                className="flex flex-col flex-1 min-h-0"
+                variants={pageTransition}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+              >
+                <Outlet />
+              </motion.div>
+            ) : (
+              <motion.div
+                key={`std:${location.pathname}`}
+                className="w-full p-3 sm:p-4 lg:p-8"
+                variants={pageTransition}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+              >
+                <Outlet />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </main>
       </div>
 

--- a/crates/librefang-api/dashboard/src/components/TomlViewer.tsx
+++ b/crates/librefang-api/dashboard/src/components/TomlViewer.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Copy, Download, Loader2 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { Modal } from "./ui/Modal";
 import { useUIStore } from "../lib/store";
+import { tabContent } from "../lib/motion";
 
 interface TomlViewerProps {
   isOpen: boolean;
@@ -126,11 +128,20 @@ export function TomlViewer({
             {t("toml_viewer.loading")}
           </div>
         ) : (
-          <div className="max-h-[65vh] overflow-x-auto overflow-y-auto rounded-xl border border-border-subtle bg-main">
-            <pre className="min-w-full px-3 py-2 text-[11px] font-mono text-text whitespace-pre-wrap">
-              {body}
-            </pre>
-          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={tab}
+              variants={tabContent}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              className="max-h-[65vh] overflow-x-auto overflow-y-auto rounded-xl border border-border-subtle bg-main"
+            >
+              <pre className="min-w-full px-3 py-2 text-[11px] font-mono text-text whitespace-pre-wrap">
+                {body}
+              </pre>
+            </motion.div>
+          </AnimatePresence>
         )}
       </div>
     </Modal>

--- a/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
+++ b/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { animate } from 'motion/react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -28,37 +29,38 @@ const mdComponents = {
   a: ({ href, children }: any) => <a href={href} className="text-brand underline" target="_blank" rel="noopener noreferrer">{children}</a>,
 };
 
+/// Streams `text` character-by-character into the markdown output to
+/// give an LLM-style "typing" effect. The reveal is driven by motion's
+/// `animate()` (instead of a hand-rolled RAF) so it joins the same
+/// animation scheduler as the rest of the dashboard and respects
+/// `prefers-reduced-motion`.
+///
+/// `speed` is milliseconds-per-character (kept from the legacy API).
+/// When the source text shrinks below the already-displayed length
+/// (e.g. the upstream message restarted), the typewriter rewinds to 0.
 export function Typewriter_v2({ text, speed = 20 }: { text: string; speed?: number }) {
   const [displayed, setDisplayed] = useState("");
-  const fullTextRef = useRef(text);
-  const currentIndexRef = useRef(0);
-  const lastUpdateTimeRef = useRef(0);
 
   useEffect(() => {
-    fullTextRef.current = text;
-    if (text.length < currentIndexRef.current) {
-      currentIndexRef.current = 0;
-      setDisplayed("");
-    }
-  }, [text]);
-
-  useEffect(() => {
-    let requestRef: number;
-    
-    const animate = (time: number) => {
-      if (currentIndexRef.current < fullTextRef.current.length) {
-        if (time - lastUpdateTimeRef.current >= speed) {
-          currentIndexRef.current = Math.min(currentIndexRef.current + 2, fullTextRef.current.length);
-          setDisplayed(fullTextRef.current.slice(0, currentIndexRef.current));
-          lastUpdateTimeRef.current = time;
-        }
-      }
-      requestRef = requestAnimationFrame(animate);
-    };
-
-    requestRef = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(requestRef);
-  }, [speed]);
+    // If upstream restarted the stream (new text shorter than what we already
+    // typed out), rewind. Otherwise resume from where we are.
+    const start = displayed.length > text.length ? 0 : displayed.length;
+    if (start === 0 && displayed !== "") setDisplayed("");
+    const remaining = text.length - start;
+    if (remaining <= 0) return;
+    const controls = animate(start, text.length, {
+      duration: (remaining * speed) / 1000,
+      ease: "linear",
+      onUpdate: (latest) => {
+        const idx = Math.min(Math.floor(latest), text.length);
+        setDisplayed(text.slice(0, idx));
+      },
+    });
+    return () => controls.stop();
+    // displayed intentionally excluded — re-running on every char update
+    // would restart the animation each frame. Only react to source changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, speed]);
 
   return useMemo(() => (
     <Markdown

--- a/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
+import { animate, motion, useMotionValue, useTransform } from "motion/react";
 
 const NON_NUMERIC_RE = /[^0-9.-]/g;
-const easeOutExpo = (p: number) => (p === 1 ? 1 : 1 - Math.pow(2, -10 * p));
 
 interface AnimatedNumberProps {
   value: number | string;
+  /** Animation duration in milliseconds (matches the legacy API). Defaults to 800. */
   duration?: number;
   prefix?: string;
   suffix?: string;
@@ -16,45 +17,35 @@ function parseValue(value: number | string): number {
   return typeof value === "string" ? parseFloat(value.replace(NON_NUMERIC_RE, "")) : value;
 }
 
-export function AnimatedNumber({ value, duration = 800, prefix = "", suffix = "", decimals = 0, className = "" }: AnimatedNumberProps) {
-  const [display, setDisplay] = useState(() => {
-    const n = parseValue(value);
-    return isNaN(n) ? String(value) : n.toFixed(decimals);
-  });
-  const prevRef = useRef(0);
-  const rafRef = useRef<number | undefined>(undefined);
+/// Smoothly tweens a numeric display when `value` changes — used for
+/// cost counters, agent counts, latency readouts. Backed by motion's
+/// `MotionValue` so the per-frame work happens off the React render
+/// path. Falls back to rendering `String(value)` if the input cannot
+/// be parsed as a number.
+export function AnimatedNumber({
+  value,
+  duration = 800,
+  prefix = "",
+  suffix = "",
+  decimals = 0,
+  className = "",
+}: AnimatedNumberProps) {
+  const target = parseValue(value);
+  const isNumeric = !isNaN(target);
+  const motionValue = useMotionValue(isNumeric ? target : 0);
+  const display = useTransform(motionValue, (latest) =>
+    `${prefix}${latest.toFixed(decimals)}${suffix}`,
+  );
 
   useEffect(() => {
-    const numValue = parseValue(value);
-    if (isNaN(numValue)) { setDisplay(String(value)); return; }
+    if (!isNumeric) return;
+    const controls = animate(motionValue, target, {
+      duration: duration / 1000,
+      ease: [0.25, 0.1, 0.25, 1],
+    });
+    return () => controls.stop();
+  }, [target, duration, motionValue, isNumeric]);
 
-    const start = prevRef.current;
-    const end = numValue;
-    const startTime = performance.now();
-
-    const animate = (now: number) => {
-      const elapsed = now - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = easeOutExpo(progress);
-      const current = start + (end - start) * eased;
-      setDisplay(current.toFixed(decimals));
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(animate);
-      } else {
-        prevRef.current = end;
-      }
-    };
-
-    rafRef.current = requestAnimationFrame(animate);
-    return () => {
-      if (rafRef.current) {
-        cancelAnimationFrame(rafRef.current);
-        const elapsed = performance.now() - startTime;
-        const progress = Math.min(elapsed / duration, 1);
-        prevRef.current = start + (end - start) * easeOutExpo(progress);
-      }
-    };
-  }, [value, duration, decimals]);
-
-  return <span className={className}>{prefix}{display}{suffix}</span>;
+  if (!isNumeric) return <span className={className}>{String(value)}</span>;
+  return <motion.span className={className}>{display}</motion.span>;
 }

--- a/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Search, Home, Layers, MessageCircle, Server, Network, Calendar, Shield, BarChart3, FileText, Settings, Bot, Clock, CheckCircle, Database, Activity, Hand, Puzzle, Cpu, Radio, Terminal, ExternalLink } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { useFocusTrap } from "../../lib/useFocusTrap";
+import { fadeInScale, APPLE_EASE } from "../../lib/motion";
 
 interface CommandItem {
   id: string;
@@ -125,8 +127,6 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
-
   const groupedCommands = filteredCommands.reduce((acc, cmd) => {
     const key = t(cmd.categoryKey);
     if (!acc[key]) acc[key] = [];
@@ -135,15 +135,28 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   }, {} as Record<string, CommandItem[]>);
 
   return (
-    <div className="fixed inset-0 z-100 flex items-start justify-center pt-[15vh]">
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label={t("command_palette.search_placeholder")}
-        className="relative w-full max-w-xl max-w-[90vw] rounded-2xl border border-border-subtle bg-surface shadow-2xl overflow-hidden animate-fade-in-scale"
-      >
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-100 flex items-start justify-center pt-[15vh]">
+          <motion.div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: APPLE_EASE }}
+          />
+          <motion.div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t("command_palette.search_placeholder")}
+            className="relative w-full max-w-xl max-w-[90vw] rounded-2xl border border-border-subtle bg-surface shadow-2xl overflow-hidden"
+            variants={fadeInScale}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
         <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-4">
           <Search className="h-5 w-5 text-text-dim shrink-0" />
           <input
@@ -187,8 +200,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
             ))
           )}
         </div>
-      </div>
-    </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
 import { useFocusTrap } from "../../lib/useFocusTrap";
+import { fadeInScale, APPLE_EASE } from "../../lib/motion";
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -57,26 +59,34 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
     return () => window.removeEventListener("keydown", handleKey);
   }, [isOpen, tone]);
 
-  if (!isOpen) return null;
-
   const isDestructive = tone === "destructive";
   const confirmBtnClass = isDestructive
     ? "bg-error text-white hover:bg-error/90 shadow-lg shadow-error/20"
     : "bg-brand text-white hover:bg-brand/90 shadow-lg shadow-brand/20";
 
   return (
-    <div
-      className="fixed inset-0 z-[150] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
-      onClick={onClose}
-    >
-      <div
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-[150] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
+          onClick={onClose}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18, ease: APPLE_EASE }}
+        >
+      <motion.div
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"
         aria-describedby="confirm-dialog-message"
-        className="relative w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl animate-fade-in-scale"
+        className="relative w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        variants={fadeInScale}
+        initial="initial"
+        animate="animate"
+        exit="exit"
       >
         <button
           onClick={onClose}
@@ -117,7 +127,9 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
             {confirmLabel ?? t("common.confirm", { defaultValue: "Confirm" })}
           </button>
         </div>
-      </div>
-    </div>
+      </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 });

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useId, memo, type ReactNode } from "react";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
 import { useFocusTrap } from "../../lib/useFocusTrap";
 
 interface ModalProps {
@@ -46,6 +47,10 @@ const SIZE_CLASSES: Record<NonNullable<ModalProps["size"]>, string> = {
   "5xl": "sm:max-w-5xl",
 };
 
+// Apple-style easing, mirrors --apple-ease in index.css so motion-driven
+// transitions match the existing CSS keyframes for non-Modal animations.
+const APPLE_EASE: [number, number, number, number] = [0.25, 0.1, 0.25, 1];
+
 /// Shared modal shell. Handles the cross-cutting concerns every page
 /// modal needs:
 ///
@@ -55,6 +60,7 @@ const SIZE_CLASSES: Record<NonNullable<ModalProps["size"]>, string> = {
 /// - Focus trap (Tab cycles inside, Shift+Tab reverses)
 /// - Focus restoration on close
 /// - aria-modal + role="dialog" for screen readers
+/// - Enter / exit animations driven by motion's <AnimatePresence>
 ///
 /// Children render inside the dialog container — provide your own
 /// body content and (optionally) your own header/footer.
@@ -77,6 +83,7 @@ export const Modal = memo(function Modal({
   const isDrawer = variant === "drawer-right";
   const isPanel = variant === "panel-right";
   const isRightDocked = isDrawer || isPanel;
+  const hasBackdrop = !isDrawer; // modal + panel-right have a dim backdrop
   // Modal traps Tab inside the dialog (no escape from the focus loop).
   // Drawer leaves Tab free so keyboard users can hop back into the
   // underlying list (which is still interactive — see container's
@@ -95,8 +102,6 @@ export const Modal = memo(function Modal({
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [isOpen]);
-
-  if (!isOpen) return null;
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     // Stop the click from bubbling to an ancestor backdrop.
@@ -124,50 +129,73 @@ export const Modal = memo(function Modal({
     ? "fixed inset-0 flex items-stretch justify-end bg-black/40 backdrop-blur-sm"
     : "fixed inset-0 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm p-0 sm:p-4";
   const dialogClass = isRightDocked
-    ? `${isDrawer ? "pointer-events-auto " : ""}relative w-full ${SIZE_CLASSES[size]} h-full sm:rounded-l-2xl sm:border-l border-border-subtle bg-surface shadow-2xl animate-slide-in-right ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`
-    : `relative w-full ${SIZE_CLASSES[size]} rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl animate-fade-in-scale max-h-[90vh] ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`;
+    ? `${isDrawer ? "pointer-events-auto " : ""}relative w-full ${SIZE_CLASSES[size]} h-full sm:rounded-l-2xl sm:border-l border-border-subtle bg-surface shadow-2xl ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`
+    : `relative w-full ${SIZE_CLASSES[size]} rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl max-h-[90vh] ${overflowVisible ? "overflow-visible" : "overflow-hidden"} flex flex-col`;
+
+  const dialogMotion = isRightDocked
+    ? {
+        initial: { x: "100%" as const, opacity: 0.6 },
+        animate: { x: 0, opacity: 1 },
+        exit: { x: "100%" as const, opacity: 0.6 },
+        transition: { duration: 0.28, ease: APPLE_EASE },
+      }
+    : {
+        initial: { opacity: 0, scale: 0.92, filter: "blur(8px)" },
+        animate: { opacity: 1, scale: 1, filter: "blur(0px)" },
+        exit: { opacity: 0, scale: 0.96, filter: "blur(6px)" },
+        transition: { duration: 0.22, ease: APPLE_EASE },
+      };
 
   return (
-    <div
-      className={containerClass}
-      style={{ zIndex }}
-      // Backdrop dismissal is a modal contract; the drawer relies on Esc
-      // and its explicit close button instead, since "click outside to
-      // close" would race with the list-click-to-switch interaction.
-      onClick={isDrawer || disableBackdropClose ? undefined : handleBackdropClick}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal={isDrawer ? "false" : "true"}
-        aria-labelledby={titleId}
-        className={dialogClass}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {(title || !hideCloseButton) && (
-          <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
-            {title ? (
-              <h3 id={titleId} className="text-sm font-bold tracking-tight">{title}</h3>
-            ) : <span />}
-            {!hideCloseButton && (
-              <button
-                onClick={onClose}
-                className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
-                aria-label={t("common.close", { defaultValue: "Close" })}
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className={containerClass}
+          style={{ zIndex }}
+          // Backdrop dismissal is a modal contract; the drawer relies on Esc
+          // and its explicit close button instead, since "click outside to
+          // close" would race with the list-click-to-switch interaction.
+          onClick={isDrawer || disableBackdropClose ? undefined : handleBackdropClick}
+          initial={hasBackdrop ? { opacity: 0 } : false}
+          animate={hasBackdrop ? { opacity: 1 } : undefined}
+          exit={hasBackdrop ? { opacity: 0 } : undefined}
+          transition={{ duration: 0.18, ease: APPLE_EASE }}
+        >
+          <motion.div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal={isDrawer ? "false" : "true"}
+            aria-labelledby={titleId}
+            className={dialogClass}
+            onClick={(e) => e.stopPropagation()}
+            {...dialogMotion}
+          >
+            {(title || !hideCloseButton) && (
+              <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
+                {title ? (
+                  <h3 id={titleId} className="text-sm font-bold tracking-tight">{title}</h3>
+                ) : <span />}
+                {!hideCloseButton && (
+                  <button
+                    onClick={onClose}
+                    className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
+                    aria-label={t("common.close", { defaultValue: "Close" })}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
             )}
-          </div>
-        )}
-        {/* `overscroll-contain` stops wheel events from chaining into the
-            page once the dialog hits its top/bottom — the bug surfaces
-            in the drawer variant (page is interactive behind the panel)
-            but the centred modal benefits too: a long modal pinned over
-            a long page used to scroll the page after the modal bottomed
-            out, which feels like the modal "leaks" the gesture. */}
-        <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">{children}</div>
-      </div>
-    </div>
+            {/* `overscroll-contain` stops wheel events from chaining into the
+                page once the dialog hits its top/bottom — the bug surfaces
+                in the drawer variant (page is interactive behind the panel)
+                but the centred modal benefits too: a long modal pinned over
+                a long page used to scroll the page after the modal bottomed
+                out, which feels like the modal "leaks" the gesture. */}
+            <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">{children}</div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 });

--- a/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { G_NAV_SHORTCUTS } from "../../lib/useKeyboardShortcuts";
 import { useFocusTrap } from "../../lib/useFocusTrap";
+import { fadeInScale, APPLE_EASE } from "../../lib/motion";
 
 interface ShortcutsHelpProps {
   isOpen: boolean;
@@ -39,18 +41,30 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
     return () => window.removeEventListener("keydown", handleKey);
   }, [isOpen]);
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-100 flex items-end sm:items-start justify-center sm:pt-[10vh] p-0 sm:p-4">
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true" onClick={onClose} />
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="shortcuts-help-title"
-        className="relative w-full sm:max-w-2xl rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl overflow-hidden animate-fade-in-scale"
-      >
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-100 flex items-end sm:items-start justify-center sm:pt-[10vh] p-0 sm:p-4">
+          <motion.div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+            aria-hidden="true"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: APPLE_EASE }}
+          />
+          <motion.div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="shortcuts-help-title"
+            className="relative w-full sm:max-w-2xl rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl overflow-hidden"
+            variants={fadeInScale}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
         <div className="flex items-center justify-between border-b border-border-subtle px-5 py-4">
           <div className="flex items-center gap-2.5">
             <div className="h-8 w-8 rounded-xl bg-brand/10 flex items-center justify-center text-brand">
@@ -107,7 +121,9 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
             </div>
           </section>
         </div>
-      </div>
-    </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/crates/librefang-api/dashboard/src/components/ui/Skeleton.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Skeleton.tsx
@@ -1,8 +1,11 @@
+import { motion } from "motion/react";
+
 export function Skeleton({ className = "" }: { className?: string }) {
   return (
-    <div
+    <motion.div
       className={`rounded-lg bg-linear-to-r from-main via-surface-hover to-main bg-[length:200%_100%] ${className}`}
-      style={{ animation: "shimmer 1.5s ease-in-out infinite" }}
+      animate={{ backgroundPosition: ["200% 0", "-200% 0"] }}
+      transition={{ duration: 1.5, ease: "easeInOut", repeat: Infinity }}
     />
   );
 }

--- a/crates/librefang-api/dashboard/src/components/ui/StaggerList.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/StaggerList.tsx
@@ -1,0 +1,70 @@
+import { Children, isValidElement, type ReactNode } from "react";
+import { AnimatePresence, motion, type HTMLMotionProps } from "motion/react";
+import { staggerContainer, staggerItem } from "../../lib/motion";
+
+interface StaggerListProps extends Omit<HTMLMotionProps<"div">, "variants" | "initial" | "animate" | "children"> {
+  children: ReactNode;
+  /** Skip wrapping each child in a motion.div — useful when callers
+   *  already provide motion children with their own variants. */
+  manualItems?: boolean;
+  /** Disable enter/exit animations for individual items. When the
+   *  list contents are stable (hardcoded cards, not driven by data),
+   *  the AnimatePresence overhead is unnecessary. Defaults to false. */
+  staticItems?: boolean;
+}
+
+/// Drop-in replacement for the legacy `.stagger-children` className.
+///
+/// Wraps each direct child in a `motion.div` that inherits the
+/// `staggerItem` variant from the container, producing the same 40ms
+/// cascade the CSS implementation produced.
+///
+/// When children come from a `.map()` over data, items animate in/out
+/// on add/remove via `<AnimatePresence>` and `layout` reflows the grid
+/// smoothly. Children must have stable keys (data IDs, not array index)
+/// for the exit animation to play.
+///
+/// Usage:
+///   <StaggerList className="grid grid-cols-3 gap-4">
+///     {items.map(item => <Card key={item.id}>…</Card>)}
+///   </StaggerList>
+export function StaggerList({ children, manualItems, staticItems, ...rest }: StaggerListProps) {
+  if (manualItems) {
+    return (
+      <motion.div
+        variants={staggerContainer}
+        initial="initial"
+        animate="animate"
+        {...rest}
+      >
+        {children}
+      </motion.div>
+    );
+  }
+
+  const wrapped = Children.map(children, (child, idx) => {
+    if (!isValidElement(child)) return child;
+    const key = (child as { key?: string | number | null }).key ?? idx;
+    return (
+      <motion.div
+        key={key}
+        variants={staggerItem}
+        layout={!staticItems}
+        {...(staticItems ? {} : { exit: "exit" as const })}
+      >
+        {child}
+      </motion.div>
+    );
+  });
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="initial"
+      animate="animate"
+      {...rest}
+    >
+      {staticItems ? wrapped : <AnimatePresence mode="popLayout">{wrapped}</AnimatePresence>}
+    </motion.div>
+  );
+}

--- a/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
 import { useUIStore } from "../../lib/store";
 import { CheckCircle, XCircle, AlertCircle, X } from "lucide-react";
+import { toastSlide } from "../../lib/motion";
 
 const TOAST_STYLES: Record<"success" | "error" | "info", string> = {
   success: "border-success/30 bg-success/10 text-success",
@@ -25,9 +27,11 @@ export function ToastContainer() {
       aria-live="polite"
       aria-atomic="false"
     >
-      {toasts.map((toast) => (
-        <ToastItem key={toast.id} id={toast.id} message={toast.message} type={toast.type} removeToast={removeToast} />
-      ))}
+      <AnimatePresence>
+        {toasts.map((toast) => (
+          <ToastItem key={toast.id} id={toast.id} message={toast.message} type={toast.type} removeToast={removeToast} />
+        ))}
+      </AnimatePresence>
     </div>
   );
 }
@@ -45,8 +49,13 @@ const ToastItem = memo(function ToastItem({ id, message, type, removeToast }: { 
   // Errors get role=alert (assertive) — they interrupt the current announcement.
   // Non-errors use role=status (polite) — they wait until the screen reader is idle.
   return (
-    <div
-      className={`pointer-events-auto flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg animate-in slide-in-from-right-5 ${TOAST_STYLES[type]}`}
+    <motion.div
+      layout
+      variants={toastSlide}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      className={`pointer-events-auto flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg ${TOAST_STYLES[type]}`}
       role={type === "error" ? "alert" : "status"}
     >
       {TOAST_ICONS[type]}
@@ -58,6 +67,6 @@ const ToastItem = memo(function ToastItem({ id, message, type, removeToast }: { 
       >
         <X className="h-3.5 w-3.5" />
       </button>
-    </div>
+    </motion.div>
   );
 });

--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -108,110 +108,9 @@ body {
   --apple-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-@keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-/* Page entrance — fade + rise + deblur */
-@keyframes fade-in-up {
-  from {
-    opacity: 0;
-    filter: blur(4px);
-    transform: translate3d(0, 16px, 0);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-/* Modal entrance — scale spring + deblur */
-@keyframes fade-in-scale {
-  0% {
-    opacity: 0;
-    filter: blur(8px);
-    transform: scale3d(0.92, 0.92, 1);
-  }
-  100% {
-    opacity: 1;
-    filter: blur(0);
-    transform: scale3d(1, 1, 1);
-  }
-}
-
-@keyframes progress-fill {
-  from { width: 0; }
-}
-
-/* ── Applied classes ────────────────────────────── */
-
-.animate-fade-in-up {
-  animation: fade-in-up 0.6s var(--apple-spring);
-}
-
-.animate-fade-in-scale {
-  animation: fade-in-scale 0.5s var(--apple-bounce);
-}
-
-@keyframes slide-in-right {
-  from {
-    transform: translate3d(100%, 0, 0);
-    opacity: 0.6;
-  }
-  to {
-    transform: translate3d(0, 0, 0);
-    opacity: 1;
-  }
-}
-
-.animate-slide-in-right {
-  animation: slide-in-right 0.28s var(--apple-ease);
-}
-
-.animate-shimmer {
-  animation: shimmer 1.5s ease-in-out infinite;
-}
-
-/* Chat message entrance — lighter than page transition: 220ms, no blur. */
-@keyframes message-in {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 6px, 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-.animate-message-in {
-  animation: message-in 0.22s var(--apple-ease);
-}
-
-/* ── Staggered children (Apple cascade) ─────────── */
-.stagger-children > * {
-  opacity: 0;
-  animation: fade-in-up 0.5s var(--apple-spring) forwards;
-}
-.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
-.stagger-children > *:nth-child(2) { animation-delay: 40ms; }
-.stagger-children > *:nth-child(3) { animation-delay: 80ms; }
-.stagger-children > *:nth-child(4) { animation-delay: 120ms; }
-.stagger-children > *:nth-child(5) { animation-delay: 160ms; }
-.stagger-children > *:nth-child(6) { animation-delay: 200ms; }
-.stagger-children > *:nth-child(7) { animation-delay: 240ms; }
-.stagger-children > *:nth-child(8) { animation-delay: 280ms; }
-.stagger-children > *:nth-child(9) { animation-delay: 320ms; }
-.stagger-children > *:nth-child(10) { animation-delay: 360ms; }
-
-/* ── Mobile: skip stagger delay ────────────────── */
-@media (max-width: 639px) {
-  .stagger-children > * {
-    animation-delay: 0ms !important;
-    animation-duration: 0.3s;
-  }
-}
+/* Animation primitives moved to motion (`src/lib/motion.ts` + per-component
+   variants). Only static (non-animated) helpers remain in this file — keep
+   the easing CSS variables above so any inline transitions can reference them. */
 
 /* ── Card hover — Apple-style depth + glow ──────── */
 .card-glow {
@@ -234,11 +133,6 @@ body {
     0 2px 8px -2px rgba(0, 0, 0, 0.3);
 }
 
-/* ── Progress bar ───────────────────────────────── */
-.animate-progress {
-  animation: progress-fill 1.2s var(--apple-spring);
-}
-
 /* ── Smooth scrollbar ───────────────────────────── */
 .scrollbar-thin::-webkit-scrollbar { width: 5px; }
 .scrollbar-thin::-webkit-scrollbar-track { background: transparent; }
@@ -251,14 +145,5 @@ body {
 .dark .scrollbar-thin::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); }
 .dark .scrollbar-thin::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.2); }
 
-/* ── Respect reduced motion ─────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .animate-fade-in-up,
-  .animate-fade-in-scale,
-  .stagger-children > * {
-    animation: none !important;
-    opacity: 1 !important;
-    filter: none !important;
-    transform: none !important;
-  }
-}
+/* prefers-reduced-motion is handled by motion (`useReducedMotion`) on a
+   per-variant basis; no global override is needed here. */

--- a/crates/librefang-api/dashboard/src/lib/motion.ts
+++ b/crates/librefang-api/dashboard/src/lib/motion.ts
@@ -1,0 +1,143 @@
+import type { Variants } from "motion/react";
+
+// Apple-style easing curves, mirror the CSS variables in index.css so
+// motion-driven transitions match the rest of the design system.
+export const APPLE_EASE: [number, number, number, number] = [0.25, 0.1, 0.25, 1];
+export const APPLE_SPRING: [number, number, number, number] = [0.22, 1, 0.36, 1];
+export const APPLE_BOUNCE: [number, number, number, number] = [0.34, 1.56, 0.64, 1];
+
+// Modal / dialog entrance: scale up + deblur. Replaces .animate-fade-in-scale.
+export const fadeInScale: Variants = {
+  initial: { opacity: 0, scale: 0.92, filter: "blur(8px)" },
+  animate: {
+    opacity: 1,
+    scale: 1,
+    filter: "blur(0px)",
+    transition: { duration: 0.5, ease: APPLE_BOUNCE },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.96,
+    filter: "blur(6px)",
+    transition: { duration: 0.22, ease: APPLE_EASE },
+  },
+};
+
+// Page / hero entrance: fade + 16px rise + deblur. Replaces .animate-fade-in-up.
+export const fadeInUp: Variants = {
+  initial: { opacity: 0, y: 16, filter: "blur(4px)" },
+  animate: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.6, ease: APPLE_SPRING },
+  },
+  exit: {
+    opacity: 0,
+    y: 8,
+    transition: { duration: 0.22, ease: APPLE_EASE },
+  },
+};
+
+// Lightweight chat-message entrance: 6px rise, no blur. Replaces .animate-message-in.
+export const messageIn: Variants = {
+  initial: { opacity: 0, y: 6 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.22, ease: APPLE_EASE },
+  },
+};
+
+// Right-docked drawer/panel entrance. Replaces .animate-slide-in-right.
+export const slideInRight: Variants = {
+  initial: { x: "100%", opacity: 0.6 },
+  animate: {
+    x: 0,
+    opacity: 1,
+    transition: { duration: 0.28, ease: APPLE_EASE },
+  },
+  exit: {
+    x: "100%",
+    opacity: 0.6,
+    transition: { duration: 0.28, ease: APPLE_EASE },
+  },
+};
+
+// Stagger container — 40ms cascade, matches the old CSS .stagger-children
+// (10 children × 40ms = 360ms). Use with `<StaggerList>` or attach manually.
+export const staggerContainer: Variants = {
+  initial: {},
+  animate: {
+    transition: { staggerChildren: 0.04, delayChildren: 0 },
+  },
+};
+
+// Single staggered child — same shape as fadeInUp but slightly faster (0.5s).
+// Includes an `exit` variant so list removal inside <AnimatePresence>
+// plays a smooth fade-and-collapse instead of disappearing instantly.
+export const staggerItem: Variants = {
+  initial: { opacity: 0, y: 16, filter: "blur(4px)" },
+  animate: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.5, ease: APPLE_SPRING },
+  },
+  exit: {
+    opacity: 0,
+    y: -8,
+    scale: 0.96,
+    transition: { duration: 0.18, ease: APPLE_EASE },
+  },
+};
+
+// Route-level entrance — a quick fade + 8px rise. Keep it short (180ms) so
+// page transitions feel snappy; longer durations make navigation feel laggy.
+export const pageTransition: Variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.18, ease: APPLE_EASE },
+  },
+  exit: {
+    opacity: 0,
+    y: -8,
+    transition: { duration: 0.12, ease: APPLE_EASE },
+  },
+};
+
+// Tab content swap — like pageTransition but horizontal, smaller travel.
+export const tabContent: Variants = {
+  initial: { opacity: 0, x: 12 },
+  animate: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: 0.18, ease: APPLE_EASE },
+  },
+  exit: {
+    opacity: 0,
+    x: -12,
+    transition: { duration: 0.12, ease: APPLE_EASE },
+  },
+};
+
+// Toast slide-in from the right edge — replaces tailwindcss-animate's
+// slide-in-from-right-5. Includes a tidy exit so dismissed toasts don't
+// just vanish.
+export const toastSlide: Variants = {
+  initial: { opacity: 0, x: 32, scale: 0.95 },
+  animate: {
+    opacity: 1,
+    x: 0,
+    scale: 1,
+    transition: { duration: 0.24, ease: APPLE_EASE },
+  },
+  exit: {
+    opacity: 0,
+    x: 32,
+    scale: 0.95,
+    transition: { duration: 0.18, ease: APPLE_EASE },
+  },
+};

--- a/crates/librefang-api/dashboard/src/pages/A2APage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.tsx
@@ -1,6 +1,9 @@
 import { formatTime } from "../lib/datetime";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
+import { fadeInScale } from "../lib/motion";
+import { StaggerList } from "../components/ui/StaggerList";
 import { sendA2ATask, getA2ATaskStatus } from "../lib/http/client";
 import type { A2AAgentItem, A2ATaskStatus } from "../lib/http/client";
 import { useA2AAgents } from "../lib/queries/network";
@@ -101,8 +104,10 @@ export function A2APage() {
       />
 
       {/* Discover overlay */}
+      <AnimatePresence>
       {showDiscover && (
-        <Card padding="md" className="animate-fade-in-scale">
+        <motion.div variants={fadeInScale} initial="initial" animate="animate" exit="exit">
+        <Card padding="md">
           <h3 className="text-sm font-black mb-3">{t("a2a.discover_agent")}</h3>
           <div className="flex flex-col sm:flex-row gap-3">
             <input
@@ -127,7 +132,9 @@ export function A2APage() {
             </button>
           </div>
         </Card>
+        </motion.div>
       )}
+      </AnimatePresence>
 
       {agentsQuery.isLoading ? (
         <div className="grid gap-4 md:grid-cols-2">
@@ -159,7 +166,7 @@ export function A2APage() {
                 }
               />
             ) : (
-              <div className="grid gap-3 md:grid-cols-2 stagger-children">
+              <StaggerList className="grid gap-3 md:grid-cols-2">
                 {agents.map((agent, idx) => (
                   <Card key={agent.url || idx} hover padding="md">
                     <div className="flex items-start justify-between">
@@ -202,7 +209,7 @@ export function A2APage() {
                     </div>
                   </Card>
                 ))}
-              </div>
+              </StaggerList>
             )}
           </div>
 
@@ -251,7 +258,7 @@ export function A2APage() {
           {trackedTasks.length > 0 && (
             <div>
               <h2 className="text-lg font-black tracking-tight mb-4">{t("a2a.tracked_tasks")}</h2>
-              <div className="space-y-2 stagger-children">
+              <StaggerList className="space-y-2">
                 {trackedTasks.map((task) => (
                   <Card key={task.id} padding="sm">
                     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
@@ -296,7 +303,7 @@ export function A2APage() {
                     )}
                   </Card>
                 ))}
-              </div>
+              </StaggerList>
             </div>
           )}
         </>

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -2,6 +2,8 @@ import { formatTime } from "../lib/datetime";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 import {
   type AgentDetail,
   type PromptVersion,
@@ -71,6 +73,7 @@ import {
   useStartExperiment,
   useSuspendAgent,
 } from "../lib/mutations/agents";
+import { StaggerList } from "../components/ui/StaggerList";
 
 /** Two-column row used inside the detail modal's value cards. */
 function DetailRow({ label, children }: { label: React.ReactNode; children: React.ReactNode }) {
@@ -750,9 +753,9 @@ export function AgentsPage() {
           />
         )
       ) : (
-        <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))] stagger-children">
+        <StaggerList className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
           {coreAgents.map(agent => renderAgentCard(agent))}
-        </div>
+        </StaggerList>
       )}
       {/* Agent Detail Drawer. Right-side inspector pattern (Linear / Figma):
           the agents list stays interactive while the drawer is open, so
@@ -1740,6 +1743,8 @@ function PromptsExperimentsModal({ agentId, agentName, onClose }: { agentId: str
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
+          <AnimatePresence mode="wait">
+          <motion.div key={activeTab} variants={tabContent} initial="initial" animate="animate" exit="exit">
           {activeTab === "versions" && (
             <div className="space-y-4">
               <div className="flex justify-end">
@@ -1924,6 +1929,8 @@ function PromptsExperimentsModal({ agentId, agentName, onClose }: { agentId: str
               )}
             </div>
           )}
+          </motion.div>
+          </AnimatePresence>
         </div>
       </div>
     </div>

--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from "../components/ui/EmptyState";
 import { BarChart3, DollarSign, Shield, Save, Loader2, Cpu, Users, Zap, TrendingUp, Activity, Clock, Gauge, Target, Download } from "lucide-react";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend } from "recharts";
+import { StaggerList } from "../components/ui/StaggerList";
 
 interface BudgetForm {
   hourly?: string;
@@ -164,13 +165,13 @@ export function AnalyticsPage() {
       />
 
       {isLoading ? (
-        <div className="grid gap-4 grid-cols-2 md:grid-cols-4 stagger-children">
+        <StaggerList className="grid gap-4 grid-cols-2 md:grid-cols-4">
           {[1, 2, 3, 4].map(i => <CardSkeleton key={i} />)}
-        </div>
+        </StaggerList>
       ) : (
         <>
           {/* KPI Cards */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4">
             {kpis.map((kpi, i) => (
               <Card key={i} hover padding="md">
                 <div className="flex items-center justify-between">
@@ -180,7 +181,7 @@ export function AnalyticsPage() {
                 <p className={`text-2xl sm:text-3xl font-black tracking-tight mt-1 sm:mt-2 ${kpi.color}`}>{kpi.value}</p>
               </Card>
             ))}
-          </div>
+          </StaggerList>
 
           {/* Cost by Agent + Cost by Model */}
           <div className="grid gap-6 md:grid-cols-2">
@@ -257,7 +258,7 @@ export function AnalyticsPage() {
           {modelPerformance.length > 0 && (
             <>
               {/* KPI Cards for Model Performance */}
-              <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
+              <StaggerList className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4">
                 {modelKpis?.map((kpi, i) => (
                   <Card key={i} hover padding="md">
                     <div className="flex items-center justify-between">
@@ -267,7 +268,7 @@ export function AnalyticsPage() {
                     <p className={`text-xl sm:text-2xl font-black tracking-tight mt-1 sm:mt-2 ${kpi.color}`}>{kpi.value}</p>
                   </Card>
                 ))}
-              </div>
+              </StaggerList>
 
               {/* Latency Comparison + Cost Comparison */}
               <div className="grid gap-6 md:grid-cols-2">

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -59,6 +59,7 @@ import { formatRelativeTime } from "../lib/datetime";
 import type { AuditQueryFilters } from "../lib/http/client";
 import type { AuditQueryEntry } from "../api";
 import { useUIStore } from "../lib/store";
+import { StaggerList } from "../components/ui/StaggerList";
 
 // `<input type="datetime-local">` produces "YYYY-MM-DDTHH:MM" with no
 // timezone. The server parses `from` / `to` as RFC-3339 (offset
@@ -1004,7 +1005,7 @@ export function AuditPage() {
                   <span className="text-text-dim/70">{group.rows.length}</span>
                 </div>
               </div>
-              <div className="space-y-2 stagger-children">
+              <StaggerList className="space-y-2">
                 {group.rows.map((e) => {
                   const variant = outcomeVariant(e.outcome);
                   const fullTimestamp = e.timestamp;
@@ -1150,7 +1151,7 @@ export function AuditPage() {
                     </div>
                   );
                 })}
-              </div>
+              </StaggerList>
             </section>
             );
           })}

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useState, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "motion/react";
+import { fadeInScale, APPLE_EASE } from "../lib/motion";
 import {
   ReactFlow,
   Background,
@@ -2215,9 +2217,24 @@ function CanvasPageInner() {
       )}
 
       {/* Shortcut help panel */}
-      {showHelp && (
-        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm p-0 sm:p-4" onClick={() => setShowHelp(false)}>
-          <div className="bg-surface rounded-t-2xl sm:rounded-2xl shadow-2xl border border-border-subtle w-full sm:w-140 sm:max-w-[90vw] max-h-[85vh] sm:max-h-[80vh] overflow-y-auto animate-fade-in-scale" onClick={e => e.stopPropagation()}>
+      <AnimatePresence>
+        {showHelp && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/30 backdrop-blur-sm p-0 sm:p-4"
+            onClick={() => setShowHelp(false)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: APPLE_EASE }}
+          >
+          <motion.div
+            className="bg-surface rounded-t-2xl sm:rounded-2xl shadow-2xl border border-border-subtle w-full sm:w-140 sm:max-w-[90vw] max-h-[85vh] sm:max-h-[80vh] overflow-y-auto"
+            onClick={e => e.stopPropagation()}
+            variants={fadeInScale}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
             <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle">
               <h3 className="text-sm font-bold">{t("canvas.shortcuts_title")}</h3>
               <button onClick={() => setShowHelp(false)} className="p-1 rounded hover:bg-main"><X className="w-4 h-4" /></button>
@@ -2247,9 +2264,10 @@ function CanvasPageInner() {
                 </div>
               ))}
             </div>
-          </div>
-        </div>
-      )}
+          </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Schedule Modal */}
       {showScheduleModal && (

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -3,6 +3,8 @@ import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 import { useTranslation } from "react-i18next";
+import { motion } from "motion/react";
+import { messageIn, fadeInUp } from "../lib/motion";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { buildAuthenticatedWebSocketUrl, sendAgentMessage, loadAgentSession } from "../api";
 import { useQueryClient } from "@tanstack/react-query";
@@ -854,7 +856,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
   }, [message.content, isUser]);
 
   return (
-    <div className={`flex animate-message-in ${isUser ? "justify-end" : "justify-start"}`}>
+    <motion.div className={`flex ${isUser ? "justify-end" : "justify-start"}`} variants={messageIn} initial="initial" animate="animate">
       <div className={`flex flex-col min-w-0 w-fit max-w-[90%] sm:max-w-[min(75%,70ch)] ${isUser ? "items-end" : "items-start"}`}>
         {/* Avatar + name */}
         <div className={`flex items-center gap-2 mb-1.5 ${isUser ? "self-end flex-row-reverse" : "self-start"}`}>
@@ -1054,7 +1056,7 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
           </div>
         )}
       </div>
-    </div>
+    </motion.div>
   );
 });
 
@@ -2147,7 +2149,7 @@ function ApprovalCard({ approval, onResolved }: { approval: ApprovalItem; onReso
     : null;
 
   return (
-    <div className={`mx-auto w-full max-w-lg rounded-2xl border ${rs.border} ${rs.bg} p-4 shadow-lg animate-fade-in-up`}>
+    <motion.div className={`mx-auto w-full max-w-lg rounded-2xl border ${rs.border} ${rs.bg} p-4 shadow-lg`} variants={fadeInUp} initial="initial" animate="animate">
       {/* Header */}
       <div className="flex items-center gap-2 mb-3">
         <ShieldAlert className={`h-5 w-5 ${rs.text}`} />
@@ -2201,7 +2203,7 @@ function ApprovalCard({ approval, onResolved }: { approval: ApprovalItem; onReso
           {t("approvals.reject")}
         </button>
       </div>
-    </div>
+    </motion.div>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CommsPage.tsx
@@ -15,6 +15,7 @@ import {
   Mail, Phone, Link2, Wifi, Globe, ChevronRight, Search, X,
   ArrowsUpFromLine, Users
 } from "lucide-react";
+import { StaggerList } from "../components/ui/StaggerList";
 
 // Channel icons
 const channelIcons: Record<string, React.ReactNode> = {
@@ -214,7 +215,7 @@ export function CommsPage() {
       {activeTab === "channels" && (
         <>
           {/* Stats Grid */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4">
             {[
               { icon: Radio, label: t("comms.total_channels"), value: channels.length, color: "text-brand", bg: "bg-brand/10" },
               { icon: CheckCircle2, label: t("comms.connected"), value: configuredCount, color: "text-success", bg: "bg-success/10" },
@@ -229,7 +230,7 @@ export function CommsPage() {
                 <p className={`text-3xl font-black tracking-tight mt-2 ${kpi.color}`}>{kpi.value}</p>
               </Card>
             ))}
-          </div>
+          </StaggerList>
 
           {/* Health Checks */}
           <Card padding="lg">

--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
@@ -10,6 +10,7 @@ import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { useUIStore } from "../lib/store";
 import { Shield, Trash2, Edit2, Plus, Target, Rocket, Bot, Database, Users, AlertTriangle, Loader2, CheckCircle2, Clock, Play, ChevronDown, ChevronRight } from "lucide-react";
+import { StaggerList } from "../components/ui/StaggerList";
 
 const TEMPLATE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   rocket: Rocket,
@@ -222,7 +223,7 @@ export function GoalsPage() {
             <h3 className="text-lg font-black tracking-tight mb-1">{t("goals.pick_template")}</h3>
             <p className="text-sm text-text-dim">{t("goals.pick_template_desc")}</p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 stagger-children">
+          <StaggerList className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
             {templates.map((tpl) => {
               const Icon = TEMPLATE_ICONS[tpl.icon] ?? Target;
               const isApplying = applyingTemplate === tpl.id;
@@ -258,12 +259,12 @@ export function GoalsPage() {
                 </Card>
               );
             })}
-          </div>
+          </StaggerList>
         </div>
       ) : (
         <>
           {/* KPI row */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4">
             {[
               { label: t("goals.total"), value: stats.total, color: "text-brand", bg: "bg-brand/10", icon: Target },
               { label: t("goals.pending"), value: stats.pending, color: "text-text-dim", bg: "bg-main", icon: Clock },
@@ -280,7 +281,7 @@ export function GoalsPage() {
                 <div className="mt-2"><strong className={`text-3xl font-black tracking-tight ${s.color}`}>{s.value}</strong></div>
               </Card>
             ))}
-          </div>
+          </StaggerList>
 
           {/* Overall progress */}
           <Card padding="md">

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -2,6 +2,8 @@ import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 import { router } from "../router";
 import {
   type HandDefinitionItem,
@@ -43,6 +45,7 @@ import {
   useHandStatsBatch,
   useHandManifestToml,
 } from "../lib/queries/hands";
+import { StaggerList } from "../components/ui/StaggerList";
 
 const TomlViewer = lazy(() => import("../components/TomlViewer").then(m => ({ default: m.TomlViewer })));
 
@@ -444,6 +447,8 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery }: {
 
       {/* Tab content */}
       <div>
+        <AnimatePresence mode="wait">
+        <motion.div key={activeTab} variants={tabContent} initial="initial" animate="animate" exit="exit">
 
         {activeTab === "agents" && (
           <div className="space-y-2">
@@ -511,6 +516,8 @@ function DetailTabs({ hand, instance, isActive, settings, settingsQuery }: {
             handName={hand.name || hand.id}
           />
         )}
+        </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   );
@@ -1516,7 +1523,7 @@ export function HandsPage() {
           }
         />
       ) : (
-        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 stagger-children">
+        <StaggerList className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6">
           {filtered.map((h) => {
             const isActive = activeHandIds.has(h.id);
             const instance = instanceByHandId.get(h.id);
@@ -1535,7 +1542,7 @@ export function HandsPage() {
               />
             );
           })}
-        </div>
+        </StaggerList>
       )}
 
       {/* Detail side panel */}

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -1,6 +1,8 @@
 import { Component, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 import {
   type McpServerConfigured, type McpServerConnected, type McpTransport,
   type McpCatalogEntry,
@@ -896,6 +898,8 @@ export function McpServersPage() {
         </button>
       </div>
 
+      <AnimatePresence mode="wait">
+      <motion.div key={tab} variants={tabContent} initial="initial" animate="animate" exit="exit" className="space-y-4">
       {tab === "servers" && (
         <>
           {/* Search + filter toolbar */}
@@ -1129,6 +1133,8 @@ export function McpServersPage() {
           )}
         </>
       )}
+      </motion.div>
+      </AnimatePresence>
 
       {/* Add / Edit Modal */}
       <Modal

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
@@ -1,5 +1,7 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 import {
   type MediaProvider,
   type MediaImageResult,
@@ -120,18 +122,14 @@ export function MediaPage() {
 
       {/* Active panel */}
       <div className="rounded-2xl border border-border-subtle bg-surface p-5">
-        {activeTab === "image" && (
-          <ImagePanel providers={imageProviders} onToast={addToast} />
-        )}
-        {activeTab === "speech" && (
-          <SpeechPanel providers={speechProviders} onToast={addToast} />
-        )}
-        {activeTab === "video" && (
-          <VideoPanel providers={videoProviders} onToast={addToast} />
-        )}
-        {activeTab === "music" && (
-          <MusicPanel providers={musicProviders} onToast={addToast} />
-        )}
+        <AnimatePresence mode="wait">
+          <motion.div key={activeTab} variants={tabContent} initial="initial" animate="animate" exit="exit">
+            {activeTab === "image" && <ImagePanel providers={imageProviders} onToast={addToast} />}
+            {activeTab === "speech" && <SpeechPanel providers={speechProviders} onToast={addToast} />}
+            {activeTab === "video" && <VideoPanel providers={videoProviders} onToast={addToast} />}
+            {activeTab === "music" && <MusicPanel providers={musicProviders} onToast={addToast} />}
+          </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -18,6 +18,7 @@ import { Modal } from "../components/ui/Modal";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import { Database, Search, Trash2, Plus, X, Sparkles, Zap, Clock, Edit2, Loader2, Settings } from "lucide-react";
+import { StaggerList } from "../components/ui/StaggerList";
 
 // Add Memory Dialog
 function AddMemoryDialog({ onClose }: { onClose: () => void }) {
@@ -139,7 +140,7 @@ function MemoryStats({ stats }: { stats: MemoryStatsResponse | null }) {
   if (!stats) return null;
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 stagger-children">
+    <StaggerList className="grid grid-cols-2 md:grid-cols-4 gap-4">
       {kpis.map((kpi, i) => (
         <Card key={i} hover padding="md">
           <div className="flex items-center justify-between">
@@ -149,7 +150,7 @@ function MemoryStats({ stats }: { stats: MemoryStatsResponse | null }) {
           <p className={`text-3xl font-black tracking-tight mt-2 ${kpi.color}`}>{kpi.value}</p>
         </Card>
       ))}
-    </div>
+    </StaggerList>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
@@ -7,6 +7,7 @@ import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
+import { StaggerList } from "../components/ui/StaggerList";
 import { Network, Globe, Server, Wifi, WifiOff, Hash, Clock } from "lucide-react";
 
 export function NetworkPage() {
@@ -44,7 +45,7 @@ export function NetworkPage() {
       ) : (
         <>
           {/* Network status cards */}
-          <div className="grid gap-2 sm:gap-4 md:grid-cols-3 stagger-children">
+          <StaggerList className="grid gap-2 sm:gap-4 md:grid-cols-3">
             <Card hover padding="md">
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">
@@ -93,7 +94,7 @@ export function NetworkPage() {
                 <p className="text-[10px] text-text-dim font-mono mt-1">{status.listen_addr}</p>
               ) : null}
             </Card>
-          </div>
+          </StaggerList>
 
           {/* Peers list */}
           <div>
@@ -109,7 +110,7 @@ export function NetworkPage() {
                 description={t("network.no_peers_desc")}
               />
             ) : (
-              <div className="grid gap-2 sm:gap-3 md:grid-cols-2 stagger-children">
+              <StaggerList className="grid gap-2 sm:gap-3 md:grid-cols-2">
                 {peers.map((peer) => (
                   <Card key={peer.id} hover padding="md">
                     <div className="flex items-start justify-between">
@@ -147,7 +148,7 @@ export function NetworkPage() {
                     ) : null}
                   </Card>
                 ))}
-              </div>
+              </StaggerList>
             )}
           </div>
         </>

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import type { HealthCheck } from "../api";
 import { Card } from "../components/ui/Card";
@@ -12,6 +13,7 @@ import { getStatusVariant } from "../lib/status";
 import { formatRelativeTime } from "../lib/datetime";
 import { useDashboardSnapshot, useVersionInfo } from "../lib/queries/overview";
 import { useQuickInit } from "../lib/mutations/overview";
+import { StaggerList } from "../components/ui/StaggerList";
 
 function formatUptime(seconds?: number): string {
   if (seconds === undefined || seconds < 0) return "-";
@@ -175,7 +177,7 @@ export function OverviewPage() {
       ) : null}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4 stagger-children">
+      <StaggerList className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
         {isLoading ? (
           // Loading skeletons
           <>
@@ -211,7 +213,7 @@ export function OverviewPage() {
             </Card>
           ))
         )}
-      </div>
+      </StaggerList>
 
       {/* Main Content Grid */}
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-3">
@@ -222,7 +224,7 @@ export function OverviewPage() {
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-xs font-bold uppercase tracking-wider text-text-dim">{t("overview.quick_actions")}</h3>
             </div>
-            <div className="grid grid-cols-2 gap-2 sm:gap-3 sm:grid-cols-4 stagger-children">
+            <StaggerList className="grid grid-cols-2 gap-2 sm:gap-3 sm:grid-cols-4">
               {quickActions.map((action) => (
                 <button
                   key={action.to}
@@ -241,7 +243,7 @@ export function OverviewPage() {
                   <span className="text-[10px] sm:text-[11px] font-bold text-center">{action.label}</span>
                 </button>
               ))}
-            </div>
+            </StaggerList>
           </Card>
 
           {/* Recent Agents */}
@@ -258,7 +260,12 @@ export function OverviewPage() {
             {isLoading ? (
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {[1, 2].map(i => (
-                  <div key={i} className="h-16 rounded-xl bg-linear-to-r from-main via-surface-hover to-main bg-[length:200%_100%] animate-shimmer" />
+                  <motion.div
+                    key={i}
+                    className="h-16 rounded-xl bg-linear-to-r from-main via-surface-hover to-main bg-[length:200%_100%]"
+                    animate={{ backgroundPosition: ["200% 0", "-200% 0"] }}
+                    transition={{ duration: 1.5, ease: "easeInOut", repeat: Infinity }}
+                  />
                 ))}
               </div>
             ) : snapshot?.agents && snapshot.agents.length > 0 ? (

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -22,6 +22,9 @@ import {
   Puzzle, Plus, Download, Trash2, Package, FolderOpen,
   GitBranch, Loader2, Check, AlertCircle, FileCode
 } from "lucide-react";
+import { StaggerList } from "../components/ui/StaggerList";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 
 const EMPTY_PLUGINS: PluginItem[] = [];
 const EMPTY_REGISTRIES: RegistryEntry[] = [];
@@ -164,7 +167,9 @@ export function PluginsPage() {
         </button>
       </div>
 
-      {/* Installed Tab */}
+      {/* Installed / Registry Tab content */}
+      <AnimatePresence mode="wait">
+      <motion.div key={tab} variants={tabContent} initial="initial" animate="animate" exit="exit">
       {tab === "installed" && (
         <div>
           {pluginsQuery.isLoading ? (
@@ -176,7 +181,7 @@ export function PluginsPage() {
               description={t("plugins.no_plugins_desc")}
             />
           ) : (
-            <div className="space-y-2 stagger-children">
+            <StaggerList className="space-y-2">
               {plugins.map(p => (
                 <div key={p.name} className="flex items-center gap-3 p-3 sm:p-4 rounded-xl sm:rounded-2xl border border-border-subtle bg-surface hover:border-brand/30 transition-colors">
                   <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl bg-brand/10 flex items-center justify-center shrink-0">
@@ -219,7 +224,7 @@ export function PluginsPage() {
                   </div>
                 </div>
               ))}
-            </div>
+            </StaggerList>
           )}
         </div>
       )}
@@ -258,7 +263,7 @@ export function PluginsPage() {
                   {reg.plugins.length === 0 ? (
                     <p className="text-xs text-text-dim italic">{t("plugins.no_available")}</p>
                   ) : (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 stagger-children">
+                    <StaggerList className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                       {reg.plugins.map(rp => (
                         <Card
                           key={rp.name}
@@ -321,7 +326,7 @@ export function PluginsPage() {
                           </div>
                         </Card>
                       ))}
-                    </div>
+                    </StaggerList>
                   )}
                 </div>
               ))}
@@ -329,6 +334,8 @@ export function PluginsPage() {
           )}
         </div>
       )}
+      </motion.div>
+      </AnimatePresence>
 
       {/* Install Modal */}
       <Modal isOpen={showInstall} onClose={() => setShowInstall(false)} title={t("plugins.install_title")} size="md" variant="panel-right">

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -2,6 +2,8 @@ import { useMutation } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
 import { useMemo, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "motion/react";
+import { tabContent } from "../lib/motion";
 import { createRegistryContent } from "../api";
 import type { ApiActionResponse, ProviderItem } from "../api";
 import { isProviderAvailable } from "../lib/status";
@@ -308,7 +310,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
 
   if (viewMode === "list") {
     return (
-      <Card hover padding="sm" className={`flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4 group transition-all ${isSelected ? "ring-2 ring-brand" : ""}`}>
+      <Card hover padding="sm" onClick={() => onViewDetails(p)} className={`flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4 group transition-all ${isSelected ? "ring-2 ring-brand" : ""}`}>
         <div className="flex items-center gap-3 w-full sm:w-auto">
           <button
             onClick={(e) => { e.stopPropagation(); onSelect(p.id, !isSelected); }}
@@ -372,19 +374,19 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
           {isConfigured ? (
             <>
               {!isDefault && (
-                <Button variant="ghost" size="sm" onClick={() => onSetDefault(p.id)} leftIcon={<Star className="w-3 h-3" />}>
+                <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onSetDefault(p.id); }} leftIcon={<Star className="w-3 h-3" />}>
                   <span className="hidden sm:inline">{t("providers.set_as_default")}</span>
                 </Button>
               )}
-              <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+              <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onConfigure(p); }} leftIcon={<Pencil className="w-3 h-3" />}>
                 <span className="hidden sm:inline">{t("common.edit")}</span>
               </Button>
-              <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+              <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onDelete(p); }} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
                 <span className="hidden sm:inline text-error">{p.is_custom ? t("common.delete") : t("providers.remove_key")}</span>
               </Button>
               <Button
                 variant="secondary" size="sm"
-                onClick={() => onTest(p.id)}
+                onClick={(e) => { e.stopPropagation(); onTest(p.id); }}
                 disabled={pendingId === p.id}
                 leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
                 className="whitespace-nowrap"
@@ -393,11 +395,11 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               </Button>
             </>
           ) : (
-            <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Key className="w-3 h-3" />}>
+            <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onConfigure(p); }} leftIcon={<Key className="w-3 h-3" />}>
               <span className="hidden sm:inline">{t("providers.config")}</span>
             </Button>
           )}
-          <Button variant="ghost" size="sm" onClick={() => onViewDetails(p)}>
+          <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onViewDetails(p); }}>
             <ChevronRight className="w-4 h-4" />
           </Button>
         </div>
@@ -407,7 +409,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
 
   // Grid view
   return (
-    <Card hover padding="none" className={`relative flex flex-col overflow-hidden group transition-all ${isSelected ? "ring-2 ring-brand" : ""}`}>
+    <Card hover padding="none" onClick={() => onViewDetails(p)} className={`relative flex flex-col overflow-hidden group transition-all ${isSelected ? "ring-2 ring-brand" : ""}`}>
       {isCli && (
         <div className="absolute top-1.5 left-0 z-10 overflow-hidden w-20 h-20 pointer-events-none">
           <div className="absolute top-[12px] left-[-18px] w-[90px] text-center text-[9px] font-black uppercase tracking-wider text-text-dim bg-surface/80 border-y border-border-subtle rotate-[-45deg] py-px">
@@ -533,7 +535,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               <Star className="w-3 h-3 mr-1 inline" />{t("providers.is_default")}
             </Badge>
           ) : isConfigured ? (
-            <button onClick={() => onSetDefault(p.id)} className="inline-flex items-center gap-1 text-[10px] font-bold text-brand/70 hover:text-brand cursor-pointer transition-colors">
+            <button onClick={(e) => { e.stopPropagation(); onSetDefault(p.id); }} className="inline-flex items-center gap-1 text-[10px] font-bold text-brand/70 hover:text-brand cursor-pointer transition-colors">
               <Star className="w-3 h-3" />{t("providers.set_as_default")}
             </button>
           ) : null}
@@ -543,15 +545,15 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
         <div className="flex gap-2 mt-auto">
           {isConfigured ? (
             <>
-              <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Pencil className="w-3 h-3" />}>
+              <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onConfigure(p); }} leftIcon={<Pencil className="w-3 h-3" />}>
                 {t("common.edit")}
               </Button>
-              <Button variant="ghost" size="sm" onClick={() => onDelete(p)} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
+              <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onDelete(p); }} leftIcon={<Trash2 className="w-3 h-3 text-error" />}>
                 {p.is_custom ? t("common.delete") : t("providers.remove_key")}
               </Button>
               <Button
                 variant="secondary" size="sm"
-                onClick={() => onTest(p.id)}
+                onClick={(e) => { e.stopPropagation(); onTest(p.id); }}
                 disabled={pendingId === p.id}
                 leftIcon={pendingId === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
                 className="flex-1 whitespace-nowrap"
@@ -560,7 +562,7 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
               </Button>
             </>
           ) : (
-            <Button variant="ghost" size="sm" onClick={() => onConfigure(p)} leftIcon={<Key className="w-3 h-3" />} className="flex-1 whitespace-nowrap">
+            <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); onConfigure(p); }} leftIcon={<Key className="w-3 h-3" />} className="flex-1 whitespace-nowrap">
               {t("providers.config")}
             </Button>
           )}
@@ -1278,6 +1280,8 @@ export function ProvidersPage() {
         )}
       </div>
 
+      <AnimatePresence mode="wait">
+      <motion.div key={activeTab} variants={tabContent} initial="initial" animate="animate" exit="exit" className="flex flex-col gap-4">
       {providersQuery.isLoading ? (
         <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
           {[1, 2, 3, 4, 5, 6].map((i) => <CardSkeleton key={i} />)}
@@ -1321,6 +1325,8 @@ export function ProvidersPage() {
           </div>
         </>
       )}
+      </motion.div>
+      </AnimatePresence>
 
       {/* Details Modal */}
       {detailsProvider && (

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -37,6 +37,7 @@ import {
   useCleanupSessions,
 } from "../lib/mutations/runtime";
 import { useReloadConfig } from "../lib/mutations/config";
+import { StaggerList } from "../components/ui/StaggerList";
 
 const OK_STATUSES = new Set(["ok", "pass", "healthy"]);
 
@@ -212,9 +213,9 @@ export function RuntimePage() {
       />
 
       {snapshotQuery.isLoading ? (
-        <div className="grid gap-4 grid-cols-2 md:grid-cols-4 stagger-children">
+        <StaggerList className="grid gap-4 grid-cols-2 md:grid-cols-4">
           {[1, 2, 3, 4].map(i => <CardSkeleton key={i} />)}
-        </div>
+        </StaggerList>
       ) : snapshotQuery.isError || healthDetailQuery.isError || securityQuery.isError ? (
         // Only gate whole page on primary overview/security sources; audit, backups, and task queues can fail independently.
         <Card padding="lg">
@@ -232,7 +233,7 @@ export function RuntimePage() {
       ) : (
         <>
           {/* ── KPI Cards ── */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4">
             {kpiCards.map((kpi, i) => (
               <Card key={i} hover padding="md">
                 <div className="flex items-center justify-between">
@@ -244,10 +245,10 @@ export function RuntimePage() {
                 <p className={`text-2xl sm:text-3xl font-black tracking-tight mt-1 sm:mt-2 ${kpi.color}`}>{kpi.value}</p>
               </Card>
             ))}
-          </div>
+          </StaggerList>
 
           {/* ── Engine Info + Runtime Config ── */}
-          <div className="grid gap-3 sm:gap-6 md:grid-cols-2 stagger-children">
+          <StaggerList className="grid gap-3 sm:gap-6 md:grid-cols-2">
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">
                 <div className="w-8 h-8 rounded-lg bg-brand/10 flex items-center justify-center"><Cpu className="h-4 w-4 text-brand" /></div>
@@ -283,10 +284,10 @@ export function RuntimePage() {
                 } />
               </div>
             </Card>
-          </div>
+          </StaggerList>
 
           {/* ── Health Detail + Security Posture ── */}
-          <div className="grid gap-3 sm:gap-6 md:grid-cols-2 stagger-children">
+          <StaggerList className="grid gap-3 sm:gap-6 md:grid-cols-2">
             {/* Health Detail */}
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">
@@ -427,10 +428,10 @@ export function RuntimePage() {
                 <p className="text-xs text-text-dim">{t("common.loading")}</p>
               )}
             </Card>
-          </div>
+          </StaggerList>
 
           {/* ── Task Queue + Audit Trail ── */}
-          <div className="grid gap-3 sm:gap-6 md:grid-cols-2 stagger-children">
+          <StaggerList className="grid gap-3 sm:gap-6 md:grid-cols-2">
             {/* Task Queue */}
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">
@@ -654,10 +655,10 @@ export function RuntimePage() {
                 </Button>
               </div>
             </Card>
-          </div>
+          </StaggerList>
 
           {/* ── Backups + Resource Summary ── */}
-          <div className="grid gap-3 sm:gap-6 md:grid-cols-2 stagger-children">
+          <StaggerList className="grid gap-3 sm:gap-6 md:grid-cols-2">
             {/* Backup Management */}
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">
@@ -743,7 +744,7 @@ export function RuntimePage() {
                 <Badge variant="success">{t("status.nominal")}</Badge>
               </div>
             </Card>
-          </div>
+          </StaggerList>
 
           {/* ── Server Control ── */}
           <Card padding="lg">

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -29,6 +29,7 @@ import {
   useUpdateTrigger,
   useDeleteTrigger,
 } from "../lib/mutations/schedules";
+import { StaggerList } from "../components/ui/StaggerList";
 
 const TRIGGER_PATTERN_PRESETS = [
   { label: "lifecycle (spawned + terminated)", value: '"lifecycle"' },
@@ -277,7 +278,7 @@ export function SchedulerPage() {
             title={t("scheduler.no_schedules")}
           />
         ) : (
-          <div className="space-y-2 stagger-children">
+          <StaggerList className="space-y-2">
             {schedules.map(s => {
               const agent = agentMap.get(s.agent_id || "");
               const isEnabled = s.enabled !== false;
@@ -362,7 +363,7 @@ export function SchedulerPage() {
                 </div>
               );
             })}
-          </div>
+          </StaggerList>
         )}
       </div>
 
@@ -377,7 +378,7 @@ export function SchedulerPage() {
             title={t("common.no_data")}
           />
         ) : (
-          <div className="space-y-2 stagger-children">
+          <StaggerList className="space-y-2">
             {triggers.map((tr: TriggerItem) => {
               const isEnabled = tr.enabled !== false;
               const targetAgent = agentMap.get(tr.target_agent_id ?? "");
@@ -435,7 +436,7 @@ export function SchedulerPage() {
                 </div>
               );
             })}
-          </div>
+          </StaggerList>
         )}
       </div>
 

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -14,6 +14,7 @@ import { EmptyState } from "../components/ui/EmptyState";
 import { useUIStore } from "../lib/store";
 import { Clock, Search, MessageCircle, Trash2, Play, Users, Tag, Check, X } from "lucide-react";
 import { truncateId } from "../lib/string";
+import { StaggerList } from "../components/ui/StaggerList";
 
 export function SessionsPage() {
   const { t } = useTranslation();
@@ -125,7 +126,7 @@ export function SessionsPage() {
           description={t("sessions.empty_desc")}
         />
       ) : (
-        <div className="space-y-2 stagger-children">
+        <StaggerList className="space-y-2">
           {sessions.map(s => {
             const agent = agentMap.get(s.agent_id || "");
             return (
@@ -203,7 +204,7 @@ export function SessionsPage() {
               </div>
             );
           })}
-        </div>
+        </StaggerList>
       )}
     </div>
   );

--- a/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
@@ -13,6 +13,7 @@ import {
   Activity, BarChart3, Clock, Globe, TrendingUp, Zap, CheckCircle2,
   ExternalLink, Cpu, DollarSign, Bot, Wrench, MessageSquare, AlertTriangle, RotateCcw, Users,
 } from "lucide-react";
+import { StaggerList } from "../components/ui/StaggerList";
 
 // ── Parsed metric types ──────────────────────────────────────────────
 
@@ -240,7 +241,7 @@ export function TelemetryPage() {
               <Badge variant="brand" className="ml-2">v{parsed.system.version}</Badge>
             ) : null}
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4 xl:grid-cols-8 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4 xl:grid-cols-8">
             <MetricCard
               label={t("telemetry.uptime")}
               icon={<Clock className="w-3.5 h-3.5 text-success" />}
@@ -302,7 +303,7 @@ export function TelemetryPage() {
               }
               variant="success"
             />
-          </div>
+          </StaggerList>
 
           {/* ── LLM & Token Usage ── */}
           <div className="flex items-center gap-2 mt-4">
@@ -310,7 +311,7 @@ export function TelemetryPage() {
             <h2 className="text-sm font-black tracking-tight uppercase">{t("telemetry.llm_usage")}</h2>
             <Badge variant="default" className="ml-2">{t("telemetry.tokens_1h")}</Badge>
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-5 stagger-children">
+          <StaggerList className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-5">
             <MetricCard
               label={t("telemetry.total_tokens")}
               icon={<BarChart3 className="w-3.5 h-3.5 text-brand" />}
@@ -341,10 +342,10 @@ export function TelemetryPage() {
               value={<p className="text-2xl font-black tracking-tight" title={totalToolCalls.toLocaleString()}>{formatCompact(totalToolCalls)}</p>}
               variant="brand"
             />
-          </div>
+          </StaggerList>
 
           {/* ── Per-Agent Table + HTTP Endpoints ── */}
-          <div className="grid gap-6 md:grid-cols-2 stagger-children">
+          <StaggerList className="grid gap-6 md:grid-cols-2">
             {/* Per-Agent Token Usage */}
             <Card padding="lg">
               <div className="flex items-center gap-2 mb-5">
@@ -389,7 +390,7 @@ export function TelemetryPage() {
                 </div>
               )}
             </Card>
-          </div>
+          </StaggerList>
 
           {/* ── Raw Prometheus ── */}
           <Card padding="lg">

--- a/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UsersPage.tsx
@@ -56,6 +56,7 @@ import { Modal } from "../components/ui/Modal";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
+import { StaggerList } from "../components/ui/StaggerList";
 
 // Single source of truth for the role enum the dashboard speaks to. Mirrors
 // `librefang_kernel::auth::UserRole` and `UserConfig::role` (lower-case).
@@ -234,10 +235,10 @@ export function UsersPage() {
 
       {/* List */}
       {usersQuery.isPending ? (
-        <div className="grid gap-4 md:grid-cols-2 stagger-children">
+        <StaggerList className="grid gap-4 md:grid-cols-2">
           <CardSkeleton />
           <CardSkeleton />
-        </div>
+        </StaggerList>
       ) : users.length === 0 ? (
         <EmptyState
           icon={<Users className="h-8 w-8" />}
@@ -248,7 +249,7 @@ export function UsersPage() {
           )}
         />
       ) : (
-        <div className="grid gap-3 md:grid-cols-2 stagger-children">
+        <StaggerList className="grid gap-3 md:grid-cols-2">
           {users.map(u => (
             <Card key={u.name} hover padding="md">
               <div className="flex items-start justify-between gap-3">
@@ -363,7 +364,7 @@ export function UsersPage() {
               </div>
             </Card>
           ))}
-        </div>
+        </StaggerList>
       )}
 
       {/* Create / edit modal */}


### PR DESCRIPTION
## Summary

Unify every project-defined animation in the dashboard on a single `motion` (formerly framer-motion) system, and fill the animation gaps that used to be missing.

This started as "the providers drawer doesn't have a close animation" and ended up replacing the entire mixed CSS-keyframes / RAF / tailwindcss-animate situation with one consistent surface so that future animation work doesn't have to choose between three styles.

## What moved to motion

| Area | Before | After |
|------|--------|-------|
| `Modal` (drawer / panel / centred) | CSS `animate-fade-in-scale` / `animate-slide-in-right`, no exit animation | `<AnimatePresence>` + variants — symmetric in/out |
| Stagger lists (21 sites) | `.stagger-children > *:nth-child(n)` cascade | `<StaggerList>` wraps each child in `motion.div` with `staggerItem` + `layout` + `exit` |
| Toast notifications | `tailwindcss-animate` `animate-in slide-in-from-right-5`, no exit | `motion` + `<AnimatePresence>` + `layout` for stack reshuffling |
| `AnimatedNumber` | hand-rolled `requestAnimationFrame` + `easeOutExpo` | `motion`'s `animate()` (same API, runs on motion's scheduler) |
| `Typewriter_v2` | hand-rolled RAF character reveal | `motion`'s `animate(0, length, { onUpdate })` |
| Skeleton shimmer | `@keyframes shimmer` + inline `style.animation` | `motion.div` with `animate={{ backgroundPosition: [...] }}` and `repeat: Infinity` |
| 7 ad-hoc `animate-fade-in-scale` Modal-likes (App login, ConfirmDialog, ShortcutsHelp, CommandPalette, CanvasPage shortcut sheet, A2APage discover panel) | one-shot CSS keyframe | `<AnimatePresence>` with proper exit |

All 6 custom `@keyframes` and the entire `.stagger-children` cascade are deleted from `src/index.css`. `--apple-spring` / `--apple-ease` / `--apple-bounce` cubic-bezier vars stay (used by static `transition` rules and mirrored as motion easing constants).

## What was added (new behaviour, not just a rename)

- **Page transitions** — `<AnimatePresence mode="wait">` around the router `Outlet`, keyed on `location.pathname`. Navigating between dashboard pages now fades + 8px rises (180ms in / 120ms out) instead of snapping.
- **Tab content swap** — 7 surfaces cross-fade tab bodies on `activeTab` change: `MediaPage` (image/speech/video/music), `AgentsPage` (versions/experiments), `HandsPage` (agents/settings/requirements/tools/schedules), `PluginsPage` (installed/registry), `McpServersPage` (servers/catalog), `ProvidersPage` (configured/unconfigured), `TomlViewer` (toml/markdown).
- **List add/remove** — `<StaggerList>` wraps each child in `<AnimatePresence layout>` with an exit variant. The 21 sites that already used the old `stagger-children` className get item-removal animations and smooth neighbour reflow for free, as long as call sites pass stable keys (which they all do — `key={item.id}`).

## What was deliberately NOT migrated

| Class | Count | Why kept |
|-------|-------|----------|
| `animate-spin` | 90 | Tailwind's built-in spinner one-liner; motion-ising every `<Loader2>` would mean wrapping each in `<motion.div animate={{rotate:360}} transition={{repeat:Infinity}}>` for zero visual benefit |
| `animate-pulse` | 32 | Same reasoning — Tailwind utility, status indicators |
| `animate-bounce` / `animate-ping` | 3 | Same |
| `transition-colors` / `transition-all` etc. | 418 | These are CSS hover/focus transitions, not keyframe animations. Re-expressing them as `whileHover` would 5-10× the code with no visual change |
| `TerminalPage` `requestAnimationFrame` calls | 5 | Not animation — `xterm.fitAddon` "wait for next frame" scheduling |

The dividing line: **project-defined animations → motion; standard Tailwind utilities and non-animation RAF → leave alone.** Industry motion-driven projects (Linear, Vercel) follow the same split.

## New shared building blocks

```ts
// src/lib/motion.ts
export const APPLE_EASE / APPLE_SPRING / APPLE_BOUNCE: [n,n,n,n];
export const fadeInScale / fadeInUp / messageIn / slideInRight: Variants;
export const staggerContainer / staggerItem: Variants;
export const pageTransition / tabContent / toastSlide: Variants;
```

```tsx
// src/components/ui/StaggerList.tsx
<StaggerList className="grid grid-cols-3 gap-4">
  {items.map(item => <Card key={item.id}>…</Card>)}
</StaggerList>
```

`<StaggerList>` is a drop-in replacement for the legacy `.stagger-children` className with `manualItems` / `staticItems` escape hatches when call sites need finer control.

## Bundle impact

`motion` (formerly `framer-motion`) was added in this PR. Main `index-*.js` chunk gzip went from ~181KB to ~222KB (+41KB). `Modal` chunk gzip ~42KB (from ~1KB) since it's now the central animation surface.

If the bundle increase is a concern, the typical follow-up is `LazyMotion` + per-component `m.div` to ship only required features — happy to do that in a follow-up if requested.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 337 passed / 3 failed; the 3 failures are `TerminalPage.test.tsx` `attachCustomKeyEventHandler` issues that pre-exist on `main` (verified via `git stash`), unrelated to this PR
- [ ] Manual smoke: open and close drawer/modal/panel — exit animation plays
- [ ] Manual smoke: navigate between pages — transition is visible
- [ ] Manual smoke: switch tabs in MediaPage / AgentsPage / HandsPage — content cross-fades
- [ ] Manual smoke: toast appears + dismisses with slide
- [ ] Manual smoke: typewriter in chat still streams character-by-character
- [ ] Manual smoke: TelemetryPage numbers still tween on update
- [ ] Manual smoke: skeleton loading still shimmers
- [ ] Verify `prefers-reduced-motion: reduce` honored (motion's built-in behaviour — animations skip to end frames)
