### PR TITLE
test(api): regenerate kernel_config_schema golden fixture

### DIFF
--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -4936,6 +4936,11 @@
             "null"
           ]
         },
+        "app_secret_env": {
+          "default": "",
+          "description": "Env var name holding the Facebook App Secret. Used for HMAC-SHA1 verification of incoming webhook POST requests via `X-Hub-Signature`. If absent or empty, verification is skipped with a warning (backwards compatibility).",
+          "type": "string"
+        },
         "default_agent": {
           "default": null,
           "description": "Default agent name to route messages to.",
@@ -7309,6 +7314,11 @@
                 "null"
               ]
             },
+            "app_secret_env": {
+              "default": "",
+              "description": "Env var name holding the Facebook App Secret. Used for HMAC-SHA1 verification of incoming webhook POST requests via `X-Hub-Signature`. If absent or empty, verification is skipped with a warning (backwards compatibility).",
+              "type": "string"
+            },
             "default_agent": {
               "default": null,
               "description": "Default agent name to route messages to.",
@@ -8466,6 +8476,11 @@
                 "usage_footer": null
               },
               "description": "Per-channel behavior overrides."
+            },
+            "security_token_env": {
+              "default": "",
+              "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. If the env var is absent or empty, verification is skipped with a warning.",
+              "type": "string"
             },
             "webhook_port": {
               "default": 3978,
@@ -9820,6 +9835,14 @@
         "ntfy_url": {
           "default": null,
           "description": "Ntfy server URL (if push_provider = \"ntfy\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public_base_url": {
+          "default": null,
+          "description": "Public base URL the QR code points mobile clients at, e.g. `https://librefang.example.com`. When set, takes precedence over the request `Host` header — required for HTTPS reverse-proxy deployments where trusting client-supplied `X-Forwarded-Proto` would let any authenticated dashboard caller forge the scheme. When `None`, the daemon falls back to `Host` + the runtime scheme.",
           "type": [
             "string",
             "null"
@@ -11595,6 +11618,11 @@
             "usage_footer": null
           },
           "description": "Per-channel behavior overrides."
+        },
+        "security_token_env": {
+          "default": "",
+          "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. If the env var is absent or empty, verification is skipped with a warning.",
+          "type": "string"
         },
         "webhook_port": {
           "default": 3978,
@@ -14542,6 +14570,7 @@
         "max_devices": 10,
         "ntfy_topic": null,
         "ntfy_url": null,
+        "public_base_url": null,
         "push_provider": "none",
         "token_expiry_secs": 300
       },


### PR DESCRIPTION
## Summary

Recently-merged PRs added new fields to `KernelConfig` without regenerating the golden fixture:

- `app_secret_env` (Messenger HMAC, #3942)
- `security_token_env` (Teams HMAC, #3942)
- `public_base_url` (mobile pairing, #3344/#3916)

The drift caused `kernel_config_schema_matches_golden_fixture` to fail on every open PR's CI (Test / Ubuntu, Windows, macOS), blocking ~30 in-flight fixes from merging even though their own changes were unrelated to the config schema.

## Regenerated via

```
cargo test -p librefang-api --test config_schema_golden -- --ignored regenerate_golden --nocapture
```

## Test plan

- [x] `cargo test -p librefang-api --test config_schema_golden` passes locally
- [ ] CI green