### PR TITLE
fix(auth,api): prevent TOTP replay, remove ?token= from WS, warn on unauthenticated network exposure

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1805,12 +1805,26 @@ pub async fn approve_request(
                             .into_response();
                         }
                     };
+                    // Replay-prevention check (#3359): reject a code that was
+                    // already used within the last 60 seconds (two TOTP windows).
+                    if state.kernel.approvals().is_totp_code_used(code) {
+                        state.kernel.approvals().record_totp_failure("api_admin");
+                        return ApiErrorResponse::bad_request(
+                            "TOTP code has already been used. Wait for the next 30-second window.",
+                        )
+                        .into_json_tuple()
+                        .into_response();
+                    }
                     match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
                         &secret,
                         code,
                         &totp_issuer,
                     ) {
-                        Ok(true) => true,
+                        Ok(true) => {
+                            // Mark this code as used to prevent replay within the window.
+                            state.kernel.approvals().record_totp_code_used(code);
+                            true
+                        }
                         Ok(false) => {
                             state.kernel.approvals().record_totp_failure("api_admin");
                             return ApiErrorResponse::bad_request("Invalid TOTP code")
@@ -2424,15 +2438,26 @@ pub async fn totp_setup(
                         None => false,
                     }
                 } else {
-                    // TOTP code
+                    // TOTP code — check replay before verifying (#3359).
+                    if state.kernel.approvals().is_totp_code_used(code) {
+                        state.kernel.approvals().record_totp_failure("api_admin");
+                        return ApiErrorResponse::bad_request(
+                            "TOTP code has already been used. Wait for the next 30-second window.",
+                        )
+                        .into_json_tuple();
+                    }
                     match state.kernel.vault_get("totp_secret") {
                         Some(secret) => {
-                            librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                            let ok = librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
                                 &secret,
                                 code,
                                 &totp_issuer,
                             )
-                            .unwrap_or(false)
+                            .unwrap_or(false);
+                            if ok {
+                                state.kernel.approvals().record_totp_code_used(code);
+                            }
+                            ok
                         }
                         None => false,
                     }
@@ -2516,12 +2541,21 @@ pub async fn totp_confirm(
         }
     };
 
+    // Replay-prevention check (#3359): reject a code already used in the last 60 s.
+    if state.kernel.approvals().is_totp_code_used(&body.code) {
+        state.kernel.approvals().record_totp_failure("api_admin");
+        return ApiErrorResponse::bad_request(
+            "TOTP code has already been used. Wait for the next 30-second window.",
+        )
+        .into_json_tuple();
+    }
     match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
         &secret,
         &body.code,
         &totp_issuer,
     ) {
         Ok(true) => {
+            state.kernel.approvals().record_totp_code_used(&body.code);
             if let Err(e) = state.kernel.vault_set("totp_confirmed", "true") {
                 return ApiErrorResponse::internal(e).into_json_tuple();
             }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -341,13 +341,28 @@ async fn dashboard_login(
                         }))
                         .into_response();
                     }
+                    // Replay-prevention check (#3359): reject a code already used
+                    // in the last 60 seconds.
+                    if state.kernel.approvals().is_totp_code_used(totp_code) {
+                        return (
+                            axum::http::StatusCode::UNAUTHORIZED,
+                            axum::response::Json(serde_json::json!({
+                                "ok": false,
+                                "error": "TOTP code has already been used. Wait for the next 30-second window.",
+                            })),
+                        )
+                            .into_response();
+                    }
                     // Verify TOTP code
                     let secret = state.kernel.vault_get("totp_secret").unwrap_or_default();
                     let issuer = policy.totp_issuer.clone();
                     match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
                         &secret, totp_code, &issuer,
                     ) {
-                        Ok(true) => { /* TOTP valid, proceed to session creation */ }
+                        Ok(true) => {
+                            // Mark code as used so it cannot be replayed.
+                            state.kernel.approvals().record_totp_code_used(totp_code);
+                        }
                         Ok(false) => {
                             return (
                                 axum::http::StatusCode::UNAUTHORIZED,
@@ -948,20 +963,27 @@ pub async fn build_router(
     // address with no authentication configured. The middleware enforces
     // fail-closed for non-loopback traffic; this warning makes the
     // operator-facing posture explicit at boot.
+    //
+    // The default bind address is 127.0.0.1:4545 (loopback-only). Operators
+    // who change api_listen to 0.0.0.0 or a public IP without configuring auth
+    // get a security warning here (#3572).
     let bind_is_loopback = listen_addr.ip().is_loopback();
     if !any_auth && !bind_is_loopback {
         if allow_no_auth {
-            tracing::warn!(
-                "LIBREFANG_ALLOW_NO_AUTH=1 is set. Running WITHOUT authentication on {}. \
-                 Anyone reachable at this address can read/write agents, channels, and keys.",
+            // LIBREFANG_ALLOW_NO_AUTH=1 means the operator knowingly accepted
+            // the risk. Use error! so the message stands out in logs regardless
+            // of the configured log level.
+            tracing::error!(
+                "SECURITY WARNING: librefang is listening on {} with no authentication. \
+                 Set api_key in config.toml or use 127.0.0.1:4545 for local-only access. \
+                 (LIBREFANG_ALLOW_NO_AUTH=1 — operator accepted risk; running open.)",
                 listen_addr
             );
         } else {
             tracing::warn!(
-                "No api_key configured and server is bound to {} (non-loopback). \
-                 Non-loopback requests will be rejected with 401. \
-                 Set api_key in config.toml, bind to 127.0.0.1, \
-                 or set LIBREFANG_ALLOW_NO_AUTH=1 to explicitly run open.",
+                "SECURITY WARNING: librefang is listening on {} with no authentication. \
+                 Set api_key in config.toml or use 127.0.0.1:4545 for local-only access. \
+                 Non-loopback requests will be rejected with 401 until an api_key is set.",
                 listen_addr
             );
         }

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -129,20 +129,21 @@ pub fn ws_query_param(uri: &Uri, key: &str) -> Option<String> {
     })
 }
 
-pub fn ws_auth_token(headers: &HeaderMap, uri: &Uri) -> Option<String> {
+/// Extract the auth token from a WebSocket upgrade request.
+///
+/// SECURITY (#3610): Only `Authorization: Bearer <token>` header is accepted.
+/// The `?token=` query-parameter form has been removed because query strings
+/// appear verbatim in proxy access logs, browser history, and server logs,
+/// leaking the credential. Clients must use the `Authorization` header during
+/// the HTTP upgrade handshake (before the WebSocket connection is established).
+///
+/// The `uri` parameter is kept for API compatibility but is no longer consulted.
+pub fn ws_auth_token(headers: &HeaderMap, _uri: &Uri) -> Option<String> {
     headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(ToOwned::to_owned)
-        .or_else(|| {
-            // Use plain percent-decoding (NOT form-urlencoded) so literal `+`
-            // characters in base64-derived tokens are preserved instead of
-            // being turned into spaces. See issue #962 (ported from openfang).
-            uri.query()
-                .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
-                .map(crate::percent_decode)
-        })
 }
 
 /// Validates the WebSocket `Origin` header against allowed origins.
@@ -297,9 +298,9 @@ pub fn detect_connection_locality(addr: &SocketAddr, headers: &HeaderMap) -> Con
 
 /// GET /api/agents/:id/ws — Upgrade to WebSocket for real-time chat.
 ///
-/// SECURITY: Authenticates via Bearer token in Authorization header
-/// or `?token=` query parameter (for browser WebSocket clients that
-/// cannot set custom headers).
+/// SECURITY: Authenticates via `Authorization: Bearer <token>` header only.
+/// The `?token=` query-parameter form has been removed (#3610) because query
+/// strings appear in proxy access logs and browser history, leaking the token.
 pub async fn agent_ws(
     ws: WebSocketUpgrade,
     State(state): State<Arc<AppState>>,
@@ -1882,9 +1883,13 @@ mod tests {
         assert_eq!(ws_query_param(&uri, "cols").as_deref(), Some("120"));
     }
 
+    /// SECURITY (#3610): `ws_auth_token` only accepts `Authorization: Bearer`.
+    /// Providing a token via `?token=` in the query string MUST be rejected
+    /// (returns `None`) so that credentials are not logged in proxy access logs.
     #[test]
-    fn test_ws_auth_token_prefers_bearer_header() {
-        let uri: Uri = "/api/terminal/ws?token=query-token".parse().unwrap();
+    fn test_ws_auth_token_header_only() {
+        // Bearer header is accepted.
+        let uri: Uri = "/api/terminal/ws".parse().unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer header-token".parse().unwrap());
         assert_eq!(
@@ -1893,29 +1898,17 @@ mod tests {
         );
     }
 
-    /// Issue #962 (ported from openfang): WS auth tokens often contain
-    /// base64 chars (`+`, `/`, `=`). The query-param branch must percent-decode
-    /// (so `%2B` -> `+`) but must NOT apply form-urlencoded semantics
-    /// (which would turn a literal `+` into a space).
     #[test]
-    fn test_ws_auth_token_percent_decodes_base64_chars() {
-        // Percent-encoded base64 token round-trips losslessly.
-        let uri: Uri = "/ws?token=abc%2Bdef%2Fghi%3D".parse().unwrap();
-        assert_eq!(
-            ws_auth_token(&HeaderMap::new(), &uri).as_deref(),
-            Some("abc+def/ghi=")
-        );
+    fn test_ws_auth_token_query_param_rejected() {
+        // ?token= in query string must NOT be extracted (security fix #3610).
+        let uri: Uri = "/api/terminal/ws?token=query-token".parse().unwrap();
+        assert_eq!(ws_auth_token(&HeaderMap::new(), &uri), None);
     }
 
     #[test]
-    fn test_ws_auth_token_preserves_literal_plus() {
-        // Literal `+` (not %20 / not space) MUST be preserved as `+`,
-        // not turned into a space the way x-www-form-urlencoded would.
-        let uri: Uri = "/ws?token=abc+def/ghi=".parse().unwrap();
-        assert_eq!(
-            ws_auth_token(&HeaderMap::new(), &uri).as_deref(),
-            Some("abc+def/ghi=")
-        );
+    fn test_ws_auth_token_no_token_returns_none() {
+        let uri: Uri = "/api/terminal/ws".parse().unwrap();
+        assert_eq!(ws_auth_token(&HeaderMap::new(), &uri), None);
     }
 
     #[test]

--- a/crates/librefang-kernel/Cargo.toml
+++ b/crates/librefang-kernel/Cargo.toml
@@ -42,6 +42,7 @@ regex = { workspace = true }
 cron = "0.16"
 totp-rs = { workspace = true }
 zeroize = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -8,6 +8,7 @@ use librefang_types::approval::{
 };
 use librefang_types::capability::glob_matches;
 use rusqlite::Connection;
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -969,6 +970,69 @@ impl ApprovalManager {
         let _ = conn.execute(
             "DELETE FROM totp_lockout WHERE sender_id = ?1",
             rusqlite::params![sender_id],
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TOTP replay prevention (issue #3359)
+    // -----------------------------------------------------------------------
+
+    /// Hash a TOTP code for replay-prevention storage.
+    ///
+    /// Stores `sha256(code)` in hex so the raw digit string is never persisted.
+    fn totp_code_hash(code: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(code.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    /// Check whether a TOTP code has already been used within the replay window.
+    ///
+    /// The window is 60 seconds (two 30-second TOTP steps) to cover both the
+    /// current step and the immediately preceding one.
+    pub fn is_totp_code_used(&self, code: &str) -> bool {
+        let Some(db) = &self.audit_db else {
+            return false;
+        };
+        let Ok(conn) = db.lock() else { return false };
+        let hash = Self::totp_code_hash(code);
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        let window_start = now_unix - 60;
+        conn.query_row(
+            "SELECT COUNT(*) FROM totp_used_codes WHERE code_hash = ?1 AND used_at >= ?2",
+            rusqlite::params![hash, window_start],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+            > 0
+    }
+
+    /// Record a successfully-verified TOTP code to prevent replay.
+    ///
+    /// Also prunes entries older than 120 seconds from the table to keep it small.
+    pub fn record_totp_code_used(&self, code: &str) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        let hash = Self::totp_code_hash(code);
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        // Upsert the used-code entry.
+        let _ = conn.execute(
+            "INSERT INTO totp_used_codes (code_hash, used_at)
+             VALUES (?1, ?2)
+             ON CONFLICT(code_hash) DO UPDATE SET used_at = excluded.used_at",
+            rusqlite::params![hash, now_unix],
+        );
+        // Prune entries older than 120 seconds.
+        let prune_before = now_unix - 120;
+        let _ = conn.execute(
+            "DELETE FROM totp_used_codes WHERE used_at < ?1",
+            rusqlite::params![prune_before],
         );
     }
 
@@ -2303,6 +2367,50 @@ mod tests {
         assert!(policy2.tool_requires_totp("shell_exec"));
         assert!(policy2.tool_requires_totp("file_write"));
         assert!(policy2.tool_requires_totp("anything"));
+    }
+
+    // -----------------------------------------------------------------------
+    // TOTP replay prevention (#3359)
+    // -----------------------------------------------------------------------
+
+    fn make_manager_with_db() -> ApprovalManager {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        librefang_memory::migration::run_migrations(&conn).unwrap();
+        let conn = Arc::new(StdMutex::new(conn));
+        ApprovalManager::new_with_db(ApprovalPolicy::default(), conn)
+    }
+
+    #[test]
+    fn test_totp_replay_prevention_code_not_used_initially() {
+        let mgr = make_manager_with_db();
+        // A fresh code should not be marked as used.
+        assert!(!mgr.is_totp_code_used("123456"));
+    }
+
+    #[test]
+    fn test_totp_replay_prevention_code_rejected_after_use() {
+        let mgr = make_manager_with_db();
+        mgr.record_totp_code_used("123456");
+        // The same code must now be detected as already used.
+        assert!(mgr.is_totp_code_used("123456"));
+    }
+
+    #[test]
+    fn test_totp_replay_prevention_different_code_not_blocked() {
+        let mgr = make_manager_with_db();
+        mgr.record_totp_code_used("123456");
+        // A different code must not be blocked.
+        assert!(!mgr.is_totp_code_used("654321"));
+    }
+
+    #[test]
+    fn test_totp_code_hash_does_not_store_plaintext() {
+        // The hash of "123456" must not equal "123456".
+        let hash = ApprovalManager::totp_code_hash("123456");
+        assert_ne!(hash, "123456");
+        // It must be a 64-character hex string (SHA-256 output).
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 24;
+const SCHEMA_VERSION: u32 = 25;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -105,6 +105,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     if current_version < 24 {
         migrate_v24(conn)?;
+    }
+
+    if current_version < 25 {
+        migrate_v25(conn)?;
     }
 
     set_schema_version(conn, SCHEMA_VERSION)?;
@@ -784,6 +788,29 @@ fn migrate_v24(conn: &Connection) -> Result<(), rusqlite::Error> {
     Ok(())
 }
 
+/// Version 25: Add `totp_used_codes` table for TOTP replay prevention.
+///
+/// Stores SHA-256 hashes of recently-used TOTP codes so that a code cannot be
+/// reused within the same 30-second window (or the adjacent window). Entries
+/// older than 120 seconds are pruned on every successful verification.
+fn migrate_v25(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS totp_used_codes (
+            code_hash  TEXT    NOT NULL,  -- SHA-256 hex of the raw 6-digit code
+            used_at    INTEGER NOT NULL,  -- Unix timestamp (seconds)
+            PRIMARY KEY (code_hash)
+        );
+        CREATE INDEX IF NOT EXISTS idx_totp_used_codes_used_at
+            ON totp_used_codes(used_at);",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (25, datetime('now'), 'Add totp_used_codes table for TOTP replay prevention')",
+        [],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -982,6 +1009,45 @@ mod tests {
         run_migrations(&conn).unwrap();
         assert!(column_exists(&conn, "usage_events", "user_id"));
         assert!(column_exists(&conn, "usage_events", "channel"));
+        assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn test_migrate_v24_creates_totp_used_codes() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Table must exist
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert!(tables.contains(&"totp_used_codes".to_string()));
+
+        // Can insert and look up a code hash
+        conn.execute(
+            "INSERT INTO totp_used_codes (code_hash, used_at) VALUES (?1, ?2)",
+            rusqlite::params!["abcdef1234", 1000_i64],
+        )
+        .unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM totp_used_codes WHERE code_hash = 'abcdef1234'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_migrate_v24_is_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        run_migrations(&conn).unwrap();
         assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
     }
 }


### PR DESCRIPTION
## Summary

- **#3359**: Track recently-used TOTP codes in SQLite (`totp_used_codes` table, migration v24). SHA-256 hashes of codes are stored; a code submitted within 60 seconds of a prior successful use is rejected as a replay. Applied to all verification sites: approval endpoint, `totp/confirm`, `totp/setup` reset, and dashboard login. Auto-prune of entries older than 120 s on every write.
- **#3610**: Remove `?token=` query-parameter support from WebSocket auth (`ws_auth_token`). Only `Authorization: Bearer <token>` header is accepted during the HTTP upgrade handshake. Query strings appear in proxy access logs and browser history, leaking the credential. Updated affected unit tests.
- **#3572**: The default `api_listen` is already `127.0.0.1:4545`. Upgraded the existing startup warning to use `tracing::error!` when `LIBREFANG_ALLOW_NO_AUTH=1` is set and `tracing::warn!` otherwise, with the exact wording from the issue spec: "SECURITY WARNING: librefang is listening on \<addr\> with no authentication. Set api_key in config.toml or use 127.0.0.1:4545 for local-only access."

## Files changed

- `crates/librefang-memory/src/migration.rs` — schema v24, `totp_used_codes` table + tests
- `crates/librefang-kernel/Cargo.toml` — add `sha2 = { workspace = true }`
- `crates/librefang-kernel/src/approval.rs` — `is_totp_code_used`, `record_totp_code_used`, `totp_code_hash` + unit tests
- `crates/librefang-api/src/routes/system.rs` — replay check wired into all TOTP verification paths
- `crates/librefang-api/src/server.rs` — replay check wired into dashboard login; upgraded startup warning
- `crates/librefang-api/src/ws.rs` — `ws_auth_token` header-only; updated tests and doc comments

## Test plan

- [ ] `cargo test -p librefang-memory` — migration v24 tests pass
- [ ] `cargo test -p librefang-kernel` — TOTP replay unit tests pass
- [ ] `cargo test -p librefang-api` — `ws_auth_token` tests pass (query-param rejected, header accepted)
- [ ] Manual: submit an approval with a TOTP code, immediately resubmit the same code — expect 400 "TOTP code has already been used"
- [ ] Manual: connect to `/api/agents/{id}/ws` with `?token=<key>` — expect 401; with `Authorization: Bearer <key>` — expect upgrade
- [ ] Manual: start daemon bound to `0.0.0.0:4545` with no `api_key` — expect SECURITY WARNING in logs