### PR TITLE
fix(a2a): enforce body limits, auth on task transcripts, pending state for discovered agents

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -565,7 +565,11 @@ pub async fn auth(
             path,
             "/.well-known/agent.json" | "/api/config/schema" | "/api/auth/providers"
         ) || dashboard_shell_public
-            || path.starts_with("/a2a/")
+            // The /a2a/agents listing is public so external callers can discover
+            // local agents without a bearer token (matches the A2A spec intent).
+            // All other /a2a/* paths — including /a2a/tasks/{id} which returns full
+            // task transcripts — require authentication (Bug #3781).
+            || path == "/a2a/agents"
             || path.starts_with("/api/uploads/")
             || path.starts_with("/api/auth/login"));
     let always_public =
@@ -1953,6 +1957,98 @@ mod tests {
             resp.status(),
             StatusCode::OK,
             "loopback with a valid bearer token must still be allowed through"
+        );
+    }
+
+    // ---- Bug #3781: GET /a2a/tasks/{id} must require auth ---------------
+    //
+    // Before the fix, `path.starts_with("/a2a/")` in the always_public_get_only
+    // block let any caller read full task transcripts (agent prompts + LLM
+    // outputs) without a bearer token. Only `/a2a/agents` (capability discovery)
+    // should remain public; task-level resources contain sensitive data.
+
+    /// GET /a2a/agents (the capability listing) must stay public — external
+    /// A2A peers call this to discover what skills a local agent exposes.
+    #[tokio::test]
+    async fn a2a_agents_listing_is_always_public() {
+        let app = Router::new()
+            .route("/a2a/agents", get(|| async { "agent list" }))
+            .layer(axum::middleware::from_fn_with_state(
+                with_key_state("secret"),
+                auth,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/a2a/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "GET /a2a/agents must be public so external A2A peers can discover local agents"
+        );
+    }
+
+    /// GET /a2a/tasks/{id} must require auth (Bug #3781). Task transcripts
+    /// contain full agent prompts and LLM outputs — sensitive operational data.
+    #[tokio::test]
+    async fn a2a_task_transcript_requires_auth() {
+        let app = Router::new()
+            .route("/a2a/tasks/{id}", get(|| async { "full task transcript" }))
+            .layer(axum::middleware::from_fn_with_state(
+                with_key_state("secret"),
+                auth,
+            ));
+
+        // Unauthenticated → must be rejected.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/a2a/tasks/some-uuid-1234")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "GET /a2a/tasks/{{id}} must require auth — it returns full task transcripts"
+        );
+    }
+
+    /// GET /a2a/tasks/{id} must allow access with a valid bearer token.
+    #[tokio::test]
+    async fn a2a_task_transcript_accessible_with_valid_token() {
+        let app = Router::new()
+            .route("/a2a/tasks/{id}", get(|| async { "full task transcript" }))
+            .layer(axum::middleware::from_fn_with_state(
+                with_key_state("secret"),
+                auth,
+            ));
+
+        let addr: std::net::SocketAddr = "203.0.113.5:40000".parse().unwrap();
+        let mut req = Request::builder()
+            .uri("/a2a/tasks/some-uuid-1234")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(addr));
+
+        let response = app.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "valid bearer token must allow access to /a2a/tasks/{{id}}"
         );
     }
 }

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6286,6 +6286,7 @@ mod monitoring_tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
+            pending_a2a_agents: dashmap::DashMap::new(),
         });
         (state, tmp)
     }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1501,6 +1501,7 @@ mod tests {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
+            pending_a2a_agents: dashmap::DashMap::new(),
         });
         (state, tmp)
     }

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -147,8 +147,7 @@ pub struct AppState {
     /// Maps discovery URL → AgentCard. Agents here are NOT trusted yet and
     /// cannot receive tasks. Use POST /api/a2a/agents/{url}/approve to promote
     /// them into the kernel's trusted external-agent list.
-    pub pending_a2a_agents:
-        DashMap<String, librefang_runtime::a2a::AgentCard>,
+    pub pending_a2a_agents: DashMap<String, librefang_runtime::a2a::AgentCard>,
     /// Prometheus metrics handle (only set when `telemetry` feature + config enabled).
     #[cfg(feature = "telemetry")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -143,6 +143,12 @@ pub struct AppState {
     /// Mutex for serializing config file writes — prevents concurrent config_set
     /// calls from reading the same file and overwriting each other's changes.
     pub config_write_lock: tokio::sync::Mutex<()>,
+    /// Pending A2A agents awaiting operator approval (Bug #3786).
+    /// Maps discovery URL → AgentCard. Agents here are NOT trusted yet and
+    /// cannot receive tasks. Use POST /api/a2a/agents/{url}/approve to promote
+    /// them into the kernel's trusted external-agent list.
+    pub pending_a2a_agents:
+        DashMap<String, librefang_runtime::a2a::AgentCard>,
     /// Prometheus metrics handle (only set when `telemetry` feature + config enabled).
     #[cfg(feature = "telemetry")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -34,6 +34,13 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/a2a/tasks/{id}/status",
             axum::routing::get(a2a_external_task_status),
         )
+        // Bug #3786: operator must explicitly approve a discovered agent before
+        // it can receive tasks. POST /api/a2a/agents/{url_encoded}/approve
+        // promotes the pending entry into the kernel's trusted list.
+        .route(
+            "/a2a/agents/{id}/approve",
+            axum::routing::post(a2a_approve_external),
+        )
 }
 
 /// Build protocol-level A2A routes (not versioned, mounted at the root path).
@@ -477,6 +484,9 @@ pub async fn a2a_cancel_task(
 // ── A2A Management Endpoints (outbound) ─────────────────────────────────
 
 /// GET /api/a2a/agents — List discovered external A2A agents.
+///
+/// Returns both `trusted` agents (approved and able to receive tasks) and
+/// `pending` agents (discovered but not yet approved by the operator).
 #[utoipa::path(
     get,
     path = "/api/a2a/agents",
@@ -491,7 +501,7 @@ pub async fn a2a_list_external_agents(State(state): State<Arc<AppState>>) -> imp
         .a2a_agents()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    let items: Vec<serde_json::Value> = agents
+    let mut items: Vec<serde_json::Value> = agents
         .iter()
         .map(|(_, card)| {
             serde_json::json!({
@@ -500,9 +510,22 @@ pub async fn a2a_list_external_agents(State(state): State<Arc<AppState>>) -> imp
                 "description": card.description,
                 "skills": card.skills,
                 "version": card.version,
+                "status": "trusted",
             })
         })
         .collect();
+    // Include pending (unapproved) agents so the operator can see and approve them.
+    for entry in state.pending_a2a_agents.iter() {
+        let card = entry.value();
+        items.push(serde_json::json!({
+            "name": card.name,
+            "url": card.url,
+            "description": card.description,
+            "skills": card.skills,
+            "version": card.version,
+            "status": "pending",
+        }));
+    }
     Json(serde_json::json!({"agents": items, "total": items.len()}))
 }
 
@@ -775,26 +798,75 @@ pub async fn a2a_discover_external(
     let client = librefang_runtime::a2a::A2aClient::new();
     match client.discover(&url).await {
         Ok(card) => {
-            let card_json = serde_json::to_value(&card).unwrap_or_default();
-            // Store in kernel's external agents list
+            // SECURITY (Bug #3786): Warn that we have no cryptographic proof
+            // the remote agent is who it claims to be. Verification relies
+            // solely on the operator reviewing the card before approving.
+            tracing::warn!(
+                url = %url,
+                agent_name = %card.name,
+                "A2A agent discovered without cryptographic verification. \
+                 The returned AgentCard has NOT been signed or authenticated. \
+                 Review the card carefully before approving (POST /api/a2a/agents/{{url}}/approve)."
+            );
+
+            // SECURITY (Bug #3786): Check for name collision with already-trusted agents.
             {
-                let mut agents = state
+                let agents = state
                     .kernel
                     .a2a_agents()
                     .lock()
                     .unwrap_or_else(|e| e.into_inner());
-                // Update or add
-                if let Some(existing) = agents.iter_mut().find(|(u, _)| u == &url) {
-                    existing.1 = card;
-                } else {
-                    agents.push((url.clone(), card));
+                // A different URL claiming the same name as an existing trusted agent is a
+                // potential impersonation attempt. Reject it to prevent confusion.
+                if let Some((existing_url, _)) =
+                    agents.iter().find(|(u, c)| c.name == card.name && u != &url)
+                {
+                    return (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "error": format!(
+                                "An agent named '{}' is already trusted from a different URL ('{}').",
+                                card.name, existing_url
+                            ),
+                            "hint": "Approve the existing agent or remove it before registering a new one with the same name."
+                        })),
+                    );
                 }
             }
+            // Also check pending agents for the same name collision.
+            if let Some(entry) = state
+                .pending_a2a_agents
+                .iter()
+                .find(|e| e.value().name == card.name && e.key() != &url)
+            {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "A pending agent named '{}' was already discovered from a different URL ('{}').",
+                            card.name, entry.key()
+                        ),
+                        "hint": "Approve or remove the existing pending entry first."
+                    })),
+                );
+            }
+
+            let card_json = serde_json::to_value(&card).unwrap_or_default();
+
+            // SECURITY (Bug #3786): Store in the PENDING list, not the trusted kernel
+            // list. The agent cannot receive tasks until the operator explicitly
+            // approves it via POST /api/a2a/agents/{url}/approve.
+            state.pending_a2a_agents.insert(url.clone(), card);
+
             (
-                StatusCode::OK,
+                StatusCode::ACCEPTED,
                 Json(serde_json::json!({
                     "url": url,
+                    "status": "pending",
                     "agent": card_json,
+                    "message": "Agent discovered and placed in pending state. \
+                                An operator must approve it before it can receive tasks. \
+                                Use POST /api/a2a/agents/{url}/approve to trust this agent.",
                 })),
             )
         }
@@ -828,6 +900,15 @@ pub async fn a2a_send_external(
         None => return ApiErrorResponse::bad_request("Missing 'message' field").into_json_tuple(),
     };
     let session_id = body["session_id"].as_str();
+
+    // SECURITY (Bug #3786): Reject sends to agents that are still pending approval.
+    if state.pending_a2a_agents.contains_key(&url) {
+        return ApiErrorResponse::bad_request(
+            "This agent is pending operator approval and cannot receive tasks. \
+             Use POST /api/a2a/agents/{url}/approve to trust it first.",
+        )
+        .into_json_tuple();
+    }
 
     // SSRF protection: validate URL before making any outbound request
     let ssrf_allowed = state
@@ -901,6 +982,94 @@ pub async fn a2a_external_task_status(
             StatusCode::BAD_GATEWAY,
             Json(serde_json::json!({"error": e})),
         ),
+    }
+}
+
+/// POST /api/a2a/agents/{id}/approve — Approve a pending external A2A agent.
+///
+/// Promotes the agent from the pending list into the kernel's trusted external-agent
+/// list, allowing it to receive tasks via `/api/a2a/send`. The `{id}` path segment
+/// should be the URL-encoded discovery URL of the agent returned by
+/// `POST /api/a2a/discover`.
+///
+/// This endpoint exists to enforce operator oversight of newly discovered agents
+/// (Bug #3786). Discovered agents are placed in a pending state and cannot be used
+/// until an operator explicitly calls this endpoint.
+#[utoipa::path(
+    post,
+    path = "/api/a2a/agents/{id}/approve",
+    tag = "a2a",
+    params(
+        ("id" = String, Path, description = "Discovery URL of the pending agent (URL-encoded)"),
+    ),
+    responses(
+        (status = 200, description = "Agent approved and promoted to trusted list", body = serde_json::Value),
+        (status = 404, description = "No pending agent found for the given URL")
+    )
+)]
+pub async fn a2a_approve_external(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    // The path parameter may be URL-encoded; decode it for matching.
+    let url = crate::percent_decode(&id);
+
+    match state.pending_a2a_agents.remove(&url) {
+        Some((_, card)) => {
+            tracing::info!(
+                url = %url,
+                agent_name = %card.name,
+                "A2A agent approved by operator and promoted to trusted list."
+            );
+            let card_json = serde_json::to_value(&card).unwrap_or_default();
+            // Promote to kernel's trusted list.
+            {
+                let mut agents = state
+                    .kernel
+                    .a2a_agents()
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                // Update existing entry (same URL) or append.
+                if let Some(existing) = agents.iter_mut().find(|(u, _)| u == &url) {
+                    existing.1 = card;
+                } else {
+                    agents.push((url.clone(), card));
+                }
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "url": url,
+                    "status": "trusted",
+                    "agent": card_json,
+                    "message": "Agent approved. It can now receive tasks via POST /api/a2a/send.",
+                })),
+            )
+        }
+        None => {
+            // Also check if it's already trusted (idempotent re-approval).
+            let agents = state
+                .kernel
+                .a2a_agents()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if agents.iter().any(|(u, _)| u == &url) {
+                return (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "url": url,
+                        "status": "trusted",
+                        "message": "Agent is already in the trusted list.",
+                    })),
+                );
+            }
+            ApiErrorResponse::not_found(format!(
+                "No pending agent found for URL '{}'. \
+                 Use POST /api/a2a/discover first.",
+                url
+            ))
+            .into_json_tuple()
+        }
     }
 }
 

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -818,8 +818,9 @@ pub async fn a2a_discover_external(
                     .unwrap_or_else(|e| e.into_inner());
                 // A different URL claiming the same name as an existing trusted agent is a
                 // potential impersonation attempt. Reject it to prevent confusion.
-                if let Some((existing_url, _)) =
-                    agents.iter().find(|(u, c)| c.name == card.name && u != &url)
+                if let Some((existing_url, _)) = agents
+                    .iter()
+                    .find(|(u, c)| c.name == card.name && u != &url)
                 {
                     return (
                         StatusCode::CONFLICT,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -860,6 +860,7 @@ pub async fn build_router(
         ),
         webhook_router,
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
         #[cfg(feature = "telemetry")]
         prometheus_handle: prom_handle,
     });
@@ -1030,8 +1031,19 @@ pub async fn build_router(
         // Webhook trigger endpoints (not versioned — external callers use fixed URLs)
         .route("/hooks/wake", axum::routing::post(routes::webhook_wake))
         .route("/hooks/agent", axum::routing::post(routes::webhook_agent))
-        // A2A protocol endpoints + MCP HTTP (protocol-level, not versioned)
-        .merge(routes::network::protocol_router())
+        // A2A protocol endpoints + MCP HTTP (protocol-level, not versioned).
+        // Apply an explicit body limit (1 MB) to inbound A2A task payloads so
+        // that external callers cannot exhaust server memory via oversized JSON
+        // bodies. This is a defence-in-depth companion to the global
+        // RequestBodyLimitLayer applied further down — the global limit uses the
+        // operator-configurable max_request_body_bytes value, which may be
+        // raised for other endpoints (e.g. file uploads). Pinning A2A separately
+        // ensures memory exhaustion DoS attacks via /a2a/tasks/send are always
+        // bounded (Bug #3785).
+        .merge(
+            routes::network::protocol_router()
+                .layer(RequestBodyLimitLayer::new(1024 * 1024)),
+        )
         // MCP HTTP endpoint (protocol-level, not versioned)
         .route("/mcp", axum::routing::post(routes::mcp_http))
         // OpenAI-compatible API (follows OpenAI versioning, not ours)

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -117,6 +117,7 @@ async fn start_test_server_with_provider(
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()
@@ -1633,6 +1634,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let api_key_state = middleware::AuthState {
@@ -2805,6 +2807,7 @@ async fn start_test_server_with_rbac_users(
         user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let api_key_state = middleware::AuthState {
@@ -3107,6 +3110,7 @@ async fn start_test_server_with_full_user_configs(
         user_api_keys: user_api_keys_lock.clone(),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let api_key_state = middleware::AuthState {

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -130,6 +130,7 @@ async fn test_full_daemon_lifecycle() {
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()
@@ -272,6 +273,7 @@ async fn test_server_immediate_responsiveness() {
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -74,6 +74,7 @@ async fn start_test_server() -> TestServer {
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/tools_invoke_test.rs
+++ b/crates/librefang-api/tests/tools_invoke_test.rs
@@ -77,6 +77,7 @@ async fn build_harness(tool_invoke: ToolInvokeConfig) -> Harness {
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -73,6 +73,7 @@ async fn boot_with_seed_users(seed: Vec<UserConfig>) -> Harness {
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
     });
 
     let app = Router::new()

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -147,6 +147,7 @@ impl TestAppState {
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             config_write_lock: tokio::sync::Mutex::new(()),
+            pending_a2a_agents: dashmap::DashMap::new(),
         })
     }
 }


### PR DESCRIPTION
## Summary

Fixes three A2A security vulnerabilities:

- **#3785** — `POST /api/a2a/discover`, `/api/a2a/send`, `/api/a2a/tasks/{id}/status` had no body size limit; added `RequestBodyLimitLayer::new(1024 * 1024)` on the A2A protocol router mount, independent of the operator-configurable global limit
- **#3781** — `GET /a2a/tasks/{id}` was unauthenticated because the middleware exempted all `/a2a/*` paths; tightened the allowlist to `/a2a/agents` only (the A2A spec's capability-discovery endpoint), so all task endpoints require Bearer auth
- **#3786** — discovered A2A agents were immediately trusted without any operator approval, could collide with existing agent names, and had no cryptographic verification warning; `POST /api/a2a/discover` now returns 202 + `pending` state, a new `POST /api/a2a/agents/{id}/approve` endpoint promotes to trusted, name conflicts return 409, and `POST /api/a2a/send` rejects tasks to still-pending agents

## Test plan

- [ ] `POST /api/a2a/discover` with body >1 MB → 413
- [ ] `GET /a2a/tasks/{id}` without Bearer → 401
- [ ] `POST /api/a2a/discover` with duplicate agent name → 409
- [ ] `POST /api/a2a/discover` → 202 with `status: pending`
- [ ] `POST /api/a2a/agents/{id}/approve` → agent moves to trusted list
- [ ] `POST /api/a2a/send` targeting pending agent → 400