### PR TITLE
fix(tests): regenerate kernel config schema golden after thread-ownership field

### DIFF
--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -539,6 +539,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -952,6 +953,11 @@
             "string",
             "null"
           ]
+        },
+        "thread_ownership_enabled": {
+          "default": true,
+          "description": "Whether thread-ownership claiming applies to this channel. When set to `false`, every routed agent dispatches even if another agent already replied in the same thread — useful for \"broadcast\" channels where multiple agents are intended to chime in together. Default `true`: a single agent owns each `(channel, thread)` for the configured TTL (and an explicit @-mention re-claims for the new agent). DMs always bypass the registry. See #3334.",
+          "type": "boolean"
         },
         "threading": {
           "default": false,
@@ -2089,6 +2095,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -2250,6 +2257,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -2345,6 +2353,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -2635,6 +2644,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -2996,6 +3006,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3084,6 +3095,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3149,6 +3161,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3217,6 +3230,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3313,6 +3327,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3414,6 +3429,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3750,6 +3766,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3905,6 +3922,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -3983,6 +4001,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -4090,6 +4109,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -4175,6 +4195,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -4270,6 +4291,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -4355,6 +4377,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -4951,6 +4974,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -5036,6 +5060,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -5190,6 +5215,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -5258,6 +5284,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -5385,6 +5412,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -5591,6 +5619,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -5679,6 +5708,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -5831,6 +5861,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -5922,6 +5953,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6018,6 +6050,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6133,6 +6166,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6231,6 +6265,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6306,6 +6341,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6384,6 +6420,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6490,6 +6527,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6568,6 +6606,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6671,6 +6710,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6772,6 +6812,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6860,6 +6901,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -6945,6 +6987,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7023,6 +7066,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7128,6 +7172,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7223,6 +7268,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7301,6 +7347,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7396,6 +7443,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7489,6 +7537,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7567,6 +7616,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7648,6 +7698,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7736,6 +7787,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7829,6 +7881,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -7907,6 +7960,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8011,6 +8065,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8092,6 +8147,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8188,6 +8244,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8308,6 +8365,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8402,6 +8460,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8519,6 +8578,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8602,6 +8662,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8695,6 +8756,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8791,6 +8853,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8864,6 +8927,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -8963,6 +9027,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9073,6 +9138,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9163,6 +9229,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9264,6 +9331,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9360,6 +9428,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9458,6 +9527,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9556,6 +9626,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -9659,6 +9730,7 @@
                 "reply_precheck": false,
                 "reply_precheck_model": null,
                 "system_prompt": null,
+                "thread_ownership_enabled": true,
                 "threading": false,
                 "typing_mode": null,
                 "usage_footer": null
@@ -10163,6 +10235,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -10246,6 +10319,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -10459,6 +10533,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -10626,6 +10701,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -10697,6 +10773,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -11105,6 +11182,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -11269,6 +11347,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -11510,6 +11589,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -11617,6 +11697,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -11826,6 +11907,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12252,6 +12334,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12338,6 +12421,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12721,6 +12805,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12810,6 +12895,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12910,6 +12996,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -12990,6 +13077,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -13252,6 +13340,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -13338,6 +13427,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -13456,6 +13546,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -13544,6 +13635,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null
@@ -13637,6 +13729,7 @@
             "reply_precheck": false,
             "reply_precheck_model": null,
             "system_prompt": null,
+            "thread_ownership_enabled": true,
             "threading": false,
             "typing_mode": null,
             "usage_footer": null


### PR DESCRIPTION
## Why

`config_schema_golden::kernel_config_schema_matches_golden_fixture` has been failing on every PR since #3414 merged (Ubuntu / Windows / macOS, e.g. #3415). #3414 added `thread_ownership_enabled: bool` to `ChannelConfig` but didn't regenerate the golden fixture, so the schema test now drifts at +93 lines and blocks every unrelated PR.

## What

Run the canonical regen command:

```
cargo test -p librefang-api --test config_schema_golden \
  -- --ignored regenerate_golden --nocapture
```

The diff is purely additive — every entry in the fixture that includes a `ChannelConfig` payload picks up `"thread_ownership_enabled": true` (the new field's default), and the schema definitions block gains the corresponding property entry. No existing structure changed.

## Test plan

- [ ] `cargo test -p librefang-api --test config_schema_golden` passes locally (verified on this branch)
- [ ] CI Test job goes green here, unblocking #3415 and any other open PRs after rebase
