### PR TITLE
fix(kernel,llm-drivers): 5 runtime behavior bugs (#3597 #3611 #3625 #3628 #3672)

### DIFF
--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -88,15 +88,128 @@ impl ApprovalManager {
     }
 
     /// Create an approval manager with persistent audit logging.
+    ///
+    /// Also restores any `pending_approvals` rows that survived across the
+    /// restart (issue #3611). Restored entries have no live `oneshot::Sender`,
+    /// so they cannot be auto-resolved by the agent loop — they surface in
+    /// the dashboard / API as pending items that require operator action.
     pub fn new_with_db(policy: ApprovalPolicy, conn: Arc<StdMutex<Connection>>) -> Self {
         let failures = Self::load_totp_lockout(&conn);
+        let pending: DashMap<Uuid, PendingRequest> = DashMap::new();
+        // Restore pending approvals from the previous session.
+        Self::restore_pending_approvals(&conn, &pending);
         Self {
-            pending: DashMap::new(),
+            pending,
             recent: std::sync::Mutex::new(VecDeque::new()),
             policy: std::sync::RwLock::new(policy),
             audit_db: Some(conn),
             totp_grace: StdMutex::new(HashMap::new()),
             totp_failures: StdMutex::new(failures),
+        }
+    }
+
+    /// Restore pending approvals from the database into the in-memory map.
+    ///
+    /// Each restored entry has no `oneshot::Sender` (the agent loop that
+    /// submitted the original request is gone) and no `deferred` payload.
+    /// They show up in the API as "needs resubmission" so an operator can
+    /// take action rather than losing them silently.
+    fn restore_pending_approvals(
+        conn: &Arc<StdMutex<Connection>>,
+        pending: &DashMap<Uuid, PendingRequest>,
+    ) {
+        let Ok(guard) = conn.lock() else { return };
+        let Ok(mut stmt) = guard.prepare(
+            "SELECT id, agent_id, session_id, tool_name, tool_input, created_at, expires_at \
+             FROM pending_approvals",
+        ) else {
+            return;
+        };
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, Option<i64>>(6)?,
+            ))
+        });
+        let Ok(rows) = rows else { return };
+        for row in rows.filter_map(|r| r.ok()) {
+            let (id_str, agent_id, session_id, tool_name, tool_input, created_at_unix, _expires_at) =
+                row;
+            let Ok(id) = id_str.parse::<Uuid>() else {
+                warn!(id = %id_str, "pending_approvals: skipping row with invalid UUID");
+                continue;
+            };
+            let requested_at = chrono::DateTime::from_timestamp(created_at_unix, 0)
+                .unwrap_or_else(chrono::Utc::now);
+            let request = ApprovalRequest {
+                id,
+                agent_id,
+                tool_name: tool_name.clone(),
+                description: format!("Restored pending approval (daemon restarted): {tool_name}"),
+                action_summary: tool_input,
+                risk_level: RiskLevel::High,
+                requested_at,
+                // Use a long timeout — operator must resolve manually.
+                timeout_secs: 86400,
+                sender_id: None,
+                channel: None,
+                route_to: Vec::new(),
+                escalation_count: 0,
+                session_id,
+            };
+            info!(
+                request_id = %id,
+                tool = %tool_name,
+                "Restored pending approval from database after restart"
+            );
+            pending.insert(
+                id,
+                PendingRequest {
+                    request,
+                    sender: None,
+                    deferred: None,
+                    submitted_at: requested_at,
+                },
+            );
+        }
+    }
+
+    /// Persist a new pending approval to the database so it survives restarts.
+    fn db_insert_pending(&self, req: &ApprovalRequest) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        let created_unix = req.requested_at.timestamp();
+        if let Err(e) = conn.execute(
+            "INSERT OR IGNORE INTO pending_approvals \
+             (id, agent_id, session_id, tool_name, tool_input, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                req.id.to_string(),
+                req.agent_id,
+                req.session_id,
+                req.tool_name,
+                &req.action_summary,
+                created_unix,
+            ],
+        ) {
+            warn!(request_id = %req.id, error = %e, "Failed to persist pending approval to database");
+        }
+    }
+
+    /// Remove a resolved/expired pending approval from the database.
+    fn db_delete_pending(&self, id: Uuid) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        if let Err(e) = conn.execute(
+            "DELETE FROM pending_approvals WHERE id = ?1",
+            rusqlite::params![id.to_string()],
+        ) {
+            warn!(request_id = %id, error = %e, "Failed to delete pending approval from database");
         }
     }
 
@@ -275,6 +388,9 @@ impl ApprovalManager {
             let req_for_timeout = current_req.clone();
 
             let (tx, rx) = tokio::sync::oneshot::channel();
+            // Persist before inserting into the in-memory map so the entry
+            // survives a daemon crash/restart (issue #3611).
+            self.db_insert_pending(&req_for_timeout);
             self.pending.insert(
                 id,
                 PendingRequest {
@@ -313,6 +429,8 @@ impl ApprovalManager {
                             .remove(&id)
                             .map(|(_, p)| p.request)
                             .unwrap_or(req_for_timeout);
+                        // Remove from persistent store (issue #3611).
+                        self.db_delete_pending(id);
                         self.push_recent(request, decision.clone(), None, Utc::now(), false);
                         warn!(request_id = %id, decision = %decision.as_str(), "Approval timed out");
                         return decision;
@@ -350,6 +468,8 @@ impl ApprovalManager {
         }
 
         let id = req.id;
+        // Persist before inserting so the entry survives a daemon restart (issue #3611).
+        self.db_insert_pending(&req);
         self.pending.insert(
             id,
             PendingRequest {
@@ -416,6 +536,8 @@ impl ApprovalManager {
                         });
                     }
                     ExpiryOutcome::Resolve(decision) => {
+                        // Remove from persistent store (issue #3611).
+                        self.db_delete_pending(id);
                         self.push_recent(
                             pending.request.clone(),
                             decision.clone(),
@@ -480,6 +602,9 @@ impl ApprovalManager {
 
         match self.pending.remove(&request_id) {
             Some((_, pending)) => {
+                // Remove from persistent store now that it is resolved (issue #3611).
+                self.db_delete_pending(request_id);
+
                 // Record TOTP grace on successful approval with TOTP.
                 if decision.is_approved() && totp_verified {
                     if let Some(uid) = user_id {

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -282,6 +282,23 @@ pub fn build_reload_plan_with_caps(
             .push("vault config changed".to_string());
     }
 
+    // Queue concurrency config — lane semaphores and per-agent caps are
+    // created once at kernel boot and cannot be resized at runtime without
+    // draining all in-flight tasks. Surfacing a restart-required diagnostic
+    // prevents silent no-ops (issue #3628).
+    if field_changed(&old.queue.concurrency, &new.queue.concurrency) {
+        plan.restart_required = true;
+        plan.restart_reasons.push(
+            "queue.concurrency.* changed — lane semaphores are fixed at boot; \
+             restart the daemon to apply the new concurrency limits"
+                .to_string(),
+        );
+        warn!(
+            "config reload: queue.concurrency.* changed but cannot be applied \
+             at runtime — restart the daemon to pick up new lane/per-agent limits"
+        );
+    }
+
     // ----- Hot-reloadable fields -----
 
     if field_changed(&old.channels, &new.channels) {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8694,6 +8694,13 @@ system_prompt = "You are a helpful assistant."
 
         // Phase 4: BeforeUser-position injections (appended; they logically
         // precede user messages that haven't arrived yet).
+        //
+        // Track message count before injection so we can roll back the
+        // in-memory state if the persist fails (issue #3672). Without a
+        // rollback, the next pass sees the injected messages in-memory but
+        // not on-disk, re-injects them, and silently invalidates the prompt
+        // cache.
+        let pre_before_user_len = session.messages.len();
         for inj in &all_injections {
             if inj.position == InjectionPosition::BeforeUser && condition_met(&inj.condition) {
                 session.messages.push(Message::system(inj.content.clone()));
@@ -8707,7 +8714,24 @@ system_prompt = "You are a helpful assistant."
 
         // Persist if anything was injected.
         if !session.messages.is_empty() {
-            let _ = self.memory.save_session(session);
+            if let Err(e) = self.memory.save_session(session) {
+                // Persist failed — roll back the Phase 4 BeforeUser injections
+                // from the in-memory session so the next call does not
+                // re-inject the same items (which would cause duplicate
+                // context and invalidate the prompt cache).
+                let after_len = session.messages.len();
+                if after_len > pre_before_user_len {
+                    session.messages.truncate(pre_before_user_len);
+                }
+                tracing::error!(
+                    session_id = %session.id.0,
+                    error = %e,
+                    rolled_back = after_len.saturating_sub(pre_before_user_len),
+                    "Failed to persist session after before_user injection; \
+                     rolled back in-memory mutations to prevent duplicate injection \
+                     and prompt-cache invalidation"
+                );
+            }
         }
 
         // Run on_session_start_script if configured (fire-and-forget).
@@ -12523,7 +12547,21 @@ system_prompt = "You are a helpful assistant."
                                 //     every fire back to the persistent
                                 //     `(agent, "cron")` session — see
                                 //     CLAUDE.md note on cron + session_mode.
-                                let wants_new_session = job.session_mode
+                                //
+                                // Resolution order (#3597): per-job override >
+                                // agent manifest default > historical persistent.
+                                // When the job has no per-job `session_mode` set
+                                // (`None`), we fall back to the agent manifest's
+                                // `session_mode` so that agents with
+                                // `session_mode = "new"` in agent.toml get
+                                // per-fire isolation for cron jobs as well.
+                                let effective_session_mode = job.session_mode.or_else(|| {
+                                    kernel
+                                        .registry
+                                        .get(agent_id)
+                                        .map(|entry| entry.manifest.session_mode)
+                                });
+                                let wants_new_session = effective_session_mode
                                     == Some(librefang_types::agent::SessionMode::New);
                                 let cron_sender = SenderContext {
                                     channel: SYSTEM_CHANNEL_CRON.to_string(),
@@ -12540,7 +12578,7 @@ system_prompt = "You are a helpful assistant."
                                 let (mode_override, fire_session_override) =
                                     crate::cron::cron_fire_session_override(
                                         agent_id,
-                                        job.session_mode,
+                                        effective_session_mode,
                                         job.id,
                                         chrono::Utc::now(),
                                     );

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -171,6 +171,14 @@ pub struct ChatGptDriver {
     token_cache: ChatGptTokenCache,
     /// HTTP client.
     client: reqwest::Client,
+    /// Single-flight mutex for token refresh (issue #3625).
+    ///
+    /// OAuth 2.1 rotates the refresh token on every use: only the first
+    /// concurrent refresh wins; the rest receive `invalid_grant`. By
+    /// serialising refresh attempts here, concurrent 401 responders wait
+    /// for the in-flight refresh and then re-check the cache — avoiding the
+    /// thundering-herd that burns the refresh token.
+    refresh_lock: tokio::sync::Mutex<()>,
 }
 
 impl ChatGptDriver {
@@ -195,6 +203,7 @@ impl ChatGptDriver {
             },
             token_cache: ChatGptTokenCache::new(),
             client,
+            refresh_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -228,7 +237,22 @@ impl ChatGptDriver {
     }
 
     /// Refresh the access token after the API explicitly rejects the current one.
+    ///
+    /// Uses a `tokio::sync::Mutex` to ensure only one refresh runs at a time
+    /// (issue #3625 — single-flight). After acquiring the lock we re-check the
+    /// cache: a sibling waiter may have already completed the refresh while we
+    /// were queued, so we can skip the network call and return the fresh token.
     async fn refresh_token(&self) -> Result<CachedSessionToken, LlmError> {
+        // Acquire the single-flight lock first.
+        let _lock = self.refresh_lock.lock().await;
+
+        // Re-check cache after acquiring the lock — a previous waiter may
+        // have already refreshed successfully while we were waiting.
+        if let Some(cached) = self.token_cache.get() {
+            debug!("ChatGPT token already refreshed by concurrent caller; reusing cached token");
+            return Ok(cached);
+        }
+
         let refresh_tok = std::env::var("CHATGPT_REFRESH_TOKEN").map_err(|_| {
             LlmError::AuthenticationFailed(
                 "ChatGPT session token was rejected and no refresh token is available. Run `librefang auth chatgpt` to re-authenticate."
@@ -243,7 +267,7 @@ impl ChatGptDriver {
             ));
         }
 
-        debug!("ChatGPT session token rejected; attempting OAuth refresh");
+        debug!("ChatGPT session token rejected; attempting OAuth refresh (single-flight)");
         let auth = tokio::time::timeout(
             Duration::from_secs(TOKEN_REFRESH_TIMEOUT_SECS),
             librefang_runtime_oauth::chatgpt_oauth::refresh_access_token(&refresh_tok),

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 25;
+const SCHEMA_VERSION: u32 = 26;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -63,6 +63,8 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(23, migrate_v23);
     run_step!(24, migrate_v24);
     run_step!(25, migrate_v25);
+
+    run_step!(26, migrate_v26);
 
     Ok(())
 }
@@ -767,6 +769,34 @@ fn migrate_v25(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (25, datetime('now'), 'Add totp_used_codes table for TOTP replay prevention')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 26: Persistent pending approvals table (issue #3611).
+///
+/// Stores approval requests that are waiting for human operator action so
+/// they survive daemon restarts. On boot the `ApprovalManager` reads this
+/// table and re-populates its in-memory DashMap. Rows are deleted when the
+/// request is resolved (approved / denied / expired / timed-out).
+fn migrate_v26(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS pending_approvals (
+            id         TEXT    PRIMARY KEY,
+            agent_id   TEXT    NOT NULL,
+            session_id TEXT,
+            tool_name  TEXT    NOT NULL,
+            tool_input TEXT    NOT NULL DEFAULT '',
+            created_at INTEGER NOT NULL,
+            expires_at INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending_approvals_agent
+            ON pending_approvals(agent_id);",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (26, datetime('now'), 'Add pending_approvals table for cross-restart persistence (issue #3611)')",
         [],
     )?;
     Ok(())


### PR DESCRIPTION
## Summary

- **#3597 — Cron respects agent-level `session_mode`**: When a cron job has no per-job `session_mode` override, the dispatcher now falls back to the agent manifest's `session_mode`. Agents with `session_mode = "new"` in `agent.toml` now get per-fire isolated sessions for cron jobs via the existing `cron_fire_session_override` path.

- **#3611 — Persist pending approvals across restarts**: `ApprovalManager` now writes pending approval requests to a new `pending_approvals` SQLite table (schema `migrate_v24`) on submit, and deletes the row on resolve/expire/timeout. On kernel boot, `new_with_db` restores surviving rows into the in-memory DashMap so they remain visible in the dashboard/API after a daemon restart instead of being silently lost.

- **#3625 — OAuth single-flight token refresh**: `ChatGptDriver` now holds a `tokio::sync::Mutex<()>` refresh lock. Concurrent 401 responders queue behind the first refresh attempt; waiters re-check the token cache after the lock releases and skip the network call if another caller already refreshed. Prevents the thundering-herd that burns the rotating OAuth refresh token.

- **#3628 — Restart warning for `queue.concurrency.*` changes**: `build_reload_plan` now classifies `queue.concurrency.*` config changes as `restart_required` with an explanatory reason string, rather than silently treating them as a no-op. Operators see the diagnostic in logs and the dashboard.

- **#3672 — `before_user` injection persist error handling**: `inject_reset_prompt` records the pre-injection message count and truncates the in-memory session back to that baseline when `save_session` fails. Prevents duplicate injection and prompt-cache invalidation on the next call.

## Changed files

| File | Issue |
|------|-------|
| `crates/librefang-kernel/src/kernel/mod.rs` | #3597, #3672 |
| `crates/librefang-kernel/src/approval.rs` | #3611 |
| `crates/librefang-memory/src/migration.rs` | #3611 |
| `crates/librefang-kernel/src/config_reload.rs` | #3628 |
| `crates/librefang-llm-drivers/src/drivers/chatgpt.rs` | #3625 |

## Test plan

- [ ] Agents with `session_mode = "new"` and cron jobs (no per-job override) get distinct session IDs across fires
- [ ] `pending_approvals` table created on fresh DB; rows appear on submit and disappear on resolve
- [ ] After daemon restart with a pending approval, the approval shows up in `/api/approvals` without requiring resubmission
- [ ] With 2+ concurrent ChatGPT 401s, only one OAuth refresh POST is made (verify via logs: `single-flight`)
- [ ] Changing `queue.concurrency.trigger_lane` in config.toml and calling `/api/config/reload` returns a restart-required response with a clear message
- [ ] Simulated `save_session` failure in `inject_reset_prompt` rolls back in-memory messages (no duplicate on next call)