### PR TITLE
feat(dashboard/mcp): land on marketplace tab when no servers configured

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2553,7 +2553,7 @@
     "auth_start_failed": "Failed to start auth",
     "auth_revoke_failed": "Failed to revoke auth",
     "tab_my_servers": "Servers",
-    "tab_catalog": "Catalog",
+    "tab_catalog": "MCP Marketplace",
     "catalog_subtitle": "Browse and install pre-configured MCP server templates",
     "catalog_empty": "No MCP server templates available",
     "catalog_empty_desc": "MCP server templates will appear after a registry sync.",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2519,7 +2519,7 @@
     "auth_start_failed": "启动认证失败",
     "auth_revoke_failed": "撤销认证失败",
     "tab_my_servers": "服务器",
-    "tab_catalog": "目录",
+    "tab_catalog": "MCP 市场",
     "catalog_subtitle": "浏览并安装预配置的 MCP 服务器模板",
     "catalog_empty": "暂无可用的 MCP 服务器模板",
     "catalog_empty_desc": "MCP 服务器模板将在 Registry 同步后显示。",

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -657,6 +657,18 @@ export function McpServersPage() {
   const configured = data?.configured ?? [];
   const connected = data?.connected ?? [];
 
+  // First-time visitors with no servers configured land on the marketplace
+  // tab — installing a template is the obvious next step, and the empty
+  // "Servers" tab gave them nothing to act on. Only fires once per mount;
+  // if the user manually switches back to "servers", we don't override.
+  const autoSwitchedRef = useRef(false);
+  useEffect(() => {
+    if (autoSwitchedRef.current) return;
+    if (!serversQuery.isSuccess) return;
+    autoSwitchedRef.current = true;
+    if (configured.length === 0) setTab("catalog");
+  }, [serversQuery.isSuccess, configured.length]);
+
   const connectedMap = useMemo(() => {
     const map = new Map<string, McpServerConnected>();
     for (const c of connected) map.set(serverIdentityOf(c), c);


### PR DESCRIPTION
## Why

The MCP servers page opens on the **Servers** tab by default. For a fresh install with zero configured servers, that tab is empty — the user sees nothing actionable and has to discover the second tab on their own. The second tab itself was labelled `Catalog` / `目录`, which is vague.

## What

Two small tweaks:

1. **Auto-land on the marketplace tab when there are 0 configured servers.** Fires once per mount via a ref guard, so a manual flip back to `Servers` isn't overridden on the next refetch. If the user has any servers configured, default behaviour is unchanged.

2. **Rename the second tab to `MCP Marketplace` / `MCP 市场`.** Matches what the surface actually is — a browseable list of installable templates.

## Test plan

- [ ] Fresh daemon with no MCP servers → page opens on Marketplace tab
- [ ] Daemon with at least one configured MCP server → page opens on Servers tab (unchanged)
- [ ] On the empty-servers case, click `Servers` tab manually, refresh data → stays on Servers (no auto-override after the initial switch)
- [ ] Confirm tab label reads `MCP Marketplace` (en) / `MCP 市场` (zh)
