### PR TITLE
fix(kernel): close two truncated test helpers blocking pre-commit fmt

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4638,6 +4638,10 @@ fn dummy_sender(channel: &str, chat_id: Option<&str>) -> SenderContext {
     SenderContext {
         channel: channel.to_string(),
         chat_id: chat_id.map(str::to_string),
+        ..Default::default()
+    }
+}
+
 // ── session_mode_override resolution + trigger concurrency caps (#3754, #3755) ──
 
 /// Helper: boot a minimal kernel in a temp directory.
@@ -4828,6 +4832,8 @@ fn resolve_dispatch_session_id_session_mode_override_beats_manifest() {
         None,
     );
     assert_eq!(got, Some(entry_sid));
+}
+
 // -- #3754: session_mode_override resolution via agent_concurrency_for --------
 
 /// An agent with `session_mode = "new"` and `max_concurrent_invocations = 3`
@@ -4916,12 +4922,7 @@ fn agent_concurrency_falls_back_to_config_default_when_unset() {
 
     let (kernel, _dir) = minimal_kernel("concurrency-default-fallback");
     // default_per_agent = 1 (KernelConfig default)
-    let expected = kernel
-        .config
-        .load()
-        .queue
-        .concurrency
-        .default_per_agent;
+    let expected = kernel.config.load().queue.concurrency.default_per_agent;
 
     let agent_id = kernel
         .spawn_agent_inner(
@@ -5068,7 +5069,11 @@ fn session_mode_persistent_plus_cap_two_is_clamped_preventing_parallel_fires() {
     let (kernel, _dir) = minimal_kernel("persistent-session-no-parallel");
     let agent_id = kernel
         .spawn_agent_inner(
-            concurrency_manifest("persistent-parallel-agent", SessionMode::Persistent, Some(2)),
+            concurrency_manifest(
+                "persistent-parallel-agent",
+                SessionMode::Persistent,
+                Some(2),
+            ),
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

A bad merge between commits 305b234e and 48a445a9 (both 2026-04-28) silently dropped the closing braces of two test helpers in `crates/librefang-kernel/src/kernel/tests.rs`:

| Line | Helper | What broke |
|---|---|---|
| 4637 | `fn dummy_sender(...)` | `SenderContext { ... }` literal + the function body never closed |
| 4821 | `fn resolve_dispatch_session_id_session_mode_override_beats_manifest()` | function body never closed |

`cargo build -p librefang-kernel --lib` still passed because `tests.rs` is not pulled into the library build, so the regression slipped past CI. But `cargo fmt --check` (and the repo's `scripts/hooks/pre-commit` that wraps it) errored with `cannot parse`, blocking every subsequent commit across the repo for everyone running the standard hook setup.

## Fix

Three lines added to `dummy_sender` (`..Default::default()` + closing braces), one line added after `resolve_dispatch_session_id_session_mode_override_beats_manifest`. Net diff is mechanical brace closure; no new behavior.

The `..Default::default()` is consistent with how the three existing callers of `dummy_sender` (`tests.rs:4712 / 4729 / 4747`) already invoke it expecting a SenderContext with only `channel` and `chat_id` set.

## Validation

- `cargo fmt -p librefang-kernel -- --check` — parses cleanly (only surfaces unrelated pre-existing fmt drift in other crates, no parse errors).
- `pre-commit` hook now passes after the standard "fmt → re-stage → commit" round-trip.

## Notes

This is the third PR I'm pushing today and the only one strictly required to unblock the others. Without it, every other contributor working from current `main` will hit the same "Please re-stage and commit again" loop forever.