### PR TITLE
fix(channels,skills,xtask): Signal SSRF guard, ClawHub SHA256 validation, expand license deny-list

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2337,20 +2337,29 @@ pub async fn start_channel_bridge_with_config(
     #[cfg(feature = "channel-signal")]
     for sig_config in config.signal.iter() {
         if !sig_config.phone_number.is_empty() {
-            let adapter = Arc::new(
-                SignalAdapter::new(
-                    sig_config.api_url.clone(),
-                    sig_config.phone_number.clone(),
-                    sig_config.allowed_users.clone(),
-                )
-                .with_account_id(sig_config.account_id.clone())
-                .with_poll_interval(sig_config.poll_interval_secs),
-            );
-            adapters.push((
-                adapter,
-                sig_config.default_agent.clone(),
-                sig_config.account_id.clone(),
-            ));
+            match SignalAdapter::with_options(
+                sig_config.api_url.clone(),
+                sig_config.phone_number.clone(),
+                sig_config.allowed_users.clone(),
+                sig_config.api_key.clone(),
+                sig_config.allow_local,
+            ) {
+                Ok(signal_adapter) => {
+                    let adapter = Arc::new(
+                        signal_adapter
+                            .with_account_id(sig_config.account_id.clone())
+                            .with_poll_interval(sig_config.poll_interval_secs),
+                    );
+                    adapters.push((
+                        adapter,
+                        sig_config.default_agent.clone(),
+                        sig_config.account_id.clone(),
+                    ));
+                }
+                Err(e) => {
+                    warn!("Signal channel disabled: {e}");
+                }
+            }
         } else {
             warn!("Signal configured but phone_number is empty, skipping");
         }

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -8216,6 +8216,11 @@
                 "null"
               ]
             },
+            "allow_local": {
+              "default": false,
+              "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses.\nDefaults to `false`; set to `true` only when signal-cli runs on localhost.",
+              "type": "boolean"
+            },
             "allowed_users": {
               "default": [],
               "description": "Allowed phone numbers (empty = allow all).",
@@ -8223,6 +8228,14 @@
                 "type": "string"
               },
               "type": "array"
+            },
+            "api_key": {
+              "default": null,
+              "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request.\nIf absent, requests are sent without an Authorization header.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "api_url": {
               "default": "http://localhost:8080",
@@ -11167,6 +11180,11 @@
             "null"
           ]
         },
+        "allow_local": {
+          "default": false,
+          "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses.\nDefaults to `false`; set to `true` only when signal-cli runs on localhost.",
+          "type": "boolean"
+        },
         "allowed_users": {
           "default": [],
           "description": "Allowed phone numbers (empty = allow all).",
@@ -11174,6 +11192,14 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "api_key": {
+          "default": null,
+          "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request.\nIf absent, requests are sent without an Authorization header.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "api_url": {
           "default": "http://localhost:8080",

--- a/crates/librefang-channels/src/signal.rs
+++ b/crates/librefang-channels/src/signal.rs
@@ -55,8 +55,8 @@ fn is_private_or_loopback(addr: IpAddr) -> bool {
 ///
 /// Returns `Ok(())` on success, `Err(message)` on violation.
 fn validate_api_url(api_url: &str, allow_local: bool) -> Result<(), String> {
-    let url = url::Url::parse(api_url)
-        .map_err(|e| format!("Signal api_url is not a valid URL: {e}"))?;
+    let url =
+        url::Url::parse(api_url).map_err(|e| format!("Signal api_url is not a valid URL: {e}"))?;
 
     match url.scheme() {
         "http" | "https" => {}
@@ -793,13 +793,27 @@ mod tests {
     #[test]
     fn test_is_private_or_loopback() {
         use std::net::Ipv4Addr;
-        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
-        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
-        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
-        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
-        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            127, 0, 0, 1
+        ))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            192, 168, 1, 1
+        ))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            10, 0, 0, 1
+        ))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            172, 16, 0, 1
+        ))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            169, 254, 1, 1
+        ))));
         // Public addresses must NOT be blocked.
-        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
-        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            1, 1, 1, 1
+        ))));
+        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(
+            8, 8, 8, 8
+        ))));
     }
 }

--- a/crates/librefang-channels/src/signal.rs
+++ b/crates/librefang-channels/src/signal.rs
@@ -9,6 +9,7 @@ use base64::Engine as _;
 use chrono::Utc;
 use futures::Stream;
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,13 +18,96 @@ use tracing::{debug, info, warn};
 
 // Poll interval is now configurable via SignalConfig.
 
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when the address is in a range that should be blocked by
+/// default (loopback, link-local, RFC-1918 private, and IPv6 ULA/link-local).
+fn is_private_or_loopback(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()                                           // 127.0.0.0/8
+                || v4.is_link_local()                                  // 169.254.0.0/16
+                || v4.is_private()                                     // 10/8, 172.16/12, 192.168/16
+                || v4.is_broadcast()                                   // 255.255.255.255
+                || v4.is_unspecified()                                 // 0.0.0.0
+                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 CGNAT
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()        // ::1
+                || v6.is_unspecified()   // ::
+                // fc00::/7  (ULA — unique local)
+                || (v6.octets()[0] & 0xFE) == 0xFC
+                // fe80::/10 (link-local)
+                || (v6.octets()[0] == 0xFE && (v6.octets()[1] & 0xC0) == 0x80)
+        }
+    }
+}
+
+/// Validate the `api_url` for SSRF safety.
+///
+/// Rules:
+/// - Scheme must be `http` or `https`.
+/// - Hostname must resolve to a non-private address unless `allow_local` is
+///   set.  We perform a blocking DNS lookup here; for a config-time check the
+///   latency is acceptable.
+///
+/// Returns `Ok(())` on success, `Err(message)` on violation.
+fn validate_api_url(api_url: &str, allow_local: bool) -> Result<(), String> {
+    let url = url::Url::parse(api_url)
+        .map_err(|e| format!("Signal api_url is not a valid URL: {e}"))?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "Signal api_url scheme '{other}' is not allowed; use http or https"
+            ));
+        }
+    }
+
+    if allow_local {
+        // Operator has explicitly acknowledged local addresses.
+        return Ok(());
+    }
+
+    // Resolve the hostname and reject private/loopback addresses.
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Signal api_url has no host".to_string())?;
+
+    let port = url.port_or_known_default().unwrap_or(80);
+
+    // std::net::ToSocketAddrs performs a synchronous DNS resolution.
+    let addrs = std::net::ToSocketAddrs::to_socket_addrs(&(host, port))
+        .map_err(|e| format!("Signal api_url DNS resolution failed for '{host}': {e}"))?;
+
+    for addr in addrs {
+        if is_private_or_loopback(addr.ip()) {
+            return Err(format!(
+                "Signal api_url '{}' resolves to a private/loopback address ({}). \
+                 Set `allow_local = true` in [channels.signal] if this is intentional.",
+                api_url,
+                addr.ip()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
 /// Signal adapter via signal-cli REST API.
 pub struct SignalAdapter {
     /// URL of signal-cli REST API (e.g., "http://localhost:8080").
     api_url: String,
     /// Registered phone number.
     phone_number: String,
-    /// HTTP client.
+    /// HTTP client (has connect + total timeouts pre-configured).
     client: reqwest::Client,
     /// Allowed phone numbers (empty = allow all).
     allowed_users: Vec<String>,
@@ -31,6 +115,8 @@ pub struct SignalAdapter {
     account_id: Option<String>,
     /// Poll interval for checking new messages.
     poll_interval: Duration,
+    /// Optional Bearer token for the signal-cli REST API.
+    api_key: Option<String>,
     /// Shutdown signal.
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -38,19 +124,57 @@ pub struct SignalAdapter {
 
 impl SignalAdapter {
     /// Create a new Signal adapter.
-    pub fn new(api_url: String, phone_number: String, allowed_users: Vec<String>) -> Self {
+    ///
+    /// # Errors
+    /// Returns an error if `api_url` fails SSRF validation (scheme not http/https,
+    /// or resolves to a private/loopback address without `allow_local = true`).
+    pub fn new(
+        api_url: String,
+        phone_number: String,
+        allowed_users: Vec<String>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::with_options(api_url, phone_number, allowed_users, None, false)
+    }
+
+    /// Create a new Signal adapter with security options.
+    ///
+    /// * `api_key`    – if `Some`, sent as `Authorization: Bearer <key>` on every request.
+    /// * `allow_local` – when `true`, SSRF validation skips the private-IP check.
+    ///
+    /// # Errors
+    /// Returns an error if `api_url` fails SSRF validation.
+    pub fn with_options(
+        api_url: String,
+        phone_number: String,
+        allowed_users: Vec<String>,
+        api_key: Option<String>,
+        allow_local: bool,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        validate_api_url(&api_url, allow_local)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+
+        let client = crate::http_client::client_builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to build HTTP client for Signal adapter: {e}").into()
+            })?;
+
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        Self {
+        Ok(Self {
             api_url,
             phone_number,
-            client: crate::http_client::new_client(),
+            client,
             allowed_users,
             account_id: None,
             poll_interval: Duration::from_secs(2),
+            api_key,
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
-        }
+        })
     }
+
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
         self.account_id = account_id;
@@ -61,6 +185,19 @@ impl SignalAdapter {
     pub fn with_poll_interval(mut self, poll_interval_secs: u64) -> Self {
         self.poll_interval = Duration::from_secs(poll_interval_secs);
         self
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Attach the `Authorization: Bearer` header when an API key is configured.
+    fn auth_request(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref key) = self.api_key {
+            builder.bearer_auth(key)
+        } else {
+            builder
+        }
     }
 
     /// Send a message via signal-cli REST API.
@@ -95,7 +232,8 @@ impl SignalAdapter {
             body["base64_attachments"] = serde_json::Value::Array(attachments.to_vec());
         }
 
-        let resp = self.client.post(&url).json(&body).send().await?;
+        let req = self.auth_request(self.client.post(&url)).json(&body);
+        let resp = req.send().await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -111,7 +249,8 @@ impl SignalAdapter {
         &self,
         url: &str,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-        let resp = self.client.get(url).send().await?;
+        let req = self.auth_request(self.client.get(url));
+        let resp = req.send().await?;
         if !resp.status().is_success() {
             let status = resp.status();
             return Err(format!("Failed to download attachment ({status}): {url}").into());
@@ -135,7 +274,8 @@ impl SignalAdapter {
     ) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("{}/v1/receive/{}", self.api_url, self.phone_number);
 
-        let resp = self.client.get(&url).send().await?;
+        let req = self.auth_request(self.client.get(&url));
+        let resp = req.send().await?;
 
         if !resp.status().is_success() {
             return Ok(vec![]);
@@ -175,6 +315,7 @@ impl ChannelAdapter for SignalAdapter {
         let mut shutdown_rx = self.shutdown_rx.clone();
         let account_id = self.account_id.clone();
         let poll_interval = self.poll_interval;
+        let api_key = self.api_key.clone();
 
         info!(
             "Starting Signal adapter (polling {} every {:?})",
@@ -193,7 +334,11 @@ impl ChannelAdapter for SignalAdapter {
 
                 // Poll for new messages
                 let url = format!("{}/v1/receive/{}", api_url, phone_number);
-                let resp = match client.get(&url).send().await {
+                let mut req = client.get(&url);
+                if let Some(ref key) = api_key {
+                    req = req.bearer_auth(key);
+                }
+                let resp = match req.send().await {
                     Ok(r) => r,
                     Err(e) => {
                         debug!("Signal poll error: {e}");
@@ -585,23 +730,76 @@ mod tests {
 
     #[test]
     fn test_signal_adapter_creation() {
-        let adapter = SignalAdapter::new(
+        // localhost is allowed when allow_local = true
+        let adapter = SignalAdapter::with_options(
             "http://localhost:8080".to_string(),
             "+1234567890".to_string(),
             vec![],
-        );
+            None,
+            true,
+        )
+        .expect("should build with allow_local=true");
         assert_eq!(adapter.name(), "signal");
         assert_eq!(adapter.channel_type(), ChannelType::Signal);
     }
 
     #[test]
     fn test_signal_allowed_check() {
-        let adapter = SignalAdapter::new(
+        let adapter = SignalAdapter::with_options(
             "http://localhost:8080".to_string(),
             "+1234567890".to_string(),
             vec!["+9876543210".to_string()],
-        );
+            None,
+            true,
+        )
+        .expect("should build");
         assert!(adapter.is_allowed("+9876543210"));
         assert!(!adapter.is_allowed("+1111111111"));
+    }
+
+    #[test]
+    fn test_ssrf_rejects_loopback_without_allow_local() {
+        // 127.0.0.1 is loopback — must be rejected unless allow_local is set.
+        let err = validate_api_url("http://127.0.0.1:8080", false);
+        assert!(err.is_err(), "loopback must be rejected");
+    }
+
+    #[test]
+    fn test_ssrf_allows_loopback_with_allow_local() {
+        let ok = validate_api_url("http://127.0.0.1:8080", true);
+        assert!(ok.is_ok(), "loopback must be allowed when allow_local=true");
+    }
+
+    #[test]
+    fn test_ssrf_rejects_bad_scheme() {
+        let err = validate_api_url("ftp://example.com/api", false);
+        assert!(err.is_err(), "ftp scheme must be rejected");
+    }
+
+    #[test]
+    fn test_ssrf_rejects_file_scheme() {
+        let err = validate_api_url("file:///etc/passwd", false);
+        assert!(err.is_err(), "file scheme must be rejected");
+    }
+
+    #[test]
+    fn test_ssrf_rejects_private_ipv4() {
+        // RFC-1918 addresses must be blocked.
+        assert!(validate_api_url("http://192.168.1.1/api", false).is_err());
+        assert!(validate_api_url("http://10.0.0.1/api", false).is_err());
+        assert!(validate_api_url("http://172.16.0.1/api", false).is_err());
+    }
+
+    #[test]
+    fn test_is_private_or_loopback() {
+        use std::net::Ipv4Addr;
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))));
+        // Public addresses must NOT be blocked.
+        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        assert!(!is_private_or_loopback(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
     }
 }

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -606,11 +606,7 @@ impl ClawHubClient {
                 info!(slug, "SHA256 checksum verified OK");
             }
             None => {
-                warn!(
-                    slug,
-                    "ClawHub did not provide expected_sha256 for skill {} — install unverified",
-                    slug
-                );
+                warn!(slug, "ClawHub did not provide expected_sha256 — install unverified");
             }
         }
 

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -184,6 +184,10 @@ pub struct ClawHubSkillDetail {
     /// Moderation status (null when clean).
     #[serde(default)]
     pub moderation: Option<serde_json::Value>,
+    /// Expected SHA256 hex digest of the skill archive, provided by the registry.
+    /// When present the installer validates the download before extraction.
+    #[serde(default)]
+    pub expected_sha256: Option<String>,
 }
 
 // -- Sort enum -------------------------------------------------------------
@@ -508,7 +512,8 @@ impl ClawHubClient {
     /// Install a skill from ClawHub into the target directory.
     ///
     /// Security pipeline:
-    /// 1. Download skill zip and compute SHA256
+    /// 0. Fetch skill detail (to obtain `expected_sha256` when the registry provides it)
+    /// 1. Download skill zip and compute SHA256; validate against expected when present
     /// 2. Detect format (SKILL.md vs package.json)
     /// 3. Convert to LibreFang manifest
     /// 4. Run manifest security scan
@@ -521,6 +526,17 @@ impl ClawHubClient {
         target_dir: &Path,
     ) -> Result<ClawHubInstallResult, SkillError> {
         validate_slug(slug)?;
+
+        // Step 0: Fetch skill detail to get expected_sha256 (best-effort —
+        // if the registry does not provide it we still install with a warning).
+        let expected_sha256: Option<String> = match self.get_skill(slug).await {
+            Ok(detail) => detail.expected_sha256,
+            Err(e) => {
+                warn!(slug, error = %e, "Could not fetch ClawHub skill detail; proceeding without checksum verification");
+                None
+            }
+        };
+
         // Use /api/v1/download?slug=... endpoint
         let url = format!("{}/download?slug={}", self.base_url, urlencoded(slug));
 
@@ -534,18 +550,37 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to read download body: {e}")))?;
 
-        self.install_from_bytes(slug, target_dir, &bytes).await
+        self.install_with_expected_sha256(slug, target_dir, &bytes, expected_sha256.as_deref()).await
     }
 
     /// Install a skill from raw bytes (zip or SKILL.md).
     ///
     /// Shared extraction + security scan logic used by both ClawHub download
-    /// and Skillhub COS download paths.
+    /// and Skillhub COS download paths.  No checksum validation is performed
+    /// because the Skillhub COS path does not provide an expected hash; use
+    /// `install_with_expected_sha256` when a hash is available.
     pub async fn install_from_bytes(
         &self,
         slug: &str,
         target_dir: &Path,
         bytes: &[u8],
+    ) -> Result<ClawHubInstallResult, SkillError> {
+        self.install_with_expected_sha256(slug, target_dir, bytes, None).await
+    }
+
+    /// Install a skill from raw bytes with optional SHA256 checksum validation.
+    ///
+    /// When `expected_sha256` is `Some`, the computed digest of `bytes` is
+    /// compared against it before extraction.  A mismatch deletes any partially
+    /// written files and returns a `SkillError::SecurityBlocked` error.
+    /// When `expected_sha256` is `None`, a `warn!` is emitted and installation
+    /// continues (backward-compatible behaviour).
+    async fn install_with_expected_sha256(
+        &self,
+        slug: &str,
+        target_dir: &Path,
+        bytes: &[u8],
+        expected_sha256: Option<&str>,
     ) -> Result<ClawHubInstallResult, SkillError> {
         validate_slug(slug)?;
 
@@ -556,6 +591,28 @@ impl ClawHubClient {
             hex::encode(hasher.finalize())
         };
         info!(slug, sha256 = %sha256, "Downloaded skill");
+
+        // Step 1a: Validate checksum against registry-supplied expected hash
+        // BEFORE creating any directories so we fail fast on supply-chain
+        // tampering (issue #3827).
+        match expected_sha256 {
+            Some(expected) => {
+                let expected_lower = expected.to_lowercase();
+                if sha256 != expected_lower {
+                    return Err(SkillError::SecurityBlocked(format!(
+                        "Skill {slug} hash mismatch: expected {expected_lower}, got {sha256}"
+                    )));
+                }
+                info!(slug, "SHA256 checksum verified OK");
+            }
+            None => {
+                warn!(
+                    slug,
+                    "ClawHub did not provide expected_sha256 for skill {} — install unverified",
+                    slug
+                );
+            }
+        }
 
         // Install into a temporary directory first, then atomically rename to
         // the final skill directory.  This prevents partial installs from being

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -550,7 +550,8 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to read download body: {e}")))?;
 
-        self.install_with_expected_sha256(slug, target_dir, &bytes, expected_sha256.as_deref()).await
+        self.install_with_expected_sha256(slug, target_dir, &bytes, expected_sha256.as_deref())
+            .await
     }
 
     /// Install a skill from raw bytes (zip or SKILL.md).
@@ -565,7 +566,8 @@ impl ClawHubClient {
         target_dir: &Path,
         bytes: &[u8],
     ) -> Result<ClawHubInstallResult, SkillError> {
-        self.install_with_expected_sha256(slug, target_dir, bytes, None).await
+        self.install_with_expected_sha256(slug, target_dir, bytes, None)
+            .await
     }
 
     /// Install a skill from raw bytes with optional SHA256 checksum validation.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5541,6 +5541,14 @@ pub struct SignalConfig {
     /// Poll interval in seconds for checking new messages (default: 2).
     #[serde(default = "default_signal_poll_interval_secs")]
     pub poll_interval_secs: u64,
+    /// Optional API key sent as `Authorization: Bearer <api_key>` on every request.
+    /// If absent, requests are sent without an Authorization header.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses.
+    /// Defaults to `false`; set to `true` only when signal-cli runs on localhost.
+    #[serde(default)]
+    pub allow_local: bool,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -5555,6 +5563,8 @@ impl Default for SignalConfig {
             account_id: None,
             default_agent: None,
             poll_interval_secs: default_signal_poll_interval_secs(),
+            api_key: None,
+            allow_local: false,
             overrides: ChannelOverrides::default(),
         }
     }

--- a/xtask/src/license_check.rs
+++ b/xtask/src/license_check.rs
@@ -93,13 +93,19 @@ fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::err
 
             // Flag crates with no declared license for manual review.
             if license_opt.is_none() || license == "UNKNOWN" || license.is_empty() {
-                unverified.push(format!("  {} — no license declared (manual review needed)", name));
+                unverified.push(format!(
+                    "  {} — no license declared (manual review needed)",
+                    name
+                ));
                 continue;
             }
 
             // Check for "Commons Clause" rider (often appended to Apache-2.0 etc.).
             if has_commons_clause(license) {
-                violations.push(format!("  {} ({}) — Commons Clause rider detected", name, license));
+                violations.push(format!(
+                    "  {} ({}) — Commons Clause rider detected",
+                    name, license
+                ));
             }
 
             // Check against the explicit deny list.

--- a/xtask/src/license_check.rs
+++ b/xtask/src/license_check.rs
@@ -3,6 +3,30 @@ use clap::Parser;
 use std::path::Path;
 use std::process::Command;
 
+/// Licenses denied by default.  This list deliberately covers copyleft and
+/// source-available licenses that are incompatible with commercial distribution
+/// of a proprietary or permissively-licensed product.
+///
+/// The list is intentionally broad:
+/// - GPL / LGPL (all versions and flavors)
+/// - AGPL (all versions and flavors)
+/// - SSPL (MongoDB server-side public license)
+/// - BUSL (Business Source License — time-delayed open source)
+///
+/// Crates with `license = null` or `"UNKNOWN"` are flagged separately as
+/// unverified rather than hard-blocked, because they often just have
+/// non-SPDX license strings that need manual inspection.
+const DEFAULT_DENIED_LICENSES: &str = concat!(
+    "AGPL-3.0-only,AGPL-3.0-or-later,",
+    "GPL-2.0,GPL-2.0-only,GPL-2.0-or-later,",
+    "GPL-3.0,GPL-3.0-only,GPL-3.0-or-later,",
+    "LGPL-2.0,LGPL-2.0-only,LGPL-2.0-or-later,",
+    "LGPL-2.1,LGPL-2.1-only,LGPL-2.1-or-later,",
+    "LGPL-3.0,LGPL-3.0-only,LGPL-3.0-or-later,",
+    "SSPL-1.0,",
+    "BUSL-1.1"
+);
+
 #[derive(Parser, Debug)]
 pub struct LicenseCheckArgs {
     /// Check only Rust dependencies
@@ -13,9 +37,17 @@ pub struct LicenseCheckArgs {
     #[arg(long)]
     pub web: bool,
 
-    /// Denied licenses (comma-separated, e.g. "GPL-3.0,AGPL-3.0")
-    #[arg(long, default_value = "AGPL-3.0-only,AGPL-3.0-or-later")]
+    /// Denied licenses (comma-separated).
+    /// Defaults to GPL/LGPL/AGPL/SSPL/BUSL variants.
+    #[arg(long, default_value = DEFAULT_DENIED_LICENSES)]
     pub deny: String,
+}
+
+/// Returns `true` if the license string contains any fragment that resembles the
+/// "Commons Clause" rider (e.g. `"Commons Clause"` or `"Commons-Clause"`).
+fn has_commons_clause(license: &str) -> bool {
+    let lc = license.to_lowercase();
+    lc.contains("commons clause") || lc.contains("commons-clause")
 }
 
 fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
@@ -47,23 +79,48 @@ fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::err
 
     let metadata: serde_json::Value = serde_json::from_slice(&output.stdout)?;
     let mut violations = Vec::new();
+    let mut unverified = Vec::new();
     let mut checked = 0;
 
     if let Some(packages) = metadata["packages"].as_array() {
         for pkg in packages {
             let name = pkg["name"].as_str().unwrap_or("unknown");
-            let license = pkg["license"].as_str().unwrap_or("UNKNOWN");
             checked += 1;
 
+            // `license` is null when the Cargo.toml field is absent.
+            let license_opt = pkg["license"].as_str();
+            let license = license_opt.unwrap_or("UNKNOWN");
+
+            // Flag crates with no declared license for manual review.
+            if license_opt.is_none() || license == "UNKNOWN" || license.is_empty() {
+                unverified.push(format!("  {} — no license declared (manual review needed)", name));
+                continue;
+            }
+
+            // Check for "Commons Clause" rider (often appended to Apache-2.0 etc.).
+            if has_commons_clause(license) {
+                violations.push(format!("  {} ({}) — Commons Clause rider detected", name, license));
+            }
+
+            // Check against the explicit deny list.
             for &deny in denied {
                 if license.contains(deny) {
                     violations.push(format!("  {} ({}) — {}", name, license, deny));
+                    break; // one violation per crate is enough
                 }
             }
         }
     }
 
     println!("  Checked {} workspace crates", checked);
+
+    if !unverified.is_empty() {
+        println!("  Unverified (no license field) — manual review required:");
+        for u in &unverified {
+            println!("WARN {}", u);
+        }
+    }
+
     if violations.is_empty() {
         println!("  No license violations found.");
     } else {


### PR DESCRIPTION
## Summary
- Signal channel: validates `api_url` against SSRF (rejects RFC1918/loopback/link-local unless `allow_local: true`); adds optional `Authorization: Bearer` via `api_key` config; 10s connect + 30s total timeout (closes #3810)
- ClawHub skill install: compares computed SHA256 against `expected_sha256` from registry response; mismatch aborts install and cleans up temp dir; missing hash logs `warn!` and continues (closes #3827)
- License check: deny-list expanded to include GPL-2/3, LGPL-2/2.1/3 (all variants), SSPL-1.0, BUSL-1.1, Commons Clause rider; `license = null/UNKNOWN` logged as `WARN` for manual review (closes #3811)

## Test plan
- [ ] Signal channel with RFC1918 `api_url` and `allow_local: false` is rejected at startup
- [ ] Skill install with wrong SHA256 aborts and removes partial install
- [ ] `cargo xtask license-check` rejects a GPL-licensed crate