### PR TITLE
fix(cli,runtime,dashboard,kernel): async TUI HTTP, tokio::fs plugin_manager, SkillsPage guard, track watcher handles, inbox spin loop

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -579,6 +579,8 @@ function CreateSkillModal({
   );
 
   const handleCreate = async () => {
+    // Guard against double-submit: bail out if a creation is already in flight.
+    if (creating || createSkillMutation.isPending) return;
     setError("");
     if (!name.trim() || !description.trim()) {
       setError(
@@ -693,16 +695,16 @@ function CreateSkillModal({
           </Button>
           <Button
             onClick={handleCreate}
-            disabled={creating}
+            disabled={creating || createSkillMutation.isPending}
             leftIcon={
-              creating ? (
+              creating || createSkillMutation.isPending ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : (
                 <Plus className="w-4 h-4" />
               )
             }
           >
-            {creating
+            {creating || createSkillMutation.isPending
               ? t("common.creating", { defaultValue: "Creating..." })
               : t("common.create")}
           </Button>

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -1696,11 +1696,9 @@ pub async fn get_plugin_state(Path(name): Path<String>) -> impl IntoResponse {
         .join(&name)
         .join(".state.json");
 
-    let content = if state_path.exists() {
-        std::fs::read_to_string(&state_path).unwrap_or_else(|_| "{}".to_string())
-    } else {
-        "{}".to_string()
-    };
+    let content = tokio::fs::read_to_string(&state_path)
+        .await
+        .unwrap_or_else(|_| "{}".to_string());
 
     let value: serde_json::Value = serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
     (StatusCode::OK, Json(value)).into_response()
@@ -1716,7 +1714,7 @@ pub async fn reset_plugin_state(Path(name): Path<String>) -> impl IntoResponse {
         .join(&name)
         .join(".state.json");
 
-    match std::fs::write(&state_path, "{}") {
+    match tokio::fs::write(&state_path, "{}").await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             ApiErrorResponse::bad_request(format!("Failed to reset state: {e}")).into_response()

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -210,6 +210,14 @@ pub enum AppEvent {
     CommsSendResult(String),
     /// Comms task post result.
     CommsTaskResult(String),
+
+    // ── Async chat helpers (previously blocking on the event-loop thread) ──
+    /// Agent model label fetched for chat header.
+    ChatModelLabelLoaded { agent_id: String, label: String },
+    /// Model list loaded for the model picker in chat.
+    ChatModelsForPicker(Vec<super::screens::chat::ModelEntry>),
+    /// Agent list loaded for the /agents chat command.
+    ChatAgentListLoaded(Vec<String>),
 }
 
 /// Spawn the crossterm polling + tick thread. Returns sender + receiver.
@@ -2879,6 +2887,90 @@ pub fn spawn_comms_task(
             let _ = tx.send(AppEvent::CommsTaskResult(
                 "Task post not supported in-process".to_string(),
             ));
+        }
+    });
+}
+
+/// Fetch the model label for a daemon agent (used when entering chat).
+/// Sends `ChatModelLabelLoaded` so the event loop can update `chat.model_label`
+/// without blocking the render/input thread.
+pub fn spawn_fetch_agent_model_label(
+    base_url: String,
+    agent_id: String,
+    tx: mpsc::Sender<AppEvent>,
+) {
+    std::thread::spawn(move || {
+        let client = daemon_client();
+        if let Ok(resp) = client
+            .get(format!("{base_url}/api/agents/{agent_id}"))
+            .send()
+        {
+            if let Ok(body) = resp.json::<serde_json::Value>() {
+                let provider = body["model_provider"].as_str().unwrap_or("?");
+                let model = body["model_name"].as_str().unwrap_or("?");
+                let label = format!("{provider}/{model}");
+                let _ = tx.send(AppEvent::ChatModelLabelLoaded { agent_id, label });
+            }
+        }
+    });
+}
+
+/// Fetch the model list from the daemon for the chat model picker.
+/// Sends `ChatModelsForPicker` so the event loop can open the picker
+/// without blocking the render/input thread.
+pub fn spawn_fetch_models_for_picker(base_url: String, tx: mpsc::Sender<AppEvent>) {
+    std::thread::spawn(move || {
+        let client = daemon_client();
+        if let Ok(resp) = client.get(format!("{base_url}/api/models")).send() {
+            if let Ok(body) = resp.json::<serde_json::Value>() {
+                let models: Vec<super::screens::chat::ModelEntry> = body["models"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter(|m| m["available"].as_bool().unwrap_or(false))
+                            .map(|m| super::screens::chat::ModelEntry {
+                                id: m["id"].as_str().unwrap_or("").to_string(),
+                                display_name: m["display_name"].as_str().unwrap_or("").to_string(),
+                                provider: m["provider"].as_str().unwrap_or("").to_string(),
+                                tier: m["tier"].as_str().unwrap_or("Balanced").to_string(),
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let _ = tx.send(AppEvent::ChatModelsForPicker(models));
+            }
+        }
+    });
+}
+
+/// Fetch the agent list from the daemon for the /agents chat command.
+/// Sends `ChatAgentListLoaded` so the event loop can push the reply
+/// without blocking the render/input thread.
+pub fn spawn_fetch_agents_for_chat(base_url: String, tx: mpsc::Sender<AppEvent>) {
+    std::thread::spawn(move || {
+        let client = daemon_client();
+        if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
+            if let Ok(body) = resp.json::<serde_json::Value>() {
+                let arr = if let Some(arr) = body.as_array() {
+                    arr.clone()
+                } else if let Some(items) = body.get("items").and_then(|v| v.as_array()) {
+                    items.clone()
+                } else {
+                    Vec::new()
+                };
+                let lines: Vec<String> = arr
+                    .iter()
+                    .map(|a| {
+                        format!(
+                            "{} [{}] {}",
+                            a["name"].as_str().unwrap_or("?"),
+                            a["state"].as_str().unwrap_or("?"),
+                            a["model_name"].as_str().unwrap_or("?"),
+                        )
+                    })
+                    .collect();
+                let _ = tx.send(AppEvent::ChatAgentListLoaded(lines));
+            }
         }
     });
 }

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -618,6 +618,30 @@ impl App {
                 self.extensions.status_msg = format!("Reconnected {id}: {tools} tools");
                 self.refresh_extension_health();
             }
+
+            // ── Async chat helpers (previously blocked the event-loop thread) ──
+            AppEvent::ChatModelLabelLoaded { agent_id: _, label } => {
+                self.chat.model_label = label;
+            }
+            AppEvent::ChatModelsForPicker(models) => {
+                if models.is_empty() {
+                    self.chat
+                        .push_message(chat::Role::System, "No models available.".to_string());
+                } else {
+                    self.chat.model_picker_models = models;
+                    self.chat.model_picker_filter.clear();
+                    self.chat.model_picker_idx = 0;
+                    self.chat.show_model_picker = true;
+                }
+            }
+            AppEvent::ChatAgentListLoaded(lines) => {
+                let msg = if lines.is_empty() {
+                    "No agents running.".to_string()
+                } else {
+                    lines.join("\n")
+                };
+                self.chat.push_message(chat::Role::System, msg);
+            }
         }
     }
 
@@ -1765,15 +1789,13 @@ impl App {
         self.chat.agent_name = name.clone();
         self.chat.mode_label = "daemon".to_string();
 
+        // Fetch model label asynchronously — avoids blocking the TUI event loop.
         if let Backend::Daemon { ref base_url, .. } = self.backend {
-            let client = crate::daemon_client();
-            if let Ok(resp) = client.get(format!("{base_url}/api/agents/{id}")).send() {
-                if let Ok(body) = resp.json::<serde_json::Value>() {
-                    let provider = body["model_provider"].as_str().unwrap_or("?");
-                    let model = body["model_name"].as_str().unwrap_or("?");
-                    self.chat.model_label = format!("{provider}/{model}");
-                }
-            }
+            event::spawn_fetch_agent_model_label(
+                base_url.clone(),
+                id.clone(),
+                self.event_tx.clone(),
+            );
         }
 
         self.chat_target = Some(ChatTarget {
@@ -1883,59 +1905,44 @@ impl App {
     // ─── Model picker ────────────────────────────────────────────────────────
 
     fn open_model_picker(&mut self) {
-        let models = match &self.backend {
+        match &self.backend {
             Backend::Daemon { base_url, .. } => {
-                let client = crate::daemon_client();
-                match client.get(format!("{base_url}/api/models")).send() {
-                    Ok(resp) => match resp.json::<serde_json::Value>() {
-                        Ok(body) => body["models"]
-                            .as_array()
-                            .map(|arr| {
-                                arr.iter()
-                                    .filter(|m| m["available"].as_bool().unwrap_or(false))
-                                    .map(|m| chat::ModelEntry {
-                                        id: m["id"].as_str().unwrap_or("").to_string(),
-                                        display_name: m["display_name"]
-                                            .as_str()
-                                            .unwrap_or("")
-                                            .to_string(),
-                                        provider: m["provider"].as_str().unwrap_or("").to_string(),
-                                        tier: m["tier"].as_str().unwrap_or("Balanced").to_string(),
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default(),
-                        Err(_) => Vec::new(),
-                    },
-                    Err(_) => Vec::new(),
-                }
+                // Fetch model list asynchronously — avoids blocking the TUI event loop.
+                // The `ChatModelsForPicker` event handler will open the picker once loaded.
+                event::spawn_fetch_models_for_picker(base_url.clone(), self.event_tx.clone());
             }
             Backend::InProcess { kernel } => {
-                let catalog = kernel.model_catalog_ref().read().unwrap_or_else(|p| p.into_inner());
-                catalog
-                    .available_models()
-                    .into_iter()
-                    .map(|e| chat::ModelEntry {
-                        id: e.id.clone(),
-                        display_name: e.display_name.clone(),
-                        provider: e.provider.clone(),
-                        tier: format!("{:?}", e.tier),
-                    })
-                    .collect()
+                let models = {
+                    let catalog = kernel
+                        .model_catalog_ref()
+                        .read()
+                        .unwrap_or_else(|p| p.into_inner());
+                    catalog
+                        .available_models()
+                        .into_iter()
+                        .map(|e| chat::ModelEntry {
+                            id: e.id.clone(),
+                            display_name: e.display_name.clone(),
+                            provider: e.provider.clone(),
+                            tier: format!("{:?}", e.tier),
+                        })
+                        .collect::<Vec<_>>()
+                };
+                if models.is_empty() {
+                    self.chat
+                        .push_message(chat::Role::System, "No models available.".to_string());
+                    return;
+                }
+                self.chat.model_picker_models = models;
+                self.chat.model_picker_filter.clear();
+                self.chat.model_picker_idx = 0;
+                self.chat.show_model_picker = true;
             }
-            Backend::None => Vec::new(),
-        };
-
-        if models.is_empty() {
-            self.chat
-                .push_message(chat::Role::System, "No models available.".to_string());
-            return;
+            Backend::None => {
+                self.chat
+                    .push_message(chat::Role::System, "No models available.".to_string());
+            }
         }
-
-        self.chat.model_picker_models = models;
-        self.chat.model_picker_filter.clear();
-        self.chat.model_picker_idx = 0;
-        self.chat.show_model_picker = true;
     }
 
     fn switch_model(&mut self, model_id: &str) {
@@ -2069,49 +2076,42 @@ impl App {
                 self.chat.push_message(chat::Role::System, s.join("\n"));
             }
             "/agents" => {
-                let mut lines = Vec::new();
                 match &self.backend {
                     Backend::Daemon { base_url, .. } => {
-                        let client = crate::daemon_client();
-                        if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
-                            if let Ok(body) = resp.json::<serde_json::Value>() {
-                                // Handle both old format (direct array) and new format ({ "items": [...] })
-                                let arr = if let Some(arr) = body.as_array() {
-                                    arr.clone()
-                                } else if let Some(items) =
-                                    body.get("items").and_then(|v| v.as_array())
-                                {
-                                    items.clone()
-                                } else {
-                                    Vec::new()
-                                };
-                                for a in arr {
-                                    lines.push(format!(
-                                        "{} [{}] {}",
-                                        a["name"].as_str().unwrap_or("?"),
-                                        a["state"].as_str().unwrap_or("?"),
-                                        a["model_name"].as_str().unwrap_or("?"),
-                                    ));
-                                }
-                            }
-                        }
+                        // Fetch agent list asynchronously — avoids blocking the TUI event loop.
+                        // The `ChatAgentListLoaded` event handler will push the reply.
+                        event::spawn_fetch_agents_for_chat(
+                            base_url.clone(),
+                            self.event_tx.clone(),
+                        );
                     }
                     Backend::InProcess { kernel } => {
-                        for e in kernel.agent_registry().list() {
-                            lines.push(format!(
-                                "{} [{:?}] {}/{}",
-                                e.name, e.state, e.manifest.model.provider, e.manifest.model.model,
-                            ));
-                        }
+                        let lines: Vec<String> = kernel
+                            .agent_registry()
+                            .list()
+                            .into_iter()
+                            .map(|e| {
+                                format!(
+                                    "{} [{:?}] {}/{}",
+                                    e.name,
+                                    e.state,
+                                    e.manifest.model.provider,
+                                    e.manifest.model.model,
+                                )
+                            })
+                            .collect();
+                        let msg = if lines.is_empty() {
+                            "No agents running.".to_string()
+                        } else {
+                            lines.join("\n")
+                        };
+                        self.chat.push_message(chat::Role::System, msg);
                     }
-                    Backend::None => {}
+                    Backend::None => {
+                        self.chat
+                            .push_message(chat::Role::System, "No agents running.".to_string());
+                    }
                 }
-                let msg = if lines.is_empty() {
-                    "No agents running.".to_string()
-                } else {
-                    lines.join("\n")
-                };
-                self.chat.push_message(chat::Role::System, msg);
             }
             "/clear" => {
                 let name = self.chat.agent_name.clone();

--- a/crates/librefang-kernel/src/background.rs
+++ b/crates/librefang-kernel/src/background.rs
@@ -14,6 +14,14 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+/// Outer loop handle + any inner watcher handles spawned by that loop.
+struct AgentTaskEntry {
+    outer: JoinHandle<()>,
+    /// Inner watcher tasks spawned by this agent's loop. These hold LLM permits
+    /// and must be aborted when the agent stops so permits are released promptly.
+    watchers: Arc<std::sync::Mutex<Vec<JoinHandle<()>>>>,
+}
+
 /// Maximum number of concurrent background LLM calls across all agents.
 const MAX_CONCURRENT_BG_LLM: usize = 5;
 
@@ -30,8 +38,8 @@ impl Drop for BusyGuard {
 
 /// Manages background task loops for autonomous agents.
 pub struct BackgroundExecutor {
-    /// Running background task handles, keyed by agent ID.
-    tasks: DashMap<AgentId, JoinHandle<()>>,
+    /// Running background task handles (outer loop + inner watcher list), keyed by agent ID.
+    tasks: DashMap<AgentId, AgentTaskEntry>,
     /// Shutdown signal receiver (from Supervisor).
     shutdown_rx: watch::Receiver<bool>,
     /// SECURITY: Global semaphore to limit concurrent background LLM calls.
@@ -126,6 +134,11 @@ impl BackgroundExecutor {
                 );
 
                 let check_interval = *check_interval_secs;
+                // Shared list of inner watcher handles so stop_agent can abort them.
+                let watcher_handles: Arc<std::sync::Mutex<Vec<JoinHandle<()>>>> =
+                    Arc::new(std::sync::Mutex::new(Vec::new()));
+                let watcher_handles_loop = watcher_handles.clone();
+
                 let handle = tokio::spawn(async move {
                     // Stagger first tick: random jitter (0..interval) so agents
                     // don't all load sessions into memory simultaneously at boot.
@@ -176,8 +189,9 @@ impl BackgroundExecutor {
                         let busy_clone = busy.clone();
                         let watcher_name = name.clone();
                         let jh = (send_message)(agent_id, prompt);
-                        // Spawn a watcher with RAII guard — busy flag clears even on panic
-                        tokio::spawn(async move {
+                        // Spawn a watcher with RAII guard — busy flag clears even on panic.
+                        // Track the handle so stop_agent can abort it and release the permit.
+                        let watcher_jh = tokio::spawn(async move {
                             let _guard = BusyGuard { flag: busy_clone };
                             let _permit = permit; // drop permit when watcher exits
                             if let Err(e) = jh.await {
@@ -189,10 +203,14 @@ impl BackgroundExecutor {
                                 );
                             }
                         });
+                        if let Ok(mut guards) = watcher_handles_loop.lock() {
+                            guards.retain(|h| !h.is_finished());
+                            guards.push(watcher_jh);
+                        }
                     }
                 });
 
-                self.tasks.insert(agent_id, handle);
+                self.tasks.insert(agent_id, AgentTaskEntry { outer: handle, watchers: watcher_handles });
             }
             ScheduleMode::Periodic { cron } => {
                 let interval_secs = parse_cron_to_secs(cron);
@@ -215,6 +233,11 @@ impl BackgroundExecutor {
                     cron = %cron, interval_secs = interval_secs,
                     "Starting periodic background loop"
                 );
+
+                // Shared list of inner watcher handles so stop_agent can abort them.
+                let watcher_handles: Arc<std::sync::Mutex<Vec<JoinHandle<()>>>> =
+                    Arc::new(std::sync::Mutex::new(Vec::new()));
+                let watcher_handles_loop = watcher_handles.clone();
 
                 let handle = tokio::spawn(async move {
                     // Stagger first tick: random jitter so agents don't spike memory together.
@@ -263,8 +286,9 @@ impl BackgroundExecutor {
                         let busy_clone = busy.clone();
                         let watcher_name = name.clone();
                         let jh = (send_message)(agent_id, prompt);
-                        // Spawn a watcher with RAII guard — busy flag clears even on panic
-                        tokio::spawn(async move {
+                        // Spawn a watcher with RAII guard — busy flag clears even on panic.
+                        // Track the handle so stop_agent can abort it and release the permit.
+                        let watcher_jh = tokio::spawn(async move {
                             let _guard = BusyGuard { flag: busy_clone };
                             let _permit = permit; // drop permit when watcher exits
                             if let Err(e) = jh.await {
@@ -276,10 +300,14 @@ impl BackgroundExecutor {
                                 );
                             }
                         });
+                        if let Ok(mut guards) = watcher_handles_loop.lock() {
+                            guards.retain(|h| !h.is_finished());
+                            guards.push(watcher_jh);
+                        }
                     }
                 });
 
-                self.tasks.insert(agent_id, handle);
+                self.tasks.insert(agent_id, AgentTaskEntry { outer: handle, watchers: watcher_handles });
             }
             ScheduleMode::Proactive { .. } => {
                 // Proactive agents rely on triggers, not a dedicated loop.
@@ -290,10 +318,19 @@ impl BackgroundExecutor {
     }
 
     /// Stop the background loop for an agent, if one is running.
+    ///
+    /// Aborts both the outer scheduling loop and any in-flight inner watcher
+    /// tasks so that LLM semaphore permits are released immediately.
     pub fn stop_agent(&self, agent_id: AgentId) {
         self.pause_flags.remove(&agent_id);
-        if let Some((_, handle)) = self.tasks.remove(&agent_id) {
-            handle.abort();
+        if let Some((_, entry)) = self.tasks.remove(&agent_id) {
+            entry.outer.abort();
+            // Abort all tracked inner watcher tasks so they release LLM permits.
+            if let Ok(mut guards) = entry.watchers.lock() {
+                for watcher in guards.drain(..) {
+                    watcher.abort();
+                }
+            }
             info!(id = %agent_id, "Background loop stopped");
         }
     }

--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -171,8 +171,17 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
                 };
 
                 if content.trim().is_empty() {
-                    // Move empty files to processed without sending
-                    let _ = move_to_processed(&path, &processed_dir).await;
+                    // Move empty files to processed without sending.
+                    // If the move fails (permissions, race), delete the file so
+                    // we don't spin forever rescanning the same empty file.
+                    if let Err(e) = move_to_processed(&path, &processed_dir).await {
+                        warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "Inbox: failed to move empty file to processed dir, removing to avoid spin loop"
+                        );
+                        let _ = tokio::fs::remove_file(&path).await;
+                    }
                     continue;
                 }
 

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -829,7 +829,8 @@ async fn install_from_registry(
         .map_err(|e| format!("Failed to parse registry response: {e}"))?;
 
     // Create target directory
-    std::fs::create_dir_all(&target_dir)
+    tokio::fs::create_dir_all(&target_dir)
+        .await
         .map_err(|e| format!("Failed to create plugin dir: {e}"))?;
 
     // Download each file — cleanup on failure
@@ -843,7 +844,7 @@ async fn install_from_registry(
 
     if let Err(e) = download_result {
         // Clean up partial download
-        let _ = std::fs::remove_dir_all(&target_dir);
+        let _ = tokio::fs::remove_dir_all(&target_dir).await;
         return Err(format!("Failed to download plugin '{name}': {e}"));
     }
 
@@ -852,9 +853,11 @@ async fn install_from_registry(
         Some(expected) => {
             // For registry plugins installed file-by-file, compute checksum over
             // the serialised manifest as a representative integrity check.
-            let manifest_bytes = std::fs::read(target_dir.join("plugin.toml")).unwrap_or_default();
+            let manifest_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
+                .await
+                .unwrap_or_default();
             if let Err(e) = verify_checksum(&manifest_bytes, &expected) {
-                let _ = std::fs::remove_dir_all(&target_dir);
+                let _ = tokio::fs::remove_dir_all(&target_dir).await;
                 return Err(e);
             }
             info!(plugin = name, "Checksum verified OK");
@@ -873,7 +876,9 @@ async fn install_from_registry(
     // refuse installation rather than silently skip.  An attacker who knows the
     // key is all-zero bytes can trivially craft valid signatures, so accepting
     // plugins while the placeholder is active is equivalent to no verification.
-    let archive_bytes = std::fs::read(target_dir.join("plugin.toml")).unwrap_or_default();
+    let archive_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
+        .await
+        .unwrap_or_default();
     if std::env::var("LIBREFANG_ARCHIVE_VERIFY").as_deref() == Ok("0") {
         debug!("Archive signature verification disabled via LIBREFANG_ARCHIVE_VERIFY=0");
     } else {
@@ -898,7 +903,7 @@ async fn install_from_registry(
         if let Err(e) =
             verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await
         {
-            let _ = std::fs::remove_dir_all(&target_dir);
+            let _ = tokio::fs::remove_dir_all(&target_dir).await;
             return Err(e);
         }
     }
@@ -979,7 +984,7 @@ async fn install_from_registry(
 
     // Bust the registry cache so subsequent searches see an up-to-date index.
     let cache_path = registry_cache_path(github_repo);
-    let _ = std::fs::remove_file(&cache_path);
+    let _ = tokio::fs::remove_file(&cache_path).await;
 
     get_plugin_info(name)
 }
@@ -1244,7 +1249,7 @@ async fn install_from_git(
     // Remove .git directory to save space
     let git_dir = target_dir.join(".git");
     if git_dir.exists() {
-        let _ = std::fs::remove_dir_all(&git_dir);
+        let _ = tokio::fs::remove_dir_all(&git_dir).await;
     }
 
     info!(plugin = manifest.name, "Installed plugin from git");


### PR DESCRIPTION
## Summary

Fixes five runtime/TUI bugs in one commit:

- **#3631 (TUI blocking HTTP)**: Three inline blocking `reqwest` calls in the TUI event-loop handlers (`enter_chat_daemon`, `open_model_picker`, `/agents` chat command) now delegate to background threads via new `spawn_fetch_agent_model_label`, `spawn_fetch_models_for_picker`, and `spawn_fetch_agents_for_chat` helpers. Results arrive via three new `AppEvent` variants (`ChatModelLabelLoaded`, `ChatModelsForPicker`, `ChatAgentListLoaded`) so the render/input loop is never blocked — no more 120 s UI freeze.

- **#3599 (tokio worker thread blocking I/O)**: Replace `std::fs::{create_dir_all, read, remove_dir_all, remove_file}` with `tokio::fs::` equivalents inside `install_from_registry` and `install_from_git` async fns (`plugin_manager.rs`). Also fixes `get_plugin_state` and `reset_plugin_state` in `routes/plugins.rs`.

- **#3617 (SkillsPage double-submit)**: Add `if creating || createSkillMutation.isPending return` guard at the top of `handleCreate` in `SkillsPage.tsx`. The button's `disabled`/icon/label now also reflect `isPending` so the UI is always accurate.

- **#3705 (watcher handle leak after stop_agent)**: Introduce `AgentTaskEntry` (`outer: JoinHandle<()>` + `watchers: Arc<Mutex<Vec<JoinHandle<()>>>>`) in `BackgroundExecutor`. Continuous and Periodic loops push each inner watcher handle into the shared list. `stop_agent` now aborts all tracked watcher handles after aborting the outer loop, immediately releasing LLM semaphore permits.

- **#3751 (inbox spin loop on empty-file move failure)**: Wrap the silent `let _ = move_to_processed(...)` in `inbox.rs` with error handling — on failure it logs a warning and removes the file so the same empty file is not rescanned on every poll tick.

## Test plan

- [ ] TUI: enter daemon chat — model label appears without UI freeze
- [ ] TUI: open model picker (`/model`) — picker opens without UI freeze
- [ ] TUI: type `/agents` in chat — list appears without UI freeze
- [ ] Plugin install from registry path uses non-blocking FS ops (no tokio runtime warnings)
- [ ] SkillsPage: rapid double-click "Create" only fires one POST
- [ ] Kill an agent running continuous/periodic background loop — verify LLM semaphore is immediately available (active watcher tasks aborted)
- [ ] Place an empty file in the inbox dir where the processed dir is read-only — verify daemon doesn't spin at 100% CPU