### PR TITLE
fix: replace let _ = error discards with tracing::warn logging

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -300,7 +300,7 @@ async fn resolve_manifest(
     let mut manifest: AgentManifest = match toml::from_str(&manifest_toml) {
         Ok(m) => m,
         Err(e) => {
-            let _ = e;
+            tracing::warn!("Failed to parse agent manifest TOML: {e}");
             let t = ErrorTranslator::new(lang);
             return Err(ManifestError {
                 message: t.t("api-error-manifest-invalid-format"),
@@ -4595,7 +4595,9 @@ pub async fn clone_agent(
             if let (Ok(src_can), Ok(dst_can)) = (src_ws.canonicalize(), dst_ws.canonicalize()) {
                 let src_identity = src_can.join(".identity");
                 let dst_identity = dst_can.join(".identity");
-                let _ = std::fs::create_dir_all(&dst_identity);
+                if let Err(e) = std::fs::create_dir_all(&dst_identity) {
+                    tracing::warn!("Failed to create identity directory for cloned agent: {e}");
+                }
                 for &fname in KNOWN_IDENTITY_FILES {
                     // Source: prefer .identity/ (post-migration), fall back to workspace root
                     let src_file = if src_identity.join(fname).exists() {

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1772,7 +1772,9 @@ pub async fn approve_request(
                                 &stored, code,
                             ) {
                                 Ok((true, updated)) => {
-                                    if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
+                                    if let Err(e) =
+                                        state.kernel.vault_set("totp_recovery_codes", &updated)
+                                    {
                                         tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
                                     }
                                     true
@@ -2417,7 +2419,9 @@ pub async fn totp_setup(
                                 &stored, code,
                             ) {
                                 Ok((true, updated)) => {
-                                    if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
+                                    if let Err(e) =
+                                        state.kernel.vault_set("totp_recovery_codes", &updated)
+                                    {
                                         tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
                                     }
                                     true
@@ -2607,7 +2611,9 @@ pub async fn totp_revoke(
                 ) {
                     Ok((true, updated)) => {
                         if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
-                            tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
+                            tracing::warn!(
+                                "Failed to persist updated TOTP recovery codes after use: {e}"
+                            );
                         }
                         true
                     }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1772,7 +1772,9 @@ pub async fn approve_request(
                                 &stored, code,
                             ) {
                                 Ok((true, updated)) => {
-                                    let _ = state.kernel.vault_set("totp_recovery_codes", &updated);
+                                    if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
+                                        tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
+                                    }
                                     true
                                 }
                                 Ok((false, _)) => {
@@ -2415,7 +2417,9 @@ pub async fn totp_setup(
                                 &stored, code,
                             ) {
                                 Ok((true, updated)) => {
-                                    let _ = state.kernel.vault_set("totp_recovery_codes", &updated);
+                                    if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
+                                        tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
+                                    }
                                     true
                                 }
                                 _ => false,
@@ -2602,7 +2606,9 @@ pub async fn totp_revoke(
                     &stored, &body.code,
                 ) {
                     Ok((true, updated)) => {
-                        let _ = state.kernel.vault_set("totp_recovery_codes", &updated);
+                        if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
+                            tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
+                        }
                         true
                     }
                     _ => false,
@@ -2634,9 +2640,15 @@ pub async fn totp_revoke(
 
     // Remove TOTP data from vault
     // vault_set to empty/false markers (vault doesn't expose remove via kernel helper)
-    let _ = state.kernel.vault_set("totp_confirmed", "false");
-    let _ = state.kernel.vault_set("totp_secret", "");
-    let _ = state.kernel.vault_set("totp_recovery_codes", "[]");
+    if let Err(e) = state.kernel.vault_set("totp_confirmed", "false") {
+        tracing::warn!("Failed to clear totp_confirmed in vault during TOTP revocation: {e}");
+    }
+    if let Err(e) = state.kernel.vault_set("totp_secret", "") {
+        tracing::warn!("Failed to clear totp_secret in vault during TOTP revocation: {e}");
+    }
+    if let Err(e) = state.kernel.vault_set("totp_recovery_codes", "[]") {
+        tracing::warn!("Failed to clear totp_recovery_codes in vault during TOTP revocation: {e}");
+    }
 
     (
         StatusCode::OK,
@@ -3518,10 +3530,12 @@ pub async fn create_backup(
         components: components.clone(),
     };
     if let Ok(manifest_json) = serde_json::to_string_pretty(&manifest) {
-        let _ = zip.start_file("manifest.json", options).and_then(|()| {
+        if let Err(e) = zip.start_file("manifest.json", options).and_then(|()| {
             std::io::Write::write_all(&mut zip, manifest_json.as_bytes())
                 .map_err(zip::result::ZipError::Io)
-        });
+        }) {
+            tracing::warn!("Failed to write manifest.json into export archive: {e}");
+        }
     }
 
     if let Err(e) = zip.finish() {

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1314,7 +1314,9 @@ pub async fn run_daemon(
             }
             // Stale PID file (process dead or different process reused PID), remove it
             info!("Removing stale daemon info file");
-            let _ = std::fs::remove_file(info_path);
+            if let Err(e) = std::fs::remove_file(info_path) {
+                tracing::warn!("Failed to remove stale daemon info file: {e}");
+            }
         }
 
         let daemon_info = DaemonInfo {
@@ -1325,7 +1327,9 @@ pub async fn run_daemon(
             platform: std::env::consts::OS.to_string(),
         };
         if let Ok(json) = serde_json::to_string_pretty(&daemon_info) {
-            let _ = std::fs::write(info_path, json);
+            if let Err(e) = std::fs::write(info_path, json) {
+                tracing::warn!("Failed to write daemon info file: {e}");
+            }
             // SECURITY: Restrict daemon info file permissions (contains PID and port).
             restrict_permissions(info_path);
         }
@@ -1464,13 +1468,15 @@ pub async fn run_daemon(
         handle.abort();
     }
     for handle in bg_tasks {
-        let _ = handle.await;
+        let _ = handle.await; // JoinError from abort() is expected; ignore it
     }
     info!("Background tasks stopped");
 
     // Clean up daemon info file
     if let Some(info_path) = daemon_info_path {
-        let _ = std::fs::remove_file(info_path);
+        if let Err(e) = std::fs::remove_file(info_path) {
+            tracing::warn!("Failed to remove daemon info file on shutdown: {e}");
+        }
     }
 
     // Stop channel bridges
@@ -1756,7 +1762,9 @@ mod observability_tests {
 #[cfg(unix)]
 fn restrict_permissions(path: &Path) {
     use std::os::unix::fs::PermissionsExt;
-    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+        tracing::warn!("Failed to restrict permissions on {}: {e}", path.display());
+    }
 }
 
 #[cfg(not(unix))]
@@ -1837,7 +1845,7 @@ fn is_process_alive(pid: u32) -> bool {
 
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = pid;
+        let _ = pid; // suppress unused variable warning on unsupported platforms
         false
     }
 }


### PR DESCRIPTION
## Summary

Replaces silent `let _ = result` error discards with `if let Err(e)` blocks that emit `tracing::warn!` log entries. Intentional ignores (aborted JoinHandles, unsupported-platform dead vars) are kept with explanatory comments.

### `routes/agents.rs` (#3371)
- TOML parse failure on agent manifest now logged
- `create_dir_all` failure on identity dir clone now logged

### `server.rs` (#3376)
- Stale PID file removal failure logged
- Daemon info write failure logged
- Shutdown cleanup file removal failure logged
- `set_permissions` failure in `restrict_permissions()` logged

### `routes/system.rs` (#3469)
- 3× `vault_set("totp_recovery_codes", …)` failures in recovery-code verification paths now logged
- 3× `vault_set` failures in TOTP revocation handler now logged
- `zip.start_file` failure in export archive handler now logged

## Fixes
- Closes #3371
- Closes #3376
- Closes #3469

## Test plan
- [ ] CI passes
- [ ] Verify warn logs appear in structured output when relevant operations fail