### PR TITLE
chore(dashboard): shorten MCP nav label to 'MCP'

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -25,7 +25,7 @@
     "skills": "Skills",
     "hands": "Hands",
     "plugins": "Plugins",
-    "mcp_servers": "MCP Servers",
+    "mcp_servers": "MCP",
     "models": "Models",
     "media": "Media",
     "analytics": "Analytics",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -25,7 +25,7 @@
     "skills": "技能",
     "hands": "Hands",
     "plugins": "插件",
-    "mcp_servers": "MCP 服务器",
+    "mcp_servers": "MCP",
     "models": "模型",
     "media": "媒体生成",
     "analytics": "分析",


### PR DESCRIPTION
## Why

The sidebar nav label was `MCP 服务器` (zh) / `MCP Servers` (en). The other items in the same nav group are short single-word labels — Skills / Hands / Plugins / Models / Memory / Analytics — so the longer MCP label looked out of place.

## What

Shorten just the sidebar label to `MCP` in both locales. Page titles, the agent-form `mcp_servers` selector label, and toast strings keep the full `MCP Servers` / `MCP 服务器` wording so the longer name still appears wherever there's room for it.

## Test plan

- [ ] Open dashboard, confirm sidebar shows `MCP` (was `MCP 服务器` / `MCP Servers`)
- [ ] Switch language toggle — both locales render `MCP`
- [ ] Open `/mcp-servers` page → page header still says full `MCP Servers` / `MCP 服务器`
- [ ] Open agent edit form → `MCP 服务器` field label unchanged
