### PR TITLE
fix(dashboard): drawer not opening on hands page (DrawerPanel mount race)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -59,8 +59,18 @@ export function DrawerPanel({
   }, [isOpen, title, size, hideCloseButton, children, open]);
 
   // External close → bubble up to the parent so it can flip its state.
+  // Only fires on a real `true → false` transition. On first mount the
+  // store is still false (effect order: ref-update → push-to-store →
+  // this watcher), and treating that initial false as "the store was
+  // closed externally" would call parent.onClose() before the drawer
+  // ever rendered. This was the "drawer won't open" bug on pages that
+  // mount DrawerPanel conditionally with `isOpen` hard-coded to true
+  // (e.g. HandDetailPanel).
+  const prevDrawerOpenRef = useRef(false);
   useEffect(() => {
-    if (isOpen && !drawerOpen) {
+    const wasOpen = prevDrawerOpenRef.current;
+    prevDrawerOpenRef.current = drawerOpen;
+    if (isOpen && wasOpen && !drawerOpen) {
       onCloseRef.current();
     }
   }, [drawerOpen, isOpen]);


### PR DESCRIPTION
## Summary

Real fix for "drawer doesn't open on /dashboard/hands". My earlier #3415 attributed this to `StaggerList`'s `layout` / `popLayout` interfering with clicks — that was a real (though smaller) issue, but **not** the cause of the hands-page drawer regression. Apologies for the misdiagnosis.

## Root cause: `DrawerPanel` mount race

`DrawerPanel` (introduced in #3356) has three `useEffect`s, declared in this order:

```tsx
// 1. ref-sync
useEffect(() => { onCloseRef.current = onClose; }, [onClose]);

// 2. push children into the global drawer slot
useEffect(() => {
  if (!isOpen) return;
  open({ title, size, hideCloseButton, body: children, onClose: ... });
}, [isOpen, ..., open]);

// 3. external-close watcher — relays Esc/X back to parent.onClose
useEffect(() => {
  if (isOpen && !drawerOpen) {
    onCloseRef.current();   // ← fires on mount!
  }
}, [drawerOpen, isOpen]);
```

On mount with `isOpen=true`:
- Render 1 captures closures: `isOpen=true`, `drawerOpen=false` (zustand initial)
- Effect 2 calls `open(...)` → store flips to `isOpen=true` synchronously, but the new value isn't visible until the *next* render
- Effect 3 still sees `drawerOpen=false` from render 1's closure → predicate `isOpen && !drawerOpen` matches → fires `onCloseRef.current()`

→ parent calls `setDetailHand(null)` → `HandDetailPanel` unmounts → `DrawerPanel` cleanup runs `close()` → drawer slot stays at width 0. The drawer never gets to render.

## Why it manifested only on `/dashboard/hands`

Two `DrawerPanel` consumers:

| Page | Pattern | Affected? |
|------|---------|-----------|
| `ModelsPage` | `<DrawerPanel isOpen={!!detailModel} ...>` mounted permanently | No — predicate is `false && !false = false` while closed, so no onClose fire on mount |
| `HandsPage` | `{detailHand && <HandDetailPanel/>}` containing `<DrawerPanel isOpen ...>` (literal `true`) | **Yes** — predicate is always `true && !false` on mount → bug |

So whether you hit the bug depended on whether the parent kept the panel mounted or conditionally rendered it. Hands took the second pattern, hence the regression looked recent and page-specific.

## Fix

Only fire the external-close callback on a genuine `drawerOpen: true → false` transition, tracked via a ref:

```tsx
const prevDrawerOpenRef = useRef(false);
useEffect(() => {
  const wasOpen = prevDrawerOpenRef.current;
  prevDrawerOpenRef.current = drawerOpen;
  if (isOpen && wasOpen && !drawerOpen) {
    onCloseRef.current();
  }
}, [drawerOpen, isOpen]);
```

Initial `false` no longer counts. Esc / X / mobile-backdrop dismissals (which all flip `drawerOpen` from true to false) still bubble up correctly.

## Test plan
- [x] `pnpm typecheck`
- [ ] Manual: `/dashboard/hands` → click any hand card → detail drawer opens
- [ ] Manual: drawer Esc / X / clicking mobile backdrop → drawer closes and parent state flips (hand card no longer "selected")
- [ ] Manual: `/dashboard/models` → click a model → drawer opens (no regression)
- [ ] Manual: switching between hands by clicking a different card while drawer is open → drawer content swaps to the new hand
