### PR TITLE
fix(api): auth-gate logs/stream SSE, set 0600 on sessions file, enforce WS origin, tighten CSP

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -609,8 +609,7 @@ pub async fn auth(
     // NOTE: /api/logs/stream (SSE) is intentionally excluded from the public
     // allowlist. It streams real-time audit/log events and must require auth
     // the same way every other sensitive read endpoint does. (#3593/#3680)
-    let dashboard_read_public =
-        is_get && (dashboard_read_exact || dashboard_read_prefix);
+    let dashboard_read_public = is_get && (dashboard_read_exact || dashboard_read_prefix);
 
     let enforce_auth_on_reads = auth_state.require_auth_for_reads && auth_configured;
 

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -606,8 +606,11 @@ pub async fn auth(
         || path.starts_with("/api/approvals/")
         || path.starts_with("/api/hands/")
         || path.starts_with("/api/cron/");
+    // NOTE: /api/logs/stream (SSE) is intentionally excluded from the public
+    // allowlist. It streams real-time audit/log events and must require auth
+    // the same way every other sensitive read endpoint does. (#3593/#3680)
     let dashboard_read_public =
-        (is_get && (dashboard_read_exact || dashboard_read_prefix)) || path == "/api/logs/stream"; // SSE stream, read-only
+        is_get && (dashboard_read_exact || dashboard_read_prefix);
 
     let enforce_auth_on_reads = auth_state.require_auth_for_reads && auth_configured;
 
@@ -860,9 +863,14 @@ pub async fn security_headers(request: Request<Body>, next: Next) -> Response<Bo
     headers.insert("x-frame-options", "DENY".parse().unwrap());
     headers.insert("x-xss-protection", "1; mode=block".parse().unwrap());
     // All JS/CSS is bundled inline — only external resource is Google Fonts.
+    // SECURITY: 'unsafe-eval' removed from script-src (#3732). 'unsafe-inline'
+    // removed from script-src as well; the bundled SPA does not need it.
+    // 'unsafe-inline' is kept in style-src only because the React/Vite bundle
+    // injects CSS-in-JS style tags at runtime and removing it would break the
+    // dashboard UI until a nonce-based approach is wired through the build.
     headers.insert(
         "content-security-policy",
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; font-src 'self' https://fonts.gstatic.com; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; font-src 'self' https://fonts.gstatic.com; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
             .parse()
             .unwrap(),
     );

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -767,6 +767,9 @@ fn load_sessions(
 }
 
 /// Persist active sessions to disk so they survive daemon restarts.
+///
+/// SECURITY: The file is written with owner-only permissions (0600) so that
+/// bearer tokens stored in it cannot be read by other local users (#3589/#3725).
 fn save_sessions(
     home_dir: &std::path::Path,
     sessions: &std::collections::HashMap<String, crate::password_hash::SessionToken>,
@@ -776,6 +779,10 @@ fn save_sessions(
         Ok(content) => {
             if let Err(e) = std::fs::write(&path, content) {
                 tracing::warn!("Failed to persist sessions: {e}");
+            } else {
+                // Restrict to owner-read/write only so bearer tokens are not
+                // world-readable on multi-user systems.
+                restrict_permissions(&path);
             }
         }
         Err(e) => tracing::warn!("Failed to serialize sessions: {e}"),

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -385,7 +385,9 @@ pub async fn agent_ws(
         let allow_remote = std::env::var("LIBREFANG_ALLOW_NO_AUTH")
             .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
             .unwrap_or(false);
-        if let Err(reason) = validate_ws_origin(&headers, listen_port, &cfg.cors_origin, allow_remote) {
+        if let Err(reason) =
+            validate_ws_origin(&headers, listen_port, &cfg.cors_origin, allow_remote)
+        {
             warn!(reason = %reason, "WebSocket upgrade rejected: Origin validation failed");
             return axum::http::StatusCode::FORBIDDEN.into_response();
         }

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -371,6 +371,26 @@ pub async fn agent_ws(
         }
     }
 
+    // SECURITY: Validate the Origin header to prevent cross-site WebSocket
+    // hijacking (#3731). validate_ws_origin is defined in this module but was
+    // previously never called from the upgrade handler. Non-browser clients
+    // (curl, native apps) omit Origin and are allowed through unconditionally.
+    {
+        let cfg = state.kernel.config_ref();
+        let listen_port = cfg
+            .api_listen
+            .parse::<std::net::SocketAddr>()
+            .ok()
+            .map(|a| a.port());
+        let allow_remote = std::env::var("LIBREFANG_ALLOW_NO_AUTH")
+            .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+            .unwrap_or(false);
+        if let Err(reason) = validate_ws_origin(&headers, listen_port, &cfg.cors_origin, allow_remote) {
+            warn!(reason = %reason, "WebSocket upgrade rejected: Origin validation failed");
+            return axum::http::StatusCode::FORBIDDEN.into_response();
+        }
+    }
+
     // SECURITY: Enforce per-IP WebSocket connection limit
     let ip = addr.ip();
     let max_ws_per_ip = state.kernel.config_ref().rate_limit.max_ws_per_ip;


### PR DESCRIPTION
## Summary

- **#3593/#3680 — `/api/logs/stream` SSE unauthenticated**: Removed `/api/logs/stream` from the `dashboard_read_public` allowlist in `middleware.rs`. The SSE endpoint was unconditionally public (the old code used `|| path == "/api/logs/stream"` outside the `is_get` condition), bypassing `require_auth_for_reads` entirely. It now falls through to the normal bearer-token gate.

- **#3589/#3725 — `sessions.json` written without 0600 permissions**: Added a `restrict_permissions()` call (already defined in `server.rs` for `daemon.json`) immediately after the successful `fs::write` in `save_sessions()`. On Unix this sets the file to owner-read/write only; on non-Unix it is a no-op.

- **#3731 — `validate_ws_origin` dead code**: Wired the existing `validate_ws_origin()` function into the `agent_ws()` WebSocket upgrade handler, immediately after the auth check. The listen port is parsed from `config.api_listen`; the extra origins list comes from `config.cors_origin` (same source the HTTP CORS layer uses); `allow_remote` mirrors the `LIBREFANG_ALLOW_NO_AUTH` env var already consulted elsewhere in the handler. Non-browser clients that omit `Origin` are still allowed through unconditionally.

- **#3732 — CSP allows `'unsafe-inline'` + `'unsafe-eval'`**: Removed both `'unsafe-inline'` and `'unsafe-eval'` from `script-src`. The bundled Vite SPA does not need either for script execution. `'unsafe-inline'` is retained in `style-src` only because the React/CSS-in-JS runtime injects `<style>` tags dynamically; removing it there would break the dashboard until a nonce is threaded through the build pipeline.

## Test plan

- [ ] `GET /api/logs/stream` without a bearer token returns 401 when `api_key` is configured
- [ ] `GET /api/logs/stream` with a valid bearer token returns the SSE stream
- [ ] After dashboard login, `~/.librefang/data/sessions.json` has mode `0600` on Linux/macOS
- [ ] WebSocket upgrade from `http://evil.example` is rejected with 403; from `http://localhost:<port>` succeeds
- [ ] Browser DevTools Security panel shows `script-src 'self'` (no `unsafe-eval` / `unsafe-inline`)