### PR TITLE
ci(nix): only run nix build on push-to-main, drop per-PR trigger

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,19 +1,15 @@
 name: Nix Build
 
-# Catches NixOS build breakage on flake.nix or workspace changes before
+# Catches NixOS build breakage on flake.nix or workspace changes after
 # they reach main. Past incidents (#2937, #2974, #3052, #3156, #3197) all
 # slipped through because regular CI doesn't exercise the Nix path.
+#
+# Runs on push-to-main only — running on every PR push burned runner
+# minutes on builds gated by flake.lock / Cargo.lock churn that isn't
+# authoritative until merge. Trigger manually with workflow_dispatch
+# when a PR explicitly needs a pre-merge nix check.
 on:
   push:
-    branches: [main]
-    paths:
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
-      - '.github/workflows/nix-build.yml'
-  pull_request:
     branches: [main]
     paths:
       - 'flake.nix'


### PR DESCRIPTION
## Summary
- Drop the `pull_request:` trigger from the Nix Build workflow so it no longer runs on every PR push.
- Keep `push: branches: [main]` (with the same paths filter) so post-merge regressions on flake.nix / Cargo.lock / workspace TOMLs still get caught.
- Keep `workflow_dispatch` for the rare PR that legitimately wants a pre-merge nix check — a contributor can run it manually from the Actions tab.

## Why
We currently have ~50 open PRs and Nix Build was firing on every push to any of them whenever Cargo.lock or a workspace Cargo.toml moved — i.e. effectively all of them. The check almost always passes (or fails on lockfile churn that isn't authoritative until merge), so the per-PR run mostly burned runner minutes without catching anything the existing `cargo build`/`cargo test` matrix wouldn't catch first.

The historical incidents the workflow header references (#2937, #2974, #3052, #3156, #3197) all landed *after* a merge to main, which is what `push: branches: [main]` still covers.

## Test plan
- [ ] Open a PR that touches `Cargo.lock` — confirm Nix Build does *not* run automatically.
- [ ] Trigger Nix Build manually via Actions → Nix Build → Run workflow → main, confirm it still builds both `librefang-cli` and `librefang-desktop`.
- [ ] Watch the next merge to main that touches a workspace TOML — confirm Nix Build runs on the resulting push.
