### PR TITLE
fix(desktop): extend RwLock/Mutex poison recovery beyond commands.rs

### DIFF
--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -115,17 +115,17 @@ pub async fn connect_remote(
     // Update interior-mutable managed state (registered once at startup).
     let app = window.app_handle();
     if let Some(state) = app.try_state::<crate::ServerUrlState>() {
-        *state.0.write().unwrap() = url.clone();
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = url.clone();
     }
     if let Some(state) = app.try_state::<crate::RemoteMode>() {
-        *state.0.write().unwrap() = true;
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = true;
     }
     // Clear local-only state when switching to remote.
     if let Some(state) = app.try_state::<crate::PortState>() {
-        *state.0.write().unwrap() = None;
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = None;
     }
     if let Some(state) = app.try_state::<crate::KernelState>() {
-        *state.0.write().unwrap() = None;
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = None;
     }
 
     info!("Connecting to remote server: {url}");
@@ -167,19 +167,19 @@ pub async fn start_local(
 
     // Update interior-mutable managed state (registered once at startup).
     if let Some(state) = app.try_state::<crate::PortState>() {
-        *state.0.write().unwrap() = Some(port);
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = Some(port);
     }
     if let Some(state) = app.try_state::<crate::KernelState>() {
-        *state.0.write().unwrap() = Some(crate::KernelInner {
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = Some(crate::KernelInner {
             kernel: handle.kernel.clone(),
             started_at: Instant::now(),
         });
     }
     if let Some(state) = app.try_state::<crate::ServerUrlState>() {
-        *state.0.write().unwrap() = url.clone();
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = url.clone();
     }
     if let Some(state) = app.try_state::<crate::RemoteMode>() {
-        *state.0.write().unwrap() = false;
+        *state.0.write().unwrap_or_else(|p| p.into_inner()) = false;
     }
 
     // Store the ServerHandle for shutdown
@@ -190,7 +190,7 @@ pub async fn start_local(
 
     // Start event forwarding for native notifications
     if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|p| p.into_inner());
         if let Some(ref inner) = *guard {
             let app_handle = app.clone();
             let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -405,7 +405,7 @@ pub fn run(server_url: Option<String>, force_local: bool) {
             // For local direct-boot mode, start event forwarding for notifications
             if !is_remote && !show_connection_screen {
                 if let Some(ks) = app.try_state::<KernelState>() {
-                    let guard = ks.0.read().unwrap();
+                    let guard = ks.0.read().unwrap_or_else(|p| p.into_inner());
                     if let Some(ref inner) = *guard {
                         let app_handle = app.handle().clone();
                         let mut event_rx = inner.kernel.event_bus_ref().subscribe_all();

--- a/crates/librefang-desktop/src/tray.rs
+++ b/crates/librefang-desktop/src/tray.rs
@@ -41,17 +41,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Informational items (disabled — display only)
     let is_remote = app
         .try_state::<crate::RemoteMode>()
-        .map(|r| *r.0.read().unwrap())
+        .map(|r| *r.0.read().unwrap_or_else(|p| p.into_inner()))
         .unwrap_or(false);
 
     let status_text = if is_remote {
         let url = app
             .try_state::<crate::ServerUrlState>()
-            .map(|s| s.0.read().unwrap().clone())
+            .map(|s| s.0.read().unwrap_or_else(|p| p.into_inner()).clone())
             .unwrap_or_else(|| "unknown".to_string());
         format!("Status: Remote ({url})")
     } else if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|p| p.into_inner());
         if let Some(ref inner) = *guard {
             let uptime = format_uptime(inner.started_at.elapsed().as_secs());
             format!("Status: Running ({uptime})")
@@ -63,7 +63,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let agent_count = if let Some(ks) = app.try_state::<crate::KernelState>() {
-        let guard = ks.0.read().unwrap();
+        let guard = ks.0.read().unwrap_or_else(|p| p.into_inner());
         if let Some(ref inner) = *guard {
             inner.kernel.agent_registry().list().len()
         } else {
@@ -148,13 +148,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "browser" => {
                 // Use ServerUrlState (works for both remote and local modes)
                 if let Some(url_state) = app.try_state::<crate::ServerUrlState>() {
-                    let url = url_state.0.read().unwrap().clone();
+                    let url = url_state
+                        .0
+                        .read()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .clone();
                     if !url.is_empty() {
                         let _ = open::that(&url);
                     }
                 } else if let Some(port) = app.try_state::<crate::PortState>() {
                     // Fallback for backward compatibility
-                    if let Some(p) = *port.0.read().unwrap() {
+                    if let Some(p) = *port.0.read().unwrap_or_else(|p| p.into_inner()) {
                         let url = format!("http://127.0.0.1:{p}");
                         let _ = open::that(&url);
                     }
@@ -163,17 +167,17 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             "change_server" => {
                 // Shut down existing local server if running.
                 if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
-                    let mut guard = holder.0.lock().unwrap();
+                    let mut guard = holder.0.lock().unwrap_or_else(|p| p.into_inner());
                     if let Some(handle) = guard.take() {
                         std::thread::spawn(move || handle.shutdown());
                     }
                 }
                 // Clear local-mode state so commands report "not running".
                 if let Some(state) = app.try_state::<crate::PortState>() {
-                    *state.0.write().unwrap() = None;
+                    *state.0.write().unwrap_or_else(|p| p.into_inner()) = None;
                 }
                 if let Some(state) = app.try_state::<crate::KernelState>() {
-                    *state.0.write().unwrap() = None;
+                    *state.0.write().unwrap_or_else(|p| p.into_inner()) = None;
                 }
 
                 // Navigate back to the connection screen


### PR DESCRIPTION
## Summary

Follow-up to #3955. That PR resolved the literal scope of #3604 — the 6 `RwLock::read().unwrap()` sites in `crates/librefang-desktop/src/commands.rs` — but the same panic-on-poison pattern still existed in three sibling files in the same crate.

| File | Sites | What gets called |
|---|---|---|
| `connection.rs` | 9 | daemon connect / disconnect lifecycle (8 writes + 1 read) |
| `tray.rs` | 9 | system-tray menu including the open-in-browser flow |
| `lib.rs` | 1 | server-startup state read |

Total: **19 sites**.

A panic in any holder thread (e.g. during a daemon restart or a tray-menu interaction) would still poison the lock and crash the entire desktop app via the next `.unwrap()` call. Replacing each with `.unwrap_or_else(|p| p.into_inner())` matches #3955's naming and lets callers continue with the last-good value.

## Why poisoned-read is safe here

The locked types are all simple — `Option<u16>` (port), `Option<KernelInner>`, `Option<String>` (URL), `bool` — where tearing is impossible. At worst the caller observes a stale value; never an inconsistent struct. Same reasoning as #3955.

## Test plan

- [x] `cargo clippy -p librefang-desktop --lib --all-features -- -D warnings` — clean
- [x] `cargo build -p librefang-desktop --lib` — ok
- [x] `cargo test -p librefang-desktop --lib` — pass
- [ ] Manual smoke (in a follow-up): force-panic a writer in `connection.rs`, confirm the desktop app stays alive and the next `read()` returns the last-good state.

## Notes

This closes the rest of #3604 — the issue can be marked closed once this lands.

No public API change. Mechanical replacement.