### PR TITLE
fix(kernel): un-break upstream/main from two bad merges

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -514,7 +514,13 @@ impl CronScheduler {
     /// (iterates up to 1440 times per job to avoid pathological inputs).
     /// `At` one-shot jobs that have already passed are silently ignored
     /// (they would have been removed on successful execution anyway).
-    pub fn warn_missed_fires(&self, since: chrono::DateTime<Utc>) {
+    ///
+    /// Distinct from [`Self::warn_missed_fires`] (no-arg), which both
+    /// logs and reschedules overdue jobs for catch-up firing. Both were
+    /// independently introduced as fixes for #3828 in PRs #3906 and
+    /// #3923 and ended up colliding on the same name; this one is the
+    /// since-windowed log-only variant.
+    pub fn log_missed_fires_since(&self, since: chrono::DateTime<Utc>) {
         let now = Utc::now();
         if since >= now {
             return;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2847,7 +2847,7 @@ impl LibreFangKernel {
                     // operators can correlate with daemon restart time in logs.
                     // This only logs warnings — it does not catch-up-fire.
                     let warn_since = chrono::Utc::now() - chrono::Duration::minutes(5);
-                    cron_scheduler.warn_missed_fires(warn_since);
+                    cron_scheduler.log_missed_fires_since(warn_since);
                 }
             }
             Err(e) => {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4638,6 +4638,10 @@ fn dummy_sender(channel: &str, chat_id: Option<&str>) -> SenderContext {
     SenderContext {
         channel: channel.to_string(),
         chat_id: chat_id.map(str::to_string),
+        ..Default::default()
+    }
+}
+
 // ── session_mode_override resolution + trigger concurrency caps (#3754, #3755) ──
 
 /// Helper: boot a minimal kernel in a temp directory.
@@ -4828,6 +4832,8 @@ fn resolve_dispatch_session_id_session_mode_override_beats_manifest() {
         None,
     );
     assert_eq!(got, Some(entry_sid));
+}
+
 // -- #3754: session_mode_override resolution via agent_concurrency_for --------
 
 /// An agent with `session_mode = "new"` and `max_concurrent_invocations = 3`


### PR DESCRIPTION
## Summary

`upstream/main` (currently at `f8ea6905`) does not compile. Two recent PRs each landed a regression that the other's tests didn't catch.

### 1. `cron.rs` — duplicate `warn_missed_fires`

PR #3906 (\`88bd0af9\`) and PR #3923 (\`b641ca65\`) both added a method named \`CronScheduler::warn_missed_fires\` to fix bug #3828, but with different signatures and different semantics:

- **PR #3906** — \`warn_missed_fires(&self)\`: logs *and* reschedules overdue jobs for catch-up firing (mutates \`next_run\`).
- **PR #3923** — \`warn_missed_fires(&self, since)\`: logs each fire that was missed in \`[since, now)\` against the schedule, no rescheduling.

Both call sites exist in \`kernel/mod.rs\` (one with-arg, one without), so removing either function would silently drop one of the features. Rename the since-windowed log-only one to \`log_missed_fires_since\` and update its single call site. Both behaviors are preserved; neither author's intent is lost.

Compiler errors before this patch: \`E0592\` (duplicate definitions) and \`E0061\` (arity mismatch at the call site).

### 2. \`tests.rs\` — unclosed \`dummy_sender\`

PR #3260 (\`305b234e\`) added \`dummy_sender\` ending with \`..Default::default() }\` followed by the function's closing \`}\`. PR #3951 (\`48a445a9\`) then appended a new test section immediately after, but the merge dropped those final three lines, leaving \`dummy_sender\` and its \`SenderContext { … }\` literal both unclosed. Restore them.

Compiler error before this patch: \`error: this file contains an unclosed delimiter\` at EOF.

## Verification

After this patch:

- \`cargo check -p librefang-kernel --tests\` — succeeds
- \`cargo test -p librefang-kernel --lib cron\` — 69 passed
- \`cargo test -p librefang-kernel --lib resolve_dispatch_session_id\` — 9 passed

## Test plan

- [ ] CI green on this PR
- [ ] After merge, \`cargo check --workspace\` on a fresh \`upstream/main\` checkout passes