### PR TITLE
fix(memory,api): SQLite FK enforcement, per-step migration transactions, save_session atomicity, schema version guard, daemon file lock

### DIFF
--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -164,6 +164,7 @@ mini = [
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1.1", features = ["process"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1197,6 +1197,14 @@ pub async fn run_daemon(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = listen_addr.parse()?;
 
+    // Acquire an exclusive file lock on `daemon.lock` so two daemons can never
+    // open the same SQLite database simultaneously. This is a true cross-process
+    // mutex that works even when the old daemon was bound to a different port
+    // (making `is_daemon_responding` return false). The lock is released when
+    // `_daemon_lock` is dropped at the end of this function.
+    let lock_path = kernel.home_dir().join("daemon.lock");
+    let _daemon_lock = acquire_daemon_lock(&lock_path)?;
+
     let kernel = Arc::new(kernel);
     kernel.set_self_handle();
     kernel.start_background_agents().await;
@@ -1931,6 +1939,55 @@ async fn shutdown_signal(api_shutdown: Arc<tokio::sync::Notify>) {
             }
         }
     }
+}
+
+/// Acquire an exclusive file lock on `path`, creating the file if needed.
+///
+/// Returns a `std::fs::File` whose OS file lock is held for as long as the
+/// handle is alive. Dropping the handle releases the lock automatically (the
+/// kernel releases all `flock` locks when the last fd for the file is closed).
+///
+/// On Unix this uses `flock(2)` with `LOCK_EX | LOCK_NB` — a true
+/// cross-process mutex. If another daemon already holds the lock the call
+/// returns `EWOULDBLOCK` immediately (non-blocking). On other platforms the
+/// file is opened as a best-effort marker only.
+fn acquire_daemon_lock(path: &Path) -> Result<std::fs::File, Box<dyn std::error::Error>> {
+    use std::fs::OpenOptions;
+
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|e| format!("Cannot open daemon lock file {}: {e}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        // SAFETY: flock(2) is safe to call on any open fd; the fd remains valid
+        // for the entire lifetime of `file`.
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if ret != 0 {
+            let errno = std::io::Error::last_os_error();
+            return Err(format!(
+                "Another LibreFang daemon is already running (could not acquire exclusive lock \
+                 on {}): {}. Stop the existing daemon before starting a new one.",
+                path.display(),
+                errno
+            )
+            .into());
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On non-Unix platforms (Windows, WASM, etc.) the lock file is created
+        // as a best-effort marker. A proper LockFileEx implementation can be
+        // added when needed.
+        let _ = &file;
+    }
+
+    Ok(file)
 }
 
 /// Check if a process with the given PID is still alive.

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -11,107 +11,59 @@ const SCHEMA_VERSION: u32 = 25;
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     let current_version = get_schema_version(conn);
 
-    if current_version < 1 {
-        migrate_v1(conn)?;
+    // Refuse to run if the DB was created by a newer binary. Silently
+    // downgrading `user_version` would corrupt v(N+1)+ columns/indexes.
+    if current_version > SCHEMA_VERSION {
+        return Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ffi::ErrorCode::CannotOpen,
+                extended_code: 0,
+            },
+            Some(format!(
+                "Database schema version {} is newer than this binary supports ({}). \
+                 Downgrade is not supported. Use the correct binary version or restore from backup.",
+                current_version, SCHEMA_VERSION
+            )),
+        ));
     }
 
-    if current_version < 2 {
-        migrate_v2(conn)?;
+    macro_rules! run_step {
+        ($version:expr, $migrate_fn:expr) => {
+            if current_version < $version {
+                let tx = conn.unchecked_transaction()?;
+                $migrate_fn(&tx)?;
+                set_schema_version(&tx, $version)?;
+                tx.commit()?;
+            }
+        };
     }
 
-    if current_version < 3 {
-        migrate_v3(conn)?;
-    }
+    run_step!(1, migrate_v1);
+    run_step!(2, migrate_v2);
+    run_step!(3, migrate_v3);
+    run_step!(4, migrate_v4);
+    run_step!(5, migrate_v5);
+    run_step!(6, migrate_v6);
+    run_step!(7, migrate_v7);
+    run_step!(8, migrate_v8);
+    run_step!(9, migrate_v9);
+    run_step!(10, migrate_v10);
+    run_step!(11, migrate_v11);
+    run_step!(12, migrate_v12);
+    run_step!(13, migrate_v13);
+    run_step!(14, migrate_v14);
+    run_step!(15, migrate_v15);
+    run_step!(16, migrate_v16);
+    run_step!(17, migrate_v17);
+    run_step!(18, migrate_v18);
+    run_step!(19, migrate_v19);
+    run_step!(20, migrate_v20);
+    run_step!(21, migrate_v21);
+    run_step!(22, migrate_v22);
+    run_step!(23, migrate_v23);
+    run_step!(24, migrate_v24);
+    run_step!(25, migrate_v25);
 
-    if current_version < 4 {
-        migrate_v4(conn)?;
-    }
-
-    if current_version < 5 {
-        migrate_v5(conn)?;
-    }
-
-    if current_version < 6 {
-        migrate_v6(conn)?;
-    }
-
-    if current_version < 7 {
-        migrate_v7(conn)?;
-    }
-
-    if current_version < 8 {
-        migrate_v8(conn)?;
-    }
-
-    if current_version < 9 {
-        migrate_v9(conn)?;
-    }
-
-    if current_version < 10 {
-        migrate_v10(conn)?;
-    }
-
-    if current_version < 11 {
-        migrate_v11(conn)?;
-    }
-
-    if current_version < 12 {
-        migrate_v12(conn)?;
-    }
-
-    if current_version < 13 {
-        migrate_v13(conn)?;
-    }
-
-    if current_version < 14 {
-        migrate_v14(conn)?;
-    }
-
-    if current_version < 15 {
-        migrate_v15(conn)?;
-    }
-
-    if current_version < 16 {
-        migrate_v16(conn)?;
-    }
-
-    if current_version < 17 {
-        migrate_v17(conn)?;
-    }
-
-    if current_version < 18 {
-        migrate_v18(conn)?;
-    }
-
-    if current_version < 19 {
-        migrate_v19(conn)?;
-    }
-
-    if current_version < 20 {
-        migrate_v20(conn)?;
-    }
-
-    if current_version < 21 {
-        migrate_v21(conn)?;
-    }
-
-    if current_version < 22 {
-        migrate_v22(conn)?;
-    }
-
-    if current_version < 23 {
-        migrate_v23(conn)?;
-    }
-
-    if current_version < 24 {
-        migrate_v24(conn)?;
-    }
-
-    if current_version < 25 {
-        migrate_v25(conn)?;
-    }
-
-    set_schema_version(conn, SCHEMA_VERSION)?;
     Ok(())
 }
 
@@ -421,16 +373,25 @@ fn migrate_v9(conn: &Connection) -> Result<(), rusqlite::Error> {
 
 /// Version 10: Add agent_id to entities and relations for per-agent cleanup.
 fn migrate_v10(conn: &Connection) -> Result<(), rusqlite::Error> {
+    // Use column_exists guards — identical to the pattern in v6, v14, v15 — so
+    // a retry after a partial failure does not error with "column already exists".
+    if !column_exists(conn, "entities", "agent_id") {
+        conn.execute(
+            "ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''",
+            [],
+        )?;
+    }
+    if !column_exists(conn, "relations", "agent_id") {
+        conn.execute(
+            "ALTER TABLE relations ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''",
+            [],
+        )?;
+    }
     conn.execute_batch(
-        "
-        ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT '';
-        ALTER TABLE relations ADD COLUMN agent_id TEXT NOT NULL DEFAULT '';
-        CREATE INDEX IF NOT EXISTS idx_entities_agent ON entities(agent_id);
-        CREATE INDEX IF NOT EXISTS idx_relations_agent ON relations(agent_id);
-
-        INSERT OR IGNORE INTO migrations (version, applied_at, description)
-        VALUES (10, datetime('now'), 'Add agent_id to entities and relations');
-        ",
+        "CREATE INDEX IF NOT EXISTS idx_entities_agent ON entities(agent_id);
+         CREATE INDEX IF NOT EXISTS idx_relations_agent ON relations(agent_id);
+         INSERT OR IGNORE INTO migrations (version, applied_at, description)
+         VALUES (10, datetime('now'), 'Add agent_id to entities and relations');",
     )?;
     Ok(())
 }

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -171,6 +171,10 @@ impl SessionStore {
     const MAX_PERSISTED_MESSAGES: usize = 200;
 
     /// Save a session to the database and update the FTS5 index.
+    ///
+    /// All three writes (INSERT session, DELETE FTS, INSERT FTS) are wrapped in
+    /// a single transaction so a crash between them cannot leave the session row
+    /// and the FTS index inconsistent.
     pub fn save_session(&self, session: &Session) -> LibreFangResult<()> {
         let conn = self
             .conn
@@ -188,12 +192,27 @@ impl SessionStore {
         let messages_blob = rmp_serde::to_vec_named(messages_to_persist)
             .map_err(|e| LibreFangError::Serialization(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
-        conn.execute(
+
+        // Extract FTS content before acquiring the transaction so we don't hold
+        // the lock longer than necessary for CPU-bound work.
+        let content = Self::extract_text_content(messages_to_persist);
+        let session_id_str = session.id.0.to_string();
+        let agent_id_str = session.agent_id.0.to_string();
+
+        // Wrap session upsert + FTS update in a single transaction so a crash
+        // between the three statements cannot leave session and FTS data
+        // inconsistent. `unchecked_transaction` is safe here because we hold
+        // the Mutex exclusively (no other thread can access this Connection).
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+        tx.execute(
             "INSERT INTO sessions (id, agent_id, messages, context_window_tokens, label, created_at, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
              ON CONFLICT(id) DO UPDATE SET messages = ?3, context_window_tokens = ?4, label = ?5, updated_at = ?6",
             rusqlite::params![
-                session.id.0.to_string(),
+                session_id_str,
                 session.agent_id.0.to_string(),
                 messages_blob,
                 session.context_window_tokens as i64,
@@ -203,23 +222,18 @@ impl SessionStore {
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-        // Update FTS5 index — extract text from persisted messages only.
-        let content = Self::extract_text_content(messages_to_persist);
-        let session_id_str = session.id.0.to_string();
-        let agent_id_str = session.agent_id.0.to_string();
-
         // Delete existing FTS entry, then insert fresh content. Log on
         // failure — silently dropping these keeps orphan/stale rows in
         // sessions_fts whose JOINs to the real sessions table return
         // NULL, poisoning full-text search results.
-        if let Err(e) = conn.execute(
+        if let Err(e) = tx.execute(
             "DELETE FROM sessions_fts WHERE session_id = ?1",
             rusqlite::params![session_id_str],
         ) {
             warn!(session_id = %session_id_str, error = %e, "Failed to clear FTS entry for session");
         }
         if !content.is_empty() {
-            if let Err(e) = conn.execute(
+            if let Err(e) = tx.execute(
                 "INSERT INTO sessions_fts (session_id, agent_id, content) VALUES (?1, ?2, ?3)",
                 rusqlite::params![session_id_str, agent_id_str, content],
             ) {
@@ -227,6 +241,7 @@ impl SessionStore {
             }
         }
 
+        tx.commit().map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
     }
 

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -55,7 +55,9 @@ impl MemorySubstrate {
             "PRAGMA journal_mode=WAL; \
              PRAGMA busy_timeout=5000; \
              PRAGMA cache_size=-2000; \
-             PRAGMA mmap_size=0;",
+             PRAGMA mmap_size=0; \
+             PRAGMA foreign_keys=ON; \
+             PRAGMA synchronous=NORMAL;",
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         run_migrations(&conn).map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -85,6 +87,11 @@ impl MemorySubstrate {
     ) -> LibreFangResult<Self> {
         let conn =
             Connection::open_in_memory().map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        conn.execute_batch(
+            "PRAGMA foreign_keys=ON; \
+             PRAGMA synchronous=NORMAL;",
+        )
+        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         run_migrations(&conn).map_err(|e| LibreFangError::Memory(e.to_string()))?;
         let shared = Arc::new(Mutex::new(conn));
 


### PR DESCRIPTION
## Summary

- **#3645** — `PRAGMA foreign_keys=ON; PRAGMA synchronous=NORMAL;` added to every connection open path in `substrate.rs` (both file-backed and in-memory). FK constraints were never enforced before; orphan rows accumulated freely.
- **#3595 / #3653** — Each `migrate_vN` call in `run_migrations` is now wrapped in its own `unchecked_transaction`, with `user_version` bumped inside that transaction. A mid-migration crash now leaves the DB at the last successfully committed step. `migrate_v10` gains `column_exists()` guards on its two `ALTER TABLE` statements (matching the pattern already used in v6/v14/v15), so a retry after a partial v10 failure no longer errors with "column already exists".
- **#3656** — `run_migrations` now returns an error immediately if `user_version > SCHEMA_VERSION`, preventing a binary downgrade from silently writing an older version number back into a newer-schema database.
- **#3647** — `save_session` wraps all three SQL statements (INSERT session, DELETE FTS, INSERT FTS) in a single transaction so a crash between them cannot leave the session row and FTS index inconsistent.
- **#3682** — `run_daemon` acquires an exclusive `flock(2)` lock on `~/.librefang/daemon.lock` before opening SQLite. This is a true cross-process mutex that prevents two daemons from sharing the same database even when the old daemon is on a different port (making `is_daemon_responding` return false).

## Test plan

- [ ] `cargo test -p librefang-memory` — existing migration idempotency and session tests pass
- [ ] Manual: start daemon, attempt to start a second — should be rejected with "could not acquire exclusive lock" error
- [ ] Manual: start daemon with a DB whose `user_version` is higher than the binary supports — should refuse to boot with a clear downgrade error
- [ ] CI passes all 2100+ tests