### PR TITLE
release: v2026.4.28-beta7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,106 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.4.28] - 2026-04-28
+
+_67 PRs from 4 contributors since v2026.4.27-beta6._
+
+### Highlights
+
+- **Auxiliary LLM client** — a dedicated cheap-tier model now handles background side tasks, reducing cost on main-agent calls
+- **BytePlus, Microsoft (GitHub Models), and Z.ai providers** — three new LLM provider families added, each with their own dedicated API key env vars
+- **Thread ownership** — prevents multiple agents from sending duplicate replies to the same thread; paired with a pause/resume foundation for resumable multi-step workflows
+- **Redesigned Users surface and dashboard UI** — compact card grid layout, push-style adaptive drawer, unified animations, and richer markdown help drawers across all pages; empty states now land on the marketplace tab automatically
+- **Auto-fill channel replies and approval notifications** — channel replies now auto-populate the recipient from the sender, and approval notifications include the agent name for clarity
+
+### Added
+
+- Add env_passthrough allowlist to skill manifest (#3219) (@neo-wanderer)
+- Include agent name in approval notifications (#3247) (@neo-wanderer)
+- Auto-Highlights + collapse boilerplate + contributor roll-up (#3257) (@houko)
+- Add per_call_cost billing for video/music modalities (#3270) (@houko)
+- Add byteplus + byteplus_coding providers (#3271) (@houko)
+- Split _coding provider env vars onto dedicated names (#3279) (@houko)
+- Add microsoft provider entry with own env var (#3281) (@houko)
+- Split zai api_key_env from zhipu (#3285) (@houko)
+- Stream plugin / python stderr per-line to tracing (#3256) (#3287) (@houko)
+- Backfill providers missing from TUI first-run setup (#3291) (@houko)
+- Aux LLM client for cheap-tier side tasks (#3314) (#3321) (@houko)
+- Add file-backed cross-process rate-limit guard (#3322) (@houko)
+- Auto-fill channel_send recipient from sender_id for replies (#3323) (@leszek3737)
+- Internationalize Users surface (en + zh) (#3324) (@houko)
+- Redesign as compact card grid (#3336) (@houko)
+- Polish UI/UX across users surface (#3341) (@houko)
+- Push-style drawer that adapts main content width (#3356) (@houko)
+- BeforePromptBuild hook can contribute prompt sections (#3358) (@houko)
+- Unify all custom animations on motion (#3365) (@houko)
+- Land on marketplace tab when no servers configured (#3411) (@houko)
+- Land on marketplace tab when no workflows (#3412) (@houko)
+- Land on marketplace tab when nothing installed (#3413) (@houko)
+- Thread ownership prevents multi-agent duplicate replies (#3414) (@houko)
+- Pause/resume foundation for resumable workflows (#3418) (@houko)
+- Honest card cursor + detail drawers for plugins / MCP / FangHub skills (#3422) (@houko)
+- I18n keys + surface plugin / MCP catalog [i18n.<lang>] blocks via Accept-Language (#3424) (@houko)
+- Regroup metrics, surface unused per-agent data, collapse endpoints (#3427) (@houko)
+- Click anywhere on a channel card to open the drawer (#3434) (@houko)
+- Rich markdown help drawer + page coverage + UserBudget redesign (#3435) (@houko)
+
+### Fixed
+
+- Unbreak main — namespace traversal substring + openapi.json bump (#3258) (@houko)
+- Add dbus to buildInputs to fix failing build (#3263) (@FrantaNautilus)
+- Install libdbus-1 so image builds and starts (closes #3259) (#3265) (@houko)
+- Keyring is target-conditional so musl/android cross builds compile (#3267) (@houko)
+- Copy deploy/ into builder so include_str! observability assets resolve (closes #3259) (#3268) (@houko)
+- Show declared tools in editor and persist to **disk** (#3269) (@leszek3737)
+- Recognize BYTEPLUS_API_KEY in provider key checks (#3274) (@houko)
+- Silence three sources of routine WARN log spam (#3275) (@houko)
+- Skip OTLP exporter when no collector is reachable (#3276) (@houko)
+- Point at recovery commands when boot integrity check fails (#3277) (@houko)
+- Align model_catalog/routing tests with current registry (#3280) (@houko)
+- Refresh provider list after Test button so latency shows (#3288) (@houko)
+- Wire missing applyDatePreset for quick-pick buttons (#3289) (@houko)
+- Align useDeleteWorkflow test with removeQueries semantics (#3290) (@houko)
+- Use correct path + auth for Anthropic-protocol providers (#3292) (@houko)
+- Add missing librefang-llm-drivers dep to unbreak main (#3294) (@houko)
+- Stop bypassing needs-changes via comment inference / push (#3312) (@houko)
+- Treat Anthropic 401/403 as reachable, not auth-failed (#3316) (@houko)
+- Decouple model-id assertions from registry catalog state (#3317) (@houko)
+- Enforce deterministic ordering for LLM-bound registries (#3325) (@houko)
+- Install libdbus-1-dev for glibc Linux CLI builds (#3357) (@houko)
+- Drop layout/AnimatePresence from StaggerList to unblock clicks (#3415) (@houko)
+- Regenerate kernel config schema golden after thread-ownership field (#3417) (@houko)
+- Drawer not opening on hands page (DrawerPanel mount race) (#3421) (@houko)
+- Add /api/auto-dream/status to dashboard read allowlist (#3426) (@houko)
+- Scale Top Endpoints status bar with call volume (#3428) (@houko)
+- Exempt loopback + cheaper cost for dashboard polls (#3430) (@houko)
+
+### Changed
+
+- Tidy env_passthrough nits from #3219 review (#3273) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Documentation
+
+- Align display name with registry rename (#3284) (@houko)
+- Align Z.ai env + add Microsoft (GitHub Models) section (#3286) (@houko)
+- Expand every page-header help drawer to a real explanation (#3433) (@houko)
+
+### Maintenance
+
+- Add Nix build workflow to catch flake breakage on PR (#3264) (@houko)
+- Add Docker build + boot smoke test on PR (#3266) (@houko)
+- Regenerate Cargo.lock for librefang-llm-drivers dep (#3318) (@houko)
+- Shorten MCP nav label to 'MCP' (#3410) (@houko)
+- Remove Settings from left sidebar nav (#3423) (@houko)
+- Expand .dockerignore for security + smaller build context (#3431) (@houko)
+- Minimal rustup profile + sync mise rust to MSRV (#3432) (@houko)
+
+</details>
+
+
 ## [2026.4.27] - 2026-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "aes 0.9.0",
  "async-trait",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "axum",
  "clap",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "librefang-types",
  "reqwest 0.13.2",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "librefang-memory",
  "librefang-runtime",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "librefang-types",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-oauth"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-wasm"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "anyhow",
  "librefang-http",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "axum",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11234,7 +11234,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.4.32276",
+  "version": "26.4.32287",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "2026.4.27-beta6"
+    "version": "2026.4.28-beta7"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.4.27-beta6",
+  "version": "2026.4.28-beta7",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.4.27-beta6",
+  "version": "2026.4.28-beta7",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.4.27b6",
+    version="2026.4.28b7",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.4.27-beta6"
+version = "2026.4.28-beta7"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -509,6 +509,30 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
         _ => println!("  Warning: cargo update failed, continuing"),
     }
 
+    // --- Regenerate OpenAPI spec + SDK clients ---
+    // openapi.json and the generated SDK source files (sdk/go/librefang.go,
+    // sdk/rust/src/lib.rs, sdk/javascript/index.js, sdk/python/librefang/
+    // librefang_client.py) embed the workspace version string. If we skip
+    // this, CI's "OpenAPI Drift" check regenerates them in the runner and
+    // fails because the version embedded in the checked-in artifacts no
+    // longer matches the just-bumped Cargo.toml.
+    println!();
+    println!("Regenerating OpenAPI spec and SDK clients...");
+    let openapi_status = Command::new("cargo")
+        .args(["xtask", "codegen", "--openapi"])
+        .current_dir(&root)
+        .status()?;
+    if !openapi_status.success() {
+        return Err("cargo xtask codegen --openapi failed".into());
+    }
+    let sdk_status = Command::new("python3")
+        .args(["scripts/codegen-sdks.py"])
+        .current_dir(&root)
+        .status()?;
+    if !sdk_status.success() {
+        return Err("python3 scripts/codegen-sdks.py failed".into());
+    }
+
     // --- Generate Dev.to article (skip for pre-releases or --no-article) ---
     let article_path = if !args.no_article && !is_prerelease && !is_lts {
         let article = root.join(format!("articles/release-{}.md", changelog_version));
@@ -632,10 +656,15 @@ pip install librefang-sdk
         "Cargo.toml",
         "Cargo.lock",
         "CHANGELOG.md",
+        "openapi.json",
         "sdk/javascript/package.json",
+        "sdk/javascript/index.js",
         "sdk/python/setup.py",
+        "sdk/python/librefang/librefang_client.py",
         "sdk/rust/Cargo.toml",
         "sdk/rust/README.md",
+        "sdk/rust/src/lib.rs",
+        "sdk/go/librefang.go",
         "packages/whatsapp-gateway/package.json",
         "crates/librefang-desktop/tauri.conf.json",
     ];
@@ -855,6 +884,24 @@ fn run_lts_patch(root: &Path, args: &ReleaseArgs) -> Result<(), Box<dyn std::err
         .current_dir(root)
         .status();
 
+    // Regenerate OpenAPI spec + SDK clients so the embedded version matches
+    // (same reason as the main release path — the OpenAPI Drift CI check
+    // would otherwise fail on this LTS bump commit).
+    let openapi_status = Command::new("cargo")
+        .args(["xtask", "codegen", "--openapi"])
+        .current_dir(root)
+        .status()?;
+    if !openapi_status.success() {
+        return Err("cargo xtask codegen --openapi failed".into());
+    }
+    let sdk_status = Command::new("python3")
+        .args(["scripts/codegen-sdks.py"])
+        .current_dir(root)
+        .status()?;
+    if !sdk_status.success() {
+        return Err("python3 scripts/codegen-sdks.py failed".into());
+    }
+
     // Commit version bump if there are changes
     let has_changes = !Command::new("git")
         .args(["diff", "--quiet"])
@@ -865,7 +912,16 @@ fn run_lts_patch(root: &Path, args: &ReleaseArgs) -> Result<(), Box<dyn std::err
 
     if has_changes {
         let _ = Command::new("git")
-            .args(["add", "Cargo.toml", "Cargo.lock"])
+            .args([
+                "add",
+                "Cargo.toml",
+                "Cargo.lock",
+                "openapi.json",
+                "sdk/javascript/index.js",
+                "sdk/python/librefang/librefang_client.py",
+                "sdk/rust/src/lib.rs",
+                "sdk/go/librefang.go",
+            ])
             .current_dir(root)
             .status();
         let lts_msg = format!("chore: bump to {}", tag);


### PR DESCRIPTION
<!-- release-tag:v2026.4.28-beta7 -->
## Release v2026.4.28-beta7

_67 PRs from 4 contributors since v2026.4.27-beta6._

### Highlights

- **Auxiliary LLM client** — a dedicated cheap-tier model now handles background side tasks, reducing cost on main-agent calls
- **BytePlus, Microsoft (GitHub Models), and Z.ai providers** — three new LLM provider families added, each with their own dedicated API key env vars
- **Thread ownership** — prevents multiple agents from sending duplicate replies to the same thread; paired with a pause/resume foundation for resumable multi-step workflows
- **Redesigned Users surface and dashboard UI** — compact card grid layout, push-style adaptive drawer, unified animations, and richer markdown help drawers across all pages; empty states now land on the marketplace tab automatically
- **Auto-fill channel replies and approval notifications** — channel replies now auto-populate the recipient from the sender, and approval notifications include the agent name for clarity

### Added

- Add env_passthrough allowlist to skill manifest (#3219) (@neo-wanderer)
- Include agent name in approval notifications (#3247) (@neo-wanderer)
- Auto-Highlights + collapse boilerplate + contributor roll-up (#3257) (@houko)
- Add per_call_cost billing for video/music modalities (#3270) (@houko)
- Add byteplus + byteplus_coding providers (#3271) (@houko)
- Split _coding provider env vars onto dedicated names (#3279) (@houko)
- Add microsoft provider entry with own env var (#3281) (@houko)
- Split zai api_key_env from zhipu (#3285) (@houko)
- Stream plugin / python stderr per-line to tracing (#3256) (#3287) (@houko)
- Backfill providers missing from TUI first-run setup (#3291) (@houko)
- Aux LLM client for cheap-tier side tasks (#3314) (#3321) (@houko)
- Add file-backed cross-process rate-limit guard (#3322) (@houko)
- Auto-fill channel_send recipient from sender_id for replies (#3323) (@leszek3737)
- Internationalize Users surface (en + zh) (#3324) (@houko)
- Redesign as compact card grid (#3336) (@houko)
- Polish UI/UX across users surface (#3341) (@houko)
- Push-style drawer that adapts main content width (#3356) (@houko)
- BeforePromptBuild hook can contribute prompt sections (#3358) (@houko)
- Unify all custom animations on motion (#3365) (@houko)
- Land on marketplace tab when no servers configured (#3411) (@houko)
- Land on marketplace tab when no workflows (#3412) (@houko)
- Land on marketplace tab when nothing installed (#3413) (@houko)
- Thread ownership prevents multi-agent duplicate replies (#3414) (@houko)
- Pause/resume foundation for resumable workflows (#3418) (@houko)
- Honest card cursor + detail drawers for plugins / MCP / FangHub skills (#3422) (@houko)
- I18n keys + surface plugin / MCP catalog [i18n.<lang>] blocks via Accept-Language (#3424) (@houko)
- Regroup metrics, surface unused per-agent data, collapse endpoints (#3427) (@houko)
- Click anywhere on a channel card to open the drawer (#3434) (@houko)
- Rich markdown help drawer + page coverage + UserBudget redesign (#3435) (@houko)

### Fixed

- Unbreak main — namespace traversal substring + openapi.json bump (#3258) (@houko)
- Add dbus to buildInputs to fix failing build (#3263) (@FrantaNautilus)
- Install libdbus-1 so image builds and starts (closes #3259) (#3265) (@houko)
- Keyring is target-conditional so musl/android cross builds compile (#3267) (@houko)
- Copy deploy/ into builder so include_str! observability assets resolve (closes #3259) (#3268) (@houko)
- Show declared tools in editor and persist to **disk** (#3269) (@leszek3737)
- Recognize BYTEPLUS_API_KEY in provider key checks (#3274) (@houko)
- Silence three sources of routine WARN log spam (#3275) (@houko)
- Skip OTLP exporter when no collector is reachable (#3276) (@houko)
- Point at recovery commands when boot integrity check fails (#3277) (@houko)
- Align model_catalog/routing tests with current registry (#3280) (@houko)
- Refresh provider list after Test button so latency shows (#3288) (@houko)
- Wire missing applyDatePreset for quick-pick buttons (#3289) (@houko)
- Align useDeleteWorkflow test with removeQueries semantics (#3290) (@houko)
- Use correct path + auth for Anthropic-protocol providers (#3292) (@houko)
- Add missing librefang-llm-drivers dep to unbreak main (#3294) (@houko)
- Stop bypassing needs-changes via comment inference / push (#3312) (@houko)
- Treat Anthropic 401/403 as reachable, not auth-failed (#3316) (@houko)
- Decouple model-id assertions from registry catalog state (#3317) (@houko)
- Enforce deterministic ordering for LLM-bound registries (#3325) (@houko)
- Install libdbus-1-dev for glibc Linux CLI builds (#3357) (@houko)
- Drop layout/AnimatePresence from StaggerList to unblock clicks (#3415) (@houko)
- Regenerate kernel config schema golden after thread-ownership field (#3417) (@houko)
- Drawer not opening on hands page (DrawerPanel mount race) (#3421) (@houko)
- Add /api/auto-dream/status to dashboard read allowlist (#3426) (@houko)
- Scale Top Endpoints status bar with call volume (#3428) (@houko)
- Exempt loopback + cheaper cost for dashboard polls (#3430) (@houko)

### Changed

- Tidy env_passthrough nits from #3219 review (#3273) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Documentation

- Align display name with registry rename (#3284) (@houko)
- Align Z.ai env + add Microsoft (GitHub Models) section (#3286) (@houko)
- Expand every page-header help drawer to a real explanation (#3433) (@houko)

### Maintenance

- Add Nix build workflow to catch flake breakage on PR (#3264) (@houko)
- Add Docker build + boot smoke test on PR (#3266) (@houko)
- Regenerate Cargo.lock for librefang-llm-drivers dep (#3318) (@houko)
- Shorten MCP nav label to 'MCP' (#3410) (@houko)
- Remove Settings from left sidebar nav (#3423) (@houko)
- Expand .dockerignore for security + smaller build context (#3431) (@houko)
- Minimal rustup profile + sync mise rust to MSRV (#3432) (@houko)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.4.27-beta6...v2026.4.28-beta7