### PR TITLE
fix(mcp): SSRF guard for OAuth discovery, validate token_endpoint domain, per-flow PKCE state, auth-gate callback

### DIFF
--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -327,26 +327,27 @@ pub async fn auth_start(
         }
     }
 
-    // Generate PKCE challenge and state.
-    // Embed the MCP server name in the state so the callback can verify the state
-    // was issued for exactly this server — prevents cross-flow CSRF where state
-    // from server A is replayed against server B's callback.
-    // Format: "{url-safe-server-name}:{random-nonce}"
+    // Generate PKCE challenge, state, and a unique flow ID.
+    //
+    // #3727: Per-flow vault keys prevent concurrent auth flows to the same
+    // server from clobbering each other's PKCE state.  The flow_id is embedded
+    // in the OAuth `state` parameter as `{flow_id}.{random_state}` so the
+    // callback can look up the correct vault entry.
+    //
+    // This supersedes the earlier per-server `{server_name}:{random}` binding
+    // (#3911) — per-flow IDs subsume the per-server protection while also
+    // allowing multiple concurrent flows against the same server.
+    let flow_id = mcp_oauth::generate_flow_id();
     let (pkce_verifier, pkce_challenge) = mcp_oauth::generate_pkce();
-    let pkce_state = format!(
-        "{}:{}",
-        percent_encode_param(&name),
-        mcp_oauth::generate_state()
-    );
+    let pkce_random = mcp_oauth::generate_state();
+    // Combined state sent to the OAuth server: "{flow_id}.{random_state}"
+    let pkce_state = format!("{flow_id}.{pkce_random}");
 
-    // Wipe any abandoned prior-flow state before storing new PKCE values.
-    for field in &["pkce_verifier", "pkce_state", "redirect_uri"] {
-        let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(&server_url, field));
-    }
-
-    // Store PKCE state in vault for the callback to retrieve
+    // Store PKCE state in vault under per-flow keys for the callback to retrieve.
+    let flow_vault_key =
+        |field: &str| KernelOAuthProvider::vault_key(&format!("{server_url}:{flow_id}"), field);
     let store = |field: &str, value: &str| -> Result<(), String> {
-        provider.vault_set(&KernelOAuthProvider::vault_key(&server_url, field), value)
+        provider.vault_set(&flow_vault_key(field), value)
     };
     if let Err(e) = store("pkce_verifier", &pkce_verifier) {
         tracing::error!(error = %e, "Failed to store PKCE verifier in vault");
@@ -435,30 +436,30 @@ pub async fn auth_callback(
     Path(name): Path<String>,
     axum::extract::Query(params): axum::extract::Query<AuthCallbackParams>,
 ) -> Response {
-    // Handle error response from authorization server
-    if let Some(ref error) = params.error {
-        let desc = params.error_description.as_deref().unwrap_or("");
-        let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
-        auth_states.insert(
-            name.clone(),
-            McpAuthState::Error {
-                message: format!("{error}: {desc}"),
-            },
-        );
-        return auth_failed(format!("{error}: {desc}"));
-    }
-
-    let code = match params.code {
-        Some(ref c) => c.clone(),
-        None => {
-            return auth_failed("Missing authorization code.");
-        }
-    };
-
+    // #3730: Validate the `state` parameter before doing anything else.
+    //
+    // The state must be present and in the form "{flow_id}.{random_nonce}".
+    // This proves the caller initiated a flow via auth_start — the nonce is
+    // stored in the vault keyed by flow_id and is never sent over any
+    // side-channel.  Validating here prevents unauthenticated callers from
+    // probing the endpoint or mutating server-side auth state.
     let received_state = match params.state {
         Some(ref s) => s.clone(),
         None => {
             return auth_failed("Missing state parameter.");
+        }
+    };
+
+    // #3727: Extract the flow_id from the state parameter.
+    // The state format set by auth_start is "{flow_id}.{random_state}".
+    // A missing dot means this callback was not initiated by this daemon.
+    let flow_id = match received_state.split_once('.') {
+        Some((fid, _)) if !fid.is_empty() => fid.to_string(),
+        _ => {
+            return auth_failed(
+                "Malformed state parameter — no valid flow ID found. \
+                 This callback may not have been initiated by this server.",
+            );
         }
     };
 
@@ -477,10 +478,12 @@ pub async fn auth_callback(
         }
     };
 
-    // Load stored PKCE state from vault
+    // Load stored PKCE state from vault using the per-flow key (#3727).
     let provider = KernelOAuthProvider::new(state.kernel.home_dir().to_path_buf());
-    let load =
-        |field: &str| provider.vault_get(&KernelOAuthProvider::vault_key(&server_url, field));
+    let flow_key_prefix = format!("{server_url}:{flow_id}");
+    let load = |field: &str| {
+        provider.vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field))
+    };
 
     let stored_state = match load("pkce_state") {
         Some(s) => s,
@@ -488,30 +491,30 @@ pub async fn auth_callback(
             tracing::error!(
                 server = %name,
                 server_url = %server_url,
-                "PKCE state not found in vault — vault may not be initialized or \
-                 LIBREFANG_VAULT_KEY not set"
+                flow_id = %flow_id,
+                "PKCE state not found in vault — vault may not be initialized, \
+                 LIBREFANG_VAULT_KEY not set, or unknown flow_id"
             );
             return auth_failed(
-                "No pending auth flow found (PKCE state missing from vault). \
+                "No pending auth flow found for this flow ID (PKCE state missing from vault). \
                  Check that LIBREFANG_VAULT_KEY is set in your environment.",
             );
         }
     };
 
-    // Validate state using constant-time comparison to prevent timing attacks.
-    // The state format is "{url-safe-server-name}:{random-nonce}" — the prefix
-    // binds the callback to the MCP server that initiated the flow.
-    let expected_prefix = format!("{}:", percent_encode_param(&name));
-    let prefix_ok = received_state.starts_with(&expected_prefix);
+    // #3730: The stored state encodes the flow_id and a random nonce; the
+    // received state must match exactly, which proves the caller initiated this
+    // specific flow.  This subsumes the earlier server-name prefix binding
+    // (#3911) — the per-flow vault key + exact-match state already binds each
+    // callback to one specific in-flight authorization.
+    // Use constant-time comparison to prevent timing attacks.
     let received_bytes = received_state.as_bytes();
     let stored_bytes = stored_state.as_bytes();
     let nonce_match = received_bytes.len() == stored_bytes.len()
         && bool::from(received_bytes.ct_eq(stored_bytes));
-    if !prefix_ok || !nonce_match {
+    if !nonce_match {
         tracing::warn!(
             server = %name,
-            prefix_ok,
-            nonce_match,
             "OAuth state validation failed — possible CSRF or cross-flow replay"
         );
         let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
@@ -523,6 +526,29 @@ pub async fn auth_callback(
         );
         return auth_failed("State parameter mismatch. This may indicate a CSRF attack.");
     }
+
+    // State is valid — now safe to inspect the OAuth response from the provider.
+    // Handling the `error` param here (after state validation) prevents
+    // unauthenticated callers from injecting arbitrary error messages into
+    // auth state (#3730).
+    if let Some(ref error) = params.error {
+        let desc = params.error_description.as_deref().unwrap_or("");
+        let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
+        auth_states.insert(
+            name.clone(),
+            McpAuthState::Error {
+                message: format!("{error}: {desc}"),
+            },
+        );
+        return auth_failed(format!("{error}: {desc}"));
+    }
+
+    let code = match params.code {
+        Some(ref c) => c.clone(),
+        None => {
+            return auth_failed("Missing authorization code.");
+        }
+    };
 
     let pkce_verifier = match load("pkce_verifier") {
         Some(v) => v,
@@ -637,9 +663,9 @@ pub async fn auth_callback(
         tracing::warn!(error = %e, "Failed to store OAuth tokens");
     }
 
-    // Clean up one-time PKCE values from vault
-    for field in &["pkce_verifier", "pkce_state", "redirect_uri"] {
-        let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(&server_url, field));
+    // Clean up one-time PKCE values from vault (per-flow key — #3727).
+    for field in &["pkce_verifier", "pkce_state", "redirect_uri", "token_endpoint", "client_id"] {
+        let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(&flow_key_prefix, field));
     }
 
     // Retry the MCP connection now that we have tokens.

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -481,9 +481,8 @@ pub async fn auth_callback(
     // Load stored PKCE state from vault using the per-flow key (#3727).
     let provider = KernelOAuthProvider::new(state.kernel.home_dir().to_path_buf());
     let flow_key_prefix = format!("{server_url}:{flow_id}");
-    let load = |field: &str| {
-        provider.vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field))
-    };
+    let load =
+        |field: &str| provider.vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field));
 
     let stored_state = match load("pkce_state") {
         Some(s) => s,
@@ -664,7 +663,13 @@ pub async fn auth_callback(
     }
 
     // Clean up one-time PKCE values from vault (per-flow key — #3727).
-    for field in &["pkce_verifier", "pkce_state", "redirect_uri", "token_endpoint", "client_id"] {
+    for field in &[
+        "pkce_verifier",
+        "pkce_state",
+        "redirect_uri",
+        "token_endpoint",
+        "client_id",
+    ] {
         let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(&flow_key_prefix, field));
     }
 

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -237,13 +237,12 @@ pub fn validate_metadata_endpoints(
     metadata: &OAuthMetadata,
     server_url: &str,
 ) -> Result<(), String> {
-    let server_parsed = Url::parse(server_url)
-        .map_err(|e| format!("Invalid server URL: {e}"))?;
+    let server_parsed = Url::parse(server_url).map_err(|e| format!("Invalid server URL: {e}"))?;
     let server_origin = server_parsed.origin();
 
     let check = |endpoint: &str, label: &str| -> Result<(), String> {
-        let parsed = Url::parse(endpoint)
-            .map_err(|e| format!("Invalid {label} URL '{endpoint}': {e}"))?;
+        let parsed =
+            Url::parse(endpoint).map_err(|e| format!("Invalid {label} URL '{endpoint}': {e}"))?;
         if parsed.origin() != server_origin {
             return Err(format!(
                 "OAuth metadata endpoint domain mismatch: {label} '{endpoint}' \
@@ -706,10 +705,10 @@ mod tests {
 
     #[test]
     fn test_well_known_url_http() {
-        let url = well_known_url("http://localhost:3000/mcp").unwrap();
+        let url = well_known_url("http://mcp.example.com:3000/mcp").unwrap();
         assert_eq!(
             url,
-            "http://localhost:3000/.well-known/oauth-authorization-server"
+            "http://mcp.example.com:3000/.well-known/oauth-authorization-server"
         );
     }
 
@@ -914,7 +913,10 @@ mod tests {
             err.contains("domain mismatch"),
             "error should mention domain mismatch: {err}"
         );
-        assert!(err.contains("token_endpoint"), "error should name the field: {err}");
+        assert!(
+            err.contains("token_endpoint"),
+            "error should name the field: {err}"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -215,10 +215,65 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
 /// Construct the `.well-known/oauth-authorization-server` URL for a given server URL.
 ///
 /// Parses the URL, extracts the origin, and appends the well-known path.
+/// Returns `None` if the origin resolves to a private/loopback/link-local
+/// host (SSRF guard — see `is_ssrf_blocked_host`).
 pub fn well_known_url(server_url: &str) -> Option<String> {
     let parsed = Url::parse(server_url).ok()?;
+    // Block SSRF before constructing the well-known URL.
+    let host = parsed.host_str()?;
+    if is_ssrf_blocked_host(host) {
+        return None;
+    }
     let origin = parsed.origin().unicode_serialization();
     Some(format!("{}/.well-known/oauth-authorization-server", origin))
+}
+
+/// Verify that every OAuth endpoint URL returned by a metadata document
+/// shares the same scheme and host (origin) as `server_url`.
+///
+/// This prevents a rogue metadata document from redirecting the token
+/// exchange or authorization flow to an attacker-controlled host.
+pub fn validate_metadata_endpoints(
+    metadata: &OAuthMetadata,
+    server_url: &str,
+) -> Result<(), String> {
+    let server_parsed = Url::parse(server_url)
+        .map_err(|e| format!("Invalid server URL: {e}"))?;
+    let server_origin = server_parsed.origin();
+
+    let check = |endpoint: &str, label: &str| -> Result<(), String> {
+        let parsed = Url::parse(endpoint)
+            .map_err(|e| format!("Invalid {label} URL '{endpoint}': {e}"))?;
+        if parsed.origin() != server_origin {
+            return Err(format!(
+                "OAuth metadata endpoint domain mismatch: {label} '{endpoint}' \
+                 does not share the same scheme+host as the MCP server '{server_url}'"
+            ));
+        }
+        Ok(())
+    };
+
+    check(&metadata.authorization_endpoint, "authorization_endpoint")?;
+    check(&metadata.token_endpoint, "token_endpoint")?;
+    if let Some(ref reg) = metadata.registration_endpoint {
+        check(reg, "registration_endpoint")?;
+    }
+    Ok(())
+}
+
+/// Generate a unique OAuth flow ID.
+///
+/// Returns 12 random bytes encoded as lowercase hex (24 chars), which is
+/// short enough to fit comfortably in a URL `state` parameter while providing
+/// ~96 bits of entropy — sufficient to prevent cross-flow confusion.
+pub fn generate_flow_id() -> String {
+    let mut buf = [0u8; 12];
+    rand::fill(&mut buf);
+    buf.iter().fold(String::with_capacity(24), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -372,12 +427,17 @@ pub async fn discover_oauth_metadata(
                     if let Ok(body) = resp.text().await {
                         match parse_authorization_server_metadata(&body, server_url) {
                             Ok(meta) => {
-                                let meta = if let Some(cfg) = config {
-                                    merge_metadata_with_config(meta, cfg)
+                                // #3713: Verify discovered endpoints share the server's origin.
+                                if let Err(e) = validate_metadata_endpoints(&meta, server_url) {
+                                    warn!(error = %e, "Tier 1: endpoint domain mismatch — rejecting metadata");
                                 } else {
-                                    meta
-                                };
-                                return Ok(meta);
+                                    let meta = if let Some(cfg) = config {
+                                        merge_metadata_with_config(meta, cfg)
+                                    } else {
+                                        meta
+                                    };
+                                    return Ok(meta);
+                                }
                             }
                             Err(e) => {
                                 warn!(error = %e, "Tier 1: failed to parse metadata");
@@ -396,6 +456,7 @@ pub async fn discover_oauth_metadata(
     }
 
     // Tier 2: .well-known URL
+    // well_known_url() already guards against SSRF (private/loopback hosts) — #3592.
     if let Some(wk_url) = well_known_url(server_url) {
         debug!(url = %wk_url, "Tier 2: fetching .well-known metadata");
         match client.get(&wk_url).send().await {
@@ -403,12 +464,17 @@ pub async fn discover_oauth_metadata(
                 if let Ok(body) = resp.text().await {
                     match parse_authorization_server_metadata(&body, server_url) {
                         Ok(meta) => {
-                            let meta = if let Some(cfg) = config {
-                                merge_metadata_with_config(meta, cfg)
+                            // #3713: Verify discovered endpoints share the server's origin.
+                            if let Err(e) = validate_metadata_endpoints(&meta, server_url) {
+                                warn!(error = %e, "Tier 2: endpoint domain mismatch — rejecting metadata");
                             } else {
-                                meta
-                            };
-                            return Ok(meta);
+                                let meta = if let Some(cfg) = config {
+                                    merge_metadata_with_config(meta, cfg)
+                                } else {
+                                    meta
+                                };
+                                return Ok(meta);
+                            }
                         }
                         Err(e) => {
                             warn!(error = %e, "Tier 2: failed to parse .well-known metadata");
@@ -772,5 +838,147 @@ mod tests {
     fn test_parse_authorization_server_metadata_invalid_json() {
         let result = parse_authorization_server_metadata("not json", "https://server.com/mcp");
         assert!(result.is_err());
+    }
+
+    // -- #3592: well_known_url SSRF guard tests --
+
+    #[test]
+    fn well_known_url_blocks_loopback_ipv4() {
+        // A server_url pointing to 127.x must not yield a well-known fetch URL.
+        assert!(well_known_url("http://127.0.0.1:8080/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_private_10_range() {
+        assert!(well_known_url("http://10.0.0.1/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_private_172_range() {
+        assert!(well_known_url("http://172.16.0.1/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_private_192_168_range() {
+        assert!(well_known_url("http://192.168.1.1/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_link_local() {
+        assert!(well_known_url("http://169.254.169.254/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_localhost_hostname() {
+        assert!(well_known_url("http://localhost/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_allows_public_host() {
+        let url = well_known_url("https://my-mcp-server.example.com/mcp").unwrap();
+        assert_eq!(
+            url,
+            "https://my-mcp-server.example.com/.well-known/oauth-authorization-server"
+        );
+    }
+
+    // -- #3713: validate_metadata_endpoints domain-mismatch tests --
+
+    #[test]
+    fn validate_metadata_endpoints_accepts_same_origin() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://example.com/auth".to_string(),
+            token_endpoint: "https://example.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: Some("https://example.com/register".to_string()),
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        assert!(validate_metadata_endpoints(&meta, "https://example.com/mcp").is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_cross_domain_token_endpoint() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://example.com/auth".to_string(),
+            token_endpoint: "https://evil.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://example.com/mcp").unwrap_err();
+        assert!(
+            err.contains("domain mismatch"),
+            "error should mention domain mismatch: {err}"
+        );
+        assert!(err.contains("token_endpoint"), "error should name the field: {err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_cross_domain_auth_endpoint() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://evil.com/auth".to_string(),
+            token_endpoint: "https://example.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://example.com/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+        assert!(err.contains("authorization_endpoint"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_cross_domain_registration_endpoint() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://example.com/auth".to_string(),
+            token_endpoint: "https://example.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: Some("https://attacker.net/register".to_string()),
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://example.com/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+        assert!(err.contains("registration_endpoint"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_no_registration_endpoint_ok() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://example.com/auth".to_string(),
+            token_endpoint: "https://example.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        assert!(validate_metadata_endpoints(&meta, "https://example.com/mcp").is_ok());
+    }
+
+    // -- #3727: generate_flow_id tests --
+
+    #[test]
+    fn generate_flow_id_is_24_hex_chars() {
+        let id = generate_flow_id();
+        assert_eq!(id.len(), 24, "expected 24 hex chars, got {id}");
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit()),
+            "expected all hex digits: {id}"
+        );
+    }
+
+    #[test]
+    fn generate_flow_id_is_unique() {
+        let ids: Vec<String> = (0..10).map(|_| generate_flow_id()).collect();
+        let unique: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
+        assert_eq!(unique.len(), ids.len(), "duplicate flow IDs generated");
     }
 }


### PR DESCRIPTION
## Summary

- **#3592** — Tier 2 `.well-known` OAuth discovery now validates the host via `is_ssrf_blocked_host()` before constructing the fetch URL. `well_known_url()` returns `None` for loopback (127.x, ::1), private (10.x, 172.16-31.x, 192.168.x), link-local (169.254.x), and blocked hostnames.
- **#3713** — New `validate_metadata_endpoints()` checks that `authorization_endpoint`, `token_endpoint`, and `registration_endpoint` from a fetched metadata document all share the same scheme+host origin as the original MCP server URL. Mismatches are rejected with "OAuth metadata endpoint domain mismatch". Applied to both Tier 1 and Tier 2 discovery paths.
- **#3727** — `auth_start` now generates a unique `flow_id` (24-char hex, ~96 bits entropy) for each OAuth flow and stores PKCE state in vault under `{server_url}:{flow_id}` instead of the shared `{server_url}` key. The `flow_id` is embedded in the OAuth `state` parameter as `{flow_id}.{random_nonce}`. The callback parses `flow_id` from `state` to look up the correct per-flow vault entry, so concurrent auth flows to the same server can no longer clobber each other.
- **#3730** — `auth_callback` now validates the `state` parameter before performing any side effects. The handler requires `state` to be present and to match the vault-stored nonce for the given `flow_id` (constant-time comparison). Only after this proof-of-initiation check does the handler process the OAuth provider's `error` or `code` parameters. This prevents unauthenticated callers from injecting error messages into `mcp_auth_states` or probing in-flight flows.

## Changed files

- `crates/librefang-runtime-mcp/src/mcp_oauth.rs` — SSRF guard in `well_known_url`, new `validate_metadata_endpoints`, new `generate_flow_id`, domain validation wired into `discover_oauth_metadata`, regression tests for all three.
- `crates/librefang-api/src/routes/mcp_auth.rs` — per-flow PKCE vault keys in `auth_start`, state-first validation + per-flow vault lookup in `auth_callback`, cleanup uses per-flow key prefix.

## Test plan

- [ ] `cargo test -p librefang-runtime-mcp` — new tests for `well_known_url` SSRF blocking (loopback, private, link-local ranges), `validate_metadata_endpoints` domain mismatch (token, auth, registration endpoints), `generate_flow_id` format and uniqueness
- [ ] Existing `extract_metadata_url` SSRF tests still pass
- [ ] Manual: start two concurrent `POST /api/mcp/servers/{name}/auth/start` flows and confirm both callbacks complete without state corruption
- [ ] Manual: callback with no `state` param returns 400 without touching auth state
- [ ] Manual: callback with a valid `state` for a different flow returns CSRF error

Closes #3592, #3713, #3727, #3730