### PR TITLE
fix(desktop): inline tauri::generate_handler! to fix E0282 on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,6 +4222,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-barcode-scanner",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
@@ -8425,6 +8426,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
 dependencies = [
  "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-barcode-scanner"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485cbcf227f04117e930be748ea71d835900466dcd1d455d5ec284d36107a305"
+dependencies = [
+ "log",
  "serde",
  "serde_json",
  "tauri",

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -143,9 +143,13 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     } else if force_local {
         // force_local is only meaningful on desktop — on mobile always use connection screen
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        { StartupMode::Local }
+        {
+            StartupMode::Local
+        }
         #[cfg(any(target_os = "ios", target_os = "android"))]
-        { StartupMode::ConnectionScreen }
+        {
+            StartupMode::ConnectionScreen
+        }
     } else if let Some(url) = std::env::var("LIBREFANG_SERVER_URL")
         .ok()
         .filter(|s| !s.is_empty())
@@ -303,9 +307,13 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     }
 
     // `generate_handler!` does not support cfg attributes inside the macro, so we
-    // build two separate lists and select the right one at compile time.
+    // build two separate handler closures and attach the correct one at compile
+    // time. The macro produces a closure whose runtime type parameter is inferred
+    // from `builder`, so we call `.invoke_handler(...)` directly inside each cfg
+    // branch — binding the result to a `let` first leaves rustc unable to infer
+    // the runtime type and triggers E0282.
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
-    let invoke_handler = tauri::generate_handler![
+    let builder = builder.invoke_handler(tauri::generate_handler![
         commands::get_port,
         commands::get_status,
         commands::get_agent_count,
@@ -321,9 +329,9 @@ pub fn run(server_url: Option<String>, force_local: bool) {
         connection::test_connection,
         connection::connect_remote,
         connection::start_local,
-    ];
+    ]);
     #[cfg(any(target_os = "ios", target_os = "android"))]
-    let invoke_handler = tauri::generate_handler![
+    let builder = builder.invoke_handler(tauri::generate_handler![
         commands::get_port,
         commands::get_status,
         commands::get_agent_count,
@@ -334,10 +342,9 @@ pub fn run(server_url: Option<String>, force_local: bool) {
         commands::uninstall_app,
         connection::test_connection,
         connection::connect_remote,
-    ];
+    ]);
 
     builder
-        .invoke_handler(invoke_handler)
         .setup(move |app| {
             if show_connection_screen {
                 let _window = WebviewWindowBuilder::new(


### PR DESCRIPTION
## Summary

Main has been red across Windows / Ubuntu / macOS since #3886 (mobile scaffold). Two failures, both in `crates/librefang-desktop/src/lib.rs`:

- **`error[E0282]: type annotations needed`** at line 308 — `let invoke_handler = tauri::generate_handler![...]` split across two cfg branches leaves rustc unable to infer the Tauri runtime type `R`. The downstream `.invoke_handler(invoke_handler)` provides no constraint because the binding is un-annotated.
- **`cargo fmt --check` failure** at line 143 — cfg-gated single-line blocks `{ StartupMode::Local }` / `{ StartupMode::ConnectionScreen }` violate rustfmt's expected layout.

Plus a third pre-existing problem: `crates/librefang-desktop/Cargo.toml` declares `tauri-plugin-barcode-scanner = "2"`, but `Cargo.lock` was never updated. Every CI run was re-locking the dep (`Locking 1 package to latest compatible version / Adding tauri-plugin-barcode-scanner v2.4.4`).

## Changes

- Inline `tauri::generate_handler![...]` directly into `.invoke_handler(...)` inside each cfg branch so `builder`'s `R` constrains the macro expansion at the call site (no intermediate `let` binding).
- Expand the two cfg-gated single-line blocks to multi-line blocks.
- Lock `tauri-plugin-barcode-scanner v2.4.4` into `Cargo.lock`.

## Type

- [x] Bug fix
- [x] CI / Tooling

## Testing

- [x] `cargo build --workspace --lib` (full workspace) — passes
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p librefang-desktop --lib -- -D warnings` — clean
- [x] Verified the original error reproduces on `main` before the fix

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries