### PR TITLE
feat(dashboard+api): i18n keys + surface plugin / MCP catalog [i18n.<lang>] blocks via Accept-Language

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -142,7 +142,11 @@
     "add": "Add",
     "remove": "Remove",
     "discard": "Discard",
-    "more_actions": "More actions"
+    "more_actions": "More actions",
+    "none": "None",
+    "metadata": "Metadata",
+    "size": "Size",
+    "path": "Path"
   },
   "status": {
     "running": "Running",
@@ -787,7 +791,11 @@
     "err_security_blocked": "Content was blocked by security scan. Please remove potentially dangerous patterns.",
     "err_invalid_name": "Invalid skill name. Use lowercase letters, numbers, hyphens, and underscores only.",
     "err_create_failed": "Failed to create skill. Please try again.",
-    "outputs": "Skill Outputs"
+    "outputs": "Skill Outputs",
+    "evo_load_failed": "Failed to load file",
+    "evo_action_failed": "Action failed",
+    "evo_delete_failed": "Delete failed",
+    "reload_failed": "Reload failed"
   },
   "hands": {
     "title": "Hands",
@@ -2424,7 +2432,9 @@
     "scaffold_failed": "Create failed",
     "scaffold_success": "Plugin created",
     "uninstall_failed": "Uninstall failed",
-    "uninstall_success": "Plugin removed"
+    "uninstall_success": "Plugin removed",
+    "invalid": "Invalid",
+    "hooks": "Hooks"
   },
   "schema_form": {
     "select_option": "Select...",
@@ -2598,7 +2608,11 @@
     "taint_skip_rule_sets_hint": "default = skip bypasses scanning entirely — rule_sets above will not fire (not even Log). Switch to default = scan for audit-only rule sets.",
     "taint_rule_sets_placeholder": "comma-separated names from [[taint_rules]]",
     "taint_rule_sets_overlap_hint": "When sets overlap on the same rule, the most permissive action wins (log > warn > block) — an audit-only set will silently neutralise a block set on the shared rule.",
-    "taint_rule_sets_unknown_hint": "Unknown rule_set name(s): {{names}} — not defined in any [[taint_rules]]. The scanner will treat them as no-ops."
+    "taint_rule_sets_unknown_hint": "Unknown rule_set name(s): {{names}} — not defined in any [[taint_rules]]. The scanner will treat them as no-ops.",
+    "view_detail": "View server details",
+    "transport": "Transport",
+    "required_env": "Required environment",
+    "setup_instructions": "Setup"
   },
   "toml_viewer": {
     "tab_toml": "TOML",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -141,7 +141,11 @@
     "add": "添加",
     "remove": "移除",
     "discard": "放弃更改",
-    "more_actions": "更多操作"
+    "more_actions": "更多操作",
+    "none": "无",
+    "metadata": "元数据",
+    "size": "大小",
+    "path": "路径"
   },
   "status": {
     "running": "运行中",
@@ -786,7 +790,11 @@
     "err_security_blocked": "内容被安全扫描拦截，请移除可疑模式。",
     "err_invalid_name": "技能名称非法：仅允许小写字母、数字、连字符、下划线。",
     "err_create_failed": "创建技能失败，请重试。",
-    "outputs": "技能输出"
+    "outputs": "技能输出",
+    "evo_load_failed": "加载文件失败",
+    "evo_action_failed": "操作失败",
+    "evo_delete_failed": "删除失败",
+    "reload_failed": "刷新失败"
   },
   "hands": {
     "title": "Hands",
@@ -2359,7 +2367,9 @@
     "scaffold_failed": "创建失败",
     "scaffold_success": "插件已创建",
     "uninstall_failed": "卸载失败",
-    "uninstall_success": "插件已移除"
+    "uninstall_success": "插件已移除",
+    "invalid": "无效",
+    "hooks": "钩子"
   },
   "telemetry": {
     "badge": "可观测性",
@@ -2564,7 +2574,11 @@
     "taint_skip_rule_sets_hint": "default = skip 会完全跳过扫描——上方 rule_sets 不会触发（包括 Log）。如需仅审计，请改回 default = scan。",
     "taint_rule_sets_placeholder": "[[taint_rules]] 中定义的名称，逗号分隔",
     "taint_rule_sets_overlap_hint": "多个集合覆盖同一规则时，最宽松的动作生效（log > warn > block）——仅审计的集合会静默使同规则上的 block 失效。",
-    "taint_rule_sets_unknown_hint": "未知 rule_set 名称：{{names}} —— 未在任何 [[taint_rules]] 中定义，扫描器会按 no-op 处理。"
+    "taint_rule_sets_unknown_hint": "未知 rule_set 名称：{{names}} —— 未在任何 [[taint_rules]] 中定义，扫描器会按 no-op 处理。",
+    "view_detail": "查看服务器详情",
+    "transport": "传输",
+    "required_env": "必需环境变量",
+    "setup_instructions": "设置说明"
   },
   "toml_viewer": {
     "tab_toml": "TOML",

--- a/crates/librefang-api/dashboard/src/main.tsx
+++ b/crates/librefang-api/dashboard/src/main.tsx
@@ -24,11 +24,21 @@ const queryClient = new QueryClient({
 // changes when the user flips languages in the UI. React Query keys do
 // not encode language, so we invalidate the affected domains on each
 // `languageChanged` event to force a refetch with the new header.
-i18n.on("languageChanged", () => {
+const onLanguageChanged = () => {
   for (const all of [pluginKeys.all, mcpKeys.all, handKeys.all, channelKeys.all]) {
     queryClient.invalidateQueries({ queryKey: all });
   }
-});
+};
+i18n.on("languageChanged", onLanguageChanged);
+
+// Vite HMR re-runs this module on edit, which would stack a fresh listener
+// on top of the previous one each time. Detach on dispose so dev sessions
+// don't accumulate redundant invalidations.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    i18n.off("languageChanged", onLanguageChanged);
+  });
+}
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/crates/librefang-api/dashboard/src/main.tsx
+++ b/crates/librefang-api/dashboard/src/main.tsx
@@ -5,7 +5,8 @@ import { RouterProvider } from "@tanstack/react-router";
 import { router } from "./router";
 import { ToastContainer } from "./components/ui/Toast";
 import "./index.css";
-import "./lib/i18n";
+import i18n from "./lib/i18n";
+import { channelKeys, handKeys, mcpKeys, pluginKeys } from "./lib/queries/keys";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,6 +16,17 @@ const queryClient = new QueryClient({
       staleTime: 30_000,
       refetchIntervalInBackground: false,
     }
+  }
+});
+
+// Backend resolves Accept-Language against `[i18n.<lang>]` blocks in
+// plugin / MCP catalog / hand / channel manifests, so the response body
+// changes when the user flips languages in the UI. React Query keys do
+// not encode language, so we invalidate the affected domains on each
+// `languageChanged` event to force a refetch with the new header.
+i18n.on("languageChanged", () => {
+  for (const all of [pluginKeys.all, mcpKeys.all, handKeys.all, channelKeys.all]) {
+    queryClient.invalidateQueries({ queryKey: all });
   }
 });
 

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1031,7 +1031,7 @@ function SupportingFileViewer({
       )}
       {error && (
         <p className="text-xs text-error">
-          {error instanceof Error ? error.message : "Failed to load file"}
+          {error instanceof Error ? error.message : t("skills.evo_load_failed")}
         </p>
       )}
       {data && (
@@ -1099,7 +1099,7 @@ function SkillDetailModal({
       addToast(successMsg, "success");
       setPane("none");
     } catch (e: unknown) {
-      addToast(e instanceof Error ? e.message : "Action failed", "error");
+      addToast(e instanceof Error ? e.message : t("skills.evo_action_failed"), "error");
     } finally {
       setBusy(false);
     }
@@ -1160,7 +1160,7 @@ function SkillDetailModal({
         );
         onClose();
       } catch (e: unknown) {
-        addToast(e instanceof Error ? e.message : "Delete failed", "error");
+        addToast(e instanceof Error ? e.message : t("skills.evo_delete_failed"), "error");
       } finally {
         setBusy(false);
       }
@@ -1632,7 +1632,7 @@ export function SkillsPage() {
         "success",
       );
     } catch (e: unknown) {
-      addToast(e instanceof Error ? e.message : "Reload failed", "error");
+      addToast(e instanceof Error ? e.message : t("skills.reload_failed"), "error");
     }
     void skillsQuery.refetch();
     void clawhubQuery.refetch();

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -2627,3 +2627,106 @@ pub async fn install_plugin_with_deps_handler(
         Err(e) => ApiErrorResponse::bad_request(e).into_response(),
     }
 }
+
+#[cfg(test)]
+mod resolve_plugin_i18n_tests {
+    use super::resolve_plugin_i18n;
+    use librefang_types::config::PluginI18n;
+    use std::collections::HashMap;
+
+    fn entry(name: Option<&str>, description: Option<&str>) -> PluginI18n {
+        PluginI18n {
+            name: name.map(String::from),
+            description: description.map(String::from),
+        }
+    }
+
+    /// No `[i18n.*]` block at all → English fields pass through untouched.
+    #[test]
+    fn empty_map_returns_english() {
+        let i18n: HashMap<String, PluginI18n> = HashMap::new();
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("zh", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "English Name");
+        assert_eq!(description.as_deref(), Some("English desc"));
+    }
+
+    /// Exact match on `lang` returns the localized fields.
+    #[test]
+    fn direct_match_overrides_both_fields() {
+        let mut i18n = HashMap::new();
+        i18n.insert("zh".to_string(), entry(Some("中文名"), Some("中文描述")));
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("zh", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "中文名");
+        assert_eq!(description.as_deref(), Some("中文描述"));
+    }
+
+    /// `zh-TW` request, only `zh-TW` registered → exact-match wins, no fallback hop.
+    #[test]
+    fn region_specific_match_preferred_over_base() {
+        let mut i18n = HashMap::new();
+        i18n.insert("zh".to_string(), entry(Some("简中"), Some("简中描述")));
+        i18n.insert(
+            "zh-TW".to_string(),
+            entry(Some("正體中文"), Some("繁中描述")),
+        );
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("zh-TW", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "正體中文");
+        assert_eq!(description.as_deref(), Some("繁中描述"));
+    }
+
+    /// `zh-TW` request, only `zh` registered → soft fallback to base tag.
+    #[test]
+    fn region_falls_back_to_base_tag() {
+        let mut i18n = HashMap::new();
+        i18n.insert("zh".to_string(), entry(Some("中文"), Some("中文描述")));
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("zh-TW", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "中文");
+        assert_eq!(description.as_deref(), Some("中文描述"));
+    }
+
+    /// Entry exists but only sets `name` → English description still fills in.
+    #[test]
+    fn partial_entry_falls_back_per_field() {
+        let mut i18n = HashMap::new();
+        i18n.insert("ja".to_string(), entry(Some("プラグイン"), None));
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("ja", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "プラグイン");
+        assert_eq!(description.as_deref(), Some("English desc"));
+    }
+
+    /// Unknown language and no fallback target → both fall back to English.
+    #[test]
+    fn unknown_lang_returns_english() {
+        let mut i18n = HashMap::new();
+        i18n.insert("zh".to_string(), entry(Some("中文"), Some("中文描述")));
+        let en_desc = Some("English desc".to_string());
+        let (name, description) = resolve_plugin_i18n("ko", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "English Name");
+        assert_eq!(description.as_deref(), Some("English desc"));
+    }
+
+    /// English description itself is `None` → propagates through cleanly.
+    #[test]
+    fn missing_english_description_propagates() {
+        let i18n: HashMap<String, PluginI18n> = HashMap::new();
+        let (name, description) = resolve_plugin_i18n("zh", "English Name", &None, &i18n);
+        assert_eq!(name, "English Name");
+        assert!(description.is_none());
+    }
+
+    /// Multi-segment tag `zh-Hant-TW` should still find `zh` via split_once
+    /// taking the first hyphen as separator.
+    #[test]
+    fn multi_segment_tag_falls_back_to_first_segment() {
+        let mut i18n = HashMap::new();
+        i18n.insert("zh".to_string(), entry(Some("中文"), Some("中文描述")));
+        let en_desc = Some("English desc".to_string());
+        let (name, _) = resolve_plugin_i18n("zh-Hant-TW", "English Name", &en_desc, &i18n);
+        assert_eq!(name, "中文");
+    }
+}

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -6,9 +6,32 @@ use axum::response::IntoResponse;
 use axum::Json;
 use std::sync::Arc;
 
-use super::AppState;
+use super::{resolve_lang, AppState, RequestLanguage};
 
 use crate::types::ApiErrorResponse;
+
+/// Pick the localized `(name, description)` for `lang` from the
+/// `[i18n.<lang>]` table parsed off a plugin manifest. Falls back to the
+/// original English fields per-string when an entry or field is missing.
+fn resolve_plugin_i18n<'a>(
+    lang: &str,
+    en_name: &'a str,
+    en_description: &'a Option<String>,
+    i18n: &'a std::collections::HashMap<String, librefang_types::config::PluginI18n>,
+) -> (String, Option<String>) {
+    let entry = i18n.get(lang).or_else(|| {
+        // Soft fallback: "zh-TW" hits "zh-TW" first, then "zh".
+        lang.split_once('-').and_then(|(base, _)| i18n.get(base))
+    });
+    let name = entry
+        .and_then(|e| e.name.as_deref())
+        .unwrap_or(en_name)
+        .to_string();
+    let description = entry
+        .and_then(|e| e.description.clone())
+        .or_else(|| en_description.clone());
+    (name, description)
+}
 
 /// Validate a GitHub registry identifier supplied by a caller.
 ///
@@ -173,7 +196,11 @@ pub struct ListPluginsQuery {
         (status = 200, description = "List installed plugins", body = serde_json::Value)
     )
 )]
-pub async fn list_plugins(Query(query): Query<ListPluginsQuery>) -> impl IntoResponse {
+pub async fn list_plugins(
+    Query(query): Query<ListPluginsQuery>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let lang = resolve_lang(lang.as_ref());
     let mut plugins = librefang_runtime::plugin_manager::list_plugins();
 
     // Apply enabled filter
@@ -193,10 +220,16 @@ pub async fn list_plugins(Query(query): Query<ListPluginsQuery>) -> impl IntoRes
     let items: Vec<serde_json::Value> = plugins
         .iter()
         .map(|p| {
+            let (name, description) = resolve_plugin_i18n(
+                lang,
+                &p.manifest.name,
+                &p.manifest.description,
+                &p.manifest.i18n,
+            );
             serde_json::json!({
-                "name": p.manifest.name,
+                "name": name,
                 "version": p.manifest.version,
-                "description": p.manifest.description,
+                "description": description,
                 "author": p.manifest.author,
                 "hooks_valid": p.hooks_valid,
                 "size_bytes": p.size_bytes,
@@ -228,28 +261,40 @@ pub async fn list_plugins(Query(query): Query<ListPluginsQuery>) -> impl IntoRes
         (status = 404, description = "Plugin not found")
     )
 )]
-pub async fn get_plugin(Path(name): Path<String>) -> impl IntoResponse {
+pub async fn get_plugin(
+    Path(name): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let lang = resolve_lang(lang.as_ref());
     match librefang_runtime::plugin_manager::get_plugin_info(&name) {
-        Ok(info) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "name": info.manifest.name,
-                "version": info.manifest.version,
-                "description": info.manifest.description,
-                "author": info.manifest.author,
-                "hooks": {
-                    "ingest": info.manifest.hooks.ingest,
-                    "after_turn": info.manifest.hooks.after_turn,
-                },
-                "hooks_valid": info.hooks_valid,
-                "size_bytes": info.size_bytes,
-                "path": info.path.display().to_string(),
-                "enabled": info.enabled,
-                "requirements": info.manifest.requirements,
-                "plugin_depends": info.manifest.plugin_depends,
-                "integrity_count": info.manifest.integrity.len(),
-            })),
-        ),
+        Ok(info) => {
+            let (loc_name, description) = resolve_plugin_i18n(
+                lang,
+                &info.manifest.name,
+                &info.manifest.description,
+                &info.manifest.i18n,
+            );
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "name": loc_name,
+                    "version": info.manifest.version,
+                    "description": description,
+                    "author": info.manifest.author,
+                    "hooks": {
+                        "ingest": info.manifest.hooks.ingest,
+                        "after_turn": info.manifest.hooks.after_turn,
+                    },
+                    "hooks_valid": info.hooks_valid,
+                    "size_bytes": info.size_bytes,
+                    "path": info.path.display().to_string(),
+                    "enabled": info.enabled,
+                    "requirements": info.manifest.requirements,
+                    "plugin_depends": info.manifest.plugin_depends,
+                    "integrity_count": info.manifest.integrity.len(),
+                })),
+            )
+        }
         Err(e) => ApiErrorResponse::not_found(e).into_json_tuple(),
     }
 }
@@ -605,7 +650,11 @@ pub async fn context_engine_metrics(State(state): State<Arc<AppState>>) -> impl 
         (status = 200, description = "Configured registries with available plugins", body = serde_json::Value)
     )
 )]
-pub async fn list_plugin_registries(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn list_plugin_registries(
+    State(state): State<Arc<AppState>>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let lang = resolve_lang(lang.as_ref());
     // Ensure the official registry is always present.
     let mut registries = state
         .kernel
@@ -651,11 +700,13 @@ pub async fn list_plugin_registries(State(state): State<Arc<AppState>>) -> impl 
             Ok(entries) => entries
                 .into_iter()
                 .map(|e| {
+                    let (name, description) =
+                        resolve_plugin_i18n(lang, &e.name, &e.description, &e.i18n);
                     serde_json::json!({
-                        "name": e.name,
+                        "name": name,
                         "installed": installed_names.contains(&e.name),
                         "version": e.version,
-                        "description": e.description,
+                        "description": description,
                         "author": e.author,
                         "hooks": e.hooks,
                     })

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -5013,11 +5013,29 @@ fn collect_installed_catalog_ids(state: &Arc<AppState>) -> std::collections::Has
 fn render_catalog_entry(
     entry: &librefang_extensions::McpCatalogEntry,
     installed_template_ids: &std::collections::HashSet<String>,
+    lang: &str,
 ) -> serde_json::Value {
+    // Pick the localized override (with `zh-TW` → `zh` soft fallback) and
+    // fall back to the English fields per-string when no entry / field is
+    // present.
+    let i18n_entry = entry.i18n.get(lang).or_else(|| {
+        lang.split_once('-')
+            .and_then(|(base, _)| entry.i18n.get(base))
+    });
+    let name = i18n_entry
+        .and_then(|e| e.name.as_deref())
+        .unwrap_or(&entry.name);
+    let description = i18n_entry
+        .and_then(|e| e.description.as_deref())
+        .unwrap_or(&entry.description);
+    let setup_instructions = i18n_entry
+        .and_then(|e| e.setup_instructions.as_deref())
+        .unwrap_or(&entry.setup_instructions);
+
     serde_json::json!({
         "id": entry.id,
-        "name": entry.name,
-        "description": entry.description,
+        "name": name,
+        "description": description,
         "icon": entry.icon,
         "category": entry.category.to_string(),
         "installed": installed_template_ids.contains(&entry.id),
@@ -5031,7 +5049,7 @@ fn render_catalog_entry(
             "get_url": e.get_url,
         })).collect::<Vec<_>>(),
         "has_oauth": entry.oauth.is_some(),
-        "setup_instructions": entry.setup_instructions,
+        "setup_instructions": setup_instructions,
     })
 }
 
@@ -5044,7 +5062,11 @@ fn render_catalog_entry(
         (status = 200, description = "MCP catalog entries", body = serde_json::Value)
     )
 )]
-pub async fn list_mcp_catalog(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn list_mcp_catalog(
+    State(state): State<Arc<AppState>>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let lang = super::resolve_lang(lang.as_ref());
     let installed_ids = collect_installed_catalog_ids(&state);
 
     let catalog = state
@@ -5055,7 +5077,7 @@ pub async fn list_mcp_catalog(State(state): State<Arc<AppState>>) -> impl IntoRe
     let entries: Vec<serde_json::Value> = catalog
         .list()
         .iter()
-        .map(|e| render_catalog_entry(e, &installed_ids))
+        .map(|e| render_catalog_entry(e, &installed_ids, lang))
         .collect();
     Json(serde_json::json!({
         "entries": entries,
@@ -5077,7 +5099,9 @@ pub async fn list_mcp_catalog(State(state): State<Arc<AppState>>) -> impl IntoRe
 pub async fn get_mcp_catalog_entry(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
+    let lang = super::resolve_lang(lang.as_ref());
     let installed_ids = collect_installed_catalog_ids(&state);
 
     let catalog = state
@@ -5088,7 +5112,7 @@ pub async fn get_mcp_catalog_entry(
     match catalog.get(&id) {
         Some(entry) => (
             StatusCode::OK,
-            Json(render_catalog_entry(entry, &installed_ids)),
+            Json(render_catalog_entry(entry, &installed_ids, lang)),
         ),
         None => ApiErrorResponse::not_found(format!("MCP catalog entry '{}' not found", id))
             .into_json_tuple(),

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -308,4 +308,88 @@ unhealthy_threshold = 5
         let err = ExtensionError::VaultLocked;
         assert!(err.to_string().contains("vault"));
     }
+
+    /// Catalog entries with `[i18n.<lang>]` blocks deserialize all three
+    /// localizable fields and survive a JSON round-trip. Catches future
+    /// regressions where someone reorders / renames a field on
+    /// `McpCatalogI18n` without updating the parser side.
+    #[test]
+    fn catalog_entry_i18n_roundtrip() {
+        let toml_str = r#"
+id = "aws"
+name = "AWS"
+description = "Manage Amazon Web Services resources via MCP."
+category = "cloud"
+icon = "lucide:cloud"
+tags = ["cloud", "aws"]
+setup_instructions = "Set AWS_* env vars."
+
+[transport]
+type = "stdio"
+command = "npx"
+args = ["-y", "@aws-mcp/server-aws"]
+
+[i18n.zh]
+name = "AWS"
+description = "通过 MCP 管理亚马逊云资源。"
+setup_instructions = "请配置 AWS_* 环境变量。"
+
+[i18n.zh-TW]
+name = "AWS"
+description = "透過 MCP 管理亞馬遜雲端資源。"
+
+[i18n.de]
+description = "Verwaltet AWS-Ressourcen über MCP."
+"#;
+        let entry: McpCatalogEntry = toml::from_str(toml_str).unwrap();
+
+        // All three locales are present.
+        assert_eq!(entry.i18n.len(), 3);
+
+        // zh: name + description + setup_instructions all set.
+        let zh = &entry.i18n["zh"];
+        assert_eq!(zh.name.as_deref(), Some("AWS"));
+        assert_eq!(
+            zh.description.as_deref(),
+            Some("通过 MCP 管理亚马逊云资源。")
+        );
+        assert_eq!(
+            zh.setup_instructions.as_deref(),
+            Some("请配置 AWS_* 环境变量。")
+        );
+
+        // zh-TW: name + description but no setup_instructions → field stays
+        // None so render_catalog_entry will fall back to the English value.
+        let zh_tw = &entry.i18n["zh-TW"];
+        assert_eq!(zh_tw.name.as_deref(), Some("AWS"));
+        assert!(zh_tw.setup_instructions.is_none());
+
+        // de: only description; name + setup_instructions remain None and
+        // the resolver will fall through to English for those.
+        let de = &entry.i18n["de"];
+        assert!(de.name.is_none());
+        assert!(de.setup_instructions.is_none());
+        assert_eq!(
+            de.description.as_deref(),
+            Some("Verwaltet AWS-Ressourcen über MCP.")
+        );
+    }
+
+    /// `[i18n.*]`-free entries still deserialize cleanly — the field is
+    /// `#[serde(default)]` so existing single-language catalogs keep working.
+    #[test]
+    fn catalog_entry_without_i18n_block() {
+        let toml_str = r#"
+id = "no-i18n"
+name = "No I18n"
+description = "single language only"
+category = "devtools"
+
+[transport]
+type = "http"
+url = "https://example.com"
+"#;
+        let entry: McpCatalogEntry = toml::from_str(toml_str).unwrap();
+        assert!(entry.i18n.is_empty());
+    }
 }

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -194,6 +194,27 @@ pub struct McpCatalogEntry {
     /// Health check configuration.
     #[serde(default)]
     pub health_check: HealthCheckConfig,
+    /// Per-language translation overrides for `name`, `description`, and
+    /// `setup_instructions`. Keyed by BCP-47 tag (`zh`, `zh-TW`, …).
+    /// API routes resolve `Accept-Language` against this table and fall
+    /// back to the top-level English fields when no entry matches.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub i18n: std::collections::HashMap<String, McpCatalogI18n>,
+}
+
+/// Per-language overrides for an MCP catalog entry's user-facing strings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpCatalogI18n {
+    /// Localized name. Falls back to the top-level `name`.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Localized description. Falls back to the top-level `description`.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Localized setup instructions. Falls back to the top-level
+    /// `setup_instructions`.
+    #[serde(default)]
+    pub setup_instructions: Option<String>,
 }
 
 /// Status of an MCP server.

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -962,25 +962,38 @@ async fn fetch_registry_plugin_meta(
         entry.hooks = hooks.keys().cloned().collect();
         entry.hooks.sort();
     }
-    if let Some(i18n) = value.get("i18n").and_then(|v| v.as_table()) {
-        for (lang, body) in i18n {
-            let Some(tbl) = body.as_table() else { continue };
-            let pi = PluginI18n {
-                name: tbl
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
-                description: tbl
-                    .get("description")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
-            };
-            if pi.name.is_some() || pi.description.is_some() {
-                entry.i18n.insert(lang.clone(), pi);
-            }
+    entry.i18n = parse_plugin_i18n_blocks(&value);
+    entry
+}
+
+/// Pull `[i18n.<lang>]` tables off a parsed plugin TOML, keeping only the
+/// `name` and `description` overrides. Empty entries (neither field set)
+/// are dropped to keep the map tight.
+///
+/// Exposed as `pub(crate)` so it can be unit-tested without a network
+/// round-trip; the production caller is `fetch_registry_plugin_meta`.
+pub(crate) fn parse_plugin_i18n_blocks(value: &toml::Value) -> HashMap<String, PluginI18n> {
+    let mut out: HashMap<String, PluginI18n> = HashMap::new();
+    let Some(i18n) = value.get("i18n").and_then(|v| v.as_table()) else {
+        return out;
+    };
+    for (lang, body) in i18n {
+        let Some(tbl) = body.as_table() else { continue };
+        let pi = PluginI18n {
+            name: tbl
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            description: tbl
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+        };
+        if pi.name.is_some() || pi.description.is_some() {
+            out.insert(lang.clone(), pi);
         }
     }
-    entry
+    out
 }
 
 /// List available plugins in a GitHub registry, enriched with manifest metadata.
@@ -4232,5 +4245,97 @@ after_turn = "hooks/after_turn.py"
         // 4. Remove
         remove_plugin("echo-memory").expect("remove failed");
         assert!(get_plugin_info("echo-memory").is_err());
+    }
+
+    /// Sanity: a manifest with no `[i18n.*]` tables yields an empty map,
+    /// not a serialization error or panic.
+    #[test]
+    fn parse_plugin_i18n_no_block() {
+        let toml_str = r#"
+name = "test-plugin"
+version = "0.1.0"
+description = "English description"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let i18n = parse_plugin_i18n_blocks(&value);
+        assert!(i18n.is_empty());
+    }
+
+    /// Multiple `[i18n.<lang>]` blocks with both fields populate cleanly.
+    #[test]
+    fn parse_plugin_i18n_multi_lang() {
+        let toml_str = r#"
+name = "auto-summarizer"
+version = "0.1.0"
+description = "English description"
+
+[i18n.zh]
+name = "自动摘要"
+description = "持续维护会话摘要。"
+
+[i18n.zh-TW]
+name = "自動摘要"
+description = "持續維護會話摘要。"
+
+[i18n.fr]
+name = "Auto-résumé"
+description = "Maintient un résumé continu."
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let i18n = parse_plugin_i18n_blocks(&value);
+        assert_eq!(i18n.len(), 3);
+        assert_eq!(i18n["zh"].name.as_deref(), Some("自动摘要"));
+        assert_eq!(i18n["zh-TW"].name.as_deref(), Some("自動摘要"));
+        assert_eq!(
+            i18n["fr"].description.as_deref(),
+            Some("Maintient un résumé continu.")
+        );
+    }
+
+    /// A block that only sets `name` (no description) survives, with
+    /// description left as `None` so callers know to fall back.
+    #[test]
+    fn parse_plugin_i18n_partial_entry() {
+        let toml_str = r#"
+[i18n.de]
+name = "Beispiel"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let i18n = parse_plugin_i18n_blocks(&value);
+        assert_eq!(i18n.len(), 1);
+        assert_eq!(i18n["de"].name.as_deref(), Some("Beispiel"));
+        assert!(i18n["de"].description.is_none());
+    }
+
+    /// A `[i18n.<lang>]` block that sets neither field is dropped — keeping
+    /// it would just take memory for no observable effect at the API
+    /// boundary.
+    #[test]
+    fn parse_plugin_i18n_empty_entry_dropped() {
+        let toml_str = r#"
+[i18n.ja]
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let i18n = parse_plugin_i18n_blocks(&value);
+        assert!(i18n.is_empty(), "empty i18n.ja entry should not be kept");
+    }
+
+    /// Non-string `name` / `description` values (e.g. someone wrote a
+    /// number by mistake) are silently ignored rather than panicking.
+    #[test]
+    fn parse_plugin_i18n_non_string_values_ignored() {
+        let toml_str = r#"
+[i18n.es]
+name = 42
+description = "Spanish description"
+"#;
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        let i18n = parse_plugin_i18n_blocks(&value);
+        assert_eq!(i18n.len(), 1);
+        assert!(i18n["es"].name.is_none(), "non-string name dropped");
+        assert_eq!(
+            i18n["es"].description.as_deref(),
+            Some("Spanish description")
+        );
     }
 }

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -10,7 +10,8 @@
 //! - **Local path**: copy from a local directory
 //! - **Git URL**: clone a git repo into the plugins directory
 
-use librefang_types::config::{PluginManifest, PluginSystemRequirement};
+use librefang_types::config::{PluginI18n, PluginManifest, PluginSystemRequirement};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
@@ -893,6 +894,11 @@ pub struct RegistryPluginEntry {
     /// Hook names declared by the plugin (e.g. `ingest`, `after_turn`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hooks: Vec<String>,
+    /// Per-language overrides for `name` / `description`. Keyed by BCP-47
+    /// tag (`zh`, `zh-TW`, …). API routes resolve `Accept-Language` against
+    /// this and fall back to the English values above.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub i18n: HashMap<String, PluginI18n>,
 }
 
 /// Disk cache file for an enriched registry listing.
@@ -955,6 +961,24 @@ async fn fetch_registry_plugin_meta(
     if let Some(hooks) = value.get("hooks").and_then(|v| v.as_table()) {
         entry.hooks = hooks.keys().cloned().collect();
         entry.hooks.sort();
+    }
+    if let Some(i18n) = value.get("i18n").and_then(|v| v.as_table()) {
+        for (lang, body) in i18n {
+            let Some(tbl) = body.as_table() else { continue };
+            let pi = PluginI18n {
+                name: tbl
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                description: tbl
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            };
+            if pi.name.is_some() || pi.description.is_some() {
+                entry.i18n.insert(lang.clone(), pi);
+            }
+        }
     }
     entry
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3620,6 +3620,30 @@ pub struct PluginManifest {
     /// ```
     #[serde(default)]
     pub requires: Vec<PluginSystemRequirement>,
+    /// Per-language translation overrides for `name` and `description`.
+    ///
+    /// Keyed by BCP-47 language tag (`zh`, `zh-TW`, `ja`, `ko`, `de`, `es`,
+    /// `fr`, …). API routes resolve `Accept-Language` against this table and
+    /// fall back to the top-level English fields when no entry matches.
+    ///
+    /// ```toml
+    /// [i18n.zh]
+    /// name = "自动摘要"
+    /// description = "持续维护会话摘要，帮助 Agent 在长对话中不丢失上下文。"
+    /// ```
+    #[serde(default)]
+    pub i18n: std::collections::HashMap<String, PluginI18n>,
+}
+
+/// A per-language override for a plugin's user-facing strings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PluginI18n {
+    /// Localized plugin name. Falls back to the top-level `name`.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Localized description. Falls back to the top-level `description`.
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 /// A single system-binary requirement declared in `plugin.toml`.


### PR DESCRIPTION
## Summary

Two-phase i18n pass for the plugin / MCP / skill surfaces in the dashboard.

### Commit 1 — Dashboard locale keys

The detail drawers added in #3422 used `t("key", { defaultValue: "English" })` but the keys were not actually registered in the locale files, so non-English users saw the English fallback. Also fixed four `addToast(e instanceof Error ? e.message : "English text", ...)` sites in `SkillsPage` that bypassed `t()` entirely.

| Namespace | New keys |
|---|---|
| `common` | `none`, `metadata`, `size`, `path` |
| `plugins` | `invalid`, `hooks` |
| `mcp` | `view_detail`, `transport`, `required_env`, `setup_instructions` |
| `skills` | `evo_load_failed`, `evo_action_failed`, `evo_delete_failed`, `reload_failed` |

### Commit 2 — Surface `[i18n.<lang>]` TOML blocks via Accept-Language

The plugin manifests in `librefang/librefang-registry` and the catalog files at `~/.librefang/mcp/catalog/*.toml` already ship rich `[i18n.zh]` / `[i18n.zh-TW]` / `[i18n.ja]` / `[i18n.ko]` / `[i18n.de]` / `[i18n.es]` / `[i18n.fr]` blocks. These were being silently dropped by serde because the receiving structs had no `i18n` field. Hands and channels already had this wiring; plugins and MCP catalog did not.

**Backend (3 crates)**

- `librefang-types`: `PluginManifest` gains `i18n: HashMap<String, PluginI18n>` (with `name` / `description` overrides).
- `librefang-runtime/plugin_manager`: `RegistryPluginEntry` gains the same map; `fetch_registry_plugin_meta` parses `[i18n.<lang>]` tables from each registry plugin's `plugin.toml`.
- `librefang-extensions`: `McpCatalogEntry` gains `i18n: HashMap<String, McpCatalogI18n>` (overrides for `name`, `description`, `setup_instructions`). Catalog loading already uses `toml::from_str`, so adding the field auto-deserializes — no `catalog.rs` changes.

**Backend routes**

- `routes/plugins.rs`: `list_plugin_registries`, `list_plugins`, `get_plugin` now take `Option<Extension<RequestLanguage>>` and resolve through a shared `resolve_plugin_i18n` helper. Soft fallback chain: `zh-TW` → `zh-TW` → `zh` → English (per-string).
- `routes/skills.rs`: `render_catalog_entry` takes a `lang` parameter and applies the same logic to MCP catalog entries. Both `list_mcp_catalog` and `get_mcp_catalog_entry` thread it through.

**Frontend wiring** — no API contract change. The fetch wrapper already sends `Accept-Language`. What was missing: invalidating the affected React Query caches when the user flips languages, since the keys do not encode language.

- `dashboard/main.tsx`: subscribe to `i18n.on("languageChanged", …)` and invalidate `pluginKeys.all`, `mcpKeys.all`, `handKeys.all`, `channelKeys.all` so the UI refetches with the new header.

## Test plan
- [x] `pnpm typecheck` passes (frontend)
- [x] `pnpm build` passes (frontend)
- [ ] Backend `cargo build --workspace --lib` (skipped at request — local machine running build-heavy task)
- [ ] Manual: `/dashboard/plugins` (Marketplace) in 中文 — registry plugins show their localized 中文 name/description
- [ ] Manual: `/dashboard/mcp` (Catalog) in 中文 — catalog templates show localized 中文 name/description/setup_instructions
- [ ] Manual: switch language while on either page — content immediately refetches with the new locale
- [ ] Manual: switch back to English — content reverts to the manifest's English baseline

## Notes

- Resolution is per-string with English fallback, so partial translations work — e.g. a plugin that only ships `[i18n.zh] name = "..."` but no localized `description` will show 中文 name + English description.
- Hands and channels' existing i18n flows are unchanged; the new `languageChanged` invalidation also re-fetches their queries so they pick up the same Accept-Language consistently.
- The official `librefang-registry` plugin manifests and the upstream MCP catalog already ship the `[i18n.*]` blocks for 7 languages; no registry change is needed.
