### PR TITLE
fix(desktop): create mobile WebviewWindow so iOS/Android stop launching black

### DIFF
--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -360,10 +360,9 @@ pub fn run(server_url: Option<String>, force_local: bool) {
 
     builder
         .setup(move |app| {
-            // Window creation is desktop-only. On iOS/Android the host OS
-            // manages the main window via tauri.conf.json's "app.windows"
-            // entry, and WebviewWindowBuilder does not expose .title() /
-            // .inner_size() / .center() on mobile.
+            // Desktop window. `.title()` / `.inner_size()` / `.center()` /
+            // `.min_inner_size()` are not exposed on mobile, so the mobile
+            // branch below has its own minimal builder.
             #[cfg(desktop)]
             {
                 if show_connection_screen {
@@ -396,6 +395,27 @@ pub fn run(server_url: Option<String>, force_local: bool) {
                     .visible(true)
                     .build()?;
                 }
+            }
+
+            // Mobile window. Without this, iOS/Android launches into a
+            // black WebView because tauri.conf.json's `app.windows` is
+            // empty and Tauri 2 does not auto-create a mobile window.
+            // The OS manages size/orientation, so we only set the URL
+            // and visibility.
+            #[cfg(mobile)]
+            {
+                let url = if show_connection_screen {
+                    WebviewUrl::CustomProtocol(
+                        "lfconnect://localhost/"
+                            .parse()
+                            .expect("lfconnect URL must parse"),
+                    )
+                } else {
+                    WebviewUrl::External(initial_url.parse().expect("Invalid server URL"))
+                };
+                let _window = WebviewWindowBuilder::new(app, "main", url)
+                    .visible(true)
+                    .build()?;
             }
 
             // Set up system tray (desktop only)


### PR DESCRIPTION
## Summary

Mobile-side blank-screen regression discovered while running the freshly-released mobile epic on an `aarch64-apple-ios-sim` simulator: the iOS build launches, the LibreFang process starts, UIKit lifecycle logs flow, but **no WKWebView is ever instantiated** — user sees a black window.

## Root cause

`crates/librefang-desktop/src/lib.rs` has a single window-creation block in `setup()` gated `#[cfg(desktop)]`. The original assumption (PR #3970): mobile would auto-create a window from `app.windows` in `tauri.conf.json`. Reality:

- `tauri.conf.json` has `app.windows = []` (intentional — desktop window creation uses `.title()` / `.inner_size()` / `.center()` / `.min_inner_size()` which the mobile builder does not expose, so a config-driven window would force calling them).
- With `app.windows = []` AND no `#[cfg(mobile)]` builder, **no window is ever created** on iOS or Android.

Result: black screen at every launch.

## Fix

Add a sibling `#[cfg(mobile)]` block that builds the same window with the chained desktop-only methods stripped. URL selection mirrors desktop:

- Connection wizard via the `lfconnect://` custom protocol when no daemon is configured
- `WebviewUrl::External(initial_url)` once a daemon is chosen

The `lfconnect` scheme is registered on the Tauri builder at `lib.rs:225` and is not cfg-gated, so it works on both desktop and mobile.

```rust
#[cfg(mobile)]
{
    let url = if show_connection_screen {
        WebviewUrl::CustomProtocol("lfconnect://localhost/".parse().expect("lfconnect URL must parse"))
    } else {
        WebviewUrl::External(initial_url.parse().expect("Invalid server URL"))
    };
    let _window = WebviewWindowBuilder::new(app, "main", url)
        .visible(true)
        .build()?;
}
```

## Test plan

- [x] **Before**: `cargo tauri ios build --target aarch64-sim --debug` + `xcrun simctl install/launch` → black screen, no WKWebView in logs.
- [x] **After**: same build + install/launch → connection wizard renders correctly.
- [ ] Android device verification (deferred — same `mobile` cfg covers both targets; will be picked up by the first manual Play Internal Testing distribution per `/operations/mobile-release`).

## Notes

- No public API change.
- ~24 lines added. Mechanical mirror of the desktop builder with desktop-only chained methods stripped.
- Pre-existing `tauri.conf.json` `frontendDist` situation is unaffected — the connection wizard is served by the `lfconnect://` custom protocol that bypasses `frontendDist` entirely. Direct-mode (`WebviewUrl::External`) hits the daemon URL over the network. Neither path needs `frontendDist` configured.