### PR TITLE
fix: prevent shell injection in skill dependency command execution

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2171,13 +2171,6 @@ pub async fn install_hand_deps(
             }
         };
 
-        // Execute the install command
-        let (shell, flag) = if cfg!(windows) {
-            ("cmd", "/C")
-        } else {
-            ("sh", "-c")
-        };
-
         // For winget on Windows, add --accept flags to avoid interactive prompts
         let final_cmd = if cfg!(windows) && cmd.starts_with("winget ") {
             format!("{cmd} --accept-source-agreements --accept-package-agreements")
@@ -2200,13 +2193,27 @@ pub async fn install_hand_deps(
             continue;
         }
 
+        // Split into program + arguments and exec directly — no shell involved.
+        // This eliminates the sh -c / cmd /C injection vector entirely.
+        let parts: Vec<&str> = final_cmd.split_whitespace().collect();
+        if parts.is_empty() {
+            results.push(serde_json::json!({
+                "key": req.key,
+                "status": "error",
+                "command": final_cmd,
+                "message": "Install command is empty",
+            }));
+            continue;
+        }
+        let program = parts[0];
+        let args = &parts[1..];
+
         tracing::info!(hand = %hand_id, dep = %req.key, cmd = %final_cmd, "Auto-installing dependency");
 
         let output = match tokio::time::timeout(
             std::time::Duration::from_secs(300),
-            tokio::process::Command::new(shell)
-                .arg(flag)
-                .arg(&final_cmd)
+            tokio::process::Command::new(program)
+                .args(args)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .stdin(std::process::Stdio::null())

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2182,7 +2182,10 @@ pub async fn install_hand_deps(
         // metacharacters that are never needed in legitimate package-manager
         // install strings (semicolons, pipes, backticks, redirects, etc.).
         if final_cmd.contains(|c: char| {
-            matches!(c, ';' | '|' | '&' | '$' | '`' | '>' | '<' | '(' | ')' | '{' | '}' | '\n' | '\r')
+            matches!(
+                c,
+                ';' | '|' | '&' | '$' | '`' | '>' | '<' | '(' | ')' | '{' | '}' | '\n' | '\r'
+            )
         }) {
             results.push(serde_json::json!({
                 "key": req.key,

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2185,6 +2185,21 @@ pub async fn install_hand_deps(
             cmd.to_string()
         };
 
+        // Guard against shell injection: reject commands that contain shell
+        // metacharacters that are never needed in legitimate package-manager
+        // install strings (semicolons, pipes, backticks, redirects, etc.).
+        if final_cmd.contains(|c: char| {
+            matches!(c, ';' | '|' | '&' | '$' | '`' | '>' | '<' | '(' | ')' | '{' | '}' | '\n' | '\r')
+        }) {
+            results.push(serde_json::json!({
+                "key": req.key,
+                "status": "error",
+                "command": final_cmd,
+                "message": "Install command contains disallowed shell metacharacters and was rejected for security reasons",
+            }));
+            continue;
+        }
+
         tracing::info!(hand = %hand_id, dep = %req.key, cmd = %final_cmd, "Auto-installing dependency");
 
         let output = match tokio::time::timeout(


### PR DESCRIPTION
## Summary

The `install_hand_deps` handler built `final_cmd` from hand definition install strings and passed it verbatim to `sh -c` (or `cmd /C` on Windows). This made shell metacharacter injection structurally possible.

### Fix

Replace shell invocation with direct exec via `tokio::process::Command`:
1. Split `final_cmd` on whitespace into `program` + `args`
2. Execute with `Command::new(program).args(args)` — no shell involved
3. Added empty-command guard to return a clear error instead of panicking

Shell metacharacter injection is now structurally impossible regardless of `final_cmd` content, since there is no shell interpreter in the execution path. The existing metacharacter validation is retained as defense-in-depth.

## Fixes
- Closes #3562

## Test plan
- [ ] CI passes
- [ ] Verify `apt-get install python3` style commands still work (split correctly)
- [ ] Verify shell metacharacters in command strings no longer execute