### PR TITLE
feat(dashboard/plugins): land on marketplace tab when nothing installed

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -1,5 +1,5 @@
 import { formatBytes } from "../lib/format";
-import { useState, useCallback, startTransition } from "react";
+import { useState, useCallback, useEffect, useRef, startTransition } from "react";
 import { useTranslation } from "react-i18next";
 import type { PluginItem, RegistryEntry } from "../api";
 import { usePlugins, usePluginRegistries } from "../lib/queries/plugins";
@@ -74,6 +74,18 @@ export function PluginsPage() {
   const depsMutation = useInstallPluginDeps();
 
   const plugins = pluginsQuery.data?.plugins ?? EMPTY_PLUGINS;
+
+  // First-time visitors with nothing installed land on the marketplace
+  // tab — installing from the registry is the obvious next step. Fires
+  // once per mount; if the user manually flips back to "Installed", the
+  // next refetch doesn't override.
+  const autoSwitchedRef = useRef(false);
+  useEffect(() => {
+    if (autoSwitchedRef.current) return;
+    if (!pluginsQuery.isSuccess) return;
+    autoSwitchedRef.current = true;
+    if (plugins.length === 0) setTab("registry");
+  }, [pluginsQuery.isSuccess, plugins.length]);
   const registries = registriesQuery.data?.registries ?? EMPTY_REGISTRIES;
 
   const onRefresh = useCallback(() => {


### PR DESCRIPTION
## Why

Same treatment as MCP servers (#3411) and Workflows (#3412). The Plugins page opens on the **Installed** tab by default. For a fresh install with zero plugins, that tab is empty — installing from the registry is the obvious next step, but the user has to discover the second tab on their own.

## What

Auto-land on the **Marketplace** tab when there are 0 plugins installed. Fires once per mount via a ref guard, so a manual flip back to `Installed` isn't overridden on the next refetch. Tab label was already `Marketplace` / `插件市场`, so no rename needed.

## Test plan

- [ ] Fresh daemon with zero plugins → page opens on Marketplace tab
- [ ] Daemon with at least one plugin → page opens on Installed (unchanged)
- [ ] Empty case, manually click `Installed`, refresh data → stays on Installed
