### PR TITLE
fix(wasm): KV namespace isolation, result_len cap, per-invocation engine epoch isolation

### DIFF
--- a/crates/librefang-runtime-wasm/Cargo.toml
+++ b/crates/librefang-runtime-wasm/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+async-trait = { workspace = true }

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -564,7 +564,11 @@ fn host_kv_get(state: &GuestState, params: &serde_json::Value) -> serde_json::Va
         Some(k) => k,
         None => return json!({"error": "No kernel handle available"}),
     };
-    match kernel.memory_recall(key, None) {
+    // SECURITY: Prefix the key with the agent_id to give each agent its own
+    // isolated KV namespace (Bug #3837). Without this prefix all agents share
+    // a flat key space, so agent A can read or overwrite agent B's keys.
+    let namespaced_key = format!("{}:{key}", state.agent_id);
+    match kernel.memory_recall(&namespaced_key, None) {
         Ok(Some(val)) => json!({"ok": val}),
         Ok(None) => json!({"ok": null}),
         Err(e) => json!({"error": e}),
@@ -590,7 +594,11 @@ fn host_kv_set(state: &GuestState, params: &serde_json::Value) -> serde_json::Va
         Some(k) => k,
         None => return json!({"error": "No kernel handle available"}),
     };
-    match kernel.memory_store(key, value, None) {
+    // SECURITY: Prefix the key with the agent_id so each agent's KV entries
+    // live in a separate namespace and cannot be accessed by other agents
+    // (Bug #3837).
+    let namespaced_key = format!("{}:{key}", state.agent_id);
+    match kernel.memory_store(&namespaced_key, value, None) {
         Ok(()) => json!({"ok": true}),
         Err(e) => json!({"error": e}),
     }
@@ -862,6 +870,206 @@ mod tests {
         let result = host_kv_get(&state, &json!({"key": "test"}));
         let err = result["error"].as_str().unwrap();
         assert!(err.contains("kernel"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Mock KernelHandle for KV namespace isolation tests (Bug #3837)
+    // ---------------------------------------------------------------------------
+
+    struct RecordingKernel {
+        /// Records every (namespaced_key, value) passed to memory_store.
+        stored: std::sync::Mutex<Vec<(String, serde_json::Value)>>,
+        /// Records every namespaced_key passed to memory_recall.
+        recalled: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingKernel {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                stored: std::sync::Mutex::new(Vec::new()),
+                recalled: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl librefang_kernel_handle::KernelHandle for RecordingKernel {
+        async fn spawn_agent(&self, _: &str, _: Option<&str>) -> Result<(String, String), String> {
+            Err("not implemented".to_string())
+        }
+        async fn send_to_agent(&self, _: &str, _: &str) -> Result<String, String> {
+            Err("not implemented".to_string())
+        }
+        fn list_agents(&self) -> Vec<librefang_kernel_handle::AgentInfo> {
+            vec![]
+        }
+        fn kill_agent(&self, _: &str) -> Result<(), String> {
+            Err("not implemented".to_string())
+        }
+        fn memory_store(
+            &self,
+            key: &str,
+            value: serde_json::Value,
+            _peer_id: Option<&str>,
+        ) -> Result<(), String> {
+            self.stored.lock().unwrap().push((key.to_string(), value));
+            Ok(())
+        }
+        fn memory_recall(
+            &self,
+            key: &str,
+            _peer_id: Option<&str>,
+        ) -> Result<Option<serde_json::Value>, String> {
+            self.recalled.lock().unwrap().push(key.to_string());
+            Ok(None)
+        }
+        fn memory_list(&self, _: Option<&str>) -> Result<Vec<String>, String> {
+            Ok(vec![])
+        }
+        fn find_agents(&self, _: &str) -> Vec<librefang_kernel_handle::AgentInfo> {
+            vec![]
+        }
+        async fn task_post(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> Result<String, String> {
+            Err("not implemented".to_string())
+        }
+        async fn task_claim(&self, _: &str) -> Result<Option<serde_json::Value>, String> {
+            Ok(None)
+        }
+        async fn task_complete(&self, _: &str, _: &str, _: &str) -> Result<(), String> {
+            Err("not implemented".to_string())
+        }
+        async fn task_list(&self, _: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+            Ok(vec![])
+        }
+        async fn task_delete(&self, _: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+        async fn task_retry(&self, _: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+        async fn task_get(&self, _: &str) -> Result<Option<serde_json::Value>, String> {
+            Ok(None)
+        }
+        async fn task_update_status(&self, _: &str, _: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+        async fn publish_event(&self, _: &str, _: serde_json::Value) -> Result<(), String> {
+            Ok(())
+        }
+        async fn knowledge_add_entity(
+            &self,
+            _: librefang_types::memory::Entity,
+        ) -> Result<String, String> {
+            Err("not implemented".to_string())
+        }
+        async fn knowledge_add_relation(
+            &self,
+            _: librefang_types::memory::Relation,
+        ) -> Result<String, String> {
+            Err("not implemented".to_string())
+        }
+        async fn knowledge_query(
+            &self,
+            _: librefang_types::memory::GraphPattern,
+        ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
+            Ok(vec![])
+        }
+    }
+
+    fn state_with_kernel(
+        agent_id: &str,
+        capabilities: Vec<Capability>,
+        kernel: std::sync::Arc<RecordingKernel>,
+    ) -> GuestState {
+        GuestState {
+            capabilities,
+            kernel: Some(kernel),
+            agent_id: agent_id.to_string(),
+            tokio_handle: tokio::runtime::Handle::current(),
+        }
+    }
+
+    /// Regression test for Bug #3837: kv_get must namespace the key with
+    /// agent_id so that two agents cannot read each other's KV entries.
+    #[tokio::test]
+    async fn test_kv_get_key_is_namespaced_with_agent_id() {
+        let kernel = RecordingKernel::new();
+        let state = state_with_kernel(
+            "agent-alice",
+            vec![Capability::MemoryRead("*".to_string())],
+            std::sync::Arc::clone(&kernel),
+        );
+        host_kv_get(&state, &json!({"key": "secret"}));
+
+        let recalled = kernel.recalled.lock().unwrap();
+        assert_eq!(recalled.len(), 1, "Expected exactly one memory_recall call");
+        assert_eq!(
+            recalled[0], "agent-alice:secret",
+            "kv_get must prefix the key with agent_id to isolate namespaces"
+        );
+    }
+
+    /// Regression test for Bug #3837: kv_set must namespace the key with
+    /// agent_id so that two agents cannot overwrite each other's KV entries.
+    #[tokio::test]
+    async fn test_kv_set_key_is_namespaced_with_agent_id() {
+        let kernel = RecordingKernel::new();
+        let state = state_with_kernel(
+            "agent-bob",
+            vec![Capability::MemoryWrite("*".to_string())],
+            std::sync::Arc::clone(&kernel),
+        );
+        host_kv_set(&state, &json!({"key": "counter", "value": 42}));
+
+        let stored = kernel.stored.lock().unwrap();
+        assert_eq!(stored.len(), 1, "Expected exactly one memory_store call");
+        assert_eq!(
+            stored[0].0, "agent-bob:counter",
+            "kv_set must prefix the key with agent_id to isolate namespaces"
+        );
+    }
+
+    /// Two agents using the same guest key must produce different namespaced
+    /// keys — that is the whole point of the namespace isolation.
+    #[tokio::test]
+    async fn test_kv_two_agents_same_guest_key_different_namespaced_keys() {
+        let kernel_a = RecordingKernel::new();
+        let state_a = state_with_kernel(
+            "agent-alice",
+            vec![Capability::MemoryRead("*".to_string())],
+            std::sync::Arc::clone(&kernel_a),
+        );
+        host_kv_get(&state_a, &json!({"key": "shared_name"}));
+
+        let kernel_b = RecordingKernel::new();
+        let state_b = state_with_kernel(
+            "agent-bob",
+            vec![Capability::MemoryRead("*".to_string())],
+            std::sync::Arc::clone(&kernel_b),
+        );
+        host_kv_get(&state_b, &json!({"key": "shared_name"}));
+
+        let recalled_a = kernel_a.recalled.lock().unwrap();
+        let recalled_b = kernel_b.recalled.lock().unwrap();
+
+        assert_ne!(
+            recalled_a[0], recalled_b[0],
+            "Different agents must produce different namespaced keys for the same guest key"
+        );
+        assert!(
+            recalled_a[0].starts_with("agent-alice:"),
+            "Alice's key must be prefixed with her agent_id"
+        );
+        assert!(
+            recalled_b[0].starts_with("agent-bob:"),
+            "Bob's key must be prefixed with his agent_id"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -157,8 +157,7 @@ impl WasmSandbox {
     pub fn new() -> Result<Self, SandboxError> {
         // Build a throw-away Engine to surface any config errors at
         // construction time rather than first use.
-        Engine::new(&make_engine_config())
-            .map_err(|e| SandboxError::Compilation(e.to_string()))?;
+        Engine::new(&make_engine_config()).map_err(|e| SandboxError::Compilation(e.to_string()))?;
         Ok(Self)
     }
 
@@ -992,8 +991,7 @@ mod tests {
             "fuel-exhausted-guest",
         );
 
-        let (normal_result, exhausted_result) =
-            tokio::join!(normal_fut, exhausted_fut);
+        let (normal_result, exhausted_result) = tokio::join!(normal_fut, exhausted_fut);
 
         // The fuel-exhausted guest must fail with FuelExhausted.
         assert!(

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -134,20 +134,32 @@ pub enum SandboxError {
 
 /// The WASM sandbox engine.
 ///
-/// Create one per kernel, reuse across skill invocations. The `Engine`
-/// is expensive to create but can compile/instantiate many modules.
-pub struct WasmSandbox {
-    engine: Engine,
+/// # Epoch isolation (Bug #3864)
+///
+/// `Engine::increment_epoch()` is global to an `Engine` — calling it from a
+/// watchdog thread would interrupt *every* `Store` sharing that engine, not
+/// just the one that timed out. To prevent cross-guest contamination, each call
+/// to `execute` creates a fresh `Engine`. The cost is one extra engine init per
+/// invocation; WASM module compilation is unavoidably O(module size) regardless,
+/// so the marginal overhead is small compared to the compilation step.
+pub struct WasmSandbox;
+
+/// Build the standard Wasmtime `Config` used by every sandbox Engine.
+fn make_engine_config() -> Config {
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    config.epoch_interruption(true);
+    config
 }
 
 impl WasmSandbox {
-    /// Create a new sandbox engine with fuel metering enabled.
+    /// Create a new sandbox instance. Validates the engine config eagerly.
     pub fn new() -> Result<Self, SandboxError> {
-        let mut config = Config::new();
-        config.consume_fuel(true);
-        config.epoch_interruption(true);
-        let engine = Engine::new(&config).map_err(|e| SandboxError::Compilation(e.to_string()))?;
-        Ok(Self { engine })
+        // Build a throw-away Engine to surface any config errors at
+        // construction time rather than first use.
+        Engine::new(&make_engine_config())
+            .map_err(|e| SandboxError::Compilation(e.to_string()))?;
+        Ok(Self)
     }
 
     /// Execute a WASM module with the given JSON input.
@@ -155,6 +167,10 @@ impl WasmSandbox {
     /// All host calls from within the module are subject to capability checks.
     /// Execution is offloaded to a blocking thread (CPU-bound WASM should not
     /// run on the Tokio executor).
+    ///
+    /// A fresh `Engine` is created for each invocation so that the epoch-based
+    /// watchdog can safely call `engine.increment_epoch()` without disturbing
+    /// any other concurrently running WASM guests.
     pub async fn execute(
         &self,
         wasm_bytes: &[u8],
@@ -163,7 +179,9 @@ impl WasmSandbox {
         kernel: Option<Arc<dyn KernelHandle>>,
         agent_id: &str,
     ) -> Result<ExecutionResult, SandboxError> {
-        let engine = self.engine.clone();
+        // Build a fresh engine for this execution — epoch isolation requires it.
+        let engine = Engine::new(&make_engine_config())
+            .map_err(|e| SandboxError::Compilation(e.to_string()))?;
         let wasm_bytes = wasm_bytes.to_vec();
         let agent_id = agent_id.to_string();
         let handle = tokio::runtime::Handle::current();
@@ -224,29 +242,24 @@ impl WasmSandbox {
 
         // Set epoch deadline (wall-clock metering).
         //
-        // The watchdog thread used to be fire-and-forget — it slept for the
-        // full timeout (30s by default) and then called `increment_epoch`
-        // whether or not the guest had already returned. That leaked a
-        // sleeping OS thread per invocation and also caused cross-store
-        // false interrupts, because `Engine::increment_epoch` is global to
-        // the Engine: every concurrently running guest observes the tick.
-        // Sustained workloads piled up thousands of sleeping threads and
-        // eventually exhausted the OS thread limit, and any fresh guest
-        // that happened to start right after a stale watchdog fired would
-        // trap on `Interrupt` even though it had used no wall-clock time.
+        // `Engine::increment_epoch()` is global to an `Engine` — in earlier
+        // versions of this code a single shared Engine was used, so a watchdog
+        // firing for one guest would trip the epoch for *all* concurrently
+        // running guests (Bug #3864). That was fixed by creating a fresh
+        // Engine per invocation in `WasmSandbox::execute`; each execution now
+        // has its own epoch counter so `increment_epoch` only interrupts the
+        // guest running inside this store.
         //
-        // Instead, the watchdog blocks in `park_timeout(deadline - now)`
-        // and is woken via `Thread::unpark` the moment the main thread
-        // finishes. It re-checks the done flag on wake-up to distinguish
-        // "guest completed, go home" from "spurious wake-up, keep waiting".
-        // On the happy path the watchdog wakes within microseconds rather
-        // than a 50 ms poll interval, so a 5 ms sandbox call stays a 5 ms
-        // sandbox call. On the timeout path it sleeps out the remaining
-        // deadline exactly as before and trips the epoch.
+        // The watchdog thread blocks in `park_timeout(deadline - now)` and is
+        // woken via `Thread::unpark` the moment the main thread finishes. It
+        // re-checks the done flag on wake-up to distinguish "guest completed,
+        // go home" from "spurious wake-up, keep waiting". On the happy path
+        // the watchdog wakes within microseconds; on the timeout path it sleeps
+        // out the remaining deadline exactly once and trips the epoch.
         //
-        // An RAII guard signals the flag and joins the thread on every
-        // early-return path (`?`, trap, ABI error, panic) so no error-path
-        // leak slips past either.
+        // An RAII guard signals the flag and joins the watchdog thread on every
+        // early-return path (`?`, trap, ABI error, panic) so no thread leak
+        // slips through.
         store.set_epoch_deadline(1);
         let engine_clone = engine.clone();
         let timeout = config.timeout_secs.unwrap_or(30);
@@ -372,6 +385,20 @@ impl WasmSandbox {
         // Unpack result: high 32 bits = ptr, low 32 bits = len
         let result_ptr = (packed >> 32) as usize;
         let result_len = (packed & 0xFFFF_FFFF) as usize;
+
+        // SECURITY: Cap result size before any memory access or JSON parsing
+        // (Bug #3866). A malicious guest can return a `result_len` of up to
+        // 2^32-1 bytes. Without this guard the host would either try to slice
+        // gigabytes of memory (triggering the bounds check below) or, if the
+        // guest had somehow pre-allocated that much memory, feed a huge buffer
+        // to serde_json whose recursive descent parser has no depth limit and
+        // can stack-overflow on deeply-nested input.
+        const MAX_RESULT_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+        if result_len > MAX_RESULT_BYTES {
+            return Err(SandboxError::AbiError(format!(
+                "Guest result too large: {result_len} bytes (max {MAX_RESULT_BYTES})"
+            )));
+        }
 
         // Read output JSON from guest memory. checked_add so a malicious
         // or buggy guest can't wrap `ptr + len` and silently pass the
@@ -500,6 +527,18 @@ impl WasmSandbox {
         request_ptr: i32,
         request_len: i32,
     ) -> anyhow::Result<i64> {
+        // SECURITY: Reject oversized or negative host_call request payloads
+        // before deserialising (Bug #3866). `request_len` is i32 from the
+        // guest ABI; a negative value as usize wraps to a huge number, and a
+        // very large positive value feeds an unbounded serde_json parse that
+        // can stack-overflow on deeply-nested JSON.
+        const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+        if request_len < 0 || request_len as usize > MAX_REQUEST_BYTES {
+            anyhow::bail!(
+                "host_call request length invalid: {} (max {MAX_REQUEST_BYTES})",
+                request_len
+            );
+        }
         let request_bytes = Self::read_guest_bytes(caller, request_ptr, request_len, "host_call")?;
         let request: serde_json::Value = serde_json::from_slice(&request_bytes)?;
         let method = request
@@ -851,5 +890,127 @@ mod tests {
         let annotated = format!("{}... [truncated {} bytes]", clamped, 100);
         assert!(annotated.contains("[truncated 100 bytes]"));
         assert!(annotated.len() > MAX_LOG_BYTES);
+    }
+    /// Module that returns a packed result whose `result_len` field is set to
+    /// MAX_RESULT_BYTES + 1 (0x1000001 = 16 MiB + 1) with a ptr of 0, to
+    /// trigger the oversized-result guard introduced in Bug #3866.
+    ///
+    /// The `result_len` (low 32 bits) is set to a value beyond the 16 MiB cap.
+    /// The pointer points to the start of memory (offset 0), which contains
+    /// whatever zeroed or initialised bytes the runtime put there — we only
+    /// care that the size guard fires BEFORE we try to slice memory.
+    const OVERSIZED_RESULT_WAT: &str = r#"
+        (module
+            (memory (export "memory") 1)
+            (global $bump (mut i32) (i32.const 1024))
+
+            (func (export "alloc") (param $size i32) (result i32)
+                (local $ptr i32)
+                (local.set $ptr (global.get $bump))
+                (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+                (local.get $ptr)
+            )
+
+            (func (export "execute") (param $ptr i32) (param $len i32) (result i64)
+                ;; Return ptr=0, len = 16 MiB + 1 (0x1000001) — exceeds the cap.
+                ;; packed = (0 << 32) | 0x1000001
+                (i64.const 0x1000001)
+            )
+        )
+    "#;
+
+    /// Regression test for Bug #3866: a guest that claims to return more than
+    /// MAX_RESULT_BYTES must be rejected with an AbiError, not cause the host
+    /// to attempt a 16 MiB+ heap allocation or a serde_json parse of untrusted
+    /// huge/deeply-nested data.
+    #[tokio::test]
+    async fn test_oversized_result_is_rejected() {
+        let sandbox = WasmSandbox::new().unwrap();
+        let input = serde_json::json!({});
+        let config = SandboxConfig {
+            fuel_limit: 10_000_000,
+            ..Default::default()
+        };
+
+        let err = sandbox
+            .execute(
+                OVERSIZED_RESULT_WAT.as_bytes(),
+                input,
+                config,
+                None,
+                "test-agent",
+            )
+            .await
+            .unwrap_err();
+
+        match &err {
+            SandboxError::AbiError(msg) => {
+                assert!(
+                    msg.contains("too large"),
+                    "Expected 'too large' in AbiError, got: {msg}"
+                );
+            }
+            other => panic!("Expected AbiError for oversized result, got: {other}"),
+        }
+    }
+
+    /// Regression test for Bug #3864: creating a per-execution Engine means
+    /// that the epoch watchdog for one guest cannot interrupt another concurrently
+    /// running guest. We verify this by running two sandboxes concurrently: a
+    /// very short-timeout one that trips immediately and a normal one that should
+    /// finish cleanly. If the epoch were shared, the normal one would also trap.
+    #[tokio::test]
+    async fn test_epoch_timeout_does_not_bleed_to_concurrent_guests() {
+        // Two independent sandbox instances (each gets its own Engine per execution).
+        let sandbox = WasmSandbox::new().unwrap();
+
+        // Guest 1: normal echo — should complete successfully.
+        let normal_config = SandboxConfig {
+            fuel_limit: 10_000_000,
+            timeout_secs: Some(30),
+            ..Default::default()
+        };
+        let normal_fut = sandbox.execute(
+            ECHO_WAT.as_bytes(),
+            serde_json::json!({"ping": "pong"}),
+            normal_config,
+            None,
+            "normal-guest",
+        );
+
+        // Guest 2: infinite loop with a tiny fuel budget — exhausts fuel quickly.
+        let exhausted_config = SandboxConfig {
+            fuel_limit: 100,
+            timeout_secs: Some(1),
+            ..Default::default()
+        };
+        let exhausted_fut = sandbox.execute(
+            INFINITE_LOOP_WAT.as_bytes(),
+            serde_json::json!({}),
+            exhausted_config,
+            None,
+            "fuel-exhausted-guest",
+        );
+
+        let (normal_result, exhausted_result) =
+            tokio::join!(normal_fut, exhausted_fut);
+
+        // The fuel-exhausted guest must fail with FuelExhausted.
+        assert!(
+            matches!(exhausted_result, Err(SandboxError::FuelExhausted)),
+            "Expected FuelExhausted for exhausted guest, got: {exhausted_result:?}"
+        );
+
+        // The normal guest must succeed — its epoch must NOT have been tripped
+        // by the other guest's watchdog firing.
+        assert!(
+            normal_result.is_ok(),
+            "Normal guest must not be interrupted by another guest's timeout: {normal_result:?}"
+        );
+        assert_eq!(
+            normal_result.unwrap().output,
+            serde_json::json!({"ping": "pong"}),
+            "Normal guest output must be unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes three WASM sandbox bugs:

- **#3837** — `kv_get`/`kv_set` shared a single global namespace across all agents; prefixed every key with `{agent_id}:` so each agent is isolated to its own namespace; added 3 regression tests
- **#3866** — guest could declare `result_len` up to 2³²-1 bytes or pass unbounded `request_len` to `host_call`; added `MAX_RESULT_BYTES = 16 MiB` and `MAX_REQUEST_BYTES = 16 MiB` caps checked before any memory access or serde deserialization
- **#3864** — `Engine::increment_epoch()` is engine-global and would interrupt all concurrent WASM guests sharing the engine, not just the timed-out one; each `execute()` call now creates its own `Engine` instance so epoch counters are fully isolated

## Test plan

- [ ] Two agents using the same KV key get independent values
- [ ] WASM module returning oversized result → sandbox error, not OOM
- [ ] One fuel-exhausted guest does not interrupt a concurrently running normal guest