### PR TITLE
chore(ci): ignore @librefang/cli-* placeholder bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      # @librefang/cli-* versions in package.json are "0.0.0" placeholders
+      # replaced by CI at publish time, not real dependencies.
+      - dependency-name: "@librefang/cli-*"
 
   # JavaScript SDK
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

- `@librefang/cli-*` versions in `packages/cli-npm/package.json` are `"0.0.0"` placeholders that CI rewrites at publish time — they're not real dependencies.
- Dependabot opened 5 PRs (#3977, #3978, #3979, #3981, #3982) trying to bump these placeholders to `2026.3.2201`. Merging any of them would replace the placeholder with a hardcoded version and break the release pipeline.
- Closed those PRs and added a `dependency-name: "@librefang/cli-*"` ignore rule to the cli-npm dependabot config so this doesn't recur.

## Test plan

- [ ] Dependabot config validation passes in CI
- [ ] Next dependabot run does not reopen `@librefang/cli-*` PRs
