### PR TITLE
fix(api): channel body limit, remove ?token= from REST routes, implement PUT agents, fix operationIds

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -728,7 +728,7 @@ pub async fn auth(
     // headers. For all other REST routes the token must come from an
     // Authorization: Bearer or X-API-Key header — query params appear in
     // access logs, Referer headers, and browser history, making them easy to
-    // accidentally leak. Bug #3838.
+    // accidentally leak.
     //
     // Allowed path prefixes:
     //   /api/agents/{id}/ws           — WebSocket upgrade (can't set headers)
@@ -742,9 +742,7 @@ pub async fn auth(
     // See issue #962 (ported from openfang).
     let is_ws_or_sse_path = path.ends_with("/ws")
         || path.starts_with("/ws/")
-        || path == "/ws"
-        || path.ends_with("/stream")
-        || path == "/api/logs/stream";
+        || path.ends_with("/stream");
 
     let query_token_decoded = if is_ws_or_sse_path {
         request

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -740,9 +740,8 @@ pub async fn auth(
     // Percent-decode (but NOT form-urlencoded) so literal `+` characters in
     // base64-derived tokens are preserved instead of being turned into spaces.
     // See issue #962 (ported from openfang).
-    let is_ws_or_sse_path = path.ends_with("/ws")
-        || path.starts_with("/ws/")
-        || path.ends_with("/stream");
+    let is_ws_or_sse_path =
+        path.ends_with("/ws") || path.starts_with("/ws/") || path.ends_with("/stream");
 
     let query_token_decoded = if is_ws_or_sse_path {
         request

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -714,6 +714,7 @@ pub async fn auth(
     // SECURITY: Use constant-time comparison to prevent timing attacks.
     let header_auth = api_token.map(&matches_any);
 
+<<<<<<< HEAD
     // SECURITY: ?token= query-string auth is deliberately NOT checked here.
     // Query parameters are written to server access logs, retained in browser
     // history, and forwarded in HTTP Referer headers to third parties. Tokens
@@ -721,6 +722,40 @@ pub async fn auth(
     // the session cookie. WebSocket upgrades are the sole exception (browsers
     // cannot set custom headers on WebSocket connections); they authenticate
     // via crate::ws::ws_auth_token, which never passes through this middleware.
+=======
+    // SECURITY: ?token= query parameter is ONLY accepted for WebSocket upgrade
+    // requests and SSE streaming endpoints where browsers cannot send custom
+    // headers. For all other REST routes the token must come from an
+    // Authorization: Bearer or X-API-Key header — query params appear in
+    // access logs, Referer headers, and browser history, making them easy to
+    // accidentally leak. Bug #3838.
+    //
+    // Allowed path prefixes:
+    //   /api/agents/{id}/ws           — WebSocket upgrade (can't set headers)
+    //   /ws/                          — any future top-level WS endpoint
+    //   /api/agents/{id}/sessions/*/stream — SSE session attach
+    //   /api/agents/{id}/message/stream   — SSE message stream
+    //   /api/logs/stream              — SSE log tail
+    //
+    // Percent-decode (but NOT form-urlencoded) so literal `+` characters in
+    // base64-derived tokens are preserved instead of being turned into spaces.
+    // See issue #962 (ported from openfang).
+    let is_ws_or_sse_path = path.ends_with("/ws")
+        || path.starts_with("/ws/")
+        || path == "/ws"
+        || path.ends_with("/stream")
+        || path == "/api/logs/stream";
+
+    let query_token_decoded = if is_ws_or_sse_path {
+        request
+            .uri()
+            .query()
+            .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
+            .map(crate::percent_decode)
+    } else {
+        None
+    };
+>>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
 
     // Accept if header auth matches a static API key or legacy token
     if header_auth == Some(true) {

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3698,7 +3698,7 @@ pub async fn update_agent(
         ),
 =======
     // Apply the new manifest to the in-memory registry (preserves runtime-only
-    // fields like workspace path and tags). Bug #3824.
+    // fields like workspace path and tags).
     if let Err(e) = state
         .kernel
         .agent_registry()
@@ -3720,7 +3720,7 @@ pub async fn update_agent(
     }
 
     // Write updated manifest to agent.toml on disk so the file matches the
-    // in-memory state and doesn't override changes on next boot (#996, #1018).
+    // in-memory state and doesn't override changes on next boot.
     state.kernel.persist_manifest_to_disk(agent_id);
 
     if let Some(entry) = state.kernel.agent_registry().get(agent_id) {

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3681,6 +3681,7 @@ pub async fn update_agent(
         }
     };
 
+<<<<<<< HEAD
     drop(t);
 
     match state.kernel.update_manifest(agent_id, manifest) {
@@ -3695,6 +3696,48 @@ pub async fn update_agent(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": e.to_string()})),
         ),
+=======
+    // Apply the new manifest to the in-memory registry (preserves runtime-only
+    // fields like workspace path and tags). Bug #3824.
+    if let Err(e) = state
+        .kernel
+        .agent_registry()
+        .replace_manifest(agent_id, manifest)
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(
+                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+            ),
+        );
+    }
+
+    // Persist updated entry to SQLite so it survives a restart.
+    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
+        if let Err(e) = state.kernel.memory_substrate().save_agent(&entry) {
+            tracing::warn!("Failed to persist agent manifest update: {e}");
+        }
+    }
+
+    // Write updated manifest to agent.toml on disk so the file matches the
+    // in-memory state and doesn't override changes on next boot (#996, #1018).
+    state.kernel.persist_manifest_to_disk(agent_id);
+
+    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ok",
+                "agent_id": entry.id.to_string(),
+                "name": entry.name,
+            })),
+        )
+    } else {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": t.t("api-error-agent-vanished")})),
+        )
+>>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
     }
 }
 

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -71,6 +71,7 @@ use crate::types::ApiErrorResponse;
     get,
     path = "/api/models",
     tag = "models",
+    operation_id = "list_all_models",
     responses(
         (status = 200, description = "List available models", body = Vec<serde_json::Value>)
     )

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1158,7 +1158,7 @@ pub async fn build_router(
     // (which was applied above to `app`). Tower layers wrap the router they
     // are attached to; a layer added to `app` after `.nest()` would not
     // cover the nested router. 1 MiB is generous for any webhook payload
-    // (Slack, Teams, Feishu, Line) while capping memory-exhaustion attacks.
+    // (Slack, Teams, Feishu, Line) while capping memory-exhaustion attacks (#3813).
     const WEBHOOK_BODY_LIMIT: usize = 1024 * 1024; // 1 MiB
     let channel_webhook_state = state.webhook_router.clone();
     let channel_routes = Router::new()

--- a/openapi.json
+++ b/openapi.json
@@ -5919,7 +5919,7 @@
         "tags": [
           "models"
         ],
-        "operationId": "list_models",
+        "operationId": "list_all_models",
         "responses": {
           "200": {
             "description": "List available models",

--- a/sdk/go/examples/test_apis.go
+++ b/sdk/go/examples/test_apis.go
@@ -14,7 +14,7 @@ func main() {
 	skills, _ := client.Skills.ListSkills()
 	fmt.Printf("Skills: %d\n", len(librefang.ToSlice(skills)))
 
-	models, _ := client.Models.ListModels()
+	models, _ := client.Models.ListAllModels()
 	fmt.Printf("Models: %d\n", len(librefang.ToSlice(models)))
 
 	providers, _ := client.Providers.ListProviders()

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -798,7 +798,7 @@ func (r *ModelsResource) CatalogUpdate() (interface{}, error) {
 	return r.client.request("POST", "/api/catalog/update", nil, nil)
 }
 
-func (r *ModelsResource) ListModels() (interface{}, error) {
+func (r *ModelsResource) ListAllModels() (interface{}, error) {
 	return r.client.request("GET", "/api/models", nil, nil)
 }
 

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -685,7 +685,7 @@ class ModelsResource {
     return this._c._request("POST", "/api/catalog/update");
   }
 
-  async listModels() {
+  async listAllModels() {
     return this._c._request("GET", "/api/models");
   }
 

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -561,7 +561,7 @@ class _ModelsResource(_Resource):
     def catalog_update(self):
         return self._c._request("POST", "/api/catalog/update")
 
-    def list_models(self):
+    def list_all_models(self):
         return self._c._request("GET", "/api/models")
 
     def list_aliases(self):

--- a/sdk/rust/examples/basic.rs
+++ b/sdk/rust/examples/basic.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Skills: {}", skills["skills"].as_array().map(|a| a.len()).unwrap_or(0));
 
     // List models
-    let models = client.models.list_models().await?;
+    let models = client.models.list_all_models().await?;
     println!("Models: {}", models["models"].as_array().map(|a| a.len()).unwrap_or(0));
 
     // List providers

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -874,7 +874,7 @@ impl ModelsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/catalog/update".to_string(), None, &[]).await
     }
 
-    pub async fn list_models(&self) -> Result<Value> {
+    pub async fn list_all_models(&self) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/models".to_string(), None, &[]).await
     }
 


### PR DESCRIPTION
## Summary
- Channel webhook routes get their own `RequestBodyLimitLayer::new(1 MiB)` on the subrouter to prevent body-limit bypass from Axum's layer ordering (closes #3813)
- `?token=` query parameter auth now only accepted on WebSocket/SSE paths (`/ws`, `/stream`, `/api/logs/stream`); all REST routes require `Authorization: Bearer` or `X-API-Key` header (closes #3838)
- `PUT /api/agents/{id}`: actually persists the new manifest — updates in-memory registry, saves to SQLite, writes `agent.toml` to disk (closes #3824)
- Deduplicated `operationId`: `list_all_models` for `GET /api/models`, `list_openai_models` for `GET /v1/models` (closes #3844)

## Test plan
- [ ] POST > 1 MiB to a channel webhook returns 413
- [ ] `GET /api/agents?token=xxx` returns 401 (no WS path)
- [ ] PUT /api/agents/{id} with new manifest — reload confirms change persisted
- [ ] OpenAPI spec has no duplicate operationIds