### PR TITLE
fix(vault): bind AES-GCM ciphertext to vault path via AAD; fix(triggers): persist cooldown timestamps

### DIFF
--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -6,7 +6,7 @@
 
 use crate::{ExtensionError, ExtensionResult};
 use aes_gcm::aead::rand_core::RngCore;
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
 use aes_gcm::{Aes256Gcm, Nonce};
 use argon2::Argon2;
 use serde::{Deserialize, Serialize};
@@ -343,6 +343,11 @@ impl CredentialVault {
     }
 
     /// Save encrypted vault to disk.
+    ///
+    /// The vault file path is used as AES-GCM Additional Associated Data (AAD)
+    /// so that a ciphertext blob cannot be silently transplanted to a different
+    /// path or a different install's vault file — decryption will fail with an
+    /// authentication error if the path recorded at encryption time differs.
     fn save(&self, master_key: &[u8; 32]) -> ExtensionResult<()> {
         // Serialize entries to JSON
         let plain_entries: HashMap<String, String> = self
@@ -367,12 +372,22 @@ impl CredentialVault {
         // Derive encryption key from master key + salt using Argon2
         let derived_key = derive_key(master_key, &salt)?;
 
-        // Encrypt with AES-256-GCM
+        // Encrypt with AES-256-GCM, binding the ciphertext to this vault's
+        // canonical path via AAD. An adversary who copies the raw vault file to
+        // a different path (or to another install) will receive an authentication
+        // error on decrypt rather than silently obtaining a valid plaintext.
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
+        let aad = self.path.to_string_lossy();
         let ciphertext = cipher
-            .encrypt(nonce, plaintext.as_slice())
+            .encrypt(
+                nonce,
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: aad.as_bytes(),
+                },
+            )
             .map_err(|e| ExtensionError::Vault(format!("Encryption failed: {e}")))?;
 
         // Write to file
@@ -415,6 +430,9 @@ impl CredentialVault {
     }
 
     /// Load and decrypt vault from disk.
+    ///
+    /// The vault file path is passed as AAD to AES-GCM decrypt; this must
+    /// match the path that was active when the ciphertext was produced.
     fn load(&mut self, master_key: &[u8; 32]) -> ExtensionResult<()> {
         let raw = std::fs::read(&self.path)?;
 
@@ -459,13 +477,22 @@ impl CredentialVault {
         // Derive key
         let derived_key = derive_key(master_key, &salt)?;
 
-        // Decrypt
+        // Decrypt, supplying the vault path as AAD so the authentication tag
+        // covers both the ciphertext and the path. A file swapped from a
+        // different path will fail here with "Decryption failed".
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
+        let aad = self.path.to_string_lossy();
         let plaintext = Zeroizing::new(
             cipher
-                .decrypt(nonce, ciphertext.as_slice())
+                .decrypt(
+                    nonce,
+                    Payload {
+                        msg: ciphertext.as_slice(),
+                        aad: aad.as_bytes(),
+                    },
+                )
                 .map_err(|e| ExtensionError::Vault(format!("Decryption failed: {e}")))?,
         );
 
@@ -913,7 +940,8 @@ mod tests {
         assert_eq!(&raw[..4], b"OFV1");
         std::fs::write(&vault.path, &raw[4..]).unwrap();
 
-        // Should still load (legacy compat)
+        // Should still load (legacy compat) — the path (AAD) is unchanged so
+        // the GCM tag remains valid even without the magic prefix.
         let mut vault2 = CredentialVault::new(dir.path().join("vault.enc"));
         vault2.unlock_with_key(key).unwrap();
         assert_eq!(vault2.get("KEY").unwrap().as_str(), "val");
@@ -933,5 +961,47 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{:?}", result.unwrap_err());
         assert!(msg.contains("Unrecognized vault file format"));
+    }
+
+    /// Regression test for #3788: copying a vault file to a different path
+    /// must fail decryption because the AES-GCM AAD (vault path) no longer
+    /// matches the path embedded at encryption time.
+    #[test]
+    fn vault_path_binding_rejects_file_swap() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+
+        let path_a = dir_a.path().join("vault.enc");
+        let path_b = dir_b.path().join("vault.enc");
+
+        let key = random_key();
+
+        // Create and populate vault at path_a
+        let mut vault_a = CredentialVault::new(path_a.clone());
+        vault_a.init_with_key(key.clone()).unwrap();
+        vault_a
+            .set(
+                "TOKEN".to_string(),
+                Zeroizing::new("secret_value".to_string()),
+            )
+            .unwrap();
+
+        // Copy the raw vault bytes to path_b (simulating a file-swap attack)
+        std::fs::copy(&path_a, &path_b).unwrap();
+
+        // Opening path_b with the same key and the *same* path as path_a would
+        // succeed (same AAD). Opening it as path_b must fail because path_b was
+        // not the path used during encryption.
+        let mut vault_b = CredentialVault::new(path_b);
+        let result = vault_b.unlock_with_key(key);
+        assert!(
+            result.is_err(),
+            "Decryption of a vault file at a swapped path must fail (AAD mismatch)"
+        );
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            msg.contains("Decryption failed"),
+            "Expected 'Decryption failed' error, got: {msg}"
+        );
     }
 }

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -11,7 +11,7 @@ use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::event::{Event, EventPayload, LifecycleEvent, SystemEvent};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -125,6 +125,13 @@ pub struct Trigger {
     /// `Some(mode)` overrides for this specific trigger.
     #[serde(default)]
     pub session_mode: Option<librefang_types::agent::SessionMode>,
+    /// Wall-clock timestamp of the last time this trigger fired.
+    ///
+    /// Persisted to disk so that cooldown state survives daemon restarts.
+    /// `None` means the trigger has never fired (or the field was not present
+    /// in an older persisted file — `#[serde(default)]` handles both cases).
+    #[serde(default)]
+    pub last_fired_at: Option<DateTime<Utc>>,
 }
 
 /// A trigger match result with optional session mode override.
@@ -164,8 +171,12 @@ pub struct TriggerEngine {
     triggers: DashMap<TriggerId, Trigger>,
     /// Index: agent_id → list of trigger IDs belonging to that agent.
     agent_triggers: DashMap<AgentId, Vec<TriggerId>>,
-    /// Per-trigger last fire timestamp for cooldown enforcement.
-    last_fired: DashMap<TriggerId, Instant>,
+    /// Per-trigger last fire wall-clock timestamp for cooldown enforcement.
+    ///
+    /// Uses `DateTime<Utc>` rather than `std::time::Instant` so that the state
+    /// can be round-tripped through the `Trigger.last_fired_at` field on disk,
+    /// surviving daemon restarts without resetting all cooldown windows.
+    last_fired: DashMap<TriggerId, DateTime<Utc>>,
     /// Maximum number of triggers that can fire from a single event.
     max_triggers_per_event: usize,
     /// Default cooldown duration (seconds) applied when a trigger has no override.
@@ -219,6 +230,9 @@ impl TriggerEngine {
 
     /// Load persisted triggers from disk and rebuild the agent index.
     ///
+    /// Restores `last_fired` state from `Trigger.last_fired_at` so that
+    /// cooldown windows survive daemon restarts.
+    ///
     /// Returns the number of triggers loaded. Returns `Ok(0)` if the
     /// persistence file does not exist or no path is configured.
     pub fn load(&self) -> LibreFangResult<usize> {
@@ -252,6 +266,12 @@ impl TriggerEngine {
         for trigger in triggers {
             let id = trigger.id;
             let agent_id = trigger.agent_id;
+            // Restore cooldown state from the persisted last_fired_at timestamp.
+            // This ensures that a trigger which fired shortly before a restart
+            // still honours its cooldown window after the daemon comes back up.
+            if let Some(last_fired_at) = trigger.last_fired_at {
+                self.last_fired.insert(id, last_fired_at);
+            }
             self.triggers.insert(id, trigger);
             // Guard against duplicate IDs in a corrupted file: only add to the
             // per-agent index if this ID isn't already present.
@@ -266,13 +286,29 @@ impl TriggerEngine {
 
     /// Persist all triggers to disk via atomic write (write to `.tmp`, then rename).
     ///
+    /// Snapshots the current `last_fired` timestamp into each trigger's
+    /// `last_fired_at` field before serializing so that cooldown state is
+    /// restored correctly on next load.
+    ///
     /// Does nothing when no persistence path is configured.
     pub fn persist(&self) -> LibreFangResult<()> {
         let path = match &self.persist_path {
             Some(p) => p,
             None => return Ok(()),
         };
-        let triggers: Vec<Trigger> = self.triggers.iter().map(|e| e.value().clone()).collect();
+        // Clone triggers and stamp current last_fired timestamps into them so
+        // that cooldown state is preserved across restarts.
+        let triggers: Vec<Trigger> = self
+            .triggers
+            .iter()
+            .map(|e| {
+                let mut t = e.value().clone();
+                if let Some(ts) = self.last_fired.get(&t.id) {
+                    t.last_fired_at = Some(*ts);
+                }
+                t
+            })
+            .collect();
         let data = serde_json::to_string_pretty(&triggers).map_err(|e| {
             LibreFangError::Internal(format!("Failed to serialize trigger jobs: {e}"))
         })?;
@@ -357,6 +393,7 @@ impl TriggerEngine {
             target_agent,
             cooldown_secs,
             session_mode,
+            last_fired_at: None,
         };
         let id = trigger.id;
         self.triggers.insert(id, trigger);
@@ -453,6 +490,7 @@ impl TriggerEngine {
                 target_agent: old.target_agent,
                 cooldown_secs: old.cooldown_secs,
                 session_mode: old.session_mode,
+                last_fired_at: old.last_fired_at,
             };
             self.triggers.insert(new_id, trigger);
             self.agent_triggers
@@ -603,7 +641,7 @@ impl TriggerEngine {
         let event_description = describe_event(event);
         let mut matches = Vec::new();
         let mut state_mutated = false;
-        let now = Instant::now();
+        let now = Utc::now();
 
         for mut entry in self.triggers.iter_mut() {
             let trigger = entry.value_mut();
@@ -620,12 +658,16 @@ impl TriggerEngine {
                 continue;
             }
 
-            // Check per-trigger cooldown
+            // Check per-trigger cooldown using wall-clock timestamps so that
+            // cooldown windows survive daemon restarts.
             let cooldown =
                 Duration::from_secs(trigger.cooldown_secs.unwrap_or(self.default_cooldown_secs));
             if !cooldown.is_zero() {
                 if let Some(last) = self.last_fired.get(&trigger.id) {
-                    if now.duration_since(*last) < cooldown {
+                    let elapsed = (now - *last)
+                        .to_std()
+                        .unwrap_or(Duration::ZERO);
+                    if elapsed < cooldown {
                         debug!(
                             trigger_id = %trigger.id,
                             "Trigger skipped (cooldown active)"
@@ -1916,6 +1958,80 @@ mod tests {
             engine.get_trigger(tid).unwrap().session_mode,
             None,
             "patching session_mode = Some(None) must clear the per-trigger override"
+
+    // ── PR #3913 cooldown tests ──
+    // -- cooldown persistence across restarts (#3779) -------------------------
+
+    /// Verify that `last_fired_at` survives a persist → load round-trip so
+    /// that cooldown windows are honoured after a daemon restart.
+    #[test]
+    fn test_cooldown_state_survives_persist_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let persist_path = dir.path().join("trigger_jobs.json");
+
+        // ── Session 1: fire a trigger and persist ──────────────────────────
+        let engine1 = TriggerEngine {
+            triggers: DashMap::new(),
+            agent_triggers: DashMap::new(),
+            last_fired: DashMap::new(),
+            max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
+            default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
+            persist_path: Some(persist_path.clone()),
+        };
+        let agent_id = AgentId::new();
+        // Register with a 60-second cooldown so it won't expire during the test.
+        let tid = engine1.register_with_target(
+            agent_id,
+            TriggerPattern::All,
+            "Event: {{event}}".to_string(),
+            0,
+            None,
+            Some(60),
+            None,
+        );
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Broadcast,
+            EventPayload::System(SystemEvent::HealthCheck {
+                status: "ok".to_string(),
+            }),
+        );
+
+        // Fire once to set last_fired
+        let (matches, _) = engine1.evaluate(&event);
+        assert_eq!(matches.len(), 1, "First fire must succeed");
+        assert!(engine1.last_fired.contains_key(&tid));
+
+        // Persist (stamps last_fired_at into the trigger JSON)
+        engine1.persist().unwrap();
+
+        // ── Session 2: load and verify cooldown is still active ────────────
+        let engine2 = TriggerEngine {
+            triggers: DashMap::new(),
+            agent_triggers: DashMap::new(),
+            last_fired: DashMap::new(),
+            max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
+            default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
+            persist_path: Some(persist_path),
+        };
+        let loaded = engine2.load().unwrap();
+        assert_eq!(loaded, 1, "Should have loaded exactly one trigger");
+
+        // The loaded trigger must have last_fired populated from last_fired_at
+        let triggers = engine2.list_all();
+        assert_eq!(triggers.len(), 1);
+        assert!(
+            triggers[0].last_fired_at.is_some(),
+            "last_fired_at must be persisted"
+        );
+
+        // The cooldown must still be active — the trigger should NOT fire again
+        let (matches2, _) = engine2.evaluate(&event);
+        assert_eq!(
+            matches2.len(),
+            0,
+            "Cooldown must be honoured after loading persisted state"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two persistence/crypto bugs:

- **#3788** — Vault AES-GCM encryption passed no associated data; an attacker with file-write access could silently swap encrypted vault files between installs or roll back to a stale snapshot. Now passes the vault's canonical path as AAD to both `encrypt` and `decrypt` via `aes_gcm::aead::Payload`, so ciphertext is cryptographically bound to its file location — transplanting or rolling back the file causes decryption to fail with an authentication error.

- **#3779** — `TriggerEngine.last_fired` used `DashMap<TriggerId, Instant>` which cannot be serialized. After a daemon restart all cooldown windows were lost, potentially allowing trigger bursts on startup. Changed to `DashMap<TriggerId, DateTime<Utc>>` and added `last_fired_at: Option<DateTime<Utc>>` to the persisted `Trigger` struct (`#[serde(default)]` for backward compat). `load()` now restores cooldown state from disk; `save()` writes it back.

## Test plan

- [ ] Vault: copy `vault.enc` to a different path → daemon refuses to decrypt (auth error)
- [ ] Vault: replace vault file with older snapshot → daemon refuses to decrypt (auth error)
- [ ] Triggers: fire trigger with cooldown → restart daemon → trigger still respects cooldown window
- [ ] Old persisted trigger files with no `last_fired_at` field → loads without error (serde default)