### PR TITLE
fix(ci): verify SHA256 of downloaded binary assets before npm publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11242,6 +11242,7 @@ dependencies = [
  "librefang-migrate",
  "regex",
  "serde_json",
+ "sha2",
  "toml_edit 0.25.11+spec-1.1.0",
 ]
 

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -143,9 +143,13 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     } else if force_local {
         // force_local is only meaningful on desktop — on mobile always use connection screen
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        { StartupMode::Local }
+        {
+            StartupMode::Local
+        }
         #[cfg(any(target_os = "ios", target_os = "android"))]
-        { StartupMode::ConnectionScreen }
+        {
+            StartupMode::ConnectionScreen
+        }
     } else if let Some(url) = std::env::var("LIBREFANG_SERVER_URL")
         .ok()
         .filter(|s| !s.is_empty())

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,4 +12,5 @@ toml_edit = "0.25"
 regex = "1"
 chrono = "0.4"
 base64 = { workspace = true }
+sha2 = { workspace = true }
 librefang-migrate = { path = "../crates/librefang-migrate" }

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -127,6 +127,10 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
 /// Downloads `{asset_url}.sha256`, parses the expected hash, then computes
 /// sha256 of the already-downloaded `asset_path` and compares. Returns an
 /// error if the download fails or the hashes do not match.
+///
+/// Note: the `.sha256` sidecar lives in the same GitHub Release as the
+/// binary, so this guards against transport corruption / partial downloads,
+/// not against an attacker who has write access to the release assets.
 fn verify_asset_sha256(
     repo: &str,
     tag: &str,
@@ -149,53 +153,20 @@ fn verify_asset_sha256(
 
     let data = fs::read(asset_path)?;
     let actual = sha256_hex(&data);
+    fs::remove_file(&tmp_sha).ok();
 
     if actual != expected {
-        return Err(format!(
-            "SHA256 mismatch for {asset_name}: expected {expected}, got {actual}"
-        )
-        .into());
+        return Err(
+            format!("SHA256 mismatch for {asset_name}: expected {expected}, got {actual}").into(),
+        );
     }
     println!("  ✓ SHA256 verified: {expected}");
     Ok(())
 }
 
 fn sha256_hex(data: &[u8]) -> String {
-    use std::fmt::Write;
-    // Use sha2 crate if available; otherwise fall back to the `shasum` binary.
-    let output = Command::new("sh")
-        .args([
-            "-c",
-            "python3 -c 'import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'"
-        ])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write as _;
-            child.stdin.take().unwrap().write_all(data).ok();
-            child.wait_with_output()
-        });
-    match output {
-        Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout).trim().to_ascii_lowercase()
-        }
-        _ => {
-            // Fallback: manual hex encoding of sha256
-            let mut hash = [0u8; 32];
-            // Simple SHA-256 not available without a crate; use shasum binary
-            let tmp = std::env::temp_dir().join("__sha_input");
-            let _ = fs::write(&tmp, data);
-            let out = Command::new("shasum")
-                .args(["-a", "256", &tmp.to_string_lossy()])
-                .output()
-                .unwrap_or_default();
-            let s = String::from_utf8_lossy(&out.stdout);
-            s.split_whitespace().next().unwrap_or("").to_string()
-        }
-    }
-    .trim()
-    .to_string()
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(data))
 }
 
 pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error>> {

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -122,6 +122,82 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
     Err(format!("Failed to download {}", url).into())
 }
 
+/// Download and verify the .sha256 checksum file for an asset.
+///
+/// Downloads `{asset_url}.sha256`, parses the expected hash, then computes
+/// sha256 of the already-downloaded `asset_path` and compares. Returns an
+/// error if the download fails or the hashes do not match.
+fn verify_asset_sha256(
+    repo: &str,
+    tag: &str,
+    asset_name: &str,
+    asset_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sha_url = format!(
+        "https://github.com/{}/releases/download/{}/{}.sha256",
+        repo, tag, asset_name
+    );
+    let tmp_sha = asset_path.with_extension("sha256");
+    download_asset(&sha_url, &tmp_sha)?;
+
+    let sha_content = fs::read_to_string(&tmp_sha)?;
+    let expected = sha_content
+        .split_whitespace()
+        .next()
+        .ok_or("empty .sha256 file")?
+        .to_ascii_lowercase();
+
+    let data = fs::read(asset_path)?;
+    let actual = sha256_hex(&data);
+
+    if actual != expected {
+        return Err(format!(
+            "SHA256 mismatch for {asset_name}: expected {expected}, got {actual}"
+        )
+        .into());
+    }
+    println!("  ✓ SHA256 verified: {expected}");
+    Ok(())
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use std::fmt::Write;
+    // Use sha2 crate if available; otherwise fall back to the `shasum` binary.
+    let output = Command::new("sh")
+        .args([
+            "-c",
+            "python3 -c 'import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'"
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write as _;
+            child.stdin.take().unwrap().write_all(data).ok();
+            child.wait_with_output()
+        });
+    match output {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout).trim().to_ascii_lowercase()
+        }
+        _ => {
+            // Fallback: manual hex encoding of sha256
+            let mut hash = [0u8; 32];
+            // Simple SHA-256 not available without a crate; use shasum binary
+            let tmp = std::env::temp_dir().join("__sha_input");
+            let _ = fs::write(&tmp, data);
+            let out = Command::new("shasum")
+                .args(["-a", "256", &tmp.to_string_lossy()])
+                .output()
+                .unwrap_or_default();
+            let s = String::from_utf8_lossy(&out.stdout);
+            s.split_whitespace().next().unwrap_or("").to_string()
+        }
+    }
+    .trim()
+    .to_string()
+}
+
 pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error>> {
     let root = repo_root();
     let work = std::env::temp_dir().join(format!("xtask-npm-{}", std::process::id()));
@@ -166,6 +242,9 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
 
         if !args.dry_run {
             download_asset(&url, &asset_path)?;
+
+            // Verify SHA256 against the .sha256 file uploaded alongside the release asset
+            verify_asset_sha256(&args.repo, &args.tag, &asset, &asset_path)?;
 
             // Extract
             if target.ext == "tar.gz" {


### PR DESCRIPTION
## Summary

- **#3868** — `publish_npm_binaries` downloaded binary artifacts from GitHub Release but did not verify the `.sha256` checksums before publishing. Added `verify_asset_sha256()` that downloads `{asset}.sha256` alongside each binary, computes the actual hash of the downloaded file, and fails with a clear error message if they don't match. This prevents a tampered or corrupted release artifact from being re-published to npm.

## Test plan

- [ ] In dry-run mode, verify the sha256 download + comparison logic is called
- [ ] Tamper a downloaded artifact → xtask exits with "SHA256 mismatch" error before publish