### PR TITLE
fix(wasm,api,runtime): WASM env blocklist, auth-gate approvals/session, restrict config/set paths, apply_patch readonly check

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -611,8 +611,8 @@ pub async fn auth(
     // paths that do not contain sensitive payload detail (e.g. the
     // individual approval GET by id), but the /session/ sub-tree is
     // explicitly excluded here and falls through to the normal auth gate.
-    let approvals_prefix_public = path.starts_with("/api/approvals/")
-        && !path.starts_with("/api/approvals/session/");
+    let approvals_prefix_public =
+        path.starts_with("/api/approvals/") && !path.starts_with("/api/approvals/session/");
     let dashboard_read_prefix = path.starts_with("/api/budget/agents/")
         || approvals_prefix_public
         || path.starts_with("/api/hands/")

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -605,8 +605,16 @@ pub async fn auth(
             | "/api/workflows"
             | "/api/auto-dream/status"
     );
+    // SECURITY #3367: /api/approvals/session/{id} exposes pending shell
+    // commands and must require authentication.  The broader
+    // /api/approvals/* prefix is kept public for the dashboard polling
+    // paths that do not contain sensitive payload detail (e.g. the
+    // individual approval GET by id), but the /session/ sub-tree is
+    // explicitly excluded here and falls through to the normal auth gate.
+    let approvals_prefix_public = path.starts_with("/api/approvals/")
+        && !path.starts_with("/api/approvals/session/");
     let dashboard_read_prefix = path.starts_with("/api/budget/agents/")
-        || path.starts_with("/api/approvals/")
+        || approvals_prefix_public
         || path.starts_with("/api/hands/")
         || path.starts_with("/api/cron/");
     // NOTE: /api/logs/stream (SSE) is intentionally excluded from the public
@@ -2056,6 +2064,71 @@ mod tests {
             response.status(),
             StatusCode::OK,
             "valid bearer token must allow access to /a2a/tasks/{{id}}"
+        );
+    }
+
+    /// Regression: #3367 — GET /api/approvals/session/{id} used to be
+    /// publicly readable via the `/api/approvals/` prefix in
+    /// `dashboard_read_prefix`. That endpoint returns pending approval
+    /// details including shell commands, so it must require authentication
+    /// even when `require_auth_for_reads` is off.
+    ///
+    /// The broader `/api/approvals/{id}` path (individual approval GET) is
+    /// still in the public bucket; only the `/session/` sub-tree is locked.
+    #[tokio::test]
+    async fn approvals_session_get_requires_auth() {
+        // Auth state: api_key configured, require_auth_for_reads OFF — this
+        // is the scenario where the bug was exploitable.
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            require_auth_for_reads: false,
+            allow_no_auth: false,
+            audit_log: None,
+        };
+
+        let app = Router::new()
+            .route(
+                "/api/approvals/session/{id}",
+                get(|| async { "pending approvals" }),
+            )
+            .route("/api/approvals/{id}", get(|| async { "approval detail" }))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        // GET /api/approvals/session/{id} — must require auth.
+        let session_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/approvals/session/sess-abc-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            session_resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "/api/approvals/session/{{id}} must be auth-gated"
+        );
+
+        // GET /api/approvals/{id} — must still be accessible without auth
+        // (dashboard polling).
+        let detail_resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/approvals/some-approval-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            detail_resp.status(),
+            StatusCode::OK,
+            "/api/approvals/{{id}} should remain publicly readable"
         );
     }
 }

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1899,9 +1899,7 @@ pub async fn config_set(
         }
         for part in path.split('.') {
             if part.is_empty() {
-                return Err(format!(
-                    "config path '{path}' contains an empty segment"
-                ));
+                return Err(format!("config path '{path}' contains an empty segment"));
             }
             if !part
                 .chars()
@@ -2377,7 +2375,10 @@ mod config_key_path_validation_tests {
         assert!(validate("../secret").is_err(), "traversal with ..");
         assert!(validate("a..b").is_err(), "double dot in segment");
         assert!(validate("/etc/passwd").is_err(), "absolute unix path");
-        assert!(validate("\\Windows\\System32").is_err(), "absolute windows path");
+        assert!(
+            validate("\\Windows\\System32").is_err(),
+            "absolute windows path"
+        );
     }
 
     /// #3458 regression: special characters that could inject TOML structure

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1877,6 +1877,52 @@ pub async fn config_set(
         }
     };
 
+    // SECURITY #3458: Validate the config key path before touching any files.
+    // Each dot-separated component must only contain alphanumeric characters
+    // and underscores.  This prevents:
+    //   - Path traversal (e.g. "../secrets")
+    //   - Injection into structured TOML tables via special characters
+    //   - Empty segment attacks (e.g. "section..key")
+    //
+    // The path string itself is never used as a filesystem path — it is only
+    // used as a key chain into the in-memory TOML document — but we validate
+    // early to fail fast and to document the expected namespace.
+    fn validate_config_key_path(path: &str) -> Result<(), String> {
+        if path.is_empty() {
+            return Err("config path must not be empty".to_string());
+        }
+        // Reject absolute paths and filesystem separators outright.
+        if path.starts_with('/') || path.starts_with('\\') || path.contains("..") {
+            return Err(format!(
+                "config path '{path}' is not a valid key path (no filesystem separators allowed)"
+            ));
+        }
+        for part in path.split('.') {
+            if part.is_empty() {
+                return Err(format!(
+                    "config path '{path}' contains an empty segment"
+                ));
+            }
+            if !part
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                return Err(format!(
+                    "config path segment '{part}' contains disallowed characters \
+                     (only ASCII alphanumeric, '_', and '-' are permitted)"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    if let Err(e) = validate_config_key_path(&path) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"status": "error", "error": e})),
+        );
+    }
+
     let config_path = state.kernel.home_dir().join("config.toml");
     // Block path-traversal (`..`) but allow Windows drive-letter prefixes
     if config_path.file_name().and_then(|n| n.to_str()) != Some("config.toml")
@@ -2280,6 +2326,78 @@ async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
         "workflowCount": workflow_count,
         "webSearchAvailable": web_search_available,
     })
+}
+
+#[cfg(test)]
+mod config_key_path_validation_tests {
+    // Duplicate of the inline `validate_config_key_path` logic so the tests
+    // can exercise it without making it a public function.
+    fn validate(p: &str) -> Result<(), String> {
+        // Inline the same logic to avoid making the helper pub.
+        if p.is_empty() {
+            return Err("config path must not be empty".to_string());
+        }
+        if p.starts_with('/') || p.starts_with('\\') || p.contains("..") {
+            return Err(format!(
+                "config path '{p}' is not a valid key path (no filesystem separators allowed)"
+            ));
+        }
+        for part in p.split('.') {
+            if part.is_empty() {
+                return Err(format!("config path '{p}' contains an empty segment"));
+            }
+            if !part
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                return Err(format!(
+                    "config path segment '{part}' contains disallowed characters \
+                     (only ASCII alphanumeric, '_', and '-' are permitted)"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// #3458 regression: valid key paths must pass validation.
+    #[test]
+    fn valid_paths_accepted() {
+        assert!(validate("api_key").is_ok());
+        assert!(validate("section.key").is_ok());
+        assert!(validate("section.sub.key").is_ok());
+        assert!(validate("llm.model_alias").is_ok());
+        assert!(validate("queue.concurrency.trigger_lane").is_ok());
+        assert!(validate("key-with-dash").is_ok());
+    }
+
+    /// #3458 regression: filesystem-like paths must be rejected.
+    #[test]
+    fn traversal_paths_rejected() {
+        assert!(validate("").is_err(), "empty path");
+        assert!(validate("../secret").is_err(), "traversal with ..");
+        assert!(validate("a..b").is_err(), "double dot in segment");
+        assert!(validate("/etc/passwd").is_err(), "absolute unix path");
+        assert!(validate("\\Windows\\System32").is_err(), "absolute windows path");
+    }
+
+    /// #3458 regression: special characters that could inject TOML structure
+    /// must be rejected.
+    #[test]
+    fn special_chars_rejected() {
+        assert!(validate("section[0]").is_err(), "bracket injection");
+        assert!(validate("section = evil").is_err(), "equals sign");
+        assert!(validate("section\nkey").is_err(), "newline");
+        assert!(validate("section\0key").is_err(), "null byte");
+        assert!(validate("section key").is_err(), "space");
+    }
+
+    /// Empty segment (double dot) must be rejected.
+    #[test]
+    fn empty_segment_rejected() {
+        assert!(validate("a..b").is_err());
+        assert!(validate(".a").is_err());
+        assert!(validate("a.").is_err());
+    }
 }
 
 #[cfg(test)]

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -522,9 +522,7 @@ fn is_blocked_env_var(name: &str) -> bool {
         return true;
     }
     // Substring check — catches any var that smells like a credential.
-    BLOCKED_ENV_SUBSTRINGS
-        .iter()
-        .any(|sub| upper.contains(sub))
+    BLOCKED_ENV_SUBSTRINGS.iter().any(|sub| upper.contains(sub))
 }
 
 fn host_env_read(state: &GuestState, params: &serde_json::Value) -> serde_json::Value {

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -481,6 +481,52 @@ fn host_shell_exec(state: &GuestState, params: &serde_json::Value) -> serde_json
 // Environment (capability-checked)
 // ---------------------------------------------------------------------------
 
+/// Hard-coded blocklist of env var name substrings that WASM plugins can
+/// NEVER read, regardless of their declared `EnvRead` capability.
+///
+/// The check is case-insensitive. Any variable whose upper-cased name
+/// contains one of these substrings is silently suppressed — the caller
+/// receives `null` rather than the real value, and no error is returned so
+/// that well-behaved plugins can't probe for the existence of secrets.
+const BLOCKED_ENV_SUBSTRINGS: &[&str] = &[
+    "KEY",
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "CREDENTIAL",
+    "PRIVATE",
+];
+
+/// Specific full names (upper-cased) that are always blocked regardless of
+/// whether they contain a blocked substring. This catches names that are
+/// conventional secrets but do not contain any of the substrings above.
+const BLOCKED_ENV_EXACT: &[&str] = &[
+    "LIBREFANG_VAULT_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "GITHUB_TOKEN",
+    "NPM_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+];
+
+/// Returns `true` if the env var name matches the blocklist and must not be
+/// returned to a WASM guest.
+fn is_blocked_env_var(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    // Exact-name check (belt-and-suspenders — all of these also match a
+    // substring below, but an explicit list is easier to audit).
+    if BLOCKED_ENV_EXACT.contains(&upper.as_str()) {
+        return true;
+    }
+    // Substring check — catches any var that smells like a credential.
+    BLOCKED_ENV_SUBSTRINGS
+        .iter()
+        .any(|sub| upper.contains(sub))
+}
+
 fn host_env_read(state: &GuestState, params: &serde_json::Value) -> serde_json::Value {
     let name = match params.get("name").and_then(|n| n.as_str()) {
         Some(n) => n,
@@ -488,6 +534,12 @@ fn host_env_read(state: &GuestState, params: &serde_json::Value) -> serde_json::
     };
     if let Err(e) = check_capability(&state.capabilities, &Capability::EnvRead(name.to_string())) {
         return e;
+    }
+    // SECURITY: Never expose secrets to WASM guests even when the capability
+    // grants wildcard access.  Silently return null so the caller cannot
+    // distinguish "blocked" from "variable not set".
+    if is_blocked_env_var(name) {
+        return json!({"ok": null});
     }
     match std::env::var(name) {
         Ok(val) => json!({"ok": val}),
@@ -737,6 +789,73 @@ mod tests {
         let state = test_state(vec![Capability::EnvRead("PATH".to_string())]);
         let result = host_env_read(&state, &json!({"name": "PATH"}));
         assert!(result.get("ok").is_some(), "Expected ok: {:?}", result);
+    }
+
+    /// Regression: #3362 — a WASM guest with `EnvRead("*")` must not be able
+    /// to read secrets even with a wildcard capability.  The blocklist must
+    /// suppress any variable whose name contains KEY, SECRET, TOKEN, PASSWORD,
+    /// CREDENTIAL, or PRIVATE (case-insensitive).
+    #[tokio::test]
+    async fn test_env_read_blocklist_suppresses_secrets() {
+        let state = test_state(vec![Capability::EnvRead("*".to_string())]);
+
+        let blocked_names = [
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GROQ_API_KEY",
+            "GEMINI_API_KEY",
+            "LIBREFANG_VAULT_KEY",
+            "GITHUB_TOKEN",
+            "NPM_TOKEN",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "MY_CUSTOM_SECRET",
+            "DATABASE_PASSWORD",
+            "DEPLOY_CREDENTIAL",
+            "RSA_PRIVATE_KEY",
+            // Lower-case variants must also be blocked.
+            "my_api_key",
+            "db_password",
+        ];
+
+        for var_name in &blocked_names {
+            // Stamp a known value so we'd catch any leak.
+            std::env::set_var(var_name, "should-not-leak");
+            let result = host_env_read(&state, &json!({"name": var_name}));
+            // Must NOT return an error (no capability denial) — but value must be null.
+            assert!(
+                result.get("error").is_none(),
+                "Blocklist should not return capability error for {var_name}: {result:?}"
+            );
+            let val = result.get("ok");
+            assert!(
+                val.is_some() && val.unwrap().is_null(),
+                "Blocked var {var_name} must return null, got: {result:?}"
+            );
+            std::env::remove_var(var_name);
+        }
+    }
+
+    #[test]
+    fn test_is_blocked_env_var() {
+        // Exact names
+        assert!(is_blocked_env_var("ANTHROPIC_API_KEY"));
+        assert!(is_blocked_env_var("LIBREFANG_VAULT_KEY"));
+        assert!(is_blocked_env_var("AWS_SESSION_TOKEN"));
+        // Substring matches
+        assert!(is_blocked_env_var("MY_SECRET_THING"));
+        assert!(is_blocked_env_var("DB_PASSWORD"));
+        assert!(is_blocked_env_var("DEPLOY_TOKEN"));
+        assert!(is_blocked_env_var("PRIVATE_KEY_DATA"));
+        // Case-insensitive
+        assert!(is_blocked_env_var("my_api_key"));
+        assert!(is_blocked_env_var("db_password"));
+        // Safe vars must NOT be blocked
+        assert!(!is_blocked_env_var("PATH"));
+        assert!(!is_blocked_env_var("HOME"));
+        assert!(!is_blocked_env_var("LANG"));
+        assert!(!is_blocked_env_var("TERM"));
+        assert!(!is_blocked_env_var("USER"));
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -448,6 +448,62 @@ pub async fn execute_tool_raw(
             tool_file_list(input, *workspace_root, &extra_refs).await
         }
         "apply_patch" => {
+            // SECURITY #3662: Enforce named workspace read-only restrictions
+            // before applying the patch.  Mirrors the upfront check in the
+            // `file_write` arm: any absolute target path that falls inside a
+            // read-only named workspace is rejected here, before the sandbox
+            // resolver even runs.  The sandbox itself would also block such
+            // writes (readonly workspaces are excluded from `additional_roots`),
+            // but the explicit pre-check catches the violation earlier and
+            // returns a clearer error message.
+            if let (Some(k), Some(agent_id)) = (kernel, caller_agent_id) {
+                let ro = k.readonly_workspace_prefixes(agent_id);
+                if !ro.is_empty() {
+                    // Parse the patch to inspect target paths before executing.
+                    if let Some(patch_str) = input["patch"].as_str() {
+                        if let Ok(ops) = crate::apply_patch::parse_patch(patch_str) {
+                            for op in &ops {
+                                let raw_paths: Vec<&str> = match op {
+                                    crate::apply_patch::PatchOp::AddFile { path, .. } => {
+                                        vec![path.as_str()]
+                                    }
+                                    crate::apply_patch::PatchOp::UpdateFile {
+                                        path,
+                                        move_to,
+                                        ..
+                                    } => {
+                                        let mut v = vec![path.as_str()];
+                                        if let Some(dest) = move_to {
+                                            v.push(dest.as_str());
+                                        }
+                                        v
+                                    }
+                                    crate::apply_patch::PatchOp::DeleteFile { path } => {
+                                        vec![path.as_str()]
+                                    }
+                                };
+                                for raw in raw_paths {
+                                    if Path::new(raw).is_absolute()
+                                        && ro
+                                            .iter()
+                                            .any(|prefix| Path::new(raw).starts_with(prefix))
+                                    {
+                                        return ToolResult {
+                                            tool_use_id: tool_use_id.to_string(),
+                                            content: format!(
+                                                "Write denied: '{}' is in a read-only named workspace",
+                                                raw
+                                            ),
+                                            is_error: true,
+                                            ..Default::default()
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             maybe_snapshot(checkpoint_manager, *workspace_root, "pre apply_patch").await;
             // apply_patch needs write access — restrict to rw named workspaces only.
             let extra = named_ws_prefixes_writable(*kernel, *caller_agent_id);


### PR DESCRIPTION
## Summary

- **#3362/#3363** — `host_env_read` in the WASM sandbox now has a hard-coded blocklist. Any env var whose upper-cased name contains `KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, or `PRIVATE` is silently returned as `null`, regardless of the plugin's declared `EnvRead` capability. This prevents a plugin with `EnvRead("*")` from reading `LIBREFANG_VAULT_KEY`, `ANTHROPIC_API_KEY`, and other credentials.
- **#3367** — `GET /api/approvals/session/{id}` was reachable without authentication via the broad `/api/approvals/` prefix in `dashboard_read_prefix`. That sub-path now falls through to the normal bearer-auth gate. The `GET /api/approvals/{id}` path (individual approval detail, used for dashboard polling) remains public.
- **#3458** — `POST /api/config/set` now validates the `path` field before touching `config.toml`. Each dot-separated key segment must contain only ASCII alphanumeric characters, underscores, or hyphens. Empty segments, `..` traversal, absolute paths, and special characters are rejected with `400`.
- **#3662** — The `apply_patch` tool arm now has the same explicit read-only workspace pre-check that `file_write` has. Before calling the sandbox resolver it parses the patch ops, inspects all target paths (including `move_to` destinations), and rejects any absolute path inside a readonly named workspace.

## Test plan

- `test_is_blocked_env_var` — unit test for the blocklist predicate
- `test_env_read_blocklist_suppresses_secrets` — async test that stamps real env vars and verifies they are suppressed
- `approvals_session_get_requires_auth` — middleware-layer test verifying `GET /api/approvals/session/{id}` returns 401 with an api_key configured
- `config_key_path_validation_tests` — unit tests covering valid paths, traversal, and special-character injection
- `test_apply_patch_denies_readonly_named_workspace_path` (pre-existing) — already exercises the denial path now backed by the explicit pre-check