### PR TITLE
fix(wasm): enforce memory limit and fix path traversal in capability check

### DIFF
--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -235,15 +235,19 @@ fn host_fs_read(state: &GuestState, params: &serde_json::Value) -> serde_json::V
         Some(p) => p,
         None => return json!({"error": "Missing 'path' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(&state.capabilities, &Capability::FileRead(path.to_string())) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY: Canonicalize first so the capability check sees the real path,
+    // not an attacker-controlled raw string with "../" sequences.
     let canonical = match safe_resolve_path(path) {
         Ok(c) => c,
         Err(e) => return e,
     };
+    // Capability check against the canonical path prevents traversal bypass.
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileRead(canonical.to_string_lossy().into_owned()),
+    ) {
+        return e;
+    }
     match std::fs::read_to_string(&canonical) {
         Ok(content) => json!({"ok": content}),
         Err(e) => json!({"error": format!("fs_read failed: {e}")}),
@@ -259,18 +263,19 @@ fn host_fs_write(state: &GuestState, params: &serde_json::Value) -> serde_json::
         Some(c) => c,
         None => return json!({"error": "Missing 'content' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(
-        &state.capabilities,
-        &Capability::FileWrite(path.to_string()),
-    ) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY: Canonicalize (via parent) first so the capability check sees
+    // the real destination, not a raw path with "../" traversal sequences.
     let write_path = match safe_resolve_parent(path) {
         Ok(p) => p,
         Err(e) => return e,
     };
+    // Capability check against the canonical path prevents traversal bypass.
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileWrite(write_path.to_string_lossy().into_owned()),
+    ) {
+        return e;
+    }
     match std::fs::write(&write_path, content) {
         Ok(()) => json!({"ok": true}),
         Err(e) => json!({"error": format!("fs_write failed: {e}")}),
@@ -282,15 +287,19 @@ fn host_fs_list(state: &GuestState, params: &serde_json::Value) -> serde_json::V
         Some(p) => p,
         None => return json!({"error": "Missing 'path' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(&state.capabilities, &Capability::FileRead(path.to_string())) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY: Canonicalize first so the capability check sees the real path,
+    // not an attacker-controlled raw string with "../" sequences.
     let canonical = match safe_resolve_path(path) {
         Ok(c) => c,
         Err(e) => return e,
     };
+    // Capability check against the canonical path prevents traversal bypass.
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileRead(canonical.to_string_lossy().into_owned()),
+    ) {
+        return e;
+    }
     match std::fs::read_dir(&canonical) {
         Ok(entries) => {
             let names: Vec<String> = entries
@@ -774,6 +783,32 @@ mod tests {
         assert!(safe_resolve_path("../etc/passwd").is_err());
         assert!(safe_resolve_path("/tmp/../../etc/passwd").is_err());
         assert!(safe_resolve_path("foo/../bar").is_err());
+    }
+
+    /// Regression for #3814: capability check must run AFTER canonicalization.
+    ///
+    /// A capability granting access to `/tmp/allowed` must NOT permit a guest
+    /// that passes `../allowed` when the working directory is `/tmp/sub` —
+    /// the raw string does not literally match `/tmp/allowed`, but
+    /// canonicalization would resolve it to the same inode. Conversely, a
+    /// traversal attempt aimed at a path outside any granted capability must
+    /// be denied even if the raw string superficially matches a prefix.
+    ///
+    /// We test the deny path here: a FileRead("*") wildcard is granted but
+    /// the path `../etc/passwd` is rejected during canonicalization (contains
+    /// `..`), so the capability check is never even reached. This validates
+    /// that canonicalization is the first gate.
+    #[tokio::test]
+    async fn test_fs_read_traversal_rejected_before_capability_check() {
+        // Even with a wildcard capability, ".." in the path must be caught by
+        // safe_resolve_path before we ever consult the capability list.
+        let state = test_state(vec![Capability::FileRead("*".to_string())]);
+        let result = host_fs_read(&state, &json!({"path": "../etc/passwd"}));
+        let err = result["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("traversal") || err.contains("resolve") || err.contains("Cannot"),
+            "Expected path-traversal or resolution error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -56,6 +56,34 @@ impl Default for SandboxConfig {
     }
 }
 
+/// `ResourceLimiter` implementation that caps WASM linear-memory growth at a
+/// configured byte ceiling. Attached to every `Store` so that WASM plugins
+/// cannot allocate unbounded host memory regardless of their fuel budget.
+struct MemoryLimiter {
+    max_bytes: usize,
+}
+
+impl wasmtime::ResourceLimiter for MemoryLimiter {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        Ok(desired <= self.max_bytes)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        // No table-element cap — only memory is bounded here.
+        Ok(true)
+    }
+}
+
 /// State carried in each WASM Store, accessible by host functions.
 pub struct GuestState {
     /// Capabilities granted to this guest — checked before every host call.
@@ -66,6 +94,8 @@ pub struct GuestState {
     pub agent_id: String,
     /// Tokio runtime handle for async operations in sync host functions.
     pub tokio_handle: tokio::runtime::Handle,
+    /// Memory limiter enforcing `SandboxConfig::max_memory_bytes`.
+    limiter: MemoryLimiter,
 }
 
 /// Result of executing a WASM module.
@@ -157,7 +187,7 @@ impl WasmSandbox {
         let module = Module::new(engine, wasm_bytes)
             .map_err(|e| SandboxError::Compilation(e.to_string()))?;
 
-        // Create store with guest state
+        // Create store with guest state (includes the memory limiter)
         let mut store = Store::new(
             engine,
             GuestState {
@@ -165,8 +195,15 @@ impl WasmSandbox {
                 kernel,
                 agent_id: agent_id.to_string(),
                 tokio_handle,
+                limiter: MemoryLimiter {
+                    max_bytes: config.max_memory_bytes,
+                },
             },
         );
+
+        // Enforce the memory cap: every memory.grow call from the guest goes
+        // through MemoryLimiter::memory_growing before any allocation happens.
+        store.limiter(|state| &mut state.limiter);
 
         // Set fuel budget (deterministic metering)
         if config.fuel_limit > 0 {
@@ -600,6 +637,33 @@ mod tests {
         let sandbox = WasmSandbox::new().unwrap();
         // Engine should be created successfully
         drop(sandbox);
+    }
+
+    /// Regression: max_memory_bytes must be enforced at runtime, not just
+    /// declared. A guest module that requests more memory than the cap should
+    /// be rejected — before this fix the cap was a no-op comment.
+    #[test]
+    fn test_memory_limiter_blocks_excess_growth() {
+        let mut limiter = MemoryLimiter {
+            // 1 MiB cap
+            max_bytes: 1024 * 1024,
+        };
+        // Within limit → allowed
+        assert_eq!(
+            limiter
+                .memory_growing(0, 64 * 1024, None)
+                .expect("should not error"),
+            true,
+            "growth within cap must be permitted"
+        );
+        // Exceeds limit → denied
+        assert_eq!(
+            limiter
+                .memory_growing(0, 2 * 1024 * 1024, None)
+                .expect("should not error"),
+            false,
+            "growth beyond cap must be denied"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -69,7 +69,7 @@ impl wasmtime::ResourceLimiter for MemoryLimiter {
         _current: usize,
         desired: usize,
         _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool, wasmtime::Error> {
         Ok(desired <= self.max_bytes)
     }
 
@@ -78,7 +78,7 @@ impl wasmtime::ResourceLimiter for MemoryLimiter {
         _current: usize,
         _desired: usize,
         _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool, wasmtime::Error> {
         // No table-element cap — only memory is bounded here.
         Ok(true)
     }


### PR DESCRIPTION
## Summary

Two WASM sandbox security fixes.

### #3528 — `max_memory_bytes` was declared but never enforced (`sandbox.rs`)

Added a `MemoryLimiter` struct implementing wasmtime's `ResourceLimiter` trait. The limiter lives inside `GuestState` and is bound to the `Store` via `store.limiter(|s| &mut s.limiter)`. Memory growth beyond `max_memory_bytes` now returns `false`, causing the WASM trap instead of silently allocating unbounded host memory.

New test: `test_memory_limiter_blocks_excess_growth`

### #3814 — Capability check ran on raw path before canonicalization (`host_functions.rs`)

All three FS host functions (`host_fs_read`, `host_fs_write`, `host_fs_list`) were checking the attacker-supplied raw path string against the capability allowlist before calling `safe_resolve_path()`. A path like `../../../etc/passwd` could pass the raw-string check if a prefix matched. Fixed by canonicalizing first, then checking the resolved absolute path.

New test: `test_fs_read_traversal_rejected_before_capability_check`

## Fixes
- Closes #3528
- Closes #3814

## Test plan
- [ ] CI passes
- [ ] `test_memory_limiter_blocks_excess_growth` passes
- [ ] `test_fs_read_traversal_rejected_before_capability_check` passes