### PR TITLE
fix(dashboard): noopener on OAuth window, htmlFor on form labels, invalidate budget after media gen, optimize streaming updates, tree-shake lucide icons

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/media.ts
@@ -1,5 +1,6 @@
 import {
   useMutation,
+  useQueryClient,
   type UseMutationOptions,
 } from "@tanstack/react-query";
 import {
@@ -12,6 +13,7 @@ import {
   type MediaVideoSubmitResult,
   type MediaMusicResult,
 } from "../http/client";
+import { budgetKeys } from "../queries/keys";
 
 export function useGenerateImage(
   options?: Partial<
@@ -22,9 +24,14 @@ export function useGenerateImage(
     >
   >,
 ) {
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: generateImage,
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: budgetKeys.all });
+      options?.onSettled?.(...args);
+    },
   });
 }
 
@@ -37,9 +44,14 @@ export function useSynthesizeSpeech(
     >
   >,
 ) {
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: synthesizeSpeech,
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: budgetKeys.all });
+      options?.onSettled?.(...args);
+    },
   });
 }
 
@@ -52,9 +64,14 @@ export function useSubmitVideo(
     >
   >,
 ) {
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: submitVideo,
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: budgetKeys.all });
+      options?.onSettled?.(...args);
+    },
   });
 }
 
@@ -67,8 +84,13 @@ export function useGenerateMusic(
     >
   >,
 ) {
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: generateMusic,
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: budgetKeys.all });
+      options?.onSettled?.(...args);
+    },
   });
 }

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -352,6 +352,36 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
     }
   }, []);
 
+  // Streaming content buffer — accumulates text_delta chunks keyed by
+  // message id without triggering a React state update on every token.
+  // A requestAnimationFrame flush drains the buffer into React state at
+  // most once per paint frame (≈16 ms), reducing the O(n × tokens) map
+  // cost to O(n × frames) where frames ≪ tokens during fast streams.
+  const streamingBufferRef = useRef<Map<string, string>>(new Map());
+  const rafHandleRef = useRef<Map<string, number>>(new Map());
+
+  const flushStreamingContent = useCallback((agentId: string, msgId: string) => {
+    const buffered = streamingBufferRef.current.get(msgId);
+    if (buffered === undefined) return;
+    streamingBufferRef.current.delete(msgId);
+    rafHandleRef.current.delete(msgId);
+    updateAgentMessages(agentId, prev => {
+      const idx = prev.findIndex(m => m.id === msgId);
+      if (idx === -1) return prev;
+      const next = prev.slice();
+      next[idx] = { ...next[idx], content: buffered, error: undefined };
+      return next;
+    });
+  }, [updateAgentMessages]);
+
+  const scheduleStreamingFlush = useCallback((agentId: string, msgId: string) => {
+    if (rafHandleRef.current.has(msgId)) return; // already scheduled
+    const handle = requestAnimationFrame(() => {
+      flushStreamingContent(agentId, msgId);
+    });
+    rafHandleRef.current.set(msgId, handle);
+  }, [flushStreamingContent]);
+
   // Save current messages to cache when switching away. The cleanup must
   // read the LATEST messages at unmount/agent-swap time, so we keep a
   // ref that tracks messages and only fire the save effect on agentId
@@ -671,9 +701,19 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
             const data = JSON.parse(event.data as string);
             if (data.type === "text_delta") {
               const chunk = data.content || "";
-              updateAgentMessages(sendAgentId, prev => prev.map(m =>
-                m.id === botMsg.id ? { ...m, content: m.content + chunk, error: undefined } : m
-              ));
+              // Accumulate into the buffer without a React state update on every token.
+              // The RAF flush drains the buffer into state at most once per paint frame.
+              const prev = streamingBufferRef.current.get(botMsg.id);
+              // Seed from the current live message content on the first delta so we
+              // don't lose any content that arrived before this batch started.
+              if (prev === undefined) {
+                // Read current content from the latest messages snapshot via ref
+                const currentContent = (messagesRef.current.find(m => m.id === botMsg.id)?.content) ?? "";
+                streamingBufferRef.current.set(botMsg.id, currentContent + chunk);
+              } else {
+                streamingBufferRef.current.set(botMsg.id, prev + chunk);
+              }
+              scheduleStreamingFlush(sendAgentId, botMsg.id);
             } else if (data.type === "thinking_delta") {
               const chunk = data.content || "";
               updateAgentMessages(sendAgentId, prev => prev.map(m =>
@@ -687,6 +727,10 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
               ));
             } else if (data.type === "typing") {
               if (data.state === "stop") {
+                // Flush any buffered streaming content before marking done
+                const rafHandle = rafHandleRef.current.get(botMsg.id);
+                if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
+                flushStreamingContent(sendAgentId, botMsg.id);
                 updateAgentMessages(sendAgentId, prev => prev.map(m =>
                   m.id === botMsg.id ? { ...m, isStreaming: false } : m
                 ));
@@ -737,10 +781,19 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 addSkillOutput({ skillName: entry.tool, agentId: sendAgentId, content: entry.content });
               }
             } else if (data.type === "silent_complete") {
+              // Cancel any pending RAF flush — message is being removed
+              const rafHandle = rafHandleRef.current.get(botMsg.id);
+              if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
+              streamingBufferRef.current.delete(botMsg.id);
+              rafHandleRef.current.delete(botMsg.id);
               updateAgentMessages(sendAgentId, prev => prev.filter(m => m.id !== botMsg.id));
               finishTurnIfCurrent(sendAgentId, botMsg.id);
               cleanup();
             } else if (data.type === "error") {
+              // Flush any buffered streaming content before showing the error
+              const rafHandle = rafHandleRef.current.get(botMsg.id);
+              if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
+              flushStreamingContent(sendAgentId, botMsg.id);
               const error = data.content || "WebSocket error";
               updateAgentMessages(sendAgentId, prev => prev.map(m =>
                 m.id === botMsg.id ? { ...m, isStreaming: false, error } : m
@@ -762,6 +815,12 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 if (!turn.responded) { cleanup(); sendViaHttp(); }
               }, 30_000);
             } else if (data.type === "response") {
+              // Cancel any pending RAF flush — the final response supersedes
+              // any buffered streaming content.
+              const rafHandle = rafHandleRef.current.get(botMsg.id);
+              if (rafHandle !== undefined) cancelAnimationFrame(rafHandle);
+              streamingBufferRef.current.delete(botMsg.id);
+              rafHandleRef.current.delete(botMsg.id);
               updateAgentMessages(sendAgentId, prev => prev.map(m =>
                 m.id === botMsg.id
                   ? {
@@ -779,10 +838,15 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
               cleanup();
             }
           } catch {
-            // Non-JSON text chunk
-            updateAgentMessages(sendAgentId, prev => prev.map(m =>
-              m.id === botMsg.id ? { ...m, content: m.content + event.data } : m
-            ));
+            // Non-JSON text chunk — treat as a streaming delta
+            const prevBuf = streamingBufferRef.current.get(botMsg.id);
+            if (prevBuf === undefined) {
+              const currentContent = (messagesRef.current.find(m => m.id === botMsg.id)?.content) ?? "";
+              streamingBufferRef.current.set(botMsg.id, currentContent + (event.data as string));
+            } else {
+              streamingBufferRef.current.set(botMsg.id, prevBuf + (event.data as string));
+            }
+            scheduleStreamingFlush(sendAgentId, botMsg.id);
           }
         };
 
@@ -819,7 +883,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
 
     // HTTP fallback — direct, no fake streaming
     await sendViaHttp();
-  }, [agentId, agents, wsConnected, ws, deepThinking, showThinkingProcess, finishTurnIfCurrent, clearHistory]);
+  }, [agentId, agents, wsConnected, ws, deepThinking, showThinkingProcess, finishTurnIfCurrent, clearHistory, scheduleStreamingFlush, flushStreamingContent]);
 
   // Abort an in-flight agent run. Hits the backend stop endpoint (which aborts
   // the tokio task on the kernel side) and optimistically finalizes any

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -1,4 +1,4 @@
-import { Component, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import React, { Component, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "motion/react";
@@ -34,17 +34,36 @@ import {
   ShieldHalf,
 } from "lucide-react";
 import { TaintPolicyEditor } from "../components/TaintPolicyEditor";
-import { DynamicIcon } from "lucide-react/dynamic";
-import type { IconName } from "lucide-react/dynamic";
+// Lazy-load individual lucide icons by name — avoids pulling the full
+// ~1500-icon registry that `lucide-react/dynamic` bundles.
+type IconName = string;
+const lazyIconCache = new Map<string, React.LazyExoticComponent<React.ComponentType<{ className?: string }>>>();
+function getLazyIcon(name: string) {
+  if (!lazyIconCache.has(name)) {
+    lazyIconCache.set(
+      name,
+      lazy(() =>
+        import("lucide-react").then((mod) => {
+          // Convert kebab-case icon name to PascalCase component name
+          const pascal = name
+            .split("-")
+            .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+            .join("");
+          const Component = (mod as Record<string, unknown>)[pascal] as React.ComponentType<{ className?: string }> | undefined;
+          if (!Component) throw new Error(`lucide icon not found: ${pascal}`);
+          return { default: Component };
+        }),
+      ),
+    );
+  }
+  return lazyIconCache.get(name)!;
+}
 
-// Wraps `DynamicIcon` so a catalog entry with a stale or mistyped
-// `lucide:xxx` name (backend-controlled, but still human-edited) falls back
-// to a neutral icon instead of throwing and blowing up the surrounding card.
-// `DynamicIcon` lazy-imports the icon module — if the name isn't a real
-// lucide icon the import rejects and the `Suspense` fallback doesn't catch
-// that; it bubbles up as a render error, which this boundary converts into
-// `fallback`.
-class DynamicIconBoundary extends Component<
+// Error boundary wrapping each lazily-loaded catalog icon. If the icon
+// name from the backend doesn't map to a real lucide export the lazy
+// import rejects — the boundary catches the render error and shows the
+// neutral fallback instead of blowing up the surrounding card.
+class LazyIconBoundary extends Component<
   { children: ReactNode; fallback: ReactNode },
   { hasError: boolean }
 > {
@@ -54,7 +73,7 @@ class DynamicIconBoundary extends Component<
   }
   componentDidCatch(error: Error) {
     // eslint-disable-next-line no-console
-    console.warn("CatalogIcon: DynamicIcon failed to load, using fallback.", error);
+    console.warn("CatalogIcon: lazy icon failed to load, using fallback.", error);
   }
   render() {
     return this.state.hasError ? this.props.fallback : this.props.children;
@@ -65,10 +84,13 @@ function CatalogIcon({ icon, className }: { icon: string; className?: string }) 
   if (icon.startsWith("lucide:")) {
     const name = icon.slice("lucide:".length) as IconName;
     const fallback = <Plug className={className} />;
+    const LazyIcon = getLazyIcon(name);
     return (
-      <DynamicIconBoundary fallback={fallback}>
-        <DynamicIcon name={name} className={className} fallback={() => fallback} />
-      </DynamicIconBoundary>
+      <LazyIconBoundary fallback={fallback}>
+        <Suspense fallback={fallback}>
+          <LazyIcon className={className} />
+        </Suspense>
+      </LazyIconBoundary>
     );
   }
   return <span className="text-xl">{icon}</span>;
@@ -347,7 +369,7 @@ function AuthBadge({
   }, [authState, polling, serverIdentity, onAuthSuccess, addToast, queryClient, t]);
 
   const handleStartAuth = useCallback(async () => {
-    const authWindow = window.open("about:blank", "_blank");
+    const authWindow = window.open("about:blank", "_blank", "noopener,noreferrer");
     try {
       const result = await startAuthMutation.mutateAsync(serverIdentity);
       if (authWindow && !authWindow.closed) {
@@ -1185,9 +1207,9 @@ export function McpServersPage() {
 
           {/* Transport type */}
           <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+            <span className="text-[10px] font-black uppercase tracking-widest text-text-dim">
               {t("mcp.transport_type")}
-            </label>
+            </span>
             <div className="flex gap-2">
               {(["stdio", "sse", "http"] as TransportType[]).map((tt) => (
                 <button
@@ -1220,9 +1242,9 @@ export function McpServersPage() {
                 placeholder={t("mcp.command_placeholder")}
               />
               <div className="flex flex-col gap-1.5">
-                <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+                <span className="text-[10px] font-black uppercase tracking-widest text-text-dim">
                   {t("mcp.args")}
-                </label>
+                </span>
                 <ArgsEditor items={form.args} onChange={(v) => updateField("args", v)} />
               </div>
             </div>
@@ -1245,10 +1267,11 @@ export function McpServersPage() {
                 <p className="text-[10px] text-warning font-bold">{t("mcp.url_hint")}</p>
               )}
               <div className="flex flex-col gap-1.5">
-                <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+                <label htmlFor="mcp-server-headers" className="text-[10px] font-black uppercase tracking-widest text-text-dim">
                   {t("mcp.headers")}
                 </label>
                 <textarea
+                  id="mcp-server-headers"
                   value={form.headers}
                   onChange={(e) => updateField("headers", e.target.value)}
                   placeholder={t("mcp.headers_placeholder")}
@@ -1271,9 +1294,9 @@ export function McpServersPage() {
 
           {/* Env vars */}
           <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+            <span className="text-[10px] font-black uppercase tracking-widest text-text-dim">
               {t("mcp.env")}
-            </label>
+            </span>
             <EnvEditor items={form.env} onChange={(v) => updateField("env", v)} />
           </div>
 
@@ -1310,7 +1333,7 @@ export function McpServersPage() {
           {(installingTemplate?.required_env ?? []).map(e => (
             <div key={e.name} className="flex flex-col gap-1.5">
               <div className="flex items-center gap-1.5">
-                <label className="text-[10px] font-black uppercase tracking-widest text-text-dim">
+                <label htmlFor={`catalog-env-${e.name}`} className="text-[10px] font-black uppercase tracking-widest text-text-dim">
                   {e.label || e.name}
                 </label>
                 {e.get_url && (
@@ -1321,6 +1344,7 @@ export function McpServersPage() {
               </div>
               {e.help && <span className="text-[9px] text-text-dim/50">{e.help}</span>}
               <input
+                id={`catalog-env-${e.name}`}
                 type={e.is_secret ? "password" : "text"}
                 value={envInputs[e.name] ?? ""}
                 onChange={(ev) => setEnvInputs(prev => ({ ...prev, [e.name]: ev.target.value }))}

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -364,7 +364,7 @@ export function PluginsPage() {
         <div className="p-5 space-y-4">
               {/* Source Tabs */}
               <div>
-                <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.source")}</label>
+                <span className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.source")}</span>
                 <div className="flex gap-2 mt-1">
                   {(["registry", "local", "git"] as const).map(s => (
                     <button key={s} onClick={() => setInstallSource(s)}
@@ -381,30 +381,30 @@ export function PluginsPage() {
               {installSource === "registry" && (
                 <>
                   <div>
-                    <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>
-                    <input value={installName} onChange={e => setInstallName(e.target.value)} className={inputClass} placeholder="e.g. echo-memory" />
+                    <label htmlFor="install-plugin-name" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>
+                    <input id="install-plugin-name" value={installName} onChange={e => setInstallName(e.target.value)} className={inputClass} placeholder="e.g. echo-memory" />
                   </div>
                   <div>
-                    <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.registry_optional")}</label>
-                    <input value={installRepo} onChange={e => setInstallRepo(e.target.value)} className={inputClass} placeholder={t("plugins.registry_placeholder")} />
+                    <label htmlFor="install-plugin-repo" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.registry_optional")}</label>
+                    <input id="install-plugin-repo" value={installRepo} onChange={e => setInstallRepo(e.target.value)} className={inputClass} placeholder={t("plugins.registry_placeholder")} />
                   </div>
                 </>
               )}
               {installSource === "local" && (
                 <div>
-                  <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.path")}</label>
-                  <input value={installPath} onChange={e => setInstallPath(e.target.value)} className={inputClass} placeholder="/path/to/plugin" />
+                  <label htmlFor="install-plugin-path" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.path")}</label>
+                  <input id="install-plugin-path" value={installPath} onChange={e => setInstallPath(e.target.value)} className={inputClass} placeholder="/path/to/plugin" />
                 </div>
               )}
               {installSource === "git" && (
                 <>
                   <div>
-                    <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.url")}</label>
-                    <input value={installUrl} onChange={e => setInstallUrl(e.target.value)} className={inputClass} placeholder="https://github.com/..." />
+                    <label htmlFor="install-plugin-url" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.url")}</label>
+                    <input id="install-plugin-url" value={installUrl} onChange={e => setInstallUrl(e.target.value)} className={inputClass} placeholder="https://github.com/..." />
                   </div>
                   <div>
-                    <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.branch")}</label>
-                    <input value={installBranch} onChange={e => setInstallBranch(e.target.value)} className={inputClass} placeholder="main" />
+                    <label htmlFor="install-plugin-branch" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.branch")}</label>
+                    <input id="install-plugin-branch" value={installBranch} onChange={e => setInstallBranch(e.target.value)} className={inputClass} placeholder="main" />
                   </div>
                 </>
               )}
@@ -430,16 +430,16 @@ export function PluginsPage() {
       <DrawerPanel isOpen={showScaffold} onClose={() => setShowScaffold(false)} title={t("plugins.scaffold_title")} size="sm">
         <div className="p-5 space-y-4">
           <div>
-            <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>
-            <input value={scaffoldName} onChange={e => setScaffoldName(e.target.value)} className={inputClass} placeholder="my-plugin" disabled={scaffoldMutation.isPending} />
+            <label htmlFor="scaffold-plugin-name" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.plugin_name")}</label>
+            <input id="scaffold-plugin-name" value={scaffoldName} onChange={e => setScaffoldName(e.target.value)} className={inputClass} placeholder="my-plugin" disabled={scaffoldMutation.isPending} />
           </div>
           <div>
-            <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.description")}</label>
-            <input value={scaffoldDesc} onChange={e => setScaffoldDesc(e.target.value)} className={inputClass} placeholder={t("plugins.scaffold_desc")} disabled={scaffoldMutation.isPending} />
+            <label htmlFor="scaffold-plugin-desc" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.description")}</label>
+            <input id="scaffold-plugin-desc" value={scaffoldDesc} onChange={e => setScaffoldDesc(e.target.value)} className={inputClass} placeholder={t("plugins.scaffold_desc")} disabled={scaffoldMutation.isPending} />
           </div>
           <div>
-            <label className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.runtime", { defaultValue: "Runtime" })}</label>
-            <select value={scaffoldRuntime} onChange={e => setScaffoldRuntime(e.target.value)} className={inputClass} disabled={scaffoldMutation.isPending}>
+            <label htmlFor="scaffold-plugin-runtime" className="text-[10px] font-bold text-text-dim uppercase">{t("plugins.runtime", { defaultValue: "Runtime" })}</label>
+            <select id="scaffold-plugin-runtime" value={scaffoldRuntime} onChange={e => setScaffoldRuntime(e.target.value)} className={inputClass} disabled={scaffoldMutation.isPending}>
               <option value="python">Python</option>
               <option value="node">Node.js</option>
               <option value="deno">Deno (TypeScript)</option>


### PR DESCRIPTION
## Summary

- **#3759** Add `noopener,noreferrer` to `window.open()` in `McpServersPage` `AuthBadge.handleStartAuth` — the popup was opened without the flag, allowing reverse tabnabbing
- **#3760** Wire `htmlFor`/`id` pairs on bare `<label>` elements in `PluginsPage` (install modal: name, repo, path, url, branch; scaffold modal: name, desc, runtime) and `McpServersPage` (catalog env setup modal inputs, headers textarea); labels for button groups changed to `<span>` since they have no associated input target
- **#3762** Add `budgetKeys.all` invalidation in `onSettled` for all four media generation mutations (`useGenerateImage`, `useSynthesizeSpeech`, `useSubmitVideo`, `useGenerateMusic`) — the UserBudget card was stale for up to 30 s after spending
- **#3767** Replace per-token `setMessages(prev => prev.map(...))` in the WebSocket `text_delta` handler with a `useRef` Map buffer that accumulates chunks and flushes into React state at most once per `requestAnimationFrame` (~16 ms); terminal events (`typing:stop`, `response`, `silent_complete`, `error`) cancel the pending frame and flush synchronously
- **#3768** Replace `import { DynamicIcon } from 'lucide-react/dynamic'` (which bundles the full ~1500-icon registry) with a per-name `React.lazy()` + dynamic `import('lucide-react')` approach; icon names are converted from kebab-case to PascalCase at load time and cached in a module-level Map; an error boundary catches unknown icon names and renders the neutral `Plug` fallback

## Test plan

- [ ] McpServersPage: click "Authorize" on an OAuth server — popup opens with `noopener` flag (verify in devtools Network/opener)
- [ ] PluginsPage: open Install and Scaffold modals, click on label text — focus should jump to the corresponding input
- [ ] McpServersPage: open Add/Edit drawer, confirm clicking "Transport Type", "Args", "Env" labels does not throw console errors
- [ ] McpServersPage catalog: open a template with `required_env`, click label text — focus jumps to the correct credential input
- [ ] MediaPage: generate an image/TTS/music — verify budget card updates within one refetch cycle after the mutation completes
- [ ] ChatPage: send a message to a streaming agent — text appears progressively without visible stuttering; open React DevTools profiler and confirm render count during streaming is significantly lower than before
- [ ] McpServersPage catalog tab: entries with `lucide:` icon names render the icon or fallback without errors; check bundle output (`pnpm run build`) — `lucide-react/dynamic` should no longer appear in the vendor chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)