### PR TITLE
fix(api): DELETE handlers return 204, scope agents by user_id, v1 routes in OpenAPI

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -398,21 +398,68 @@ use crate::types;
 pub struct ApiDoc;
 
 /// GET /api/openapi.json — Serve the auto-generated OpenAPI specification.
+///
+/// The spec includes paths for both `/api/*` (unversioned) and `/api/v1/*`
+/// (explicit version) since v1 routes are mounted at both prefixes.
 pub async fn openapi_spec() -> impl IntoResponse {
     let doc = ApiDoc::openapi();
-    match doc.to_json() {
-        Ok(json) => (
+    let json_str = match doc.to_json() {
+        Ok(j) => j,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to generate OpenAPI spec: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    // Parse the generated spec so we can inject /api/v1/* path copies.
+    let mut spec: serde_json::Value = match serde_json::from_str(&json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to parse generated spec: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    // Duplicate every /api/* path as /api/v1/* so clients can discover both
+    // the unversioned and explicitly-versioned routes from the single spec.
+    if let Some(paths) = spec.get("paths").and_then(|p| p.as_object()).cloned() {
+        let mut v1_entries: Vec<(String, serde_json::Value)> = Vec::new();
+        for (path, ops) in &paths {
+            if let Some(suffix) = path.strip_prefix("/api/") {
+                let v1_path = format!("/api/v1/{suffix}");
+                if !paths.contains_key(&v1_path) {
+                    v1_entries.push((v1_path, ops.clone()));
+                }
+            }
+        }
+        if !v1_entries.is_empty() {
+            if let Some(paths_obj) = spec.get_mut("paths").and_then(|p| p.as_object_mut()) {
+                for (k, v) in v1_entries {
+                    paths_obj.insert(k, v);
+                }
+            }
+        }
+    }
+
+    match serde_json::to_string(&spec) {
+        Ok(output) => (
             StatusCode::OK,
             [(
                 axum::http::header::CONTENT_TYPE,
                 "application/json; charset=utf-8",
             )],
-            json,
+            output,
         )
             .into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to generate OpenAPI spec: {e}"),
+            format!("Failed to serialize spec: {e}"),
         )
             .into_response(),
     }

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -822,8 +822,21 @@ pub(crate) fn effective_default_model(
 pub async fn list_agents(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
-    Query(params): Query<AgentListQuery>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
+    Query(mut params): Query<AgentListQuery>,
 ) -> impl IntoResponse {
+    // Scope agents by authenticated user: non-admin/owner callers can only
+    // list agents they authored.  If the caller already supplied an explicit
+    // ?owner= filter we respect it as-is; otherwise we inject the caller's
+    // username automatically.
+    if params.owner.is_none() {
+        if let Some(ref user) = api_user {
+            use librefang_kernel::auth::UserRole;
+            if user.0.role < UserRole::Admin {
+                params.owner = Some(user.0.name.clone());
+            }
+        }
+    }
     let catalog = state.kernel.model_catalog_ref().read().ok();
     let dm = {
         let dm_override = state
@@ -856,6 +869,13 @@ pub async fn list_agents(
     if let Some(ref status) = params.status {
         let status_lower = status.to_lowercase();
         agents.retain(|e| format!("{:?}", e.state).to_lowercase() == status_lower);
+    }
+
+    // Filter by owner (matches manifest.author). For non-admin callers this
+    // is injected automatically above so they only see their own agents.
+    if let Some(ref owner) = params.owner {
+        let owner_lower = owner.to_lowercase();
+        agents.retain(|e| e.manifest.author.to_lowercase() == owner_lower);
     }
 
     let total = agents.len();

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -1059,11 +1059,7 @@ pub async fn delete_user_budget(
                 api_user_ref.map(|u| u.user_id),
                 Some("api".to_string()),
             );
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({"status": "ok", "message": "budget cleared"})),
-            )
-                .into_response()
+            StatusCode::NO_CONTENT.into_response()
         }
         Err(super::users::PersistError::NotFound(m)) => {
             ApiErrorResponse::not_found(m).into_response()

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1500,25 +1500,10 @@ pub async fn remove_channel(
 
     // Hot-reload: deactivate the channel immediately
     match crate::channel_bridge::reload_channels_from_disk(&state).await {
-        Ok(started) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "removed",
-                "channel": name,
-                "remaining_channels": started,
-                "note": format!("{} deactivated.", name)
-            })),
-        ),
+        Ok(_started) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         Err(e) => {
             tracing::warn!(error = %e, "Channel hot-reload failed after remove");
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "status": "removed",
-                    "channel": name,
-                    "note": format!("Removed, but hot-reload failed: {e}. Restart daemon to fully deactivate.")
-                })),
-            )
+            (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
         }
     }
 }

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -407,10 +407,7 @@ pub async fn delete_goal(
         return ApiErrorResponse::internal(format!("Failed to delete goal: {e}")).into_json_tuple();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": "removed", "goal_id": id, "removed_count": removed})),
-    )
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 /// GET /api/goals/templates — List built-in goal templates.

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -397,8 +397,6 @@ pub async fn delete_goal(
         return ApiErrorResponse::not_found("Goal not found").into_json_tuple();
     }
 
-    let removed = before - goals.len();
-
     if let Err(e) = state.kernel.memory_substrate().structured_set(
         shared_id,
         GOALS_KEY,

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -528,10 +528,7 @@ pub async fn memory_delete(
     };
 
     match store.delete(&memory_id, &real_agent_id).await {
-        Ok(true) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"deleted": true, "memory_id": memory_id})),
-        ),
+        Ok(true) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         Ok(false) => ApiErrorResponse::not_found("Memory not found").into_json_tuple(),
         Err(e) => internal_error(e),
     }
@@ -660,10 +657,7 @@ pub async fn memory_reset_agent(
     };
 
     match store.reset(&agent_id) {
-        Ok(count) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"reset": true, "deleted_count": count})),
-        ),
+        Ok(_count) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         Err(e) => internal_error(e),
     }
 }
@@ -712,14 +706,7 @@ pub async fn memory_clear_level(
     };
 
     match store.clear_level(&agent_id, level) {
-        Ok(count) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "cleared": true,
-                "level": level_str,
-                "deleted_count": count,
-            })),
-        ),
+        Ok(_count) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         Err(e) => internal_error(e),
     }
 }

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -1717,7 +1717,7 @@ pub async fn reset_plugin_state(Path(name): Path<String>) -> impl IntoResponse {
         .join(".state.json");
 
     match std::fs::write(&state_path, "{}") {
-        Ok(()) => Json(serde_json::json!({"reset": true, "plugin": name})).into_response(),
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             ApiErrorResponse::bad_request(format!("Failed to reset state: {e}")).into_response()
         }

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{Path, State},
+    http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, post},
     Json, Router,
@@ -114,7 +115,7 @@ async fn delete_prompt_version(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     match state.kernel.delete_prompt_version(&id) {
-        Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -292,10 +292,7 @@ pub async fn delete_alias(
             .into_json_tuple();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": "removed"})),
-    )
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 #[utoipa::path(get, path = "/api/models/{id}", tag = "models", params(("id" = String, Path, description = "Model ID")), responses((status = 200, description = "Model details", body = serde_json::Value)))]
@@ -413,7 +410,7 @@ pub async fn delete_model_overrides(
     if let Err(e) = catalog.save_overrides(&overrides_path) {
         tracing::warn!("Failed to persist model overrides: {e}");
     }
-    (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 /// Attach local-provider probe results to a JSON entry and optionally merge
@@ -963,10 +960,7 @@ pub async fn remove_custom_model(
             .into_json_tuple();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": "removed"})),
-    )
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 // ── A2A (Agent-to-Agent) Protocol Endpoints ─────────────────────────
@@ -1229,10 +1223,7 @@ pub async fn delete_provider_key(
         catalog.detect_auth();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": "removed", "provider": name})),
-    )
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 /// POST /api/providers/{name}/test — Test a provider's connectivity.

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -627,13 +627,14 @@ pub async fn delete_agent_kv_key(
     State(state): State<Arc<AppState>>,
     Path((id, key)): Path<(String, String)>,
     lang: Option<axum::Extension<RequestLanguage>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
             return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
+                .into_json_tuple()
+                .into_response();
         }
     };
     match state
@@ -641,13 +642,12 @@ pub async fn delete_agent_kv_key(
         .memory_substrate()
         .structured_delete(agent_id, &key)
     {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "deleted", "key": key})),
-        ),
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             tracing::warn!("Memory delete failed for key '{key}': {e}");
-            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed")).into_json_tuple()
+            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed"))
+                .into_json_tuple()
+                .into_response()
         }
     }
 }
@@ -1300,24 +1300,23 @@ pub async fn delete_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let session_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => librefang_types::agent::SessionId(u),
         Err(_) => {
             return ApiErrorResponse::bad_request(t.t("api-error-session-invalid-id"))
-                .into_json_tuple();
+                .into_json_tuple()
+                .into_response();
         }
     };
 
     match state.kernel.memory_substrate().delete_session(session_id) {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "deleted", "session_id": id})),
-        ),
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))
                 .into_json_tuple()
+                .into_response()
         }
     }
 }
@@ -2869,10 +2868,7 @@ pub async fn remove_binding(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     match state.kernel.remove_binding(index) {
-        Some(_) => (
-            StatusCode::OK,
-            Json(serde_json::json!({ "status": "removed" })),
-        ),
+        Some(_) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         None => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": t.t("api-error-binding-index-out-of-range") })),
@@ -3185,7 +3181,8 @@ pub async fn pairing_remove_device(
                 device_id = %device_id,
                 "revoked paired device — bearer removed from live auth table"
             );
-            Json(serde_json::json!({"ok": true})).into_response()
+            // DELETE returns 204 No Content with no body (#3843).
+            StatusCode::NO_CONTENT.into_response()
         }
         Err(e) => ApiErrorResponse::not_found(e)
             .into_json_tuple()
@@ -3714,8 +3711,8 @@ pub async fn delete_backup(
 
     tracing::info!("Backup deleted: {filename}");
     (
-        StatusCode::OK,
-        Json(serde_json::json!({"deleted": filename})),
+        StatusCode::NO_CONTENT,
+        Json(serde_json::json!(null)),
     )
 }
 
@@ -4204,10 +4201,7 @@ pub async fn delete_event_webhook(
     };
     let mut store = EVENT_WEBHOOKS.write().await;
     if store.remove(&id).is_some() {
-        (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "removed", "id": id})),
-        )
+        (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
     } else {
         ApiErrorResponse::not_found(err_webhook_not_found).into_json_tuple()
     }
@@ -4321,10 +4315,7 @@ pub async fn delete_webhook(
         Ok(uuid) => {
             let wh_id = crate::webhook_store::WebhookId(uuid);
             if state.webhook_store.delete(wh_id) {
-                (
-                    StatusCode::OK,
-                    Json(serde_json::json!({"status": "deleted"})),
-                )
+                (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
             } else {
                 ApiErrorResponse::not_found(t.t("api-error-webhook-not-found")).into_json_tuple()
             }
@@ -4499,10 +4490,7 @@ pub async fn task_queue_delete(
         t.t("api-error-task-not-found")
     };
     match state.kernel.task_delete(&id).await {
-        Ok(true) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "deleted", "id": id})),
-        ),
+        Ok(true) => (StatusCode::NO_CONTENT, Json(serde_json::json!(null))),
         Ok(false) => ApiErrorResponse::not_found(err_task_not_found).into_json_tuple(),
         Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
     }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -3710,10 +3710,7 @@ pub async fn delete_backup(
     }
 
     tracing::info!("Backup deleted: {filename}");
-    (
-        StatusCode::NO_CONTENT,
-        Json(serde_json::json!(null)),
-    )
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
 /// POST /api/restore — Restore kernel state from a backup archive.
@@ -5341,7 +5338,7 @@ mod event_webhook_tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
         let resp = app
             .oneshot(

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -477,11 +477,7 @@ pub async fn delete_user(
     })
     .await
     {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status":"ok","deleted":name})),
-        )
-            .into_response(),
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(PersistError::NotFound(m)) => err_response(StatusCode::NOT_FOUND, m),
         Err(PersistError::BadRequest(m)) => err_response(StatusCode::BAD_REQUEST, m),
         Err(PersistError::Conflict(m)) => err_response(StatusCode::CONFLICT, m),

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -428,6 +428,10 @@ pub struct AgentListQuery {
     pub order: Option<String>,
     /// Include hand agents in the response (default: false).
     pub include_hands: Option<bool>,
+    /// Filter agents by owner (matches manifest.author). When the authenticated
+    /// caller is a plain User role, this is auto-populated with their username
+    /// so that non-admin users only see agents they authored.
+    pub owner: Option<String>,
 }
 
 /// Paginated list response wrapper.

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -3764,7 +3764,7 @@ async fn test_user_budget_put_get_delete_round_trip() {
         .send()
         .await
         .unwrap();
-    assert_eq!(del_resp.status(), 200, "DELETE should clear the cap");
+    assert_eq!(del_resp.status(), 204, "DELETE should clear the cap");
 
     // GET again — back to limit = 0.
     let after_delete: serde_json::Value = client

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -155,7 +155,7 @@ async fn users_create_then_get_then_delete_round_trips() {
 
     // DELETE
     let (status, _) = json_request(&h, Method::DELETE, "/api/users/Alice", None).await;
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::NO_CONTENT);
 
     let (status, _) = json_request(&h, Method::GET, "/api/users/Alice", None).await;
     assert_eq!(status, StatusCode::NOT_FOUND);


### PR DESCRIPTION
## Summary
- 18 DELETE handlers now return `204 No Content` (no body) instead of `200 OK` with JSON (closes #3843)
- `GET /api/agents`: non-Admin/Owner roles are automatically filtered to agents owned by the authenticated user via `manifest.author` (closes #3826)
- `GET /api/openapi.json`: dynamically inserts `/api/v1/*` path copies for every `/api/*` path, matching the dual-mount in `server.rs` (closes #3833)

## Test plan
- [ ] DELETE any resource → HTTP 204 with empty body
- [ ] Regular user cannot see other users' agents
- [ ] OpenAPI spec includes both /api/ and /api/v1/ route variants