### PR TITLE
feat(dashboard): mobile-first responsive pass (#3343)

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -701,7 +701,7 @@ export function App() {
           </div>
         </nav>
 
-        <div className={`border-t border-border-subtle p-4 ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-28 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
+        <div className={`border-t border-border-subtle p-4 pb-safe ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-28 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
           <div className="rounded-xl bg-linear-to-r from-success/5 to-transparent p-3 border border-success/10">
             <p className="text-[10px] font-bold text-text-dim uppercase tracking-wider">{t("common.status")}</p>
             <div className="mt-2 flex items-center gap-2">

--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -701,7 +701,7 @@ export function App() {
           </div>
         </nav>
 
-        <div className={`border-t border-border-subtle p-4 pb-safe ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-28 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
+        <div className={`border-t border-border-subtle pt-4 px-4 pb-safe-4 ${isSidebarCollapsed ? "lg:max-h-0 lg:opacity-0 lg:overflow-hidden lg:p-0! lg:m-0! lg:mb-0!" : "lg:max-h-28 lg:opacity-100"} transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] overflow-hidden`}>
           <div className="rounded-xl bg-linear-to-r from-success/5 to-transparent p-3 border border-success/10">
             <p className="text-[10px] font-bold text-text-dim uppercase tracking-wider">{t("common.status")}</p>
             <div className="mt-2 flex items-center gap-2">

--- a/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
@@ -4,10 +4,9 @@
  *
  * Usage:
  *   <ResponsiveTable
- *     columns={[{ key: "name", label: "Name" }, ...]}
+ *     columns={[{ key: "name", label: "Name", render: (row) => row.name }, ...]}
  *     rows={items}
  *     rowKey={(row) => row.id}
- *     columns={[{ key: "name", label: "Name", render: (row) => row.name }, ...]}
  *   />
  */
 

--- a/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
@@ -1,0 +1,115 @@
+/**
+ * ResponsiveTable — renders a `<table>` on md+ viewports and stacked cards on
+ * smaller screens. Avoids horizontal scrolling on phones without losing data.
+ *
+ * Usage:
+ *   <ResponsiveTable
+ *     columns={[{ key: "name", label: "Name" }, ...]}
+ *     rows={items}
+ *     rowKey={(row) => row.id}
+ *     renderCell={(col, row) => row[col.key]}
+ *   />
+ */
+
+import type { ReactNode } from "react";
+
+export interface ResponsiveTableColumn<T> {
+  key: string;
+  label: string;
+  /** Hide this column in the card view — use for columns that are
+   *  redundant (e.g. a "row number" column) when stacked. */
+  hideInCard?: boolean;
+  /** Optional custom render. Falls back to `(row as any)[col.key]` if omitted. */
+  render?: (row: T) => ReactNode;
+  /** th className override. */
+  thClass?: string;
+  /** td className override. */
+  tdClass?: string;
+}
+
+interface Props<T> {
+  columns: ResponsiveTableColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string | number;
+  /** Extra classes for the wrapping div. */
+  className?: string;
+  /** Message shown when `rows` is empty. */
+  empty?: ReactNode;
+}
+
+export function ResponsiveTable<T>({
+  columns,
+  rows,
+  rowKey,
+  className = "",
+  empty,
+}: Props<T>) {
+  if (rows.length === 0 && empty) {
+    return <div className={className}>{empty}</div>;
+  }
+
+  const visibleCols = columns.filter((c) => !c.hideInCard);
+
+  return (
+    <div className={className}>
+      {/* ── Desktop table (md+) ───────────────────────────── */}
+      <div className="hidden md:block overflow-x-auto rounded-xl border border-border-subtle">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border-subtle bg-surface-hover/50">
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  className={
+                    col.thClass ??
+                    "px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim"
+                  }
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={rowKey(row)}
+                className="border-b last:border-0 border-border-subtle hover:bg-surface-hover/30 transition-colors"
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={col.tdClass ?? "px-4 py-3 text-sm"}
+                  >
+                    {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "")}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Mobile cards (< md) ───────────────────────────── */}
+      <div className="md:hidden flex flex-col gap-2">
+        {rows.map((row) => (
+          <div
+            key={rowKey(row)}
+            className="rounded-xl border border-border-subtle bg-surface p-3 text-sm space-y-1.5"
+          >
+            {visibleCols.map((col) => (
+              <div key={col.key} className="flex items-start gap-2 min-w-0">
+                <span className="shrink-0 w-24 text-[11px] font-bold uppercase tracking-wider text-text-dim">
+                  {col.label}
+                </span>
+                <span className="flex-1 min-w-0 text-text break-words">
+                  {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "—")}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
@@ -7,7 +7,7 @@
  *     columns={[{ key: "name", label: "Name" }, ...]}
  *     rows={items}
  *     rowKey={(row) => row.id}
- *     renderCell={(col, row) => row[col.key]}
+ *     columns={[{ key: "name", label: "Name", render: (row) => row.name }, ...]}
  *   />
  */
 
@@ -81,7 +81,7 @@ export function ResponsiveTable<T>({
                     key={col.key}
                     className={col.tdClass ?? "px-4 py-3 text-sm"}
                   >
-                    {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "")}
+                    {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "—")}
                   </td>
                 ))}
               </tr>

--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -147,3 +147,20 @@ body {
 
 /* prefers-reduced-motion is handled by motion (`useReducedMotion`) on a
    per-variant basis; no global override is needed here. */
+
+/* ── iOS / Android safe-area insets ────────────── */
+/* Applied to elements that sit at the edge of the screen (sidebar bottom,
+   chat input bar, sticky action bars) so content clears the iOS home
+   indicator and Android gesture navigation bar. */
+@utility pb-safe {
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 0px);
+}
+@utility pt-safe {
+  padding-top: max(env(safe-area-inset-top, 0px), 0px);
+}
+@utility pl-safe {
+  padding-left: max(env(safe-area-inset-left, 0px), 0px);
+}
+@utility pr-safe {
+  padding-right: max(env(safe-area-inset-right, 0px), 0px);
+}

--- a/crates/librefang-api/dashboard/src/index.css
+++ b/crates/librefang-api/dashboard/src/index.css
@@ -151,9 +151,20 @@ body {
 /* ── iOS / Android safe-area insets ────────────── */
 /* Applied to elements that sit at the edge of the screen (sidebar bottom,
    chat input bar, sticky action bars) so content clears the iOS home
-   indicator and Android gesture navigation bar. */
+   indicator and Android gesture navigation bar.
+
+   pb-safe         — pure inset, no minimum (for fixed wrappers with no base padding)
+   pb-safe-2 / -4  — inset OR base padding, whichever is larger; use these when the
+                     element already has p-2 / p-4 padding and must not lose it on
+                     non-mobile platforms where the inset is 0. */
 @utility pb-safe {
-  padding-bottom: max(env(safe-area-inset-bottom, 0px), 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+@utility pb-safe-2 {
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.5rem);
+}
+@utility pb-safe-4 {
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 1rem);
 }
 @utility pt-safe {
   padding-top: max(env(safe-area-inset-top, 0px), 0px);

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -178,44 +178,47 @@ function AuditLogTab() {
     );
   }
 
-  const auditColumns: ResponsiveTableColumn<ApprovalAuditEntry>[] = [
-    {
-      key: "tool_name",
-      label: t("approvals.auditLog.tool"),
-      tdClass: "px-4 py-3 font-medium",
-      render: (e) => e.tool_name,
-    },
-    {
-      key: "agent_id",
-      label: t("approvals.auditLog.agent"),
-      tdClass: "px-4 py-3 text-text-dim",
-      render: (e) => e.agent_id,
-    },
-    {
-      key: "decision",
-      label: t("approvals.auditLog.decision"),
-      tdClass: "px-4 py-3",
-      render: (e) => decisionBadge(e.decision, t),
-    },
-    {
-      key: "decided_by",
-      label: t("approvals.auditLog.decidedBy"),
-      tdClass: "px-4 py-3 text-text-dim",
-      render: (e) => e.decided_by ?? "—",
-    },
-    {
-      key: "decided_at",
-      label: t("approvals.auditLog.decidedAt"),
-      tdClass: "px-4 py-3 text-text-dim text-xs",
-      render: (e) => (e.decided_at ? new Date(e.decided_at).toLocaleString() : "—"),
-    },
-    {
-      key: "feedback",
-      label: t("approvals.auditLog.feedback"),
-      tdClass: "px-4 py-3 text-text-dim text-xs max-w-48 truncate",
-      render: (e) => e.feedback ?? "—",
-    },
-  ];
+  const auditColumns = useMemo<ResponsiveTableColumn<ApprovalAuditEntry>[]>(
+    () => [
+      {
+        key: "tool_name",
+        label: t("approvals.auditLog.tool"),
+        tdClass: "px-4 py-3 font-medium",
+        render: (e) => e.tool_name,
+      },
+      {
+        key: "agent_id",
+        label: t("approvals.auditLog.agent"),
+        tdClass: "px-4 py-3 text-text-dim",
+        render: (e) => e.agent_id,
+      },
+      {
+        key: "decision",
+        label: t("approvals.auditLog.decision"),
+        tdClass: "px-4 py-3",
+        render: (e) => decisionBadge(e.decision, t),
+      },
+      {
+        key: "decided_by",
+        label: t("approvals.auditLog.decidedBy"),
+        tdClass: "px-4 py-3 text-text-dim",
+        render: (e) => e.decided_by ?? "—",
+      },
+      {
+        key: "decided_at",
+        label: t("approvals.auditLog.decidedAt"),
+        tdClass: "px-4 py-3 text-text-dim text-xs",
+        render: (e) => (e.decided_at ? new Date(e.decided_at).toLocaleString() : "—"),
+      },
+      {
+        key: "feedback",
+        label: t("approvals.auditLog.feedback"),
+        tdClass: "px-4 py-3 text-text-dim text-xs max-w-48 truncate",
+        render: (e) => e.feedback ?? "—",
+      },
+    ],
+    [t],
+  );
 
   return (
     <div className="flex flex-col gap-4">

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "../components/ui/EmptyState";
 import { ErrorState } from "../components/ui/ErrorState";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
+import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/ResponsiveTable";
 import { Badge } from "../components/ui/Badge";
 import { useUIStore } from "../lib/store";
 import { CheckCircle, XCircle, Clock, MessageSquare, ChevronLeft, ChevronRight } from "lucide-react";
@@ -177,51 +178,52 @@ function AuditLogTab() {
     );
   }
 
+  const auditColumns: ResponsiveTableColumn<ApprovalAuditEntry>[] = [
+    {
+      key: "tool_name",
+      label: t("approvals.auditLog.tool"),
+      tdClass: "px-4 py-3 font-medium",
+      render: (e) => e.tool_name,
+    },
+    {
+      key: "agent_id",
+      label: t("approvals.auditLog.agent"),
+      tdClass: "px-4 py-3 text-text-dim",
+      render: (e) => e.agent_id,
+    },
+    {
+      key: "decision",
+      label: t("approvals.auditLog.decision"),
+      tdClass: "px-4 py-3",
+      render: (e) => decisionBadge(e.decision, t),
+    },
+    {
+      key: "decided_by",
+      label: t("approvals.auditLog.decidedBy"),
+      tdClass: "px-4 py-3 text-text-dim",
+      render: (e) => e.decided_by ?? "—",
+    },
+    {
+      key: "decided_at",
+      label: t("approvals.auditLog.decidedAt"),
+      tdClass: "px-4 py-3 text-text-dim text-xs",
+      render: (e) => (e.decided_at ? new Date(e.decided_at).toLocaleString() : "—"),
+    },
+    {
+      key: "feedback",
+      label: t("approvals.auditLog.feedback"),
+      tdClass: "px-4 py-3 text-text-dim text-xs max-w-48 truncate",
+      render: (e) => e.feedback ?? "—",
+    },
+  ];
+
   return (
     <div className="flex flex-col gap-4">
-      {/* Table */}
-      <div className="overflow-x-auto rounded-xl border border-border-subtle">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border-subtle bg-surface-hover/50">
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.tool")}
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.agent")}
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.decision")}
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.decidedBy")}
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.decidedAt")}
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim">
-                {t("approvals.auditLog.feedback")}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map((entry) => (
-              <tr key={entry.id} className="border-b last:border-0 border-border-subtle hover:bg-surface-hover/30 transition-colors">
-                <td className="px-4 py-3 font-medium">{entry.tool_name}</td>
-                <td className="px-4 py-3 text-text-dim">{entry.agent_id}</td>
-                <td className="px-4 py-3">{decisionBadge(entry.decision, t)}</td>
-                <td className="px-4 py-3 text-text-dim">{entry.decided_by ?? "-"}</td>
-                <td className="px-4 py-3 text-text-dim text-xs">
-                  {entry.decided_at ? new Date(entry.decided_at).toLocaleString() : "-"}
-                </td>
-                <td className="px-4 py-3 text-text-dim text-xs max-w-48 truncate">
-                  {entry.feedback ?? "-"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <ResponsiveTable
+        columns={auditColumns}
+        rows={entries}
+        rowKey={(e) => e.id}
+      />
 
       {/* Pagination */}
       <div className="flex items-center justify-between text-sm text-text-dim">

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -2755,7 +2755,7 @@ export function ChatPage() {
           </div>
 
           {/* Input area */}
-          <div className={`p-2 sm:p-4 pb-safe border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
+          <div className={`pt-2 px-2 pb-safe-2 sm:pt-4 sm:px-4 sm:pb-safe-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
               agentId={selectedAgentId ?? ""}
               onSend={sendMessage}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -2755,7 +2755,7 @@ export function ChatPage() {
           </div>
 
           {/* Input area */}
-          <div className={`p-2 sm:p-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
+          <div className={`p-2 sm:p-4 pb-safe border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
               agentId={selectedAgentId ?? ""}
               onSend={sendMessage}

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -1019,7 +1019,7 @@ export function ConfigPage({ category }: { category: string }) {
 
       {/* Sticky unsaved changes bar */}
       {hasPendingChanges && (
-        <div className="fixed bottom-0 left-0 right-0 z-40 flex justify-center pointer-events-none">
+        <div className="fixed bottom-0 left-0 right-0 z-40 flex justify-center pointer-events-none pb-safe">
           <div className="mb-5 flex items-center gap-3 px-4 py-2.5 rounded-2xl border border-warning/30 bg-surface shadow-lg pointer-events-auto">
             <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
             <span className="text-xs font-semibold text-warning">


### PR DESCRIPTION
## Summary

Closes #3343. Part of Epic #3351.

- **Safe-area insets** — `@utility pb-safe / pt-safe / pl-safe / pr-safe` via `env(safe-area-inset-*)` in `index.css`; applied to sidebar bottom, chat input bar, and ConfigPage unsaved-changes bar so iOS home indicator / Android gesture nav never overlap interactive content
- **`ResponsiveTable` component** — `src/components/ui/ResponsiveTable.tsx`; renders `<table>` on `md+`, stacked label+value cards on `< md`; desktop layout fully unchanged
- **ApprovalsPage audit log** migrated to `ResponsiveTable` — the only 6-column raw `<table>` in the codebase now collapses cleanly at 390 px with no horizontal scroll

Already in good shape (no changes needed): drawer nav (`isMobileMenuOpen` system), viewport meta (`viewport-fit=cover`), Modal bottom-sheet pattern (`items-end sm:items-center`), AgentsPage/WorkflowsPage card grids, ChatPage textarea auto-grow + 44 pt min-height tap targets.

## Test plan

- [ ] Resize browser to 390 × 844 — ApprovalsPage audit log shows stacked cards, no horizontal scroll
- [ ] iOS Simulator / Android emulator — home indicator / gesture nav bar does not overlap chat input or sidebar bottom
- [ ] ConfigPage: make a change, unsaved-changes bar sits above the gesture nav bar on mobile
- [ ] Desktop at ≥ 1280 px — ApprovalsPage shows full table, no visual regression anywhere