### PR TITLE
fix(a2a): cap on-boot load at max_tasks instead of slurping retention window

### DIFF
--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -361,7 +361,16 @@ impl A2aTaskStore {
         }
     }
 
-    /// Load all tasks from the DB into the in-memory map.
+    /// Load the most recent `max_tasks` rows from the DB into the in-memory
+    /// map.
+    ///
+    /// Bound matters: a long-running daemon accumulates rows up to the
+    /// 7-day retention window, which can be far more than `max_tasks`.
+    /// Loading every row would (a) blow `max_tasks` on boot and force an
+    /// immediate cascade of capacity evictions and (b) hold the full
+    /// row set in memory during decode.  Older rows still live in the
+    /// DB and stay reachable through `get()`'s SQLite fallback when a
+    /// poller asks for them by ID.
     fn db_load_into_memory(&mut self) {
         let db_arc = match &self.db {
             Some(d) => d,
@@ -369,7 +378,10 @@ impl A2aTaskStore {
         };
         let conn = db_arc.lock().unwrap_or_else(|e| e.into_inner());
         let mut stmt = match conn.prepare(
-            "SELECT id, status, session_id, messages_json, artifacts_json, agent_id, caller_a2a_agent_id FROM a2a_tasks_v2",
+            "SELECT id, status, session_id, messages_json, artifacts_json, agent_id, caller_a2a_agent_id
+             FROM a2a_tasks_v2
+             ORDER BY updated_at DESC
+             LIMIT ?1",
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -378,7 +390,7 @@ impl A2aTaskStore {
             }
         };
 
-        let rows: Vec<_> = match stmt.query_map([], |row| {
+        let rows: Vec<_> = match stmt.query_map(rusqlite::params![self.max_tasks as i64], |row| {
             Ok((
                 row.get::<_, String>(0)?,         // id
                 row.get::<_, String>(1)?,         // status (JSON)
@@ -1389,5 +1401,52 @@ mod tests {
             .expect("evicted task must still be retrievable from the DB");
         assert_eq!(got.id, "evicted-1");
         assert_eq!(got.session_id.as_deref(), Some("s1"));
+    }
+
+    /// `with_persistence` must not load more than `max_tasks` rows on boot,
+    /// even when the DB has accumulated many more (long-running daemon
+    /// inside the 7-day retention window).  The `LIMIT` clause picks the
+    /// most recently updated rows; older rows stay reachable via the
+    /// `get()` SQLite fallback path.
+    #[test]
+    fn test_persistence_load_respects_max_tasks_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("a2a.db");
+
+        // First daemon lifetime: insert 10 tasks under a generous cap.
+        {
+            let store = A2aTaskStore::with_persistence(20, &db_path);
+            for i in 0..10 {
+                store.insert(A2aTask {
+                    id: format!("t-{i:02}"),
+                    session_id: None,
+                    status: A2aTaskStatus::Completed.into(),
+                    messages: vec![],
+                    artifacts: vec![],
+                    agent_id: None,
+                    caller_a2a_agent_id: None,
+                });
+            }
+        }
+
+        // Second lifetime: tighter cap.  The DB still has 10 rows, but the
+        // in-memory map must hold at most 3 to honour the new cap.
+        let restarted = A2aTaskStore::with_persistence(3, &db_path);
+        let in_memory_len = {
+            let tasks = restarted.tasks.lock().unwrap();
+            tasks.len()
+        };
+        assert_eq!(
+            in_memory_len, 3,
+            "boot load must respect max_tasks=3, got {in_memory_len}"
+        );
+
+        // Older rows still reachable through the DB fallback path.
+        for i in 0..10 {
+            assert!(
+                restarted.get(&format!("t-{i:02}")).is_some(),
+                "task t-{i:02} must remain queryable after restart (DB fallback)"
+            );
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #3935 (A2A task SQLite persistence).

## Problem

`A2aTaskStore::db_load_into_memory` loads **every** row in `a2a_tasks_v2` on construction, with no upper bound:

```sql
SELECT id, status, ... FROM a2a_tasks_v2
```

A daemon running for a week accumulates rows up to the 7-day retention horizon — easily far more than `max_tasks` (default 1024 in typical configs).  Booting then:

1. Reads every row into a `Vec<_>` regardless of `max_tasks` → transient memory spike during decode.
2. Inserts them all into the in-memory `HashMap`, blowing past `max_tasks`.
3. Sits above-cap until the next `insert()` triggers capacity eviction — and that only kicks in on mutation, not at boot.

So a freshly-restarted daemon with 10k DB rows holds 10k tasks in memory for an indefinite stretch even though `max_tasks` is 1024.

## Fix

Add `ORDER BY updated_at DESC LIMIT max_tasks` to the load query.  The most recently touched rows (the ones a poller is most likely to hit) make it into memory; older rows stay in the DB and remain reachable through `get()`'s existing SQLite fallback path — already covered by `test_persistence_get_falls_back_to_db_after_eviction`, so persistence semantics are unchanged for callers polling by ID.

## Test

`test_persistence_load_respects_max_tasks_cap`: writes 10 rows under a generous cap, restarts with `max_tasks=3`, asserts the in-memory map holds exactly 3 and that all 10 remain queryable through `get()` (DB fallback intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)