### PR TITLE
fix(kernel): serialize triggers/workflow persist writes to close in-process tmp-file race

### DIFF
--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -184,6 +184,11 @@ pub struct TriggerEngine {
     /// Path to the persistence file (`<home>/trigger_jobs.json`).
     /// `None` means no persistence (used in tests).
     persist_path: Option<PathBuf>,
+    /// Serializes `persist()` writes so concurrent callers (event
+    /// dispatch, API routes, restart handlers) within a single process
+    /// don't `O_TRUNC` the same `.tmp.{pid}` path and produce a torn
+    /// file before rename.  Mirrors `CronScheduler::persist_lock`.
+    persist_lock: std::sync::Mutex<()>,
 }
 
 impl TriggerEngine {
@@ -196,6 +201,7 @@ impl TriggerEngine {
             max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
             default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
             persist_path: None,
+            persist_lock: std::sync::Mutex::new(()),
         }
     }
 
@@ -211,6 +217,7 @@ impl TriggerEngine {
             max_triggers_per_event: config.max_per_event.max(1),
             default_cooldown_secs: config.cooldown_secs,
             persist_path: Some(home_dir.join("trigger_jobs.json")),
+            persist_lock: std::sync::Mutex::new(()),
         }
     }
 
@@ -292,6 +299,7 @@ impl TriggerEngine {
     ///
     /// Does nothing when no persistence path is configured.
     pub fn persist(&self) -> LibreFangResult<()> {
+        let _guard = self.persist_lock.lock().unwrap_or_else(|e| e.into_inner());
         let path = match &self.persist_path {
             Some(p) => p,
             None => return Ok(()),
@@ -1978,6 +1986,7 @@ mod tests {
             max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
             default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
             persist_path: Some(persist_path.clone()),
+            persist_lock: std::sync::Mutex::new(()),
         };
         let agent_id = AgentId::new();
         // Register with a 60-second cooldown so it won't expire during the test.
@@ -2015,6 +2024,7 @@ mod tests {
             max_triggers_per_event: DEFAULT_MAX_TRIGGERS_PER_EVENT,
             default_cooldown_secs: DEFAULT_COOLDOWN_SECS,
             persist_path: Some(persist_path),
+            persist_lock: std::sync::Mutex::new(()),
         };
         let loaded = engine2.load().unwrap();
         assert_eq!(loaded, 1, "Should have loaded exactly one trigger");

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -347,6 +347,11 @@ pub struct WorkflowEngine {
     runs: Arc<DashMap<WorkflowRunId, WorkflowRun>>,
     /// Optional path to persist completed/failed runs (`~/.librefang/workflow_runs.json`).
     persist_path: Option<PathBuf>,
+    /// Serializes `persist_runs` writes so concurrent callers within a
+    /// single process don't `O_TRUNC` the same `.tmp.{pid}` path and
+    /// produce a torn file before rename.  `Arc` so the engine stays
+    /// `Clone` (mutexes are shared, not duplicated).
+    persist_lock: Arc<std::sync::Mutex<()>>,
 }
 
 /// Evaluate a conditional expression against the previous step output.
@@ -458,6 +463,7 @@ impl WorkflowEngine {
             workflows: Arc::new(RwLock::new(HashMap::new())),
             runs: Arc::new(DashMap::new()),
             persist_path: None,
+            persist_lock: Arc::new(std::sync::Mutex::new(())),
         }
     }
 
@@ -469,6 +475,7 @@ impl WorkflowEngine {
             workflows: Arc::new(RwLock::new(HashMap::new())),
             runs: Arc::new(DashMap::new()),
             persist_path: Some(home_dir.join("data").join("workflow_runs.json")),
+            persist_lock: Arc::new(std::sync::Mutex::new(())),
         }
     }
 
@@ -530,6 +537,7 @@ impl WorkflowEngine {
 
     /// Persist completed/failed runs to disk via atomic write.
     fn persist_runs(&self) {
+        let _guard = self.persist_lock.lock().unwrap_or_else(|e| e.into_inner());
         let path = match &self.persist_path {
             Some(p) => p,
             None => return,


### PR DESCRIPTION
Follow-up to #3954 (atomic persist with fsync) — extends the fix to triggers/workflow which #3946 already resolved for cron.

## Problem

#3954 named the staging file with the process ID (`triggers.json.tmp.<pid>`) so two daemons can't clobber each other's tmp.  Inside a single process every thread still hits the same path, so two concurrent `persist()` calls race:

```
T1: File::create(tmp)   // O_TRUNC, holds fd_a
T2: File::create(tmp)   // O_TRUNC, holds fd_b — wipes T1's bytes
T1: write_all (resumed) // partial overlap
T2: write_all
T1: rename(tmp -> final)  // ships interleaved bytes
T2: rename(tmp -> final)  // ENOENT — T1 already renamed
```

#3946 already noticed this for `CronScheduler` and added a `persist_lock: Mutex<()>` that serializes writes inside the process.  The same call-site shape applies to:

- `TriggerEngine::persist()` — invoked from ~10 paths in `kernel/mod.rs` (event dispatch, hot-reload, mutation API routes, restart handlers).
- `WorkflowEngine::persist_runs()` — invoked from the workflow execution path concurrently with API CRUD.

Without a lock those two are still exposed.

## Fix

Add the same `persist_lock` to `TriggerEngine` and `WorkflowEngine` and acquire it at the top of `persist()` / `persist_runs()`.  Mirrors the cron pattern:
- leaf mutex (holds during fs IO + serde, no nested locks);
- poison-tolerant via `unwrap_or_else(|e| e.into_inner())`;
- inner type is `()`, so poisoning never carries corrupt state.

`WorkflowEngine` derives `Clone`, so its lock is `Arc<Mutex<()>>` — clones share the same mutex (correct semantic: cloned engines target the same persist path, must serialize).

## No new tests

The race manifests only under timing pressure and is hard to assert deterministically without injecting fault points.  Following the established `CronScheduler::persist_lock` pattern keeps this consistent with the rest of the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)