### PR TITLE
fix(kernel): per-task trigger depth, observable event bus drops, DST-aware cron log

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -567,10 +567,69 @@ pub fn compute_next_run_after(
                             match tz_str.parse::<chrono_tz::Tz>() {
                                 Ok(timezone) => {
                                     let base_local = base.with_timezone(&timezone);
-                                    sched
+                                    let result = sched
                                         .after(&base_local)
                                         .next()
-                                        .map(|dt| dt.with_timezone(&Utc))
+                                        .map(|dt| dt.with_timezone(&Utc));
+
+                                    // DST observability (bug #3831):
+                                    //
+                                    // The `cron` crate iterates in the target timezone using
+                                    // `chrono_tz`, which already handles DST correctly:
+                                    //
+                                    //  • Spring-forward (clocks skip 2:00–3:00 locally):
+                                    //    `chrono_tz` returns `MappedLocalTime::None` for times
+                                    //    in the gap.  The cron iterator skips those instants and
+                                    //    advances to the next valid occurrence.  The job silently
+                                    //    fires late or not at all on that day.
+                                    //
+                                    //  • Fall-back (clocks repeat 1:00–2:00 locally):
+                                    //    `chrono_tz` returns `MappedLocalTime::Ambiguous`.  The
+                                    //    cron iterator picks the *first* occurrence (pre-fold),
+                                    //    so the job fires once on the earlier UTC equivalent and
+                                    //    then advances normally — the second occurrence is
+                                    //    skipped.
+                                    //
+                                    // Both cases are handled safely but invisibly.  Emit a
+                                    // `warn!` so operators know when a scheduled time is in a
+                                    // DST transition window and the actual fire time was adjusted.
+                                    if let Some(next) = result {
+                                        let next_local = next.with_timezone(&timezone);
+                                        // Compare UTC offsets in seconds to detect a DST
+                                        // boundary crossing between the reference time and
+                                        // the computed next-fire.  We avoid importing the
+                                        // `chrono::Offset` trait by using the chrono
+                                        // `DateTime::offset()` return value's seconds_east()
+                                        // helper, which is available directly on
+                                        // `chrono_tz::TzOffset` via `OffsetComponents`.
+                                        let base_utc_secs = (base_local.naive_utc()
+                                            - base_local.naive_local())
+                                        .num_seconds();
+                                        let next_utc_secs = (next_local.naive_utc()
+                                            - next_local.naive_local())
+                                        .num_seconds();
+                                        if base_utc_secs != next_utc_secs {
+                                            // The UTC offset changed between the reference time
+                                            // and the computed next-fire — a DST boundary was
+                                            // crossed.  Warn with the adjusted UTC time so
+                                            // operators can reconcile with their intent.
+                                            warn!(
+                                                expr = %expr,
+                                                timezone = %tz_str,
+                                                base_local = %base_local.format("%Y-%m-%dT%H:%M:%S%z"),
+                                                adjusted_utc = %next.format("%Y-%m-%dT%H:%M:%SZ"),
+                                                adjusted_local = %next_local.format("%Y-%m-%dT%H:%M:%S%z"),
+                                                "Cron job next-fire crosses a DST boundary in \
+                                                 timezone '{}'; scheduled local time may have been \
+                                                 skipped (spring-forward) or moved to the first \
+                                                 occurrence (fall-back). Next fire adjusted to {}",
+                                                tz_str,
+                                                next.format("%Y-%m-%dT%H:%M:%SZ"),
+                                            );
+                                        }
+                                    }
+
+                                    result
                                 }
                                 Err(_) => {
                                     warn!(

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -572,36 +572,11 @@ pub fn compute_next_run_after(
                                         .next()
                                         .map(|dt| dt.with_timezone(&Utc));
 
-                                    // DST observability (bug #3831):
-                                    //
-                                    // The `cron` crate iterates in the target timezone using
-                                    // `chrono_tz`, which already handles DST correctly:
-                                    //
-                                    //  • Spring-forward (clocks skip 2:00–3:00 locally):
-                                    //    `chrono_tz` returns `MappedLocalTime::None` for times
-                                    //    in the gap.  The cron iterator skips those instants and
-                                    //    advances to the next valid occurrence.  The job silently
-                                    //    fires late or not at all on that day.
-                                    //
-                                    //  • Fall-back (clocks repeat 1:00–2:00 locally):
-                                    //    `chrono_tz` returns `MappedLocalTime::Ambiguous`.  The
-                                    //    cron iterator picks the *first* occurrence (pre-fold),
-                                    //    so the job fires once on the earlier UTC equivalent and
-                                    //    then advances normally — the second occurrence is
-                                    //    skipped.
-                                    //
-                                    // Both cases are handled safely but invisibly.  Emit a
-                                    // `warn!` so operators know when a scheduled time is in a
-                                    // DST transition window and the actual fire time was adjusted.
+                                    // Warn when a DST boundary is crossed: spring-forward may
+                                    // silently skip a scheduled local time; fall-back picks the
+                                    // earlier UTC occurrence.
                                     if let Some(next) = result {
                                         let next_local = next.with_timezone(&timezone);
-                                        // Compare UTC offsets in seconds to detect a DST
-                                        // boundary crossing between the reference time and
-                                        // the computed next-fire.  We avoid importing the
-                                        // `chrono::Offset` trait by using the chrono
-                                        // `DateTime::offset()` return value's seconds_east()
-                                        // helper, which is available directly on
-                                        // `chrono_tz::TzOffset` via `OffsetComponents`.
                                         let base_utc_secs = (base_local.naive_utc()
                                             - base_local.naive_local())
                                         .num_seconds();
@@ -609,10 +584,6 @@ pub fn compute_next_run_after(
                                             - next_local.naive_local())
                                         .num_seconds();
                                         if base_utc_secs != next_utc_secs {
-                                            // The UTC offset changed between the reference time
-                                            // and the computed next-fire — a DST boundary was
-                                            // crossed.  Warn with the adjusted UTC time so
-                                            // operators can reconcile with their intent.
                                             warn!(
                                                 expr = %expr,
                                                 timezone = %tz_str,

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -20,23 +20,13 @@ pub struct EventBus {
     agent_channels: DashMap<AgentId, broadcast::Sender<Event>>,
     /// Event history ring buffer.
     history: Arc<RwLock<VecDeque<Event>>>,
-    /// Count of events where the intended recipient agent had no active
-    /// receiver.  Incremented when an agent-targeted send finds the
-    /// per-agent broadcast channel with no live subscribers (bug #3793).
-    ///
-    /// Note: tokio `broadcast::Sender::send` returns `Err` only when
-    /// there are *no receivers* — the channel is a ring buffer that never
-    /// rejects the sender; slow receivers get `RecvError::Lagged` instead.
-    /// We therefore track the "no-receiver" condition as a drop because
-    /// the event would not reach any consumer.
+    /// Count of events dropped because the per-agent channel had no active receiver.
     dropped_count: AtomicU64,
     /// Timestamp of the last drop warning log (for rate-limiting).
     last_drop_warn: std::sync::Mutex<std::time::Instant>,
 }
 
-/// Return a short human-readable label for an `EventPayload` variant.
-/// Used in drop-warning log fields so operators can identify which event
-/// types are being silently lost without decoding the full payload.
+/// Maps an `EventPayload` variant to a short label for drop-warning log fields.
 fn payload_kind(payload: &EventPayload) -> &'static str {
     match payload {
         EventPayload::Message(_) => "Message",
@@ -65,23 +55,6 @@ impl EventBus {
     }
 
     /// Publish an event to the bus.
-    ///
-    /// # Drop semantics (bug #3793)
-    ///
-    /// `tokio::broadcast` is a *ring buffer*: the sender never blocks and
-    /// never returns an error because the channel is "full".  Instead, slow
-    /// receivers are skipped with `RecvError::Lagged`.  `Sender::send`
-    /// returns `Err` **only** when there are zero active receivers.
-    ///
-    /// We therefore distinguish two cases:
-    ///
-    /// * **Global broadcast / pattern / system channels** — it is normal for
-    ///   these to have no subscribers during early boot or when no agent is
-    ///   listening.  A failed send is logged at `debug` level only.
-    /// * **Per-agent channels** — if a channel entry exists but has no
-    ///   receiver, the agent has disconnected without cleaning up.  This is
-    ///   a genuine drop that warrants a `warn!` with event-type information
-    ///   so operators can diagnose which event kinds are lost.
     pub async fn publish(&self, event: Event) {
         debug!(
             event_id = %event.id,
@@ -103,12 +76,9 @@ impl EventBus {
         match &event.target {
             EventTarget::Agent(agent_id) => {
                 if let Some(sender) = self.agent_channels.get(agent_id) {
-                    // Per-agent channel: Err means no active receiver for this
-                    // specific agent — the event is genuinely lost.
                     if sender.send(event.clone()).is_err() {
                         let total =
                             self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
-                        // Rate-limit to at most one warning per 10 seconds.
                         if let Ok(mut last) = self.last_drop_warn.lock() {
                             if last.elapsed() >= std::time::Duration::from_secs(10) {
                                 warn!(
@@ -125,8 +95,6 @@ impl EventBus {
                 }
             }
             EventTarget::Broadcast => {
-                // Global broadcast: no-receiver is expected when no system
-                // subscriber is registered; log at debug only.
                 if self.sender.send(event.clone()).is_err() {
                     debug!(
                         event_id = %event.id,
@@ -157,7 +125,6 @@ impl EventBus {
                 }
             }
             EventTarget::Pattern(_pattern) => {
-                // No-receiver on the pattern channel is non-critical.
                 if self.sender.send(event.clone()).is_err() {
                     debug!(
                         event_id = %event.id,
@@ -167,7 +134,6 @@ impl EventBus {
                 }
             }
             EventTarget::System => {
-                // No-receiver on the system channel is non-critical.
                 if self.sender.send(event.clone()).is_err() {
                     debug!(
                         event_id = %event.id,

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -77,8 +77,7 @@ impl EventBus {
             EventTarget::Agent(agent_id) => {
                 if let Some(sender) = self.agent_channels.get(agent_id) {
                     if sender.send(event.clone()).is_err() {
-                        let total =
-                            self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
+                        let total = self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
                         if let Ok(mut last) = self.last_drop_warn.lock() {
                             if last.elapsed() >= std::time::Duration::from_secs(10) {
                                 warn!(
@@ -109,8 +108,8 @@ impl EventBus {
                     }
                 }
                 if agent_drops > 0 {
-                    let total =
-                        self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed) + agent_drops;
+                    let total = self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed)
+                        + agent_drops;
                     if let Ok(mut last) = self.last_drop_warn.lock() {
                         if last.elapsed() >= std::time::Duration::from_secs(10) {
                             warn!(

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -2,7 +2,7 @@
 
 use dashmap::DashMap;
 use librefang_types::agent::AgentId;
-use librefang_types::event::{Event, EventTarget};
+use librefang_types::event::{Event, EventPayload, EventTarget};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -20,10 +20,35 @@ pub struct EventBus {
     agent_channels: DashMap<AgentId, broadcast::Sender<Event>>,
     /// Event history ring buffer.
     history: Arc<RwLock<VecDeque<Event>>>,
-    /// Count of events dropped due to full channels.
+    /// Count of events where the intended recipient agent had no active
+    /// receiver.  Incremented when an agent-targeted send finds the
+    /// per-agent broadcast channel with no live subscribers (bug #3793).
+    ///
+    /// Note: tokio `broadcast::Sender::send` returns `Err` only when
+    /// there are *no receivers* — the channel is a ring buffer that never
+    /// rejects the sender; slow receivers get `RecvError::Lagged` instead.
+    /// We therefore track the "no-receiver" condition as a drop because
+    /// the event would not reach any consumer.
     dropped_count: AtomicU64,
     /// Timestamp of the last drop warning log (for rate-limiting).
     last_drop_warn: std::sync::Mutex<std::time::Instant>,
+}
+
+/// Return a short human-readable label for an `EventPayload` variant.
+/// Used in drop-warning log fields so operators can identify which event
+/// types are being silently lost without decoding the full payload.
+fn payload_kind(payload: &EventPayload) -> &'static str {
+    match payload {
+        EventPayload::Message(_) => "Message",
+        EventPayload::ToolResult(_) => "ToolResult",
+        EventPayload::MemoryUpdate(_) => "MemoryUpdate",
+        EventPayload::Lifecycle(_) => "Lifecycle",
+        EventPayload::Network(_) => "Network",
+        EventPayload::System(_) => "System",
+        EventPayload::ApprovalRequested(_) => "ApprovalRequested",
+        EventPayload::ApprovalResolved(_) => "ApprovalResolved",
+        EventPayload::Custom(_) => "Custom",
+    }
 }
 
 impl EventBus {
@@ -40,10 +65,28 @@ impl EventBus {
     }
 
     /// Publish an event to the bus.
+    ///
+    /// # Drop semantics (bug #3793)
+    ///
+    /// `tokio::broadcast` is a *ring buffer*: the sender never blocks and
+    /// never returns an error because the channel is "full".  Instead, slow
+    /// receivers are skipped with `RecvError::Lagged`.  `Sender::send`
+    /// returns `Err` **only** when there are zero active receivers.
+    ///
+    /// We therefore distinguish two cases:
+    ///
+    /// * **Global broadcast / pattern / system channels** — it is normal for
+    ///   these to have no subscribers during early boot or when no agent is
+    ///   listening.  A failed send is logged at `debug` level only.
+    /// * **Per-agent channels** — if a channel entry exists but has no
+    ///   receiver, the agent has disconnected without cleaning up.  This is
+    ///   a genuine drop that warrants a `warn!` with event-type information
+    ///   so operators can diagnose which event kinds are lost.
     pub async fn publish(&self, event: Event) {
         debug!(
             event_id = %event.id,
             source = %event.source,
+            kind = payload_kind(&event.payload),
             "Publishing event"
         );
 
@@ -57,49 +100,82 @@ impl EventBus {
         }
 
         // Route to target
-        let mut drops: u64 = 0;
         match &event.target {
             EventTarget::Agent(agent_id) => {
                 if let Some(sender) = self.agent_channels.get(agent_id) {
+                    // Per-agent channel: Err means no active receiver for this
+                    // specific agent — the event is genuinely lost.
                     if sender.send(event.clone()).is_err() {
-                        drops += 1;
+                        let total =
+                            self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
+                        // Rate-limit to at most one warning per 10 seconds.
+                        if let Ok(mut last) = self.last_drop_warn.lock() {
+                            if last.elapsed() >= std::time::Duration::from_secs(10) {
+                                warn!(
+                                    agent_id = %agent_id,
+                                    event_id = %event.id,
+                                    event_kind = payload_kind(&event.payload),
+                                    total_dropped = total,
+                                    "Event bus: agent has no active receiver, event dropped — \
+                                     consider increasing queue capacity or checking agent health",
+                                );
+                                *last = std::time::Instant::now();
+                            }
+                        }
                     }
                 }
             }
             EventTarget::Broadcast => {
+                // Global broadcast: no-receiver is expected when no system
+                // subscriber is registered; log at debug only.
                 if self.sender.send(event.clone()).is_err() {
-                    drops += 1;
+                    debug!(
+                        event_id = %event.id,
+                        event_kind = payload_kind(&event.payload),
+                        "Broadcast event: no global subscribers"
+                    );
                 }
+                let mut agent_drops: u64 = 0;
                 for entry in self.agent_channels.iter() {
                     if entry.value().send(event.clone()).is_err() {
-                        drops += 1;
+                        agent_drops += 1;
+                    }
+                }
+                if agent_drops > 0 {
+                    let total =
+                        self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed) + agent_drops;
+                    if let Ok(mut last) = self.last_drop_warn.lock() {
+                        if last.elapsed() >= std::time::Duration::from_secs(10) {
+                            warn!(
+                                dropped = agent_drops,
+                                total_dropped = total,
+                                event_kind = payload_kind(&event.payload),
+                                "Event bus: broadcast reached agents with no active receivers, \
+                                 events dropped — consider increasing queue capacity",
+                            );
+                            *last = std::time::Instant::now();
+                        }
                     }
                 }
             }
             EventTarget::Pattern(_pattern) => {
-                // Phase 1: broadcast to all for pattern matching
+                // No-receiver on the pattern channel is non-critical.
                 if self.sender.send(event.clone()).is_err() {
-                    drops += 1;
+                    debug!(
+                        event_id = %event.id,
+                        event_kind = payload_kind(&event.payload),
+                        "Pattern event: no global subscribers"
+                    );
                 }
             }
             EventTarget::System => {
+                // No-receiver on the system channel is non-critical.
                 if self.sender.send(event.clone()).is_err() {
-                    drops += 1;
-                }
-            }
-        }
-
-        if drops > 0 {
-            let total = self.dropped_count.fetch_add(drops, Ordering::Relaxed) + drops;
-            // Rate-limit warning logs to once per 10 seconds.
-            if let Ok(mut last) = self.last_drop_warn.lock() {
-                if last.elapsed() >= std::time::Duration::from_secs(10) {
-                    warn!(
-                        dropped = drops,
-                        total_dropped = total,
-                        "Event bus: channel full, events dropped"
+                    debug!(
+                        event_id = %event.id,
+                        event_kind = payload_kind(&event.payload),
+                        "System event: no global subscribers"
                     );
-                    *last = std::time::Instant::now();
                 }
             }
         }

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -116,8 +116,7 @@ impl EventBus {
                                     event_id = %event.id,
                                     event_kind = payload_kind(&event.payload),
                                     total_dropped = total,
-                                    "Event bus: agent has no active receiver, event dropped — \
-                                     consider increasing queue capacity or checking agent health",
+                                    "Event bus: agent has no active receiver, event dropped — check agent health",
                                 );
                                 *last = std::time::Instant::now();
                             }
@@ -150,8 +149,7 @@ impl EventBus {
                                 dropped = agent_drops,
                                 total_dropped = total,
                                 event_kind = payload_kind(&event.payload),
-                                "Event bus: broadcast reached agents with no active receivers, \
-                                 events dropped — consider increasing queue capacity",
+                                "Event bus: broadcast reached agents with no active receivers, events dropped",
                             );
                             *last = std::time::Instant::now();
                         }
@@ -201,7 +199,7 @@ impl EventBus {
         history.iter().rev().take(limit).cloned().collect()
     }
 
-    /// Return the total number of events dropped due to full channels.
+    /// Return the total number of events dropped due to no active receivers.
     pub fn dropped_count(&self) -> u64 {
         self.dropped_count.load(Ordering::Relaxed)
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -61,6 +61,20 @@ pub(crate) const SYSTEM_CHANNEL_CRON: &str = "cron";
 /// have no user to attribute to. Issue #3243.
 pub(crate) const SYSTEM_CHANNEL_AUTONOMOUS: &str = "autonomous";
 
+// ---------------------------------------------------------------------------
+// Per-task trigger recursion depth (bug #3780)
+// ---------------------------------------------------------------------------
+
+/// Per-task trigger-chain recursion depth counter.
+///
+/// Declared at module level so it has a true `'static` key, as required by
+/// `tokio::task_local!`.  Each independent event-processing task establishes
+/// its own scope via `PUBLISH_EVENT_DEPTH.scope(Cell::new(0), future)`,
+/// keeping depth counts isolated between concurrent chains.
+tokio::task_local! {
+    static PUBLISH_EVENT_DEPTH: std::cell::Cell<u32>;
+}
+
 /// Build the MCP bridge config that lets CLI-based drivers (Claude Code)
 /// reach back into the daemon's own `/mcp` endpoint. Uses loopback when the
 /// API listens on a wildcard address.
@@ -11061,15 +11075,56 @@ system_prompt = "You are a helpful assistant."
     /// Any matching triggers will dispatch messages to the subscribing agents.
     /// Returns the list of trigger matches that were dispatched.
     /// Includes depth limiting to prevent circular trigger chains.
+    ///
+    /// # Depth tracking — per-task, not global (bug #3780)
+    ///
+    /// Previously a `static AtomicU32` was shared across every concurrent
+    /// event chain: chain A's depth increments could push chain B over the
+    /// limit even though B had no circular dependency.  We now use a
+    /// `tokio::task_local!` cell (`PUBLISH_EVENT_DEPTH`, defined at module
+    /// level) so each independent task maintains its own counter.
+    ///
+    /// * Top-level call (no scope active): wraps the body in
+    ///   `PUBLISH_EVENT_DEPTH.scope(Cell::new(0), …)`.
+    /// * Recursive call (scope already active in this task): reads and
+    ///   mutates the existing `Cell` directly, without opening a new scope
+    ///   (which would shadow the outer counter and reset it to 0).
     pub async fn publish_event(&self, event: Event) -> Vec<crate::triggers::TriggerMatch> {
+        let already_scoped = PUBLISH_EVENT_DEPTH.try_with(|_| ()).is_ok();
+
+        if already_scoped {
+            // Recursive invocation from within the same task — reuse the
+            // existing scope so the depth accumulates correctly.
+            self.publish_event_inner(event).await
+        } else {
+            // Top-level invocation — establish an isolated per-chain scope.
+            PUBLISH_EVENT_DEPTH
+                .scope(std::cell::Cell::new(0), self.publish_event_inner(event))
+                .await
+        }
+    }
+
+    /// Inner implementation of [`publish_event`].
+    ///
+    /// Requires `PUBLISH_EVENT_DEPTH` task-local to be active in the calling
+    /// task (guaranteed by [`publish_event`]).
+    async fn publish_event_inner(
+        &self,
+        event: Event,
+    ) -> Vec<crate::triggers::TriggerMatch> {
         let cfg = self.config.load_full();
-        // Depth guard: prevent circular trigger chains
-        static TRIGGER_DEPTH: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
         let max_trigger_depth = cfg.triggers.max_depth as u32;
 
-        let depth = TRIGGER_DEPTH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Read and increment the per-task depth counter.
+        let depth = PUBLISH_EVENT_DEPTH.with(|c| {
+            let d = c.get();
+            c.set(d + 1);
+            d
+        });
+
         if depth >= max_trigger_depth {
-            TRIGGER_DEPTH.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            // Restore before returning — no drop guard in the early-exit path.
+            PUBLISH_EVENT_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
             warn!(
                 depth,
                 "Trigger depth limit reached, skipping evaluation to prevent circular chain"
@@ -11077,11 +11132,13 @@ system_prompt = "You are a helpful assistant."
             return vec![];
         }
 
-        // Decrement depth on all exit paths using a drop guard
+        // Decrement on all exit paths via drop guard.
         struct DepthGuard;
         impl Drop for DepthGuard {
             fn drop(&mut self) {
-                TRIGGER_DEPTH.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                // `PUBLISH_EVENT_DEPTH` is always active when DepthGuard is
+                // alive (we only create it after the early-exit check above).
+                let _ = PUBLISH_EVENT_DEPTH.try_with(|c| c.set(c.get().saturating_sub(1)));
             }
         }
         let _guard = DepthGuard;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -65,7 +65,11 @@ pub(crate) const SYSTEM_CHANNEL_AUTONOMOUS: &str = "autonomous";
 // Per-task trigger recursion depth (bug #3780)
 // ---------------------------------------------------------------------------
 
-/// Per-task trigger-chain recursion depth; module-level for the `'static` key required by `tokio::task_local!`.
+// Per-task trigger-chain recursion depth counter.
+// Declared at module level so it has a true `'static` key, as required by
+// `tokio::task_local!`.  Each independent event-processing task establishes
+// its own scope via `PUBLISH_EVENT_DEPTH.scope(Cell::new(0), future)`,
+// keeping depth counts isolated between concurrent chains.
 tokio::task_local! {
     static PUBLISH_EVENT_DEPTH: std::cell::Cell<u32>;
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -11088,10 +11088,7 @@ system_prompt = "You are a helpful assistant."
     }
 
     /// Inner body of [`publish_event`]; requires `PUBLISH_EVENT_DEPTH` scope to be active.
-    async fn publish_event_inner(
-        &self,
-        event: Event,
-    ) -> Vec<crate::triggers::TriggerMatch> {
+    async fn publish_event_inner(&self, event: Event) -> Vec<crate::triggers::TriggerMatch> {
         let cfg = self.config.load_full();
         let max_trigger_depth = cfg.triggers.max_depth as u32;
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -65,12 +65,7 @@ pub(crate) const SYSTEM_CHANNEL_AUTONOMOUS: &str = "autonomous";
 // Per-task trigger recursion depth (bug #3780)
 // ---------------------------------------------------------------------------
 
-/// Per-task trigger-chain recursion depth counter.
-///
-/// Declared at module level so it has a true `'static` key, as required by
-/// `tokio::task_local!`.  Each independent event-processing task establishes
-/// its own scope via `PUBLISH_EVENT_DEPTH.scope(Cell::new(0), future)`,
-/// keeping depth counts isolated between concurrent chains.
+/// Per-task trigger-chain recursion depth; module-level for the `'static` key required by `tokio::task_local!`.
 tokio::task_local! {
     static PUBLISH_EVENT_DEPTH: std::cell::Cell<u32>;
 }
@@ -11075,26 +11070,10 @@ system_prompt = "You are a helpful assistant."
     /// Any matching triggers will dispatch messages to the subscribing agents.
     /// Returns the list of trigger matches that were dispatched.
     /// Includes depth limiting to prevent circular trigger chains.
-    ///
-    /// # Depth tracking — per-task, not global (bug #3780)
-    ///
-    /// Previously a `static AtomicU32` was shared across every concurrent
-    /// event chain: chain A's depth increments could push chain B over the
-    /// limit even though B had no circular dependency.  We now use a
-    /// `tokio::task_local!` cell (`PUBLISH_EVENT_DEPTH`, defined at module
-    /// level) so each independent task maintains its own counter.
-    ///
-    /// * Top-level call (no scope active): wraps the body in
-    ///   `PUBLISH_EVENT_DEPTH.scope(Cell::new(0), …)`.
-    /// * Recursive call (scope already active in this task): reads and
-    ///   mutates the existing `Cell` directly, without opening a new scope
-    ///   (which would shadow the outer counter and reset it to 0).
     pub async fn publish_event(&self, event: Event) -> Vec<crate::triggers::TriggerMatch> {
         let already_scoped = PUBLISH_EVENT_DEPTH.try_with(|_| ()).is_ok();
 
         if already_scoped {
-            // Recursive invocation from within the same task — reuse the
-            // existing scope so the depth accumulates correctly.
             self.publish_event_inner(event).await
         } else {
             // Top-level invocation — establish an isolated per-chain scope.
@@ -11104,10 +11083,7 @@ system_prompt = "You are a helpful assistant."
         }
     }
 
-    /// Inner implementation of [`publish_event`].
-    ///
-    /// Requires `PUBLISH_EVENT_DEPTH` task-local to be active in the calling
-    /// task (guaranteed by [`publish_event`]).
+    /// Inner body of [`publish_event`]; requires `PUBLISH_EVENT_DEPTH` scope to be active.
     async fn publish_event_inner(
         &self,
         event: Event,
@@ -11115,7 +11091,6 @@ system_prompt = "You are a helpful assistant."
         let cfg = self.config.load_full();
         let max_trigger_depth = cfg.triggers.max_depth as u32;
 
-        // Read and increment the per-task depth counter.
         let depth = PUBLISH_EVENT_DEPTH.with(|c| {
             let d = c.get();
             c.set(d + 1);
@@ -11136,8 +11111,7 @@ system_prompt = "You are a helpful assistant."
         struct DepthGuard;
         impl Drop for DepthGuard {
             fn drop(&mut self) {
-                // `PUBLISH_EVENT_DEPTH` is always active when DepthGuard is
-                // alive (we only create it after the early-exit check above).
+                // Guard is only created after the early-exit check, so the scope is always active.
                 let _ = PUBLISH_EVENT_DEPTH.try_with(|c| c.set(c.get().saturating_sub(1)));
             }
         }


### PR DESCRIPTION
## Summary
- `TRIGGER_DEPTH`: replaced global `AtomicU32` with `tokio::task_local! { PUBLISH_EVENT_DEPTH: Cell<u32> }` — each event chain now has an isolated depth counter, preventing false "too deep" rejections from concurrent independent chains (closes #3780)
- Event bus: drop events emit `tracing::warn!` with `agent_id`, `event_kind`, `event_id`, and running `total_dropped` counter; per-agent channel drops distinguished from broadcast-with-no-receivers (closes #3793)
- Cron DST: after computing `next_utc`, compares UTC offsets of base and next local times; if they differ (DST boundary crossed), emits `warn!` with the expression, timezone, and adjusted UTC/local times (closes #3831)

## Test plan
- [ ] Two concurrent event chains do not interfere with each other's depth counter
- [ ] Event dropped when channel full produces a warn! log
- [ ] DST boundary cron fire produces a warn! log with adjusted time