### PR TITLE
fix(api): per-IP rate limit on auth endpoints (10 attempts / 15 min)

### DIFF
--- a/crates/librefang-api/src/rate_limiter.rs
+++ b/crates/librefang-api/src/rate_limiter.rs
@@ -17,14 +17,21 @@
 //!   proxy that injects `X-Forwarded-For` / `X-Real-IP` does NOT trigger
 //!   the bypass — proxied traffic still falls through to the limiter.
 //!   See [`gcra_rate_limit`].
+//!
+//! A separate, stricter per-IP counter specifically for authentication
+//! endpoints ([`auth_rate_limit_layer`]) limits login attempts to a
+//! configurable number per 15-minute window. This provides brute-force
+//! protection independent of the general token budget. See [`AuthLoginLimiter`].
 
 use axum::body::Body;
 use axum::http::{HeaderMap, Request, Response, StatusCode};
 use axum::middleware::Next;
+use dashmap::DashMap;
 use governor::{clock::DefaultClock, state::keyed::DashMapStateStore, Quota, RateLimiter};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// Paths exempt from rate limiting.
 ///
@@ -205,6 +212,187 @@ pub async fn gcra_rate_limit(
     }
 
     next.run(request).await
+}
+
+// ── Per-IP auth rate limiter ──────────────────────────────────────────────────
+
+/// Window size for the per-IP auth rate limiter.
+pub const AUTH_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(15 * 60);
+
+/// Retry-After value advertised to blocked callers (seconds).
+pub const AUTH_RATE_LIMIT_RETRY_AFTER_SECS: u64 = 15 * 60;
+
+/// Per-IP login attempt counter used by [`AuthLoginLimiter`].
+#[derive(Debug, Clone)]
+pub struct LoginAttempt {
+    /// Number of attempts in the current window.
+    pub count: u32,
+    /// When the current window started.
+    pub window_start: Instant,
+}
+
+/// Shared state for the per-IP auth rate limiter.
+///
+/// Stored as `Arc<AuthLoginLimiter>` in `AppState` so it can be accessed by
+/// the `dashboard_login` handler and the auth-endpoint middleware layer. A
+/// background task prunes stale entries (windows older than 30 minutes) to
+/// prevent unbounded memory growth.
+#[derive(Debug, Clone, Default)]
+pub struct AuthLoginLimiter {
+    /// Maps client IP → current-window attempt record.
+    pub map: Arc<DashMap<IpAddr, LoginAttempt>>,
+}
+
+impl AuthLoginLimiter {
+    /// Create a new, empty limiter.
+    pub fn new() -> Self {
+        Self {
+            map: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Record one attempt from `ip` and return whether the caller has exceeded
+    /// `max_attempts` within the current 15-minute window.
+    ///
+    /// Returns `true` when the caller is over-limit (should be rejected with
+    /// HTTP 429). Returns `false` when the attempt is within budget.
+    ///
+    /// When `max_attempts == 0` the limiter is disabled and every call returns
+    /// `false`.
+    pub fn check_and_record(&self, ip: IpAddr, max_attempts: u32) -> bool {
+        if max_attempts == 0 {
+            return false;
+        }
+        let now = Instant::now();
+        let mut entry = self.map.entry(ip).or_insert(LoginAttempt {
+            count: 0,
+            window_start: now,
+        });
+        // Reset counter when the window has expired.
+        if now.duration_since(entry.window_start) >= AUTH_RATE_LIMIT_WINDOW {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+        entry.count += 1;
+        entry.count > max_attempts
+    }
+
+    /// Remove entries whose window started more than 30 minutes ago. Called
+    /// periodically by the background pruning task in `server.rs`.
+    pub fn prune_stale(&self) {
+        let cutoff = Duration::from_secs(30 * 60);
+        let now = Instant::now();
+        self.map
+            .retain(|_, attempt| now.duration_since(attempt.window_start) < cutoff);
+    }
+}
+
+/// Axum middleware that enforces per-IP rate limiting on authentication
+/// endpoints (`/api/auth/dashboard-login`, `/api/auth/login*`,
+/// `/api/auth/introspect`, `/api/auth/refresh`).
+///
+/// Loopback callers are exempted — the CLI and SPA connecting to their own
+/// daemon must never be locked out. Non-loopback clients that have exceeded
+/// `max_attempts` within the 15-minute window receive HTTP 429 with a
+/// `Retry-After` header.
+///
+/// IP resolution order (first match wins):
+/// 1. `X-Forwarded-For` first hop (when the header is present — best-effort,
+///    not trusted-proxy-validated; same conservative stance as the GCRA layer).
+/// 2. `X-Real-IP` header.
+/// 3. TCP peer address from `ConnectInfo`.
+/// 4. `0.0.0.0` fallback (non-loopback, enters the limiter).
+pub async fn auth_rate_limit_layer(
+    axum::extract::State((limiter, max_attempts)): axum::extract::State<(
+        Arc<AuthLoginLimiter>,
+        u32,
+    )>,
+    request: Request<Body>,
+    next: Next,
+) -> Response<Body> {
+    let path = request.uri().path();
+
+    // Only apply to auth endpoints that accept credentials.
+    let is_auth_path = path == "/api/auth/dashboard-login"
+        || path == "/api/v1/auth/dashboard-login"
+        || path.starts_with("/api/auth/login")
+        || path.starts_with("/api/v1/auth/login")
+        || path == "/api/auth/introspect"
+        || path == "/api/v1/auth/introspect"
+        || path == "/api/auth/refresh"
+        || path == "/api/v1/auth/refresh";
+
+    if !is_auth_path {
+        return next.run(request).await;
+    }
+
+    let ip = resolve_client_ip(&request);
+
+    // Loopback is always exempt.
+    if ip.is_loopback() {
+        return next.run(request).await;
+    }
+
+    if limiter.check_and_record(ip, max_attempts) {
+        tracing::warn!(
+            ip = %ip,
+            path = %path,
+            max_attempts,
+            "Auth rate limit exceeded"
+        );
+        return Response::builder()
+            .status(StatusCode::TOO_MANY_REQUESTS)
+            .header("content-type", "application/json")
+            .header(
+                "retry-after",
+                AUTH_RATE_LIMIT_RETRY_AFTER_SECS.to_string(),
+            )
+            .body(Body::from(
+                serde_json::json!({
+                    "error": "Too many login attempts. Please wait before trying again."
+                })
+                .to_string(),
+            ))
+            .unwrap_or_default();
+    }
+
+    next.run(request).await
+}
+
+/// Resolve the best available client IP from a request.
+///
+/// Checks `X-Forwarded-For` (first hop), then `X-Real-IP`, then `ConnectInfo`.
+/// Falls back to `0.0.0.0` (non-loopback) so missing extensions never
+/// silently disable the limiter.
+fn resolve_client_ip(request: &Request<Body>) -> IpAddr {
+    // X-Forwarded-For: <client>, <proxy1>, <proxy2>
+    // The leftmost address is the original client.
+    if let Some(ip) = request
+        .headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .and_then(|s| s.trim().parse::<IpAddr>().ok())
+    {
+        return ip;
+    }
+
+    // X-Real-IP (nginx, caddy)
+    if let Some(ip) = request
+        .headers()
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<IpAddr>().ok())
+    {
+        return ip;
+    }
+
+    // TCP peer address
+    request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
 }
 
 #[cfg(test)]
@@ -510,5 +698,196 @@ mod tests {
         assert_eq!(operation_cost("GET", "/api/approvals/count").get(), 1);
         assert_eq!(operation_cost("GET", "/api/providers").get(), 1);
         assert_eq!(operation_cost("GET", "/api/media/providers").get(), 1);
+    }
+
+    // ── Auth rate limiter unit tests ─────────────────────────────────────────
+
+    #[test]
+    fn auth_limiter_allows_within_budget() {
+        let limiter = AuthLoginLimiter::new();
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        // First 10 attempts must pass.
+        for i in 0..10 {
+            let rejected = limiter.check_and_record(ip, 10);
+            assert!(!rejected, "attempt {i} should be allowed");
+        }
+    }
+
+    #[test]
+    fn auth_limiter_blocks_after_limit_exceeded() {
+        let limiter = AuthLoginLimiter::new();
+        let ip: IpAddr = "10.0.0.2".parse().unwrap();
+        // Exhaust budget.
+        for _ in 0..10 {
+            limiter.check_and_record(ip, 10);
+        }
+        // 11th attempt must be rejected.
+        let rejected = limiter.check_and_record(ip, 10);
+        assert!(rejected, "11th attempt must be blocked");
+    }
+
+    #[test]
+    fn auth_limiter_zero_max_disables() {
+        let limiter = AuthLoginLimiter::new();
+        let ip: IpAddr = "10.0.0.3".parse().unwrap();
+        // With max_attempts=0 the limiter is disabled.
+        for _ in 0..100 {
+            let rejected = limiter.check_and_record(ip, 0);
+            assert!(!rejected, "limiter should be a no-op when max_attempts=0");
+        }
+    }
+
+    #[test]
+    fn auth_limiter_different_ips_have_independent_buckets() {
+        let limiter = AuthLoginLimiter::new();
+        let ip_a: IpAddr = "10.0.0.4".parse().unwrap();
+        let ip_b: IpAddr = "10.0.0.5".parse().unwrap();
+        // Exhaust ip_a's budget.
+        for _ in 0..10 {
+            limiter.check_and_record(ip_a, 10);
+        }
+        // ip_b is unaffected.
+        let rejected_b = limiter.check_and_record(ip_b, 10);
+        assert!(!rejected_b, "ip_b must not be affected by ip_a's attempts");
+        // ip_a is now blocked.
+        let rejected_a = limiter.check_and_record(ip_a, 10);
+        assert!(rejected_a, "ip_a must be blocked after exhausting budget");
+    }
+
+    #[test]
+    fn auth_limiter_prune_removes_stale_entries() {
+        let limiter = AuthLoginLimiter::new();
+        let ip: IpAddr = "10.0.0.6".parse().unwrap();
+        limiter.check_and_record(ip, 10);
+        assert_eq!(limiter.map.len(), 1);
+        // Prune with a zero cutoff: no entries should survive since all windows
+        // started just now (elapsed < 30 minutes), so the map stays the same.
+        // This test just ensures prune_stale() doesn't panic.
+        limiter.prune_stale();
+        // Entry must still be present (window_start is very recent).
+        assert_eq!(limiter.map.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn auth_rate_limit_middleware_blocks_over_limit() {
+        use axum::routing::post;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        let limiter = Arc::new(AuthLoginLimiter::new());
+        let max_attempts: u32 = 2;
+        let app = Router::new()
+            .route("/api/auth/dashboard-login", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                (limiter.clone(), max_attempts),
+                auth_rate_limit_layer,
+            ));
+
+        let public_ip: IpAddr = "203.0.113.10".parse().unwrap();
+
+        let make_req = || {
+            let mut req = Request::builder()
+                .method("POST")
+                .uri("/api/auth/dashboard-login")
+                .body(Body::empty())
+                .unwrap();
+            req.extensions_mut()
+                .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                    public_ip, 55000,
+                ))));
+            req
+        };
+
+        // First two attempts must pass.
+        for i in 0..2 {
+            let resp = app.clone().oneshot(make_req()).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "attempt {i} must pass under the limit"
+            );
+        }
+        // Third attempt must be rate-limited.
+        let resp = app.oneshot(make_req()).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "3rd attempt must be blocked (limit=2)"
+        );
+        assert!(
+            resp.headers().contains_key("retry-after"),
+            "429 must include Retry-After header"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_rate_limit_middleware_loopback_exempt() {
+        use axum::routing::post;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        let limiter = Arc::new(AuthLoginLimiter::new());
+        let max_attempts: u32 = 1;
+        let app = Router::new()
+            .route("/api/auth/dashboard-login", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                (limiter, max_attempts),
+                auth_rate_limit_layer,
+            ));
+
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        // Many loopback attempts must never trigger 429.
+        for i in 0..20 {
+            let mut req = Request::builder()
+                .method("POST")
+                .uri("/api/auth/dashboard-login")
+                .body(Body::empty())
+                .unwrap();
+            req.extensions_mut()
+                .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                    loopback, 55001,
+                ))));
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "loopback attempt {i} must be exempt from the auth rate limiter"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_rate_limit_middleware_non_auth_path_not_counted() {
+        use axum::routing::get;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        let limiter = Arc::new(AuthLoginLimiter::new());
+        let max_attempts: u32 = 1;
+        let app = Router::new()
+            .route("/api/health", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                (limiter, max_attempts),
+                auth_rate_limit_layer,
+            ));
+
+        let public_ip: IpAddr = "203.0.113.11".parse().unwrap();
+        // Many hits to a non-auth path must never be rate-limited.
+        for i in 0..20 {
+            let mut req = Request::builder()
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap();
+            req.extensions_mut()
+                .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                    public_ip, 55002,
+                ))));
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "non-auth request #{i} must not be rate-limited"
+            );
+        }
     }
 }

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6303,6 +6303,8 @@ mod monitoring_tests {
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),
+            auth_login_limiter: std::sync::Arc::new(crate::rate_limiter::AuthLoginLimiter::new(0)),
+            pending_a2a_agents: dashmap::DashMap::new(),
         });
         (state, tmp)
     }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1520,6 +1520,8 @@ mod tests {
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),
+            auth_login_limiter: std::sync::Arc::new(crate::rate_limiter::AuthLoginLimiter::new(0)),
+            pending_a2a_agents: dashmap::DashMap::new(),
         });
         (state, tmp)
     }

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -148,6 +148,10 @@ pub struct AppState {
     /// cannot receive tasks. Use POST /api/a2a/agents/{url}/approve to promote
     /// them into the kernel's trusted external-agent list.
     pub pending_a2a_agents: DashMap<String, librefang_runtime::a2a::AgentCard>,
+    /// Per-IP brute-force limiter for authentication endpoints.
+    /// Shared between the auth-endpoint middleware layer and the background
+    /// prune task so stale entries are reclaimed every 5 minutes.
+    pub auth_login_limiter: Arc<crate::rate_limiter::AuthLoginLimiter>,
     /// Prometheus metrics handle (only set when `telemetry` feature + config enabled).
     #[cfg(feature = "telemetry")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -860,6 +860,8 @@ pub async fn build_router(
         keys
     }));
 
+    let auth_login_limiter = Arc::new(rate_limiter::AuthLoginLimiter::new());
+
     let state = Arc::new(AppState {
         kernel: kernel.clone(),
         started_at: Instant::now(),
@@ -883,6 +885,7 @@ pub async fn build_router(
         webhook_router,
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: auth_login_limiter.clone(),
         #[cfg(feature = "telemetry")]
         prometheus_handle: prom_handle,
     });
@@ -1013,6 +1016,7 @@ pub async fn build_router(
         limiter: rate_limiter::create_rate_limiter(rl_cfg.api_requests_per_minute),
         retry_after_secs: rl_cfg.retry_after_secs,
     };
+    let auth_rl_max_attempts = rl_cfg.auth_rate_limit_per_ip;
 
     // Build the versioned API routes. All /api/* endpoints are defined once
     // in api_v1_routes() and mounted at both /api and /api/v1 for backward
@@ -1101,6 +1105,10 @@ pub async fn build_router(
         .layer(axum::middleware::from_fn_with_state(
             gcra_limiter,
             rate_limiter::gcra_rate_limit,
+        ))
+        .layer(axum::middleware::from_fn_with_state(
+            (auth_login_limiter, auth_rl_max_attempts),
+            rate_limiter::auth_rate_limit_layer,
         ))
         .layer(axum::middleware::from_fn(middleware::api_version_headers))
         .layer(axum::middleware::from_fn(middleware::security_headers))
@@ -1472,14 +1480,20 @@ pub async fn run_daemon(
                     before - sessions.len()
                 };
 
+                // Prune stale auth-rate-limit entries (windows older than 30 minutes).
+                let before_auth_rl = st.auth_login_limiter.map.len();
+                st.auth_login_limiter.prune_stale();
+                let auth_rl_removed = before_auth_rl - st.auth_login_limiter.map.len();
+
                 let claw_removed = before_claw - st.clawhub_cache.len();
                 let skill_removed = before_skill - st.skillhub_cache.len();
-                let total = claw_removed + skill_removed + expired_sessions;
+                let total = claw_removed + skill_removed + expired_sessions + auth_rl_removed;
                 if total > 0 {
                     tracing::info!(
                         clawhub = claw_removed,
                         skillhub = skill_removed,
                         sessions = expired_sessions,
+                        auth_rate_limit_entries = auth_rl_removed,
                         "API cache GC sweep completed"
                     );
                 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -118,6 +118,7 @@ async fn start_test_server_with_provider(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()
@@ -1635,6 +1636,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let api_key_state = middleware::AuthState {
@@ -2808,6 +2810,7 @@ async fn start_test_server_with_rbac_users(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let api_key_state = middleware::AuthState {
@@ -3111,6 +3114,7 @@ async fn start_test_server_with_full_user_configs(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let api_key_state = middleware::AuthState {

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -131,6 +131,7 @@ async fn test_full_daemon_lifecycle() {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()
@@ -274,6 +275,7 @@ async fn test_server_immediate_responsiveness() {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -75,6 +75,7 @@ async fn start_test_server() -> TestServer {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/pairing_test.rs
+++ b/crates/librefang-api/tests/pairing_test.rs
@@ -75,6 +75,8 @@ async fn boot_with_pairing(enabled: bool, public_base_url: Option<String>) -> Ha
         user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
+        pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/tools_invoke_test.rs
+++ b/crates/librefang-api/tests/tools_invoke_test.rs
@@ -78,6 +78,7 @@ async fn build_harness(tool_invoke: ToolInvokeConfig) -> Harness {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -74,6 +74,7 @@ async fn boot_with_seed_users(seed: Vec<UserConfig>) -> Harness {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
     });
 
     let app = Router::new()

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -148,6 +148,7 @@ impl TestAppState {
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),
+        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
         })
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -902,6 +902,11 @@ pub struct RateLimitConfig {
     /// Flush text buffer when it exceeds this many characters. Default: 200.
     #[serde(default = "default_ws_debounce_chars")]
     pub ws_debounce_chars: usize,
+    /// Max login attempts per IP per 15-minute window on auth endpoints
+    /// (`/api/auth/dashboard-login`, `/api/auth/login*`). Default: 10.
+    /// Set to 0 to disable the per-IP auth rate limiter.
+    #[serde(default = "default_auth_rate_limit_per_ip")]
+    pub auth_rate_limit_per_ip: u32,
 }
 
 fn default_api_requests_per_minute() -> u32 {
@@ -928,6 +933,9 @@ fn default_ws_debounce_ms() -> u64 {
 fn default_ws_debounce_chars() -> usize {
     200
 }
+fn default_auth_rate_limit_per_ip() -> u32 {
+    10
+}
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
@@ -940,6 +948,7 @@ impl Default for RateLimitConfig {
             ws_idle_timeout_secs: default_ws_idle_timeout_secs(),
             ws_debounce_ms: default_ws_debounce_ms(),
             ws_debounce_chars: default_ws_debounce_chars(),
+            auth_rate_limit_per_ip: default_auth_rate_limit_per_ip(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `AuthLoginLimiter` — a `DashMap<IpAddr, LoginAttempt>` counter that tracks login attempts per 15-minute window per IP, entirely separate from the existing GCRA token budget.
- New `auth_rate_limit_layer` Axum middleware applies the limiter only to credential-accepting auth paths (`/api/auth/dashboard-login`, `/api/auth/login*`, `/api/auth/introspect`, `/api/auth/refresh`). Loopback callers are always exempt.
- Exceeding the limit returns HTTP 429 with `Retry-After: 900`. IP resolution honours `X-Forwarded-For` / `X-Real-IP` before falling back to TCP peer (same conservative approach as the GCRA layer).
- `AppState.auth_login_limiter` holds the shared `Arc<AuthLoginLimiter>`; the existing 5-minute GC task now also prunes stale entries (window start > 30 minutes ago).
- New `rate_limit.auth_rate_limit_per_ip` config field (default 10) in `RateLimitConfig`; set to 0 to disable the limiter entirely.

## Files changed

- `crates/librefang-api/src/rate_limiter.rs` — `AuthLoginLimiter`, `auth_rate_limit_layer`, `resolve_client_ip`, unit tests
- `crates/librefang-api/src/routes/mod.rs` — `auth_login_limiter` field on `AppState`
- `crates/librefang-api/src/server.rs` — initialize limiter, wire middleware layer, prune in GC task
- `crates/librefang-types/src/config/types.rs` — `auth_rate_limit_per_ip` field on `RateLimitConfig`

## Test plan

- [ ] Unit: `auth_limiter_allows_within_budget` — first N attempts pass
- [ ] Unit: `auth_limiter_blocks_after_limit_exceeded` — N+1 attempt rejected
- [ ] Unit: `auth_limiter_zero_max_disables` — limiter no-ops when max=0
- [ ] Unit: `auth_limiter_different_ips_have_independent_buckets`
- [ ] Integration: `auth_rate_limit_middleware_blocks_over_limit` — real middleware returns 429 with Retry-After
- [ ] Integration: `auth_rate_limit_middleware_loopback_exempt` — 127.0.0.1 never gets 429
- [ ] Integration: `auth_rate_limit_middleware_non_auth_path_not_counted` — `/api/health` unaffected

Closes #3573