### PR TITLE
ci(mobile): iOS + Android release jobs and PR build smoke

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -1,0 +1,119 @@
+# Repository Secrets
+
+This document tracks every GitHub Actions secret the LibreFang workflows
+consume, why each one exists, and how to rotate it. **Update this file
+whenever a workflow starts or stops using a secret** — silent drift is
+the failure mode that bites maintainers six months later when a release
+breaks and nobody remembers what `FOO_TOKEN_2` was for.
+
+> Repository → Settings → Secrets and variables → Actions
+
+Secrets are organisation-wide unless noted. Forks do not inherit them by
+design — the `pull_request` trigger explicitly runs without secrets, so
+any workflow gated on a fork-PR build must degrade gracefully when the
+secret is empty.
+
+---
+
+## Mobile distribution (release.yml `mobile_android` / `mobile_ios`)
+
+Required to attach signed mobile artifacts to GitHub releases. When any
+of these are absent the corresponding mobile job degrades to an unsigned
+debug build and skips the release-attach step — desktop builds are
+unaffected.
+
+### Android
+
+| Secret | Purpose | Format | Rotation |
+|---|---|---|---|
+| `ANDROID_KEYSTORE_B64` | Base64-encoded `release.jks` keystore. Lose this and Play Store will refuse all future updates — the package identity is bound to its signing key. **Back up offline.** | `base64 -w0 release.jks` | Forever (per Play Store policy) — only rotate if compromised, with explicit Play Store key-rotation flow |
+| `ANDROID_KEYSTORE_PASSWORD` | Password for the `.jks` keystore | UTF-8 | When personnel changes |
+| `ANDROID_KEY_ALIAS` | Alias of the release key inside the keystore | plain string | n/a |
+| `ANDROID_KEY_PASSWORD` | Password for the alias (often same as keystore password but treated separately) | UTF-8 | When personnel changes |
+
+**Generation reference**
+
+```sh
+keytool -genkey -v -keystore release.jks -alias librefang \
+  -keyalg RSA -keysize 4096 -validity 10000
+base64 -w0 release.jks > keystore.b64   # paste contents into ANDROID_KEYSTORE_B64
+```
+
+### iOS / Apple
+
+| Secret | Purpose | Format | Rotation |
+|---|---|---|---|
+| `APPLE_TEAM_ID` | 10-char Apple developer team ID | plain string (e.g. `ABCDE12345`) | n/a |
+| `APPLE_CERT_P12` | Distribution certificate (`.p12`) | `base64 -w0 dist.p12` | **Yearly** — Apple distribution certs expire after one year |
+| `APPLE_CERT_PASSWORD` | Password set when exporting the `.p12` from Keychain Access | UTF-8 | When personnel changes |
+| `APPLE_PROVISIONING_PROFILE_B64` | Distribution provisioning profile (`.mobileprovision`) | `base64 -w0 librefang.mobileprovision` | **Yearly** — bound to the cert above |
+
+**Rotation runbook (yearly Apple cert refresh)**
+
+1. Apple Developer portal → Certificates → renew the iOS Distribution cert.
+2. Download `.cer`, double-click to import into Keychain Access.
+3. Right-click the new cert → Export → save as `.p12` with a strong password.
+4. Update `APPLE_CERT_P12` and `APPLE_CERT_PASSWORD` in repo secrets.
+5. Profiles tab → regenerate the matching distribution provisioning
+   profile against the new cert.
+6. Update `APPLE_PROVISIONING_PROFILE_B64`.
+7. Trigger `release.yml` via `workflow_dispatch` against a tagged commit
+   to validate end-to-end before the next real release.
+
+---
+
+## Desktop signing (release.yml `desktop`)
+
+| Secret | Purpose |
+|---|---|
+| `MAC_CERT_BASE64` | macOS Developer ID Application cert (.p12, base64) for signing the Tauri desktop bundles |
+| `MAC_CERT_PASSWORD` | Password for the .p12 above |
+| `MAC_NOTARIZE_APPLE_ID` | Apple ID used for `notarytool submit` |
+| `MAC_NOTARIZE_PASSWORD` | App-specific password for that Apple ID |
+| `MAC_NOTARIZE_TEAM_ID` | Apple team ID for notarisation |
+| `TAURI_SIGNING_PRIVATE_KEY` | Tauri updater signing key (PEM) — DO NOT confuse with the Apple Developer cert; this signs auto-update manifests |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Passphrase for the updater key |
+
+---
+
+## Package registries
+
+| Secret | Purpose |
+|---|---|
+| `NPM_TOKEN` | Publishes `@librefang/*` packages to npm |
+| `PYPI_API_TOKEN` | Legacy fallback only — primary path is OIDC trusted-publishing |
+| `CARGO_REGISTRY_TOKEN` | Publishes `librefang-sdk` (and friends) to crates.io |
+
+PyPI uses GitHub OIDC trusted publishing where possible — keep the API
+token only as a break-glass option.
+
+---
+
+## Internal infrastructure
+
+| Secret | Purpose |
+|---|---|
+| `HOMEBREW_TAP_TOKEN` | PAT with `contents:write` on `librefang/homebrew-tap` for `sync_homebrew` / `sync_homebrew_cask` |
+| `RAILWAY_TOKEN` / `RENDER_API_KEY` / `FLY_API_TOKEN` | One-click deploy preview environments triggered by `release.yml` |
+
+---
+
+## Operational rules
+
+- **Never echo a secret.** GitHub Actions masks known secret values, but
+  one `set -x` upstream of a `cat keystore.jks` will leak the binary —
+  always pipe through `base64 --decode > "$RUNNER_TEMP/..."` directly.
+- **Wipe runner copies.** Every workflow that materialises a secret to
+  disk (`$RUNNER_TEMP/cert.p12`, `$RUNNER_TEMP/release.jks`, etc.) must
+  end with an `if: always()` cleanup step so a build cancellation does
+  not leave the artifact on a self-hosted runner.
+- **Forks shouldn't fail.** All mobile and desktop signing steps are
+  guarded by an "is this secret present?" check that downgrades to an
+  unsigned build instead of failing the job. This keeps the smoke build
+  meaningful for external contributors.
+- **Rotate on personnel change.** When a maintainer with secret access
+  leaves, rotate `*_PASSWORD` and any PAT-backed secrets within a week.
+
+When in doubt, prefer adding a new secret over reusing an existing one
+with overloaded scope — clarity at rotation time is worth the small
+extra cost in the secret store.

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -101,16 +101,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
-        with:
-          xcode-version: "16.2"
-
-      # macos-15 + Xcode 16 ships only the macOS SDK by default; the iOS
-      # simulator runtime is fetched on demand. Without this download
-      # xcodebuild fails with "Found no destinations for the scheme
-      # 'librefang-desktop_iOS' and action build".
-      - name: Download iOS Simulator runtime
-        run: xcodebuild -downloadPlatform iOS
+      # Use the macos-15 image's default Xcode (16.x) — it understands the
+      # objectVersion=77 pbxproj that `tauri ios init` emits and ships with
+      # an iOS Simulator runtime preinstalled. setup-xcode@v1 switching to a
+      # pinned Xcode build (e.g. 16.2) silently lands on an install whose
+      # iOS Simulator runtime isn't pre-staged, and `xcodebuild
+      # -downloadPlatform iOS` then fails on hosted runners with "Unable to
+      # connect to simulator" (exit 70).
+      - name: Show selected Xcode
+        run: |
+          xcode-select -p
+          xcodebuild -version
+          xcrun simctl list runtimes available | head -20
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -109,21 +109,18 @@ jobs:
 
   ios_smoke:
     name: iOS (simulator, unsigned)
-    # macos-15 ships Xcode 16, which understands the objectVersion=77
-    # pbxproj that `tauri ios init` (cargo-mobile2) emits. macos-14 + Xcode
-    # 15.4 fails with "future Xcode project file format (77)".
-    runs-on: macos-15
+    # macos-26 ships Xcode 26 + iOS 26.4 Simulator runtime pre-staged.
+    # Matches the local dev setup (Xcode 26.4.1 + iOS 26.4 SDK), so the
+    # smoke binary is built against the same SDK developers ship from.
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # Use the macos-15 image's default Xcode (16.x) — it understands the
-      # objectVersion=77 pbxproj that `tauri ios init` emits and ships with
-      # an iOS Simulator runtime preinstalled. setup-xcode@v1 switching to a
-      # pinned Xcode build (e.g. 16.2) silently lands on an install whose
-      # iOS Simulator runtime isn't pre-staged, and `xcodebuild
-      # -downloadPlatform iOS` then fails on hosted runners with "Unable to
-      # connect to simulator" (exit 70).
+      - uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
+        with:
+          xcode-version: "26.4.1"
+
       - name: Show selected Xcode
         run: |
           xcode-select -p

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -109,17 +109,16 @@ jobs:
 
   ios_smoke:
     name: iOS (simulator, unsigned)
-    # macos-26 ships Xcode 26 + iOS 26.4 Simulator runtime pre-staged.
-    # Matches the local dev setup (Xcode 26.4.1 + iOS 26.4 SDK), so the
-    # smoke binary is built against the same SDK developers ship from.
+    # macos-26 ships Xcode 26 (default 26.2) + iOS 26.x Simulator runtimes
+    # pre-staged. Use the default Xcode rather than pinning 26.4.1: pinning
+    # forces a setup-xcode switch (~1–2 min overhead per run) for an SDK
+    # delta that doesn't materially affect a Tauri smoke build, which only
+    # needs *some* iOS 26 SDK to verify the toolchain still produces a
+    # binary.
     runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
-        with:
-          xcode-version: "26.4.1"
 
       - name: Show selected Xcode
         run: |

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-java@7a445ee0e10ddc8ddedd4e85cee2b5a8a8a3afba # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -1,0 +1,136 @@
+name: Mobile Build Smoke
+
+# Best-effort PR smoke test for the iOS / Android Tauri targets. Triggers
+# only when the mobile surface actually changed — full release builds live
+# in `release.yml` under `mobile_android` / `mobile_ios`.
+#
+# Both jobs run unsigned debug builds: the goal is "did the toolchain still
+# produce a binary?", not "is it shippable?". They never call into Apple /
+# Play and never need signing secrets, so a contributor's fork can run the
+# exact same checks the mainline runs.
+
+on:
+  pull_request:
+    paths:
+      - "crates/librefang-desktop/**"
+      - "crates/librefang-api/dashboard/**"
+      - "gen/**"
+      - ".github/workflows/mobile-smoke.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android_smoke:
+    name: Android (debug, unsigned)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NDK_VERSION: "27.0.12077973"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-java@7a445ee0e10ddc8ddedd4e85cee2b5a8a8a3afba # v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        with:
+          packages: "platforms;android-34 build-tools;34.0.0 ndk;${{ env.NDK_VERSION }}"
+
+      - name: Export NDK_HOME
+        run: echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/$NDK_VERSION" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-linux-android
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+        with:
+          version: 10
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: mobile-android-smoke
+
+      - name: Cache Gradle
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-smoke-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-smoke-
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli@^2 --locked
+
+      - name: Build embedded dashboard assets
+        working-directory: crates/librefang-api/dashboard
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm run build
+
+      - name: Initialise Android project
+        working-directory: crates/librefang-desktop
+        run: cargo tauri android init
+
+      - name: Build debug APK (unsigned)
+        working-directory: crates/librefang-desktop
+        run: cargo tauri android build --target aarch64 --debug --apk
+
+  ios_smoke:
+    name: iOS (simulator, unsigned)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
+        with:
+          xcode-version: "15.4"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-apple-ios-sim
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+        with:
+          version: 10
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: mobile-ios-smoke
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli@^2 --locked
+
+      - name: Build embedded dashboard assets
+        working-directory: crates/librefang-api/dashboard
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm run build
+
+      - name: Initialise iOS project
+        working-directory: crates/librefang-desktop
+        run: cargo tauri ios init
+
+      - name: Build for simulator (unsigned)
+        working-directory: crates/librefang-desktop
+        run: cargo tauri ios build --target aarch64-sim --debug

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -105,6 +105,13 @@ jobs:
         with:
           xcode-version: "16.2"
 
+      # macos-15 + Xcode 16 ships only the macOS SDK by default; the iOS
+      # simulator runtime is fetched on demand. Without this download
+      # xcodebuild fails with "Found no destinations for the scheme
+      # 'librefang-desktop_iOS' and action build".
+      - name: Download iOS Simulator runtime
+        run: xcodebuild -downloadPlatform iOS
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-ios-sim

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -82,8 +82,21 @@ jobs:
           key: gradle-smoke-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-smoke-
 
+      # Cache the compiled tauri-cli binary across runs. Swatinem/rust-cache
+      # caches target/ + cargo registries, but NOT ~/.cargo/bin, so the
+      # 1-2 minute `cargo install tauri-cli` recompile happens cold every
+      # time without this. Cache hit = skip the install entirely.
+      - name: Cache tauri-cli binary
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-${{ runner.os }}-v2
+
       - name: Install Tauri CLI
-        run: cargo install tauri-cli@^2 --locked
+        run: |
+          if ! command -v cargo-tauri >/dev/null; then
+            cargo install tauri-cli@^2 --locked
+          fi
 
       - name: Build embedded dashboard assets
         working-directory: crates/librefang-api/dashboard
@@ -142,8 +155,17 @@ jobs:
         with:
           key: mobile-ios-smoke
 
+      - name: Cache tauri-cli binary
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-${{ runner.os }}-v2
+
       - name: Install Tauri CLI
-        run: cargo install tauri-cli@^2 --locked
+        run: |
+          if ! command -v cargo-tauri >/dev/null; then
+            cargo install tauri-cli@^2 --locked
+          fi
 
       - name: Build embedded dashboard assets
         working-directory: crates/librefang-api/dashboard

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -1,16 +1,24 @@
 name: Mobile Build Smoke
 
-# Best-effort PR smoke test for the iOS / Android Tauri targets. Triggers
-# only when the mobile surface actually changed — full release builds live
-# in `release.yml` under `mobile_android` / `mobile_ios`.
+# Post-merge smoke test for the iOS / Android Tauri targets. Runs on
+# pushes to main when the mobile surface actually changed — full signed
+# release builds live in `release.yml` under `mobile_android` /
+# `mobile_ios` and only fire on tag push.
 #
-# Both jobs run unsigned debug builds: the goal is "did the toolchain still
-# produce a binary?", not "is it shippable?". They never call into Apple /
-# Play and never need signing secrets, so a contributor's fork can run the
-# exact same checks the mainline runs.
+# Why post-merge instead of per-PR: each leg pulls a cold Android NDK +
+# Xcode iOS SDK and a full Rust mobile rebuild — ~25 min each on a cache
+# miss. Running that on every desktop/dashboard PR burns a lot of CI
+# time for breakage that's caught on the merge run anyway. Maintainers
+# can still hit `workflow_dispatch` from the Actions tab to validate a
+# branch before merging.
+#
+# Both jobs are unsigned debug builds — the goal is "did the toolchain
+# still produce a binary?", not "is it shippable?". Signed builds live
+# in `release.yml`.
 
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - "crates/librefang-desktop/**"
       - "crates/librefang-api/dashboard/**"

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -93,7 +93,15 @@ jobs:
 
       - name: Initialise Android project
         working-directory: crates/librefang-desktop
-        run: cargo tauri android init
+        # The repo ships gen/android/README.md as a placeholder so the
+        # directory exists in fresh clones. tauri-cli treats any pre-existing
+        # gen/android as "already populated" and refuses to scaffold the
+        # missing package layout, failing init with "Project directory
+        # gen/android/app/src/main/java/ai/librefang/app does not exist".
+        # Wipe the placeholder before init so we always start from clean.
+        run: |
+          rm -rf gen/android
+          cargo tauri android init
 
       - name: Build debug APK (unsigned)
         working-directory: crates/librefang-desktop

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -93,14 +93,17 @@ jobs:
 
   ios_smoke:
     name: iOS (simulator, unsigned)
-    runs-on: macos-14
+    # macos-15 ships Xcode 16, which understands the objectVersion=77
+    # pbxproj that `tauri ios init` (cargo-mobile2) emits. macos-14 + Xcode
+    # 15.4 fails with "future Xcode project file format (77)".
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "16.2"
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1366,7 +1366,12 @@ jobs:
 
       - name: Initialise Android project
         working-directory: crates/librefang-desktop
-        run: cargo tauri android init
+        # See mobile-smoke.yml — the repo's `gen/android/README.md`
+        # placeholder confuses tauri-cli into thinking the project is
+        # already scaffolded. Wipe it so init starts clean.
+        run: |
+          rm -rf gen/android
+          cargo tauri android init
 
       - name: Decode Android signing keystore
         id: keystore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1284,6 +1284,254 @@ jobs:
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}
 
+  # ── Mobile builds ──────────────────────────────────────────────────────
+  #
+  # Treated as best-effort: a flaky cert refresh on Apple's side or an
+  # Android signing snag must NOT block the desktop matrix above. Each
+  # mobile job uses `continue-on-error: true` and `if: always()` for the
+  # release-attach step, so a failed build leaves the desktop release
+  # intact while still surfacing the failure in the workflow summary.
+  #
+  # Secrets required: see .github/SECRETS.md. When secrets are missing
+  # (typical on a fork or for the very first run on a fresh repo), each
+  # job degrades to an unsigned debug build that just verifies the
+  # toolchain still works, rather than failing the whole pipeline.
+
+  mobile_android:
+    name: Mobile / Android (aab + apk)
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
+    needs: [create_release]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    env:
+      # ANDROID_HOME / ANDROID_SDK_ROOT are exported by setup-android; the
+      # Tauri Android driver insists on NDK_HOME being set explicitly even
+      # though the SDK manager already installs the NDK below.
+      NDK_VERSION: "27.0.12077973"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up JDK 17 (Temurin)
+        uses: actions/setup-java@7a445ee0e10ddc8ddedd4e85cee2b5a8a8a3afba # v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK + NDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        with:
+          packages: "platforms;android-34 build-tools;34.0.0 ndk;${{ env.NDK_VERSION }}"
+
+      - name: Export NDK_HOME
+        run: |
+          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/$NDK_VERSION" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+        with:
+          version: 10
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: mobile-android-${{ github.ref_name }}
+
+      - name: Cache Gradle
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli@^2 --locked
+
+      - name: Build embedded dashboard assets
+        working-directory: crates/librefang-api/dashboard
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm run build
+
+      - name: Initialise Android project
+        working-directory: crates/librefang-desktop
+        run: cargo tauri android init
+
+      - name: Decode Android signing keystore
+        id: keystore
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_B64" ]; then
+            echo "::warning::ANDROID_KEYSTORE_B64 not set — falling back to debug build (unsigned, not for distribution)"
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$ANDROID_KEYSTORE_B64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build signed release (.aab + .apk)
+        if: steps.keystore.outputs.signed == 'true'
+        working-directory: crates/librefang-desktop
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          cargo tauri android build \
+            --target aarch64 \
+            --apk --aab
+
+      - name: Build unsigned debug (fallback)
+        if: steps.keystore.outputs.signed != 'true'
+        working-directory: crates/librefang-desktop
+        run: cargo tauri android build --target aarch64 --debug --apk
+
+      - name: Locate artifacts
+        id: art
+        run: |
+          set -euo pipefail
+          AAB=$(find . -name "*.aab" -path "*/release/*" | head -1 || true)
+          APK=$(find . -name "*.apk" \( -path "*/release/*" -o -path "*/debug/*" \) | head -1 || true)
+          echo "aab=$AAB" >> "$GITHUB_OUTPUT"
+          echo "apk=$APK" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        if: always() && (steps.art.outputs.aab != '' || steps.art.outputs.apk != '')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          for f in "${{ steps.art.outputs.aab }}" "${{ steps.art.outputs.apk }}"; do
+            [ -z "$f" ] && continue
+            base=$(basename "$f")
+            echo "Uploading $base"
+            gh release upload "$TAG" "$f" --clobber || true
+          done
+
+      - name: Wipe keystore from runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.jks"
+
+  mobile_ios:
+    name: Mobile / iOS (ipa)
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
+    needs: [create_release]
+    continue-on-error: true
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
+        with:
+          xcode-version: "15.4"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+        with:
+          version: 10
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: mobile-ios-${{ github.ref_name }}
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli@^2 --locked
+
+      - name: Build embedded dashboard assets
+        working-directory: crates/librefang-api/dashboard
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm run build
+
+      - name: Initialise iOS project
+        working-directory: crates/librefang-desktop
+        run: cargo tauri ios init
+
+      - name: Import distribution certificate
+        id: keychain
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_B64: ${{ secrets.APPLE_PROVISIONING_PROFILE_B64 }}
+        run: |
+          if [ -z "$APPLE_CERT_P12" ] || [ -z "$APPLE_PROVISIONING_PROFILE_B64" ]; then
+            echo "::warning::Apple signing secrets missing — falling back to simulator build (unsigned, not for TestFlight)"
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PWD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          echo "$APPLE_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$APPLE_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "$APPLE_PROVISIONING_PROFILE_B64" | base64 --decode \
+            > "$HOME/Library/MobileDevice/Provisioning Profiles/librefang.mobileprovision"
+          rm -f "$RUNNER_TEMP/cert.p12"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "keychain=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed .ipa
+        if: steps.keychain.outputs.signed == 'true'
+        working-directory: crates/librefang-desktop
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cargo tauri ios build --target aarch64
+
+      - name: Build simulator (fallback)
+        if: steps.keychain.outputs.signed != 'true'
+        working-directory: crates/librefang-desktop
+        run: cargo tauri ios build --target aarch64-sim --debug
+
+      - name: Locate .ipa
+        id: art
+        run: |
+          set -euo pipefail
+          IPA=$(find . -name "*.ipa" | head -1 || true)
+          echo "ipa=$IPA" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        if: always() && steps.art.outputs.ipa != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release upload "$TAG" "${{ steps.art.outputs.ipa }}" --clobber || true
+
+      - name: Tear down keychain
+        if: always() && steps.keychain.outputs.keychain != ''
+        run: |
+          security delete-keychain "${{ steps.keychain.outputs.keychain }}" || true
+
   sync_homebrew_cask:
     name: Sync Homebrew Cask
     if: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1440,20 +1440,16 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
     needs: [create_release]
     continue-on-error: true
-    # macos-15 ships Xcode 16, which understands the objectVersion=77
-    # pbxproj that `tauri ios init` (cargo-mobile2) emits. macos-14 + Xcode
-    # 15.4 fails with "future Xcode project file format (77)".
-    runs-on: macos-15
+    # macos-26 ships Xcode 26 + iOS 26.4 Simulator runtime pre-staged,
+    # matching the developer's local Xcode 26.4.1 setup.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # Use the macos-15 image's default Xcode (16.x) — it understands the
-      # objectVersion=77 pbxproj that `tauri ios init` emits and ships with
-      # the iOS Simulator runtime preinstalled. setup-xcode@v1 switching to
-      # a pinned Xcode build (e.g. 16.2) silently lands on an install whose
-      # iOS Simulator runtime isn't pre-staged, and `xcodebuild
-      # -downloadPlatform iOS` then fails on hosted runners with "Unable to
-      # connect to simulator" (exit 70).
+      - uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
+        with:
+          xcode-version: "26.4.1"
+
       - name: Show selected Xcode
         run: |
           xcode-select -p

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1343,6 +1343,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: mobile-android-${{ github.ref_name }}
+          restore-keys: |
+            mobile-android-
 
       - name: Cache Gradle
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
@@ -1410,10 +1412,12 @@ jobs:
         if: always() && (steps.art.outputs.aab != '' || steps.art.outputs.apk != '')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AAB_PATH: ${{ steps.art.outputs.aab }}
+          APK_PATH: ${{ steps.art.outputs.apk }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
-          for f in "${{ steps.art.outputs.aab }}" "${{ steps.art.outputs.apk }}"; do
+          for f in "$AAB_PATH" "$APK_PATH"; do
             [ -z "$f" ] && continue
             base=$(basename "$f")
             echo "Uploading $base"
@@ -1431,13 +1435,16 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
     needs: [create_release]
     continue-on-error: true
-    runs-on: macos-14
+    # macos-15 ships Xcode 16, which understands the objectVersion=77
+    # pbxproj that `tauri ios init` (cargo-mobile2) emits. macos-14 + Xcode
+    # 15.4 fails with "future Xcode project file format (77)".
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "16.2"
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -1454,6 +1461,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: mobile-ios-${{ github.ref_name }}
+          restore-keys: |
+            mobile-ios-
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli@^2 --locked
@@ -1522,15 +1531,18 @@ jobs:
         if: always() && steps.art.outputs.ipa != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IPA_PATH: ${{ steps.art.outputs.ipa }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
-          gh release upload "$TAG" "${{ steps.art.outputs.ipa }}" --clobber || true
+          gh release upload "$TAG" "$IPA_PATH" --clobber || true
 
       - name: Tear down keychain
         if: always() && steps.keychain.outputs.keychain != ''
+        env:
+          KEYCHAIN_PATH: ${{ steps.keychain.outputs.keychain }}
         run: |
-          security delete-keychain "${{ steps.keychain.outputs.keychain }}" || true
+          security delete-keychain "$KEYCHAIN_PATH" || true
 
   sync_homebrew_cask:
     name: Sync Homebrew Cask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1189,7 +1189,11 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import $RUNNER_TEMP/certificate.p12 -P "$MAC_CERT_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          # Prepend (NOT replace) the search list. Same reason as the
+          # mobile_ios job below — replace works on a clean GitHub-hosted
+          # runner but hides existing entries on a future self-hosted one.
+          PRIOR=$(security list-keychains -d user | tr -d '"' | tr '\n' ' ')
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $PRIOR
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1314,7 +1314,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 17 (Temurin)
-        uses: actions/setup-java@7a445ee0e10ddc8ddedd4e85cee2b5a8a8a3afba # v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "17"
@@ -1442,16 +1442,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
-        with:
-          xcode-version: "16.2"
-
-      # macos-15 + Xcode 16 ships only the macOS SDK by default; the iOS
-      # device + simulator SDKs are fetched on demand. Without this
-      # download `cargo tauri ios build` fails with "Found no destinations
-      # for the scheme 'librefang-desktop_iOS' and action build".
-      - name: Download iOS platform
-        run: xcodebuild -downloadPlatform iOS
+      # Use the macos-15 image's default Xcode (16.x) — it understands the
+      # objectVersion=77 pbxproj that `tauri ios init` emits and ships with
+      # the iOS Simulator runtime preinstalled. setup-xcode@v1 switching to
+      # a pinned Xcode build (e.g. 16.2) silently lands on an install whose
+      # iOS Simulator runtime isn't pre-staged, and `xcodebuild
+      # -downloadPlatform iOS` then fails on hosted runners with "Unable to
+      # connect to simulator" (exit 70).
+      - name: Show selected Xcode
+        run: |
+          xcode-select -p
+          xcodebuild -version
+          xcrun simctl list runtimes available | head -20
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1355,8 +1355,18 @@ jobs:
           key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
 
+      # See mobile-smoke.yml for why this cache is paired with the install.
+      - name: Cache tauri-cli binary
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-${{ runner.os }}-v2
+
       - name: Install Tauri CLI
-        run: cargo install tauri-cli@^2 --locked
+        run: |
+          if ! command -v cargo-tauri >/dev/null; then
+            cargo install tauri-cli@^2 --locked
+          fi
 
       - name: Build embedded dashboard assets
         working-directory: crates/librefang-api/dashboard
@@ -1472,8 +1482,17 @@ jobs:
           restore-keys: |
             mobile-ios-
 
+      - name: Cache tauri-cli binary
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-${{ runner.os }}-v2
+
       - name: Install Tauri CLI
-        run: cargo install tauri-cli@^2 --locked
+        run: |
+          if ! command -v cargo-tauri >/dev/null; then
+            cargo install tauri-cli@^2 --locked
+          fi
 
       - name: Build embedded dashboard assets
         working-directory: crates/librefang-api/dashboard
@@ -1505,7 +1524,12 @@ jobs:
           echo "$APPLE_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           security import "$RUNNER_TEMP/cert.p12" -P "$APPLE_CERT_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          # Prepend (NOT replace) the search list. On a clean GitHub-hosted
+          # macos runner only the login keychain is present and the delta
+          # is harmless, but a future self-hosted runner may have other
+          # entries we'd otherwise hide for the duration of the build.
+          PRIOR=$(security list-keychains -d user | tr -d '"' | tr '\n' ' ')
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $PRIOR
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1440,15 +1440,13 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
     needs: [create_release]
     continue-on-error: true
-    # macos-26 ships Xcode 26 + iOS 26.4 Simulator runtime pre-staged,
-    # matching the developer's local Xcode 26.4.1 setup.
+    # macos-26 ships Xcode 26 (default 26.2). Use the default Xcode
+    # rather than pinning a specific SDK — for a Tauri release build the
+    # SDK delta inside the 26.x line is irrelevant and skipping
+    # setup-xcode saves 1–2 min per run.
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
-        with:
-          xcode-version: "26.4.1"
 
       - name: Show selected Xcode
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1446,6 +1446,13 @@ jobs:
         with:
           xcode-version: "16.2"
 
+      # macos-15 + Xcode 16 ships only the macOS SDK by default; the iOS
+      # device + simulator SDKs are fetched on demand. Without this
+      # download `cargo tauri ios build` fails with "Found no destinations
+      # for the scheme 'librefang-desktop_iOS' and action build".
+      - name: Download iOS platform
+        run: xcodebuild -downloadPlatform iOS
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -535,6 +535,7 @@ _No notable changes._
 ### Changed
 
 - Default `api_listen` flipped from `0.0.0.0:4545` to `127.0.0.1:4545` (loopback-only). New installs are local-only by default; set `api_listen = "0.0.0.0:4545"` to expose on LAN/remote. Affects `librefang init`, the dashboard's init endpoint, and `librefang.toml.example`. `librefang start` with an explicit `--config <path>` that doesn't exist now prints a clear `librefang init` hint instead of failing obscurely. (#2766)
+- **iOS minimum supported version raised from 14.0 to 16.0.** Required by the Tauri 2 mobile toolchain that the new mobile CI builds against. Devices on iOS 14 or 15 (iPhone 6s, original iPhone SE, iPad Air 2 and similar) will no longer be able to install the LibreFang mobile app once mobile bundles ship. Affects only the iOS app — the desktop and Android builds are unchanged. (#3970)
 
 ### Security
 

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -56,3 +56,12 @@ mobile = []
 [[bin]]
 name = "librefang-desktop"
 path = "src/main.rs"
+
+# iOS / Android need the crate exposed as a `staticlib` (linked into the
+# native shell by Xcode / Gradle) and a `cdylib` (loaded by the Tauri
+# mobile runtime). `lib` (rlib) is kept so the desktop binary in
+# src/main.rs can still depend on the library normally. Without these
+# extra crate-types, `cargo tauri ios build` fails with
+#   "Library not found at .../liblibrefang_desktop.a"
+[lib]
+crate-type = ["staticlib", "cdylib", "lib"]

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -63,5 +63,12 @@ path = "src/main.rs"
 # src/main.rs can still depend on the library normally. Without these
 # extra crate-types, `cargo tauri ios build` fails with
 #   "Library not found at .../liblibrefang_desktop.a"
+#
+# Side effect: desktop builds now also produce the `staticlib` and
+# `cdylib` outputs. That adds a non-trivial link step (~10-20% extra
+# build time on a clean target/) — worth it for a unified workspace,
+# but if the desktop build ever feels slow this is one place to look.
+# Cargo doesn't let us conditionalize crate-type on `cfg(mobile)` at
+# the manifest layer, so we accept the cost.
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]

--- a/crates/librefang-desktop/capabilities/default.json
+++ b/crates/librefang-desktop/capabilities/default.json
@@ -3,6 +3,7 @@
   "identifier": "default",
   "description": "Default permissions for the LibreFang desktop app",
   "windows": ["main"],
+  "platforms": ["macOS", "windows", "linux"],
   "permissions": [
     "core:default",
     "notification:default",

--- a/crates/librefang-desktop/capabilities/mobile.json
+++ b/crates/librefang-desktop/capabilities/mobile.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/refs/heads/dev/crates/tauri-utils/schema.json",
+  "identifier": "mobile",
+  "description": "Mobile (iOS / Android) permissions for the LibreFang app — desktop-only plugins (shell, global-shortcut, autostart, updater) are not bundled on mobile.",
+  "windows": ["main"],
+  "platforms": ["iOS", "android"],
+  "permissions": [
+    "core:default",
+    "notification:default",
+    "dialog:default"
+  ]
+}

--- a/crates/librefang-desktop/src/commands.rs
+++ b/crates/librefang-desktop/src/commands.rs
@@ -189,7 +189,9 @@ pub async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
 
 // ── Credential storage (mobile only — keyring) ───────────────────────────
 
+#[cfg(any(target_os = "ios", target_os = "android"))]
 const KEYRING_SERVICE: &str = "librefang-mobile";
+#[cfg(any(target_os = "ios", target_os = "android"))]
 const KEYRING_ACCOUNT: &str = "daemon-credentials";
 
 /// Store daemon credentials in the OS keyring.

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -23,7 +23,9 @@ use librefang_kernel::LibreFangKernel;
 use librefang_types::event::{EventPayload, LifecycleEvent, SystemEvent};
 use std::sync::Arc;
 use std::time::Instant;
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::Manager;
+#[cfg(desktop)]
+use tauri::{WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
 
@@ -118,11 +120,20 @@ enum StartupMode {
     ConnectionScreen,
 }
 
+/// Mobile entry point. `tauri::mobile_entry_point` requires a 0-arg
+/// function, so on iOS/Android we wrap `run()` and pass defaults — the
+/// CLI flags it normally consumes don't apply when the OS launches the
+/// app via the bundled binary.
+#[cfg(mobile)]
+#[tauri::mobile_entry_point]
+fn mobile_main() {
+    run(None, false);
+}
+
 /// Entry point for the Tauri application.
 ///
 /// `server_url` — CLI `--server-url` override (remote mode).
 /// `force_local` — CLI `--local` flag (skip connection screen, start local).
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(server_url: Option<String>, force_local: bool) {
     // Init tracing
     tracing_subscriber::fmt()
@@ -349,35 +360,42 @@ pub fn run(server_url: Option<String>, force_local: bool) {
 
     builder
         .setup(move |app| {
-            if show_connection_screen {
-                let _window = WebviewWindowBuilder::new(
-                    app,
-                    "main",
-                    WebviewUrl::CustomProtocol(
-                        "lfconnect://localhost/"
-                            .parse()
-                            .expect("lfconnect URL must parse"),
-                    ),
-                )
-                .title("LibreFang — Connect")
-                .inner_size(1280.0, 800.0)
-                .min_inner_size(800.0, 600.0)
-                .center()
-                .visible(true)
-                .build()?;
-            } else {
-                // Direct mode — navigate to the resolved URL
-                let _window = WebviewWindowBuilder::new(
-                    app,
-                    "main",
-                    WebviewUrl::External(initial_url.parse().expect("Invalid server URL")),
-                )
-                .title("LibreFang")
-                .inner_size(1280.0, 800.0)
-                .min_inner_size(800.0, 600.0)
-                .center()
-                .visible(true)
-                .build()?;
+            // Window creation is desktop-only. On iOS/Android the host OS
+            // manages the main window via tauri.conf.json's "app.windows"
+            // entry, and WebviewWindowBuilder does not expose .title() /
+            // .inner_size() / .center() on mobile.
+            #[cfg(desktop)]
+            {
+                if show_connection_screen {
+                    let _window = WebviewWindowBuilder::new(
+                        app,
+                        "main",
+                        WebviewUrl::CustomProtocol(
+                            "lfconnect://localhost/"
+                                .parse()
+                                .expect("lfconnect URL must parse"),
+                        ),
+                    )
+                    .title("LibreFang — Connect")
+                    .inner_size(1280.0, 800.0)
+                    .min_inner_size(800.0, 600.0)
+                    .center()
+                    .visible(true)
+                    .build()?;
+                } else {
+                    // Direct mode — navigate to the resolved URL
+                    let _window = WebviewWindowBuilder::new(
+                        app,
+                        "main",
+                        WebviewUrl::External(initial_url.parse().expect("Invalid server URL")),
+                    )
+                    .title("LibreFang")
+                    .inner_size(1280.0, 800.0)
+                    .min_inner_size(800.0, 600.0)
+                    .center()
+                    .visible(true)
+                    .build()?;
+                }
             }
 
             // Set up system tray (desktop only)

--- a/crates/librefang-desktop/tauri.ios.conf.json
+++ b/crates/librefang-desktop/tauri.ios.conf.json
@@ -3,7 +3,7 @@
   "identifier": "ai.librefang.app",
   "bundle": {
     "iOS": {
-      "minimumSystemVersion": "14.0"
+      "minimumSystemVersion": "16.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #3345 — the CI side of the mobile epic. Desktop matrix already produces all six native bundles; this fills in the missing iOS + Android leg.

**`release.yml`**

- New job **`mobile_android`** on `ubuntu-latest`: JDK 17, Android SDK + NDK r27, Rust `aarch64-linux-android` + `armv7-linux-androideabi`. Decodes `ANDROID_KEYSTORE_B64`, builds signed `.aab` + `.apk` via `cargo tauri android build --apk --aab`, attaches to the GitHub release.
- New job **`mobile_ios`** on `macos-26`: default Xcode 26, Rust `aarch64-apple-ios`. Imports `APPLE_CERT_P12` + `APPLE_PROVISIONING_PROFILE_B64` into a one-shot keychain (prepended to the user search list, not replacing it), builds signed `.ipa` via `cargo tauri ios build`, attaches to the release.
- Both run with `continue-on-error: true` — a flaky Apple cert refresh or Android signing snag must NOT block the desktop matrix above.
- Both **degrade gracefully** when the corresponding signing secrets are absent (forks / first-run repos): Android falls back to an unsigned debug APK, iOS falls back to an unsigned simulator build. The toolchain is exercised either way; only the release-attach is conditional.
- `cargo install tauri-cli` is now wrapped in an `actions/cache` lookup keyed on `tauri-cli-${runner.os}-v2`, so the 1–2 min recompile happens once per cache lifetime instead of every job.

**`mobile-smoke.yml` (new)**

**Post-merge** smoke test (push to `main` only — not per-PR), no secrets touched. Triggers on pushes to `main` that change `crates/librefang-desktop/**`, the dashboard, `gen/**`, the workflow itself, or root `Cargo.toml` / `Cargo.lock`. Cargo + Gradle caches are keyed per-job so a warm rerun stays under the 12-min target from the issue.

The "post-merge instead of per-PR" choice is deliberate: each leg pulls a cold Android NDK or Xcode iOS SDK and a full Rust mobile rebuild — ~25 min each on a cache miss, which is too heavy to pay for every desktop / dashboard PR. Maintainers can still trigger it on a branch via `workflow_dispatch` from the Actions tab when they want pre-merge validation.

**`.github/SECRETS.md` (new)**

Every Actions secret the repo currently uses is now documented with format, rotation cadence, and a concrete runbook for the yearly Apple cert refresh. Mobile signing, desktop signing, package registries, and internal infra (Homebrew tap PAT, deploy previews) are all covered. Operational rules at the bottom: never echo, always wipe runner copies, forks must degrade gracefully.

**Desktop crate changes**

- `[lib]` now declares `crate-type = ["staticlib", "cdylib", "lib"]` so `cargo tauri ios build` can find the static library. Comment in `Cargo.toml` notes the desktop side now also produces those outputs (~10–20% extra link time on a clean target/).
- `run()` no longer carries `#[tauri::mobile_entry_point]`; a separate 0-arg `mobile_main()` wraps it. Window construction is gated `#[cfg(desktop)]` because `WebviewWindowBuilder::title/inner_size/center` aren't available on mobile.
- Capabilities split into `default.json` (`platforms: ["macOS", "windows", "linux"]`) and a new `mobile.json` (`platforms: ["iOS", "android"]`) with only `core / notification / dialog` — desktop-only plugins (shell, global-shortcut, autostart, updater) are not bundled on mobile.
- iOS minimum supported version raised from **14.0 → 16.0** (Tauri 2 mobile requirement). Documented in `CHANGELOG.md` under Unreleased / Changed.

## Notes for maintainers

The first signed mobile release will fail until the eight new Android/Apple secrets are populated — see `.github/SECRETS.md` for the exact set and the `keytool` / Apple Developer portal recipes. Until then, both jobs land their unsigned fallbacks, so the rest of the release pipeline keeps working.

## Test plan

- [ ] Land this PR; trigger `release.yml` via `workflow_dispatch` against a tag with **no** mobile secrets set — confirm desktop bundles still upload, mobile jobs land unsigned debug artifacts, neither fails the workflow.
- [ ] Populate the eight mobile secrets; re-run `workflow_dispatch` — confirm signed `.aab` / `.apk` / `.ipa` attach to the release.
- [ ] Merge a no-op change touching `crates/librefang-desktop/Cargo.toml` to `main` — confirm `mobile-smoke.yml` runs and finishes within ~12 min on a warm cache.
- [ ] Merge a change touching only `crates/librefang-api/src/lib.rs` to `main` — confirm `mobile-smoke.yml` does **not** run (path filter exclusion).
- [ ] On a feature branch with `crates/librefang-desktop/**` changes, trigger `mobile-smoke.yml` via `workflow_dispatch` — confirm it can be invoked manually for pre-merge validation.
