### PR TITLE
fix(runtime,types): compile error and clippy manual_strip in #3925 follow-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,6 +4222,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-barcode-scanner",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
@@ -8425,6 +8426,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
 dependencies = [
  "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-barcode-scanner"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485cbcf227f04117e930be748ea71d835900466dcd1d455d5ec284d36107a305"
+dependencies = [
+ "log",
  "serde",
  "serde_json",
  "tauri",

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -235,15 +235,23 @@ fn host_fs_read(state: &GuestState, params: &serde_json::Value) -> serde_json::V
         Some(p) => p,
         None => return json!({"error": "Missing 'path' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(&state.capabilities, &Capability::FileRead(path.to_string())) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY (fix #3814): canonicalize FIRST so that path traversal components
+    // are resolved/rejected before the capability gate runs. Checking capability
+    // against the raw path allows an attacker to pass a non-canonical path that
+    // matches a granted capability pattern but resolves to a different file after
+    // canonicalization (or vice-versa). By resolving first we guarantee that the
+    // capability is evaluated against the exact path the OS will access.
     let canonical = match safe_resolve_path(path) {
         Ok(c) => c,
         Err(e) => return e,
     };
+    let canonical_str = canonical.to_string_lossy();
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileRead(canonical_str.to_string()),
+    ) {
+        return e;
+    }
     match std::fs::read_to_string(&canonical) {
         Ok(content) => json!({"ok": content}),
         Err(e) => json!({"error": format!("fs_read failed: {e}")}),
@@ -259,18 +267,21 @@ fn host_fs_write(state: &GuestState, params: &serde_json::Value) -> serde_json::
         Some(c) => c,
         None => return json!({"error": "Missing 'content' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(
-        &state.capabilities,
-        &Capability::FileWrite(path.to_string()),
-    ) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY (fix #3814): resolve the write destination FIRST (rejecting traversal),
+    // then check FileWrite capability against the canonical path. For new files the
+    // parent directory is canonicalized and the filename is appended so the
+    // capability check reflects the real on-disk location.
     let write_path = match safe_resolve_parent(path) {
         Ok(p) => p,
         Err(e) => return e,
     };
+    let write_path_str = write_path.to_string_lossy();
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileWrite(write_path_str.to_string()),
+    ) {
+        return e;
+    }
     match std::fs::write(&write_path, content) {
         Ok(()) => json!({"ok": true}),
         Err(e) => json!({"error": format!("fs_write failed: {e}")}),
@@ -282,15 +293,18 @@ fn host_fs_list(state: &GuestState, params: &serde_json::Value) -> serde_json::V
         Some(p) => p,
         None => return json!({"error": "Missing 'path' parameter"}),
     };
-    // Check capability with raw path first
-    if let Err(e) = check_capability(&state.capabilities, &Capability::FileRead(path.to_string())) {
-        return e;
-    }
-    // SECURITY: Reject path traversal after capability gate
+    // SECURITY (fix #3814): canonicalize before capability check (same rationale as fs_read).
     let canonical = match safe_resolve_path(path) {
         Ok(c) => c,
         Err(e) => return e,
     };
+    let canonical_str = canonical.to_string_lossy();
+    if let Err(e) = check_capability(
+        &state.capabilities,
+        &Capability::FileRead(canonical_str.to_string()),
+    ) {
+        return e;
+    }
     match std::fs::read_dir(&canonical) {
         Ok(entries) => {
             let names: Vec<String> = entries
@@ -820,6 +834,37 @@ mod tests {
         assert_eq!(
             extract_host_from_url("http://example.com"),
             "example.com:80"
+        );
+    }
+
+    /// Regression for #3814: capability check must use the canonical path,
+    /// not the raw path supplied by the guest. A traversal path like
+    /// `../../etc/passwd` must be rejected by path resolution *before* any
+    /// capability comparison can be made — it must never reach the file read.
+    #[tokio::test]
+    async fn test_fs_read_traversal_rejected_before_capability_check() {
+        // Even with a wildcard FileRead grant, traversal paths are rejected.
+        let state = test_state(vec![Capability::FileRead("*".to_string())]);
+        let result = host_fs_read(&state, &json!({"path": "../../etc/passwd"}));
+        let err = result["error"].as_str().unwrap();
+        assert!(
+            err.contains("traversal") || err.contains("forbidden"),
+            "traversal path must be rejected; got: {err}"
+        );
+    }
+
+    /// Regression for #3814: same for fs_write.
+    #[tokio::test]
+    async fn test_fs_write_traversal_rejected_before_capability_check() {
+        let state = test_state(vec![Capability::FileWrite("*".to_string())]);
+        let result = host_fs_write(
+            &state,
+            &json!({"path": "../../tmp/evil.txt", "content": "x"}),
+        );
+        let err = result["error"].as_str().unwrap();
+        assert!(
+            err.contains("traversal") || err.contains("forbidden"),
+            "traversal path must be rejected; got: {err}"
         );
     }
 }

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -671,7 +671,7 @@ pub async fn execute_tool_raw(
                                 let after = &command[idx + ps.len()..];
                                 after.is_empty() || after.starts_with('/')
                                     || after.starts_with('"')
-                                    || after.starts_with(''')
+                                    || after.starts_with('\'')
                                     || after.starts_with(' ')
                             } else {
                                 false

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -626,6 +626,74 @@ pub async fn execute_tool_raw(
                 }
             }
 
+            // SECURITY (fix #3822): enforce named workspace read-only restrictions for
+            // shell_exec. The shell tool runs commands that can write arbitrary paths,
+            // so we scan the command string (and any explicit args array) for references
+            // to read-only workspace paths and block execution if any are found.
+            // This mirrors the read-only enforcement already applied to file_write and
+            // apply_patch (see the "file_write" arm above).
+            if let (Some(k), Some(agent_id)) = (kernel, caller_agent_id) {
+                let ro_prefixes = k.readonly_workspace_prefixes(agent_id);
+                if !ro_prefixes.is_empty() {
+                    // Collect the command string and all argument strings as a single
+                    // list of tokens to scan. We look for any token that starts with
+                    // (or equals) a read-only workspace prefix, which indicates the
+                    // shell command is targeting a read-only workspace path.
+                    let mut tokens: Vec<&str> = vec![command];
+                    if let Some(args_arr) = input.get("args").and_then(|a| a.as_array()) {
+                        for v in args_arr {
+                            if let Some(s) = v.as_str() {
+                                tokens.push(s);
+                            }
+                        }
+                    }
+                    for ro_prefix in &ro_prefixes {
+                        let prefix_str = ro_prefix.to_string_lossy();
+                        // A token references a read-only workspace if it starts with the
+                        // prefix path. We also check that the match is at a path boundary
+                        // (next char is '/' or the token equals the prefix exactly) to
+                        // avoid false-positives on shared prefixes like /data vs /data2.
+                        let blocked = tokens.iter().any(|token| {
+                            if let Some(rest) = token.strip_prefix(prefix_str.as_ref()) {
+                                rest.is_empty() || rest.starts_with('/')
+                            } else {
+                                false
+                            }
+                        });
+                        // Also check if the prefix path string appears as a contiguous
+                        // substring within the full command (handles redirect operators,
+                        // quoted paths, etc.). This is a best-effort heuristic — the
+                        // primary check is the token scan above.
+                        let in_command = {
+                            let ps = prefix_str.as_ref();
+                            if let Some(idx) = command.find(ps) {
+                                // Verify path boundary after the match
+                                let after = &command[idx + ps.len()..];
+                                after.is_empty() || after.starts_with('/')
+                                    || after.starts_with('"')
+                                    || after.starts_with(''')
+                                    || after.starts_with(' ')
+                            } else {
+                                false
+                            }
+                        };
+                        if blocked || in_command {
+                            // Find the workspace name for the error message. The name is
+                            // not stored in the prefix list, so we report the path.
+                            return ToolResult {
+                                tool_use_id: tool_use_id.to_string(),
+                                content: format!(
+                                    "shell_exec blocked: path '{}' is in a read-only workspace (mode = r). Writes are not allowed.",
+                                    prefix_str
+                                ),
+                                is_error: true,
+                                ..Default::default()
+                            };
+                        }
+                    }
+                }
+            }
+
             let effective_allowed_env_vars = allowed_env_vars.or_else(|| {
                 exec_policy.and_then(|policy| {
                     if policy.allowed_env_vars.is_empty() {
@@ -7382,6 +7450,129 @@ mod tests {
         .await;
         assert!(result.is_error, "expected denial, got: {}", result.content);
         assert!(!target.exists(), "file should not have been written");
+    }
+
+    // ── Bug #3822: shell_exec must respect named workspace read-only mode ────
+
+    /// Regression for #3822: `shell_exec` must be blocked when the command
+    /// string references a path that falls inside a read-only named workspace.
+    /// Previously the shell tool had no such check; a plugin could bypass the
+    /// read-only restriction by issuing a shell command that writes to the
+    /// supposedly read-only workspace path.
+    #[tokio::test]
+    async fn test_shell_exec_blocked_for_readonly_workspace_path() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+
+        // Configure the shared workspace as read-only.
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadOnly)]);
+
+        // Construct a command string that references the read-only path.
+        let ro_path = shared_canon.to_str().unwrap();
+        let command = format!("touch {ro_path}/evil.txt");
+
+        let result = execute_tool(
+            "test-id",
+            "shell_exec",
+            &serde_json::json!({"command": command}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000008"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            result.is_error,
+            "shell_exec referencing a read-only workspace path must be blocked; got: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("read-only"),
+            "error must mention read-only; got: {}",
+            result.content
+        );
+        // Verify the file was NOT created.
+        assert!(!shared_canon.join("evil.txt").exists());
+    }
+
+    /// Read-only workspace enforcement must NOT block commands that do not
+    /// reference the read-only workspace path.
+    #[tokio::test]
+    async fn test_shell_exec_allowed_when_not_targeting_readonly_workspace() {
+        use librefang_types::agent::WorkspaceMode;
+
+        let primary = tempfile::tempdir().expect("primary");
+        let shared = tempfile::tempdir().expect("shared");
+        let shared_canon = shared.path().canonicalize().unwrap();
+
+        // Read-only shared workspace — but the command targets the primary workspace.
+        let kernel = make_named_ws_kernel(vec![(shared_canon.clone(), WorkspaceMode::ReadOnly)]);
+
+        // A command that does NOT reference the read-only path should go through
+        // (it may still fail for other reasons — e.g., exec policy — but it must
+        // not be blocked by the workspace read-only check).
+        let result = execute_tool(
+            "test-id",
+            "shell_exec",
+            &serde_json::json!({"command": "echo hello"}),
+            Some(&kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000009"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        // Must NOT be blocked by read-only check. It may be blocked by exec policy
+        // (if one is set) but should not contain "read-only" in the error.
+        if result.is_error {
+            assert!(
+                !result.content.contains("read-only"),
+                "must not be blocked by read-only check; got: {}",
+                result.content
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -186,36 +186,150 @@ pub fn validate_capability_inheritance(
     Ok(())
 }
 
-/// Simple glob pattern matching supporting '*' as wildcard.
+/// Glob pattern matching supporting `*` and `**` wildcards.
 ///
-/// Pattern rules:
-/// - `"*"` matches anything
-/// - `"prefix*"` matches values starting with `prefix`
-/// - `"*suffix"` matches values ending with `suffix`
-/// - `"prefix*suffix"` matches values starting with `prefix` and ending with `suffix`
-/// - Exact string matches itself
+/// # Pattern rules
+///
+/// **Single-segment wildcard `*`** — matches any characters **except** the
+/// path/URL separator `/`. This prevents path traversal via capability globs:
+/// `data/*` matches `data/file.txt` but NOT `data/../../etc/passwd`.
+///
+/// **Double-segment wildcard `**`** — matches any characters including `/`,
+/// so `data/**` matches `data/a/b/c/file.txt`.
+///
+/// **Bare `*`** (the entire pattern is just `"*"`) — matches anything, for
+/// backward compatibility with the universal wildcard grant.
+///
+/// **No `/` in pattern** — falls back to the original single-wildcard
+/// matching so non-path patterns (tool names, hostnames, memory scopes, etc.)
+/// continue to work as before: `file_*` matches `file_read`, `*.openai.com`
+/// matches `api.openai.com`, and so on.
+///
+/// # Rationale
+///
+/// The original `*` implementation used `str::ends_with` / `str::starts_with`
+/// which let `*` silently cross `/` separators. A grant of `FileRead("data/*")`
+/// was supposed to allow reads inside the `data/` directory but instead also
+/// matched `data/../../etc/passwd` (containing the traversal after the `*`).
+/// Fixing `*` to stop at `/` closes this class of capability bypass.
 pub fn glob_matches(pattern: &str, value: &str) -> bool {
+    // Bare "*" is the universal match — keep it fast and unchanged.
     if pattern == "*" {
         return true;
     }
+    // Exact match is always valid.
     if pattern == value {
         return true;
     }
+
+    // If the pattern contains a path separator we apply segment-aware matching
+    // so that a single `*` cannot cross a `/`.
+    if pattern.contains('/') {
+        return glob_matches_path(pattern, value);
+    }
+
+    // No path separator in pattern: use the original wildcard logic so tool
+    // names ("file_*"), hostname globs ("*.openai.com:443"), memory scope
+    // patterns, etc. keep working exactly as before.
+    glob_matches_simple(pattern, value)
+}
+
+/// Original (legacy) single-wildcard matching used when the pattern has no `/`.
+///
+/// `*` matches any sequence of characters (including `.`, `:`, etc.).
+fn glob_matches_simple(pattern: &str, value: &str) -> bool {
     if let Some(suffix) = pattern.strip_prefix('*') {
-        return value.ends_with(suffix);
+        // "*suffix" — but only if there's no second '*' in suffix.
+        // Multi-wildcard patterns without '/' fall through to the find() branch.
+        if !suffix.contains('*') {
+            return value.ends_with(suffix);
+        }
     }
     if let Some(prefix) = pattern.strip_suffix('*') {
-        return value.starts_with(prefix);
+        if !prefix.contains('*') {
+            return value.starts_with(prefix);
+        }
     }
-    // Check for middle wildcard: "prefix*suffix"
+    // Middle wildcard or multi-wildcard: find first '*' and check prefix+suffix.
     if let Some(star_pos) = pattern.find('*') {
         let prefix = &pattern[..star_pos];
         let suffix = &pattern[star_pos + 1..];
+        // Recursively handle the suffix in case it contains more wildcards.
+        if suffix.contains('*') {
+            // For simplicity, only support one level of recursion here.
+            if value.starts_with(prefix) {
+                return glob_matches_simple(suffix, &value[prefix.len()..]);
+            }
+            return false;
+        }
         return value.starts_with(prefix)
             && value.ends_with(suffix)
             && value.len() >= prefix.len() + suffix.len();
     }
     false
+}
+
+/// Path-aware glob matching used when the pattern contains `/`.
+///
+/// Splits both pattern and value on `/` and matches segment by segment.
+/// A single `*` within a segment matches any characters **except** `/`.
+/// A `**` segment matches zero or more complete path segments (like `/**/`).
+fn glob_matches_path(pattern: &str, value: &str) -> bool {
+    let pat_segs: Vec<&str> = pattern.split('/').collect();
+    let val_segs: Vec<&str> = value.split('/').collect();
+    glob_match_segments(&pat_segs, &val_segs)
+}
+
+/// Recursive segment-by-segment matcher.
+fn glob_match_segments(pat: &[&str], val: &[&str]) -> bool {
+    match (pat.first(), val.first()) {
+        // Both exhausted at the same time: success.
+        (None, None) => true,
+        // Pattern exhausted but value still has segments: no match.
+        // (The single-segment `*` cannot silently consume extra segments.)
+        (None, _) => false,
+        // Value exhausted but pattern still has segments: only succeed if every
+        // remaining pattern segment is `**` (which can match zero segments).
+        (_, None) => pat.iter().all(|s| *s == "**"),
+        (Some(&"**"), _) => {
+            // "**" can match zero or more segments. Try consuming 0, 1, 2, …
+            // segments from val until we find a match or exhaust val.
+            let rest_pat = &pat[1..];
+            // Match zero segments consumed by **
+            if glob_match_segments(rest_pat, val) {
+                return true;
+            }
+            // Match one or more segments consumed by **
+            for i in 1..=val.len() {
+                if glob_match_segments(rest_pat, &val[i..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        (Some(p), Some(v)) => {
+            // Match this segment, then recurse on the rest.
+            if segment_matches(p, v) {
+                glob_match_segments(&pat[1..], &val[1..])
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Match a single path segment (`*` = any chars except `/`).
+fn segment_matches(pattern: &str, value: &str) -> bool {
+    if pattern == "*" || pattern == value {
+        return true;
+    }
+    // Use the simple matcher restricted to a single segment (no `/` in either).
+    // Because we've already split on `/`, neither string should contain `/`;
+    // but double-check to be safe.
+    if value.contains('/') {
+        return false;
+    }
+    glob_matches_simple(pattern, value)
 }
 
 #[cfg(test)]
@@ -394,5 +508,102 @@ mod tests {
             .filter(|(p, _)| glob_matches(p, tool))
             .max_by_key(|(p, _)| p.len());
         assert!(best.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bug #3863: glob separator safety — `*` must not cross `/`
+    // -----------------------------------------------------------------------
+
+    /// `data/*` must match a file directly inside `data/` but NOT a path
+    /// that uses `..` to escape the directory boundary.
+    #[test]
+    fn test_glob_star_does_not_cross_path_separator() {
+        // Should match — `*` covers a single segment "file.txt"
+        assert!(
+            glob_matches("data/*", "data/file.txt"),
+            "data/* must match data/file.txt"
+        );
+        // Must NOT match — `*` cannot span across the `/..` traversal segments
+        assert!(
+            !glob_matches("data/*", "data/../../etc/passwd"),
+            "data/* must NOT match data/../../etc/passwd"
+        );
+        // Must NOT match — extra segments beyond the single `*`
+        assert!(
+            !glob_matches("data/*", "data/subdir/file.txt"),
+            "data/* must NOT match data/subdir/file.txt (use data/** for that)"
+        );
+    }
+
+    /// `**` must be able to match across path segments.
+    #[test]
+    fn test_glob_double_star_crosses_path_separator() {
+        assert!(
+            glob_matches("data/**", "data/subdir/file.txt"),
+            "data/** must match data/subdir/file.txt"
+        );
+        assert!(
+            glob_matches("data/**", "data/file.txt"),
+            "data/** must match data/file.txt"
+        );
+    }
+
+    /// URL capability patterns: `*` in the host portion must NOT match an
+    /// entirely different domain. The host string is already extracted as
+    /// `hostname:port` before this function is called, so the separator to
+    /// guard against is `.`, which is intentionally NOT blocked by `*` (we
+    /// want `*.openai.com:443` to work). However, `/` in the scheme-stripped
+    /// URL path portion MUST be blocked. This test exercises the scheme-level
+    /// guard via the `https://…/*` pattern.
+    #[test]
+    fn test_glob_url_star_does_not_cross_scheme_host_boundary() {
+        // Pattern allows a specific path on example.com
+        assert!(
+            glob_matches("https://example.com/*", "https://example.com/foo"),
+            "https://example.com/* must match https://example.com/foo"
+        );
+        // Must NOT match a different host — `*` cannot cross the scheme+host boundary
+        assert!(
+            !glob_matches("https://example.com/*", "https://evil.com/foo"),
+            "https://example.com/* must NOT match https://evil.com/foo"
+        );
+    }
+
+    /// Bare `*` (universal grant) must still match everything — including paths
+    /// with `/`, so that `FileRead("*")` continues to work as a super-grant.
+    #[test]
+    fn test_glob_bare_star_still_matches_all() {
+        assert!(glob_matches("*", "/etc/passwd"));
+        assert!(glob_matches("*", "data/../../etc/passwd"));
+        assert!(glob_matches("*", "any-tool-name"));
+        assert!(glob_matches("*", "https://example.com/path"));
+    }
+
+    /// Non-path patterns (tool names, hostnames) must continue to work
+    /// with `*` crossing `.`, `-`, `_`, and other non-`/` separators.
+    #[test]
+    fn test_glob_non_path_patterns_unchanged() {
+        // Tool name patterns
+        assert!(glob_matches("file_*", "file_read"));
+        assert!(glob_matches("mcp_*", "mcp_server_tool"));
+        // Hostname patterns (no `/` in pattern)
+        assert!(glob_matches("*.openai.com:443", "api.openai.com:443"));
+        assert!(glob_matches("api.*.com", "api.openai.com"));
+        // Memory scope patterns
+        assert!(glob_matches("agent:*", "agent:abc123"));
+    }
+
+    /// A path capability grant of `/data/*` must work for files at that level
+    /// but not grant access to the traversal escape `/data/../../etc/passwd`.
+    #[test]
+    fn test_capability_file_read_path_glob_blocks_traversal() {
+        assert!(capability_matches(
+            &Capability::FileRead("/data/*".to_string()),
+            &Capability::FileRead("/data/myfile.txt".to_string()),
+        ));
+        assert!(!capability_matches(
+            &Capability::FileRead("/data/*".to_string()),
+            &Capability::FileRead("/data/../../etc/passwd".to_string()),
+        ));
     }
 }

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -257,8 +257,8 @@ fn glob_matches_simple(pattern: &str, value: &str) -> bool {
         // Recursively handle the suffix in case it contains more wildcards.
         if suffix.contains('*') {
             // For simplicity, only support one level of recursion here.
-            if value.starts_with(prefix) {
-                return glob_matches_simple(suffix, &value[prefix.len()..]);
+            if let Some(rest) = value.strip_prefix(prefix) {
+                return glob_matches_simple(suffix, rest);
             }
             return false;
         }


### PR DESCRIPTION
## Summary

Follow-up fixes for the changes introduced in #3925. That PR has two issues that block CI:

- **Compile error** (`librefang-runtime`): `tool_runner.rs:674` uses `'''` as a Rust char literal for a single-quote character; Rust requires this to be written `'\''`. Causes a hard compile failure of the entire crate.
- **Clippy error** (`librefang-types`): `capability.rs:260–261` manually strips a prefix with `starts_with` + slice indexing, triggering `clippy::manual_strip` which is treated as an error under `-D warnings`. Fixed with `strip_prefix`.

Both changes are semantically identical — no logic change.

## Test plan

- [x] `cargo build -p librefang-runtime --lib` — passes after fix
- [x] `cargo clippy -p librefang-types --lib -- -D warnings` — clean after fix
- [x] `cargo test -p librefang-runtime-wasm` — 30 tests pass
- [x] `cargo test -p librefang-types` — 708 tests pass
- [x] `cargo test -p librefang-runtime -- test_shell_exec_blocked_for_readonly test_shell_exec_allowed_when_not_targeting` — 2 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtZyTe11v9jdTFLohmk74b)_