### PR TITLE
chore(dashboard): remove Settings from left sidebar nav

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -558,7 +558,6 @@ export function App() {
         { to: "/config/security", label: t("config.cat_security"), icon: Shield },
         { to: "/config/network", label: t("config.cat_network"), icon: Share2 },
         { to: "/config/infra", label: t("config.cat_infra"), icon: Server },
-        { to: "/settings", label: t("nav.settings"), icon: Settings },
       ],
     },
     {


### PR DESCRIPTION
## Why

`/settings` was reachable from two places:
1. The left sidebar's **Configure** group (alongside `/config/memory`, `/config/tools`, …)
2. The user-menu dropdown in the top-right header (UserCircle → Settings)

That's redundant, and the sidebar's Configure group is meant for **per-area** config pages — a generic `/settings` entry doesn't fit the group's theme.

## What

Drop the sidebar entry, keep the user-dropdown entry.

## Test plan

- [ ] Open `/dashboard` → confirm Settings no longer appears in the left sidebar's Configure group
- [ ] Click UserCircle (top-right) → Settings entry still present, navigates to `/settings`
- [ ] `pnpm typecheck` clean (verified locally)
