### PR TITLE
fix: recover from poisoned locks, log Anthropic errors, log shutdown persist failures

### DIFF
--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -418,7 +418,7 @@ impl StandaloneChat {
                 }
             }
             Backend::InProcess { kernel } => {
-                let catalog = kernel.model_catalog_ref().read().unwrap();
+                let catalog = kernel.model_catalog_ref().read().unwrap_or_else(|p| p.into_inner());
                 catalog
                     .available_models()
                     .into_iter()

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -1892,7 +1892,7 @@ impl App {
                 }
             }
             Backend::InProcess { kernel } => {
-                let catalog = kernel.model_catalog_ref().read().unwrap();
+                let catalog = kernel.model_catalog_ref().read().unwrap_or_else(|p| p.into_inner());
                 catalog
                     .available_models()
                     .into_iter()

--- a/crates/librefang-desktop/src/commands.rs
+++ b/crates/librefang-desktop/src/commands.rs
@@ -13,7 +13,7 @@ use tauri_plugin_autostart::ManagerExt;
 pub fn get_port(port: tauri::State<'_, PortState>) -> Result<u16, String> {
     port.0
         .read()
-        .unwrap()
+        .unwrap_or_else(|p| p.into_inner())
         .ok_or_else(|| "No local server running".to_string())
 }
 
@@ -26,9 +26,9 @@ pub fn get_status(
     let p = port
         .0
         .read()
-        .unwrap()
+        .unwrap_or_else(|p| p.into_inner())
         .ok_or_else(|| "No local server running".to_string())?;
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|p| p.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -46,7 +46,7 @@ pub fn get_status(
 /// Get the number of registered agents.
 #[tauri::command]
 pub fn get_agent_count(kernel_state: tauri::State<'_, KernelState>) -> Result<usize, String> {
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|p| p.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -91,7 +91,7 @@ pub fn import_agent_toml(
     let dest = agent_dir.join("agent.toml");
     std::fs::write(&dest, &content).map_err(|e| format!("Failed to write manifest: {e}"))?;
 
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|p| p.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -139,7 +139,7 @@ pub fn import_skill_file(
     let dest = skills_dir.join(&file_name);
     std::fs::copy(src, &dest).map_err(|e| format!("Failed to copy skill file: {e}"))?;
 
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|p| p.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -793,7 +793,7 @@ impl LibreFangKernel {
     /// runtime via [`update_budget_config`], so callers always see the
     /// latest values set through the API.
     pub fn budget_config(&self) -> librefang_types::config::BudgetConfig {
-        self.budget_config.read().unwrap().clone()
+        self.budget_config.read().unwrap_or_else(|p| p.into_inner()).clone()
     }
 
     /// Safely mutate the runtime budget configuration.
@@ -802,7 +802,7 @@ impl LibreFangKernel {
     /// All writes are serialised through an `RwLock` write-guard, which
     /// eliminates the data-race hazard of the old raw-pointer approach.
     pub fn update_budget_config(&self, f: impl FnOnce(&mut librefang_types::config::BudgetConfig)) {
-        let mut guard = self.budget_config.write().unwrap();
+        let mut guard = self.budget_config.write().unwrap_or_else(|p| p.into_inner());
         f(&mut guard);
     }
 
@@ -12831,10 +12831,14 @@ system_prompt = "You are a helpful assistant."
 
         // Update agent states to Suspended in persistent storage (not delete)
         for entry in self.registry.list() {
-            let _ = self.registry.set_state(entry.id, AgentState::Suspended);
+            if let Err(e) = self.registry.set_state(entry.id, AgentState::Suspended) {
+                tracing::error!(agent_id = %entry.id, "failed to set agent state to Suspended on shutdown: {e}");
+            }
             // Re-save with Suspended state for clean resume on next boot
             if let Some(updated) = self.registry.get(entry.id) {
-                let _ = self.memory.save_agent(&updated);
+                if let Err(e) = self.memory.save_agent(&updated) {
+                    tracing::error!(agent_id = %entry.id, "failed to persist agent state on shutdown: {e}");
+                }
             }
         }
 

--- a/crates/librefang-llm-drivers/src/credential_pool.rs
+++ b/crates/librefang-llm-drivers/src/credential_pool.rs
@@ -208,7 +208,7 @@ impl CredentialPool {
         // Lock the entire inner state so that the RoundRobin index read and
         // the credential selection happen atomically — no other thread can
         // advance the index between reading it and using it.
-        let mut inner = self.inner.lock().expect("credential pool lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         match self.strategy {
             PoolStrategy::FillFirst => Self::acquire_fill_first(&inner.credentials),
             PoolStrategy::RoundRobin => {
@@ -243,7 +243,7 @@ impl CredentialPool {
     /// exhausted (402).  The credential is placed in cooldown for
     /// `exhausted_ttl`.
     pub fn mark_exhausted(&self, api_key: &str) {
-        let mut inner = self.inner.lock().expect("credential pool lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let until = Instant::now() + self.exhausted_ttl;
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
             c.exhausted_until = Some(until);
@@ -254,7 +254,7 @@ impl CredentialPool {
     /// credential's `request_count` and clears any leftover exhaustion marker
     /// (e.g. if a provider recovered before the TTL expired).
     pub fn mark_success(&self, api_key: &str) {
-        let mut inner = self.inner.lock().expect("credential pool lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
             c.request_count = c.request_count.saturating_add(1);
             // Always clear the exhaustion marker on success — the key is working
@@ -265,7 +265,7 @@ impl CredentialPool {
 
     /// Number of currently available (non-exhausted) credentials.
     pub fn available_count(&self) -> usize {
-        let inner = self.inner.lock().expect("credential pool lock poisoned");
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         inner
             .credentials
             .iter()
@@ -275,7 +275,7 @@ impl CredentialPool {
 
     /// Total number of credentials in the pool (available + exhausted).
     pub fn total_count(&self) -> usize {
-        let inner = self.inner.lock().expect("credential pool lock poisoned");
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         inner.credentials.len()
     }
 
@@ -286,7 +286,7 @@ impl CredentialPool {
     /// and exhaustion status.  The list is sorted by priority descending,
     /// matching the internal ordering.
     pub fn snapshot(&self) -> Vec<CredentialSnapshot> {
-        let inner = self.inner.lock().expect("credential pool lock poisoned");
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         inner
             .credentials
             .iter()

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -424,7 +424,10 @@ impl LlmDriver for AnthropicDriver {
             }
 
             if !resp.status().is_success() {
-                let body = resp.text().await.unwrap_or_default();
+                let body = resp.text().await.unwrap_or_else(|e| {
+                    tracing::warn!("failed to read Anthropic error body: {e}");
+                    String::new()
+                });
                 let message = serde_json::from_str::<ApiErrorResponse>(&body)
                     .map(|e| e.error.message)
                     .unwrap_or(body);
@@ -549,7 +552,10 @@ impl LlmDriver for AnthropicDriver {
             }
 
             if !resp.status().is_success() {
-                let body = resp.text().await.unwrap_or_default();
+                let body = resp.text().await.unwrap_or_else(|e| {
+                    tracing::warn!("failed to read Anthropic error body: {e}");
+                    String::new()
+                });
                 let message = serde_json::from_str::<ApiErrorResponse>(&body)
                     .map(|e| e.error.message)
                     .unwrap_or(body);


### PR DESCRIPTION
## Summary

- **#3674** (`credential_pool.rs`): Replace all 6 `.expect("credential pool lock poisoned")` calls with `.unwrap_or_else(|p| p.into_inner())` so a panicking writer no longer kills every subsequent LLM caller.
- **#3689** (`kernel/mod.rs`, `tui/chat_runner.rs`, `tui/mod.rs`): Same poison-recovery pattern on the `budget_config` RwLock (read + write) and the `model_catalog` RwLock in both TUI files.
- **#3604** (`desktop/commands.rs`): All 5 `RwLock::read().unwrap()` calls in Tauri command handlers replaced with `unwrap_or_else(|p| p.into_inner())`.
- **#3723** (`drivers/anthropic.rs`): Both `complete()` and `stream()` error-body paths changed from `unwrap_or_default()` to `unwrap_or_else(|e| { tracing::warn!(...); String::new() })` so network/encoding failures are visible in logs.
- **#3665** (`kernel/mod.rs` `shutdown()`): `let _ = self.registry.set_state(...)` and `let _ = self.memory.save_agent(...)` in the shutdown loop are replaced with `if let Err(e) = ... { tracing::error!(...) }` so operators know when agent state wasn't persisted.

## Test plan

- [ ] CI passes (cargo test --workspace)
- [ ] No new clippy warnings
- [ ] Verify credential pool tests still pass (pool strategy tests cover all 6 lock sites)