### PR TITLE
fix(ci): harden workflow shell injection, add dependabot npm/pip coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,39 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "ci"
+
+  # Dashboard (React/pnpm)
+  - package-ecosystem: "npm"
+    directory: "/crates/librefang-api/dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # CLI npm wrapper package
+  - package-ecosystem: "npm"
+    directory: "/packages/cli-npm"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # JavaScript SDK
+  - package-ecosystem: "npm"
+    directory: "/sdk/javascript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Python SDK
+  - package-ecosystem: "pip"
+    directory: "/sdk/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/scripts/discussion-to-issue.sh
+++ b/.github/scripts/discussion-to-issue.sh
@@ -3,21 +3,26 @@
 # Create a GitHub Issue from a Discussion.
 # Shared by auto-promote, manual-promote, and backfill jobs.
 #
-# Usage:
-#   discussion-to-issue.sh <disc_number> <disc_title> <disc_url> <disc_author> <disc_category>
+# Usage (all values passed as environment variables — never positional args
+# from ${{ }} expressions to prevent shell injection):
+#   DISC_NUMBER=<n> DISC_TITLE=<t> DISC_URL=<u> DISC_AUTHOR=<a> \
+#   DISC_CATEGORY=<c> bash discussion-to-issue.sh
 #
-# Env: GH_TOKEN, REPO
+# Env: GH_TOKEN, REPO, DISC_NUMBER, DISC_TITLE, DISC_URL, DISC_AUTHOR, DISC_CATEGORY
 #   MANUAL=true — bypass content filters (used by /to-issue command)
 #
 # Exit 0 on success or skip (duplicate). Exit 1 on error.
 
 set -euo pipefail
 
-DISC_NUMBER="$1"
-DISC_TITLE="$2"
-DISC_URL="$3"
-DISC_AUTHOR="$4"
-DISC_CATEGORY="$5"
+# All caller-supplied values arrive via environment variables so that
+# attacker-controlled content (discussion title, author login, etc.) is
+# never interpolated into the shell command line.
+: "${DISC_NUMBER:?DISC_NUMBER env var is required}"
+: "${DISC_TITLE:?DISC_TITLE env var is required}"
+: "${DISC_URL:?DISC_URL env var is required}"
+: "${DISC_AUTHOR:?DISC_AUTHOR env var is required}"
+: "${DISC_CATEGORY:?DISC_CATEGORY env var is required}"
 
 DISC_JSON=$(gh api "repos/${REPO}/discussions/${DISC_NUMBER}" 2>/dev/null || true)
 if [ -z "$DISC_JSON" ]; then

--- a/.github/workflows/discussion-to-issue.yml
+++ b/.github/workflows/discussion-to-issue.yml
@@ -98,7 +98,7 @@ jobs:
             echo "=== Scanning category: ${CAT} ==="
 
             gh api "repos/${REPO}/discussions" --paginate --jq \
-              ".[] | select(.category.name == \"${CAT}\") | @base64" \
+              --arg cat "$CAT" '.[] | select(.category.name == $cat) | @base64' \
             | while IFS= read -r row; do
                 decoded=$(printf '%s' "$row" | base64 -d)
                 num=$(printf '%s' "$decoded" | jq -r '.number')

--- a/.github/workflows/discussion-to-issue.yml
+++ b/.github/workflows/discussion-to-issue.yml
@@ -41,13 +41,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-        run: |
-          bash .github/scripts/discussion-to-issue.sh \
-            "${{ github.event.discussion.number }}" \
-            "${{ github.event.discussion.title }}" \
-            "${{ github.event.discussion.html_url }}" \
-            "${{ github.event.discussion.user.login }}" \
-            "${{ github.event.discussion.category.name }}"
+          DISC_NUMBER: ${{ github.event.discussion.number }}
+          DISC_TITLE: ${{ github.event.discussion.title }}
+          DISC_URL: ${{ github.event.discussion.html_url }}
+          DISC_AUTHOR: ${{ github.event.discussion.user.login }}
+          DISC_CATEGORY: ${{ github.event.discussion.category.name }}
+        run: bash .github/scripts/discussion-to-issue.sh
 
   # ── Manual /to-issue command from maintainers ────────────────────
   manual-promote:
@@ -67,13 +66,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           MANUAL: 'true'
-        run: |
-          bash .github/scripts/discussion-to-issue.sh \
-            "${{ github.event.discussion.number }}" \
-            "${{ github.event.discussion.title }}" \
-            "${{ github.event.discussion.html_url }}" \
-            "${{ github.event.discussion.user.login }}" \
-            "${{ github.event.discussion.category.name }}"
+          DISC_NUMBER: ${{ github.event.discussion.number }}
+          DISC_TITLE: ${{ github.event.discussion.title }}
+          DISC_URL: ${{ github.event.discussion.html_url }}
+          DISC_AUTHOR: ${{ github.event.discussion.user.login }}
+          DISC_CATEGORY: ${{ github.event.discussion.category.name }}
+        run: bash .github/scripts/discussion-to-issue.sh
 
   # ── Backfill: scheduled + manual ─────────────────────────────────
   backfill:
@@ -108,8 +106,9 @@ jobs:
                 url=$(printf '%s' "$decoded" | jq -r '.html_url')
                 author=$(printf '%s' "$decoded" | jq -r '.user.login')
 
-                bash .github/scripts/discussion-to-issue.sh \
-                  "$num" "$title" "$url" "$author" "$CAT" \
+                DISC_NUMBER="$num" DISC_TITLE="$title" DISC_URL="$url" \
+                  DISC_AUTHOR="$author" DISC_CATEGORY="$CAT" \
+                  bash .github/scripts/discussion-to-issue.sh \
                   || echo "  (skipped or failed)"
 
                 sleep 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,10 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Extract tag from PR body and create
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          TAG=$(echo "${{ github.event.pull_request.body }}" | grep -oP '(?<=<!-- release-tag:)(v[^ ]+)(?= -->)' || true)
+          TAG=$(printf '%s' "$PR_BODY" | grep -oP '(?<=<!-- release-tag:)(v[^ ]+)(?= -->)' || true)
           if [ -z "$TAG" ]; then
             echo "No release-tag marker found, skipping"
             exit 0


### PR DESCRIPTION
## Summary

- **#3676** — `release.yml` `tag_on_merge` job: `${{ github.event.pull_request.body }}` was interpolated directly inside a `run:` bash block with `HOMEBREW_TAP_TOKEN` in scope. Fixed by routing the PR body through an `env: PR_BODY:` map and reading it as `$PR_BODY` in the shell.

- **#3807** — `discussion-to-issue.yml`: discussion title, author login, URL, and number were passed as positional arguments via `${{ }}` expressions directly inside `run:` blocks (both `auto-promote` and `manual-promote` jobs). Fixed by moving all untrusted values to `env:` map entries (`DISC_TITLE`, `DISC_AUTHOR`, etc.) and updating `discussion-to-issue.sh` to read from environment variables instead of `$1-$5`.

- **#3809** — All `npm publish` calls in `release.yml` already include `--ignore-scripts` (`sdk_javascript` and `sdk_cli_npm` jobs, lines 1695/1711/1749). No change required.

- **#3870** — `dependabot.yml` was missing npm/pip coverage. Added `npm` entries for `crates/librefang-api/dashboard`, `packages/cli-npm`, and `sdk/javascript`; added `pip` entry for `sdk/python`. All four directories were verified to exist with the appropriate manifest files.

## Test plan

- [ ] Verify `release.yml` `tag_on_merge` job no longer contains any `${{ github.event.pull_request.* }}` inside `run:` blocks
- [ ] Verify `discussion-to-issue.yml` no longer passes any `${{ github.event.discussion.* }}` as shell arguments
- [ ] Verify `discussion-to-issue.sh` validates all required env vars with `: "${VAR:?}"` guards
- [ ] Confirm `dependabot.yml` now lists npm entries for the three JS directories and pip for the Python SDK
- [ ] Confirm CI passes on this branch

Closes #3676, #3807, #3870