### PR TITLE
chore(docker): expand .dockerignore for security + smaller build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,22 +1,101 @@
+# .dockerignore — what NOT to send to the Docker daemon as build context.
+#
+# Two goals: (1) keep secrets and runtime user data out of build layers,
+# (2) cut context-upload time for remote builders by skipping caches and
+# large generated dirs the Dockerfile rebuilds itself.
+#
+# Mirrors most of .gitignore's exclusions because anything not in git
+# probably shouldn't be in the image either. Patterns reuse the same
+# structure for easier review.
+
+# ── Secrets and user-private state ────────────────────────────────────
+.env
+.env.*
+secrets.env
+secrets.env.*
+config.toml
+*.pem
+*.key
+*.cert
+*.p12
+*.pfx
+
+# ── Runtime data files ────────────────────────────────────────────────
+# Local databases and journal files left over from `librefang start` —
+# may contain user prompts, agent state, message history.
+*.db
+*.db-shm
+*.db-wal
+*.sqlite
+*.sqlite3
+collector_hand_state.json
+collector_knowledge_base.json
+predictions_database.json
+prediction_report_*.md
+message_journal.jsonl
+BUILD_LOG.md
+
+# ── Build outputs (Dockerfile rebuilds these inside the image) ────────
+target
+target-*
+target-isolated
+crates/librefang-api/static/react/
+dist
+**/*.rs.bk
+result
+/rust_out
+
+# ── Node.js — vendored deps + dashboard caches ────────────────────────
+node_modules
+.vite
+.wrangler
+.serena
+
+# ── VCS, CI, repo metadata ────────────────────────────────────────────
 .git
 .github
-.claude
+.gitattributes
+.gitnexus
+
+# ── Editor / dev-shell / agent state ──────────────────────────────────
 .vscode
 .idea
-target
+.devcontainer
+.cargo
+.config
+.envrc
+.direnv
+.claude
+.codex
+.omc
+.qwen
+.plans
+*.swp
+*.swo
+*~
+
+# ── Local toolchain pinning ───────────────────────────────────────────
+flake.nix
+flake.lock
+mise.toml
+mise.lock
+
+# ── Docs and ancillary repo content not built into the image ──────────
+# `examples/` stays in the context — librefang-cli/src/templates.rs
+# uses include_str! to embed examples/custom-agent/agent.toml at
+# compile time, so excluding it breaks the build.
 docs
 sdk
 scripts
+articles
+i18n
+web
 *.md
 !crates/**/*.md
 LICENSE-*
 CLAUDE.md
-BUILD_LOG.md
-.env
-.env.*
-*.db
-*.sqlite
-*.pem
-*.key
+AGENTS.md
+
+# ── OS metadata ───────────────────────────────────────────────────────
 Thumbs.db
 .DS_Store


### PR DESCRIPTION
## Why

The existing `.dockerignore` was 17 lines and had real gaps in two categories:

1. **Secrets / runtime data that `.gitignore` excludes but `.dockerignore` did not.** A local `librefang start` leaves files like `config.toml`, `*.db-wal`, `secrets.env`, `collector_*.json`, `message_journal.jsonl` in the working tree. `docker build` reads the entire context (minus dockerignore) into a tarball that ships to the daemon — anything not excluded ends up readable in build layers. The Dockerfile is selective (`COPY crates ./crates` etc.) so most of these don't end up in the final image, but **a config.toml at repo root would be picked up by any user who tweaks the Dockerfile to `COPY . .`**, and the build context tarball is still a private copy moving across the network on remote builders.

2. **Large generated dirs that bloat upload time without affecting the final image.** `target/` was excluded but `target-*` / `target-isolated` siblings weren't. `node_modules` (anywhere) wasn't. `crates/librefang-api/static/react/` (the dashboard build output the Dockerfile rebuilds itself in the dashboard-builder stage) wasn't.

## What

Rewrite `.dockerignore` mirroring `.gitignore`'s structure, grouped by intent so future edits land in the right section. Net: 17 → ~80 lines, mostly comment + grouping.

### Highlights

**Security** — adds `secrets.env*`, `config.toml`, `*.cert`, `*.p12`, `*.pfx`, `*.db-shm`, `*.db-wal`, `*.sqlite3`. (Existing `.env*`, `*.db`, `*.sqlite`, `*.pem`, `*.key` retained.)

**Runtime user data** — adds `collector_*.json`, `predictions_database.json`, `prediction_report_*.md`, `message_journal.jsonl`.

**Build / cache** — adds `target-*`, `target-isolated`, `crates/librefang-api/static/react/`, `node_modules`, `dist`, `result` (Nix), `.vite`, `.wrangler`, `.serena`, `.direnv`, `/rust_out`, `**/*.rs.bk`.

**Editor / agent state** — adds `.devcontainer`, `.cargo` (potential registry tokens), `.config`, `.envrc`, `.codex`, `.omc`, `.qwen`, `.plans`, `*.swp`, `*.swo`, `*~`.

**Local toolchain** — adds `flake.nix`, `flake.lock`, `mise.toml`, `mise.lock` (none referenced by `deploy/Dockerfile`).

### Deliberate non-exclusion

`examples/` stays in the build context. `crates/librefang-cli/src/templates.rs` does `include_str!("../../../examples/custom-agent/agent.toml")` at compile time — excluding `examples/` would break the build. Comment in the file documents this for future readers.

## Test plan

- [ ] CI Docker build (`Docker / linux/amd64` job) still succeeds — proves we didn't ignore something the Dockerfile relies on
- [ ] Build context size measurably smaller — `docker build --no-cache .` upload phase should drop noticeably for repos with `target-*` / `node_modules` / `static/react` populated
- [ ] No `config.toml`, `secrets.env`, `*.db-wal`, etc. accidentally end up in final image (already ensured by Dockerfile's selective COPY, but defense in depth)
