### PR TITLE
fix(kernel): release_reservation() for non-LLM paths; reserve 0 under unlimited quota

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4931,9 +4931,10 @@ system_prompt = "You are a helpful assistant."
         // Skip suspended agents — cron/triggers should not dispatch to them
         if entry.state == AgentState::Suspended {
             tracing::debug!(agent_id = %agent_id, "Skipping message to suspended agent");
-            // Release the reservation immediately — no tokens will be consumed
+            // No LLM call is made; release reservation without inflating
+            // llm_calls or the burst window.
             self.scheduler
-                .settle_reservation(agent_id, token_reservation, &Default::default());
+                .release_reservation(agent_id, token_reservation);
             return Ok(AgentLoopResult::default());
         }
 
@@ -5269,11 +5270,10 @@ system_prompt = "You are a helpful assistant."
                 Ok(result)
             }
             Err(e) => {
-                // Release the pre-charged token reservation — no tokens were
-                // consumed because the agent loop failed before or during the
-                // LLM call.
+                // Release the pre-charged token reservation — the agent loop
+                // failed before completing, no usage to settle.
                 self.scheduler
-                    .settle_reservation(agent_id, token_reservation, &Default::default());
+                    .release_reservation(agent_id, token_reservation);
 
                 // SECURITY: Record failed message in audit trail
                 self.audit_log.record(
@@ -5719,12 +5719,12 @@ system_prompt = "You are a helpful assistant."
                         Ok(result)
                     }
                     Err(e) => {
-                        // Release reservation — no tokens consumed
-                        kernel_clone.scheduler.settle_reservation(
-                            agent_id,
-                            token_reservation,
-                            &Default::default(),
-                        );
+                        // Non-LLM agent (wasm/python) failed — never made an
+                        // LLM call, release reservation without inflating
+                        // llm_calls.
+                        kernel_clone
+                            .scheduler
+                            .release_reservation(agent_id, token_reservation);
                         kernel_clone.supervisor.record_panic();
                         warn!(agent_id = %agent_id, error = %e, "Non-LLM agent failed");
                         Err(e)
@@ -6539,13 +6539,11 @@ system_prompt = "You are a helpful assistant."
                     Ok(result)
                 }
                 Err(e) => {
-                    // Release the pre-charged token reservation — the loop
-                    // failed so no tokens need to be permanently reserved.
-                    kernel_clone.scheduler.settle_reservation(
-                        agent_id,
-                        token_reservation,
-                        &Default::default(),
-                    );
+                    // Release the pre-charged token reservation — the
+                    // streaming loop failed, no usage to settle.
+                    kernel_clone
+                        .scheduler
+                        .release_reservation(agent_id, token_reservation);
                     kernel_clone.supervisor.record_panic();
                     warn!(agent_id = %agent_id, error = %e, "Streaming agent loop failed");
                     // Lifecycle: emit TurnFailed before cleanup so subscribers

--- a/crates/librefang-kernel/src/scheduler.rs
+++ b/crates/librefang-kernel/src/scheduler.rs
@@ -241,8 +241,12 @@ impl AgentScheduler {
     ///
     /// Returns `Ok(estimated_tokens)` (the amount reserved) on success, or
     /// `Err(QuotaExceeded)` if the reservation would breach the limit.
-    /// Returns `Ok(0)` when no quota is configured for the agent (caller
-    /// should still call `record_usage` normally in that case).
+    /// Returns `Ok(0)` whenever no reservation was actually pre-charged —
+    /// either because no quota is registered for the agent, or because the
+    /// effective token limit is `0` (unlimited).  The caller must treat the
+    /// returned value as the exact amount to pass to `settle_reservation` /
+    /// `release_reservation`; a non-zero return is the only signal that
+    /// `total_tokens` was incremented.
     pub fn check_quota_and_reserve(
         &self,
         agent_id: AgentId,
@@ -260,27 +264,30 @@ impl AgentScheduler {
         tracker.reset_if_expired();
 
         let token_limit = quota.effective_token_limit();
-        if token_limit > 0 {
-            let projected = tracker.total_tokens.saturating_add(estimated_tokens);
-            if projected > token_limit {
-                return Err(LibreFangError::QuotaExceeded(format!(
-                    "Token limit would be exceeded: {} + {} reserved > {}",
-                    tracker.total_tokens, estimated_tokens, token_limit
-                )));
-            }
-            // Burst check against the projected spend
-            let burst_cap = token_limit / 5;
-            let tokens_last_min = tracker.tokens_in_last_minute();
-            if burst_cap > 0 && tokens_last_min.saturating_add(estimated_tokens) > burst_cap {
-                return Err(LibreFangError::QuotaExceeded(format!(
-                    "Token burst limit would be exceeded: {} + {} reserved in last minute (max {}/min)",
-                    tokens_last_min, estimated_tokens, burst_cap
-                )));
-            }
-            // Atomically pre-charge inside the same DashMap entry write-lock
-            tracker.total_tokens = projected;
+        if token_limit == 0 {
+            // Unlimited quota: nothing to reserve. Returning 0 ensures
+            // callers won't later ask settle/release to subtract a
+            // reservation that was never added to `total_tokens`.
+            return Ok(0);
         }
-
+        let projected = tracker.total_tokens.saturating_add(estimated_tokens);
+        if projected > token_limit {
+            return Err(LibreFangError::QuotaExceeded(format!(
+                "Token limit would be exceeded: {} + {} reserved > {}",
+                tracker.total_tokens, estimated_tokens, token_limit
+            )));
+        }
+        // Burst check against the projected spend
+        let burst_cap = token_limit / 5;
+        let tokens_last_min = tracker.tokens_in_last_minute();
+        if burst_cap > 0 && tokens_last_min.saturating_add(estimated_tokens) > burst_cap {
+            return Err(LibreFangError::QuotaExceeded(format!(
+                "Token burst limit would be exceeded: {} + {} reserved in last minute (max {}/min)",
+                tokens_last_min, estimated_tokens, burst_cap
+            )));
+        }
+        // Atomically pre-charge inside the same DashMap entry write-lock
+        tracker.total_tokens = projected;
         Ok(estimated_tokens)
     }
 
@@ -321,6 +328,29 @@ impl AgentScheduler {
             tracker
                 .token_timestamps
                 .push_back((Instant::now(), actual_tokens));
+        }
+    }
+
+    /// Release a prior `check_quota_and_reserve` reservation without
+    /// recording an LLM call.
+    ///
+    /// Use this on paths that pre-charged a reservation but then never
+    /// actually invoked the LLM: a suspended agent skipped at dispatch
+    /// time, a non-LLM (wasm/python) agent that errored out before any
+    /// LLM hop, an agent loop that failed before the first LLM call.
+    /// Decreasing `total_tokens` by the reserved amount restores the
+    /// pre-reservation state without inflating `llm_calls` or polluting
+    /// the burst-detection sliding window with zero-value entries.
+    ///
+    /// Distinct from `settle_reservation`, which is for paths where an
+    /// LLM call **was** attempted (it always increments `llm_calls`).
+    pub fn release_reservation(&self, agent_id: AgentId, estimated_tokens: u64) {
+        if estimated_tokens == 0 {
+            return;
+        }
+        if let Some(mut tracker) = self.usage.get_mut(&agent_id) {
+            tracker.reset_if_expired();
+            tracker.total_tokens = tracker.total_tokens.saturating_sub(estimated_tokens);
         }
     }
 
@@ -634,5 +664,103 @@ mod tests {
         );
         // llm_calls is still incremented — the call was attempted.
         assert_eq!(after.llm_calls, 1);
+    }
+
+    /// `release_reservation` must roll back the pre-charged total without
+    /// counting an LLM call or polluting the burst window with a zero-token
+    /// timestamp.  Used by paths that pre-charged a reservation but never
+    /// actually invoked the LLM (suspended-agent skip, non-LLM agent
+    /// failure, agent loop failing before the first LLM hop).
+    #[test]
+    fn test_release_reservation_does_not_count_as_llm_call() {
+        let scheduler = AgentScheduler::new();
+        let id = AgentId::new();
+        let quota = ResourceQuota {
+            max_llm_tokens_per_hour: Some(100_000),
+            max_tool_calls_per_minute: 0,
+            ..Default::default()
+        };
+        scheduler.register(id, quota);
+
+        let reserved = scheduler.check_quota_and_reserve(id, 500).unwrap();
+        let before = scheduler.get_usage(id).unwrap();
+        assert_eq!(before.total_tokens, 500, "reservation pre-charged");
+        assert_eq!(before.llm_calls, 0);
+
+        scheduler.release_reservation(id, reserved);
+
+        let after = scheduler.get_usage(id).unwrap();
+        assert_eq!(after.total_tokens, 0, "reservation rolled back");
+        assert_eq!(
+            after.llm_calls, 0,
+            "release path must not count as an LLM call"
+        );
+        assert_eq!(after.input_tokens, 0);
+        assert_eq!(after.output_tokens, 0);
+    }
+
+    /// `release_reservation(0, _)` is a no-op (used when no quota is
+    /// configured and `check_quota_and_reserve` returned 0).
+    #[test]
+    fn test_release_reservation_zero_is_noop() {
+        let scheduler = AgentScheduler::new();
+        let id = AgentId::new();
+        scheduler.register(id, ResourceQuota::default());
+        scheduler.release_reservation(id, 0);
+        let after = scheduler.get_usage(id).unwrap();
+        assert_eq!(after.total_tokens, 0);
+        assert_eq!(after.llm_calls, 0);
+    }
+
+    /// `check_quota_and_reserve` must return 0 when the agent has a quota
+    /// registered but its effective token limit is 0 (unlimited).  A
+    /// non-zero return would tell callers a reservation had been
+    /// pre-charged, so settle/release would later subtract from
+    /// `total_tokens` even though the reserve step never added anything.
+    #[test]
+    fn test_check_quota_and_reserve_unlimited_returns_zero() {
+        let scheduler = AgentScheduler::new();
+        let id = AgentId::new();
+        // Quota registered, but max_llm_tokens_per_hour = None → unlimited.
+        scheduler.register(id, ResourceQuota::default());
+
+        // First record some real usage so total_tokens is non-zero — this
+        // is the state where the bug would have been observable.
+        scheduler.record_usage(
+            id,
+            &TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                ..Default::default()
+            },
+        );
+        let before = scheduler.get_usage(id).unwrap();
+        assert_eq!(before.total_tokens, 150);
+
+        // Reserve under an unlimited quota — should return 0 (no charge).
+        let reserved = scheduler.check_quota_and_reserve(id, 1000).unwrap();
+        assert_eq!(reserved, 0, "unlimited quota must not pre-charge");
+
+        // total_tokens unchanged by the reserve call.
+        let after_reserve = scheduler.get_usage(id).unwrap();
+        assert_eq!(after_reserve.total_tokens, 150);
+
+        // Settle with the returned reservation (0) — falls through to the
+        // `record_usage`-equivalent branch and adds actual to total.
+        scheduler.settle_reservation(
+            id,
+            reserved,
+            &TokenUsage {
+                input_tokens: 200,
+                output_tokens: 80,
+                ..Default::default()
+            },
+        );
+        let after_settle = scheduler.get_usage(id).unwrap();
+        assert_eq!(
+            after_settle.total_tokens, 430,
+            "150 prior + 280 actual; no reservation to subtract"
+        );
+        assert_eq!(after_settle.llm_calls, 2);
     }
 }


### PR DESCRIPTION
Follow-up to #3969 — two reservation-lifecycle regressions.

## Problem 1 — `llm_calls` inflated on no-LLM paths

#3969 introduced `settle_reservation` and replaced four `record_usage` call sites with `settle_reservation(_, reservation, &Default::default())` on paths that **never actually invoked the LLM**:

- Suspended-agent skip at dispatch (`mod.rs:4936`)
- Non-LLM (wasm/python) agent failure (`mod.rs:5723`)
- Non-streaming agent-loop failure (`mod.rs:5276`)
- Streaming agent-loop failure (`mod.rs:6544`)

`settle_reservation` unconditionally runs `tracker.llm_calls += 1` and pushes a zero-token entry into the burst-detection sliding window.  So every suspended-agent skip, every wasm/python crash, and every loop failure now counts as a successful LLM call in metrics.  Pre-#3969 semantics: `record_usage` was called only on the success path → `llm_calls = successful LLM calls`.

The author's `test_settle_empty_usage_releases_full_reservation` asserts `llm_calls == 1` after a settle-with-empty, with the comment *"the call was attempted"* — but the four call sites above include a path (suspended skip) where no LLM call is even prepared, let alone attempted.

### Fix

Add `release_reservation(agent_id, estimated_tokens)` that **only** rolls back `total_tokens`.  Leave `settle_reservation` untouched so the existing test still passes (it remains the right tool for paths where an LLM call was attempted but returned empty/error usage).  Switch all four no-LLM paths to `release_reservation`.

## Problem 2 — `check_quota_and_reserve` returns non-zero under unlimited quota

```rust
if token_limit > 0 {
    // ... pre-charge total_tokens ...
}
Ok(estimated_tokens)  // ← runs even when the if-block didn't pre-charge
```

When an agent has a quota registered but `effective_token_limit() == 0` (the documented "unlimited" sentinel), the inner block is skipped — `total_tokens` is not incremented — but the function still returns `Ok(estimated_tokens)`.  Callers then pass that non-zero value into `settle_reservation` / `release_reservation`, both of which call `total_tokens.saturating_sub(estimated_tokens)`.  Result: every turn for an unlimited-quota agent silently decrements (or saturates to 0) `total_tokens`, corrupting metrics.

### Fix

Return `Ok(0)` early when `token_limit == 0`.  The only non-zero return is now the exact amount actually pre-charged, matching the `settle_reservation` / `release_reservation` contract.

## Test plan

- `test_release_reservation_does_not_count_as_llm_call` — release leaves `llm_calls == 0` and `total_tokens == 0`.
- `test_release_reservation_zero_is_noop` — `release_reservation(_, 0)` is a no-op (covers the no-quota call path).
- `test_check_quota_and_reserve_unlimited_returns_zero` — unlimited quota returns 0; subsequent `settle_reservation(_, 0, &actual)` correctly adds `actual` to `total_tokens` without under-counting.
- Author's existing `test_settle_empty_usage_releases_full_reservation` still passes — `settle_reservation` semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)