### PR TITLE
fix(api/middleware): add /api/auto-dream/status to dashboard read allowlist

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -600,6 +600,7 @@ pub async fn auth(
             | "/api/mcp/catalog"
             | "/api/mcp/health"
             | "/api/workflows"
+            | "/api/auto-dream/status"
     );
     let dashboard_read_prefix = path.starts_with("/api/budget/agents/")
         || path.starts_with("/api/approvals/")
@@ -1538,6 +1539,41 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/api/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// `/api/auto-dream/status` is a dashboard read — same shape as
+    /// `/api/agents` etc.: GET returns the global toggle + per-agent
+    /// state, drives the Settings page's Dream Mode card. Must not 401
+    /// when no auth is configured (default install) so the SPA renders.
+    /// POST endpoints under `/api/auto-dream/agents/*` (trigger / abort /
+    /// enabled) stay write-protected — they are not added to the
+    /// allowlist.
+    #[tokio::test]
+    async fn test_auto_dream_status_get_is_dashboard_read_public() {
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            require_auth_for_reads: false,
+            allow_no_auth: false,
+            audit_log: None,
+        };
+        let app = Router::new()
+            .route("/api/auto-dream/status", get(|| async { "status" }))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auto-dream/status")
                     .body(Body::empty())
                     .unwrap(),
             )


### PR DESCRIPTION
## Why

The Settings page's Dream Mode card showed `加载梦境模式状态失败` / "Failed to load auto-dream status" on every load.

Root cause: `GET /api/auto-dream/status` was registered as a route (`routes::auto_dream::router`) but never added to the auth middleware's `dashboard_read_exact` allowlist in `middleware.rs`. Any deployment with auth configured plus `require_auth_for_reads` enabled — or any unauthenticated SPA load before login — sent the request through the auth gate and got 401, so the React Query hook surfaced the error toast.

## What

One entry added to `dashboard_read_exact`:

```rust
| "/api/auto-dream/status"
```

Mirrors every other dashboard-read endpoint already in the list (`/api/agents`, `/api/config`, `/api/budget`, `/api/sessions`, …). All public via GET only.

POST endpoints (`/api/auto-dream/agents/{id}/trigger`, `/api/auto-dream/agents/{id}/abort`, `/api/auto-dream/agents/{id}/enabled`) stay **write-protected** — they require auth, as before.

## Tests

New `test_auto_dream_status_get_is_dashboard_read_public` pins the contract: with no API key configured, GET `/api/auto-dream/status` returns 200, not 401.

## Test plan

- [x] `cargo test -p librefang-api --lib middleware` clean
- [ ] CI green on workspace test
- [ ] Live: open `/dashboard/settings`, confirm Dream Mode card loads instead of showing the error toast
