### PR TITLE
fix(dashboard): drop layout/AnimatePresence from StaggerList to unblock clicks

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/StaggerList.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/StaggerList.tsx
@@ -1,16 +1,9 @@
 import { Children, isValidElement, type ReactNode } from "react";
-import { AnimatePresence, motion, type HTMLMotionProps } from "motion/react";
+import { motion, type HTMLMotionProps } from "motion/react";
 import { staggerContainer, staggerItem } from "../../lib/motion";
 
 interface StaggerListProps extends Omit<HTMLMotionProps<"div">, "variants" | "initial" | "animate" | "children"> {
   children: ReactNode;
-  /** Skip wrapping each child in a motion.div — useful when callers
-   *  already provide motion children with their own variants. */
-  manualItems?: boolean;
-  /** Disable enter/exit animations for individual items. When the
-   *  list contents are stable (hardcoded cards, not driven by data),
-   *  the AnimatePresence overhead is unnecessary. Defaults to false. */
-  staticItems?: boolean;
 }
 
 /// Drop-in replacement for the legacy `.stagger-children` className.
@@ -19,44 +12,20 @@ interface StaggerListProps extends Omit<HTMLMotionProps<"div">, "variants" | "in
 /// `staggerItem` variant from the container, producing the same 40ms
 /// cascade the CSS implementation produced.
 ///
-/// When children come from a `.map()` over data, items animate in/out
-/// on add/remove via `<AnimatePresence>` and `layout` reflows the grid
-/// smoothly. Children must have stable keys (data IDs, not array index)
-/// for the exit animation to play.
+/// Behaviour: enter-only animation. We deliberately do NOT use `layout`
+/// / `<AnimatePresence>` / `popLayout` here. Those add exit animation
+/// and neighbour reflow, but motion's `layout` toggles
+/// `pointer-events: none` on the wrapped element while a layout
+/// animation is running — which silently breaks click handling on
+/// click-to-open cards (Hands, Plugins, etc) any time the surrounding
+/// list re-measures (refetch, font load, viewport resize). Match the
+/// old CSS exactly: items fade in, deletions just disappear.
 ///
 /// Usage:
 ///   <StaggerList className="grid grid-cols-3 gap-4">
 ///     {items.map(item => <Card key={item.id}>…</Card>)}
 ///   </StaggerList>
-export function StaggerList({ children, manualItems, staticItems, ...rest }: StaggerListProps) {
-  if (manualItems) {
-    return (
-      <motion.div
-        variants={staggerContainer}
-        initial="initial"
-        animate="animate"
-        {...rest}
-      >
-        {children}
-      </motion.div>
-    );
-  }
-
-  const wrapped = Children.map(children, (child, idx) => {
-    if (!isValidElement(child)) return child;
-    const key = (child as { key?: string | number | null }).key ?? idx;
-    return (
-      <motion.div
-        key={key}
-        variants={staggerItem}
-        layout={!staticItems}
-        {...(staticItems ? {} : { exit: "exit" as const })}
-      >
-        {child}
-      </motion.div>
-    );
-  });
-
+export function StaggerList({ children, ...rest }: StaggerListProps) {
   return (
     <motion.div
       variants={staggerContainer}
@@ -64,7 +33,15 @@ export function StaggerList({ children, manualItems, staticItems, ...rest }: Sta
       animate="animate"
       {...rest}
     >
-      {staticItems ? wrapped : <AnimatePresence mode="popLayout">{wrapped}</AnimatePresence>}
+      {Children.map(children, (child, idx) => {
+        if (!isValidElement(child)) return child;
+        const key = (child as { key?: string | number | null }).key ?? idx;
+        return (
+          <motion.div key={key} variants={staggerItem}>
+            {child}
+          </motion.div>
+        );
+      })}
     </motion.div>
   );
 }

--- a/crates/librefang-api/dashboard/src/lib/motion.ts
+++ b/crates/librefang-api/dashboard/src/lib/motion.ts
@@ -74,8 +74,6 @@ export const staggerContainer: Variants = {
 };
 
 // Single staggered child — same shape as fadeInUp but slightly faster (0.5s).
-// Includes an `exit` variant so list removal inside <AnimatePresence>
-// plays a smooth fade-and-collapse instead of disappearing instantly.
 export const staggerItem: Variants = {
   initial: { opacity: 0, y: 16, filter: "blur(4px)" },
   animate: {
@@ -83,12 +81,6 @@ export const staggerItem: Variants = {
     y: 0,
     filter: "blur(0px)",
     transition: { duration: 0.5, ease: APPLE_SPRING },
-  },
-  exit: {
-    opacity: 0,
-    y: -8,
-    scale: 0.96,
-    transition: { duration: 0.18, ease: APPLE_EASE },
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #3365 where click-to-open card grids (Hands detail drawer, Plugins, Skills, MCP Servers, …) would silently stop responding to clicks after the list re-measured.

## Root cause

`StaggerList` wraps each child in a `motion.div` with `layout={true}` and the parent in `<AnimatePresence mode="popLayout">`. The intent was: list item deletions fade out smoothly and neighbours reflow.

The undocumented side effect: motion's layout system sets `pointer-events: none` on the wrapped element while a layout animation is running, to prevent hover hand-offs from interrupting the tween. `popLayout` additionally switches exiting children to `position: absolute`.

Any time the surrounding list re-measures — react-query `refetchInterval` firing (Hands polls every 30s), font load, viewport resize, filter toggle, even an unrelated layout shift in a parent — those guards fire and **eat clicks for the duration of the animation**. Users see the cursor change to a pointer over the card, click, and nothing happens.

Reproducible on `/dashboard/hands`: open the page, wait ~30s for the first poll, click a hand card → drawer doesn't open.

## Fix

Revert `StaggerList` to enter-only stagger, matching the original `.stagger-children` CSS exactly: items fade in with a 40ms cascade, deletions just disappear. No `layout`, no `<AnimatePresence>`, no `popLayout`.

Trade-off: list deletions no longer animate. We didn't have that animation before #3365 anyway, so this is a wash from a UX perspective and the click reliability is much more important.

Also clean up:
- Remove the dead-code `manualItems` / `staticItems` props on `StaggerList` (no call site used them — flagged by review on #3365).
- Remove the now-redundant `exit` variant on `staggerItem` since nothing wraps it in `<AnimatePresence>` anymore.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [ ] Manual: open `/dashboard/hands`, wait through one poll (30s), click a hand card → drawer opens
- [ ] Manual: same on `/dashboard/plugins`, `/dashboard/skills`, `/dashboard/mcp-servers`
- [ ] Manual: stagger entrance on first page load still cascades over ~360ms

## Affected pages

All 21 sites that use `<StaggerList>` get more reliable click handling. None lose any animation users were relying on (the layout/exit animation only existed in `main` for ~36 hours since #3365 merged).
