### PR TITLE
fix(skills,api,auth,cli): cap SKILL.md size, auth-gate uploads, enforce OIDC nonce, atomic init write, random keyring fallback

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -570,7 +570,8 @@ pub async fn auth(
             // All other /a2a/* paths — including /a2a/tasks/{id} which returns full
             // task transcripts — require authentication (Bug #3781).
             || path == "/a2a/agents"
-            || path.starts_with("/api/uploads/")
+            // /api/uploads/* is intentionally NOT in the public list — uploads
+            // require authentication, UUID guessing is not access control (#3361).
             || path.starts_with("/api/auth/login"));
     let always_public =
         always_public_method_free || always_public_get_only || is_mcp_oauth_callback;

--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -765,9 +765,13 @@ async fn handle_code_exchange(
         if !id_token.is_empty() && !provider.jwks_uri.is_empty() {
             match validate_jwt_cached(id_token, &provider.jwks_uri, &provider.audience).await {
                 Ok(c) => {
-                    // Verify nonce matches the one from our state token.
-                    if let Some(ref token_nonce) = c.nonce {
-                        if token_nonce != &state_payload.nonce {
+                    // Verify nonce claim against the nonce we sent in the auth request.
+                    // Two failure cases must both be rejected:
+                    //   1. Nonce claim present but doesn't match (replay / token swap).
+                    //   2. Nonce claim absent even though we sent a nonce (provider
+                    //      non-compliance that could be used to bypass nonce binding).
+                    match c.nonce {
+                        Some(ref token_nonce) if token_nonce != &state_payload.nonce => {
                             warn!("Nonce mismatch in ID token");
                             return (
                                 StatusCode::BAD_REQUEST,
@@ -775,6 +779,21 @@ async fn handle_code_exchange(
                             )
                                 .into_response();
                         }
+                        None => {
+                            // We always send a nonce; a well-behaved provider must echo it.
+                            warn!(
+                                "ID token is missing the nonce claim — \
+                                 rejecting to prevent nonce-bypass attack"
+                            );
+                            return (
+                                StatusCode::BAD_REQUEST,
+                                Json(serde_json::json!({
+                                    "error": "ID token missing required nonce claim"
+                                })),
+                            )
+                                .into_response();
+                        }
+                        Some(_) => {} // nonce present and matches — OK
                     }
                     Some(c)
                 }

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -612,9 +612,19 @@ pub fn run() -> InitResult {
             .draw(|f| draw(f, f.area(), &mut state))
             .expect("draw failed");
 
-        // Check for background key-test result
+        // Check for background key-test result.
+        // The API key is written to disk HERE — after validation — not on the
+        // initial Enter press (fixes #3629: write-before-validate).
         if state.key_test == KeyTestState::Testing {
             if let Ok(ok) = test_rx.try_recv() {
+                // Persist the key now that we have a test result. We write for
+                // both Ok (verified) and Warn (unverified but user confirmed)
+                // so the daemon can pick it up either way.
+                if let Some(p) = state.provider() {
+                    if !p.env_var.is_empty() {
+                        let _ = dotenv::save_env_key(p.env_var, &state.api_key_input);
+                    }
+                }
                 state.key_test = if ok {
                     KeyTestState::Ok
                 } else {
@@ -802,9 +812,11 @@ pub fn run() -> InitResult {
                                 if !state.api_key_input.is_empty()
                                     && state.key_test == KeyTestState::Idle =>
                             {
-                                if let Some(p) = state.provider() {
-                                    let _ = dotenv::save_env_key(p.env_var, &state.api_key_input);
-                                }
+                                // Validate the API key with the provider BEFORE writing it to
+                                // disk. The dotenv write happens only after the test result
+                                // arrives (see the test_rx polling block above). This prevents
+                                // a partially-written .env file if the wizard is cancelled
+                                // while the test is in flight (fixes #3629).
                                 state.key_test = KeyTestState::Testing;
                                 let provider_name = state
                                     .provider()

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -698,20 +698,91 @@ fn load_keyring_key() -> Result<Zeroizing<String>, String> {
     }
 }
 
-/// Generate a machine-specific fingerprint for keyring key wrapping.
+/// Return a stable, unpredictable 32-byte machine secret used as the input
+/// to the Argon2id wrapping-key derivation for the file-based keyring fallback.
+///
+/// # Security design
+/// The old implementation derived this value from `username + hostname`, which
+/// is predictable to any local user and therefore provided no meaningful
+/// protection against a local attacker reading the `.keyring` file.
+///
+/// This version stores a randomly-generated 32-byte value in a 0600-permissioned
+/// file on first call. Subsequent calls read the same value so the wrapping key
+/// is stable across restarts while still being unguessable.
+///
+/// If the file cannot be created (e.g. a read-only filesystem), we fall back to
+/// the predictable username+hostname derivation and emit a warning — the same
+/// degraded security as before, but only as a last resort.
 #[cfg(not(test))]
 fn machine_fingerprint() -> Vec<u8> {
     use sha2::Digest;
-    let mut hasher = Sha256::new();
-    // Mix in username + hostname for basic machine binding
-    if let Ok(user) = std::env::var("USERNAME").or_else(|_| std::env::var("USER")) {
-        hasher.update(user.as_bytes());
+
+    let fingerprint_path = dirs::data_local_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("librefang")
+        .join(".machine-id");
+
+    // Try to read an existing random machine-id.
+    if let Ok(bytes) = std::fs::read(&fingerprint_path) {
+        if bytes.len() == 32 {
+            return bytes;
+        }
+        // Length mismatch — stale or corrupt file; regenerate below.
+        warn!(
+            "Unexpected machine-id file length ({} bytes) at {:?} — regenerating",
+            bytes.len(),
+            fingerprint_path
+        );
     }
-    if let Ok(host) = std::env::var("COMPUTERNAME").or_else(|_| std::env::var("HOSTNAME")) {
-        hasher.update(host.as_bytes());
+
+    // Generate a fresh random 32-byte value.
+    let mut random_id = [0u8; 32];
+    OsRng.fill_bytes(&mut random_id);
+
+    // Persist with restrictive permissions so other local users cannot read it.
+    if let Some(parent) = fingerprint_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
     }
-    hasher.update(b"librefang-vault-v1");
-    hasher.finalize().to_vec()
+    match std::fs::write(&fingerprint_path, &random_id) {
+        Ok(()) => {
+            // Restrict to owner-read/write only on Unix.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &fingerprint_path,
+                    std::fs::Permissions::from_mode(0o600),
+                );
+            }
+            warn!(
+                "OS keyring unavailable — generated random machine-id for keyring fallback at {:?}. \
+                 This file must not be deleted; losing it makes the vault unrecoverable.",
+                fingerprint_path
+            );
+        }
+        Err(e) => {
+            // Cannot persist — fall back to the predictable derivation with a
+            // strong warning. This is the same security level as the old code.
+            warn!(
+                "Could not persist machine-id for keyring fallback ({e}): \
+                 falling back to predictable username+hostname derivation. \
+                 Set LIBREFANG_VAULT_KEY for a secure alternative."
+            );
+            let mut hasher = Sha256::new();
+            if let Ok(user) = std::env::var("USERNAME").or_else(|_| std::env::var("USER")) {
+                hasher.update(user.as_bytes());
+            }
+            if let Ok(host) =
+                std::env::var("COMPUTERNAME").or_else(|_| std::env::var("HOSTNAME"))
+            {
+                hasher.update(host.as_bytes());
+            }
+            hasher.update(b"librefang-vault-v1");
+            return hasher.finalize().to_vec();
+        }
+    }
+
+    random_id.to_vec()
 }
 
 /// Derive a 256-bit wrapping key from a machine fingerprint + salt using Argon2id.

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -772,9 +772,7 @@ fn machine_fingerprint() -> Vec<u8> {
             if let Ok(user) = std::env::var("USERNAME").or_else(|_| std::env::var("USER")) {
                 hasher.update(user.as_bytes());
             }
-            if let Ok(host) =
-                std::env::var("COMPUTERNAME").or_else(|_| std::env::var("HOSTNAME"))
-            {
+            if let Ok(host) = std::env::var("COMPUTERNAME").or_else(|_| std::env::var("HOSTNAME")) {
                 hasher.update(host.as_bytes());
             }
             hasher.update(b"librefang-vault-v1");

--- a/crates/librefang-skills/src/openclaw_compat.rs
+++ b/crates/librefang-skills/src/openclaw_compat.rs
@@ -123,6 +123,10 @@ pub fn detect_skillmd(dir: &Path) -> bool {
 /// # Markdown body
 /// Instructions for the LLM...
 /// ```
+/// Maximum allowed size for a SKILL.md file (1 MiB).
+/// Files larger than this are rejected to prevent billion-laughs / zip-bomb DoS.
+pub const MAX_SKILL_MD_BYTES: usize = 1_048_576;
+
 pub fn parse_skillmd(path: &Path) -> Result<(SkillMdFrontmatter, String), SkillError> {
     if has_parent_dir_component(path) {
         return Err(SkillError::InvalidManifest(format!(
@@ -130,7 +134,26 @@ pub fn parse_skillmd(path: &Path) -> Result<(SkillMdFrontmatter, String), SkillE
             path.display()
         )));
     }
+    // Check file size before reading to guard against DoS via oversized files.
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.len() > MAX_SKILL_MD_BYTES as u64 => {
+            return Err(SkillError::InvalidManifest(format!(
+                "SKILL.md at {} exceeds the 1 MiB size limit ({} bytes)",
+                path.display(),
+                meta.len()
+            )));
+        }
+        Err(e) => return Err(SkillError::Io(e)),
+        Ok(_) => {}
+    }
     let content = std::fs::read_to_string(path)?;
+    // Double-check in-memory size after read (accounts for encoding differences).
+    if content.len() > MAX_SKILL_MD_BYTES {
+        return Err(SkillError::InvalidManifest(format!(
+            "SKILL.md at {} exceeds the 1 MiB size limit",
+            path.display()
+        )));
+    }
     parse_skillmd_str(&content)
 }
 


### PR DESCRIPTION
## Summary

- **#3456** (`librefang-skills`): `parse_skillmd` now rejects SKILL.md files larger than 1 MiB via `std::fs::metadata` pre-check and an in-memory post-read check. Prevents billion-laughs / zip-bomb DoS through oversized YAML frontmatter expansion.
- **#3361** (`librefang-api/middleware`): Removed `/api/uploads/*` from the always-public GET allowlist. Upload files now require authentication, same as every other API endpoint. UUID guessing is no longer a sufficient access control mechanism.
- **#3364** (`librefang-api/oauth`): OIDC ID-token validation now rejects tokens where the `nonce` claim is **absent** (not only mismatched). We always send a nonce in the authorization request; a conformant provider must echo it. The previous silent fallback to the userinfo endpoint when nonce was absent could be used to bypass nonce binding.
- **#3629** (`librefang-cli/init_wizard`): The init wizard no longer writes the API key to `~/.librefang/.env` on the initial Enter keypress. The `dotenv::save_env_key` call was moved to the background test result handler so the file is written only after the validation response arrives. Cancelling (Ctrl+C) during the test now leaves no partial file.
- **#3606** (`librefang-extensions/vault`): `machine_fingerprint()` no longer derives the file-based keyring wrapping key from predictable `username+hostname`. It now generates a cryptographically random 32-byte value on first use, writes it to a `0600`-permissioned file, and reads that file on subsequent calls. Falls back to the previous predictable derivation (with a `WARN` log) only if the file cannot be persisted.

## Test plan

- [ ] Confirm SKILL.md files > 1 MiB are rejected with `InvalidManifest` from `parse_skillmd`
- [ ] Confirm `GET /api/uploads/{uuid}` returns 401/403 without a valid API key or session token
- [ ] Confirm OIDC callback rejects an ID token whose `nonce` claim is absent
- [ ] Confirm OIDC callback still rejects a `nonce` mismatch as before
- [ ] Confirm init wizard does not write `.env` if Ctrl+C is pressed while key test is in flight
- [ ] Confirm init wizard writes `.env` after the key test resolves (both Ok and Warn paths)
- [ ] Confirm vault unlock works after `machine_fingerprint` generates a new `.machine-id` file
- [ ] Confirm `.machine-id` is created with 0600 permissions on Unix