### PR TITLE
fix(auth): atomic TOTP/recovery-code operations, require email_verified in OIDC, persist lockout counter

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1472,7 +1472,10 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                                             true
                                         }
                                         Ok((false, _)) => {
-                                            self.kernel.approvals().record_totp_failure(sender_id);
+                                            let _ = self
+                                                .kernel
+                                                .approvals()
+                                                .record_totp_failure(sender_id);
                                             return "Invalid recovery code.".into();
                                         }
                                         Err(e) => return format!("Recovery code error: {e}"),
@@ -1495,7 +1498,10 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                             ) {
                                 Ok(true) => true,
                                 Ok(false) => {
-                                    self.kernel.approvals().record_totp_failure(sender_id);
+                                    let _ = self
+                                        .kernel
+                                        .approvals()
+                                        .record_totp_failure(sender_id);
                                     return "Invalid TOTP code.".into();
                                 }
                                 Err(e) => return format!("TOTP error: {e}"),

--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -296,6 +296,10 @@ pub struct ResolvedProvider {
     pub allowed_domains: Vec<String>,
     #[serde(skip)]
     pub audience: String,
+    /// Whether to require `email_verified: true` in the ID token / userinfo
+    /// response before allowing login.  Defaults to `true` (#3703).
+    #[serde(skip)]
+    pub require_email_verified: bool,
 }
 
 // ── Token exchange response ─────────────────────────────────────────────
@@ -838,6 +842,44 @@ async fn handle_code_exchange(
         }
     };
 
+    // SECURITY (#3703): Require email_verified = true before allowing login.
+    // Without this check, a provider that supports unverified email addresses
+    // can be exploited to claim an address in `allowed_domains` without actually
+    // owning that address.
+    if provider.require_email_verified {
+        match claims.email_verified {
+            Some(true) => {} // verified — allow login to proceed
+            Some(false) => {
+                warn!(
+                    sub = %claims.sub,
+                    provider = %provider.id,
+                    "OIDC login rejected: email_verified = false"
+                );
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "Email address not verified by identity provider"
+                    })),
+                )
+                    .into_response();
+            }
+            None => {
+                warn!(
+                    sub = %claims.sub,
+                    provider = %provider.id,
+                    "OIDC login rejected: email_verified claim absent"
+                );
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "Email address not verified by identity provider"
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    }
+
     // Check allowed domains.
     if !provider.allowed_domains.is_empty() {
         if let Some(ref email) = claims.email {
@@ -1337,7 +1379,7 @@ pub(crate) async fn resolve_providers(
 
     // Multi-provider mode.
     for provider in &config.providers {
-        match resolve_single_provider(provider).await {
+        match resolve_single_provider(provider, config.require_email_verified).await {
             Ok(p) => resolved.push(p),
             Err(e) => warn!(
                 provider_id = %provider.id,
@@ -1368,6 +1410,7 @@ pub(crate) async fn resolve_providers(
                     } else {
                         config.audience.clone()
                     },
+                    require_email_verified: config.require_email_verified,
                 });
             }
             Err(e) => warn!(error = %e, "Failed to resolve legacy OIDC provider"),
@@ -1379,6 +1422,7 @@ pub(crate) async fn resolve_providers(
 
 async fn resolve_single_provider(
     provider: &librefang_types::config::OidcProvider,
+    global_require_email_verified: bool,
 ) -> Result<ResolvedProvider, String> {
     let display_name = if provider.display_name.is_empty() {
         provider.id.clone()
@@ -1391,6 +1435,11 @@ async fn resolve_single_provider(
     } else {
         provider.audience.clone()
     };
+
+    // Per-provider override takes precedence over the global setting.
+    let require_email_verified = provider
+        .require_email_verified
+        .unwrap_or(global_require_email_verified);
 
     // If explicit URLs are provided, use them directly (e.g., GitHub).
     if !provider.auth_url.is_empty() && !provider.token_url.is_empty() {
@@ -1407,6 +1456,7 @@ async fn resolve_single_provider(
             client_secret_env: provider.client_secret_env.clone(),
             allowed_domains: provider.allowed_domains.clone(),
             audience,
+            require_email_verified,
         });
     }
 
@@ -1448,6 +1498,7 @@ async fn resolve_single_provider(
         client_secret_env: provider.client_secret_env.clone(),
         allowed_domains: provider.allowed_domains.clone(),
         audience,
+        require_email_verified,
     })
 }
 
@@ -1886,6 +1937,7 @@ mod tests {
                 scopes: vec!["read:user".to_string()],
                 allowed_domains: vec![],
                 audience: String::new(),
+                require_email_verified: None,
             }],
             ..Default::default()
         };
@@ -1917,6 +1969,7 @@ mod tests {
                 scopes: vec!["openid".to_string()],
                 allowed_domains: vec![],
                 audience: String::new(),
+                require_email_verified: None,
             }],
             ..Default::default()
         };
@@ -1958,6 +2011,7 @@ mod tests {
                     scopes: vec!["openid".to_string()],
                     allowed_domains: vec![],
                     audience: String::new(),
+                    require_email_verified: None,
                 },
                 librefang_types::config::OidcProvider {
                     id: "bad".to_string(),
@@ -1973,6 +2027,7 @@ mod tests {
                     scopes: vec!["openid".to_string()],
                     allowed_domains: vec![],
                     audience: String::new(),
+                    require_email_verified: None,
                 },
             ],
             ..Default::default()

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1835,7 +1835,12 @@ pub async fn approve_request(
                     match state.kernel.vault_redeem_recovery_code(code) {
                         Ok(true) => true,
                         Ok(false) => {
-                            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                            if state
+                                .kernel
+                                .approvals()
+                                .record_totp_failure("api_admin")
+                                .is_err()
+                            {
                                 return ApiErrorResponse::internal(
                                     "Failed to persist TOTP failure counter",
                                 )
@@ -1885,7 +1890,12 @@ pub async fn approve_request(
                         }
                         Ok(false) => {
                             // Fail-secure: reject even if counter persist fails (#3372).
-                            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                            if state
+                                .kernel
+                                .approvals()
+                                .record_totp_failure("api_admin")
+                                .is_err()
+                            {
                                 return ApiErrorResponse::internal(
                                     "Failed to persist TOTP failure counter",
                                 )
@@ -2521,7 +2531,12 @@ pub async fn totp_setup(
                 };
                 if !verified {
                     // Fail-secure: reject even if counter persist fails (#3372).
-                    if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                    if state
+                        .kernel
+                        .approvals()
+                        .record_totp_failure("api_admin")
+                        .is_err()
+                    {
                         return ApiErrorResponse::internal(
                             "Failed to persist TOTP failure counter",
                         )
@@ -2649,7 +2664,12 @@ pub async fn totp_confirm(
         }
         Ok(false) => {
             // Fail-secure: reject even if counter persist fails (#3372).
-            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+            if state
+                .kernel
+                .approvals()
+                .record_totp_failure("api_admin")
+                .is_err()
+            {
                 return ApiErrorResponse::internal("Failed to persist TOTP failure counter")
                     .into_json_tuple();
             }
@@ -2739,7 +2759,12 @@ pub async fn totp_revoke(
 
     if !verified {
         // Fail-secure: reject even if counter persist fails (#3372).
-        if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+        if state
+            .kernel
+            .approvals()
+            .record_totp_failure("api_admin")
+            .is_err()
+        {
             return ApiErrorResponse::internal("Failed to persist TOTP failure counter")
                 .into_json_tuple();
         }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1830,34 +1830,24 @@ pub async fn approve_request(
         match body.totp_code.as_deref() {
             Some(code) => {
                 if ApprovalManager::is_recovery_code_format(code) {
-                    match state.kernel.vault_get("totp_recovery_codes") {
-                        Some(stored) => {
-                            match librefang_kernel::approval::ApprovalManager::verify_recovery_code(
-                                &stored, code,
-                            ) {
-                                Ok((true, updated)) => {
-                                    if let Err(e) =
-                                        state.kernel.vault_set("totp_recovery_codes", &updated)
-                                    {
-                                        tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
-                                    }
-                                    true
-                                }
-                                Ok((false, _)) => {
-                                    state.kernel.approvals().record_totp_failure("api_admin");
-                                    return ApiErrorResponse::bad_request("Invalid recovery code")
-                                        .into_json_tuple()
-                                        .into_response();
-                                }
-                                Err(e) => {
-                                    return ApiErrorResponse::bad_request(e)
-                                        .into_json_tuple()
-                                        .into_response();
-                                }
+                    // Atomically redeem the recovery code (fixes TOCTOU #3560
+                    // and vault_set-failure bypass #3633).
+                    match state.kernel.vault_redeem_recovery_code(code) {
+                        Ok(true) => true,
+                        Ok(false) => {
+                            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                                return ApiErrorResponse::internal(
+                                    "Failed to persist TOTP failure counter",
+                                )
+                                .into_json_tuple()
+                                .into_response();
                             }
+                            return ApiErrorResponse::bad_request("Invalid recovery code")
+                                .into_json_tuple()
+                                .into_response();
                         }
-                        None => {
-                            return ApiErrorResponse::bad_request("No recovery codes configured")
+                        Err(e) => {
+                            return ApiErrorResponse::internal(e)
                                 .into_json_tuple()
                                 .into_response();
                         }
@@ -1894,7 +1884,14 @@ pub async fn approve_request(
                             true
                         }
                         Ok(false) => {
-                            state.kernel.approvals().record_totp_failure("api_admin");
+                            // Fail-secure: reject even if counter persist fails (#3372).
+                            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                                return ApiErrorResponse::internal(
+                                    "Failed to persist TOTP failure counter",
+                                )
+                                .into_json_tuple()
+                                .into_response();
+                            }
                             return ApiErrorResponse::bad_request("Invalid TOTP code")
                                 .into_json_tuple()
                                 .into_response();
@@ -2490,24 +2487,12 @@ pub async fn totp_setup(
             }
             Some(code) => {
                 let verified = if ApprovalManager::is_recovery_code_format(code) {
-                    // Recovery code
-                    match state.kernel.vault_get("totp_recovery_codes") {
-                        Some(stored) => {
-                            match librefang_kernel::approval::ApprovalManager::verify_recovery_code(
-                                &stored, code,
-                            ) {
-                                Ok((true, updated)) => {
-                                    if let Err(e) =
-                                        state.kernel.vault_set("totp_recovery_codes", &updated)
-                                    {
-                                        tracing::warn!("Failed to persist updated TOTP recovery codes after use: {e}");
-                                    }
-                                    true
-                                }
-                                _ => false,
-                            }
+                    // Atomically redeem the recovery code (fixes TOCTOU #3560 / #3633).
+                    match state.kernel.vault_redeem_recovery_code(code) {
+                        Ok(matched) => matched,
+                        Err(e) => {
+                            return ApiErrorResponse::internal(e).into_json_tuple();
                         }
-                        None => false,
                     }
                 } else {
                     // TOTP code — check replay before verifying (#3359).
@@ -2535,7 +2520,13 @@ pub async fn totp_setup(
                     }
                 };
                 if !verified {
-                    state.kernel.approvals().record_totp_failure("api_admin");
+                    // Fail-secure: reject even if counter persist fails (#3372).
+                    if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                        return ApiErrorResponse::internal(
+                            "Failed to persist TOTP failure counter",
+                        )
+                        .into_json_tuple();
+                    }
                     return ApiErrorResponse::bad_request(
                         "Invalid current_code. Provide a valid TOTP or recovery code to reset.",
                     )
@@ -2657,7 +2648,11 @@ pub async fn totp_confirm(
             )
         }
         Ok(false) => {
-            state.kernel.approvals().record_totp_failure("api_admin");
+            // Fail-secure: reject even if counter persist fails (#3372).
+            if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+                return ApiErrorResponse::internal("Failed to persist TOTP failure counter")
+                    .into_json_tuple();
+            }
             ApiErrorResponse::bad_request(
                 "Invalid TOTP code. Check your authenticator app and try again.",
             )
@@ -2718,25 +2713,15 @@ pub async fn totp_revoke(
         return ApiErrorResponse::bad_request("TOTP is not enrolled.").into_json_tuple();
     }
 
-    // Verify the provided code (recovery codes are consumed on use)
+    // Verify the provided code (recovery codes are consumed on use).
+    // For recovery codes, use the atomic vault_redeem_recovery_code path
+    // (fixes TOCTOU #3560 and vault_set-failure bypass #3633).
     let verified = if ApprovalManager::is_recovery_code_format(&body.code) {
-        match state.kernel.vault_get("totp_recovery_codes") {
-            Some(stored) => {
-                match librefang_kernel::approval::ApprovalManager::verify_recovery_code(
-                    &stored, &body.code,
-                ) {
-                    Ok((true, updated)) => {
-                        if let Err(e) = state.kernel.vault_set("totp_recovery_codes", &updated) {
-                            tracing::warn!(
-                                "Failed to persist updated TOTP recovery codes after use: {e}"
-                            );
-                        }
-                        true
-                    }
-                    _ => false,
-                }
+        match state.kernel.vault_redeem_recovery_code(&body.code) {
+            Ok(matched) => matched,
+            Err(e) => {
+                return ApiErrorResponse::internal(e).into_json_tuple();
             }
-            None => false,
         }
     } else {
         match state.kernel.vault_get("totp_secret") {
@@ -2753,7 +2738,11 @@ pub async fn totp_revoke(
     };
 
     if !verified {
-        state.kernel.approvals().record_totp_failure("api_admin");
+        // Fail-secure: reject even if counter persist fails (#3372).
+        if state.kernel.approvals().record_totp_failure("api_admin").is_err() {
+            return ApiErrorResponse::internal("Failed to persist TOTP failure counter")
+                .into_json_tuple();
+        }
         return ApiErrorResponse::bad_request(
             "Invalid code. Provide a valid TOTP or recovery code.",
         )

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -2886,6 +2886,11 @@
           "description": "Redirect URL for the OAuth2 authorization code flow callback. Defaults to `http://127.0.0.1:4545/api/auth/callback`.",
           "type": "string"
         },
+        "require_email_verified": {
+          "default": true,
+          "description": "Require `email_verified = true` in the OIDC ID token before allowing login. Defaults to `true`. Set to `false` only if your identity provider does not set this claim. When `true`, logins where the claim is absent or false are rejected — prevents `allowed_domains` impersonation via unverified addresses (#3703).",
+          "type": "boolean"
+        },
         "scopes": {
           "default": [
             "openid",
@@ -5533,6 +5538,14 @@
           "default": "http://127.0.0.1:4545/api/auth/callback",
           "description": "OAuth2 redirect URI. Defaults to `http://127.0.0.1:4545/api/auth/callback`.",
           "type": "string"
+        },
+        "require_email_verified": {
+          "default": null,
+          "description": "Override the global `require_email_verified` setting for this provider. `None` means inherit from `ExternalAuthConfig::require_email_verified`. Set to `false` only if this specific provider does not issue `email_verified` claims (e.g. GitHub's user API does not include the field for OAuth2 flows).",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "scopes": {
           "default": [

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -915,7 +915,13 @@ impl ApprovalManager {
     }
 
     /// Record a TOTP verification failure.
-    pub fn record_totp_failure(&self, sender_id: &str) {
+    ///
+    /// Returns `Ok(())` if the failure was recorded and persisted to the
+    /// database, or `Err(())` if the database write failed. Callers MUST
+    /// treat `Err(())` as a rejection — if we cannot persist the counter we
+    /// cannot enforce the brute-force cap across restarts, so the safest
+    /// course is to deny the request (fail-secure, fix for #3372 / #3584).
+    pub fn record_totp_failure(&self, sender_id: &str) -> Result<(), ()> {
         let mut failures = self.totp_failures.lock().unwrap_or_else(|e| e.into_inner());
         let entry = failures.entry(sender_id.to_string()).or_insert((0, None));
         // Reset counter if lockout window expired
@@ -939,7 +945,8 @@ impl ApprovalManager {
         }
         let (count, locked_at_instant) = *entry;
         drop(failures);
-        // Persist lockout state so it survives a daemon restart
+        // Persist lockout state so it survives a daemon restart.
+        // If the DB write fails, return Err so callers can reject fail-secure.
         let locked_at_unix = locked_at_instant.map(|t| {
             let elapsed = t.elapsed().as_secs();
             std::time::SystemTime::now()
@@ -948,13 +955,24 @@ impl ApprovalManager {
                 .as_secs()
                 .saturating_sub(elapsed) as i64
         });
-        self.persist_totp_lockout_save(sender_id, count, locked_at_unix);
+        self.persist_totp_lockout_save(sender_id, count, locked_at_unix)
     }
 
-    fn persist_totp_lockout_save(&self, sender_id: &str, failures: u32, locked_at: Option<i64>) {
-        let Some(db) = &self.audit_db else { return };
-        let Ok(conn) = db.lock() else { return };
-        let _ = conn.execute(
+    fn persist_totp_lockout_save(
+        &self,
+        sender_id: &str,
+        failures: u32,
+        locked_at: Option<i64>,
+    ) -> Result<(), ()> {
+        let Some(db) = &self.audit_db else {
+            // No DB configured — in-memory only, accept the failure record.
+            return Ok(());
+        };
+        let Ok(conn) = db.lock() else {
+            warn!(sender_id, "TOTP lockout DB unavailable; rejecting attempt fail-secure");
+            return Err(());
+        };
+        let result = conn.execute(
             "INSERT INTO totp_lockout (sender_id, failures, locked_at)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(sender_id) DO UPDATE SET
@@ -962,6 +980,14 @@ impl ApprovalManager {
                  locked_at = excluded.locked_at",
             rusqlite::params![sender_id, failures as i64, locked_at],
         );
+        if let Err(e) = result {
+            warn!(
+                sender_id,
+                "Failed to persist TOTP failure counter to DB: {e}; rejecting attempt fail-secure"
+            );
+            return Err(());
+        }
+        Ok(())
     }
 
     fn persist_totp_lockout_clear(&self, sender_id: &str) {

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -969,7 +969,10 @@ impl ApprovalManager {
             return Ok(());
         };
         let Ok(conn) = db.lock() else {
-            warn!(sender_id, "TOTP lockout DB unavailable; rejecting attempt fail-secure");
+            warn!(
+                sender_id,
+                "TOTP lockout DB unavailable; rejecting attempt fail-secure"
+            );
             return Err(());
         };
         let result = conn.execute(
@@ -2365,7 +2368,7 @@ mod tests {
 
         // Record failures up to threshold
         for _ in 0..5 {
-            mgr.record_totp_failure("user1");
+            let _ = mgr.record_totp_failure("user1");
         }
         assert!(mgr.is_totp_locked_out("user1"));
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1422,10 +1422,11 @@ impl LibreFangKernel {
             Ok((true, updated)) => {
                 // #3633: if the vault write fails, treat the attempt as failed
                 // rather than granting access with a still-valid code.
-                self.vault_set("totp_recovery_codes", &updated).map_err(|e| {
-                    warn!("vault_set failed when consuming recovery code: {e}");
-                    "Internal error persisting recovery code consumption".to_string()
-                })?;
+                self.vault_set("totp_recovery_codes", &updated)
+                    .map_err(|e| {
+                        warn!("vault_set failed when consuming recovery code: {e}");
+                        "Internal error persisting recovery code consumption".to_string()
+                    })?;
                 Ok(true)
             }
             Ok((false, _)) => Ok(false),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -658,6 +658,13 @@ pub struct LibreFangKernel {
     /// don't take effect on the active filter (the hot-reload action is a
     /// no-op with a warning).
     pub(crate) log_reloader: OnceLock<crate::log_reload::LogLevelReloaderArc>,
+    /// Serialises all recovery-code redemption attempts so the
+    /// read-verify-write sequence is atomic within the process.
+    /// Fixes the TOCTOU race described in issue #3560: without this lock a
+    /// concurrent second request that reads the same code list before the
+    /// first request has written the updated list can redeem the same code
+    /// twice.
+    vault_recovery_codes_mutex: std::sync::Mutex<()>,
 }
 
 /// Bounded in-memory delivery receipt tracker.
@@ -1385,6 +1392,45 @@ impl LibreFangKernel {
         vault
             .set(key.to_string(), zeroize::Zeroizing::new(value.to_string()))
             .map_err(|e| format!("Vault write failed: {e}"))
+    }
+
+    /// Atomically redeem a TOTP recovery code.
+    ///
+    /// Acquires `vault_recovery_codes_mutex`, reads the stored code list,
+    /// verifies `code`, removes it from the list, and writes back the
+    /// updated list — all under the lock.  This prevents the TOCTOU race
+    /// in issue #3560 where two concurrent requests could both succeed with
+    /// the same code before either had written the updated (shortened) list.
+    ///
+    /// Returns:
+    /// - `Ok(true)`  — code matched and was consumed (vault updated).
+    /// - `Ok(false)` — code did not match (vault unchanged).
+    /// - `Err(e)`    — vault read/write error, or vault_set failed (#3633).
+    pub fn vault_redeem_recovery_code(&self, code: &str) -> Result<bool, String> {
+        // Hold the mutex for the entire read-verify-write sequence.
+        let _guard = self
+            .vault_recovery_codes_mutex
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let stored = match self.vault_get("totp_recovery_codes") {
+            Some(s) => s,
+            None => return Err("No recovery codes configured".to_string()),
+        };
+
+        match crate::approval::ApprovalManager::verify_recovery_code(&stored, code) {
+            Ok((true, updated)) => {
+                // #3633: if the vault write fails, treat the attempt as failed
+                // rather than granting access with a still-valid code.
+                self.vault_set("totp_recovery_codes", &updated).map_err(|e| {
+                    warn!("vault_set failed when consuming recovery code: {e}");
+                    "Internal error persisting recovery code consumption".to_string()
+                })?;
+                Ok(true)
+            }
+            Ok((false, _)) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     /// Workflow engine.
@@ -3092,6 +3138,7 @@ impl LibreFangKernel {
             },
             taint_rules_swap: initial_taint_rules,
             log_reloader: OnceLock::new(),
+            vault_recovery_codes_mutex: std::sync::Mutex::new(()),
         };
 
         // Initialize proactive memory system (mem0-style) from config.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3711,6 +3711,12 @@ pub struct ExternalAuthConfig {
     /// When configured, these take precedence over the top-level single-provider fields.
     #[serde(default)]
     pub providers: Vec<OidcProvider>,
+    /// Require `email_verified = true` in the OIDC ID token before allowing login.
+    /// Defaults to `true`. Set to `false` only if your identity provider does not
+    /// set this claim. When `true`, logins where the claim is absent or false are
+    /// rejected — prevents `allowed_domains` impersonation via unverified addresses (#3703).
+    #[serde(default = "default_true")]
+    pub require_email_verified: bool,
 }
 
 /// Configuration for a single OIDC/OAuth2 provider.
@@ -3758,6 +3764,12 @@ pub struct OidcProvider {
     /// JWT audience claim to validate.
     #[serde(default)]
     pub audience: String,
+    /// Override the global `require_email_verified` setting for this provider.
+    /// `None` means inherit from `ExternalAuthConfig::require_email_verified`.
+    /// Set to `false` only if this specific provider does not issue `email_verified`
+    /// claims (e.g. GitHub's user API does not include the field for OAuth2 flows).
+    #[serde(default)]
+    pub require_email_verified: Option<bool>,
 }
 
 fn default_oauth_client_secret_env() -> String {
@@ -3793,6 +3805,7 @@ impl Default for ExternalAuthConfig {
             audience: String::new(),
             session_ttl_secs: default_session_ttl(),
             providers: Vec::new(),
+            require_email_verified: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **#3560 / #3584 (TOCTOU races)**: Recovery-code redemption and TOTP failure-counter updates are now atomic. `vault_redeem_recovery_code()` holds a `Mutex<()>` across the full read-verify-write cycle so two concurrent requests cannot redeem the same one-time code. `record_totp_failure` / `persist_totp_lockout_save` now return `Result<(), ()>` so callers can detect and act on persistence failures.
- **#3633 (fail-open after vault_set error)**: `totp_revoke` (and `totp_setup`) now use `vault_redeem_recovery_code()` exclusively and propagate any `Err` as a 500 — a vault write failure no longer silently grants login. `totp_confirm` / `totp_revoke` now check the `record_totp_failure` return value and return 500 on DB error rather than continuing.
- **#3703 (OIDC email_verified)**: `handle_code_exchange` enforces `email_verified = true` before the `allowed_domains` check. New `require_email_verified: bool` on `ExternalAuthConfig` (default `true`) and `require_email_verified: Option<bool>` on `OidcProvider` (per-provider override). Config schema golden file updated.
- **#3372 (lockout counter not persisted on DB error)**: `persist_totp_lockout_save` now returns `Err(())` on any SQLite failure; callers treat this as fail-secure and reject the attempt, so a DB hiccup cannot reset the brute-force counter by allowing an in-memory state that is never flushed.

## Changed files

| File | Change |
|------|--------|
| `crates/librefang-kernel/src/approval.rs` | `record_totp_failure` / `persist_totp_lockout_save` return `Result<(), ()>`; atomic DB upsert |
| `crates/librefang-kernel/src/kernel/mod.rs` | `vault_recovery_codes_mutex`, `vault_redeem_recovery_code()` |
| `crates/librefang-api/src/routes/system.rs` | Atomic recovery-code path in `totp_revoke`; fail-secure failure counter; error propagation in `totp_setup` |
| `crates/librefang-api/src/oauth.rs` | `email_verified` enforcement in `handle_code_exchange`; new `require_email_verified` field on `ResolvedProvider` |
| `crates/librefang-types/src/config/types.rs` | `require_email_verified` on `ExternalAuthConfig` and `OidcProvider` |
| `crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json` | Schema entries for both new fields |

## Test plan

- [ ] Confirm existing TOTP approval tests still pass (`cargo test -p librefang-kernel`)
- [ ] Confirm golden schema test passes (`cargo test -p librefang-api -- golden`)
- [ ] Manually verify OIDC login is rejected when `email_verified = false` or absent
- [ ] Manually verify concurrent recovery-code redemption attempts: only the first succeeds
- [ ] Verify daemon restart no longer resets in-flight lockout state (lockout survives restart)