### PR TITLE
fix(desktop): handle RwLock/Mutex poison instead of panicking on .unwrap()

### DIFF
--- a/crates/librefang-desktop/src/commands.rs
+++ b/crates/librefang-desktop/src/commands.rs
@@ -13,7 +13,7 @@ use tauri_plugin_autostart::ManagerExt;
 pub fn get_port(port: tauri::State<'_, PortState>) -> Result<u16, String> {
     port.0
         .read()
-        .unwrap()
+        .unwrap_or_else(|e| e.into_inner())
         .ok_or_else(|| "No local server running".to_string())
 }
 
@@ -26,9 +26,9 @@ pub fn get_status(
     let p = port
         .0
         .read()
-        .unwrap()
+        .unwrap_or_else(|e| e.into_inner())
         .ok_or_else(|| "No local server running".to_string())?;
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|e| e.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -46,7 +46,7 @@ pub fn get_status(
 /// Get the number of registered agents.
 #[tauri::command]
 pub fn get_agent_count(kernel_state: tauri::State<'_, KernelState>) -> Result<usize, String> {
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|e| e.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -91,7 +91,7 @@ pub fn import_agent_toml(
     let dest = agent_dir.join("agent.toml");
     std::fs::write(&dest, &content).map_err(|e| format!("Failed to write manifest: {e}"))?;
 
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|e| e.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;
@@ -139,7 +139,7 @@ pub fn import_skill_file(
     let dest = skills_dir.join(&file_name);
     std::fs::copy(src, &dest).map_err(|e| format!("Failed to copy skill file: {e}"))?;
 
-    let guard = kernel_state.0.read().unwrap();
+    let guard = kernel_state.0.read().unwrap_or_else(|e| e.into_inner());
     let inner = guard
         .as_ref()
         .ok_or_else(|| "No local server running".to_string())?;

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -115,17 +115,17 @@ pub async fn connect_remote(
     // Update interior-mutable managed state (registered once at startup).
     let app = window.app_handle();
     if let Some(state) = app.try_state::<crate::ServerUrlState>() {
-        *state.0.write().unwrap() = url.clone();
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = url.clone();
     }
     if let Some(state) = app.try_state::<crate::RemoteMode>() {
-        *state.0.write().unwrap() = true;
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = true;
     }
     // Clear local-only state when switching to remote.
     if let Some(state) = app.try_state::<crate::PortState>() {
-        *state.0.write().unwrap() = None;
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = None;
     }
     if let Some(state) = app.try_state::<crate::KernelState>() {
-        *state.0.write().unwrap() = None;
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = None;
     }
 
     info!("Connecting to remote server: {url}");
@@ -167,19 +167,19 @@ pub async fn start_local(
 
     // Update interior-mutable managed state (registered once at startup).
     if let Some(state) = app.try_state::<crate::PortState>() {
-        *state.0.write().unwrap() = Some(port);
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = Some(port);
     }
     if let Some(state) = app.try_state::<crate::KernelState>() {
-        *state.0.write().unwrap() = Some(crate::KernelInner {
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = Some(crate::KernelInner {
             kernel: handle.kernel.clone(),
             started_at: Instant::now(),
         });
     }
     if let Some(state) = app.try_state::<crate::ServerUrlState>() {
-        *state.0.write().unwrap() = url.clone();
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = url.clone();
     }
     if let Some(state) = app.try_state::<crate::RemoteMode>() {
-        *state.0.write().unwrap() = false;
+        *state.0.write().unwrap_or_else(|e| e.into_inner()) = false;
     }
 
     // Store the ServerHandle for shutdown
@@ -190,7 +190,7 @@ pub async fn start_local(
 
     // Start event forwarding for native notifications
     if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|e| e.into_inner());
         if let Some(ref inner) = *guard {
             let app_handle = app.clone();
             let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -405,7 +405,7 @@ pub fn run(server_url: Option<String>, force_local: bool) {
             // For local direct-boot mode, start event forwarding for notifications
             if !is_remote && !show_connection_screen {
                 if let Some(ks) = app.try_state::<KernelState>() {
-                    let guard = ks.0.read().unwrap();
+                    let guard = ks.0.read().unwrap_or_else(|e| e.into_inner());
                     if let Some(ref inner) = *guard {
                         let app_handle = app.handle().clone();
                         let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();

--- a/crates/librefang-desktop/src/tray.rs
+++ b/crates/librefang-desktop/src/tray.rs
@@ -41,17 +41,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Informational items (disabled — display only)
     let is_remote = app
         .try_state::<crate::RemoteMode>()
-        .map(|r| *r.0.read().unwrap())
+        .map(|r| *r.0.read().unwrap_or_else(|e| e.into_inner()))
         .unwrap_or(false);
 
     let status_text = if is_remote {
         let url = app
             .try_state::<crate::ServerUrlState>()
-            .map(|s| s.0.read().unwrap().clone())
+            .map(|s| s.0.read().unwrap_or_else(|e| e.into_inner()).clone())
             .unwrap_or_else(|| "unknown".to_string());
         format!("Status: Remote ({url})")
     } else if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|e| e.into_inner());
         if let Some(ref inner) = *guard {
             let uptime = format_uptime(inner.started_at.elapsed().as_secs());
             format!("Status: Running ({uptime})")
@@ -63,7 +63,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let agent_count = if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|e| e.into_inner());
         if let Some(ref inner) = *guard {
             inner.kernel.agent_registry().list().len()
         } else {
@@ -148,13 +148,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "browser" => {
                 // Use ServerUrlState (works for both remote and local modes)
                 if let Some(url_state) = app.try_state::<crate::ServerUrlState>() {
-                    let url = url_state.0.read().unwrap().clone();
+                    let url = url_state
+                        .0
+                        .read()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .clone();
                     if !url.is_empty() {
                         let _ = open::that(&url);
                     }
                 } else if let Some(port) = app.try_state::<crate::PortState>() {
                     // Fallback for backward compatibility
-                    if let Some(p) = *port.0.read().unwrap() {
+                    if let Some(p) = *port.0.read().unwrap_or_else(|e| e.into_inner()) {
                         let url = format!("http://127.0.0.1:{p}");
                         let _ = open::that(&url);
                     }
@@ -163,17 +167,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "change_server" => {
                 // Shut down existing local server if running.
                 if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
-                    let mut guard = holder.0.lock().unwrap();
+                    let mut guard = holder.0.lock().unwrap_or_else(|e| e.into_inner());
                     if let Some(handle) = guard.take() {
                         std::thread::spawn(move || handle.shutdown());
                     }
                 }
                 // Clear local-mode state so commands report "not running".
                 if let Some(state) = app.try_state::<crate::PortState>() {
-                    *state.0.write().unwrap() = None;
+                    *state.0.write().unwrap_or_else(|e| e.into_inner()) = None;
                 }
                 if let Some(state) = app.try_state::<crate::KernelState>() {
-                    *state.0.write().unwrap() = None;
+                    *state.0.write().unwrap_or_else(|e| e.into_inner()) = None;
                 }
 
                 // Navigate back to the connection screen


### PR DESCRIPTION
## Summary

Closes #3604.

The desktop crate consistently used `.read() / .write() / .lock().unwrap()` on `RwLock` and `Mutex` guards. Once any holder thread panicked, every subsequent unwrap on that lock would crash the entire desktop app instead of degrading gracefully — including IPC handlers the user is actively interacting with.

Replace with `.unwrap_or_else(|e| e.into_inner())` everywhere across the desktop crate so a poisoned lock surfaces the inner data and lets callers continue.

## Why poisoned-read is safe here

Reading after a poison can return half-updated data, but the affected types in this crate are all simple — `Option<u16>` (port), `Option<KernelInner>`, `Option<String>` (URL), `bool` — where tearing is not possible. At worst the caller observes a stale value; never an inconsistent struct.

## Scope expansion vs the issue

The issue lists `commands.rs` lines 14, 27, 29, 47, 92, 140 (the user-facing IPC surface). The same bug class exists in three sibling files in the same crate. Leaving them would mean the next panic on a connection-state write or a tray menu click still kills the app.

| File | Sites fixed | What gets called |
|---|---|---|
| `commands.rs` | 6 | IPC: `get_port`, `get_status`, `get_agent_count`, `import_agent_toml`, `import_skill_file` |
| `connection.rs` | 9 | Daemon connect / disconnect lifecycle |
| `tray.rs` | 9 | System-tray menu, including the open-in-browser flow |
| `lib.rs` | 1 | Server-startup state read |

Total: **25 sites**.

## Test plan

- [x] `cargo clippy -p librefang-desktop --lib --all-features -- -D warnings` — clean
- [x] `cargo build -p librefang-desktop --lib` — ok
- [x] `cargo test -p librefang-desktop --lib` — pass
- [ ] Manual smoke: open the desktop app, force-panic a writer (e.g. via a test command that panics inside a `write()` guard), then exercise an IPC command — confirm the app continues running and the next read returns the last-good value instead of crashing.

## Notes

No behavior change in the happy path. The only observable difference is during fault injection: app stays alive instead of dying.

Mechanical replacement; no public API change.