### PR TITLE
fix(ci): skip Cloudflare deploy step for fork PRs in deploy-web workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -45,6 +45,7 @@ jobs:
       - run: cd web && pnpm build
 
       - name: Deploy to Cloudflare Pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- `deploy-docs.yml` already had a guard to skip the Cloudflare Pages deploy step for fork PRs (`github.event.pull_request.head.repo.full_name == github.repository`), but `deploy-web.yml` was missing it
- Fork PRs don't have access to repository secrets, so wrangler fails with a `CLOUDFLARE_API_TOKEN` error
- Adds the same `if:` condition to `deploy-web.yml` for consistency

Fixes the CI failure seen on PRs like #3937.