### PR TITLE
fix(dashboard): CanvasPage React Query migration, raise agent limit, SSE keep-alive, paginate sessions/approvals, complete AgentItem type

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -269,6 +269,14 @@ export interface AgentItem {
   identity?: AgentIdentity;
   is_hand?: boolean;
   web_search_augmentation?: "off" | "auto" | "always";
+  /** UUID of the parent agent that spawned this one, if any. */
+  parent_agent_id?: string;
+  /** UUIDs of child agents spawned by this agent. */
+  children?: string[];
+  /** Active session UUID. */
+  session_id?: string;
+  /** Categorisation tags. */
+  tags?: string[];
 }
 
 export interface PaginatedResponse<T> {
@@ -1136,7 +1144,7 @@ export async function listAgents(
   opts: { includeHands?: boolean } = {},
 ): Promise<AgentItem[]> {
   const params = new URLSearchParams({
-    limit: "200",
+    limit: "500",
     sort: "last_active",
     order: "desc",
   });

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -106,6 +106,7 @@ export {
   pollVideo,
   // workflows
   listWorkflows,
+  getWorkflow,
   listWorkflowRuns,
   getWorkflowRun,
   listWorkflowTemplates,

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
   listWorkflows,
+  getWorkflow,
   listWorkflowRuns,
   getWorkflowRun,
   listWorkflowTemplates,
@@ -29,6 +30,13 @@ export const workflowQueries = {
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
     }),
+  detail: (workflowId: string) =>
+    queryOptions({
+      queryKey: workflowKeys.detail(workflowId),
+      queryFn: () => getWorkflow(workflowId),
+      enabled: !!workflowId,
+      staleTime: STALE_MS,
+    }),
   runs: (workflowId: string) =>
     queryOptions({
       queryKey: workflowKeys.runs(workflowId),
@@ -54,6 +62,10 @@ export const workflowQueries = {
 
 export function useWorkflows(options: QueryOverrides = {}) {
   return useQuery(withOverrides(workflowQueries.list(), options));
+}
+
+export function useWorkflowDetail(workflowId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(workflowQueries.detail(workflowId), options));
 }
 
 export function useWorkflowRuns(workflowId: string, options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -25,7 +25,7 @@ import {
   ConnectionLineType,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { listAgents, listWorkflows, getWorkflow, createSchedule, type AgentItem, type WorkflowItem, type WorkflowTemplate as ApiWorkflowTemplate, type DryRunResult, type WorkflowStepResult } from "../api";
+import { type AgentItem, type WorkflowItem, type WorkflowTemplate as ApiWorkflowTemplate, type DryRunResult, type WorkflowStepResult } from "../api";
 import { Card } from "../components/ui/Card";
 import { ScheduleModal } from "../components/ui/ScheduleModal";
 import { DrawerPanel } from "../components/ui/DrawerPanel";
@@ -50,7 +50,10 @@ import {
   useSaveWorkflowAsTemplate,
   useUpdateWorkflow as useUpdateWorkflowMutation,
 } from "../lib/mutations/workflows";
-import { useWorkflowTemplates } from "../lib/queries/workflows";
+import { useCreateSchedule } from "../lib/mutations/schedules";
+import { useWorkflows, useWorkflowTemplates, workflowQueries } from "../lib/queries/workflows";
+import { useAgents } from "../lib/queries/agents";
+import { useQueryClient } from "@tanstack/react-query";
 
 type CanvasDraft = {
   nodes: Node[];
@@ -676,8 +679,11 @@ function CanvasPageInner() {
   const { fitView } = useReactFlow();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
-  const [agents, setAgents] = useState<AgentItem[]>([]);
-  const [workflows, setWorkflows] = useState<WorkflowItem[]>([]);
+  const queryClient = useQueryClient();
+  const agentsQuery = useAgents();
+  const agents = agentsQuery.data ?? [];
+  const workflowsQuery = useWorkflows();
+  const workflows = workflowsQuery.data ?? [];
   const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowItem | null>(null);
   const [workflowName, setWorkflowName] = useState("");
   const [workflowDescription, setWorkflowDescription] = useState("");
@@ -708,6 +714,7 @@ function CanvasPageInner() {
   const updateWorkflowMutation = useUpdateWorkflowMutation();
   const deleteWorkflowMutation = useDeleteWorkflow();
   const runWorkflowMutation = useRunWorkflow();
+  const createScheduleMutation = useCreateSchedule();
   const dryRunWorkflowMutation = useDryRunWorkflow();
   const saveWorkflowAsTemplateMutation = useSaveWorkflowAsTemplate();
 
@@ -1177,7 +1184,7 @@ function CanvasPageInner() {
   }, [t, setNodes, setEdges, showError, toErrorMessage]);
 
   const loadWorkflowIntoCanvas = useCallback(async (workflowId: string, fallback?: WorkflowItem | null) => {
-    const detail = await getWorkflow(workflowId);
+    const detail = await queryClient.fetchQuery(workflowQueries.detail(workflowId));
     let wfNodes: Node[];
     let wfEdges: Edge[];
     const layout = detail.layout as { nodes?: Node[]; edges?: Edge[] } | undefined;
@@ -1229,22 +1236,20 @@ function CanvasPageInner() {
       description: detail.description || fallback?.description || "",
     } as WorkflowItem);
     setErrorMsg(null);
-  }, [setNodes, setEdges]);
+  }, [setNodes, setEdges, queryClient]);
 
-  // Load agents, workflows, then load template or workflow from URL
+  // Load template or workflow from URL once agent/workflow data is available
   useEffect(() => {
-    Promise.all([listAgents(), listWorkflows()])
-      .then(async ([a, w]) => {
-        setAgents(a);
-        setWorkflows(w);
+    if (agentsQuery.isLoading || workflowsQuery.isLoading) return;
+    const run = async () => {
         const draft = readCanvasDraft();
         // 1. Try loading from sessionStorage template
-        const templateState = loadTemplate(a);
+        const templateState = loadTemplate(agents);
         if (templateState !== "missing") return;
         // 2. Try loading from URL ?wf= parameter
         if (routeWorkflowId) {
           try {
-            await loadWorkflowIntoCanvas(routeWorkflowId, w.find((item) => item.id === routeWorkflowId) ?? null);
+            await loadWorkflowIntoCanvas(routeWorkflowId, workflows.find((item) => item.id === routeWorkflowId) ?? null);
             return;
           } catch (e: unknown) {
             showError(toErrorMessage(e, t("canvas.workflow_load_error", { defaultValue: "Failed to load workflow" })));
@@ -1260,9 +1265,9 @@ function CanvasPageInner() {
         if (draft) {
           applyCanvasState(draft);
         }
-      })
-      .catch((e: unknown) => { showError(toErrorMessage(e, t("canvas.load_error", { defaultValue: "Failed to load data" }))); });
-  }, [routeTimestamp, routeWorkflowId, applyCanvasState, loadTemplate, loadWorkflowIntoCanvas, showError, t, toErrorMessage]);
+    };
+    run().catch((e: unknown) => { showError(toErrorMessage(e, t("canvas.load_error", { defaultValue: "Failed to load data" }))); });
+  }, [routeTimestamp, routeWorkflowId, agents, workflows, agentsQuery.isLoading, workflowsQuery.isLoading, applyCanvasState, loadTemplate, loadWorkflowIntoCanvas, showError, t, toErrorMessage, setNodes, setEdges]);
 
   // Persist only unsaved blank-canvas drafts. Saved workflows should reload from backend.
   useEffect(() => {
@@ -1519,9 +1524,6 @@ function CanvasPageInner() {
         description: workflowDescription,
       } as WorkflowItem;
       setSelectedWorkflow(updatedWorkflow);
-      setWorkflows((prev) => prev.map((workflow) => workflow.id === workflowId
-        ? { ...workflow, name: resolvedName, description: workflowDescription }
-        : workflow));
       setWorkflowName(resolvedName);
       navigate({ to: "/canvas", search: { t: undefined, wf: workflowId }, replace: true });
       clearDraft();
@@ -1546,7 +1548,6 @@ function CanvasPageInner() {
       created_at: created.created_at,
     } as WorkflowItem;
     setSelectedWorkflow(createdWorkflow);
-    setWorkflows((prev) => [createdWorkflow, ...prev.filter((workflow) => workflow.id !== createdId)]);
     setWorkflowName(resolvedName);
     navigate({ to: "/canvas", search: { t: undefined, wf: createdId }, replace: true });
     clearDraft();
@@ -1691,7 +1692,6 @@ function CanvasPageInner() {
   const handleDeleteConfirmed = useCallback(async (id: string) => {
     try {
       await deleteWorkflowMutation.mutateAsync(id);
-      setWorkflows(prev => prev.filter(w => w.id !== id));
       if (selectedWorkflow?.id === id) {
         setSelectedWorkflow(null);
         setNodes([]); setEdges([]);
@@ -1730,17 +1730,15 @@ function CanvasPageInner() {
   const handleTemplateInstantiate = useCallback(async (workflowId: string) => {
     setShowTemplateBrowser(false);
     try {
-      const updatedList = await listWorkflows();
-      setWorkflows(updatedList);
-      const created = updatedList.find(w => w.id === workflowId);
-      if (created) {
-        await loadWorkflowIntoCanvas(created.id, created);
-        navigate({ to: "/canvas", search: { t: undefined, wf: created.id }, replace: true });
-      }
+      // Invalidate the workflows cache so the list refreshes
+      await queryClient.invalidateQueries({ queryKey: workflowQueries.list().queryKey });
+      const created = workflows.find(w => w.id === workflowId);
+      await loadWorkflowIntoCanvas(workflowId, created ?? null);
+      navigate({ to: "/canvas", search: { t: undefined, wf: workflowId }, replace: true });
     } catch (e: unknown) {
       showError(toErrorMessage(e, t("canvas.template_instantiate_error")));
     }
-  }, [loadWorkflowIntoCanvas, navigate, showError, t, toErrorMessage]);
+  }, [queryClient, workflows, loadWorkflowIntoCanvas, navigate, showError, t, toErrorMessage]);
 
   // Valid agent step count
   const agentStepCount = useMemo(() => buildSteps(nodes).length, [nodes, buildSteps]);
@@ -2282,7 +2280,7 @@ function CanvasPageInner() {
           onSave={async (cron, tz) => {
             if (!selectedWorkflow?.id) return;
             try {
-              await createSchedule({ name: `${workflowName || "workflow"} schedule`, cron, tz, workflow_id: selectedWorkflow.id, enabled: true });
+              await createScheduleMutation.mutateAsync({ name: `${workflowName || "workflow"} schedule`, cron, tz, workflow_id: selectedWorkflow.id, enabled: true });
               setShowScheduleModal(false);
               showToast(t("canvas.scheduled", { defaultValue: "Schedule created" }));
             } catch (e: any) { showError(e?.message || String(e)); }

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -785,6 +785,10 @@ pub(crate) fn enrich_agent_json(
             "color": e.identity.color,
         },
         "web_search_augmentation": e.manifest.web_search_augmentation,
+        "parent_agent_id": e.parent.as_ref().map(|p| p.to_string()),
+        "children": e.children.iter().map(|c| c.to_string()).collect::<Vec<_>>(),
+        "session_id": e.session_id.0.to_string(),
+        "tags": e.tags,
     })
 }
 
@@ -902,7 +906,7 @@ pub async fn list_agents(
 
     // -- Pagination --
     let offset = params.offset.unwrap_or(0);
-    let limit = params.limit.map(|l| l.min(100));
+    let limit = params.limit.map(|l| l.min(500));
     let agents: Vec<librefang_types::agent::AgentEntry> = if let Some(lim) = limit {
         agents.into_iter().skip(offset).take(lim).collect()
     } else {
@@ -2242,7 +2246,13 @@ pub async fn send_message_stream(
         }
     });
 
-    Sse::new(sse_stream).into_response()
+    Sse::new(sse_stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(std::time::Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response()
 }
 
 /// GET /api/agents/{id}/sessions/{session_id}/stream — attach to a session's

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1235,19 +1235,64 @@ pub async fn invoke_tool(
 // Session listing endpoints
 // ---------------------------------------------------------------------------
 
+/// Pagination query parameters shared by list endpoints.
+#[derive(serde::Deserialize, Default)]
+pub struct PaginationParams {
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+impl PaginationParams {
+    const DEFAULT_LIMIT: usize = 100;
+    const MAX_LIMIT: usize = 500;
+
+    fn effective_limit(&self) -> usize {
+        self.limit
+            .unwrap_or(Self::DEFAULT_LIMIT)
+            .min(Self::MAX_LIMIT)
+    }
+
+    fn effective_offset(&self) -> usize {
+        self.offset.unwrap_or(0)
+    }
+}
+
 /// GET /api/sessions — List all sessions with metadata.
 #[utoipa::path(
     get,
     path = "/api/sessions",
     tag = "sessions",
+    params(
+        ("limit" = Option<usize>, Query, description = "Max items (default 100, max 500)"),
+        ("offset" = Option<usize>, Query, description = "Items to skip"),
+    ),
     responses(
-        (status = 200, description = "List sessions", body = Vec<serde_json::Value>)
+        (status = 200, description = "Paginated list of sessions", body = serde_json::Value)
     )
 )]
-pub async fn list_sessions(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn list_sessions(
+    State(state): State<Arc<AppState>>,
+    Query(pagination): Query<PaginationParams>,
+) -> impl IntoResponse {
     match state.kernel.memory_substrate().list_sessions() {
-        Ok(sessions) => Json(serde_json::json!({"sessions": sessions})),
-        Err(_) => Json(serde_json::json!({"sessions": []})),
+        Ok(all_sessions) => {
+            let total = all_sessions.len();
+            let offset = pagination.effective_offset();
+            let limit = pagination.effective_limit();
+            let items: Vec<_> = all_sessions.into_iter().skip(offset).take(limit).collect();
+            Json(serde_json::json!({
+                "sessions": items,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+            }))
+        }
+        Err(_) => Json(serde_json::json!({
+            "sessions": [],
+            "total": 0,
+            "offset": 0,
+            "limit": PaginationParams::DEFAULT_LIMIT,
+        })),
     }
 }
 
@@ -1557,8 +1602,20 @@ fn approval_to_json(
 ///
 /// Transforms field names to match the dashboard template expectations:
 /// `action_summary` → `action`, `agent_id` → `agent_name`, `requested_at` → `created_at`.
-#[utoipa::path(get, path = "/api/approvals", tag = "approvals", responses((status = 200, description = "List pending and recent approvals", body = Vec<serde_json::Value>)))]
-pub async fn list_approvals(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+#[utoipa::path(
+    get,
+    path = "/api/approvals",
+    tag = "approvals",
+    params(
+        ("limit" = Option<usize>, Query, description = "Max items (default 100, max 500)"),
+        ("offset" = Option<usize>, Query, description = "Items to skip"),
+    ),
+    responses((status = 200, description = "Paginated list of pending and recent approvals", body = serde_json::Value))
+)]
+pub async fn list_approvals(
+    State(state): State<Arc<AppState>>,
+    Query(pagination): Query<PaginationParams>,
+) -> impl IntoResponse {
     let pending = state.kernel.approvals().list_pending();
     let recent = state.kernel.approvals().list_recent(50);
 
@@ -1615,8 +1672,16 @@ pub async fn list_approvals(State(state): State<Arc<AppState>>) -> impl IntoResp
     });
 
     let total = approvals.len();
+    let offset = pagination.effective_offset();
+    let limit = pagination.effective_limit();
+    let items: Vec<_> = approvals.into_iter().skip(offset).take(limit).collect();
 
-    Json(serde_json::json!({"approvals": approvals, "total": total}))
+    Json(serde_json::json!({
+        "approvals": items,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    }))
 }
 
 /// GET /api/approvals/{id} — Get a single approval request by ID.


### PR DESCRIPTION
## Summary

- **#3601** — `CanvasPage` now uses `useAgents()` and `useWorkflows()` hooks instead of direct `listAgents()`/`listWorkflows()` calls. `getWorkflow()` is called via `queryClient.fetchQuery(workflowQueries.detail(id))`. `createSchedule()` replaced with `useCreateSchedule()` mutation. Exported `getWorkflow` via `src/lib/http/client.ts` and added `workflowQueries.detail` + `useWorkflowDetail` hook to `src/lib/queries/workflows.ts`.
- **#3602** — Backend `list_agents` hard cap raised from 100 to 500 (`agents.rs`). Frontend `listAgents()` request updated from `limit: "200"` to `limit: "500"`.
- **#3690** — `/api/agents/{id}/message/stream` SSE endpoint now calls `.keep_alive(KeepAlive::new().interval(15s).text("keep-alive"))`, matching the existing session-stream endpoint pattern.
- **#3691** — `GET /api/sessions` and `GET /api/approvals` now accept `limit` (default 100, max 500) and `offset` query params. Responses include `total`, `offset`, and `limit` fields for pagination.
- **#3702** — `AgentItem` TypeScript interface extended with `parent_agent_id`, `children`, `session_id`, and `tags` fields. Backend `enrich_agent_json` updated to serialize these fields from `AgentEntry`.

## Test plan

- [ ] Dashboard canvas page loads agents and workflows without direct API imports
- [ ] Agents list with >100 agents returns up to 500 items
- [ ] SSE `/message/stream` keeps connection alive through proxy idle timeouts
- [ ] `/api/sessions?limit=50&offset=0` returns paginated response with `total` field
- [ ] `/api/approvals?limit=50` returns paginated response with `total` field
- [ ] TypeScript compiles without errors on `AgentItem` usage sites
- [ ] Fork/parent relationships visible in UI via new `parent_agent_id` field