### PR TITLE
fix(channels): mandatory webhook HMAC verification + SSRF guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,14 @@ _No notable changes._
 
 - Default `api_listen` flipped from `0.0.0.0:4545` to `127.0.0.1:4545` (loopback-only). New installs are local-only by default; set `api_listen = "0.0.0.0:4545"` to expose on LAN/remote. Affects `librefang init`, the dashboard's init endpoint, and `librefang.toml.example`. `librefang start` with an explicit `--config <path>` that doesn't exist now prints a clear `librefang init` hint instead of failing obscurely. (#2766)
 
+### Security
+
+- **Channel webhook HMAC verification is now mandatory** for Messenger, LINE, Teams, Viber, and DingTalk. Previously, missing signature headers were silently bypassed; they now return `400 Bad Request`, and signature mismatches return `401 Unauthorized`. **Action required if you operate any of these channels:**
+  - **Messenger** — set `MESSENGER_APP_SECRET` to your Facebook App Secret (the new `app_secret_env` field in `[channels.messenger]` defaults to this). If unset, signatures are skipped with a startup warning and the endpoint stays unauthenticated — production should always set it.
+  - **Teams** — set `TEAMS_SECURITY_TOKEN` to the base64 outgoing-webhook security token from the Teams portal (the new `security_token_env` field in `[channels.teams]`). Same fallback semantics as Messenger.
+  - **LINE / Viber / DingTalk** — no new env vars, but probes that don't carry the platform's signature header (curl, monitoring health checks pointed at the webhook path) will now return 4xx instead of 200.
+- **Outbound `[channels.webhook] callback_url` is SSRF-guarded.** Adapters refuse to start if the URL resolves to a private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local, multicast, or cloud-metadata range. Catches IPv6 short forms like `[::]`, IPv4-mapped (`[::ffff:127.0.0.1]`), NAT64, and trailing-dot FQDNs. **Action required**: local dev setups using `callback_url = "http://127.0.0.1/..."` must switch to a public tunnel (ngrok, cloudflared) or omit `callback_url`. (#3942)
+
 ## [2026.4.18] - 2026-04-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -592,7 +592,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -602,15 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -1117,12 +1108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,7 +1596,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1725,7 +1710,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1792,21 +1777,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "block-buffer",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1999,7 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2045,7 +2019,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -3109,7 +3083,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4148,9 +4122,10 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
- "sha1 0.11.0",
+ "sha1",
  "sha2",
  "smallvec",
+ "subtle",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -4871,7 +4846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -7053,8 +7028,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
+ "const-oid",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -7723,18 +7698,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -7751,7 +7715,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -7844,7 +7808,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -9190,7 +9154,7 @@ dependencies = [
  "hmac",
  "qrcodegen-image",
  "rand 0.9.2",
- "sha1 0.10.6",
+ "sha1",
  "sha2",
  "url",
  "urlencoding",
@@ -9377,7 +9341,7 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,9 @@ walkdir = "2"
 
 # Security
 sha2 = { version = "0.10", features = ["oid"] }
-sha1 = "0.11"
+# sha1 0.10 is paired with hmac 0.12 via digest 0.10. sha1 0.11+ moved to
+# digest 0.11 and is incompatible with our hmac version.
+sha1 = "0.10"
 aes = "0.9"
 cbc = "0.2"
 hmac = "0.12"

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2629,16 +2629,10 @@ pub async fn start_channel_bridge_with_config(
             let verify_token =
                 read_token(&ms_config.verify_token_env, "Messenger (verify)").unwrap_or_default();
             let app_secret =
-                read_token(&ms_config.app_secret_env, "Messenger (app_secret)")
-                    .unwrap_or_default();
+                read_token(&ms_config.app_secret_env, "Messenger (app_secret)").unwrap_or_default();
             let adapter = Arc::new(
-                MessengerAdapter::new(
-                    page_token,
-                    verify_token,
-                    app_secret,
-                    ms_config.webhook_port,
-                )
-                .with_account_id(ms_config.account_id.clone()),
+                MessengerAdapter::new(page_token, verify_token, app_secret, ms_config.webhook_port)
+                    .with_account_id(ms_config.account_id.clone()),
             );
             adapters.push((
                 adapter,
@@ -3147,7 +3141,11 @@ pub async fn start_channel_bridge_with_config(
     #[cfg(feature = "channel-webhook")]
     for wh_config in config.webhook.iter() {
         if let Some(secret) = read_token(&wh_config.secret_env, "Webhook") {
-            match WebhookAdapter::new(secret, wh_config.listen_port, wh_config.callback_url.clone()) {
+            match WebhookAdapter::new(
+                secret,
+                wh_config.listen_port,
+                wh_config.callback_url.clone(),
+            ) {
                 Ok(wa) => {
                     let adapter = Arc::new(
                         wa.with_account_id(wh_config.account_id.clone())

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2403,10 +2403,14 @@ pub async fn start_channel_bridge_with_config(
     #[cfg(feature = "channel-teams")]
     for tm_config in config.teams.iter() {
         if let Some(password) = read_token(&tm_config.app_password_env, "Teams") {
+            let security_token =
+                read_token(&tm_config.security_token_env, "Teams (security_token)")
+                    .unwrap_or_default();
             let adapter = Arc::new(
                 TeamsAdapter::new(
                     tm_config.app_id.clone(),
                     password,
+                    security_token,
                     tm_config.webhook_port,
                     tm_config.allowed_tenants.clone(),
                 )
@@ -2624,9 +2628,17 @@ pub async fn start_channel_bridge_with_config(
         if let Some(page_token) = read_token(&ms_config.page_token_env, "Messenger (page)") {
             let verify_token =
                 read_token(&ms_config.verify_token_env, "Messenger (verify)").unwrap_or_default();
+            let app_secret =
+                read_token(&ms_config.app_secret_env, "Messenger (app_secret)")
+                    .unwrap_or_default();
             let adapter = Arc::new(
-                MessengerAdapter::new(page_token, verify_token, ms_config.webhook_port)
-                    .with_account_id(ms_config.account_id.clone()),
+                MessengerAdapter::new(
+                    page_token,
+                    verify_token,
+                    app_secret,
+                    ms_config.webhook_port,
+                )
+                .with_account_id(ms_config.account_id.clone()),
             );
             adapters.push((
                 adapter,
@@ -3135,20 +3147,22 @@ pub async fn start_channel_bridge_with_config(
     #[cfg(feature = "channel-webhook")]
     for wh_config in config.webhook.iter() {
         if let Some(secret) = read_token(&wh_config.secret_env, "Webhook") {
-            let adapter = Arc::new(
-                WebhookAdapter::new(
-                    secret,
-                    wh_config.listen_port,
-                    wh_config.callback_url.clone(),
-                )
-                .with_account_id(wh_config.account_id.clone())
-                .with_deliver_only(wh_config.deliver_only, wh_config.deliver.clone()),
-            );
-            adapters.push((
-                adapter,
-                wh_config.default_agent.clone(),
-                wh_config.account_id.clone(),
-            ));
+            match WebhookAdapter::new(secret, wh_config.listen_port, wh_config.callback_url.clone()) {
+                Ok(wa) => {
+                    let adapter = Arc::new(
+                        wa.with_account_id(wh_config.account_id.clone())
+                            .with_deliver_only(wh_config.deliver_only, wh_config.deliver.clone()),
+                    );
+                    adapters.push((
+                        adapter,
+                        wh_config.default_agent.clone(),
+                        wh_config.account_id.clone(),
+                    ));
+                }
+                Err(e) => {
+                    tracing::error!("Webhook adapter rejected by SSRF guard: {e}");
+                }
+            }
         }
     }
 

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -172,6 +172,7 @@ sha2 = { workspace = true }
 sha1 = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+subtle = { workspace = true }
 html-escape = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 regex = { workspace = true }

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -633,14 +633,17 @@ impl ChannelAdapter for DingTalkAdapter {
                         // Verify signature
                         if !DingTalkAdapter::verify_signature(&secret, ts, signature) {
                             warn!("DingTalk: invalid signature");
-                            return axum::http::StatusCode::FORBIDDEN;
+                            return axum::http::StatusCode::UNAUTHORIZED;
                         }
 
-                        // Check timestamp freshness (1 hour window)
+                        // Check timestamp freshness (1 hour window).
+                        // A stale timestamp is treated as a possible replay,
+                        // so we reject as unauthorized rather than forbidden —
+                        // matching the missing/invalid-signature path.
                         let now = Utc::now().timestamp_millis();
                         if (now - ts).unsigned_abs() > 3_600_000 {
                             warn!("DingTalk: stale timestamp");
-                            return axum::http::StatusCode::FORBIDDEN;
+                            return axum::http::StatusCode::UNAUTHORIZED;
                         }
 
                         if let Some((text, sender_id, sender_nick, conv_id, is_group)) =
@@ -911,7 +914,11 @@ mod tests {
         let ts: i64 = 1700000000000;
         let good_sig = DingTalkAdapter::compute_signature(secret, ts);
         // Different timestamp → signature mismatch
-        assert!(!DingTalkAdapter::verify_signature(secret, ts + 1, &good_sig));
+        assert!(!DingTalkAdapter::verify_signature(
+            secret,
+            ts + 1,
+            &good_sig
+        ));
     }
 
     #[test]

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -607,29 +607,40 @@ impl ChannelAdapter for DingTalkAdapter {
                     let secret = Arc::clone(&secret);
                     let account_id = Arc::clone(&account_id);
                     async move {
-                        // Extract timestamp and sign from headers
+                        // Extract timestamp and sign from headers.
+                        // A missing or non-numeric timestamp is always a hard error —
+                        // never silently skip HMAC verification.
                         let timestamp_str = headers
                             .get("timestamp")
                             .and_then(|v| v.to_str().ok())
-                            .unwrap_or("0");
+                            .unwrap_or("");
                         let signature = headers
                             .get("sign")
                             .and_then(|v| v.to_str().ok())
                             .unwrap_or("");
 
-                        // Verify signature
-                        if let Ok(ts) = timestamp_str.parse::<i64>() {
-                            if !DingTalkAdapter::verify_signature(&secret, ts, signature) {
-                                warn!("DingTalk: invalid signature");
-                                return axum::http::StatusCode::FORBIDDEN;
+                        let ts = match timestamp_str.parse::<i64>() {
+                            Ok(t) => t,
+                            Err(_) => {
+                                warn!(
+                                    "DingTalk: missing or non-numeric timestamp header — \
+                                     rejecting request"
+                                );
+                                return axum::http::StatusCode::BAD_REQUEST;
                             }
+                        };
 
-                            // Check timestamp freshness (1 hour window)
-                            let now = Utc::now().timestamp_millis();
-                            if (now - ts).unsigned_abs() > 3_600_000 {
-                                warn!("DingTalk: stale timestamp");
-                                return axum::http::StatusCode::FORBIDDEN;
-                            }
+                        // Verify signature
+                        if !DingTalkAdapter::verify_signature(&secret, ts, signature) {
+                            warn!("DingTalk: invalid signature");
+                            return axum::http::StatusCode::FORBIDDEN;
+                        }
+
+                        // Check timestamp freshness (1 hour window)
+                        let now = Utc::now().timestamp_millis();
+                        if (now - ts).unsigned_abs() > 3_600_000 {
+                            warn!("DingTalk: stale timestamp");
+                            return axum::http::StatusCode::FORBIDDEN;
                         }
 
                         if let Some((text, sender_id, sender_nick, conv_id, is_group)) =
@@ -892,6 +903,15 @@ mod tests {
         assert!(result.is_some());
         let (_, _, _, _, is_group) = result.unwrap();
         assert!(!is_group);
+    }
+
+    #[test]
+    fn test_dingtalk_verify_signature_rejects_wrong_timestamp() {
+        let secret = "test-secret";
+        let ts: i64 = 1700000000000;
+        let good_sig = DingTalkAdapter::compute_signature(secret, ts);
+        // Different timestamp → signature mismatch
+        assert!(!DingTalkAdapter::verify_signature(secret, ts + 1, &good_sig));
     }
 
     #[test]

--- a/crates/librefang-channels/src/http_client.rs
+++ b/crates/librefang-channels/src/http_client.rs
@@ -1,5 +1,6 @@
-//! Shared HTTP client builder with fallback CA roots.
+//! Shared HTTP client builder with fallback CA roots and SSRF guard.
 
+use std::net::IpAddr;
 use std::sync::OnceLock;
 
 static TLS_CONFIG: OnceLock<rustls::ClientConfig> = OnceLock::new();
@@ -29,4 +30,176 @@ pub fn new_client() -> reqwest::Client {
     client_builder()
         .build()
         .expect("HTTP client with bundled CA roots should always build")
+}
+
+/// Validate that a URL from a channel payload is safe to fetch server-side.
+///
+/// Rejects:
+/// - Non-http/https schemes
+/// - IP literals or hostnames that are private/loopback/link-local/metadata-service
+///   addresses (prevents SSRF)
+///
+/// This is a best-effort guard against *obvious* SSRF vectors. It checks the
+/// host string directly without performing DNS resolution (DNS-rebind attacks
+/// must be mitigated at the network layer or with a resolving SSRF proxy).
+pub fn validate_url_for_fetch(url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => return Err(format!("scheme '{scheme}' is not allowed; only http/https")),
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?;
+
+    // If the host is an IP literal, check directly.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_private_ip(ip) {
+            return Err(format!("host '{host}' resolves to a private/reserved address"));
+        }
+        return Ok(());
+    }
+
+    // Reject obviously private hostnames without DNS resolution.
+    let host_lower = host.to_ascii_lowercase();
+    if is_private_hostname(&host_lower) {
+        return Err(format!("host '{host}' is a reserved or private hostname"));
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if `ip` is in any private, loopback, link-local, or
+/// cloud-metadata address range.
+fn is_private_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            // Loopback: 127.0.0.0/8
+            if o[0] == 127 {
+                return true;
+            }
+            // Private: 10.0.0.0/8
+            if o[0] == 10 {
+                return true;
+            }
+            // Private: 172.16.0.0/12
+            if o[0] == 172 && (16..=31).contains(&o[1]) {
+                return true;
+            }
+            // Private: 192.168.0.0/16
+            if o[0] == 192 && o[1] == 168 {
+                return true;
+            }
+            // Link-local: 169.254.0.0/16  (includes AWS/GCP/Azure metadata at 169.254.169.254)
+            if o[0] == 169 && o[1] == 254 {
+                return true;
+            }
+            // Unspecified: 0.0.0.0/8
+            if o[0] == 0 {
+                return true;
+            }
+            false
+        }
+        IpAddr::V6(v6) => {
+            // Loopback ::1
+            if v6.is_loopback() {
+                return true;
+            }
+            let segs = v6.segments();
+            // Link-local fe80::/10
+            if (segs[0] & 0xffc0) == 0xfe80 {
+                return true;
+            }
+            // Unique local fc00::/7  (covers fd00::/8 etc.)
+            if (segs[0] & 0xfe00) == 0xfc00 {
+                return true;
+            }
+            // Unspecified ::
+            if v6.is_unspecified() {
+                return true;
+            }
+            false
+        }
+    }
+}
+
+/// Returns `true` for hostnames that are obviously private without requiring DNS.
+fn is_private_hostname(host: &str) -> bool {
+    // localhost and variants
+    if host == "localhost" || host.ends_with(".localhost") {
+        return true;
+    }
+    // .local mDNS names
+    if host.ends_with(".local") {
+        return true;
+    }
+    // Common internal hostname patterns
+    if host == "metadata.google.internal"
+        || host == "metadata"
+        || host == "169.254.169.254"
+    {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_url_allows_public_https() {
+        assert!(validate_url_for_fetch("https://example.com/image.png").is_ok());
+        assert!(validate_url_for_fetch("http://cdn.example.org/file").is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_bad_scheme() {
+        assert!(validate_url_for_fetch("ftp://example.com/file").is_err());
+        assert!(validate_url_for_fetch("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_loopback() {
+        assert!(validate_url_for_fetch("http://127.0.0.1/admin").is_err());
+        assert!(validate_url_for_fetch("http://[::1]/admin").is_err());
+        assert!(validate_url_for_fetch("http://localhost/admin").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_private_ranges() {
+        assert!(validate_url_for_fetch("http://10.0.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://172.16.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://172.31.255.255/").is_err());
+        assert!(validate_url_for_fetch("http://192.168.1.1/").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_metadata_service() {
+        assert!(validate_url_for_fetch("http://169.254.169.254/latest/meta-data/").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_ipv6_unique_local() {
+        assert!(validate_url_for_fetch("http://[fd00::1]/").is_err());
+        assert!(validate_url_for_fetch("http://[fe80::1]/").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_private_hostname() {
+        assert!(validate_url_for_fetch("http://metadata.google.internal/").is_err());
+        assert!(validate_url_for_fetch("http://myserver.local/").is_err());
+    }
+
+    #[test]
+    fn test_172_boundary() {
+        // 172.15.x is public; 172.16.x – 172.31.x is private; 172.32.x is public
+        assert!(validate_url_for_fetch("http://172.15.0.1/").is_ok());
+        assert!(validate_url_for_fetch("http://172.16.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://172.31.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://172.32.0.1/").is_ok());
+    }
 }

--- a/crates/librefang-channels/src/http_client.rs
+++ b/crates/librefang-channels/src/http_client.rs
@@ -1,6 +1,6 @@
-//! Shared HTTP client builder with fallback CA roots and SSRF guard.
+//! Shared HTTP client builder, SSRF guard, and constant-time HMAC compare.
 
-use std::net::IpAddr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::OnceLock;
 
 static TLS_CONFIG: OnceLock<rustls::ClientConfig> = OnceLock::new();
@@ -32,16 +32,33 @@ pub fn new_client() -> reqwest::Client {
         .expect("HTTP client with bundled CA roots should always build")
 }
 
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+
 /// Validate that a URL from a channel payload is safe to fetch server-side.
 ///
 /// Rejects:
-/// - Non-http/https schemes
-/// - IP literals or hostnames that are private/loopback/link-local/metadata-service
-///   addresses (prevents SSRF)
+/// - Non-http/https schemes (`file://`, `ftp://`, …).
+/// - IP literals — IPv4 or IPv6 — that fall in any loopback, private,
+///   link-local, unique-local, broadcast, multicast, reserved, or
+///   cloud-metadata range.
+/// - IPv4 written in any non-canonical form (short form `127.1`, decimal
+///   `2130706433`, octal `0177.0.0.1`, hex `0x7f.0.0.1`). The WHATWG URL
+///   parser inside [`url::Url::host`] normalizes these to a 4-octet
+///   `Ipv4Addr` before we run the private-range check.
+/// - IPv4-mapped IPv6 (`::ffff:7f00:1`) and the RFC 6052 NAT64 well-known
+///   prefix (`64:ff9b::7f00:1`) when the embedded IPv4 is private. Both
+///   route to a `127.x.x.x` socket on the wire even though the literal is
+///   IPv6.
+/// - Hostnames that match a known internal pattern (`localhost`,
+///   `*.localhost`, `*.local`, `metadata`, `metadata.google.internal`,
+///   `169.254.169.254`). The trailing-dot FQDN form (`localhost.`) is
+///   normalized away before comparison.
 ///
-/// This is a best-effort guard against *obvious* SSRF vectors. It checks the
-/// host string directly without performing DNS resolution (DNS-rebind attacks
-/// must be mitigated at the network layer or with a resolving SSRF proxy).
+/// **Out of scope by design:** DNS resolution. A public hostname may
+/// still resolve to `127.0.0.1` (DNS rebinding); mitigate that at the
+/// network layer or with a resolving SSRF proxy.
 pub fn validate_url_for_fetch(url: &str) -> Result<(), String> {
     let parsed = url::Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
 
@@ -50,156 +67,277 @@ pub fn validate_url_for_fetch(url: &str) -> Result<(), String> {
         scheme => return Err(format!("scheme '{scheme}' is not allowed; only http/https")),
     }
 
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| "URL has no host".to_string())?;
+    // `host()` returns the WHATWG-normalized `Host` enum; using `host_str()`
+    // would lose information (IPv4 short forms get a string back, IPv6
+    // gets the bracketed form like `"[::1]"` which `IpAddr::from_str`
+    // refuses) and route through the wrong branch.
+    let host = parsed.host().ok_or_else(|| "URL has no host".to_string())?;
 
-    // If the host is an IP literal, check directly.
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_ip(ip) {
-            return Err(format!("host '{host}' resolves to a private/reserved address"));
+    match host {
+        url::Host::Ipv4(v4) => {
+            if is_private_ipv4(v4) {
+                return Err(format!("host resolves to private/reserved IPv4 {v4}"));
+            }
         }
-        return Ok(());
-    }
-
-    // Reject obviously private hostnames without DNS resolution.
-    let host_lower = host.to_ascii_lowercase();
-    if is_private_hostname(&host_lower) {
-        return Err(format!("host '{host}' is a reserved or private hostname"));
+        url::Host::Ipv6(v6) => {
+            // IPv4-mapped (::ffff:x.x.x.x) and NAT64 (64:ff9b::x.x.x.x)
+            // both deliver packets to an IPv4 endpoint on the wire. Check
+            // the embedded IPv4 against the private table before falling
+            // back to pure-IPv6 ranges.
+            if let Some(v4) = ipv6_embedded_ipv4(v6) {
+                if is_private_ipv4(v4) {
+                    return Err(format!("host '{v6}' embeds private IPv4 {v4}"));
+                }
+            }
+            if is_private_ipv6(v6) {
+                return Err(format!("host resolves to private/reserved IPv6 {v6}"));
+            }
+        }
+        url::Host::Domain(domain) => {
+            // Strip the trailing dot of an FQDN so "localhost." doesn't
+            // bypass the "localhost" comparison.
+            let trimmed = domain.trim_end_matches('.').to_ascii_lowercase();
+            if is_private_hostname(&trimmed) {
+                return Err(format!("host '{domain}' is a reserved or private hostname"));
+            }
+        }
     }
 
     Ok(())
 }
 
-/// Returns `true` if `ip` is in any private, loopback, link-local, or
-/// cloud-metadata address range.
-fn is_private_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            let o = v4.octets();
-            // Loopback: 127.0.0.0/8
-            if o[0] == 127 {
-                return true;
-            }
-            // Private: 10.0.0.0/8
-            if o[0] == 10 {
-                return true;
-            }
-            // Private: 172.16.0.0/12
-            if o[0] == 172 && (16..=31).contains(&o[1]) {
-                return true;
-            }
-            // Private: 192.168.0.0/16
-            if o[0] == 192 && o[1] == 168 {
-                return true;
-            }
-            // Link-local: 169.254.0.0/16  (includes AWS/GCP/Azure metadata at 169.254.169.254)
-            if o[0] == 169 && o[1] == 254 {
-                return true;
-            }
-            // Unspecified: 0.0.0.0/8
-            if o[0] == 0 {
-                return true;
-            }
-            false
-        }
-        IpAddr::V6(v6) => {
-            // Loopback ::1
-            if v6.is_loopback() {
-                return true;
-            }
-            let segs = v6.segments();
-            // Link-local fe80::/10
-            if (segs[0] & 0xffc0) == 0xfe80 {
-                return true;
-            }
-            // Unique local fc00::/7  (covers fd00::/8 etc.)
-            if (segs[0] & 0xfe00) == 0xfc00 {
-                return true;
-            }
-            // Unspecified ::
-            if v6.is_unspecified() {
-                return true;
-            }
-            false
-        }
+/// IPv4 ranges that are not safe to dial from a server-side fetch.
+fn is_private_ipv4(v4: Ipv4Addr) -> bool {
+    let o = v4.octets();
+    // First-octet rules cover four big blocks cleanly:
+    //   0.0.0.0/8         — "this network" / unspecified
+    //   10.0.0.0/8        — RFC 1918 private
+    //   127.0.0.0/8       — loopback
+    //   224.0.0.0/4       — multicast (224.x.x.x – 239.x.x.x)
+    //   240.0.0.0/4       — reserved + 255.255.255.255 broadcast
+    if matches!(o[0], 0 | 10 | 127) || matches!(o[0], 224..=255) {
+        return true;
     }
+    matches!(
+        (o[0], o[1]),
+        // 100.64.0.0/10 — RFC 6598 carrier-grade NAT (shared address)
+        (100, 64..=127)
+        // 169.254.0.0/16 — link-local (incl. cloud metadata 169.254.169.254)
+        | (169, 254)
+        // 172.16.0.0/12 — RFC 1918 private
+        | (172, 16..=31)
+        // 192.168.0.0/16 — RFC 1918 private
+        | (192, 168)
+    ) || (
+        // 192.0.0.0/24 — IETF protocol assignments (deliberately /24, NOT /16)
+        o[0] == 192 && o[1] == 0 && o[2] == 0
+    )
 }
 
-/// Returns `true` for hostnames that are obviously private without requiring DNS.
-fn is_private_hostname(host: &str) -> bool {
-    // localhost and variants
-    if host == "localhost" || host.ends_with(".localhost") {
+/// IPv6 ranges that are not safe to dial.
+fn is_private_ipv6(v6: Ipv6Addr) -> bool {
+    if v6.is_loopback() || v6.is_unspecified() {
         return true;
     }
-    // .local mDNS names
-    if host.ends_with(".local") {
+    let segs = v6.segments();
+    // Link-local fe80::/10
+    if (segs[0] & 0xffc0) == 0xfe80 {
         return true;
     }
-    // Common internal hostname patterns
-    if host == "metadata.google.internal"
-        || host == "metadata"
-        || host == "169.254.169.254"
-    {
+    // Unique local fc00::/7  (covers fd00::/8)
+    if (segs[0] & 0xfe00) == 0xfc00 {
+        return true;
+    }
+    // Multicast ff00::/8
+    if (segs[0] & 0xff00) == 0xff00 {
         return true;
     }
     false
+}
+
+/// Extract an IPv4 address embedded in an IPv6 in the two ways an
+/// attacker can use to reach an IPv4 endpoint via an IPv6 host:
+/// IPv4-mapped (`::ffff:x.x.x.x`, RFC 4291 §2.5.5.2) and NAT64
+/// (`64:ff9b::x.x.x.x`, RFC 6052).
+fn ipv6_embedded_ipv4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
+    if let Some(v4) = v6.to_ipv4_mapped() {
+        return Some(v4);
+    }
+    let s = v6.segments();
+    if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6].iter().all(|seg| *seg == 0) {
+        return Some(Ipv4Addr::new(
+            (s[6] >> 8) as u8,
+            (s[6] & 0xff) as u8,
+            (s[7] >> 8) as u8,
+            (s[7] & 0xff) as u8,
+        ));
+    }
+    None
+}
+
+/// Hostnames that should be refused without resolution.
+fn is_private_hostname(host: &str) -> bool {
+    if host == "localhost" || host.ends_with(".localhost") {
+        return true;
+    }
+    if host.ends_with(".local") {
+        return true;
+    }
+    matches!(
+        host,
+        "metadata" | "metadata.google.internal" | "metadata.azure.com" | "169.254.169.254"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Constant-time HMAC compare
+// ---------------------------------------------------------------------------
+
+/// Constant-time equality for HMAC digests.
+///
+/// Always compares full slices and returns `false` on length mismatch.
+/// Backed by the `subtle` crate so the comparison is genuinely
+/// constant-time (the hand-rolled `for ... |= a ^ b` form risks being
+/// auto-vectorized into an early-exit `memcmp` by future compilers).
+pub(crate) fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    if a.len() != b.len() {
+        return false;
+    }
+    a.ct_eq(b).into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // -------- SSRF guard ---------------------------------------------------
+
     #[test]
-    fn test_validate_url_allows_public_https() {
+    fn allows_public_https() {
         assert!(validate_url_for_fetch("https://example.com/image.png").is_ok());
         assert!(validate_url_for_fetch("http://cdn.example.org/file").is_ok());
     }
 
     #[test]
-    fn test_validate_url_rejects_bad_scheme() {
+    fn rejects_bad_scheme() {
         assert!(validate_url_for_fetch("ftp://example.com/file").is_err());
         assert!(validate_url_for_fetch("file:///etc/passwd").is_err());
+        assert!(validate_url_for_fetch("gopher://example.com/").is_err());
+        assert!(validate_url_for_fetch("javascript:alert(1)").is_err());
     }
 
     #[test]
-    fn test_validate_url_rejects_loopback() {
-        assert!(validate_url_for_fetch("http://127.0.0.1/admin").is_err());
-        assert!(validate_url_for_fetch("http://[::1]/admin").is_err());
-        assert!(validate_url_for_fetch("http://localhost/admin").is_err());
+    fn rejects_canonical_loopback_and_private() {
+        for url in [
+            "http://127.0.0.1/admin",
+            "http://[::1]/admin",
+            "http://localhost/admin",
+            "http://10.0.0.1/",
+            "http://172.16.0.1/",
+            "http://172.31.255.255/",
+            "http://192.168.1.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[fd00::1]/",
+            "http://[fe80::1]/",
+        ] {
+            assert!(
+                validate_url_for_fetch(url).is_err(),
+                "expected reject for {url}"
+            );
+        }
+    }
+
+    /// All of these are common SSRF bypass tricks. The WHATWG URL parser
+    /// normalizes IPv4 short forms before we ever get to the private-range
+    /// check, so the guard catches them.
+    #[test]
+    fn rejects_ipv4_short_forms() {
+        for url in [
+            "http://127.1/",
+            "http://2130706433/",
+            "http://0177.0.0.1/",
+            "http://0x7f.0.0.1/",
+            "http://0/",
+        ] {
+            assert!(
+                validate_url_for_fetch(url).is_err(),
+                "expected reject for {url}"
+            );
+        }
+    }
+
+    /// IPv6 unspecified / IPv4-mapped / NAT64 — all reach an IPv4 endpoint
+    /// on the wire even though the literal looks IPv6.
+    #[test]
+    fn rejects_ipv6_embedded_ipv4_paths_to_private() {
+        for url in [
+            "http://[::]/",
+            "http://[::ffff:127.0.0.1]/",
+            "http://[::ffff:7f00:1]/",
+            "http://[::ffff:10.0.0.1]/",
+            "http://[::ffff:169.254.169.254]/",
+            "http://[64:ff9b::7f00:1]/",
+            "http://[ff02::1]/", // multicast
+        ] {
+            assert!(
+                validate_url_for_fetch(url).is_err(),
+                "expected reject for {url}"
+            );
+        }
     }
 
     #[test]
-    fn test_validate_url_rejects_private_ranges() {
-        assert!(validate_url_for_fetch("http://10.0.0.1/").is_err());
-        assert!(validate_url_for_fetch("http://172.16.0.1/").is_err());
-        assert!(validate_url_for_fetch("http://172.31.255.255/").is_err());
-        assert!(validate_url_for_fetch("http://192.168.1.1/").is_err());
+    fn rejects_trailing_dot_fqdn() {
+        assert!(validate_url_for_fetch("http://localhost./").is_err());
+        assert!(validate_url_for_fetch("http://metadata.google.internal./").is_err());
     }
 
     #[test]
-    fn test_validate_url_rejects_metadata_service() {
-        assert!(validate_url_for_fetch("http://169.254.169.254/latest/meta-data/").is_err());
-    }
-
-    #[test]
-    fn test_validate_url_rejects_ipv6_unique_local() {
-        assert!(validate_url_for_fetch("http://[fd00::1]/").is_err());
-        assert!(validate_url_for_fetch("http://[fe80::1]/").is_err());
-    }
-
-    #[test]
-    fn test_validate_url_rejects_private_hostname() {
+    fn rejects_metadata_hostnames() {
         assert!(validate_url_for_fetch("http://metadata.google.internal/").is_err());
+        assert!(validate_url_for_fetch("http://metadata.azure.com/").is_err());
         assert!(validate_url_for_fetch("http://myserver.local/").is_err());
     }
 
     #[test]
-    fn test_172_boundary() {
-        // 172.15.x is public; 172.16.x – 172.31.x is private; 172.32.x is public
+    fn rejects_carrier_nat_and_protocol_ranges() {
+        // 100.64.0.0/10
+        assert!(validate_url_for_fetch("http://100.64.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://100.127.255.255/").is_err());
+        assert!(validate_url_for_fetch("http://100.128.0.1/").is_ok()); // outside CGN
+                                                                        // 192.0.0.0/24
+        assert!(validate_url_for_fetch("http://192.0.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://192.0.1.1/").is_ok());
+        // multicast / reserved
+        assert!(validate_url_for_fetch("http://224.0.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://255.255.255.255/").is_err());
+    }
+
+    #[test]
+    fn ipv4_172_16_boundary() {
         assert!(validate_url_for_fetch("http://172.15.0.1/").is_ok());
         assert!(validate_url_for_fetch("http://172.16.0.1/").is_err());
         assert!(validate_url_for_fetch("http://172.31.0.1/").is_err());
         assert!(validate_url_for_fetch("http://172.32.0.1/").is_ok());
+    }
+
+    /// Userinfo (`user@host`) does not change the host. The host is the
+    /// part after the `@`.
+    #[test]
+    fn userinfo_does_not_fool_host_check() {
+        assert!(validate_url_for_fetch("http://attacker.com@127.0.0.1/").is_err());
+        assert!(validate_url_for_fetch("http://attacker.com@example.com/").is_ok());
+    }
+
+    // -------- ct_eq --------------------------------------------------------
+
+    #[test]
+    fn ct_eq_matches_only_exact_bytes() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"abcd"));
+        assert!(!ct_eq(b"abc", b""));
+        assert!(ct_eq(b"", b""));
     }
 }

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -376,17 +376,23 @@ impl ChannelAdapter for LineAdapter {
                     let tx = Arc::clone(&tx);
                     let account_id = Arc::clone(&account_id);
                     async move {
-                        // Verify X-Line-Signature
-                        let signature = headers
+                        // Verify X-Line-Signature — header is mandatory.
+                        // A missing header is an error (HTTP 400); a present but
+                        // non-matching signature is HTTP 401.
+                        let signature = match headers
                             .get("x-line-signature")
                             .and_then(|v| v.to_str().ok())
-                            .unwrap_or("");
+                        {
+                            Some(s) => s.to_owned(),
+                            None => {
+                                warn!("LINE: missing X-Line-Signature header");
+                                return axum::http::StatusCode::BAD_REQUEST;
+                            }
+                        };
 
                         let body_bytes = serde_json::to_vec(&body.0).unwrap_or_default();
 
-                        if !signature.is_empty()
-                            && !verify_line_signature(secret.as_bytes(), &body_bytes, signature)
-                        {
+                        if !verify_line_signature(secret.as_bytes(), &body_bytes, &signature) {
                             warn!("LINE: invalid webhook signature");
                             return axum::http::StatusCode::UNAUTHORIZED;
                         }

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -211,31 +211,20 @@ fn verify_line_signature(secret: &[u8], body: &[u8], signature: &str) -> bool {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
 
-    type HmacSha256 = Hmac<Sha256>;
-
-    let Ok(mut mac) = HmacSha256::new_from_slice(secret) else {
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret) else {
         warn!("LINE: failed to create HMAC instance");
         return false;
     };
     mac.update(body);
     let result = mac.finalize().into_bytes();
 
-    // Compare with constant-time base64 decode + verify
     use base64::Engine;
     let Ok(expected) = base64::engine::general_purpose::STANDARD.decode(signature) else {
         warn!("LINE: invalid base64 in X-Line-Signature");
         return false;
     };
 
-    // Constant-time comparison to prevent timing attacks
-    if result.len() != expected.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (a, b) in result.iter().zip(expected.iter()) {
-        diff |= a ^ b;
-    }
-    diff == 0
+    crate::http_client::ct_eq(&result, &expected)
 }
 
 /// Parse a LINE webhook event into a `ChannelMessage`.
@@ -370,35 +359,36 @@ impl ChannelAdapter for LineAdapter {
                 let secret = Arc::clone(&channel_secret);
                 let tx = Arc::clone(&tx);
                 let account_id = Arc::clone(&account_id);
-                move |headers: axum::http::HeaderMap,
-                      body: axum::extract::Json<serde_json::Value>| {
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let secret = Arc::clone(&secret);
                     let tx = Arc::clone(&tx);
                     let account_id = Arc::clone(&account_id);
                     async move {
                         // Verify X-Line-Signature — header is mandatory.
-                        // A missing header is an error (HTTP 400); a present but
-                        // non-matching signature is HTTP 401.
-                        let signature = match headers
+                        // The HMAC must cover the *raw wire bytes*, not bytes
+                        // round-tripped through `serde_json::Value` (which
+                        // would normalize key order, whitespace, and number
+                        // formatting and never match LINE's actual digest).
+                        let Some(signature) = headers
                             .get("x-line-signature")
                             .and_then(|v| v.to_str().ok())
-                        {
-                            Some(s) => s.to_owned(),
-                            None => {
-                                warn!("LINE: missing X-Line-Signature header");
-                                return axum::http::StatusCode::BAD_REQUEST;
-                            }
+                        else {
+                            warn!("LINE: missing X-Line-Signature header");
+                            return axum::http::StatusCode::BAD_REQUEST;
                         };
 
-                        let body_bytes = serde_json::to_vec(&body.0).unwrap_or_default();
-
-                        if !verify_line_signature(secret.as_bytes(), &body_bytes, &signature) {
+                        if !verify_line_signature(secret.as_bytes(), &body, signature) {
                             warn!("LINE: invalid webhook signature");
                             return axum::http::StatusCode::UNAUTHORIZED;
                         }
 
+                        let body_json: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(v) => v,
+                            Err(_) => return axum::http::StatusCode::BAD_REQUEST,
+                        };
+
                         // Parse events array
-                        if let Some(events) = body.0["events"].as_array() {
+                        if let Some(events) = body_json["events"].as_array() {
                             for event in events {
                                 if let Some(mut msg) = parse_line_event(event) {
                                     // Inject account_id for multi-bot routing
@@ -634,6 +624,62 @@ mod tests {
         });
 
         assert!(parse_line_event(&event).is_none());
+    }
+
+    #[test]
+    fn test_verify_line_signature_round_trip() {
+        use base64::Engine;
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let secret = b"channel-secret-bytes";
+        let body = br#"{"events":[{"type":"message","message":{"text":"hi"}}],"destination":"U1"}"#;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let digest = mac.finalize().into_bytes();
+        let sig = base64::engine::general_purpose::STANDARD.encode(digest);
+
+        assert!(verify_line_signature(secret, body, &sig));
+        // Wrong secret → reject.
+        assert!(!verify_line_signature(b"different-secret", body, &sig));
+        // Mutated body → reject.
+        let mutated =
+            br#"{"events":[{"type":"message","message":{"text":"HI"}}],"destination":"U1"}"#;
+        assert!(!verify_line_signature(secret, mutated, &sig));
+    }
+
+    /// Regression test for the wire-bytes vs JSON-roundtrip bug: LINE's
+    /// HMAC must verify the raw bytes the platform sent, not the bytes
+    /// produced by re-serializing `serde_json::Value`. The two diverge in
+    /// at least key ordering and whitespace, so the roundtripped form
+    /// will never match the original digest.
+    #[test]
+    fn test_line_signature_breaks_when_body_round_tripped_through_value() {
+        use base64::Engine;
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let secret = b"channel-secret-bytes";
+        // Wire body has b before a, plus extra whitespace — a real LINE
+        // payload's exact byte layout is up to LINE.
+        let wire_body = br#"{"b":1,  "a":2}"#;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret).unwrap();
+        mac.update(wire_body);
+        let digest = mac.finalize().into_bytes();
+        let sig = base64::engine::general_purpose::STANDARD.encode(digest);
+
+        assert!(verify_line_signature(secret, wire_body, &sig));
+
+        // Round-trip through serde_json::Value re-orders keys and removes
+        // whitespace, so the digest no longer matches. (This is exactly
+        // what the previous handler was doing, which would have rejected
+        // every legitimate LINE webhook.)
+        let value: serde_json::Value = serde_json::from_slice(wire_body).unwrap();
+        let round_tripped = serde_json::to_vec(&value).unwrap();
+        assert_ne!(wire_body.as_slice(), round_tripped.as_slice());
+        assert!(!verify_line_signature(secret, &round_tripped, &sig));
     }
 
     #[test]

--- a/crates/librefang-channels/src/messenger.rs
+++ b/crates/librefang-channels/src/messenger.rs
@@ -42,14 +42,7 @@ fn verify_hub_signature(app_secret: &[u8], body: &[u8], signature_header: &str) 
     mac.update(body);
     let result = mac.finalize().into_bytes();
 
-    if result.len() != expected_bytes.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (a, b) in result.iter().zip(expected_bytes.iter()) {
-        diff |= a ^ b;
-    }
-    diff == 0
+    crate::http_client::ct_eq(&result, &expected_bytes)
 }
 
 /// Facebook Graph API base URL for sending messages.
@@ -95,6 +88,13 @@ impl MessengerAdapter {
         app_secret: String,
         _webhook_port: u16,
     ) -> Self {
+        if app_secret.is_empty() {
+            warn!(
+                "Messenger: no app_secret configured — webhook signature \
+                 verification is DISABLED. Set app_secret_env to harden \
+                 this endpoint."
+            );
+        }
         Self {
             page_token: Zeroizing::new(page_token),
             verify_token: Zeroizing::new(verify_token),
@@ -246,24 +246,18 @@ impl MessengerAdapter {
                     let account_id = Arc::clone(&account_id);
                     async move {
                         // Verify X-Hub-Signature (HMAC-SHA1 with app_secret).
-                        if app_secret.is_empty() {
-                            warn!(
-                                "Messenger: no app_secret configured — \
-                                 webhook signature verification is DISABLED. \
-                                 Set app_secret to harden this endpoint."
-                            );
-                        } else {
-                            let sig = headers
-                                .get("x-hub-signature")
-                                .and_then(|v| v.to_str().ok())
-                                .unwrap_or("");
-                            if sig.is_empty() {
-                                warn!("Messenger: missing X-Hub-Signature header — rejecting request");
-                                return axum::http::StatusCode::FORBIDDEN;
-                            }
+                        // The "no app_secret configured" warning was logged
+                        // once at construction time — request path stays quiet.
+                        if !app_secret.is_empty() {
+                            let Some(sig) =
+                                headers.get("x-hub-signature").and_then(|v| v.to_str().ok())
+                            else {
+                                warn!("Messenger: missing X-Hub-Signature header");
+                                return axum::http::StatusCode::BAD_REQUEST;
+                            };
                             if !verify_hub_signature(app_secret.as_bytes(), &body, sig) {
-                                warn!("Messenger: invalid X-Hub-Signature — rejecting request");
-                                return axum::http::StatusCode::FORBIDDEN;
+                                warn!("Messenger: invalid X-Hub-Signature");
+                                return axum::http::StatusCode::UNAUTHORIZED;
                             }
                         }
 

--- a/crates/librefang-channels/src/messenger.rs
+++ b/crates/librefang-channels/src/messenger.rs
@@ -18,6 +18,40 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
+/// Verify a Facebook Messenger X-Hub-Signature header using HMAC-SHA1.
+///
+/// The header format is `sha1=<hex-digest>`.
+/// The expected digest is `HMAC-SHA1(app_secret, raw_body)`.
+fn verify_hub_signature(app_secret: &[u8], body: &[u8], signature_header: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha1::Sha1;
+
+    let hex_sig = match signature_header.strip_prefix("sha1=") {
+        Some(s) => s,
+        None => return false,
+    };
+
+    let Ok(expected_bytes) = hex::decode(hex_sig) else {
+        return false;
+    };
+
+    let Ok(mut mac) = Hmac::<Sha1>::new_from_slice(app_secret) else {
+        warn!("Messenger: failed to create HMAC-SHA1 instance");
+        return false;
+    };
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+
+    if result.len() != expected_bytes.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in result.iter().zip(expected_bytes.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
 /// Facebook Graph API base URL for sending messages.
 const GRAPH_API_BASE: &str = "https://graph.facebook.com/v18.0";
 
@@ -37,6 +71,9 @@ pub struct MessengerAdapter {
     page_token: Zeroizing<String>,
     /// SECURITY: Verify token for webhook registration, zeroized on drop.
     verify_token: Zeroizing<String>,
+    /// SECURITY: App secret for HMAC-SHA1 webhook signature verification.
+    /// If empty, signature verification is skipped with a loud warning.
+    app_secret: Zeroizing<String>,
     /// HTTP client for outbound API calls.
     client: reqwest::Client,
     /// Optional account identifier for multi-bot routing.
@@ -49,11 +86,19 @@ impl MessengerAdapter {
     /// # Arguments
     /// * `page_token` - Facebook page access token for the Send API.
     /// * `verify_token` - Token used to verify the webhook during Facebook's setup.
+    /// * `app_secret` - Facebook App Secret for HMAC-SHA1 webhook verification.
+    ///   Pass an empty string to skip verification (logs a warning).
     /// * `webhook_port` - Local port (accepted from config, unused with shared server).
-    pub fn new(page_token: String, verify_token: String, _webhook_port: u16) -> Self {
+    pub fn new(
+        page_token: String,
+        verify_token: String,
+        app_secret: String,
+        _webhook_port: u16,
+    ) -> Self {
         Self {
             page_token: Zeroizing::new(page_token),
             verify_token: Zeroizing::new(verify_token),
+            app_secret: Zeroizing::new(app_secret),
             client: crate::http_client::new_client(),
             account_id: None,
         }
@@ -158,9 +203,10 @@ impl MessengerAdapter {
     ///
     /// The router handles:
     /// - GET `/webhook` — Facebook webhook verification challenge
-    /// - POST `/webhook` — Incoming message events
+    /// - POST `/webhook` — Incoming message events (HMAC-SHA1 verified via X-Hub-Signature)
     fn build_webhook_router(&self, tx: mpsc::Sender<ChannelMessage>) -> axum::Router {
         let verify_token = Arc::new(self.verify_token.clone());
+        let app_secret = Arc::new(self.app_secret.clone());
         let account_id = Arc::new(self.account_id.clone());
         let tx = Arc::new(tx);
 
@@ -190,17 +236,48 @@ impl MessengerAdapter {
                 }
             })
             .post({
-                // Incoming message handler
+                // Incoming message handler — verify HMAC-SHA1 before processing.
                 let tx = Arc::clone(&tx);
-                move |body: axum::extract::Json<serde_json::Value>| {
+                let app_secret = Arc::clone(&app_secret);
+                let account_id = Arc::clone(&account_id);
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let tx = Arc::clone(&tx);
+                    let app_secret = Arc::clone(&app_secret);
+                    let account_id = Arc::clone(&account_id);
                     async move {
-                        let object = body.0["object"].as_str().unwrap_or("");
+                        // Verify X-Hub-Signature (HMAC-SHA1 with app_secret).
+                        if app_secret.is_empty() {
+                            warn!(
+                                "Messenger: no app_secret configured — \
+                                 webhook signature verification is DISABLED. \
+                                 Set app_secret to harden this endpoint."
+                            );
+                        } else {
+                            let sig = headers
+                                .get("x-hub-signature")
+                                .and_then(|v| v.to_str().ok())
+                                .unwrap_or("");
+                            if sig.is_empty() {
+                                warn!("Messenger: missing X-Hub-Signature header — rejecting request");
+                                return axum::http::StatusCode::FORBIDDEN;
+                            }
+                            if !verify_hub_signature(app_secret.as_bytes(), &body, sig) {
+                                warn!("Messenger: invalid X-Hub-Signature — rejecting request");
+                                return axum::http::StatusCode::FORBIDDEN;
+                            }
+                        }
+
+                        let json_body: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(v) => v,
+                            Err(_) => return axum::http::StatusCode::BAD_REQUEST,
+                        };
+
+                        let object = json_body["object"].as_str().unwrap_or("");
                         if object != "page" {
                             return axum::http::StatusCode::OK;
                         }
 
-                        if let Some(entries) = body.0["entry"].as_array() {
+                        if let Some(entries) = json_body["entry"].as_array() {
                             for entry in entries {
                                 let msgs = parse_messenger_entry(entry);
                                 for mut msg in msgs {
@@ -450,6 +527,7 @@ mod tests {
         let adapter = MessengerAdapter::new(
             "page-token-123".to_string(),
             "verify-token-456".to_string(),
+            "app-secret-789".to_string(),
             8080,
         );
         assert_eq!(adapter.name(), "messenger");
@@ -461,9 +539,40 @@ mod tests {
 
     #[test]
     fn test_messenger_both_tokens() {
-        let adapter = MessengerAdapter::new("page-tok".to_string(), "verify-tok".to_string(), 9000);
+        let adapter = MessengerAdapter::new(
+            "page-tok".to_string(),
+            "verify-tok".to_string(),
+            "app-sec".to_string(),
+            9000,
+        );
         assert_eq!(adapter.page_token.as_str(), "page-tok");
         assert_eq!(adapter.verify_token.as_str(), "verify-tok");
+        assert_eq!(adapter.app_secret.as_str(), "app-sec");
+    }
+
+    #[test]
+    fn test_verify_hub_signature_valid() {
+        use hmac::{Hmac, Mac};
+        use sha1::Sha1;
+
+        let secret = b"my-app-secret";
+        let body = b"test payload body";
+
+        let mut mac = Hmac::<Sha1>::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let result = mac.finalize().into_bytes();
+        let hex_sig = format!("sha1={}", hex::encode(result));
+
+        assert!(verify_hub_signature(secret, body, &hex_sig));
+    }
+
+    #[test]
+    fn test_verify_hub_signature_invalid() {
+        let secret = b"my-app-secret";
+        let body = b"test payload body";
+        assert!(!verify_hub_signature(secret, body, "sha1=deadbeef"));
+        assert!(!verify_hub_signature(secret, body, "bad-format"));
+        assert!(!verify_hub_signature(secret, body, ""));
     }
 
     #[test]

--- a/crates/librefang-channels/src/teams.rs
+++ b/crates/librefang-channels/src/teams.rs
@@ -18,6 +18,49 @@ use tokio::sync::{mpsc, RwLock};
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
+/// Verify a Microsoft Teams outgoing-webhook HMAC-SHA256 signature.
+///
+/// The `Authorization` header carries `HMAC <base64-digest>`.
+/// The expected digest is `Base64(HMAC-SHA256(security_token_bytes, raw_body))`.
+/// The security token is provided as a base64-encoded string in the Teams portal;
+/// the raw bytes are the HMAC key.
+fn verify_teams_signature(security_token_b64: &str, body: &[u8], auth_header: &str) -> bool {
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let claimed_b64 = match auth_header.strip_prefix("HMAC ") {
+        Some(s) => s.trim(),
+        None => return false,
+    };
+
+    let Ok(claimed_bytes) = base64::engine::general_purpose::STANDARD.decode(claimed_b64) else {
+        warn!("Teams: invalid base64 in Authorization header");
+        return false;
+    };
+
+    let Ok(key_bytes) = base64::engine::general_purpose::STANDARD.decode(security_token_b64) else {
+        warn!("Teams: invalid base64 in configured security_token");
+        return false;
+    };
+
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(&key_bytes) else {
+        warn!("Teams: failed to create HMAC-SHA256 instance");
+        return false;
+    };
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+
+    if result.len() != claimed_bytes.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in result.iter().zip(claimed_bytes.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
 /// OAuth2 token endpoint for Bot Framework.
 const OAUTH_TOKEN_URL: &str =
     "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
@@ -38,6 +81,10 @@ pub struct TeamsAdapter {
     app_id: String,
     /// SECURITY: App password is zeroized on drop to prevent memory disclosure.
     app_password: Zeroizing<String>,
+    /// SECURITY: Outgoing webhook security token (base64-encoded bytes from Teams portal).
+    /// Used for HMAC-SHA256 verification of inbound webhook requests.
+    /// If empty, verification is skipped with a warning (backwards compatibility).
+    security_token: Zeroizing<String>,
     /// Restrict inbound activities to specific Azure AD tenant IDs (empty = allow all).
     allowed_tenants: Vec<String>,
     /// HTTP client for outbound API calls.
@@ -53,16 +100,21 @@ impl TeamsAdapter {
     ///
     /// * `app_id` — Bot Framework application ID.
     /// * `app_password` — Bot Framework application password (client secret).
+    /// * `security_token` — Base64-encoded outgoing webhook security token from the
+    ///   Teams portal. Used to verify HMAC-SHA256 signatures on inbound webhooks.
+    ///   Pass an empty string to disable signature verification (logs a warning).
     /// * `allowed_tenants` — Azure AD tenant IDs to accept (empty = accept all).
     pub fn new(
         app_id: String,
         app_password: String,
+        security_token: String,
         _webhook_port: u16,
         allowed_tenants: Vec<String>,
     ) -> Self {
         Self {
             app_id,
             app_password: Zeroizing::new(app_password),
+            security_token: Zeroizing::new(security_token),
             allowed_tenants,
             client: crate::http_client::new_client(),
             account_id: None,
@@ -295,6 +347,7 @@ impl ChannelAdapter for TeamsAdapter {
         let app_id = Arc::new(self.app_id.clone());
         let allowed_tenants = Arc::new(self.allowed_tenants.clone());
         let account_id = Arc::new(self.account_id.clone());
+        let security_token = Arc::new(self.security_token.clone());
 
         let app = axum::Router::new().route(
             "/webhook",
@@ -303,13 +356,44 @@ impl ChannelAdapter for TeamsAdapter {
                 let tenants = Arc::clone(&allowed_tenants);
                 let tx = Arc::clone(&tx);
                 let account_id = Arc::clone(&account_id);
-                move |body: axum::extract::Json<serde_json::Value>| {
+                let security_token = Arc::clone(&security_token);
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let app_id = Arc::clone(&app_id);
                     let tenants = Arc::clone(&tenants);
                     let tx = Arc::clone(&tx);
                     let account_id = Arc::clone(&account_id);
+                    let security_token = Arc::clone(&security_token);
                     async move {
-                        if let Some(mut msg) = parse_teams_activity(&body, &app_id, &tenants) {
+                        // Verify HMAC-SHA256 signature if a security_token is configured.
+                        if security_token.is_empty() {
+                            warn!(
+                                "Teams: no security_token configured — \
+                                 webhook signature verification is DISABLED. \
+                                 Set security_token to harden this endpoint."
+                            );
+                        } else {
+                            let auth = headers
+                                .get("authorization")
+                                .and_then(|v| v.to_str().ok())
+                                .unwrap_or("");
+                            if auth.is_empty() {
+                                warn!("Teams: missing Authorization header — rejecting request");
+                                return axum::http::StatusCode::UNAUTHORIZED;
+                            }
+                            if !verify_teams_signature(&security_token, &body, auth) {
+                                warn!("Teams: invalid HMAC-SHA256 signature — rejecting request");
+                                return axum::http::StatusCode::UNAUTHORIZED;
+                            }
+                        }
+
+                        let json_body: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(v) => v,
+                            Err(_) => return axum::http::StatusCode::BAD_REQUEST,
+                        };
+
+                        if let Some(mut msg) =
+                            parse_teams_activity(&json_body, &app_id, &tenants)
+                        {
                             // Inject account_id for multi-bot routing
                             if let Some(ref aid) = *account_id {
                                 msg.metadata
@@ -411,6 +495,7 @@ mod tests {
         let adapter = TeamsAdapter::new(
             "app-id-123".to_string(),
             "app-password".to_string(),
+            "".to_string(),
             3978,
             vec![],
         );
@@ -423,14 +508,56 @@ mod tests {
         let adapter = TeamsAdapter::new(
             "app-id".to_string(),
             "password".to_string(),
+            "".to_string(),
             3978,
             vec!["tenant-abc".to_string()],
         );
         assert!(adapter.is_allowed_tenant("tenant-abc"));
         assert!(!adapter.is_allowed_tenant("tenant-xyz"));
 
-        let open = TeamsAdapter::new("app-id".to_string(), "password".to_string(), 3978, vec![]);
+        let open = TeamsAdapter::new(
+            "app-id".to_string(),
+            "password".to_string(),
+            "".to_string(),
+            3978,
+            vec![],
+        );
         assert!(open.is_allowed_tenant("any-tenant"));
+    }
+
+    #[test]
+    fn test_verify_teams_signature_valid() {
+        use base64::Engine;
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        // Build a known HMAC key (raw bytes), base64-encode it as the "security token".
+        let key_bytes = b"test-teams-key-bytes-16bytes!!xx";
+        let security_token_b64 =
+            base64::engine::general_purpose::STANDARD.encode(key_bytes);
+
+        let body = b"teams webhook body";
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(key_bytes).unwrap();
+        mac.update(body);
+        let result = mac.finalize().into_bytes();
+        let sig_b64 = base64::engine::general_purpose::STANDARD.encode(result);
+        let auth_header = format!("HMAC {sig_b64}");
+
+        assert!(verify_teams_signature(&security_token_b64, body, &auth_header));
+    }
+
+    #[test]
+    fn test_verify_teams_signature_invalid() {
+        use base64::Engine;
+        let key_bytes = b"test-teams-key-bytes-16bytes!!xx";
+        let security_token_b64 =
+            base64::engine::general_purpose::STANDARD.encode(key_bytes);
+
+        let body = b"teams webhook body";
+        assert!(!verify_teams_signature(&security_token_b64, body, "HMAC badsig=="));
+        assert!(!verify_teams_signature(&security_token_b64, body, "Bearer token"));
+        assert!(!verify_teams_signature(&security_token_b64, body, ""));
     }
 
     #[test]

--- a/crates/librefang-channels/src/teams.rs
+++ b/crates/librefang-channels/src/teams.rs
@@ -22,9 +22,11 @@ use zeroize::Zeroizing;
 ///
 /// The `Authorization` header carries `HMAC <base64-digest>`.
 /// The expected digest is `Base64(HMAC-SHA256(security_token_bytes, raw_body))`.
-/// The security token is provided as a base64-encoded string in the Teams portal;
-/// the raw bytes are the HMAC key.
-fn verify_teams_signature(security_token_b64: &str, body: &[u8], auth_header: &str) -> bool {
+///
+/// `key_bytes` is the *decoded* security-token raw key — Teams provides the
+/// token base64-encoded in the portal, but `TeamsAdapter::new` decodes it
+/// once at construction so verify path stays hot-loop-cheap.
+fn verify_teams_signature(key_bytes: &[u8], body: &[u8], auth_header: &str) -> bool {
     use base64::Engine;
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
@@ -39,26 +41,14 @@ fn verify_teams_signature(security_token_b64: &str, body: &[u8], auth_header: &s
         return false;
     };
 
-    let Ok(key_bytes) = base64::engine::general_purpose::STANDARD.decode(security_token_b64) else {
-        warn!("Teams: invalid base64 in configured security_token");
-        return false;
-    };
-
-    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(&key_bytes) else {
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(key_bytes) else {
         warn!("Teams: failed to create HMAC-SHA256 instance");
         return false;
     };
     mac.update(body);
     let result = mac.finalize().into_bytes();
 
-    if result.len() != claimed_bytes.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (a, b) in result.iter().zip(claimed_bytes.iter()) {
-        diff |= a ^ b;
-    }
-    diff == 0
+    crate::http_client::ct_eq(&result, &claimed_bytes)
 }
 
 /// OAuth2 token endpoint for Bot Framework.
@@ -81,10 +71,15 @@ pub struct TeamsAdapter {
     app_id: String,
     /// SECURITY: App password is zeroized on drop to prevent memory disclosure.
     app_password: Zeroizing<String>,
-    /// SECURITY: Outgoing webhook security token (base64-encoded bytes from Teams portal).
-    /// Used for HMAC-SHA256 verification of inbound webhook requests.
-    /// If empty, verification is skipped with a warning (backwards compatibility).
-    security_token: Zeroizing<String>,
+    /// SECURITY: Decoded outgoing-webhook security-token raw bytes used as
+    /// the HMAC-SHA256 key for inbound webhook verification.
+    ///
+    /// `None` means no token configured (verification is skipped, with a
+    /// loud warning logged at construction). The base64 form from the
+    /// Teams portal is decoded once in `new()`; misconfigurations
+    /// (non-base64 input) collapse to `None` so the per-request hot path
+    /// stays branch-free.
+    security_token_key: Option<Zeroizing<Vec<u8>>>,
     /// Restrict inbound activities to specific Azure AD tenant IDs (empty = allow all).
     allowed_tenants: Vec<String>,
     /// HTTP client for outbound API calls.
@@ -111,10 +106,30 @@ impl TeamsAdapter {
         _webhook_port: u16,
         allowed_tenants: Vec<String>,
     ) -> Self {
+        use base64::Engine;
+        let security_token_key = if security_token.is_empty() {
+            warn!(
+                "Teams: no security_token configured — webhook signature \
+                 verification is DISABLED. Set security_token_env to harden \
+                 this endpoint."
+            );
+            None
+        } else {
+            match base64::engine::general_purpose::STANDARD.decode(&security_token) {
+                Ok(bytes) => Some(Zeroizing::new(bytes)),
+                Err(e) => {
+                    warn!(
+                        "Teams: configured security_token is not valid base64 \
+                         ({e}); webhook signature verification is DISABLED."
+                    );
+                    None
+                }
+            }
+        };
         Self {
             app_id,
             app_password: Zeroizing::new(app_password),
-            security_token: Zeroizing::new(security_token),
+            security_token_key,
             allowed_tenants,
             client: crate::http_client::new_client(),
             account_id: None,
@@ -347,7 +362,13 @@ impl ChannelAdapter for TeamsAdapter {
         let app_id = Arc::new(self.app_id.clone());
         let allowed_tenants = Arc::new(self.allowed_tenants.clone());
         let account_id = Arc::new(self.account_id.clone());
-        let security_token = Arc::new(self.security_token.clone());
+        // Clone the decoded HMAC key once for the route closure. `None`
+        // means "no token configured" — verification was already warned
+        // about at construction time, the request path stays silent.
+        let key: Option<Arc<Zeroizing<Vec<u8>>>> = self
+            .security_token_key
+            .as_ref()
+            .map(|k| Arc::new(k.clone()));
 
         let app = axum::Router::new().route(
             "/webhook",
@@ -356,32 +377,23 @@ impl ChannelAdapter for TeamsAdapter {
                 let tenants = Arc::clone(&allowed_tenants);
                 let tx = Arc::clone(&tx);
                 let account_id = Arc::clone(&account_id);
-                let security_token = Arc::clone(&security_token);
+                let key = key.clone();
                 move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let app_id = Arc::clone(&app_id);
                     let tenants = Arc::clone(&tenants);
                     let tx = Arc::clone(&tx);
                     let account_id = Arc::clone(&account_id);
-                    let security_token = Arc::clone(&security_token);
+                    let key = key.clone();
                     async move {
-                        // Verify HMAC-SHA256 signature if a security_token is configured.
-                        if security_token.is_empty() {
-                            warn!(
-                                "Teams: no security_token configured — \
-                                 webhook signature verification is DISABLED. \
-                                 Set security_token to harden this endpoint."
-                            );
-                        } else {
-                            let auth = headers
-                                .get("authorization")
-                                .and_then(|v| v.to_str().ok())
-                                .unwrap_or("");
-                            if auth.is_empty() {
-                                warn!("Teams: missing Authorization header — rejecting request");
-                                return axum::http::StatusCode::UNAUTHORIZED;
-                            }
-                            if !verify_teams_signature(&security_token, &body, auth) {
-                                warn!("Teams: invalid HMAC-SHA256 signature — rejecting request");
+                        if let Some(key) = key.as_ref() {
+                            let Some(auth) =
+                                headers.get("authorization").and_then(|v| v.to_str().ok())
+                            else {
+                                warn!("Teams: missing Authorization header");
+                                return axum::http::StatusCode::BAD_REQUEST;
+                            };
+                            if !verify_teams_signature(key, &body, auth) {
+                                warn!("Teams: invalid HMAC-SHA256 signature");
                                 return axum::http::StatusCode::UNAUTHORIZED;
                             }
                         }
@@ -391,9 +403,7 @@ impl ChannelAdapter for TeamsAdapter {
                             Err(_) => return axum::http::StatusCode::BAD_REQUEST,
                         };
 
-                        if let Some(mut msg) =
-                            parse_teams_activity(&json_body, &app_id, &tenants)
-                        {
+                        if let Some(mut msg) = parse_teams_activity(&json_body, &app_id, &tenants) {
                             // Inject account_id for multi-bot routing
                             if let Some(ref aid) = *account_id {
                                 msg.metadata
@@ -531,10 +541,7 @@ mod tests {
         use hmac::{Hmac, Mac};
         use sha2::Sha256;
 
-        // Build a known HMAC key (raw bytes), base64-encode it as the "security token".
-        let key_bytes = b"test-teams-key-bytes-16bytes!!xx";
-        let security_token_b64 =
-            base64::engine::general_purpose::STANDARD.encode(key_bytes);
+        let key_bytes: &[u8] = b"test-teams-key-bytes-16bytes!!xx";
 
         let body = b"teams webhook body";
 
@@ -544,20 +551,31 @@ mod tests {
         let sig_b64 = base64::engine::general_purpose::STANDARD.encode(result);
         let auth_header = format!("HMAC {sig_b64}");
 
-        assert!(verify_teams_signature(&security_token_b64, body, &auth_header));
+        assert!(verify_teams_signature(key_bytes, body, &auth_header));
     }
 
     #[test]
     fn test_verify_teams_signature_invalid() {
-        use base64::Engine;
-        let key_bytes = b"test-teams-key-bytes-16bytes!!xx";
-        let security_token_b64 =
-            base64::engine::general_purpose::STANDARD.encode(key_bytes);
-
+        let key_bytes: &[u8] = b"test-teams-key-bytes-16bytes!!xx";
         let body = b"teams webhook body";
-        assert!(!verify_teams_signature(&security_token_b64, body, "HMAC badsig=="));
-        assert!(!verify_teams_signature(&security_token_b64, body, "Bearer token"));
-        assert!(!verify_teams_signature(&security_token_b64, body, ""));
+        assert!(!verify_teams_signature(key_bytes, body, "HMAC badsig=="));
+        assert!(!verify_teams_signature(key_bytes, body, "Bearer token"));
+        assert!(!verify_teams_signature(key_bytes, body, ""));
+    }
+
+    /// Constructor must record the warning *and* leave verification disabled
+    /// (key set to `None`) when the operator misconfigures the env var with
+    /// non-base64 input. Otherwise the per-request path would silently fail.
+    #[test]
+    fn test_teams_invalid_base64_token_disables_verification() {
+        let adapter = TeamsAdapter::new(
+            "app".into(),
+            "pw".into(),
+            "this is not base64!!!".into(),
+            3978,
+            vec![],
+        );
+        assert!(adapter.security_token_key.is_none());
     }
 
     #[test]

--- a/crates/librefang-channels/src/viber.rs
+++ b/crates/librefang-channels/src/viber.rs
@@ -36,14 +36,7 @@ fn verify_viber_signature(auth_token: &[u8], body: &[u8], signature_hex: &str) -
     mac.update(body);
     let result = mac.finalize().into_bytes();
 
-    if result.len() != claimed.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (a, b) in result.iter().zip(claimed.iter()) {
-        diff |= a ^ b;
-    }
-    diff == 0
+    crate::http_client::ct_eq(&result, &claimed)
 }
 
 /// Viber set webhook endpoint.
@@ -373,17 +366,16 @@ impl ChannelAdapter for ViberAdapter {
                     let account_id = Arc::clone(&account_id);
                     async move {
                         // Verify X-Viber-Content-Signature (HMAC-SHA256 with auth_token).
-                        let sig = headers
+                        let Some(sig) = headers
                             .get("x-viber-content-signature")
                             .and_then(|v| v.to_str().ok())
-                            .unwrap_or("");
-                        if sig.is_empty() {
-                            warn!("Viber: missing X-Viber-Content-Signature header — rejecting request");
-                            return axum::http::StatusCode::FORBIDDEN;
-                        }
+                        else {
+                            warn!("Viber: missing X-Viber-Content-Signature header");
+                            return axum::http::StatusCode::BAD_REQUEST;
+                        };
                         if !verify_viber_signature(auth_token.as_bytes(), &body, sig) {
-                            warn!("Viber: invalid X-Viber-Content-Signature — rejecting request");
-                            return axum::http::StatusCode::FORBIDDEN;
+                            warn!("Viber: invalid X-Viber-Content-Signature");
+                            return axum::http::StatusCode::UNAUTHORIZED;
                         }
 
                         let json_body: serde_json::Value = match serde_json::from_slice(&body) {

--- a/crates/librefang-channels/src/viber.rs
+++ b/crates/librefang-channels/src/viber.rs
@@ -18,6 +18,34 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use zeroize::Zeroizing;
 
+/// Verify the `X-Viber-Content-Signature` header (HMAC-SHA256 with the auth token).
+///
+/// The header contains the raw hex digest (no prefix).
+fn verify_viber_signature(auth_token: &[u8], body: &[u8], signature_hex: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let Ok(claimed) = hex::decode(signature_hex) else {
+        return false;
+    };
+
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(auth_token) else {
+        warn!("Viber: failed to create HMAC-SHA256 instance");
+        return false;
+    };
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+
+    if result.len() != claimed.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in result.iter().zip(claimed.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
 /// Viber set webhook endpoint.
 const VIBER_SET_WEBHOOK_URL: &str = "https://chatapi.viber.com/pa/set_webhook";
 
@@ -331,15 +359,39 @@ impl ChannelAdapter for ViberAdapter {
         let (tx, rx) = mpsc::channel::<ChannelMessage>(256);
         let tx = Arc::new(tx);
         let account_id = Arc::new(self.account_id.clone());
+        let auth_token = Arc::new(self.auth_token.clone());
 
         let router = axum::Router::new().route(
             "/webhook",
             axum::routing::post({
                 let tx = Arc::clone(&tx);
-                move |body: axum::extract::Json<serde_json::Value>| {
+                let auth_token = Arc::clone(&auth_token);
+                let account_id = Arc::clone(&account_id);
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let tx = Arc::clone(&tx);
+                    let auth_token = Arc::clone(&auth_token);
+                    let account_id = Arc::clone(&account_id);
                     async move {
-                        if let Some(mut msg) = parse_viber_event(&body.0) {
+                        // Verify X-Viber-Content-Signature (HMAC-SHA256 with auth_token).
+                        let sig = headers
+                            .get("x-viber-content-signature")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("");
+                        if sig.is_empty() {
+                            warn!("Viber: missing X-Viber-Content-Signature header — rejecting request");
+                            return axum::http::StatusCode::FORBIDDEN;
+                        }
+                        if !verify_viber_signature(auth_token.as_bytes(), &body, sig) {
+                            warn!("Viber: invalid X-Viber-Content-Signature — rejecting request");
+                            return axum::http::StatusCode::FORBIDDEN;
+                        }
+
+                        let json_body: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(v) => v,
+                            Err(_) => return axum::http::StatusCode::BAD_REQUEST,
+                        };
+
+                        if let Some(mut msg) = parse_viber_event(&json_body) {
                             // Inject account_id for multi-bot routing
                             if let Some(ref aid) = *account_id {
                                 msg.metadata
@@ -435,6 +487,31 @@ impl ChannelAdapter for ViberAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_verify_viber_signature_valid() {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let token = b"my-viber-auth-token";
+        let body = b"viber webhook payload";
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(token).unwrap();
+        mac.update(body);
+        let result = mac.finalize().into_bytes();
+        let hex_sig = hex::encode(result);
+
+        assert!(verify_viber_signature(token, body, &hex_sig));
+    }
+
+    #[test]
+    fn test_verify_viber_signature_invalid() {
+        let token = b"my-viber-auth-token";
+        let body = b"viber webhook payload";
+        assert!(!verify_viber_signature(token, body, "deadbeef"));
+        assert!(!verify_viber_signature(token, body, ""));
+        assert!(!verify_viber_signature(token, body, "not-hex!@#$"));
+    }
 
     #[test]
     fn test_viber_adapter_creation() {

--- a/crates/librefang-channels/src/webhook.rs
+++ b/crates/librefang-channels/src/webhook.rs
@@ -82,9 +82,8 @@ impl WebhookAdapter {
         callback_url: Option<String>,
     ) -> Result<Self, String> {
         if let Some(ref url) = callback_url {
-            crate::http_client::validate_url_for_fetch(url).map_err(|e| {
-                format!("WebhookAdapter: callback_url rejected by SSRF guard: {e}")
-            })?;
+            crate::http_client::validate_url_for_fetch(url)
+                .map_err(|e| format!("WebhookAdapter: callback_url rejected by SSRF guard: {e}"))?;
         }
         Ok(Self {
             secret: Zeroizing::new(secret),

--- a/crates/librefang-channels/src/webhook.rs
+++ b/crates/librefang-channels/src/webhook.rs
@@ -73,15 +73,27 @@ impl WebhookAdapter {
     /// * `secret` - Shared secret for HMAC-SHA256 signature verification.
     /// * `listen_port` - Port to listen for incoming webhook POST requests.
     /// * `callback_url` - Optional URL to POST outbound messages to.
-    pub fn new(secret: String, _listen_port: u16, callback_url: Option<String>) -> Self {
-        Self {
+    ///
+    /// Returns an error if `callback_url` is present but points to a private/
+    /// loopback/metadata-service host (SSRF guard).
+    pub fn new(
+        secret: String,
+        _listen_port: u16,
+        callback_url: Option<String>,
+    ) -> Result<Self, String> {
+        if let Some(ref url) = callback_url {
+            crate::http_client::validate_url_for_fetch(url).map_err(|e| {
+                format!("WebhookAdapter: callback_url rejected by SSRF guard: {e}")
+            })?;
+        }
+        Ok(Self {
             secret: Zeroizing::new(secret),
             callback_url,
             client: crate::http_client::new_client(),
             account_id: None,
             deliver_only: false,
             deliver_target: None,
-        }
+        })
     }
 
     /// Set the account_id for multi-bot routing. Returns self for builder chaining.
@@ -411,7 +423,8 @@ mod tests {
             "my-secret".to_string(),
             9000,
             Some("https://example.com/callback".to_string()),
-        );
+        )
+        .expect("public URL should be accepted");
         assert_eq!(adapter.name(), "webhook");
         assert_eq!(
             adapter.channel_type(),
@@ -422,8 +435,42 @@ mod tests {
 
     #[test]
     fn test_webhook_no_callback() {
-        let adapter = WebhookAdapter::new("secret".to_string(), 9000, None);
+        let adapter = WebhookAdapter::new("secret".to_string(), 9000, None).unwrap();
         assert!(!adapter.has_callback());
+    }
+
+    #[test]
+    fn test_webhook_rejects_private_callback_url() {
+        assert!(WebhookAdapter::new(
+            "secret".to_string(),
+            9000,
+            Some("http://127.0.0.1/hook".to_string()),
+        )
+        .is_err());
+
+        assert!(WebhookAdapter::new(
+            "secret".to_string(),
+            9000,
+            Some("http://192.168.1.1/hook".to_string()),
+        )
+        .is_err());
+
+        assert!(WebhookAdapter::new(
+            "secret".to_string(),
+            9000,
+            Some("http://169.254.169.254/latest/meta-data/".to_string()),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_webhook_accepts_public_callback_url() {
+        assert!(WebhookAdapter::new(
+            "secret".to_string(),
+            9000,
+            Some("https://hooks.example.com/receiver".to_string()),
+        )
+        .is_ok());
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5633,6 +5633,11 @@ pub struct TeamsConfig {
     pub app_id: String,
     /// Env var name holding the app password.
     pub app_password_env: String,
+    /// Env var name holding the outgoing webhook security token (base64-encoded).
+    /// Used for HMAC-SHA256 verification of inbound webhook requests.
+    /// If the env var is absent or empty, verification is skipped with a warning.
+    #[serde(default)]
+    pub security_token_env: String,
     /// Port for the incoming webhook.
     pub webhook_port: u16,
     /// Allowed tenant IDs (empty = allow all).
@@ -5653,6 +5658,7 @@ impl Default for TeamsConfig {
         Self {
             app_id: String::new(),
             app_password_env: "TEAMS_APP_PASSWORD".to_string(),
+            security_token_env: "TEAMS_SECURITY_TOKEN".to_string(),
             webhook_port: 3978,
             allowed_tenants: vec![],
             account_id: None,
@@ -6018,6 +6024,12 @@ pub struct MessengerConfig {
     pub page_token_env: String,
     /// Env var name holding the webhook verify token.
     pub verify_token_env: String,
+    /// Env var name holding the Facebook App Secret.
+    /// Used for HMAC-SHA1 verification of incoming webhook POST requests
+    /// via `X-Hub-Signature`. If absent or empty, verification is skipped
+    /// with a warning (backwards compatibility).
+    #[serde(default)]
+    pub app_secret_env: String,
     /// Port for the incoming webhook.
     pub webhook_port: u16,
     /// Unique identifier for this bot instance (used for multi-bot routing).
@@ -6035,6 +6047,7 @@ impl Default for MessengerConfig {
         Self {
             page_token_env: "MESSENGER_PAGE_TOKEN".to_string(),
             verify_token_env: "MESSENGER_VERIFY_TOKEN".to_string(),
+            app_secret_env: "MESSENGER_APP_SECRET".to_string(),
             webhook_port: 8452,
             account_id: None,
             default_agent: None,

--- a/docs/src/app/configuration/channels/page.mdx
+++ b/docs/src/app/configuration/channels/page.mdx
@@ -31,6 +31,17 @@ Channels with a per-secret env var (Messenger `app_secret_env`, Teams `security_
 
 Outbound webhook URLs (`callback_url` on `[channels.webhook]`) are run through an SSRF guard at adapter construction: any private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local (`169.254/16`, `fe80::/10`), unique-local (`fc00::/7`), multicast, or cloud-metadata (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.com`) target — including IPv6-bracket forms like `[::]`, `[::ffff:127.0.0.1]`, NAT64 `[64:ff9b::7f00:1]`, and trailing-dot FQDNs — is rejected with a startup error.
 
+#### Upgrading from earlier versions
+
+If you are upgrading from a release before this contract was introduced:
+
+1. **Operating Messenger?** Copy your **App Secret** from the Facebook app dashboard and export it as `MESSENGER_APP_SECRET` (or whatever name you set `app_secret_env` to). Without it, inbound webhooks still work but are unauthenticated — a warning is logged once at startup.
+2. **Operating Teams?** Copy the outgoing-webhook **security token** (base64) from the Teams portal and export it as `TEAMS_SECURITY_TOKEN` (or whatever you set `security_token_env` to). Same fallback semantics — warning once, no verification.
+3. **Operating LINE / Viber / DingTalk?** No new env var to set, but probes/health-checks that hit the webhook path without the platform's signature header now return `400`/`401`. Real platform traffic always carries a signature, so genuine inbound is unaffected; only direct probes break.
+4. **Using `[channels.webhook]` with `callback_url` pointing at a private address?** The most common case is a local dev setup with `callback_url = "http://127.0.0.1/..."`. The adapter now refuses to start with that. Switch to a public tunnel (e.g. ngrok, cloudflared) or omit `callback_url` entirely if you don't need outbound delivery.
+
+If you operate **none** of the channels above, no action is required — your existing config keeps working unchanged.
+
 #### `[channels.telegram]`
 
 ```toml

--- a/docs/src/app/configuration/channels/page.mdx
+++ b/docs/src/app/configuration/channels/page.mdx
@@ -16,6 +16,21 @@ All 45 channel adapters are configured under `[channels.<name>]`. Each channel i
 | `account_id` | string or null | `null` | Unique identifier for this bot instance. Used for multi-bot routing via `[[bindings]]` match rules. |
 | `overrides` | object | (defaults) | Per-channel behavior overrides. See [Channel Overrides](#channel-overrides). |
 
+### Webhook security
+
+Channels that receive inbound traffic over HTTP enforce a uniform contract:
+
+| Outcome | Status |
+|---|---|
+| Required header missing or malformed (`X-Hub-Signature`, `X-Line-Signature`, `X-Viber-Content-Signature`, `Authorization: HMAC …`, DingTalk `timestamp`/`sign`) | **400 Bad Request** |
+| Header present but signature mismatched, replayed, or expired | **401 Unauthorized** |
+
+HMAC verification covers the **raw wire bytes** (not bytes round-tripped through `serde_json::Value`), so the signing key set in the platform portal must match the env var configured below. Comparison runs in constant time.
+
+Channels with a per-secret env var (Messenger `app_secret_env`, Teams `security_token_env`) fall back to "skip verification + log a startup warning" when the env var is unset — this preserves backwards compatibility but should never be left unset in production.
+
+Outbound webhook URLs (`callback_url` on `[channels.webhook]`) are run through an SSRF guard at adapter construction: any private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local (`169.254/16`, `fe80::/10`), unique-local (`fc00::/7`), multicast, or cloud-metadata (`169.254.169.254`, `metadata.google.internal`, `metadata.azure.com`) target — including IPv6-bracket forms like `[::]`, `[::ffff:127.0.0.1]`, NAT64 `[64:ff9b::7f00:1]`, and trailing-dot FQDNs — is rejected with a startup error.
+
 #### `[channels.telegram]`
 
 ```toml
@@ -175,6 +190,7 @@ allowed_senders = []
 [channels.teams]
 app_id = ""
 app_password_env = "TEAMS_APP_PASSWORD"
+security_token_env = "TEAMS_SECURITY_TOKEN"
 # webhook_port = 3978  # Deprecated: webhooks now share the API port
 allowed_tenants = []
 ```
@@ -183,6 +199,7 @@ allowed_tenants = []
 |-------|------|---------|-------------|
 | `app_id` | string | `""` | Azure Bot App ID. |
 | `app_password_env` | string | `"TEAMS_APP_PASSWORD"` | Env var holding the Azure Bot Framework app password. |
+| `security_token_env` | string | `"TEAMS_SECURITY_TOKEN"` | Env var holding the **outgoing webhook security token** (base64-encoded, copied from the Teams portal). Used for HMAC-SHA256 verification of every inbound `Authorization: HMAC <…>` header. If unset or non-base64, signature verification is skipped and a warning is logged once at startup — production deployments should always set this. |
 | `webhook_port` | u16 | `3978` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `allowed_tenants` | list of strings | `[]` | Azure AD tenant IDs allowed. Empty = allow all. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -324,7 +341,7 @@ access_token_env = "LINE_CHANNEL_ACCESS_TOKEN"
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | Env var holding the LINE channel secret. |
+| `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | Env var holding the LINE channel secret. **Required** — every inbound webhook must carry a matching `X-Line-Signature`; missing → 400, mismatched → 401. |
 | `access_token_env` | string | `"LINE_CHANNEL_ACCESS_TOKEN"` | Env var holding the LINE channel access token. |
 | `webhook_port` | u16 | `8450` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -340,7 +357,7 @@ webhook_url = ""
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | Env var holding the Viber Bot auth token. |
+| `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | Env var holding the Viber Bot auth token. **Required** — also used as the HMAC-SHA256 key to verify every inbound `X-Viber-Content-Signature`; missing → 400, mismatched → 401. |
 | `webhook_url` | string | `""` | Public URL for the Viber webhook endpoint. |
 | `webhook_port` | u16 | `8451` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -351,6 +368,7 @@ webhook_url = ""
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
+app_secret_env = "MESSENGER_APP_SECRET"
 # webhook_port = 8452  # Deprecated: webhooks now share the API port
 ```
 
@@ -358,6 +376,7 @@ verify_token_env = "MESSENGER_VERIFY_TOKEN"
 |-------|------|---------|-------------|
 | `page_token_env` | string | `"MESSENGER_PAGE_TOKEN"` | Env var holding the Facebook page access token. |
 | `verify_token_env` | string | `"MESSENGER_VERIFY_TOKEN"` | Env var holding the webhook verify token. |
+| `app_secret_env` | string | `"MESSENGER_APP_SECRET"` | Env var holding the **Facebook App Secret**. Used for HMAC-SHA1 verification of every inbound `X-Hub-Signature` header. If unset, signature verification is skipped and a warning is logged once at startup — production deployments should always set this. |
 | `webhook_port` | u16 | `8452` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
@@ -620,7 +639,7 @@ secret_env = "DINGTALK_SECRET"
 | `app_key_env` | string | `"DINGTALK_APP_KEY"` | Env var holding the DingTalk App Key (stream mode). |
 | `app_secret_env` | string | `"DINGTALK_APP_SECRET"` | Env var holding the DingTalk App Secret (stream mode). |
 | `access_token_env` | string | `"DINGTALK_ACCESS_TOKEN"` | Env var holding the DingTalk webhook access token (webhook mode). |
-| `secret_env` | string | `"DINGTALK_SECRET"` | Env var holding the DingTalk signing secret (webhook mode). |
+| `secret_env` | string | `"DINGTALK_SECRET"` | Env var holding the DingTalk signing secret (webhook mode). **Required** — webhook mode rejects requests without a numeric `timestamp` header (400), with a stale or mismatched signature (401). |
 | `webhook_port` | u16 | `8457` | **Deprecated.** Previously used for standalone webhook server; now ignored. All webhooks share the API port. |
 | `robot_code` | string or null | `null` | Robot code for stream mode replies (defaults to app_key). |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -702,7 +721,7 @@ listen_port = 8460
 |-------|------|---------|-------------|
 | `secret_env` | string | `"WEBHOOK_SECRET"` | Env var holding the HMAC signing secret for verifying incoming webhooks. |
 | `listen_port` | u16 | `8460` | Port to listen for incoming webhook requests. |
-| `callback_url` | string or null | `null` | URL to POST outgoing messages to. |
+| `callback_url` | string or null | `null` | URL to POST outgoing messages to. **SSRF-guarded:** the daemon refuses to start the adapter if this resolves to a private, loopback, link-local, multicast, or cloud-metadata range (e.g. `127.0.0.1`, `10.0.0.1`, `169.254.169.254`, `[::1]`, `[::ffff:127.0.0.1]`). Public hostnames only. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.voice]`

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -964,6 +964,7 @@ allowed_senders = []
 [channels.teams]
 app_id = ""
 app_password_env = "TEAMS_APP_PASSWORD"
+security_token_env = "TEAMS_SECURITY_TOKEN"
 webhook_port = 3978
 allowed_tenants = []
 ```
@@ -972,6 +973,7 @@ allowed_tenants = []
 |-------|------|---------|-------------|
 | `app_id` | string | `""` | Azure Bot App ID. |
 | `app_password_env` | string | `"TEAMS_APP_PASSWORD"` | Env var holding the Azure Bot Framework app password. |
+| `security_token_env` | string | `"TEAMS_SECURITY_TOKEN"` | Env var holding the **outgoing webhook security token** (base64-encoded, copied from the Teams portal). Used for HMAC-SHA256 verification of every inbound `Authorization: HMAC <…>` header. If unset or non-base64, signature verification is skipped and a warning is logged once at startup — production should always set this. |
 | `webhook_port` | u16 | `3978` | Port for the Bot Framework incoming webhook. |
 | `allowed_tenants` | list of strings | `[]` | Azure AD tenant IDs allowed. Empty = allow all. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -1113,7 +1115,7 @@ webhook_port = 8450
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | Env var holding the LINE channel secret. |
+| `channel_secret_env` | string | `"LINE_CHANNEL_SECRET"` | Env var holding the LINE channel secret. **Required** — every inbound webhook must carry a matching `X-Line-Signature`; missing → 400, mismatched → 401. |
 | `access_token_env` | string | `"LINE_CHANNEL_ACCESS_TOKEN"` | Env var holding the LINE channel access token. |
 | `webhook_port` | u16 | `8450` | Port for the incoming webhook. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -1129,7 +1131,7 @@ webhook_port = 8451
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | Env var holding the Viber Bot auth token. |
+| `auth_token_env` | string | `"VIBER_AUTH_TOKEN"` | Env var holding the Viber Bot auth token. **Required** — also used as the HMAC-SHA256 key to verify every inbound `X-Viber-Content-Signature`; missing → 400, mismatched → 401. |
 | `webhook_url` | string | `""` | Public URL for the Viber webhook endpoint. |
 | `webhook_port` | u16 | `8451` | Port for the incoming webhook. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -1140,6 +1142,7 @@ webhook_port = 8451
 [channels.messenger]
 page_token_env = "MESSENGER_PAGE_TOKEN"
 verify_token_env = "MESSENGER_VERIFY_TOKEN"
+app_secret_env = "MESSENGER_APP_SECRET"
 webhook_port = 8452
 ```
 
@@ -1147,6 +1150,7 @@ webhook_port = 8452
 |-------|------|---------|-------------|
 | `page_token_env` | string | `"MESSENGER_PAGE_TOKEN"` | Env var holding the Facebook page access token. |
 | `verify_token_env` | string | `"MESSENGER_VERIFY_TOKEN"` | Env var holding the webhook verify token. |
+| `app_secret_env` | string | `"MESSENGER_APP_SECRET"` | Env var holding the **Facebook App Secret**. Used for HMAC-SHA1 verification of every inbound `X-Hub-Signature` header. If unset, signature verification is skipped and a warning is logged once at startup — production should always set this. |
 | `webhook_port` | u16 | `8452` | Port for the incoming webhook. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
@@ -1409,7 +1413,7 @@ webhook_port = 8457
 | `app_key_env` | string | `"DINGTALK_APP_KEY"` | Env var holding the DingTalk App Key (stream mode). |
 | `app_secret_env` | string | `"DINGTALK_APP_SECRET"` | Env var holding the DingTalk App Secret (stream mode). |
 | `access_token_env` | string | `"DINGTALK_ACCESS_TOKEN"` | Env var holding the DingTalk webhook access token (webhook mode). |
-| `secret_env` | string | `"DINGTALK_SECRET"` | Env var holding the DingTalk signing secret (webhook mode). |
+| `secret_env` | string | `"DINGTALK_SECRET"` | Env var holding the DingTalk signing secret (webhook mode). **Required** — webhook mode rejects requests without a numeric `timestamp` header (400), with a stale or mismatched signature (401). |
 | `webhook_port` | u16 | `8457` | Port for the incoming webhook (webhook mode only). |
 | `robot_code` | string or null | `null` | Robot code for stream mode replies (defaults to app_key). |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
@@ -1491,7 +1495,7 @@ listen_port = 8460
 |-------|------|---------|-------------|
 | `secret_env` | string | `"WEBHOOK_SECRET"` | Env var holding the HMAC signing secret for verifying incoming webhooks. |
 | `listen_port` | u16 | `8460` | Port to listen for incoming webhook requests. |
-| `callback_url` | string or null | `null` | URL to POST outgoing messages to. |
+| `callback_url` | string or null | `null` | URL to POST outgoing messages to. **SSRF-guarded:** the daemon refuses to start the adapter if this resolves to a private, loopback, link-local, multicast, or cloud-metadata range (e.g. `127.0.0.1`, `10.0.0.1`, `169.254.169.254`, `[::1]`, `[::ffff:127.0.0.1]`). Public hostnames only. |
 | `default_agent` | string or null | `null` | Agent name to route messages to. |
 
 #### `[channels.linkedin]`

--- a/docs/src/app/configuration/security/page.mdx
+++ b/docs/src/app/configuration/security/page.mdx
@@ -360,6 +360,7 @@ Complete table of all environment variables referenced by the configuration. Non
 | `MATRIX_ACCESS_TOKEN` | Matrix | Matrix homeserver access token. |
 | `EMAIL_PASSWORD` | Email | Email account password or app password. |
 | `TEAMS_APP_PASSWORD` | Teams | Azure Bot Framework app password. |
+| `TEAMS_SECURITY_TOKEN` | Teams | Outgoing webhook security token (base64) — HMAC-SHA256 key used to verify the `Authorization: HMAC <…>` header on every inbound activity. Production deployments should always set this. |
 | `MATTERMOST_TOKEN` | Mattermost | Mattermost bot token. |
 | `TWITCH_OAUTH_TOKEN` | Twitch | Twitch OAuth token. |
 | `ROCKETCHAT_TOKEN` | Rocket.Chat | Rocket.Chat auth token. |
@@ -371,6 +372,7 @@ Complete table of all environment variables referenced by the configuration. Non
 | `VIBER_AUTH_TOKEN` | Viber | Viber Bot auth token. |
 | `MESSENGER_PAGE_TOKEN` | Messenger | Facebook page access token. |
 | `MESSENGER_VERIFY_TOKEN` | Messenger | Webhook verification token. |
+| `MESSENGER_APP_SECRET` | Messenger | Facebook App Secret — HMAC-SHA1 key used to verify the `X-Hub-Signature` header on every inbound webhook. Production deployments should always set this. |
 | `REDDIT_CLIENT_SECRET` | Reddit | Reddit app client secret. |
 | `REDDIT_PASSWORD` | Reddit | Reddit bot account password. |
 | `MASTODON_ACCESS_TOKEN` | Mastodon | Mastodon access token. |


### PR DESCRIPTION
## Summary

- **#3438 (Messenger)**: Add mandatory HMAC-SHA1 `X-Hub-Signature` verification. POST handler now reads raw bytes before JSON deserialization so the HMAC covers the wire body. Missing header → 403; bad HMAC → 403; no `app_secret` configured → loud warning + skip (backwards compat). New config field `app_secret_env` (default `MESSENGER_APP_SECRET`).
- **#3439 (LINE)**: Make `X-Line-Signature` mandatory. Missing header was silently bypassing the check; now returns HTTP 400 Bad Request.
- **#3440 (Teams)**: Add HMAC-SHA256 verification via `Authorization: HMAC <base64>` header using the outgoing webhook security token. New `security_token_env` config field (default `TEAMS_SECURITY_TOKEN`). Missing/bad header → 401; no token configured → loud warning + skip.
- **#3440 (Viber)**: Add mandatory HMAC-SHA256 verification of `X-Viber-Content-Signature` header using the `auth_token`. Missing → 403; invalid → 403.
- **#3441 (DingTalk)**: Timestamp parse failure is now HTTP 400 instead of silently skipping HMAC verification. A missing or non-numeric `timestamp` header always rejects the request.
- **#3442 / #3701 (SSRF)**: Add `validate_url_for_fetch()` to `http_client.rs`. Rejects non-http/https schemes and IP literals or hostnames in loopback (127.x / ::1), RFC-1918 private (10.x / 172.16-31.x / 192.168.x), link-local (169.254.x / fe80::), unique-local (fc00::/7), and cloud metadata service ranges. `WebhookAdapter::new()` now returns `Result<Self, String>` and rejects private `callback_url` values at construction time. `channel_bridge.rs` logs an error and skips the adapter on rejection.

## Changed files

- `crates/librefang-channels/src/http_client.rs` — SSRF guard + unit tests
- `crates/librefang-channels/src/messenger.rs` — HMAC-SHA1 verify + `app_secret` field + tests
- `crates/librefang-channels/src/line.rs` — mandatory signature check
- `crates/librefang-channels/src/teams.rs` — HMAC-SHA256 verify + `security_token` field + tests
- `crates/librefang-channels/src/viber.rs` — HMAC-SHA256 verify + tests
- `crates/librefang-channels/src/dingtalk.rs` — hard 400 on bad timestamp + test
- `crates/librefang-channels/src/webhook.rs` — SSRF-guard on `callback_url` + tests
- `crates/librefang-types/src/config/types.rs` — new `security_token_env` (Teams) and `app_secret_env` (Messenger) config fields with `#[serde(default)]`
- `crates/librefang-api/src/channel_bridge.rs` — wire new config fields to adapter constructors; handle `WebhookAdapter::new` `Result`

## Test plan

- [ ] All existing tests still pass
- [ ] `test_verify_hub_signature_valid/invalid` — Messenger HMAC-SHA1 coverage
- [ ] `test_verify_teams_signature_valid/invalid` — Teams HMAC-SHA256 coverage
- [ ] `test_verify_viber_signature_valid/invalid` — Viber HMAC-SHA256 coverage
- [ ] `test_webhook_rejects_private_callback_url` / `test_webhook_accepts_public_callback_url` — SSRF guard coverage
- [ ] `test_validate_url_*` — SSRF guard unit tests in `http_client.rs`
- [ ] `test_dingtalk_verify_signature_rejects_wrong_timestamp` — DingTalk timestamp coverage

Closes #3438, #3439, #3440, #3441, #3442, #3701