### PR TITLE
feat(kernel/workflow): pause/resume foundation for resumable workflows

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -169,8 +169,31 @@ pub enum ErrorMode {
 pub enum WorkflowRunState {
     Pending,
     Running,
+    /// The run was paused mid-execution and is waiting for an external
+    /// signal (an approval, a human-supplied input, etc.) before it
+    /// continues. Carry the `resume_token` the caller must present to
+    /// `WorkflowEngine::resume_run`, the wall-clock pause time, and a
+    /// human-readable reason for log/UI surfaces.
+    ///
+    /// Per-run snapshot data (step index, variable bindings, current
+    /// input) lives in fields on `WorkflowRun` rather than this variant
+    /// because runs are also used as raw step-history records — the
+    /// snapshot needs to be readable without matching on the state. See
+    /// #3335.
+    Paused {
+        resume_token: Uuid,
+        reason: String,
+        paused_at: DateTime<Utc>,
+    },
     Completed,
     Failed,
+}
+
+impl WorkflowRunState {
+    /// True when the run is in the `Paused` variant.
+    pub fn is_paused(&self) -> bool {
+        matches!(self, WorkflowRunState::Paused { .. })
+    }
 }
 
 /// A running workflow instance.
@@ -196,6 +219,45 @@ pub struct WorkflowRun {
     pub started_at: DateTime<Utc>,
     /// Completed at.
     pub completed_at: Option<DateTime<Utc>>,
+    /// Pause request set externally via [`WorkflowEngine::pause_run`].
+    /// Honored at the next step boundary in
+    /// [`WorkflowEngine::execute_run_sequential`] — at which point this
+    /// field is consumed and the state transitions to
+    /// [`WorkflowRunState::Paused`] using the same `resume_token`. A
+    /// non-`None` value with state still `Running` means the engine has
+    /// not yet observed the request. See #3335.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause_request: Option<PauseRequest>,
+    /// When the run is paused, the index of the next step to execute on
+    /// resume (so already-completed steps are not re-run). Set when the
+    /// engine honors a pause request; cleared when resume completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_step_index: Option<usize>,
+    /// Variable bindings as of the pause point. Restored into the local
+    /// `variables` map on resume so subsequent steps see the same
+    /// `{{var_name}}` substitutions they would have seen if the workflow
+    /// had not paused.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub paused_variables: HashMap<String, String>,
+    /// `current_input` (output of the last completed step) as of the
+    /// pause point. Restored on resume so the paused step receives the
+    /// same `{{input}}` it would have seen.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_current_input: Option<String>,
+}
+
+/// External pause request lodged on a `WorkflowRun`. Pre-generates the
+/// `resume_token` so the caller can begin waiting for the corresponding
+/// approval / input artifact before the execution loop has actually
+/// transitioned the run to `WorkflowRunState::Paused`. The execution loop
+/// reuses this same token when it honors the request, guaranteeing the
+/// caller's resume call will match. See #3335.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PauseRequest {
+    /// Human-readable explanation surfaced in logs and UI.
+    pub reason: String,
+    /// Token the caller must present to [`WorkflowEngine::resume_run`].
+    pub resume_token: Uuid,
 }
 
 /// Result from a single workflow step.
@@ -405,12 +467,22 @@ impl WorkflowEngine {
         };
         // Acquire a blocking read — called from async context after state update.
         let runs = self.runs.blocking_read();
+        // Persist:
+        //   - terminal runs (Completed / Failed) for history queries
+        //   - paused runs (#3335) so a daemon restart preserves the
+        //     snapshot needed to resume — without this, a paused run
+        //     becomes unrecoverable on restart.
+        // Pending / Running are not persisted: they have no durable
+        // boundary on which to roll forward and would otherwise come
+        // back as zombie runs after a crash.
         let terminal: Vec<&WorkflowRun> = runs
             .values()
             .filter(|r| {
                 matches!(
                     r.state,
-                    WorkflowRunState::Completed | WorkflowRunState::Failed
+                    WorkflowRunState::Completed
+                        | WorkflowRunState::Failed
+                        | WorkflowRunState::Paused { .. }
                 )
             })
             .collect();
@@ -625,6 +697,10 @@ impl WorkflowEngine {
             error: None,
             started_at: Utc::now(),
             completed_at: None,
+            pause_request: None,
+            paused_step_index: None,
+            paused_variables: HashMap::new(),
+            paused_current_input: None,
         };
 
         let mut runs = self.runs.write().await;
@@ -894,6 +970,139 @@ impl WorkflowEngine {
         Ok(layers)
     }
 
+    /// Request that an in-flight workflow run pause at the next step
+    /// boundary. Returns the `resume_token` the caller must hand back to
+    /// [`Self::resume_run`].
+    ///
+    /// The actual transition to [`WorkflowRunState::Paused`] happens inside
+    /// the execution loop — the loop reads `pause_request` at the top of
+    /// each step iteration and, if set, snapshots
+    /// `(step_index, variables, current_input)` and updates the run's
+    /// state with the pre-generated token. Calling `pause_run` on an
+    /// already-paused run is idempotent: the existing token is returned.
+    ///
+    /// Errors:
+    /// - `Err` if the run is unknown.
+    /// - `Err` if the run has already finished (`Completed` / `Failed`).
+    pub async fn pause_run(
+        &self,
+        run_id: WorkflowRunId,
+        reason: impl Into<String>,
+    ) -> Result<Uuid, String> {
+        let mut runs = self.runs.write().await;
+        let run = runs
+            .get_mut(&run_id)
+            .ok_or_else(|| format!("Workflow run not found: {run_id}"))?;
+        match &run.state {
+            WorkflowRunState::Pending | WorkflowRunState::Running => {
+                if let Some(existing) = &run.pause_request {
+                    return Ok(existing.resume_token);
+                }
+                let token = Uuid::new_v4();
+                run.pause_request = Some(PauseRequest {
+                    reason: reason.into(),
+                    resume_token: token,
+                });
+                Ok(token)
+            }
+            WorkflowRunState::Paused { resume_token, .. } => Ok(*resume_token),
+            WorkflowRunState::Completed | WorkflowRunState::Failed => Err(format!(
+                "Cannot pause workflow run {run_id}: state is terminal"
+            )),
+        }
+    }
+
+    /// Resume a paused workflow run from where it stopped.
+    ///
+    /// Verifies that the run is in [`WorkflowRunState::Paused`] and that
+    /// the supplied `resume_token` matches the one stored on the run, then
+    /// restores the snapshotted bindings + input and re-enters
+    /// `execute_run_sequential` at the saved step index. The DAG path
+    /// does not yet support pause/resume — see
+    /// [`Self::execute_run_dag`] for the explicit guard.
+    ///
+    /// Returns the eventual workflow output (or step error) just like the
+    /// original `execute_run`.
+    pub async fn resume_run<F, Fut>(
+        &self,
+        run_id: WorkflowRunId,
+        resume_token: Uuid,
+        agent_resolver: impl Fn(&StepAgent) -> Option<(AgentId, String, bool)>,
+        send_message: F,
+    ) -> Result<String, String>
+    where
+        F: Fn(AgentId, String) -> Fut + Sync,
+        Fut: std::future::Future<Output = Result<(String, u64, u64), String>> + Send,
+    {
+        // Validate state + token, snapshot what we need, flip state back to
+        // Running, then drop the lock before re-entering execution. The
+        // execution path takes the same write lock per step, so we must
+        // not hold it across the await.
+        let workflow = {
+            let mut runs = self.runs.write().await;
+            let run = runs
+                .get_mut(&run_id)
+                .ok_or_else(|| format!("Workflow run not found: {run_id}"))?;
+            match &run.state {
+                WorkflowRunState::Paused {
+                    resume_token: stored,
+                    ..
+                } => {
+                    if *stored != resume_token {
+                        return Err(format!(
+                            "Resume token mismatch for run {run_id}: presented token does not match stored token"
+                        ));
+                    }
+                }
+                other => {
+                    return Err(format!(
+                        "Cannot resume workflow run {run_id}: state is {other:?}, expected Paused"
+                    ));
+                }
+            }
+            // Flip back to Running and clear pause_request so the loop does
+            // not re-pause itself immediately. paused_step_index /
+            // paused_variables / paused_current_input are read by
+            // execute_run_sequential and cleared once consumed.
+            run.state = WorkflowRunState::Running;
+            run.pause_request = None;
+            self.workflows
+                .read()
+                .await
+                .get(&run.workflow_id)
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "Workflow definition {workflow_id} not found",
+                        workflow_id = run.workflow_id
+                    )
+                })?
+        };
+
+        // Re-enter the sequential path. It looks at paused_step_index /
+        // paused_variables / paused_current_input on the run and resumes
+        // from there. The dispatch over has_dag_deps mirrors execute_run.
+        let has_dag_deps = workflow.steps.iter().any(|s| !s.depends_on.is_empty());
+        let result = if has_dag_deps {
+            // Symmetric guard with execute_run_dag's check; we only reach
+            // this path if a run was paused via the sequential path before
+            // the DAG branch was selected, which the DAG guard refuses to
+            // do today. Belt-and-suspenders so resume can never fan out
+            // into the unsupported DAG executor by accident.
+            Err(
+                "Resuming a workflow with DAG dependencies is not yet supported (#3335 follow-up)"
+                    .to_string(),
+            )
+        } else {
+            // `input` here is unused on the resume path because the loop
+            // pulls `paused_current_input` off the run when present.
+            self.execute_run_sequential(run_id, &workflow, "", &agent_resolver, &send_message)
+                .await
+        };
+        self.persist_runs_async().await;
+        result
+    }
+
     /// Execute a workflow run step-by-step.
     ///
     /// This method takes a closure that sends messages to agents,
@@ -966,12 +1175,64 @@ impl WorkflowEngine {
         F: Fn(AgentId, String) -> Fut + Sync,
         Fut: std::future::Future<Output = Result<(String, u64, u64), String>> + Send,
     {
-        let mut current_input = input.to_string();
+        // Resume snapshot: when the run was previously paused, the prior
+        // execution stored `(step_index, variables, current_input)` on the
+        // run before transitioning to `Paused`. Restore them here so the
+        // loop picks up exactly where it stopped, then clear the snapshot
+        // so a future pause sets fresh values.
+        let (mut current_input, mut variables, mut i) = {
+            let mut runs = self.runs.write().await;
+            if let Some(run) = runs.get_mut(&run_id) {
+                if let Some(saved_idx) = run.paused_step_index.take() {
+                    let saved_vars = std::mem::take(&mut run.paused_variables);
+                    let saved_input = run.paused_current_input.take().unwrap_or_default();
+                    debug!(
+                        run_id = %run_id,
+                        resume_step = saved_idx,
+                        var_count = saved_vars.len(),
+                        "Resuming workflow run from saved snapshot"
+                    );
+                    (saved_input, saved_vars, saved_idx)
+                } else {
+                    (input.to_string(), HashMap::new(), 0_usize)
+                }
+            } else {
+                (input.to_string(), HashMap::new(), 0_usize)
+            }
+        };
         let mut all_outputs: Vec<String> = Vec::new();
-        let mut variables: HashMap<String, String> = HashMap::new();
-        let mut i = 0;
 
         while i < workflow.steps.len() {
+            // Pause-request gate. Honored at the top of every step
+            // iteration so an in-flight step is allowed to finish before
+            // the run pauses — partial-step rollback would be a much
+            // larger feature than #3335 requires.
+            let pending_pause = {
+                let runs = self.runs.read().await;
+                runs.get(&run_id).and_then(|r| r.pause_request.clone())
+            };
+            if let Some(pause) = pending_pause {
+                let mut runs = self.runs.write().await;
+                if let Some(run) = runs.get_mut(&run_id) {
+                    run.paused_step_index = Some(i);
+                    run.paused_variables = variables.clone();
+                    run.paused_current_input = Some(current_input.clone());
+                    run.pause_request = None;
+                    run.state = WorkflowRunState::Paused {
+                        resume_token: pause.resume_token,
+                        reason: pause.reason.clone(),
+                        paused_at: Utc::now(),
+                    };
+                }
+                info!(
+                    run_id = %run_id,
+                    resume_step = i,
+                    reason = %pause.reason,
+                    "Workflow run paused at step boundary"
+                );
+                return Ok(current_input);
+            }
+
             let step = &workflow.steps[i];
 
             debug!(
@@ -1421,6 +1682,25 @@ impl WorkflowEngine {
         F: Fn(AgentId, String) -> Fut + Sync,
         Fut: std::future::Future<Output = Result<(String, u64, u64), String>> + Send,
     {
+        // Pause/resume support is sequential-path only in #3335. If a pause
+        // request was lodged before the engine routed into the DAG branch,
+        // refuse cleanly rather than silently dropping the request — the
+        // DAG executor would never observe `pause_request` and the run
+        // would just complete normally, leaving the caller's `resume_run`
+        // call hanging. The follow-up to add per-layer pause checkpoints
+        // tracks against #3335.
+        let dag_pause_requested = {
+            let runs = self.runs.read().await;
+            runs.get(&run_id)
+                .and_then(|r| r.pause_request.as_ref().map(|p| p.reason.clone()))
+        };
+        if let Some(reason) = dag_pause_requested {
+            return Err(format!(
+                "Pause requested ({reason}) but the workflow uses DAG dependencies; \
+                 pause/resume is supported on the sequential path only (#3335 follow-up)"
+            ));
+        }
+
         let layers = Self::topological_sort(&workflow.steps)?;
         let mut variables: HashMap<String, String> = HashMap::new();
         // Track which step names have failed so we can skip dependents
@@ -3732,6 +4012,10 @@ prompt_template = "do {{x}}"
             error: None,
             started_at: Utc::now(),
             completed_at: Some(Utc::now()),
+            pause_request: None,
+            paused_step_index: None,
+            paused_variables: HashMap::new(),
+            paused_current_input: None,
         }
     }
 
@@ -3795,6 +4079,10 @@ prompt_template = "do {{x}}"
             error: None,
             started_at: Utc::now(),
             completed_at: None,
+            pause_request: None,
+            paused_step_index: None,
+            paused_variables: HashMap::new(),
+            paused_current_input: None,
         };
         let running_id = running.id;
 
@@ -3916,5 +4204,262 @@ prompt_template = "do {{x}}"
         assert!(!evaluate_condition("", "hello"));
         // Both empty
         assert!(evaluate_condition("", ""));
+    }
+
+    // -- #3335 pause / resume tests ----------------------------------------
+
+    #[tokio::test]
+    async fn pause_after_first_step_then_resume_finishes_workflow() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let engine = Arc::new(WorkflowEngine::new());
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine
+            .create_run(wf_id, "raw data".to_string())
+            .await
+            .unwrap();
+
+        // Shared state: capture the resume token from inside the sender so
+        // the test can present it later. The first sender invocation
+        // triggers `pause_run` so the loop honors the request *before*
+        // step 2 — verifying that pause respects step boundaries.
+        let captured_token = Arc::new(std::sync::Mutex::new(None::<Uuid>));
+        let pause_requested = Arc::new(AtomicBool::new(false));
+
+        let engine_for_sender = Arc::clone(&engine);
+        let captured_for_sender = Arc::clone(&captured_token);
+        let pause_for_sender = Arc::clone(&pause_requested);
+
+        let sender = move |_id: AgentId, msg: String| {
+            let engine = Arc::clone(&engine_for_sender);
+            let captured = Arc::clone(&captured_for_sender);
+            let pause_flag = Arc::clone(&pause_for_sender);
+            async move {
+                if !pause_flag.swap(true, Ordering::SeqCst) {
+                    let token = engine
+                        .pause_run(run_id, "test pause request")
+                        .await
+                        .expect("pause_run should succeed on a Running workflow");
+                    *captured.lock().unwrap() = Some(token);
+                }
+                Ok((format!("Processed: {msg}"), 100_u64, 50_u64))
+            }
+        };
+
+        // First execute_run: runs step 1, sender requests pause, loop
+        // honors at the next step boundary (before step 2).
+        engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .expect("execute_run should pause cleanly without erroring");
+
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(
+            matches!(run.state, WorkflowRunState::Paused { .. }),
+            "expected Paused, got {:?}",
+            run.state
+        );
+        assert_eq!(
+            run.paused_step_index,
+            Some(1),
+            "should pause before step index 1 (step 2)"
+        );
+        assert_eq!(
+            run.step_results.len(),
+            1,
+            "exactly one step should have completed before the pause"
+        );
+
+        let token = captured_token
+            .lock()
+            .unwrap()
+            .expect("sender should have captured a token");
+
+        // Resume: replay from saved snapshot, executing the remaining step.
+        let sender_resume = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 100_u64, 50_u64))
+        };
+        let result = engine
+            .resume_run(run_id, token, mock_resolver, sender_resume)
+            .await
+            .expect("resume_run should succeed");
+        assert!(result.contains("Processed:"));
+
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(
+            matches!(run.state, WorkflowRunState::Completed),
+            "expected Completed, got {:?}",
+            run.state
+        );
+        assert_eq!(run.step_results.len(), 2);
+        assert!(
+            run.paused_step_index.is_none(),
+            "snapshot should be cleared after resume"
+        );
+        assert!(run.paused_variables.is_empty());
+        assert!(run.paused_current_input.is_none());
+    }
+
+    #[tokio::test]
+    async fn resume_run_with_wrong_token_is_rejected() {
+        let engine = WorkflowEngine::new();
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+
+        // Pause-before-execute: loop will pause at step 0 immediately,
+        // giving us a Paused state with a known token.
+        let real_token = engine
+            .pause_run(run_id, "before-start pause")
+            .await
+            .unwrap();
+        let sender = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .unwrap();
+
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(matches!(run.state, WorkflowRunState::Paused { .. }));
+
+        let bogus_token = Uuid::new_v4();
+        assert_ne!(bogus_token, real_token);
+        let sender2 = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        let err = engine
+            .resume_run(run_id, bogus_token, mock_resolver, sender2)
+            .await
+            .expect_err("resume_run with wrong token must error");
+        assert!(err.contains("token"), "error should mention token: {err}");
+
+        // Run is still Paused — a failed resume attempt does not flip state.
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(matches!(run.state, WorkflowRunState::Paused { .. }));
+    }
+
+    #[tokio::test]
+    async fn resume_run_on_non_paused_run_is_rejected() {
+        let engine = WorkflowEngine::new();
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+        // No pause requested — run is in Pending.
+        let sender = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        let err = engine
+            .resume_run(run_id, Uuid::new_v4(), mock_resolver, sender)
+            .await
+            .expect_err("resume_run on non-paused run must error");
+        assert!(
+            err.contains("expected Paused"),
+            "error should mention required state: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn paused_run_round_trips_through_persist_and_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let original_token: Uuid;
+        let original_run_id: WorkflowRunId;
+
+        // Phase 1: build a paused run on engine instance #1, then persist.
+        {
+            let engine = Arc::new(WorkflowEngine::new_with_persistence(tmp.path()));
+            let wf_id = engine.register(test_workflow()).await;
+            let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+            original_run_id = run_id;
+            original_token = engine
+                .pause_run(run_id, "before-start pause")
+                .await
+                .unwrap();
+            let sender = |_id: AgentId, msg: String| async move {
+                Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+            };
+            engine
+                .execute_run(run_id, mock_resolver, sender)
+                .await
+                .unwrap();
+            // `execute_run` ends with `persist_runs_async().await`, which
+            // routes through `spawn_blocking` and respects the runtime.
+            // Awaiting `execute_run` already implies the persist completed.
+        }
+
+        // Phase 2: load from disk into a fresh engine, verify the
+        // Paused-state run came back with its token + snapshot intact.
+        // `load_runs` uses `blocking_write` internally, so wrap in
+        // `block_in_place` (requires multi-thread runtime, which this
+        // test selects via the `flavor` attribute).
+        let engine = WorkflowEngine::new_with_persistence(tmp.path());
+        let count = tokio::task::block_in_place(|| engine.load_runs()).unwrap();
+        assert_eq!(count, 1);
+        let run = engine.get_run(original_run_id).await.unwrap();
+        match &run.state {
+            WorkflowRunState::Paused { resume_token, .. } => {
+                assert_eq!(
+                    *resume_token, original_token,
+                    "persisted resume_token must match across daemon restart"
+                );
+            }
+            other => panic!("expected Paused after reload, got {:?}", other),
+        }
+        assert_eq!(run.paused_step_index, Some(0));
+    }
+
+    #[tokio::test]
+    async fn pause_request_on_dag_workflow_returns_explicit_error() {
+        let engine = Arc::new(WorkflowEngine::new());
+        // Build a 2-step workflow whose second step `depends_on` the
+        // first — that's enough for `execute_run` to route into the
+        // DAG executor.
+        let wf = Workflow {
+            id: WorkflowId::new(),
+            name: "dag".into(),
+            description: "".into(),
+            steps: vec![
+                WorkflowStep {
+                    name: "a".into(),
+                    agent: StepAgent::ByName { name: "x".into() },
+                    prompt_template: "{{input}}".into(),
+                    mode: StepMode::Sequential,
+                    timeout_secs: 30,
+                    error_mode: ErrorMode::Fail,
+                    output_var: None,
+                    inherit_context: None,
+                    depends_on: vec![],
+                },
+                WorkflowStep {
+                    name: "b".into(),
+                    agent: StepAgent::ByName { name: "y".into() },
+                    prompt_template: "{{input}}".into(),
+                    mode: StepMode::Sequential,
+                    timeout_secs: 30,
+                    error_mode: ErrorMode::Fail,
+                    output_var: None,
+                    inherit_context: None,
+                    depends_on: vec!["a".into()],
+                },
+            ],
+            created_at: Utc::now(),
+            layout: None,
+        };
+        let wf_id = engine.register(wf).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+
+        // Lodge a pause request *before* execute_run — DAG executor must
+        // refuse cleanly rather than silently dropping the request.
+        let _ = engine.pause_run(run_id, "dag pause").await.unwrap();
+        let sender = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        let err = engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .expect_err("DAG executor with pause request must return an explicit error");
+        assert!(
+            err.contains("DAG"),
+            "error should mention DAG limitation: {err}"
+        );
     }
 }

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -276,8 +276,20 @@ impl WorkflowRun {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PauseRequest {
     /// Human-readable explanation surfaced in logs and UI.
+    ///
+    /// **SECURITY:** persisted plaintext to `workflow_runs.json` and
+    /// shown back to operators. Do not pass secrets, PII, or
+    /// approval-gating tokens here — use a side channel referenced by
+    /// id instead.
     pub reason: String,
     /// Token the caller must present to [`WorkflowEngine::resume_run`].
+    ///
+    /// **SECURITY:** today this is stored plaintext in `workflow_runs.json`
+    /// alongside the run. Anyone with read access to the daemon home
+    /// directory can recover live tokens and resume an arbitrary paused
+    /// workflow. Acceptable for the kernel-internal foundation in this
+    /// PR; the future REST handler must hash tokens at rest before that
+    /// surface ships. Tracked as a follow-up against #3335.
     pub resume_token: Uuid,
 }
 
@@ -469,14 +481,44 @@ impl WorkflowEngine {
         }
         let data = std::fs::read_to_string(path)
             .map_err(|e| format!("Failed to read workflow runs: {e}"))?;
-        let runs: Vec<WorkflowRun> = serde_json::from_str(&data)
-            .map_err(|e| format!("Failed to parse workflow runs: {e}"))?;
+
+        // Per-entry tolerant parse rather than `Vec<WorkflowRun>` in one
+        // shot: an old daemon reading a file written by a newer daemon
+        // may encounter rows with shapes it doesn't know (e.g. the
+        // tagged `Paused { ... }` variant added in #3335). Failing the
+        // whole load on the first bad row would drop *all* persisted
+        // history; instead, skip unrecognized rows with a WARN. Newer
+        // daemons reading older files still parse cleanly because every
+        // post-foundation field is `#[serde(default)]`.
+        let raw_rows: Vec<serde_json::Value> = serde_json::from_str(&data)
+            .map_err(|e| format!("Failed to parse workflow runs (top-level array): {e}"))?;
+        let total = raw_rows.len();
+        let mut runs: Vec<WorkflowRun> = Vec::with_capacity(total);
+        let mut skipped: usize = 0;
+        for (idx, row) in raw_rows.into_iter().enumerate() {
+            match serde_json::from_value::<WorkflowRun>(row) {
+                Ok(run) => runs.push(run),
+                Err(e) => {
+                    skipped += 1;
+                    warn!(
+                        index = idx,
+                        error = %e,
+                        "Skipping unrecognized workflow run during load (likely a newer schema; \
+                         downgrade-safe rollback)"
+                    );
+                }
+            }
+        }
+
         let count = runs.len();
         let mut map = self.runs.blocking_write();
         for run in runs {
             map.insert(run.id, run);
         }
-        debug!(count, "Loaded persisted workflow runs from disk");
+        debug!(
+            count,
+            skipped, total, "Loaded persisted workflow runs from disk"
+        );
         Ok(count)
     }
 
@@ -1001,6 +1043,20 @@ impl WorkflowEngine {
     /// `(step_index, variables, current_input)` and updates the run's
     /// state with the pre-generated token. Calling `pause_run` on an
     /// already-paused run is idempotent: the existing token is returned.
+    ///
+    /// **DAG workflows fail-closed on pause.** Workflows whose steps use
+    /// `depends_on` are routed through the DAG executor, which does not
+    /// yet support pause. If `pause_run` is lodged on a DAG workflow,
+    /// the next `execute_run` call will mark the run `Failed` with a
+    /// "DAG pause not supported" error rather than silently completing.
+    /// Callers that don't know which executor a workflow targets should
+    /// either inspect `Workflow::steps` first or accept the fail-closed
+    /// behavior. Per-layer DAG pause checkpoints track as a follow-up
+    /// against #3335.
+    ///
+    /// **SECURITY:** the `reason` string is persisted plaintext to
+    /// `workflow_runs.json` and surfaced to operators. Do not include
+    /// secrets, PII, or approval-gating values in it.
     ///
     /// Errors:
     /// - `Err` if the run is unknown.
@@ -4535,6 +4591,116 @@ prompt_template = "do {{x}}"
         assert!(
             err.contains("DAG"),
             "error should mention DAG limitation: {err}"
+        );
+
+        // Refuse path must also flip the run to Failed and clear the
+        // lingering pause_request — otherwise a buggy caller sees a run
+        // stuck in Running with a pause_request that nothing will ever
+        // honor (review feedback on #3418).
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(
+            matches!(run.state, WorkflowRunState::Failed),
+            "DAG refuse must mark the run Failed, got {:?}",
+            run.state
+        );
+        assert!(
+            run.pause_request.is_none(),
+            "pause_request must be cleared after DAG refuse"
+        );
+        assert!(run.error.as_deref().unwrap_or("").contains("DAG"));
+    }
+
+    #[tokio::test]
+    async fn pause_run_is_idempotent_returns_same_token() {
+        let engine = WorkflowEngine::new();
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+
+        let token1 = engine.pause_run(run_id, "first").await.unwrap();
+        let token2 = engine.pause_run(run_id, "second").await.unwrap();
+        let token3 = engine.pause_run(run_id, "third").await.unwrap();
+        assert_eq!(token1, token2);
+        assert_eq!(token2, token3);
+
+        // Reason from the *first* call wins — later calls must not
+        // overwrite the message that surfaces in logs / UI.
+        let run = engine.get_run(run_id).await.unwrap();
+        let lodged = run.pause_request.expect("request should be present");
+        assert_eq!(lodged.reason, "first");
+    }
+
+    #[tokio::test]
+    async fn resume_run_after_completion_is_rejected() {
+        let engine = Arc::new(WorkflowEngine::new());
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+
+        // Pause-before-execute → loop pauses at step 0 → resume runs
+        // the workflow to completion.
+        let token = engine.pause_run(run_id, "before-start").await.unwrap();
+        let sender = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .unwrap();
+        let sender2 = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        engine
+            .resume_run(run_id, token, mock_resolver, sender2)
+            .await
+            .unwrap();
+
+        // Run is now Completed. A second resume_run with the same token
+        // must error rather than silently re-running the workflow.
+        let run = engine.get_run(run_id).await.unwrap();
+        assert!(matches!(run.state, WorkflowRunState::Completed));
+        let sender3 = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        let err = engine
+            .resume_run(run_id, token, mock_resolver, sender3)
+            .await
+            .expect_err("double-resume on a completed run must error");
+        assert!(
+            err.contains("expected Paused"),
+            "error should explain state mismatch: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_then_execute_on_pending_pauses_at_step_zero() {
+        let engine = WorkflowEngine::new();
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine.create_run(wf_id, "data".to_string()).await.unwrap();
+
+        // Run is Pending — pause is lodged before any step has executed.
+        let token = engine.pause_run(run_id, "pre-start").await.unwrap();
+        let sender = |_id: AgentId, msg: String| async move {
+            Ok((format!("Processed: {msg}"), 1_u64, 1_u64))
+        };
+        engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .expect("pause-at-zero path must not error");
+
+        let run = engine.get_run(run_id).await.unwrap();
+        match &run.state {
+            WorkflowRunState::Paused { resume_token, .. } => {
+                assert_eq!(*resume_token, token);
+            }
+            other => panic!("expected Paused, got {:?}", other),
+        }
+        assert_eq!(
+            run.paused_step_index,
+            Some(0),
+            "pre-start pause should snapshot at step index 0"
+        );
+        assert!(
+            run.step_results.is_empty(),
+            "no steps should have executed before the pause"
         );
     }
 }

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use librefang_types::agent::AgentId;
 use librefang_types::subagent::SubagentContext;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -183,6 +183,10 @@ pub enum WorkflowRunState {
     Paused {
         resume_token: Uuid,
         reason: String,
+        /// Wall-clock pause time. Surfaced in logs / UI today; future
+        /// follow-up will use this to drive a TTL-based GC sweep that
+        /// auto-expires Paused runs older than a configurable threshold
+        /// (#3335 GC follow-up).
         paused_at: DateTime<Utc>,
     },
     Completed,
@@ -236,14 +240,31 @@ pub struct WorkflowRun {
     /// Variable bindings as of the pause point. Restored into the local
     /// `variables` map on resume so subsequent steps see the same
     /// `{{var_name}}` substitutions they would have seen if the workflow
-    /// had not paused.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub paused_variables: HashMap<String, String>,
+    /// had not paused. `BTreeMap` rather than `HashMap` so the persisted
+    /// JSON has a stable key order — re-serializing a paused run twice
+    /// in a row produces byte-identical output, which keeps audit logs
+    /// and external snapshots clean.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub paused_variables: BTreeMap<String, String>,
     /// `current_input` (output of the last completed step) as of the
     /// pause point. Restored on resume so the paused step receives the
     /// same `{{input}}` it would have seen.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub paused_current_input: Option<String>,
+}
+
+impl WorkflowRun {
+    /// Wipe every pause-related field on the run. Called from terminal
+    /// transitions (Completed / Failed) so a Pause request lodged after
+    /// the loop's last boundary check or a snapshot left over from a
+    /// failed resume does not survive on a finished run as ghost data.
+    /// See #3335 review.
+    fn clear_pause_state(&mut self) {
+        self.pause_request = None;
+        self.paused_step_index = None;
+        self.paused_variables.clear();
+        self.paused_current_input = None;
+    }
 }
 
 /// External pause request lodged on a `WorkflowRun`. Pre-generates the
@@ -699,7 +720,7 @@ impl WorkflowEngine {
             completed_at: None,
             pause_request: None,
             paused_step_index: None,
-            paused_variables: HashMap::new(),
+            paused_variables: BTreeMap::new(),
             paused_current_input: None,
         };
 
@@ -1099,6 +1120,7 @@ impl WorkflowEngine {
             self.execute_run_sequential(run_id, &workflow, "", &agent_resolver, &send_message)
                 .await
         };
+        self.cleanup_terminal_pause_state(run_id).await;
         self.persist_runs_async().await;
         result
     }
@@ -1147,19 +1169,35 @@ impl WorkflowEngine {
 
         // Check if any step has non-empty depends_on — if so, use DAG execution
         let has_dag_deps = workflow.steps.iter().any(|s| !s.depends_on.is_empty());
-        if has_dag_deps {
-            let result = self
-                .execute_run_dag(run_id, &workflow, &input, &agent_resolver, &send_message)
-                .await;
-            self.persist_runs_async().await;
-            return result;
-        }
-
-        let result = self
-            .execute_run_sequential(run_id, &workflow, &input, &agent_resolver, &send_message)
-            .await;
+        let result = if has_dag_deps {
+            self.execute_run_dag(run_id, &workflow, &input, &agent_resolver, &send_message)
+                .await
+        } else {
+            self.execute_run_sequential(run_id, &workflow, &input, &agent_resolver, &send_message)
+                .await
+        };
+        self.cleanup_terminal_pause_state(run_id).await;
         self.persist_runs_async().await;
         result
+    }
+
+    /// Wipe pause-related fields on the run if it ended up in a terminal
+    /// state (Completed / Failed). Called once at the bottom of
+    /// `execute_run` and `resume_run` so every terminal transition gets
+    /// the same cleanup, regardless of which inner branch (sequential
+    /// happy path, DAG entry-guard refuse, mid-step Failed) ran. Avoids
+    /// scattering identical clear-five-fields blocks across ~10 sites.
+    /// See #3335 review.
+    async fn cleanup_terminal_pause_state(&self, run_id: WorkflowRunId) {
+        let mut runs = self.runs.write().await;
+        if let Some(run) = runs.get_mut(&run_id) {
+            if matches!(
+                run.state,
+                WorkflowRunState::Completed | WorkflowRunState::Failed
+            ) {
+                run.clear_pause_state();
+            }
+        }
     }
 
     /// Sequential workflow execution (extracted for persistence wrapping).
@@ -1177,15 +1215,23 @@ impl WorkflowEngine {
     {
         // Resume snapshot: when the run was previously paused, the prior
         // execution stored `(step_index, variables, current_input)` on the
-        // run before transitioning to `Paused`. Restore them here so the
-        // loop picks up exactly where it stopped, then clear the snapshot
-        // so a future pause sets fresh values.
+        // run before transitioning to `Paused`. Clone (not take!) so a
+        // mid-resume failure leaves the snapshot intact for future
+        // retry-from-failure paths — the snapshot is only authoritatively
+        // cleared on successful completion, see the Completed transition
+        // at the bottom of this function. The pause-mid-loop branch
+        // overwrites the snapshot with fresh values when it transitions
+        // back to Paused.
         let (mut current_input, mut variables, mut i) = {
-            let mut runs = self.runs.write().await;
-            if let Some(run) = runs.get_mut(&run_id) {
-                if let Some(saved_idx) = run.paused_step_index.take() {
-                    let saved_vars = std::mem::take(&mut run.paused_variables);
-                    let saved_input = run.paused_current_input.take().unwrap_or_default();
+            let runs = self.runs.read().await;
+            if let Some(run) = runs.get(&run_id) {
+                if let Some(saved_idx) = run.paused_step_index {
+                    let saved_vars: HashMap<String, String> = run
+                        .paused_variables
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    let saved_input = run.paused_current_input.clone().unwrap_or_default();
                     debug!(
                         run_id = %run_id,
                         resume_step = saved_idx,
@@ -1215,7 +1261,10 @@ impl WorkflowEngine {
                 let mut runs = self.runs.write().await;
                 if let Some(run) = runs.get_mut(&run_id) {
                     run.paused_step_index = Some(i);
-                    run.paused_variables = variables.clone();
+                    run.paused_variables = variables
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
                     run.paused_current_input = Some(current_input.clone());
                     run.pause_request = None;
                     run.state = WorkflowRunState::Paused {
@@ -1652,12 +1701,20 @@ impl WorkflowEngine {
             i += 1;
         }
 
-        // Mark workflow as completed
+        // Mark workflow as completed. Clear the pause snapshot fields and
+        // any orphan `pause_request` that may have been lodged after the
+        // last step boundary check — a pause requested between the loop's
+        // final iteration and this transition would otherwise survive on a
+        // Completed run as dead data.
         let final_output = current_input.clone();
         if let Some(r) = self.runs.write().await.get_mut(&run_id) {
             r.state = WorkflowRunState::Completed;
             r.output = Some(final_output.clone());
             r.completed_at = Some(Utc::now());
+            r.pause_request = None;
+            r.paused_step_index = None;
+            r.paused_variables.clear();
+            r.paused_current_input = None;
         }
 
         info!(run_id = %run_id, "Workflow completed successfully");
@@ -1695,6 +1752,24 @@ impl WorkflowEngine {
                 .and_then(|r| r.pause_request.as_ref().map(|p| p.reason.clone()))
         };
         if let Some(reason) = dag_pause_requested {
+            // Mark the run Failed and consume the lingering pause_request
+            // before returning. Without this the run stays Running with
+            // `pause_request: Some(_)` forever, looking like a live
+            // workflow that just never executes — and `cleanup_terminal_pause_state`
+            // (called by execute_run after we return) wouldn't run because
+            // state isn't terminal. Set Failed so the cleanup pass picks it up.
+            {
+                let mut runs = self.runs.write().await;
+                if let Some(run) = runs.get_mut(&run_id) {
+                    run.state = WorkflowRunState::Failed;
+                    run.error = Some(format!(
+                        "DAG workflow refused to start: pause requested ({reason}) \
+                         but pause/resume is supported on the sequential path only \
+                         (#3335 follow-up)"
+                    ));
+                    run.completed_at = Some(Utc::now());
+                }
+            }
             return Err(format!(
                 "Pause requested ({reason}) but the workflow uses DAG dependencies; \
                  pause/resume is supported on the sequential path only (#3335 follow-up)"
@@ -4014,7 +4089,7 @@ prompt_template = "do {{x}}"
             completed_at: Some(Utc::now()),
             pause_request: None,
             paused_step_index: None,
-            paused_variables: HashMap::new(),
+            paused_variables: BTreeMap::new(),
             paused_current_input: None,
         }
     }
@@ -4081,7 +4156,7 @@ prompt_template = "do {{x}}"
             completed_at: None,
             pause_request: None,
             paused_step_index: None,
-            paused_variables: HashMap::new(),
+            paused_variables: BTreeMap::new(),
             paused_current_input: None,
         };
         let running_id = running.id;


### PR DESCRIPTION
First slice of #3335. Lands the **state machine + persistence primitives** for resumable workflows. ApprovalManager wiring, REST/CLI surface, DAG-path support, GC, and the requester/approver capability check are explicit follow-ups against the same issue (listed below).

## Why split

Issue #3335's full acceptance criteria are a multi-PR effort. This PR keeps the diff to one file (~550 lines including tests) so reviewers can focus on the state-machine shape — once it lands, downstream work (approval integration, API endpoints, dashboard surface) plugs into a stable substrate.

## What lands

### Types

- `WorkflowRunState::Paused { resume_token, reason, paused_at }` carries the token a caller must present to `resume_run`.
- `WorkflowRun` gains four `#[serde(default)]` fields that survive round-trips with old persisted JSON:
  - `pause_request: Option<PauseRequest>` — set by `pause_run`, consumed at the next step boundary.
  - `paused_step_index: Option<usize>` — where to resume.
  - `paused_variables: HashMap<String, String>` — `{{var}}` bindings restored on resume.
  - `paused_current_input: Option<String>` — input that would have fed the paused step.
- `PauseRequest { reason, resume_token }` — token is generated when `pause_run` is called so the caller can begin waiting on the corresponding approval / input artifact before the executor has honored the request. The executor reuses the same token at the actual transition.

### API

```rust
WorkflowEngine::pause_run(run_id, reason) -> Uuid
WorkflowEngine::resume_run(run_id, token, resolver, sender) -> Result<String>
```

`pause_run` is idempotent — paused-already returns the existing token; errors on Completed / Failed. `resume_run` verifies state + token, restores snapshot, flips state to Running, re-enters `execute_run_sequential`. Snapshot fields are cleared on success; a wrong-token attempt leaves state untouched.

### Executor changes

`execute_run_sequential` reads `pause_request` at the top of every step iteration. On honoring it snapshots `(step_index, variables, current_input)` into the run, transitions to `Paused`, and returns the intermediate output. **In-flight steps finish first** — partial-step rollback would be a much bigger feature than #3335 requires.

`execute_run_dag` refuses cleanly when a pause request is lodged, rather than silently dropping it (the DAG executor would never observe `pause_request` and the run would just complete, leaving the caller's `resume_run` call hanging).

### Persistence

`persist_runs` filter extended to `Completed | Failed | Paused`. Paused runs round-trip through daemon restart with their token + snapshot intact; a fresh `load_runs` restores them and a subsequent `resume_run` works as if no restart had happened. `Pending` / `Running` are still skipped — they have no durable boundary.

## Tests (5 new)

| Test | What it verifies |
|---|---|
| `pause_after_first_step_then_resume_finishes_workflow` | Sender triggers pause from inside step 1; loop honors at the boundary before step 2; resume completes with `step_results.len() == 2` and snapshot fields cleared |
| `resume_run_with_wrong_token_is_rejected` | Resume with random token errors and leaves state Paused |
| `resume_run_on_non_paused_run_is_rejected` | Resume on Pending run errors with "expected Paused" |
| `paused_run_round_trips_through_persist_and_load` | (multi-thread flavor) Build paused run on engine #1, load into engine #2, assert resume_token + snapshot survive |
| `pause_request_on_dag_workflow_returns_explicit_error` | DAG run with pause request returns the explicit follow-up error rather than silently completing |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib --no-fail-fast` 637 passed (5 new, no regressions)
- [x] Backward compat: persisted `workflow_runs.json` from before this change loads cleanly because all new fields are `#[serde(default)]`

## Follow-ups (separate PRs against #3335)

- ApprovalManager wiring — a step returning "needs approval" triggers pause + registers with the existing TOTP / escalation flow.
- `POST /api/workflows/runs/{id}/resume` + `GET /api/workflows/runs/paused` for dashboard / external callers.
- CLI `librefang workflow run paused list / resume <id>`.
- DAG executor pause/resume (per-layer checkpoints).
- GC for paused workflows older than a configurable TTL.
- Capability check: the approver must match the original requester.
- Real-LLM integration test exercising the full pause-while-executing path through `send_message_streaming_with_sender_and_opts` (the current tests use mock senders).
