### PR TITLE
fix(ci): resolve Rust SDK example compile errors and Android CLI build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,7 +467,9 @@ jobs:
         with:
           key: cli-aarch64-linux-android-${{ github.ref_name }}
       - name: Build CLI (Android aarch64)
-        run: cross build --release --target aarch64-linux-android --bin librefang
+        # channel-email excluded: rustls-connector 0.23.0 calls Verifier::new_with_extra_roots
+        # which is not implemented in rustls-platform-verifier 0.7.0 on Android.
+        run: cross build --release --target aarch64-linux-android --bin librefang --no-default-features --features android,telemetry
       - name: Package
         run: |
           cd target/aarch64-linux-android/release

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -137,6 +137,22 @@ all-channels = [
     "channel-qq", "channel-voice", "channel-wechat", "channel-wecom",
 ]
 
+# All channels except email — used for Android targets where rustls-connector's
+# rustls-platform-verifier dependency doesn't implement new_with_extra_roots on Android.
+all-channels-no-email = [
+    "channel-telegram", "channel-discord", "channel-slack", "channel-matrix",
+    "channel-webhook", "channel-whatsapp", "channel-signal",
+    "channel-teams", "channel-mattermost", "channel-irc", "channel-google-chat",
+    "channel-twitch", "channel-rocketchat", "channel-zulip", "channel-xmpp",
+    "channel-bluesky", "channel-feishu", "channel-line", "channel-mastodon",
+    "channel-messenger", "channel-reddit", "channel-revolt", "channel-viber",
+    "channel-flock", "channel-guilded", "channel-keybase", "channel-nextcloud",
+    "channel-nostr", "channel-pumble", "channel-threema", "channel-twist",
+    "channel-webex", "channel-dingtalk", "channel-discourse", "channel-gitter",
+    "channel-gotify", "channel-linkedin", "channel-mumble", "channel-ntfy",
+    "channel-qq", "channel-voice", "channel-wechat", "channel-wecom",
+]
+
 # Mini: 12 core channels
 mini = [
     "channel-telegram", "channel-discord", "channel-slack", "channel-matrix",

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -9,6 +9,9 @@ description = "CLI tool for the LibreFang Agent OS"
 default = ["librefang-api/all-channels", "telemetry"]
 all-channels = ["librefang-api/all-channels"]
 mini = ["librefang-api/mini"]
+# Android target: exclude channel-email (rustls-connector 0.23.0 + rustls-platform-verifier 0.7.0
+# incompatibility — Verifier::new_with_extra_roots not implemented on Android).
+android = ["librefang-api/all-channels-no-email"]
 telemetry = ["librefang-api/telemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:tracing-opentelemetry"]
 
 [[bin]]

--- a/sdk/rust/examples/basic.rs
+++ b/sdk/rust/examples/basic.rs
@@ -5,16 +5,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = LibreFang::new("http://127.0.0.1:4545");
 
     // List skills
-    let skills = client.skills().list().await?;
-    println!("Skills: {}", skills.skills.len());
+    let skills = client.skills.list_skills().await?;
+    println!("Skills: {}", skills["skills"].as_array().map(|a| a.len()).unwrap_or(0));
 
     // List models
-    let models = client.models().list().await?;
-    println!("Models: {}", models.models.len());
+    let models = client.models.list_models().await?;
+    println!("Models: {}", models["models"].as_array().map(|a| a.len()).unwrap_or(0));
 
-    // List providers - debug
-    let providers = client.providers().list().await?;
-    println!("Providers: {}", providers.providers.len());
+    // List providers
+    let providers = client.models.list_providers().await?;
+    println!("Providers: {}", providers["providers"].as_array().map(|a| a.len()).unwrap_or(0));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Rust SDK**: `examples/basic.rs` called struct fields as methods (`client.skills()`) and used non-existent method names (`.list()`, `.providers()`). Fixed to use correct field access and actual method names (`list_skills`, `list_models`, `list_providers`). Also fixed `Value` field access to use JSON indexing.
- **Android CLI**: `rustls-connector 0.23.0` calls `Verifier::new_with_extra_roots()` which is not implemented in `rustls-platform-verifier 0.7.0` on Android targets. Added `all-channels-no-email` feature to `librefang-api`, `android` feature to `librefang-cli`, and updated the CI cross-build command to use `--no-default-features --features android,telemetry` to work around the upstream incompatibility.

Fixes the two failing jobs in https://github.com/librefang/librefang/actions/runs/25027152489.

## Test plan

- [ ] `SDK / Rust (crates.io)` job passes
- [ ] `CLI / aarch64-linux-android` job passes