### PR TITLE
test(kernel): integration tests for session_mode_override resolution and trigger concurrency caps

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4634,6 +4634,36 @@ fn dummy_sender(channel: &str, chat_id: Option<&str>) -> SenderContext {
     SenderContext {
         channel: channel.to_string(),
         chat_id: chat_id.map(str::to_string),
+// ── session_mode_override resolution + trigger concurrency caps (#3754, #3755) ──
+
+/// Helper: boot a minimal kernel in a temp directory.
+fn minimal_kernel(test_name: &str) -> (LibreFangKernel, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join(test_name);
+    std::fs::create_dir_all(home.join("data")).unwrap();
+    let cfg = KernelConfig {
+        home_dir: home.clone(),
+        data_dir: home.join("data"),
+        ..KernelConfig::default()
+    };
+    let k = LibreFangKernel::boot_with_config(cfg).expect("kernel should boot");
+    (k, dir)
+}
+
+/// Helper: minimal agent manifest with a specific session_mode and
+/// max_concurrent_invocations.
+fn concurrency_manifest(
+    name: &str,
+    session_mode: librefang_types::agent::SessionMode,
+    max_concurrent: Option<u32>,
+) -> AgentManifest {
+    AgentManifest {
+        name: name.to_string(),
+        description: "concurrency test agent".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        session_mode,
+        max_concurrent_invocations: max_concurrent,
         ..Default::default()
     }
 }
@@ -4794,4 +4824,264 @@ fn resolve_dispatch_session_id_session_mode_override_beats_manifest() {
         None,
     );
     assert_eq!(got, Some(entry_sid));
+// -- #3754: session_mode_override resolution via agent_concurrency_for --------
+
+/// An agent with `session_mode = "new"` and `max_concurrent_invocations = 3`
+/// must produce a semaphore with capacity 3 — no clamping should occur.
+#[test]
+fn agent_concurrency_new_session_allows_cap_above_one() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("concurrency-new-session");
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("new-agent", SessionMode::New, Some(3)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+    assert_eq!(
+        sem.available_permits(),
+        3,
+        "session_mode=new with max_concurrent_invocations=3 must produce a semaphore with 3 permits"
+    );
+
+    kernel.shutdown();
+}
+
+/// An agent with `session_mode = "persistent"` and
+/// `max_concurrent_invocations = 4` must be clamped to 1 — parallel writes
+/// to a single session's history are undefined, so the resolver silently
+/// enforces serialisation.
+#[test]
+fn agent_concurrency_persistent_session_clamps_cap_to_one() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("concurrency-persistent-clamp");
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("persistent-agent", SessionMode::Persistent, Some(4)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+    assert_eq!(
+        sem.available_permits(),
+        1,
+        "session_mode=persistent with max_concurrent_invocations=4 must be clamped to 1"
+    );
+
+    kernel.shutdown();
+}
+
+/// An agent with `session_mode = "persistent"` and
+/// `max_concurrent_invocations = 1` (i.e. the cap already equals 1) must
+/// produce a capacity-1 semaphore with no spurious WARN.
+#[test]
+fn agent_concurrency_persistent_session_with_cap_one_is_fine() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("concurrency-persistent-cap-one");
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("persistent-cap-one", SessionMode::Persistent, Some(1)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+    assert_eq!(sem.available_permits(), 1);
+
+    kernel.shutdown();
+}
+
+/// When `max_concurrent_invocations` is absent the resolver must fall back to
+/// `queue.concurrency.default_per_agent` (default: 1) regardless of
+/// session_mode.
+#[test]
+fn agent_concurrency_falls_back_to_config_default_when_unset() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("concurrency-default-fallback");
+    // default_per_agent = 1 (KernelConfig default)
+    let expected = kernel
+        .config
+        .load()
+        .queue
+        .concurrency
+        .default_per_agent;
+
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("default-fallback-agent", SessionMode::New, None),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+    assert_eq!(
+        sem.available_permits(),
+        expected,
+        "absent max_concurrent_invocations must use default_per_agent config value"
+    );
+
+    kernel.shutdown();
+}
+
+// -- #3755: three-layer concurrency caps joint integration --------------------
+
+/// Verify that the global `Lane::Trigger` semaphore correctly limits total
+/// concurrent trigger fires across the whole kernel.  We use a capacity-2
+/// queue and prove that the third caller cannot acquire a permit immediately.
+#[tokio::test]
+async fn trigger_lane_global_semaphore_limits_total_concurrency() {
+    use librefang_runtime::command_lane::{CommandQueue, Lane};
+
+    let queue = CommandQueue::with_capacities(3, 2, 3, 2); // trigger capacity = 2
+    let trigger_sem = queue.semaphore_for_lane(Lane::Trigger);
+
+    let p1 = trigger_sem.clone().try_acquire_owned().unwrap();
+    let p2 = trigger_sem.clone().try_acquire_owned().unwrap();
+
+    // Third acquire must fail because both permits are held.
+    assert!(
+        trigger_sem.clone().try_acquire_owned().is_err(),
+        "global trigger lane must block when all permits are held"
+    );
+
+    // Release one permit — now a third caller can proceed.
+    drop(p1);
+    assert!(
+        trigger_sem.clone().try_acquire_owned().is_ok(),
+        "releasing a permit must allow the next waiter to proceed"
+    );
+
+    drop(p2);
+}
+
+/// Verify that the per-agent semaphore enforces `max_concurrent_invocations`
+/// independently from the global lane semaphore.  Two agents each get their
+/// own semaphore; exhausting one must not affect the other.
+#[test]
+fn per_agent_semaphore_is_isolated_per_agent() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("per-agent-semaphore-isolation");
+
+    let agent_a = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("agent-a", SessionMode::New, Some(2)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn agent-a");
+
+    let agent_b = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("agent-b", SessionMode::New, Some(1)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn agent-b");
+
+    let sem_a = kernel.agent_concurrency_for(agent_a);
+    let sem_b = kernel.agent_concurrency_for(agent_b);
+
+    // Exhaust agent-a's 2 permits.
+    let _pa1 = sem_a.clone().try_acquire_owned().unwrap();
+    let _pa2 = sem_a.clone().try_acquire_owned().unwrap();
+    assert!(
+        sem_a.clone().try_acquire_owned().is_err(),
+        "agent-a semaphore must be exhausted after 2 acquires"
+    );
+
+    // agent-b still has its own capacity — exhausting agent-a must not affect it.
+    let _pb1 = sem_b.clone().try_acquire_owned().unwrap();
+    assert!(
+        sem_b.clone().try_acquire_owned().is_err(),
+        "agent-b semaphore must be exhausted after 1 acquire"
+    );
+
+    kernel.shutdown();
+}
+
+/// `session_mode = "new"` + `max_concurrent_invocations = 2` must produce a
+/// semaphore with 2 permits and each permit must be independently acquirable,
+/// meaning two concurrent trigger fires on the same agent can actually run in
+/// parallel (different sessions, no serialisation needed).
+#[test]
+fn session_mode_new_with_cap_two_allows_two_concurrent_fires() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("new-session-parallel-fires");
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("parallel-trigger-agent", SessionMode::New, Some(2)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+
+    // Both permits must be acquirable simultaneously, representing two
+    // concurrent trigger dispatches each running in its own fresh session.
+    let p1 = sem.clone().try_acquire_owned();
+    let p2 = sem.clone().try_acquire_owned();
+    assert!(p1.is_ok(), "first concurrent fire must acquire a permit");
+    assert!(p2.is_ok(), "second concurrent fire must acquire a permit");
+
+    // A third concurrent fire must wait.
+    assert!(
+        sem.clone().try_acquire_owned().is_err(),
+        "third concurrent fire must block once both permits are taken"
+    );
+
+    kernel.shutdown();
+}
+
+/// `session_mode = "persistent"` + `max_concurrent_invocations = 2` gets
+/// clamped to 1: a second concurrent fire on the same persistent session
+/// must NOT be able to run in parallel (would corrupt session history).
+/// The per-agent semaphore acts as the enforcement mechanism.
+#[test]
+fn session_mode_persistent_plus_cap_two_is_clamped_preventing_parallel_fires() {
+    use librefang_types::agent::SessionMode;
+
+    let (kernel, _dir) = minimal_kernel("persistent-session-no-parallel");
+    let agent_id = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("persistent-parallel-agent", SessionMode::Persistent, Some(2)),
+            None,
+            None,
+            None,
+        )
+        .expect("spawn failed");
+
+    let sem = kernel.agent_concurrency_for(agent_id);
+
+    // After clamping, capacity = 1: only one concurrent fire is allowed.
+    let p1 = sem.clone().try_acquire_owned();
+    assert!(p1.is_ok(), "first fire must acquire the single permit");
+
+    // A second concurrent fire must be blocked — not a second permit to take.
+    assert!(
+        sem.clone().try_acquire_owned().is_err(),
+        "persistent-session agent must serialize fires even when cap=2 was requested"
+    );
+
+    kernel.shutdown();
 }

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -1690,4 +1690,223 @@ mod tests {
             "assignee_match:self must accept the owner's display name too"
         );
     }
+
+    // -- session_mode_override propagation (#3754) ---------------------------------
+
+    /// Per-trigger `session_mode: Some(New)` must surface as `Some(New)` on
+    /// every `TriggerMatch` produced by that trigger — the dispatcher uses this
+    /// to materialise a fresh `SessionId` instead of reusing the canonical one.
+    #[test]
+    fn session_mode_new_override_propagates_to_trigger_match() {
+        use librefang_types::agent::SessionMode;
+
+        let engine = TriggerEngine::new();
+        let agent_id = AgentId::new();
+        let tid = engine.register_with_target(
+            agent_id,
+            TriggerPattern::All,
+            "event: {{event}}".to_string(),
+            0,
+            None,
+            Some(0), // zero cooldown so the trigger fires immediately on every evaluation
+            Some(SessionMode::New),
+        );
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Broadcast,
+            EventPayload::System(SystemEvent::HealthCheck {
+                status: "ok".to_string(),
+            }),
+        );
+        let (matches, _) = engine.evaluate(&event);
+
+        assert_eq!(matches.len(), 1, "trigger must fire");
+        assert_eq!(
+            matches[0].session_mode_override,
+            Some(SessionMode::New),
+            "session_mode_override must be Some(New) when trigger carries session_mode = New"
+        );
+
+        // Verify the field is preserved through the full round-trip: take the trigger,
+        // restore it under a new agent id, and check it still fires with the same override.
+        let taken = engine.take_agent_triggers(agent_id);
+        let new_agent = AgentId::new();
+        engine.restore_triggers(new_agent, taken);
+
+        let (matches2, _) = engine.evaluate(&event);
+        assert_eq!(matches2.len(), 1, "restored trigger must still fire");
+        assert_eq!(
+            matches2[0].session_mode_override,
+            Some(SessionMode::New),
+            "session_mode_override must survive take/restore"
+        );
+
+        // The trigger should also survive a patch that touches other fields.
+        let restored_triggers = engine.list_agent_triggers(new_agent);
+        let restored_id = restored_triggers[0].id;
+        engine.update(
+            restored_id,
+            TriggerPatch {
+                prompt_template: Some("updated: {{event}}".to_string()),
+                ..Default::default()
+            },
+        );
+        let after_patch = engine.get_trigger(restored_id).unwrap();
+        assert_eq!(
+            after_patch.session_mode,
+            Some(SessionMode::New),
+            "session_mode must not be touched by a patch that only changes prompt_template"
+        );
+
+        let _ = tid; // referenced above
+    }
+
+    /// Per-trigger `session_mode: Some(Persistent)` must produce
+    /// `session_mode_override = Some(Persistent)` — an explicit override wins
+    /// even if the value matches the default.
+    #[test]
+    fn session_mode_persistent_override_propagates_to_trigger_match() {
+        use librefang_types::agent::SessionMode;
+
+        let engine = TriggerEngine::new();
+        let agent_id = AgentId::new();
+        engine.register_with_target(
+            agent_id,
+            TriggerPattern::All,
+            "event: {{event}}".to_string(),
+            0,
+            None,
+            Some(0),
+            Some(SessionMode::Persistent),
+        );
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Broadcast,
+            EventPayload::System(SystemEvent::HealthCheck {
+                status: "ok".to_string(),
+            }),
+        );
+        let (matches, _) = engine.evaluate(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].session_mode_override,
+            Some(SessionMode::Persistent),
+            "session_mode_override must be Some(Persistent) for an explicit Persistent trigger"
+        );
+    }
+
+    /// When `Trigger.session_mode` is `None` the dispatcher falls back to the
+    /// agent manifest default.  The trigger engine's job is solely to surface
+    /// `None` on `TriggerMatch.session_mode_override` — the actual resolution
+    /// (`None` → manifest default) happens in the kernel dispatch loop.
+    #[test]
+    fn session_mode_none_trigger_yields_none_override() {
+        let engine = TriggerEngine::new();
+        let agent_id = AgentId::new();
+        engine.register_with_target(
+            agent_id,
+            TriggerPattern::All,
+            "event: {{event}}".to_string(),
+            0,
+            None,
+            Some(0),
+            None, // no per-trigger session mode
+        );
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Broadcast,
+            EventPayload::System(SystemEvent::HealthCheck {
+                status: "ok".to_string(),
+            }),
+        );
+        let (matches, _) = engine.evaluate(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].session_mode_override,
+            None,
+            "session_mode_override must be None when the trigger has no override; \
+             the dispatcher should then fall back to the agent manifest default"
+        );
+    }
+
+    /// Model the dispatcher's `effective_mode = mode_override.unwrap_or(manifest_mode)`
+    /// resolution inline so we have a named regression test pinned to exactly
+    /// the four documented cases without needing a full kernel.
+    #[test]
+    fn session_mode_resolution_order_per_trigger_over_manifest() {
+        use librefang_types::agent::SessionMode;
+
+        // Helper that mimics the single line in the kernel dispatch loop.
+        let resolve = |trigger_override: Option<SessionMode>, manifest: SessionMode| -> SessionMode {
+            trigger_override.unwrap_or(manifest)
+        };
+
+        // Case 1: trigger override = New → New regardless of manifest
+        assert_eq!(
+            resolve(Some(SessionMode::New), SessionMode::Persistent),
+            SessionMode::New,
+            "per-trigger New must beat manifest Persistent"
+        );
+
+        // Case 2: trigger override = Persistent → Persistent regardless of manifest
+        assert_eq!(
+            resolve(Some(SessionMode::Persistent), SessionMode::New),
+            SessionMode::Persistent,
+            "per-trigger Persistent must beat manifest New"
+        );
+
+        // Case 3: no trigger override → fall through to manifest New
+        assert_eq!(
+            resolve(None, SessionMode::New),
+            SessionMode::New,
+            "absent override must yield manifest New"
+        );
+
+        // Case 4: no trigger override → fall through to manifest Persistent
+        assert_eq!(
+            resolve(None, SessionMode::Persistent),
+            SessionMode::Persistent,
+            "absent override must yield manifest Persistent"
+        );
+    }
+
+    /// `update()` with `session_mode: Some(None)` must clear the per-trigger
+    /// session mode override (revert to inheriting the manifest default).
+    #[test]
+    fn patch_session_mode_some_none_clears_override() {
+        use librefang_types::agent::SessionMode;
+
+        let engine = TriggerEngine::new();
+        let agent_id = AgentId::new();
+        let tid = engine.register_with_target(
+            agent_id,
+            TriggerPattern::All,
+            "event: {{event}}".to_string(),
+            0,
+            None,
+            Some(0),
+            Some(SessionMode::New),
+        );
+
+        // Sanity: override is present before the patch.
+        assert_eq!(engine.get_trigger(tid).unwrap().session_mode, Some(SessionMode::New));
+
+        // Clear the override.
+        engine.update(
+            tid,
+            TriggerPatch {
+                session_mode: Some(None),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            engine.get_trigger(tid).unwrap().session_mode,
+            None,
+            "patching session_mode = Some(None) must clear the per-trigger override"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 5 unit tests in `crates/librefang-kernel/src/triggers.rs` covering the four documented `session_mode_override` resolution cases and take/restore/patch round-trips (closes #3754)
- Adds 8 unit tests in `crates/librefang-kernel/src/kernel/tests.rs` covering the three-layer trigger concurrency cap system — global `Lane::Trigger` semaphore, per-agent semaphore sizing, the `persistent + cap > 1 → clamp to 1` rule, and joint interactions (closes #3755)

## Changes

**`crates/librefang-kernel/src/triggers.rs`**

Five tests in the existing `#[cfg(test)] mod tests` block:

| Test | What it pins |
|------|-------------|
| `session_mode_new_override_propagates_to_trigger_match` | `Some(New)` surfaces on `TriggerMatch` and survives take/restore + unrelated patch |
| `session_mode_persistent_override_propagates_to_trigger_match` | Explicit `Some(Persistent)` is preserved |
| `session_mode_none_trigger_yields_none_override` | Absent override stays `None`, delegating to the dispatcher |
| `session_mode_resolution_order_per_trigger_over_manifest` | Directly exercises `mode_override.unwrap_or(manifest_mode)` for all four cases |
| `patch_session_mode_some_none_clears_override` | `TriggerPatch { session_mode: Some(None) }` correctly clears a previously set override |

**`crates/librefang-kernel/src/kernel/tests.rs`**

Eight tests covering per-agent semaphore sizing and three-layer joint interaction:

- `agent_concurrency_new_session_allows_cap_above_one`
- `agent_concurrency_persistent_session_clamps_cap_to_one`
- `agent_concurrency_persistent_session_with_cap_one_is_fine`
- `agent_concurrency_falls_back_to_config_default_when_unset`
- `trigger_lane_global_semaphore_limits_total_concurrency`
- `per_agent_semaphore_is_isolated_per_agent`
- `session_mode_new_with_cap_two_allows_two_concurrent_fires`
- `session_mode_persistent_plus_cap_two_is_clamped_preventing_parallel_fires`

## Test plan

- [ ] All new tests are pure unit tests with no I/O side effects beyond the temp-dir required by `LibreFangKernel::boot_with_config`
- [ ] No new dependencies added
- [ ] Tests follow existing patterns in `triggers.rs` and `kernel/tests.rs`
- [ ] No `cargo build/test/clippy` run locally — CI validates compilation