### PR TITLE
feat(dashboard/workflows): land on marketplace tab when no workflows

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1149,7 +1149,7 @@
     "nodes_unit": "nodes",
     "automation_hub": "Automation Hub",
     "templates": "Templates",
-    "template_library": "Template Library",
+    "template_library": "Workflow Marketplace",
     "my_workflows": "My Workflows",
     "use_template": "Use Template",
     "create_blank": "Create Blank",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1125,7 +1125,7 @@
     "nodes_unit": "个节点",
     "automation_hub": "自动化中心",
     "templates": "模板",
-    "template_library": "模板库",
+    "template_library": "工作流市场",
     "my_workflows": "我的工作流",
     "use_template": "使用模板",
     "create_blank": "创建空白工作流",

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -1,5 +1,5 @@
 import { formatDate } from "../lib/datetime";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -157,6 +157,18 @@ export function WorkflowsPage() {
     () => allWorkflows.find(w => w.id === scheduleWorkflowId),
     [allWorkflows, scheduleWorkflowId]
   );
+
+  // First-time visitors with no workflows configured land on the
+  // marketplace tab — instantiating a template is the obvious next
+  // step. Fires once per mount; if the user manually flips back to
+  // "My Workflows", we don't override on the next refetch.
+  const autoSwitchedRef = useRef(false);
+  useEffect(() => {
+    if (autoSwitchedRef.current) return;
+    if (!workflowsQuery.isSuccess) return;
+    autoSwitchedRef.current = true;
+    if ((workflowsQuery.data ?? []).length === 0) setActiveTab("templates");
+  }, [workflowsQuery.isSuccess, workflowsQuery.data]);
 
   useEffect(() => {
     if (!workflowsQuery.isSuccess) return;


### PR DESCRIPTION
## Why

Mirrors the MCP servers page treatment in #3411. The Workflows page opens on **My Workflows** by default. For a fresh install with no workflows yet, that tab is empty and offers no entry point — the user has to discover the template tab to make progress.

## What

1. **Auto-land on the marketplace tab when there are 0 workflows.** Fires once per mount via a ref guard, so manual flips back to `My Workflows` aren't overridden on the next refetch. If any workflow exists, behaviour is unchanged.

2. **Rename the second tab from `Template Library` / `模板库` to `Workflow Marketplace` / `工作流市场`.** Parity with the MCP page, and `Marketplace` better describes what the surface is — installable templates, not a passive library.

## Test plan

- [ ] Fresh daemon with zero workflows → page opens on Marketplace tab
- [ ] Daemon with at least one workflow → page opens on My Workflows (unchanged)
- [ ] Empty case, manually click `My Workflows`, refresh → stays on My Workflows
- [ ] Tab label reads `Workflow Marketplace` (en) / `工作流市场` (zh)
