### PR TITLE
fix(kernel): atomic running_tasks swap to close abort-handle race

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -6583,10 +6583,20 @@ system_prompt = "You are a helpful assistant."
         // (auto_memorize, dream) which has its own join handle and doesn't
         // need external cancellation via the registry.
         if !is_fork {
-            // #3739: abort any previous task before replacing it so we don't
-            // orphan an in-flight LLM call by dropping its abort handle.
-            if let Some((_, old_task)) =
-                self.running_tasks.remove(&(agent_id, effective_session_id))
+            // #3739: atomically swap in the new task and abort the previous
+            // one if any.  `DashMap::insert` returns the displaced value
+            // under the same shard write-lock, so two concurrent
+            // `send_message_full` calls for the same (agent, session)
+            // can never both observe an empty slot and lose one of the
+            // abort handles.  The earlier `remove(...) → insert(...)`
+            // sequence had exactly that race window.
+            let new_task = RunningTask {
+                abort: handle.abort_handle(),
+                started_at: chrono::Utc::now(),
+            };
+            if let Some(old_task) = self
+                .running_tasks
+                .insert((agent_id, effective_session_id), new_task)
             {
                 tracing::debug!(
                     agent_id = %agent_id,
@@ -6595,13 +6605,6 @@ system_prompt = "You are a helpful assistant."
                 );
                 old_task.abort.abort();
             }
-            self.running_tasks.insert(
-                (agent_id, effective_session_id),
-                RunningTask {
-                    abort: handle.abort_handle(),
-                    started_at: chrono::Utc::now(),
-                },
-            );
         }
 
         Ok((rx, handle))


### PR DESCRIPTION
Follow-up to #3960 (#3739).

## Problem

#3960 set out to fix orphaned in-flight LLM calls when `send_message_full` re-enters for the same (agent, session) — the previous task's `AbortHandle` was being dropped without `abort()` being called, leaking the in-flight LLM call.

The implementation used `DashMap::remove` followed by `DashMap::insert`:

```rust
if let Some((_, old_task)) = self.running_tasks.remove(&(agent_id, effective_session_id)) {
    old_task.abort.abort();
}
self.running_tasks.insert((agent_id, effective_session_id), RunningTask { … });
```

These are two separate operations.  The shard write-lock is released between them, which is the same race window the fix was supposed to close:

```
T1: remove → Some(old)            (slot empty after this)
T2: remove → None                 (slot still empty)
T1: abort old, insert new1
T2: insert new2                   (overwrites new1)
⇒ new1's AbortHandle is dropped without abort being called
```

`new1`'s LLM call is now orphaned — the exact failure mode #3739 described, just inside a tighter window.

## Fix

`DashMap::insert(k, v)` returns the displaced value (`Option<V>`) inside a single shard write-lock.  Use that directly so the swap is atomic with no observable empty slot:

```rust
let new_task = RunningTask { … };
if let Some(old_task) = self.running_tasks.insert((agent_id, sid), new_task) {
    old_task.abort.abort();
}
```

No remove/insert race window.  Behaviour identical when there's no contention; correct under contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)