### PR TITLE
fix(api,types,kernel): repair main — conflict markers, duplicate fn, unclosed delimiter, stale schema golden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,6 +4043,7 @@ dependencies = [
  "http-body-util",
  "include_dir",
  "jsonwebtoken",
+ "libc",
  "librefang-channels",
  "librefang-extensions",
  "librefang-hands",
@@ -4307,6 +4308,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
+ "sha2",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -4468,6 +4471,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "shlex",
  "tar",
@@ -4528,6 +4532,7 @@ name = "librefang-runtime-wasm"
 version = "2026.4.28-beta7"
 dependencies = [
  "anyhow",
+ "async-trait",
  "librefang-http",
  "librefang-kernel-handle",
  "librefang-types",

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -81,9 +81,7 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
     let mut tmp = path.to_path_buf();
     let file_name = path
         .file_name()
-        .ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename")
-        })?
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename"))?
         .to_os_string();
     let mut tmp_name = file_name;
     tmp_name.push(format!(".{}.{seq}.tmp", std::process::id()));

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -714,7 +714,6 @@ pub async fn auth(
     // SECURITY: Use constant-time comparison to prevent timing attacks.
     let header_auth = api_token.map(&matches_any);
 
-<<<<<<< HEAD
     // SECURITY: ?token= query-string auth is deliberately NOT checked here.
     // Query parameters are written to server access logs, retained in browser
     // history, and forwarded in HTTP Referer headers to third parties. Tokens
@@ -722,37 +721,6 @@ pub async fn auth(
     // the session cookie. WebSocket upgrades are the sole exception (browsers
     // cannot set custom headers on WebSocket connections); they authenticate
     // via crate::ws::ws_auth_token, which never passes through this middleware.
-=======
-    // SECURITY: ?token= query parameter is ONLY accepted for WebSocket upgrade
-    // requests and SSE streaming endpoints where browsers cannot send custom
-    // headers. For all other REST routes the token must come from an
-    // Authorization: Bearer or X-API-Key header — query params appear in
-    // access logs, Referer headers, and browser history, making them easy to
-    // accidentally leak.
-    //
-    // Allowed path prefixes:
-    //   /api/agents/{id}/ws           — WebSocket upgrade (can't set headers)
-    //   /ws/                          — any future top-level WS endpoint
-    //   /api/agents/{id}/sessions/*/stream — SSE session attach
-    //   /api/agents/{id}/message/stream   — SSE message stream
-    //   /api/logs/stream              — SSE log tail
-    //
-    // Percent-decode (but NOT form-urlencoded) so literal `+` characters in
-    // base64-derived tokens are preserved instead of being turned into spaces.
-    // See issue #962 (ported from openfang).
-    let is_ws_or_sse_path =
-        path.ends_with("/ws") || path.starts_with("/ws/") || path.ends_with("/stream");
-
-    let query_token_decoded = if is_ws_or_sse_path {
-        request
-            .uri()
-            .query()
-            .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
-            .map(crate::percent_decode)
-    } else {
-        None
-    };
->>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
 
     // Accept if header auth matches a static API key or legacy token
     if header_auth == Some(true) {

--- a/crates/librefang-api/src/rate_limiter.rs
+++ b/crates/librefang-api/src/rate_limiter.rs
@@ -343,10 +343,7 @@ pub async fn auth_rate_limit_layer(
         return Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
             .header("content-type", "application/json")
-            .header(
-                "retry-after",
-                AUTH_RATE_LIMIT_RETRY_AFTER_SECS.to_string(),
-            )
+            .header("retry-after", AUTH_RATE_LIMIT_RETRY_AFTER_SECS.to_string())
             .body(Body::from(
                 serde_json::json!({
                     "error": "Too many login attempts. Please wait before trying again."

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1541,8 +1541,10 @@ pub async fn send_message(
             };
             let t = ErrorTranslator::new(l);
             ApiErrorResponse {
-                error: t
-                    .t_args("api-error-message-delivery-failed", &[("reason", &e.to_string())]),
+                error: t.t_args(
+                    "api-error-message-delivery-failed",
+                    &[("reason", &e.to_string())],
+                ),
                 code: Some(code.to_string()),
                 r#type: Some(code.to_string()),
                 details: None,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3681,63 +3681,25 @@ pub async fn update_agent(
         }
     };
 
-<<<<<<< HEAD
     drop(t);
 
+    // `update_manifest` preserves workspace/name/tags, re-grants capabilities,
+    // refreshes scheduler quotas, persists to SQLite, and writes agent.toml.
+    // Per-agent concurrency caps and session_mode caches still require
+    // kill+respawn — flagged in the response note.
     match state.kernel.update_manifest(agent_id, manifest) {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({
                 "status": "ok",
                 "agent_id": id,
+                "note": "Manifest persisted; capabilities and scheduler quotas refreshed in place. Per-agent concurrency caps and session-mode changes take effect after the agent is killed and respawned.",
             })),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": e.to_string()})),
         ),
-=======
-    // Apply the new manifest to the in-memory registry (preserves runtime-only
-    // fields like workspace path and tags).
-    if let Err(e) = state
-        .kernel
-        .agent_registry()
-        .replace_manifest(agent_id, manifest)
-    {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
-            ),
-        );
-    }
-
-    // Persist updated entry to SQLite so it survives a restart.
-    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
-        if let Err(e) = state.kernel.memory_substrate().save_agent(&entry) {
-            tracing::warn!("Failed to persist agent manifest update: {e}");
-        }
-    }
-
-    // Write updated manifest to agent.toml on disk so the file matches the
-    // in-memory state and doesn't override changes on next boot.
-    state.kernel.persist_manifest_to_disk(agent_id);
-
-    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
-        (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "ok",
-                "agent_id": entry.id.to_string(),
-                "name": entry.name,
-            })),
-        )
-    } else {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": t.t("api-error-agent-vanished")})),
-        )
->>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
     }
 }
 

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -149,9 +149,7 @@ fn default_user_id() -> String {
 /// semantically correct codes for `InvalidInput` (400), `AgentNotFound` /
 /// `SessionNotFound` (404), `CapabilityDenied` (403), and `QuotaExceeded` (429)
 /// so callers can distinguish between client errors and server errors.
-fn internal_error(
-    e: impl std::fmt::Display,
-) -> (StatusCode, Json<serde_json::Value>) {
+fn internal_error(e: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
     map_memory_error(e.to_string())
 }
 
@@ -161,9 +159,7 @@ fn map_memory_error(msg: String) -> (StatusCode, Json<serde_json::Value>) {
     // providing correct HTTP semantics.
     let status = if msg.starts_with("Invalid input:") {
         StatusCode::BAD_REQUEST
-    } else if msg.starts_with("Agent not found:")
-        || msg.starts_with("Session not found:")
-    {
+    } else if msg.starts_with("Agent not found:") || msg.starts_with("Session not found:") {
         StatusCode::NOT_FOUND
     } else if msg.starts_with("Capability denied:") {
         StatusCode::FORBIDDEN
@@ -174,10 +170,7 @@ fn map_memory_error(msg: String) -> (StatusCode, Json<serde_json::Value>) {
         StatusCode::INTERNAL_SERVER_ERROR
     };
 
-    (
-        status,
-        Json(serde_json::json!({ "error": msg })),
-    )
+    (status, Json(serde_json::json!({ "error": msg })))
 }
 
 /// Build a [`MemoryNamespaceGuard`] for the current request from the

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -1254,37 +1254,39 @@ pub async fn clawhub_cn_install(
             let manifest_path = skill_dir.join("skill.toml");
             if manifest_path.exists() {
                 match std::fs::read_to_string(&manifest_path) {
-                    Ok(toml_str) => match toml::from_str::<librefang_skills::SkillManifest>(&toml_str) {
-                        Ok(mut manifest) => {
-                            manifest.source = Some(librefang_skills::SkillSource::ClawHubCn {
-                                slug: req.slug.clone(),
-                                version: result.version.clone(),
-                            });
-                            match toml::to_string_pretty(&manifest) {
-                                Ok(updated) => {
-                                    if let Err(e) = std::fs::write(&manifest_path, updated) {
+                    Ok(toml_str) => {
+                        match toml::from_str::<librefang_skills::SkillManifest>(&toml_str) {
+                            Ok(mut manifest) => {
+                                manifest.source = Some(librefang_skills::SkillSource::ClawHubCn {
+                                    slug: req.slug.clone(),
+                                    version: result.version.clone(),
+                                });
+                                match toml::to_string_pretty(&manifest) {
+                                    Ok(updated) => {
+                                        if let Err(e) = std::fs::write(&manifest_path, updated) {
+                                            tracing::warn!(
+                                                slug = %req.slug,
+                                                path = %manifest_path.display(),
+                                                "Failed to write provenance to skill.toml: {e}"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
                                         tracing::warn!(
                                             slug = %req.slug,
-                                            path = %manifest_path.display(),
-                                            "Failed to write provenance to skill.toml: {e}"
+                                            "Failed to serialize skill manifest for provenance patch: {e}"
                                         );
                                     }
                                 }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        slug = %req.slug,
-                                        "Failed to serialize skill manifest for provenance patch: {e}"
-                                    );
-                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    slug = %req.slug,
+                                    "Failed to parse skill.toml for provenance patch: {e}"
+                                );
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                slug = %req.slug,
-                                "Failed to parse skill.toml for provenance patch: {e}"
-                            );
-                        }
-                    },
+                    }
                     Err(e) => {
                         tracing::warn!(
                             slug = %req.slug,

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1871,7 +1871,7 @@ pub async fn approve_request(
                     // Replay-prevention check (#3359): reject a code that was
                     // already used within the last 60 seconds (two TOTP windows).
                     if state.kernel.approvals().is_totp_code_used(code) {
-                        state.kernel.approvals().record_totp_failure("api_admin");
+                        let _ = state.kernel.approvals().record_totp_failure("api_admin");
                         return ApiErrorResponse::bad_request(
                             "TOTP code has already been used. Wait for the next 30-second window.",
                         )
@@ -2507,7 +2507,7 @@ pub async fn totp_setup(
                 } else {
                     // TOTP code — check replay before verifying (#3359).
                     if state.kernel.approvals().is_totp_code_used(code) {
-                        state.kernel.approvals().record_totp_failure("api_admin");
+                        let _ = state.kernel.approvals().record_totp_failure("api_admin");
                         return ApiErrorResponse::bad_request(
                             "TOTP code has already been used. Wait for the next 30-second window.",
                         )
@@ -2639,7 +2639,7 @@ pub async fn totp_confirm(
 
     // Replay-prevention check (#3359): reject a code already used in the last 60 s.
     if state.kernel.approvals().is_totp_code_used(&body.code) {
-        state.kernel.approvals().record_totp_failure("api_admin");
+        let _ = state.kernel.approvals().record_totp_failure("api_admin");
         return ApiErrorResponse::bad_request(
             "TOTP code has already been used. Wait for the next 30-second window.",
         )

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -118,7 +118,9 @@ async fn start_test_server_with_provider(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()
@@ -1636,7 +1638,9 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let api_key_state = middleware::AuthState {
@@ -2810,7 +2814,9 @@ async fn start_test_server_with_rbac_users(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let api_key_state = middleware::AuthState {
@@ -3114,7 +3120,9 @@ async fn start_test_server_with_full_user_configs(
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let api_key_state = middleware::AuthState {

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -131,7 +131,9 @@ async fn test_full_daemon_lifecycle() {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()
@@ -275,7 +277,9 @@ async fn test_server_immediate_responsiveness() {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -5148,6 +5148,22 @@
           },
           "type": "array"
         },
+        "max_llm_tokens_per_peer_per_hour": {
+          "description": "SECURITY (#3876): Optional cumulative LLM token budget per OFP peer per hour.\n\nWhen set, the node tracks how many tokens each peer's requests have consumed in the current hour window. If a peer exceeds this budget the request is rejected with a 429 error.\n\nmeans no per-peer token cap (default). Set to a value like to bound the LLM spend a single federated peer can force.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "max_messages_per_peer_per_minute": {
+          "default": 60,
+          "description": "SECURITY (#3876): Maximum number of  requests a single OFP peer may send per minute before being rate-limited.\n\nEach peer connection is tracked independently. Excess messages are rejected with a 429 error response; a  is emitted with the peer ID and current rate so operators can investigate abuse.\n\nSet to  to disable per-peer message rate limiting (not recommended for production federations). Default: 60.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
         "max_peers": {
           "default": 50,
           "description": "Maximum number of connected peers.",
@@ -8218,7 +8234,7 @@
             },
             "allow_local": {
               "default": false,
-              "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses.\nDefaults to `false`; set to `true` only when signal-cli runs on localhost.",
+              "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses. Defaults to `false`; set to `true` only when signal-cli runs on localhost.",
               "type": "boolean"
             },
             "allowed_users": {
@@ -8231,7 +8247,7 @@
             },
             "api_key": {
               "default": null,
-              "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request.\nIf absent, requests are sent without an Authorization header.",
+              "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request. If absent, requests are sent without an Authorization header.",
               "type": [
                 "string",
                 "null"
@@ -10471,6 +10487,13 @@
           "minimum": 0.0,
           "type": "integer"
         },
+        "auth_rate_limit_per_ip": {
+          "default": 10,
+          "description": "Max login attempts per IP per 15-minute window on auth endpoints (`/api/auth/dashboard-login`, `/api/auth/login*`). Default: 10. Set to 0 to disable the per-IP auth rate limiter.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
         "max_ws_per_ip": {
           "default": 5,
           "description": "Maximum concurrent WebSocket connections per IP. Default: 5.",
@@ -10848,7 +10871,7 @@
       "type": "object"
     },
     "SanitizeConfig": {
-      "description": "Configuration for channel input sanitization / prompt-injection detection.\n\n```toml [sanitize] mode = \"warn\"           # off | warn | block max_message_length = 32768 custom_block_patterns = [\"(?i)secret\\\\s+code\"] ```",
+      "description": "Configuration for channel input sanitization / prompt-injection detection.\n\nThe sanitizer is **enabled by default** (mode = \"block\"). To opt out set `disable_input_sanitizer = true` in `[sanitize]` or change `mode`:\n\n```toml [sanitize] mode = \"block\"          # off | warn | block  (default: block) max_message_length = 32768 custom_block_patterns = [\"(?i)secret\\\\s+code\"] # disable_input_sanitizer = true  # emergency opt-out ```",
       "properties": {
         "custom_block_patterns": {
           "default": [],
@@ -10857,6 +10880,11 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "disable_input_sanitizer": {
+          "default": false,
+          "description": "Emergency opt-out: set to `true` to disable all input sanitization. Not recommended for production — prefer `mode = \"warn\"` for monitoring without blocking, or `mode = \"off\"` for a softer disable.",
+          "type": "boolean"
         },
         "max_message_length": {
           "default": 32768,
@@ -10871,7 +10899,7 @@
               "$ref": "#/definitions/SanitizeMode"
             }
           ],
-          "default": "off",
+          "default": "block",
           "description": "Sanitization mode."
         }
       },
@@ -10881,7 +10909,7 @@
       "description": "Input sanitization mode for channel messages.",
       "oneOf": [
         {
-          "description": "No checking — all messages pass through (default).",
+          "description": "No checking — all messages pass through. Set `mode = \"off\"` in `[sanitize]` to opt out of prompt-injection detection.",
           "enum": [
             "off"
           ],
@@ -10895,7 +10923,7 @@
           "type": "string"
         },
         {
-          "description": "Reject the message and send an error to the user.",
+          "description": "Reject the message and send an error to the user (default).",
           "enum": [
             "block"
           ],
@@ -11182,7 +11210,7 @@
         },
         "allow_local": {
           "default": false,
-          "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses.\nDefaults to `false`; set to `true` only when signal-cli runs on localhost.",
+          "description": "When `true`, allow the `api_url` to point at loopback / RFC-1918 addresses. Defaults to `false`; set to `true` only when signal-cli runs on localhost.",
           "type": "boolean"
         },
         "allowed_users": {
@@ -11195,7 +11223,7 @@
         },
         "api_key": {
           "default": null,
-          "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request.\nIf absent, requests are sent without an Authorization header.",
+          "description": "Optional API key sent as `Authorization: Bearer <api_key>` on every request. If absent, requests are sent without an Authorization header.",
           "type": [
             "string",
             "null"
@@ -14324,6 +14352,7 @@
         "issuer_url": "",
         "providers": [],
         "redirect_url": "http://127.0.0.1:4545/api/auth/callback",
+        "require_email_verified": true,
         "scopes": [
           "openid",
           "profile",
@@ -14560,6 +14589,7 @@
         "listen_addresses": [
           "/ip4/0.0.0.0/tcp/0"
         ],
+        "max_messages_per_peer_per_minute": 60,
         "max_peers": 50,
         "mdns_enabled": true,
         "shared_secret": ""
@@ -14790,6 +14820,7 @@
       ],
       "default": {
         "api_requests_per_minute": 500,
+        "auth_rate_limit_per_ip": 10,
         "max_ws_per_ip": 5,
         "retry_after_secs": 60,
         "ws_debounce_chars": 200,
@@ -14839,8 +14870,9 @@
       ],
       "default": {
         "custom_block_patterns": [],
+        "disable_input_sanitizer": false,
         "max_message_length": 32768,
-        "mode": "off"
+        "mode": "block"
       },
       "description": "Input sanitization / prompt-injection detection for channel messages."
     },
@@ -15184,6 +15216,13 @@
       ],
       "default": null,
       "description": "Webhook trigger configuration (external event injection)."
+    },
+    "workflow_stale_timeout_minutes": {
+      "default": 60,
+      "description": "How long (in minutes) a workflow run may remain in the `Running` or `Pending` state before it is considered stale after a daemon restart.\n\nOn boot the engine scans all persisted runs and marks any that are older than this threshold as `Failed` with the error `\"Interrupted by daemon restart\"`.  Set to `0` to disable recovery. Default: `60` minutes.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
     },
     "workspaces_dir": {
       "default": null,

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -75,7 +75,9 @@ async fn start_test_server() -> TestServer {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/pairing_test.rs
+++ b/crates/librefang-api/tests/pairing_test.rs
@@ -76,7 +76,9 @@ async fn boot_with_pairing(enabled: bool, public_base_url: Option<String>) -> Ha
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/tools_invoke_test.rs
+++ b/crates/librefang-api/tests/tools_invoke_test.rs
@@ -78,7 +78,9 @@ async fn build_harness(tool_invoke: ToolInvokeConfig) -> Harness {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()

--- a/crates/librefang-api/tests/users_test.rs
+++ b/crates/librefang-api/tests/users_test.rs
@@ -74,7 +74,9 @@ async fn boot_with_seed_users(seed: Vec<UserConfig>) -> Harness {
         provider_test_cache: dashmap::DashMap::new(),
         config_write_lock: tokio::sync::Mutex::new(()),
         pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+        auth_login_limiter: std::sync::Arc::new(
+            librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+        ),
     });
 
     let app = Router::new()

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -610,8 +610,7 @@ impl ChannelAdapter for DingTalkAdapter {
                 let tx = Arc::clone(&tx);
                 let secret = Arc::clone(&secret);
                 let account_id = Arc::clone(&account_id);
-                move |headers: axum::http::HeaderMap,
-                      body: axum::body::Bytes| {
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
                     let tx = Arc::clone(&tx);
                     let secret = Arc::clone(&secret);
                     let account_id = Arc::clone(&account_id);
@@ -874,7 +873,9 @@ mod tests {
         let timestamp: i64 = 1700000000000;
         let body = b"webhook-body";
         let sig = DingTalkAdapter::compute_signature(secret, timestamp, body);
-        assert!(DingTalkAdapter::verify_signature(secret, timestamp, body, &sig));
+        assert!(DingTalkAdapter::verify_signature(
+            secret, timestamp, body, &sig
+        ));
         assert!(!DingTalkAdapter::verify_signature(
             secret, timestamp, body, "bad-sig"
         ));

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -266,10 +266,9 @@ impl MessageJournal {
     /// Call periodically or on shutdown.
     pub async fn compact(&self) {
         let inner = self.inner.lock().await;
-        let tmp_path = inner.path.with_extension(format!(
-            "jsonl.tmp.{}",
-            std::process::id()
-        ));
+        let tmp_path = inner
+            .path
+            .with_extension(format!("jsonl.tmp.{}", std::process::id()));
         let result = (|| -> std::io::Result<()> {
             let mut file = std::fs::File::create(&tmp_path)?;
             for entry in inner.pending.values() {

--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -418,7 +418,10 @@ impl StandaloneChat {
                 }
             }
             Backend::InProcess { kernel } => {
-                let catalog = kernel.model_catalog_ref().read().unwrap_or_else(|p| p.into_inner());
+                let catalog = kernel
+                    .model_catalog_ref()
+                    .read()
+                    .unwrap_or_else(|p| p.into_inner());
                 catalog
                     .available_models()
                     .into_iter()

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -402,8 +402,7 @@ pub fn spawn_daemon_stream(
     std::thread::spawn(move || {
         use std::io::{BufRead, BufReader, Read};
 
-        let client =
-            make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(300));
+        let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(300));
 
         let url = format!("{base_url}/api/agents/{agent_id}/message/stream");
         let resp = client
@@ -532,8 +531,7 @@ fn daemon_fallback(
     message: &str,
     api_key: Option<&str>,
 ) -> Result<AgentLoopResult, String> {
-    let client =
-        make_daemon_client_with_timeout(api_key, Duration::from_secs(120));
+    let client = make_daemon_client_with_timeout(api_key, Duration::from_secs(120));
 
     let resp = client
         .post(format!("{base_url}/api/agents/{agent_id}/message"))
@@ -585,8 +583,7 @@ pub fn spawn_daemon_agent(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || {
-        let client =
-            make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(30));
+        let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(30));
 
         let resp = client
             .post(format!("{base_url}/api/agents"))
@@ -819,7 +816,8 @@ pub fn spawn_fetch_channels(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
 pub fn spawn_test_channel(backend: BackendRef, channel: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
         BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
+            let client =
+                make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/channels/{channel}/test"))
@@ -939,7 +937,8 @@ pub fn spawn_run_workflow(
 ) {
     std::thread::spawn(move || match backend {
         BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(60));
+            let client =
+                make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(60));
 
             match client
                 .post(format!("{base_url}/api/workflows/{workflow_id}/run"))
@@ -977,7 +976,8 @@ pub fn spawn_create_workflow(
 ) {
     std::thread::spawn(move || match backend {
         BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
+            let client =
+                make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/workflows"))
@@ -1050,7 +1050,8 @@ pub fn spawn_create_trigger(
 ) {
     std::thread::spawn(move || match backend {
         BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
+            let client =
+                make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(10));
 
             match client
                 .post(format!("{base_url}/api/triggers"))
@@ -1390,7 +1391,9 @@ fn make_daemon_client_with_timeout(
         }
         builder = builder.default_headers(headers);
     }
-    builder.build().unwrap_or_else(|_| crate::http_client::new_client())
+    builder
+        .build()
+        .unwrap_or_else(|_| crate::http_client::new_client())
 }
 
 /// Fetch sessions list.
@@ -2149,7 +2152,8 @@ pub fn spawn_delete_provider_key(backend: BackendRef, name: String, tx: mpsc::Se
 pub fn spawn_test_provider(backend: BackendRef, name: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || match backend {
         BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(15));
+            let client =
+                make_daemon_client_with_timeout(api_key.as_deref(), Duration::from_secs(15));
             let start = std::time::Instant::now();
             match client
                 .post(format!("{base_url}/api/providers/{name}/test"))

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -120,7 +120,9 @@ enum Backend {
         /// API key read from config.toml `api_key`, forwarded to every HTTP request.
         api_key: Option<String>,
     },
-    InProcess { kernel: Arc<LibreFangKernel> },
+    InProcess {
+        kernel: Arc<LibreFangKernel>,
+    },
     None,
 }
 
@@ -1906,7 +1908,12 @@ impl App {
         match &self.backend {
             Backend::Daemon { base_url, api_key } => {
                 self.agents.sub = agents::AgentSubScreen::Spawning;
-                event::spawn_daemon_agent(base_url.clone(), toml_content, api_key.clone(), self.event_tx.clone());
+                event::spawn_daemon_agent(
+                    base_url.clone(),
+                    toml_content,
+                    api_key.clone(),
+                    self.event_tx.clone(),
+                );
             }
             Backend::InProcess { kernel } => {
                 let manifest: librefang_types::agent::AgentManifest =
@@ -2112,10 +2119,7 @@ impl App {
                     Backend::Daemon { base_url, .. } => {
                         // Fetch agent list asynchronously — avoids blocking the TUI event loop.
                         // The `ChatAgentListLoaded` event handler will push the reply.
-                        event::spawn_fetch_agents_for_chat(
-                            base_url.clone(),
-                            self.event_tx.clone(),
-                        );
+                        event::spawn_fetch_agents_for_chat(base_url.clone(), self.event_tx.clone());
                     }
                     Backend::InProcess { kernel } => {
                         let lines: Vec<String> = kernel

--- a/crates/librefang-kernel/src/background.rs
+++ b/crates/librefang-kernel/src/background.rs
@@ -210,7 +210,13 @@ impl BackgroundExecutor {
                     }
                 });
 
-                self.tasks.insert(agent_id, AgentTaskEntry { outer: handle, watchers: watcher_handles });
+                self.tasks.insert(
+                    agent_id,
+                    AgentTaskEntry {
+                        outer: handle,
+                        watchers: watcher_handles,
+                    },
+                );
             }
             ScheduleMode::Periodic { cron } => {
                 let interval_secs = parse_cron_to_secs(cron);
@@ -307,7 +313,13 @@ impl BackgroundExecutor {
                     }
                 });
 
-                self.tasks.insert(agent_id, AgentTaskEntry { outer: handle, watchers: watcher_handles });
+                self.tasks.insert(
+                    agent_id,
+                    AgentTaskEntry {
+                        outer: handle,
+                        watchers: watcher_handles,
+                    },
+                );
             }
             ScheduleMode::Proactive { .. } => {
                 // Proactive agents rely on triggers, not a dedicated loop.

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -142,10 +142,9 @@ impl CronScheduler {
                 LibreFangError::Internal(format!("Failed to create cron jobs dir: {e}"))
             })?;
         }
-        let tmp_path = self.persist_path.with_extension(format!(
-            "json.tmp.{}",
-            std::process::id()
-        ));
+        let tmp_path = self
+            .persist_path
+            .with_extension(format!("json.tmp.{}", std::process::id()));
         {
             use std::io::Write as _;
             let mut f = std::fs::File::create(&tmp_path).map_err(|e| {

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -112,8 +112,8 @@ impl EventBus {
                     }
                 }
                 if agent_drops > 0 {
-                    let total = self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed)
-                        + agent_drops;
+                    let total =
+                        self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed) + agent_drops;
                     if let Ok(mut last) = self.last_drop_warn.lock() {
                         if last.elapsed() >= std::time::Duration::from_secs(10) {
                             warn!(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -839,7 +839,10 @@ impl LibreFangKernel {
     /// runtime via [`update_budget_config`], so callers always see the
     /// latest values set through the API.
     pub fn budget_config(&self) -> librefang_types::config::BudgetConfig {
-        self.budget_config.read().unwrap_or_else(|p| p.into_inner()).clone()
+        self.budget_config
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// Safely mutate the runtime budget configuration.
@@ -848,7 +851,10 @@ impl LibreFangKernel {
     /// All writes are serialised through an `RwLock` write-guard, which
     /// eliminates the data-race hazard of the old raw-pointer approach.
     pub fn update_budget_config(&self, f: impl FnOnce(&mut librefang_types::config::BudgetConfig)) {
-        let mut guard = self.budget_config.write().unwrap_or_else(|p| p.into_inner());
+        let mut guard = self
+            .budget_config
+            .write()
+            .unwrap_or_else(|p| p.into_inner());
         f(&mut guard);
     }
 
@@ -6579,9 +6585,8 @@ system_prompt = "You are a helpful assistant."
         if !is_fork {
             // #3739: abort any previous task before replacing it so we don't
             // orphan an in-flight LLM call by dropping its abort handle.
-            if let Some((_, old_task)) = self
-                .running_tasks
-                .remove(&(agent_id, effective_session_id))
+            if let Some((_, old_task)) =
+                self.running_tasks.remove(&(agent_id, effective_session_id))
             {
                 tracing::debug!(
                     agent_id = %agent_id,

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -111,10 +111,10 @@ impl KernelOAuthProvider {
         // POSTing.  The stored value may predate policy tightening or have
         // been written by a compromised flow — always re-check before making
         // outbound requests.
-        if let Err(reason) =
-            librefang_runtime::mcp_oauth::is_ssrf_blocked_url(&token_endpoint)
-        {
-            return Err(format!("SSRF: token_endpoint rejected for refresh: {reason}"));
+        if let Err(reason) = librefang_runtime::mcp_oauth::is_ssrf_blocked_url(&token_endpoint) {
+            return Err(format!(
+                "SSRF: token_endpoint rejected for refresh: {reason}"
+            ));
         }
 
         let client_id = self.vault_get(&Self::vault_key(server_url, "client_id"));

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -664,9 +664,7 @@ impl TriggerEngine {
                 Duration::from_secs(trigger.cooldown_secs.unwrap_or(self.default_cooldown_secs));
             if !cooldown.is_zero() {
                 if let Some(last) = self.last_fired.get(&trigger.id) {
-                    let elapsed = (now - *last)
-                        .to_std()
-                        .unwrap_or(Duration::ZERO);
+                    let elapsed = (now - *last).to_std().unwrap_or(Duration::ZERO);
                     if elapsed < cooldown {
                         debug!(
                             trigger_id = %trigger.id,
@@ -1876,8 +1874,7 @@ mod tests {
         let (matches, _) = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(
-            matches[0].session_mode_override,
-            None,
+            matches[0].session_mode_override, None,
             "session_mode_override must be None when the trigger has no override; \
              the dispatcher should then fall back to the agent manifest default"
         );
@@ -1891,9 +1888,9 @@ mod tests {
         use librefang_types::agent::SessionMode;
 
         // Helper that mimics the single line in the kernel dispatch loop.
-        let resolve = |trigger_override: Option<SessionMode>, manifest: SessionMode| -> SessionMode {
-            trigger_override.unwrap_or(manifest)
-        };
+        let resolve = |trigger_override: Option<SessionMode>,
+                       manifest: SessionMode|
+         -> SessionMode { trigger_override.unwrap_or(manifest) };
 
         // Case 1: trigger override = New → New regardless of manifest
         assert_eq!(
@@ -1943,7 +1940,10 @@ mod tests {
         );
 
         // Sanity: override is present before the patch.
-        assert_eq!(engine.get_trigger(tid).unwrap().session_mode, Some(SessionMode::New));
+        assert_eq!(
+            engine.get_trigger(tid).unwrap().session_mode,
+            Some(SessionMode::New)
+        );
 
         // Clear the override.
         engine.update(

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -1958,8 +1958,9 @@ mod tests {
             engine.get_trigger(tid).unwrap().session_mode,
             None,
             "patching session_mode = Some(None) must clear the per-trigger override"
+        );
+    }
 
-    // ── PR #3913 cooldown tests ──
     // -- cooldown persistence across restarts (#3779) -------------------------
 
     /// Verify that `last_fired_at` survives a persist → load round-trip so

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -868,9 +868,7 @@ impl LlmDriver for GeminiDriver {
                         message: None,
                     }
                 } else {
-                    LlmError::Overloaded {
-                        retry_after_ms,
-                    }
+                    LlmError::Overloaded { retry_after_ms }
                 });
             }
 
@@ -993,9 +991,7 @@ impl LlmDriver for GeminiDriver {
                         message: None,
                     }
                 } else {
-                    LlmError::Overloaded {
-                        retry_after_ms,
-                    }
+                    LlmError::Overloaded { retry_after_ms }
                 });
             }
 
@@ -1028,9 +1024,7 @@ impl LlmDriver for GeminiDriver {
             let mut byte_stream = resp.bytes_stream();
             while let Some(chunk_result) = byte_stream.next().await {
                 if receiver_dropped {
-                    tracing::debug!(
-                        "streaming receiver dropped; cancelling Gemini LLM stream"
-                    );
+                    tracing::debug!("streaming receiver dropped; cancelling Gemini LLM stream");
                     break;
                 }
                 let chunk = chunk_result.map_err(|e| LlmError::Http(e.to_string()))?;

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -978,9 +978,7 @@ impl LlmDriver for OpenAIDriver {
                     continue;
                 }
                 return Err(LlmError::RateLimited {
-                    retry_after_ms: retry_after
-                        .as_millis()
-                        .min(u64::MAX as u128) as u64,
+                    retry_after_ms: retry_after.as_millis().min(u64::MAX as u128) as u64,
                     message: None,
                 });
             }
@@ -1388,9 +1386,7 @@ impl LlmDriver for OpenAIDriver {
                     continue;
                 }
                 return Err(LlmError::RateLimited {
-                    retry_after_ms: retry_after
-                        .as_millis()
-                        .min(u64::MAX as u128) as u64,
+                    retry_after_ms: retry_after.as_millis().min(u64::MAX as u128) as u64,
                     message: None,
                 });
             }
@@ -1536,7 +1532,9 @@ impl LlmDriver for OpenAIDriver {
             let mut byte_stream = resp.bytes_stream();
             while let Some(chunk_result) = byte_stream.next().await {
                 if receiver_dropped {
-                    tracing::debug!("streaming receiver dropped; cancelling OpenAI-compatible LLM stream");
+                    tracing::debug!(
+                        "streaming receiver dropped; cancelling OpenAI-compatible LLM stream"
+                    );
                     break;
                 }
                 let chunk = chunk_result.map_err(|e| LlmError::Http(e.to_string()))?;
@@ -1606,7 +1604,11 @@ impl LlmDriver for OpenAIDriver {
                                 for action in think_filter.process(text) {
                                     match action {
                                         FilterAction::EmitText(t) => {
-                                            if tx.send(StreamEvent::TextDelta { text: t }).await.is_err() {
+                                            if tx
+                                                .send(StreamEvent::TextDelta { text: t })
+                                                .await
+                                                .is_err()
+                                            {
                                                 receiver_dropped = true;
                                             }
                                         }
@@ -1729,7 +1731,11 @@ impl LlmDriver for OpenAIDriver {
                             }
                         }
                         FilterAction::EmitThinking(t) => {
-                            if tx.send(StreamEvent::ThinkingDelta { text: t }).await.is_err() {
+                            if tx
+                                .send(StreamEvent::ThinkingDelta { text: t })
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -241,7 +241,8 @@ impl SessionStore {
             }
         }
 
-        tx.commit().map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        tx.commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
     }
 

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -263,7 +263,6 @@ pub fn is_ssrf_blocked_url(url_str: &str) -> Result<(), String> {
     Ok(())
 }
 
-
 /// Construct the `.well-known/oauth-authorization-server` URL for a given server URL.
 ///
 /// Parses the URL, extracts the origin, and appends the well-known path.
@@ -447,11 +446,13 @@ pub fn parse_authorization_server_metadata(
 
     // SSRF guard — validate every discovered endpoint URL.
     for (label, url_str) in [
-        ("authorization_endpoint", raw.authorization_endpoint.as_str()),
+        (
+            "authorization_endpoint",
+            raw.authorization_endpoint.as_str(),
+        ),
         ("token_endpoint", raw.token_endpoint.as_str()),
     ] {
-        let parsed =
-            Url::parse(url_str).map_err(|e| format!("{label} is not a valid URL: {e}"))?;
+        let parsed = Url::parse(url_str).map_err(|e| format!("{label} is not a valid URL: {e}"))?;
         let host = parsed
             .host_str()
             .ok_or_else(|| format!("{label} has no host"))?;

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -828,9 +828,7 @@ impl A2aClient {
             .map_err(|e| format!("A2A discovery failed: {e}"))?;
 
         if response.status().is_redirection() {
-            return Err(
-                "A2A request redirect not followed (SSRF prevention)".to_string(),
-            );
+            return Err("A2A request redirect not followed (SSRF prevention)".to_string());
         }
         if !response.status().is_success() {
             return Err(format!("A2A discovery returned {}", response.status()));
@@ -874,9 +872,7 @@ impl A2aClient {
             .map_err(|e| format!("A2A send_task failed: {e}"))?;
 
         if response.status().is_redirection() {
-            return Err(
-                "A2A request redirect not followed (SSRF prevention)".to_string(),
-            );
+            return Err("A2A request redirect not followed (SSRF prevention)".to_string());
         }
 
         let body: serde_json::Value = response
@@ -914,9 +910,7 @@ impl A2aClient {
             .map_err(|e| format!("A2A get_task failed: {e}"))?;
 
         if response.status().is_redirection() {
-            return Err(
-                "A2A request redirect not followed (SSRF prevention)".to_string(),
-            );
+            return Err("A2A request redirect not followed (SSRF prevention)".to_string());
         }
 
         let body: serde_json::Value = response

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -2898,9 +2898,7 @@ async fn tool_agent_send(
     // turn, causing an unrecoverable deadlock (issue #3613).
     if let Some(caller) = caller_agent_id {
         if caller == agent_id {
-            return Err(
-                "agent_send: an agent cannot send a message to itself".to_string(),
-            );
+            return Err("agent_send: an agent cannot send a message to itself".to_string());
         }
     }
 

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -608,7 +608,10 @@ impl ClawHubClient {
                 info!(slug, "SHA256 checksum verified OK");
             }
             None => {
-                warn!(slug, "ClawHub did not provide expected_sha256 — install unverified");
+                warn!(
+                    slug,
+                    "ClawHub did not provide expected_sha256 — install unverified"
+                );
             }
         }
 
@@ -616,11 +619,7 @@ impl ClawHubClient {
         // the final skill directory.  This prevents partial installs from being
         // loaded on the next daemon start if extraction is interrupted.
         let skill_dir = resolve_skill_dir(target_dir, slug)?;
-        let tmp_dir = target_dir.join(format!(
-            ".installing-{}-{}",
-            slug,
-            std::process::id()
-        ));
+        let tmp_dir = target_dir.join(format!(".installing-{}-{}", slug, std::process::id()));
         // Clean up any leftover temp dir from a previous crashed install.
         if tmp_dir.exists() {
             let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/crates/librefang-skills/src/loader.rs
+++ b/crates/librefang-skills/src/loader.rs
@@ -471,7 +471,9 @@ async fn execute_node(
     let output = match tokio::time::timeout(timeout_dur, child.wait_with_output()).await {
         Ok(Ok(out)) => out,
         Ok(Err(e)) => {
-            return Err(SkillError::ExecutionFailed(format!("Wait for Node.js: {e}")));
+            return Err(SkillError::ExecutionFailed(format!(
+                "Wait for Node.js: {e}"
+            )));
         }
         Err(_) => {
             // wait_with_output() consumed `child`; the future is dropped here

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -152,7 +152,10 @@ impl SkillRegistry {
                     if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                         if name.starts_with(".installing-") {
                             if let Err(e) = std::fs::remove_dir_all(&path) {
-                                warn!("Failed to clean up stale install dir {}: {e}", path.display());
+                                warn!(
+                                    "Failed to clean up stale install dir {}: {e}",
+                                    path.display()
+                                );
                             } else {
                                 warn!("Removed stale install directory: {}", path.display());
                             }

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -149,8 +149,9 @@ impl TestAppState {
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),
             auth_login_limiter: std::sync::Arc::new(
-                librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+                librefang_api::rate_limiter::AuthLoginLimiter::new(),
             ),
+            gcra_limiter: librefang_api::rate_limiter::create_rate_limiter(0),
         })
     }
 }

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -148,7 +148,9 @@ impl TestAppState {
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),
-        auth_login_limiter: std::sync::Arc::new(librefang_api::rate_limiter::AuthLoginLimiter::new(0)),
+            auth_login_limiter: std::sync::Arc::new(
+                librefang_api::rate_limiter::AuthLoginLimiter::new(0),
+            ),
         })
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5156,7 +5156,7 @@ pub struct NetworkConfig {
     pub max_messages_per_peer_per_minute: u32,
     /// SECURITY (#3876): Optional cumulative LLM token budget per OFP peer per hour.
     ///
-    /// When set, the node tracks how many tokens each peer's 
+    /// When set, the node tracks how many tokens each peer's
     /// requests have consumed in the current hour window. If a peer exceeds
     /// this budget the request is rejected with a 429 error.
     ///
@@ -5196,8 +5196,14 @@ impl std::fmt::Debug for NetworkConfig {
                     "<redacted>"
                 },
             )
-            .field("max_messages_per_peer_per_minute", &self.max_messages_per_peer_per_minute)
-            .field("max_llm_tokens_per_peer_per_hour", &self.max_llm_tokens_per_peer_per_hour)
+            .field(
+                "max_messages_per_peer_per_minute",
+                &self.max_messages_per_peer_per_minute,
+            )
+            .field(
+                "max_llm_tokens_per_peer_per_hour",
+                &self.max_llm_tokens_per_peer_per_hour,
+            )
             .finish()
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3927,11 +3927,6 @@ fn default_max_upload_size_bytes() -> usize {
     10 * 1024 * 1024
 }
 
-/// Default workflow stale timeout: 60 minutes.
-fn default_workflow_stale_timeout_minutes() -> u64 {
-    60
-}
-
 /// Default maximum concurrent background LLM calls.
 fn default_max_concurrent_bg_llm() -> usize {
     5

--- a/crates/librefang-wire/src/peer.rs
+++ b/crates/librefang-wire/src/peer.rs
@@ -160,7 +160,10 @@ impl PeerRateLimiter {
         let one_minute = Duration::from_secs(60);
 
         if self.max_msgs_per_minute > 0 {
-            let mut entry = self.msg_counts.entry(peer_id.to_string()).or_insert((0, now));
+            let mut entry = self
+                .msg_counts
+                .entry(peer_id.to_string())
+                .or_insert((0, now));
             let (count, window_start) = &mut *entry;
             if now.duration_since(*window_start) >= one_minute {
                 // New window — reset counter
@@ -204,7 +207,10 @@ impl PeerRateLimiter {
         let now = Instant::now();
         let one_hour = Duration::from_secs(3600);
 
-        let mut entry = self.token_counts.entry(peer_id.to_string()).or_insert((0, now));
+        let mut entry = self
+            .token_counts
+            .entry(peer_id.to_string())
+            .or_insert((0, now));
         let (total, window_start) = &mut *entry;
         if now.duration_since(*window_start) >= one_hour {
             // New hour window — reset
@@ -961,7 +967,8 @@ async fn connection_loop(
             }
             // Handle requests (produce response)
             WireMessageKind::Request(_) => {
-                let response = handle_request_in_loop(&msg, handle, peer_node_id, rate_limiter).await;
+                let response =
+                    handle_request_in_loop(&msg, handle, peer_node_id, rate_limiter).await;
                 if let Some(key) = session_key {
                     write_message_authenticated(writer, &response, key).await?;
                 } else {


### PR DESCRIPTION
## Summary

Main currently does not compile and would fail the \`config_schema_golden\` CI test even if it did. Four issues from the recent multi-PR rebase storm:

| File | Issue |
|------|-------|
| `crates/librefang-api/src/middleware.rs` | conflict marker around `?token=` query handling |
| `crates/librefang-api/src/routes/agents.rs` | conflict marker in `update_agent` body |
| `crates/librefang-types/src/config/types.rs` | `default_workflow_stale_timeout_minutes` defined twice (E0428) |
| `crates/librefang-kernel/src/triggers.rs` | `patch_session_mode_some_none_clears_override` test missing closing `);`/`}` — unclosed delimiter at end of `mod tests` |
| `crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json` | stale: missing fields & doc updates from #3931 / #3936 / #3943 / #3950; `SanitizeMode` default still says `"off"` though code default is `Block` |

`cargo check -p librefang-types` reproduces the duplicate-fn error.
`cargo check -p librefang-kernel` reproduces the unclosed-delimiter error.
`cargo test --test config_schema_golden -p librefang-api` reproduces the schema mismatch (regenerated via `--ignored regenerate_golden`).

## Resolution

1. **middleware.rs** — take HEAD's strict policy (no `?token=` accepted in the auth middleware). Browser EventSource SSE auth is via session cookie (`withCredentials: true`); WebSocket auth goes through `crate::ws::ws_auth_token` which now also reads `bearer.<token>` sub-protocol from #3963.
2. **agents.rs** — take HEAD's `update_manifest` path. Already covers everything the duplicate manual sequence did and propagates SQLite errors.
3. **types.rs** — drop the second, identical `default_workflow_stale_timeout_minutes` definition.
4. **triggers.rs** — close the test that was bleeding into the next test's separator comment.
5. **kernel_config_schema.golden.json** — regenerate.

## Verification

```
$ grep -rn '^<<<<<<<\|^=======$\|^>>>>>>>' crates/
# empty
$ cargo check --workspace 2>&1 | tail -3
   Finished `dev` profile [unoptimized + debuginfo] target(s)
$ cargo test --test config_schema_golden -p librefang-api
test result: ok
```

## Test plan

- [ ] CI green
- [ ] Regression-tested: \`PUT /api/agents/{id}\` returns the operator note via \`update_manifest\`
- [ ] Auth middleware rejects unauthenticated REST requests with \`?token=\` in URL
- [ ] Schema golden test passes