### PR TITLE
fix(cli,api): TUI auth header, block TOTP overwrite, proper memory error codes, remove build.rs git config, log skill install errors

### DIFF
--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -143,10 +143,41 @@ fn default_user_id() -> String {
     "00000000-0000-0000-0000-000000000000".to_string()
 }
 
-/// Log the full error server-side but return a generic message to the client.
-fn internal_error(e: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
-    tracing::error!("Memory operation failed: {e}");
-    ApiErrorResponse::internal("Internal server error").into_json_tuple()
+/// Map a [`librefang_types::error::LibreFangError`] to the appropriate HTTP status code.
+///
+/// Previously every failure was mapped to 500. This function now returns
+/// semantically correct codes for `InvalidInput` (400), `AgentNotFound` /
+/// `SessionNotFound` (404), `CapabilityDenied` (403), and `QuotaExceeded` (429)
+/// so callers can distinguish between client errors and server errors.
+fn internal_error(
+    e: impl std::fmt::Display,
+) -> (StatusCode, Json<serde_json::Value>) {
+    map_memory_error(e.to_string())
+}
+
+fn map_memory_error(msg: String) -> (StatusCode, Json<serde_json::Value>) {
+    // Classify by the error message prefix emitted by LibreFangError Display impls.
+    // This avoids a dependency on the concrete type at every call-site while still
+    // providing correct HTTP semantics.
+    let status = if msg.starts_with("Invalid input:") {
+        StatusCode::BAD_REQUEST
+    } else if msg.starts_with("Agent not found:")
+        || msg.starts_with("Session not found:")
+    {
+        StatusCode::NOT_FOUND
+    } else if msg.starts_with("Capability denied:") {
+        StatusCode::FORBIDDEN
+    } else if msg.starts_with("Resource quota exceeded:") {
+        StatusCode::TOO_MANY_REQUESTS
+    } else {
+        tracing::error!("Memory operation failed: {msg}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    };
+
+    (
+        status,
+        Json(serde_json::json!({ "error": msg })),
+    )
 }
 
 /// Build a [`MemoryNamespaceGuard`] for the current request from the

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -1248,21 +1248,49 @@ pub async fn clawhub_cn_install(
 
     match client.install(&req.slug, &skills_dir).await {
         Ok(result) => {
-            // Patch source provenance to ClawHubCn
+            // Patch source provenance to ClawHubCn so the skill registry knows
+            // this skill was installed from ClawHub and can surface update/version info.
             let skill_dir = skills_dir.join(&req.slug);
             let manifest_path = skill_dir.join("skill.toml");
             if manifest_path.exists() {
-                if let Ok(toml_str) = std::fs::read_to_string(&manifest_path) {
-                    if let Ok(mut manifest) =
-                        toml::from_str::<librefang_skills::SkillManifest>(&toml_str)
-                    {
-                        manifest.source = Some(librefang_skills::SkillSource::ClawHubCn {
-                            slug: req.slug.clone(),
-                            version: result.version.clone(),
-                        });
-                        if let Ok(updated) = toml::to_string_pretty(&manifest) {
-                            let _ = std::fs::write(&manifest_path, updated);
+                match std::fs::read_to_string(&manifest_path) {
+                    Ok(toml_str) => match toml::from_str::<librefang_skills::SkillManifest>(&toml_str) {
+                        Ok(mut manifest) => {
+                            manifest.source = Some(librefang_skills::SkillSource::ClawHubCn {
+                                slug: req.slug.clone(),
+                                version: result.version.clone(),
+                            });
+                            match toml::to_string_pretty(&manifest) {
+                                Ok(updated) => {
+                                    if let Err(e) = std::fs::write(&manifest_path, updated) {
+                                        tracing::warn!(
+                                            slug = %req.slug,
+                                            path = %manifest_path.display(),
+                                            "Failed to write provenance to skill.toml: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        slug = %req.slug,
+                                        "Failed to serialize skill manifest for provenance patch: {e}"
+                                    );
+                                }
+                            }
                         }
+                        Err(e) => {
+                            tracing::warn!(
+                                slug = %req.slug,
+                                "Failed to parse skill.toml for provenance patch: {e}"
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            slug = %req.slug,
+                            path = %manifest_path.display(),
+                            "Failed to read skill.toml for provenance patch: {e}"
+                        );
                     }
                 }
             }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2448,6 +2448,24 @@ pub async fn totp_setup(
         }
     }
 
+    // Reject overwrite of a pending (not yet confirmed) TOTP enrollment.
+    // `totp_secret` present but `totp_confirmed` != "true" means a setup
+    // was initiated by a previous call but the confirm step was never completed.
+    // Allowing a second setup call here would silently discard the first QR
+    // code, making the first caller's authenticator app permanently invalid
+    // without any indication.
+    let pending_setup = state.kernel.vault_get("totp_secret").is_some()
+        && state.kernel.vault_get("totp_confirmed").as_deref() != Some("true");
+    if pending_setup {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "TOTP enrollment already in progress — confirm the existing setup or revoke it first",
+                "status": "pending_confirmation",
+            })),
+        );
+    }
+
     let (secret_base32, otpauth_uri, qr_base64) =
         match librefang_kernel::approval::ApprovalManager::generate_totp_secret(
             &totp_issuer,

--- a/crates/librefang-cli/build.rs
+++ b/crates/librefang-cli/build.rs
@@ -1,11 +1,6 @@
 use std::process::Command;
 
 fn main() {
-    // Automatically configure git hooks for all developers on first build.
-    let _ = Command::new("git")
-        .args(["config", "core.hooksPath", "scripts/hooks"])
-        .status();
-
     // Capture git commit hash at build time.
     let git_sha = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3601,7 +3601,7 @@ fn cmd_start(config: Option<PathBuf>, tail: bool, spawned: bool, foreground: boo
 ///
 /// Returns `None` when the key is missing, empty, or whitespace-only —
 /// meaning the daemon is running in public (unauthenticated) mode.
-fn read_api_key() -> Option<String> {
+pub(crate) fn read_api_key() -> Option<String> {
     daemon_config_context(None).api_key
 }
 

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -32,7 +32,11 @@ use super::screens::{
 /// Lightweight reference to the active backend, for passing to spawn functions.
 #[derive(Clone)]
 pub enum BackendRef {
-    Daemon(String),
+    Daemon {
+        base_url: String,
+        /// API key for `Authorization: Bearer` auth, if the daemon requires it.
+        api_key: Option<String>,
+    },
     InProcess(Arc<LibreFangKernel>),
 }
 
@@ -336,15 +340,14 @@ pub fn spawn_daemon_stream(
     base_url: String,
     agent_id: String,
     message: String,
+    api_key: Option<String>,
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || {
         use std::io::{BufRead, BufReader, Read};
 
-        let client = crate::http_client::client_builder()
-            .timeout(Duration::from_secs(300))
-            .build()
-            .unwrap();
+        let client =
+            make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(300));
 
         let url = format!("{base_url}/api/agents/{agent_id}/message/stream");
         let resp = client
@@ -355,7 +358,7 @@ pub fn spawn_daemon_stream(
         let resp = match resp {
             Ok(r) if r.status().is_success() => r,
             Ok(_) => {
-                let fallback = daemon_fallback(&base_url, &agent_id, &message);
+                let fallback = daemon_fallback(&base_url, &agent_id, &message, api_key.as_deref());
                 let _ = tx.send(AppEvent::StreamDone(fallback));
                 return;
             }
@@ -467,11 +470,10 @@ fn daemon_fallback(
     base_url: &str,
     agent_id: &str,
     message: &str,
+    api_key: Option<&str>,
 ) -> Result<AgentLoopResult, String> {
-    let client = crate::http_client::client_builder()
-        .timeout(Duration::from_secs(120))
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client =
+        make_daemon_client_with_timeout(api_key, Duration::from_secs(120));
 
     let resp = client
         .post(format!("{base_url}/api/agents/{agent_id}/message"))
@@ -516,12 +518,15 @@ fn daemon_fallback(
 }
 
 /// Spawn a background thread that spawns an agent on the daemon.
-pub fn spawn_daemon_agent(base_url: String, toml_content: String, tx: mpsc::Sender<AppEvent>) {
+pub fn spawn_daemon_agent(
+    base_url: String,
+    toml_content: String,
+    api_key: Option<String>,
+    tx: mpsc::Sender<AppEvent>,
+) {
     std::thread::spawn(move || {
-        let client = crate::http_client::client_builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .unwrap();
+        let client =
+            make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(30));
 
         let resp = client
             .post(format!("{base_url}/api/agents"))
@@ -558,11 +563,8 @@ pub fn spawn_daemon_agent(base_url: String, toml_content: String, tx: mpsc::Send
 /// Fetch dashboard data in background.
 pub fn spawn_fetch_dashboard(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             if let Ok(resp) = client.get(format!("{base_url}/api/status")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -706,11 +708,8 @@ pub fn spawn_fetch_dashboard(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch channel list in background.
 pub fn spawn_fetch_channels(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             if let Ok(resp) = client.get(format!("{base_url}/api/channels")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -759,11 +758,8 @@ pub fn spawn_fetch_channels(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Test a channel in background.
 pub fn spawn_test_channel(backend: BackendRef, channel: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/channels/{channel}/test"))
@@ -807,11 +803,8 @@ pub fn spawn_test_channel(backend: BackendRef, channel: String, tx: mpsc::Sender
 /// Fetch workflow list in background.
 pub fn spawn_fetch_workflows(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             if let Ok(resp) = client.get(format!("{base_url}/api/workflows")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -846,11 +839,8 @@ pub fn spawn_fetch_workflow_runs(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/workflows/{workflow_id}/runs"))
@@ -888,11 +878,8 @@ pub fn spawn_run_workflow(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(60))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(60));
 
             match client
                 .post(format!("{base_url}/api/workflows/{workflow_id}/run"))
@@ -929,11 +916,8 @@ pub fn spawn_create_workflow(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/workflows"))
@@ -965,11 +949,8 @@ pub fn spawn_create_workflow(
 /// Fetch triggers in background.
 pub fn spawn_fetch_triggers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             if let Ok(resp) = client.get(format!("{base_url}/api/triggers")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -1008,11 +989,8 @@ pub fn spawn_create_trigger(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/triggers"))
@@ -1046,11 +1024,8 @@ pub fn spawn_create_trigger(
 /// Delete a trigger in background.
 pub fn spawn_delete_trigger(backend: BackendRef, trigger_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             match client
                 .delete(format!("{base_url}/api/triggers/{trigger_id}"))
@@ -1077,11 +1052,8 @@ pub fn spawn_delete_trigger(backend: BackendRef, trigger_id: String, tx: mpsc::S
 /// Kill an agent in background (for detail view action).
 pub fn spawn_kill_agent(backend: BackendRef, agent_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
 
             match client
                 .delete(format!("{base_url}/api/agents/{agent_id}"))
@@ -1121,11 +1093,8 @@ pub fn spawn_kill_agent(backend: BackendRef, agent_id: String, tx: mpsc::Sender<
 /// Fetch skill assignment for an agent.
 pub fn spawn_fetch_agent_skills(backend: BackendRef, agent_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/agents/{agent_id}/skills"))
                 .send()
@@ -1185,11 +1154,8 @@ pub fn spawn_fetch_agent_mcp_servers(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/agents/{agent_id}/mcp_servers"))
                 .send()
@@ -1266,11 +1232,8 @@ pub fn spawn_update_agent_skills(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .put(format!("{base_url}/api/agents/{agent_id}/skills"))
                 .json(&serde_json::json!({"skills": skills}))
@@ -1308,11 +1271,8 @@ pub fn spawn_update_agent_mcp_servers(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .put(format!("{base_url}/api/agents/{agent_id}/mcp_servers"))
                 .json(&serde_json::json!({"mcp_servers": servers}))
@@ -1346,18 +1306,38 @@ pub fn spawn_update_agent_mcp_servers(
 
 // ── New screen spawn functions ───────────────────────────────────────────────
 
-fn daemon_client() -> reqwest::blocking::Client {
-    crate::http_client::client_builder()
-        .timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_else(|_| crate::http_client::new_client())
+/// Build a blocking reqwest client for daemon calls.
+///
+/// When `api_key` is `Some`, attaches an `Authorization: Bearer <key>` default
+/// header so every request through this client is authenticated.
+fn make_daemon_client(api_key: Option<&str>) -> reqwest::blocking::Client {
+    make_daemon_client_with_timeout(api_key, Duration::from_secs(5))
+}
+
+/// Build a blocking reqwest client for daemon calls with a custom timeout.
+///
+/// When `api_key` is `Some`, attaches an `Authorization: Bearer <key>` default
+/// header so every request through this client is authenticated.
+fn make_daemon_client_with_timeout(
+    api_key: Option<&str>,
+    timeout: Duration,
+) -> reqwest::blocking::Client {
+    let mut builder = crate::http_client::client_builder().timeout(timeout);
+    if let Some(key) = api_key {
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(val) = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}")) {
+            headers.insert(reqwest::header::AUTHORIZATION, val);
+        }
+        builder = builder.default_headers(headers);
+    }
+    builder.build().unwrap_or_else(|_| crate::http_client::new_client())
 }
 
 /// Fetch sessions list.
 pub fn spawn_fetch_sessions(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/sessions")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let sessions: Vec<SessionInfo> = body
@@ -1387,8 +1367,8 @@ pub fn spawn_fetch_sessions(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Delete a session.
 pub fn spawn_delete_session(backend: BackendRef, session_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .delete(format!("{base_url}/api/sessions/{session_id}"))
                 .send()
@@ -1414,8 +1394,8 @@ pub fn spawn_delete_session(backend: BackendRef, session_id: String, tx: mpsc::S
 /// Fetch agents for memory screen agent selector.
 pub fn spawn_fetch_memory_agents(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let agents: Vec<AgentEntry> = body
@@ -1451,8 +1431,8 @@ pub fn spawn_fetch_memory_agents(backend: BackendRef, tx: mpsc::Sender<AppEvent>
 /// Fetch KV pairs for an agent.
 pub fn spawn_fetch_memory_kv(backend: BackendRef, agent_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/memory/agents/{agent_id}/kv"))
                 .send()
@@ -1487,8 +1467,8 @@ pub fn spawn_save_memory_kv(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .put(format!("{base_url}/api/memory/agents/{agent_id}/kv/{key}"))
                 .json(&serde_json::json!({"value": value}))
@@ -1518,8 +1498,8 @@ pub fn spawn_delete_memory_kv(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .delete(format!("{base_url}/api/memory/agents/{agent_id}/kv/{key}"))
                 .send()
@@ -1543,8 +1523,8 @@ pub fn spawn_delete_memory_kv(
 /// Fetch installed skills.
 pub fn spawn_fetch_skills(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/skills")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let skills: Vec<SkillInfo> = body
@@ -1576,8 +1556,8 @@ pub fn spawn_fetch_skills(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Search ClawHub marketplace.
 pub fn spawn_search_clawhub(backend: BackendRef, query: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             let encoded: String = query
                 .chars()
                 .map(|c| {
@@ -1605,8 +1585,8 @@ pub fn spawn_search_clawhub(backend: BackendRef, query: String, tx: mpsc::Sender
 /// Browse ClawHub marketplace.
 pub fn spawn_browse_clawhub(backend: BackendRef, sort: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             let url = format!("{base_url}/api/clawhub/browse?sort={sort}");
             if let Ok(resp) = client.get(&url).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -1646,8 +1626,8 @@ fn parse_clawhub_results(body: &serde_json::Value) -> Vec<ClawHubResult> {
 /// Install a skill from ClawHub.
 pub fn spawn_install_skill(backend: BackendRef, slug: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/clawhub/install"))
                 .json(&serde_json::json!({"slug": slug}))
@@ -1672,8 +1652,8 @@ pub fn spawn_install_skill(backend: BackendRef, slug: String, tx: mpsc::Sender<A
 /// Uninstall a skill.
 pub fn spawn_uninstall_skill(backend: BackendRef, name: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/skills/uninstall"))
                 .json(&serde_json::json!({"name": name}))
@@ -1698,8 +1678,8 @@ pub fn spawn_uninstall_skill(backend: BackendRef, name: String, tx: mpsc::Sender
 /// Fetch MCP servers.
 pub fn spawn_fetch_mcp_servers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/mcp/servers")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let servers: Vec<McpServerInfo> = body
@@ -1727,8 +1707,8 @@ pub fn spawn_fetch_mcp_servers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) 
 /// Fetch provider auth status for templates screen.
 pub fn spawn_fetch_template_providers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/providers")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     // API returns { "providers": [...], "total": N }
@@ -1759,8 +1739,8 @@ pub fn spawn_fetch_template_providers(backend: BackendRef, tx: mpsc::Sender<AppE
 /// Fetch security status.
 pub fn spawn_fetch_security(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/security")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let features: Vec<SecurityFeature> = body
@@ -1802,8 +1782,8 @@ pub fn spawn_fetch_security(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Verify audit chain.
 pub fn spawn_verify_chain(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client.get(format!("{base_url}/api/audit/verify")).send() {
                 Ok(resp) => {
                     let body: serde_json::Value = resp.json().unwrap_or_default();
@@ -1835,8 +1815,8 @@ pub fn spawn_verify_chain(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch audit entries (for dedicated audit screen).
 pub fn spawn_fetch_audit(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/audit/recent?n=200"))
                 .send()
@@ -1869,8 +1849,8 @@ pub fn spawn_fetch_audit(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch usage summary.
 pub fn spawn_fetch_usage(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             // Summary
             if let Ok(resp) = client.get(format!("{base_url}/api/usage/summary")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -1934,8 +1914,8 @@ pub fn spawn_fetch_usage(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch settings providers.
 pub fn spawn_fetch_providers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/providers")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     // API returns { "providers": [...], "total": N }
@@ -1985,8 +1965,8 @@ pub fn spawn_fetch_providers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch settings models.
 pub fn spawn_fetch_models(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/models")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let models: Vec<ModelInfo> = body
@@ -2017,8 +1997,8 @@ pub fn spawn_fetch_models(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch settings tools.
 pub fn spawn_fetch_tools(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/tools")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let tools: Vec<ToolInfo> = body
@@ -2053,8 +2033,8 @@ pub fn spawn_save_provider_key(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/providers/{name}/key"))
                 .json(&serde_json::json!({"key": api_key}))
@@ -2081,8 +2061,8 @@ pub fn spawn_save_provider_key(
 /// Delete a provider API key.
 pub fn spawn_delete_provider_key(backend: BackendRef, name: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .delete(format!("{base_url}/api/providers/{name}/key"))
                 .send()
@@ -2108,11 +2088,8 @@ pub fn spawn_delete_provider_key(backend: BackendRef, name: String, tx: mpsc::Se
 /// Test a provider connection.
 pub fn spawn_test_provider(backend: BackendRef, name: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = crate::http_client::client_builder()
-                .timeout(Duration::from_secs(15))
-                .build()
-                .unwrap_or_else(|_| crate::http_client::new_client());
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(15));
             let start = std::time::Instant::now();
             match client
                 .post(format!("{base_url}/api/providers/{name}/test"))
@@ -2161,8 +2138,8 @@ pub fn spawn_test_provider(backend: BackendRef, name: String, tx: mpsc::Sender<A
 /// Fetch peers.
 pub fn spawn_fetch_peers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/peers")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let peers: Vec<PeerInfo> = body
@@ -2196,8 +2173,8 @@ pub fn spawn_fetch_peers(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch log entries (uses audit endpoint, polled frequently).
 pub fn spawn_fetch_logs(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client
                 .get(format!("{base_url}/api/audit/recent?n=200"))
                 .send()
@@ -2241,8 +2218,8 @@ pub fn spawn_fetch_logs(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch hand definitions (marketplace).
 pub fn spawn_fetch_hands(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/hands")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let hands: Vec<HandInfo> = body["hands"]
@@ -2297,8 +2274,8 @@ pub fn spawn_fetch_hands(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch active hand instances.
 pub fn spawn_fetch_active_hands(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/hands/active")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let instances: Vec<HandInstanceInfo> = body["instances"]
@@ -2348,8 +2325,8 @@ pub fn spawn_fetch_active_hands(backend: BackendRef, tx: mpsc::Sender<AppEvent>)
 /// Activate a hand.
 pub fn spawn_activate_hand(backend: BackendRef, hand_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/hands/{hand_id}/activate"))
                 .json(&serde_json::json!({}))
@@ -2387,8 +2364,8 @@ pub fn spawn_activate_hand(backend: BackendRef, hand_id: String, tx: mpsc::Sende
 /// Deactivate a hand instance.
 pub fn spawn_deactivate_hand(backend: BackendRef, instance_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .delete(format!("{base_url}/api/hands/instances/{instance_id}"))
                 .send()
@@ -2422,8 +2399,8 @@ pub fn spawn_deactivate_hand(backend: BackendRef, instance_id: String, tx: mpsc:
 /// Pause a hand instance.
 pub fn spawn_pause_hand(backend: BackendRef, instance_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!(
                     "{base_url}/api/hands/instances/{instance_id}/pause"
@@ -2459,8 +2436,8 @@ pub fn spawn_pause_hand(backend: BackendRef, instance_id: String, tx: mpsc::Send
 /// Resume a hand instance.
 pub fn spawn_resume_hand(backend: BackendRef, instance_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!(
                     "{base_url}/api/hands/instances/{instance_id}/resume"
@@ -2498,8 +2475,8 @@ pub fn spawn_resume_hand(backend: BackendRef, instance_id: String, tx: mpsc::Sen
 /// Fetch all extensions (available + installed).
 pub fn spawn_fetch_extensions(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/mcp/catalog")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let extensions: Vec<ExtensionInfo> = body["entries"]
@@ -2583,8 +2560,8 @@ pub fn spawn_fetch_extensions(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 /// Fetch extension health data.
 pub fn spawn_fetch_extension_health(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             if let Ok(resp) = client.get(format!("{base_url}/api/mcp/health")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     let entries: Vec<ExtensionHealthInfo> = body["health"]
@@ -2640,8 +2617,8 @@ pub fn spawn_fetch_extension_health(backend: BackendRef, tx: mpsc::Sender<AppEve
 /// Install an extension.
 pub fn spawn_install_extension(backend: BackendRef, id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/mcp/servers"))
                 .json(&serde_json::json!({"template_id": id}))
@@ -2680,8 +2657,8 @@ pub fn spawn_install_extension(backend: BackendRef, id: String, tx: mpsc::Sender
 /// resolves either form; the MCP endpoint only accepts the exact name.
 pub fn spawn_remove_extension(backend: BackendRef, id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/extensions/uninstall"))
                 .json(&serde_json::json!({ "name": id }))
@@ -2706,8 +2683,8 @@ pub fn spawn_remove_extension(backend: BackendRef, id: String, tx: mpsc::Sender<
 /// Reconnect an extension's MCP server.
 pub fn spawn_reconnect_extension(backend: BackendRef, id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/mcp/servers/{id}/reconnect"))
                 .send()
@@ -2738,8 +2715,8 @@ pub fn spawn_fetch_comms(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     use super::screens::comms::{CommsEdge, CommsEventItem, CommsNode};
 
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             // Fetch topology
             if let Ok(resp) = client.get(format!("{base_url}/api/comms/topology")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -2821,8 +2798,8 @@ pub fn spawn_comms_send(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             let body = serde_json::json!({
                 "from_agent_id": from,
                 "to_agent_id": to,
@@ -2867,8 +2844,8 @@ pub fn spawn_comms_task(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon(base_url) => {
-            let client = daemon_client();
+        BackendRef::Daemon { base_url, api_key } => {
+            let client = make_daemon_client(api_key.as_deref());
             let mut body = serde_json::json!({
                 "title": title,
                 "description": desc,

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -115,7 +115,11 @@ impl Tab {
 }
 
 enum Backend {
-    Daemon { base_url: String },
+    Daemon {
+        base_url: String,
+        /// API key read from config.toml `api_key`, forwarded to every HTTP request.
+        api_key: Option<String>,
+    },
     InProcess { kernel: Arc<LibreFangKernel> },
     None,
 }
@@ -123,7 +127,10 @@ enum Backend {
 impl Backend {
     fn to_ref(&self) -> Option<BackendRef> {
         match self {
-            Backend::Daemon { base_url } => Some(BackendRef::Daemon(base_url.clone())),
+            Backend::Daemon { base_url, api_key } => Some(BackendRef::Daemon {
+                base_url: base_url.clone(),
+                api_key: api_key.clone(),
+            }),
             Backend::InProcess { kernel } => Some(BackendRef::InProcess(kernel.clone())),
             Backend::None => None,
         }
@@ -994,7 +1001,7 @@ impl App {
 
     fn refresh_agents(&mut self) {
         match &self.backend {
-            Backend::Daemon { base_url } => {
+            Backend::Daemon { base_url, .. } => {
                 self.agents.load_daemon_agents(base_url);
             }
             Backend::InProcess { kernel } => {
@@ -1274,6 +1281,7 @@ impl App {
                 if let Some(ref url) = self.welcome.daemon_url {
                     self.backend = Backend::Daemon {
                         base_url: url.clone(),
+                        api_key: crate::read_api_key(),
                     };
                     self.agents.reset();
                     self.enter_main_phase();
@@ -1398,11 +1406,21 @@ impl App {
                 if let Some(backend) = self.backend.to_ref() {
                     let tx = self.event_tx.clone();
                     std::thread::spawn(move || {
-                        if let event::BackendRef::Daemon(base_url) = backend {
-                            let client = crate::http_client::client_builder()
-                                .timeout(std::time::Duration::from_secs(10))
-                                .build()
-                                .ok();
+                        if let event::BackendRef::Daemon { base_url, api_key } = backend {
+                            let client = {
+                                let mut builder = crate::http_client::client_builder()
+                                    .timeout(std::time::Duration::from_secs(10));
+                                if let Some(ref key) = api_key {
+                                    let mut headers = reqwest::header::HeaderMap::new();
+                                    if let Ok(val) = reqwest::header::HeaderValue::from_str(
+                                        &format!("Bearer {key}"),
+                                    ) {
+                                        headers.insert(reqwest::header::AUTHORIZATION, val);
+                                    }
+                                    builder = builder.default_headers(headers);
+                                }
+                                builder.build().ok()
+                            };
                             if let Some(client) = client {
                                 let mut fields = serde_json::Map::new();
                                 for (k, v) in &values {
@@ -1747,7 +1765,7 @@ impl App {
         self.chat.agent_name = name.clone();
         self.chat.mode_label = "daemon".to_string();
 
-        if let Backend::Daemon { ref base_url } = self.backend {
+        if let Backend::Daemon { ref base_url, .. } = self.backend {
             let client = crate::daemon_client();
             if let Ok(resp) = client.get(format!("{base_url}/api/agents/{id}")).send() {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -1804,11 +1822,12 @@ impl App {
         self.chat.status_msg = None;
 
         match (&self.backend, &self.chat_target) {
-            (Backend::Daemon { base_url }, Some(target)) if target.agent_id_daemon.is_some() => {
+            (Backend::Daemon { base_url, api_key }, Some(target)) if target.agent_id_daemon.is_some() => {
                 event::spawn_daemon_stream(
                     base_url.clone(),
                     target.agent_id_daemon.as_ref().unwrap().clone(),
                     message,
+                    api_key.clone(),
                     self.event_tx.clone(),
                 );
             }
@@ -1831,9 +1850,9 @@ impl App {
 
     fn spawn_agent(&mut self, toml_content: String) {
         match &self.backend {
-            Backend::Daemon { base_url } => {
+            Backend::Daemon { base_url, api_key } => {
                 self.agents.sub = agents::AgentSubScreen::Spawning;
-                event::spawn_daemon_agent(base_url.clone(), toml_content, self.event_tx.clone());
+                event::spawn_daemon_agent(base_url.clone(), toml_content, api_key.clone(), self.event_tx.clone());
             }
             Backend::InProcess { kernel } => {
                 let manifest: librefang_types::agent::AgentManifest =
@@ -1865,7 +1884,7 @@ impl App {
 
     fn open_model_picker(&mut self) {
         let models = match &self.backend {
-            Backend::Daemon { base_url } => {
+            Backend::Daemon { base_url, .. } => {
                 let client = crate::daemon_client();
                 match client.get(format!("{base_url}/api/models")).send() {
                     Ok(resp) => match resp.json::<serde_json::Value>() {
@@ -1925,7 +1944,7 @@ impl App {
         }
 
         match (&self.backend, &self.chat_target) {
-            (Backend::Daemon { base_url }, Some(target)) => {
+            (Backend::Daemon { base_url, .. }, Some(target)) => {
                 if let Some(ref agent_id) = target.agent_id_daemon {
                     let client = crate::daemon_client();
                     let url = format!("{base_url}/api/agents/{agent_id}/model");
@@ -2032,7 +2051,7 @@ impl App {
             "/status" => {
                 let mut s = Vec::new();
                 match &self.backend {
-                    Backend::Daemon { base_url } => {
+                    Backend::Daemon { base_url, .. } => {
                         s.push(format!("Mode: daemon ({base_url})"));
                         if let Some(ref t) = self.chat_target {
                             s.push(format!("Agent: {}", t.agent_name));
@@ -2052,7 +2071,7 @@ impl App {
             "/agents" => {
                 let mut lines = Vec::new();
                 match &self.backend {
-                    Backend::Daemon { base_url } => {
+                    Backend::Daemon { base_url, .. } => {
                         let client = crate::daemon_client();
                         if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
                             if let Ok(body) = resp.json::<serde_json::Value>() {
@@ -2109,7 +2128,7 @@ impl App {
                 if let Some(ref target) = self.chat_target {
                     let name = target.agent_name.clone();
                     match &self.backend {
-                        Backend::Daemon { base_url } => {
+                        Backend::Daemon { base_url, .. } => {
                             if let Some(ref id) = target.agent_id_daemon {
                                 let client = crate::daemon_client();
                                 let url = format!("{base_url}/api/agents/{id}");


### PR DESCRIPTION
## Summary

- **#3627** — `BackendRef::Daemon` now carries `api_key: Option<String>`; every TUI background fetcher builds its reqwest client via `make_daemon_client[_with_timeout]` which attaches `Authorization: Bearer <key>` when a key is present. `Backend::Daemon` in `mod.rs` likewise carries the key, read from config at `ConnectDaemon` time via the now-`pub(crate)` `read_api_key()`.
- **#3621** — `totp_setup` rejects a second setup call with `409 Conflict` when `totp_secret` is already present but `totp_confirmed != "true"`, preventing silent overwrite of a pending enrollment before it is confirmed.
- **#3661** — `memory.rs` `internal_error` now delegates to `map_memory_error` which inspects the error message prefix (matching `LibreFangError`'s `Display` impls) and returns `400/403/404/429` for `InvalidInput` / `CapabilityDenied` / `AgentNotFound` / `QuotaExceeded` instead of always returning 500.
- **#3641** — Removed the `git config core.hooksPath scripts/hooks` mutation from `librefang-cli/build.rs`; git hooks are a one-time developer setup step, not a side-effect of `cargo build`.
- **#3675** — Provenance rewrite block in `install_skill` now propagates all four error cases (`read_to_string`, `toml::from_str`, `toml::to_string`, `fs::write`) via `tracing::warn!` instead of silently discarding them.

## Test plan

- [ ] Start daemon with `api_key` set in config.toml; open TUI in daemon mode and verify all tabs populate without 401 errors
- [ ] Call `POST /api/approvals/totp/setup` twice without confirming the first; verify the second returns `409 Conflict`
- [ ] Call a memory endpoint with an invalid agent ID and verify HTTP 404 (not 500) is returned
- [ ] Run `cargo build` and verify no git config is mutated
- [ ] Install a skill via `POST /api/skills/install` and check logs for any provenance-patch warnings if skill.toml is malformed