### PR TITLE
fix(kernel,channels): atomic persist with fsync for cron/config/webhook/agent-flag

### DIFF
--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -66,6 +66,48 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
+/// Write `content` to `path` atomically via a sibling temp file + rename.
+///
+/// The temp file receives a unique name derived from the process ID and a
+/// per-process monotonic counter so concurrent writers never share a staging
+/// file.  The file is `sync_all`-ed before the rename so a power loss between
+/// the two syscalls does not leave a zero-byte file in place of the original.
+pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+
+    let mut tmp = path.to_path_buf();
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename")
+        })?
+        .to_os_string();
+    let mut tmp_name = file_name;
+    tmp_name.push(format!(".{}.{seq}.tmp", std::process::id()));
+    tmp.set_file_name(tmp_name);
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(content)?;
+        f.sync_all()?;
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
 pub mod channel_bridge;
 pub mod middleware;
 pub mod oauth;

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -272,7 +272,7 @@ api_key_env = "{api_key_env}"
 "#
     );
 
-    if let Err(e) = std::fs::write(&config_path, &config_content) {
+    if let Err(e) = crate::atomic_write(&config_path, config_content.as_bytes()) {
         return Json(serde_json::json!({
             "status": "error",
             "message": format!("Failed to write config: {e}")
@@ -2010,7 +2010,7 @@ pub async fn config_set(
     }
 
     // Write back — preserves comments, whitespace, and key ordering
-    if let Err(e) = std::fs::write(&config_path, &new_toml_str) {
+    if let Err(e) = crate::atomic_write(&config_path, new_toml_str.as_bytes()) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"status": "error", "error": format!("write failed: {e}")})),

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1776,7 +1776,8 @@ fn persist_default_model(
     };
     let root = doc.as_table_mut().ok_or("Config is not a TOML table")?;
     root.insert("default_model".to_string(), toml::Value::Table(dm_table));
-    std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
+    let toml_str = toml::to_string_pretty(&doc)?;
+    crate::atomic_write(config_path, toml_str.as_bytes())?;
     Ok(())
 }
 
@@ -1912,7 +1913,8 @@ fn upsert_provider_url(
         std::fs::create_dir_all(parent)?;
     }
 
-    std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
+    let toml_str = toml::to_string_pretty(&doc)?;
+    crate::atomic_write(config_path, toml_str.as_bytes())?;
     Ok(())
 }
 
@@ -1956,7 +1958,8 @@ fn upsert_provider_proxy_url(
         );
     }
 
-    std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
+    let toml_str = toml::to_string_pretty(&doc)?;
+    crate::atomic_write(config_path, toml_str.as_bytes())?;
     Ok(())
 }
 

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -1009,7 +1009,7 @@ where
     // concurrent requests with the old key SHOULD fail).
     let mut user_keys_guard = state.user_api_keys.write().await;
 
-    std::fs::write(&config_path, &new_toml)
+    crate::atomic_write(&config_path, new_toml.as_bytes())
         .map_err(|e| PersistError::Internal(format!("write failed: {e}")))?;
 
     if let Err(e) = state.kernel.reload_config().await {

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -289,8 +289,26 @@ impl WebhookStore {
     pub fn load(path: PathBuf) -> Self {
         let data = if path.exists() {
             match std::fs::read_to_string(&path) {
-                Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
-                Err(_) => StoreData::default(),
+                Ok(contents) => match serde_json::from_str(&contents) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        tracing::error!(
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to deserialize webhook store — starting with empty store; \
+                             existing subscriptions may have been lost"
+                        );
+                        StoreData::default()
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(
+                        path = %path.display(),
+                        error = %e,
+                        "Failed to read webhook store file — starting with empty store"
+                    );
+                    StoreData::default()
+                }
             }
         } else {
             StoreData::default()
@@ -301,7 +319,7 @@ impl WebhookStore {
         }
     }
 
-    /// Persist current state to disk.
+    /// Persist current state to disk atomically (write tmp → fsync → rename).
     fn persist(&self, data: &StoreData) -> Result<(), String> {
         let json =
             serde_json::to_string_pretty(data).map_err(|e| format!("serialize error: {e}"))?;
@@ -309,8 +327,8 @@ impl WebhookStore {
         if let Some(parent) = self.path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        // Set restrictive permissions on the file (contains secrets)
-        std::fs::write(&self.path, json).map_err(|e| format!("write error: {e}"))?;
+        crate::atomic_write(&self.path, json.as_bytes())
+            .map_err(|e| format!("write error: {e}"))?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -212,7 +212,10 @@ impl MessageJournal {
     /// Call periodically or on shutdown.
     pub async fn compact(&self) {
         let inner = self.inner.lock().await;
-        let tmp_path = inner.path.with_extension("jsonl.tmp");
+        let tmp_path = inner.path.with_extension(format!(
+            "jsonl.tmp.{}",
+            std::process::id()
+        ));
         let result = (|| -> std::io::Result<()> {
             let mut file = std::fs::File::create(&tmp_path)?;
             for entry in inner.pending.values() {
@@ -220,6 +223,7 @@ impl MessageJournal {
                 writeln!(file, "{line}")?;
             }
             file.flush()?;
+            file.sync_all()?;
             std::fs::rename(&tmp_path, &inner.path)?;
             Ok(())
         })();

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -133,10 +133,22 @@ impl CronScheduler {
                 LibreFangError::Internal(format!("Failed to create cron jobs dir: {e}"))
             })?;
         }
-        let tmp_path = self.persist_path.with_extension("json.tmp");
-        std::fs::write(&tmp_path, data.as_bytes()).map_err(|e| {
-            LibreFangError::Internal(format!("Failed to write cron jobs temp file: {e}"))
-        })?;
+        let tmp_path = self.persist_path.with_extension(format!(
+            "json.tmp.{}",
+            std::process::id()
+        ));
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(&tmp_path).map_err(|e| {
+                LibreFangError::Internal(format!("Failed to create cron jobs temp file: {e}"))
+            })?;
+            f.write_all(data.as_bytes()).map_err(|e| {
+                LibreFangError::Internal(format!("Failed to write cron jobs temp file: {e}"))
+            })?;
+            f.sync_all().map_err(|e| {
+                LibreFangError::Internal(format!("Failed to fsync cron jobs temp file: {e}"))
+            })?;
+        }
         std::fs::rename(&tmp_path, &self.persist_path).map_err(|e| {
             LibreFangError::Internal(format!("Failed to rename cron jobs file: {e}"))
         })?;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9311,7 +9311,7 @@ system_prompt = "You are a helpful assistant."
                     // Append after [agent] section or at end
                     format!("{content}\nenabled = {enabled}\n")
                 };
-                if let Err(e) = std::fs::write(&toml_path, new_content) {
+                if let Err(e) = atomic_write_toml(&toml_path, &new_content) {
                     warn!("Failed to persist enabled={enabled} for {name}: {e}");
                 }
             }

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -276,10 +276,19 @@ impl TriggerEngine {
         let data = serde_json::to_string_pretty(&triggers).map_err(|e| {
             LibreFangError::Internal(format!("Failed to serialize trigger jobs: {e}"))
         })?;
-        let tmp_path = path.with_extension("json.tmp");
-        std::fs::write(&tmp_path, data.as_bytes()).map_err(|e| {
-            LibreFangError::Internal(format!("Failed to write trigger jobs temp file: {e}"))
-        })?;
+        let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(&tmp_path).map_err(|e| {
+                LibreFangError::Internal(format!("Failed to create trigger jobs temp file: {e}"))
+            })?;
+            f.write_all(data.as_bytes()).map_err(|e| {
+                LibreFangError::Internal(format!("Failed to write trigger jobs temp file: {e}"))
+            })?;
+            f.sync_all().map_err(|e| {
+                LibreFangError::Internal(format!("Failed to fsync trigger jobs temp file: {e}"))
+            })?;
+        }
         std::fs::rename(&tmp_path, path).map_err(|e| {
             LibreFangError::Internal(format!("Failed to rename trigger jobs file: {e}"))
         })?;

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -570,13 +570,24 @@ impl WorkflowEngine {
                 return;
             }
         }
-        let tmp_path = path.with_extension("json.tmp");
-        if let Err(e) = std::fs::write(&tmp_path, data.as_bytes()) {
-            warn!("Failed to write workflow runs temp file: {e}");
-            return;
+        let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
+        {
+            use std::io::Write as _;
+            let write_result = (|| -> std::io::Result<()> {
+                let mut f = std::fs::File::create(&tmp_path)?;
+                f.write_all(data.as_bytes())?;
+                f.sync_all()?;
+                Ok(())
+            })();
+            if let Err(e) = write_result {
+                warn!("Failed to write workflow runs temp file: {e}");
+                let _ = std::fs::remove_file(&tmp_path);
+                return;
+            }
         }
         if let Err(e) = std::fs::rename(&tmp_path, path) {
             warn!("Failed to rename workflow runs file: {e}");
+            let _ = std::fs::remove_file(&tmp_path);
             return;
         }
         debug!("Persisted workflow runs to disk");


### PR DESCRIPTION
## Summary

Fixes 5 non-atomic persistence bugs that could corrupt or zero out files on power loss or SIGKILL:

- **#3626** (`cron.rs`, `message_journal.rs`): `sync_all()` missing before rename — power loss could leave a zero-byte tmp file renamed over the real file.
- **#3636** (`routes/config.rs`, `routes/providers.rs`, `routes/users.rs`): bare `std::fs::write` for `config.toml` — a SIGKILL mid-write truncates the file.
- **#3648** (`cron.rs`, `triggers.rs`, `workflow.rs`, `message_journal.rs`): all used a fixed `.tmp` extension, so concurrent writers share a single staging file and clobber each other.
- **#3650** (`webhook_store.rs`): `std::fs::write` was non-atomic; silent `unwrap_or_default()` on deserialization failure hid data loss.
- **#3669** (`kernel/mod.rs`): enabled-flag toggle used `std::fs::write` instead of the existing `atomic_write_toml` helper.

## Changes

- `crates/librefang-api/src/lib.rs`: add `pub(crate) atomic_write` helper (PID + counter unique tmp name, `sync_all` before rename, cleanup on error) shared by all API routes.
- `crates/librefang-kernel/src/cron.rs`: `File::create → write_all → sync_all → rename`; PID-suffixed tmp name.
- `crates/librefang-kernel/src/triggers.rs`: same pattern.
- `crates/librefang-kernel/src/workflow.rs`: same pattern; also cleans up tmp on rename failure.
- `crates/librefang-channels/src/message_journal.rs`: add `sync_all` before rename; PID-suffixed tmp name.
- `crates/librefang-api/src/webhook_store.rs`: replace `std::fs::write` with `crate::atomic_write`; replace silent `unwrap_or_default` with `tracing::error!`.
- `crates/librefang-api/src/routes/config.rs`: two `std::fs::write` → `crate::atomic_write`.
- `crates/librefang-api/src/routes/providers.rs`: three `std::fs::write` → `crate::atomic_write`.
- `crates/librefang-api/src/routes/users.rs`: one `std::fs::write` → `crate::atomic_write`.
- `crates/librefang-kernel/src/kernel/mod.rs`: enabled-flag toggle → `atomic_write_toml`.

## Test plan

- [ ] Existing unit tests for `atomic_write_toml` in `kernel/tests.rs` still pass (pattern is identical to the new helper)
- [ ] `WebhookStore` persistence roundtrip test passes (the `persist` path is now atomic)
- [ ] No stray `.json.tmp` or `.toml.tmp` files left on normal shutdown
- [ ] Concurrent cron/trigger fires no longer race on a single staging file (tmp name includes PID)

Resolves #3626 #3636 #3648 #3650 #3669