### PR TITLE
fix(ci): use listing API instead of search API in welcome workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -23,9 +23,9 @@ jobs:
 
           if [ "${{ github.event_name }}" = "issues" ]; then
             NUMBER="${{ github.event.issue.number }}"
-            # Check if this is the author's first issue
-            COUNT=$(gh api "search/issues?q=repo:${REPO}+author:${AUTHOR}+is:issue" --jq '.total_count')
-            if [ "$COUNT" -le 1 ]; then
+            # Check if this is the author's first issue (use listing API, not search — search has secondary rate limits and indexing delays)
+            COUNT=$(gh issue list --repo "$REPO" --author "$AUTHOR" --state all --limit 2 --json number --jq 'length')
+            if [ "$COUNT" -lt 2 ]; then
               gh issue comment "$NUMBER" --repo "$REPO" --body "$(cat <<'MSG'
           Thanks for opening your first issue! 🎉
 
@@ -40,9 +40,9 @@ jobs:
 
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             NUMBER="${{ github.event.pull_request.number }}"
-            # Check if this is the author's first PR
-            COUNT=$(gh api "search/issues?q=repo:${REPO}+author:${AUTHOR}+is:pr" --jq '.total_count')
-            if [ "$COUNT" -le 1 ]; then
+            # Check if this is the author's first PR (use listing API, not search — search has secondary rate limits and indexing delays)
+            COUNT=$(gh pr list --repo "$REPO" --author "$AUTHOR" --state all --limit 2 --json number --jq 'length')
+            if [ "$COUNT" -lt 2 ]; then
               gh pr comment "$NUMBER" --repo "$REPO" --body "$(cat <<'MSG'
           Thanks for your first pull request! 🎉
 


### PR DESCRIPTION
## Summary

- `welcome.yml` was using the GitHub Search API (`search/issues?q=...`) to check if a contributor is a first-timer
- Search API has secondary rate limits and eventual-consistency indexing delays — when PRs are opened in rapid succession the count comes back as 0 or null, causing the welcome message to fire for every contributor regardless of their history
- Proven by data: `houko` (1626 PRs) was receiving "Thanks for your first pull request! 🎉" on PRs #3428, #3429, #3431, #3432, #3433, #3434, #3436

## Fix

Replace the unreliable search calls with `gh pr list / gh issue list --limit 2`, which uses the paginated listing endpoint:
- No search rate limits
- Consistent results
- Fetches at most 2 records — if the author has ≥ 2 PRs/issues, they're not a first-timer