### PR TITLE
ci(docker): only run docker build on push-to-main, drop per-PR trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,28 +1,22 @@
 name: Docker Build
 
-# Catches Dockerfile / runtime breakage on PR before it reaches the
+# Catches Dockerfile / runtime breakage on main before it reaches the
 # release pipeline. Past incidents — #3058 (logs dir) and #3259 (missing
 # libdbus, blocked the entire v2026.4.27-beta6 image release) — both
 # slipped through because the docker job in release.yml only fires on
-# tag push, not on PRs.
+# tag push.
 #
 # Build-only validation isn't enough: #3259 would still pass a pure
 # `docker build` if we only fixed the builder stage and forgot the
 # runtime SO. So we also boot the image and probe /api/health to catch
 # missing runtime libs / entrypoint regressions.
+#
+# Runs on push-to-main only — running on every PR push burned runner
+# minutes on builds gated by Cargo.lock / pnpm-lock churn that isn't
+# authoritative until merge. Trigger manually with workflow_dispatch
+# when a PR explicitly needs a pre-merge docker check.
 on:
   push:
-    branches: [main]
-    paths:
-      - 'Dockerfile'
-      - 'deploy/docker-entrypoint.sh'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
-      - 'crates/librefang-api/dashboard/package.json'
-      - 'crates/librefang-api/dashboard/pnpm-lock.yaml'
-      - '.github/workflows/docker-build.yml'
-  pull_request:
     branches: [main]
     paths:
       - 'Dockerfile'


### PR DESCRIPTION
## Summary
- Drop the `pull_request:` trigger from the Docker Build workflow so it no longer runs on every PR push.
- Keep `push: branches: [main]` (with the same paths filter) so post-merge regressions in the Dockerfile / entrypoint / workspace TOMLs still get caught before the release pipeline.
- Keep `workflow_dispatch` for the rare PR that legitimately wants a pre-merge docker check — a contributor can run it manually from the Actions tab.

## Why
Same rationale as #3994 (Nix Build): Docker Build was firing on every PR push that touched `Cargo.lock` / `pnpm-lock.yaml` / a workspace `Cargo.toml` — across the open PR queue, that's a lot of runner minutes for a check that mostly catches lockfile churn that isn't authoritative until merge.

The historical incidents the workflow header references (#3058, #3259) both landed *after* a merge to main, which `push: branches: [main]` still covers.

## Test plan
- [ ] Open a PR that touches `Cargo.lock` — confirm Docker Build does *not* run automatically.
- [ ] Trigger Docker Build manually via Actions → Docker Build → Run workflow → main, confirm it still builds and probes `/api/health`.
- [ ] Watch the next merge to main that touches the Dockerfile or a workspace TOML — confirm Docker Build runs on the resulting push.
