### PR TITLE
fix(channels): use atomic vault_redeem_recovery_code in channel-bridge approve path

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1458,30 +1458,31 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                     }
                     match totp_code {
                         Some(code) if ApprovalManager::is_recovery_code_format(code) => {
-                            // Recovery code
-                            match self.kernel.vault_get("totp_recovery_codes") {
-                                Some(stored) => {
-                                    match librefang_kernel::approval::ApprovalManager::verify_recovery_code(
-                                        &stored,
-                                        code,
-                                    ) {
-                                        Ok((true, updated)) => {
-                                            let _ = self
-                                                .kernel
-                                                .vault_set("totp_recovery_codes", &updated);
-                                            true
-                                        }
-                                        Ok((false, _)) => {
-                                            let _ = self
-                                                .kernel
-                                                .approvals()
-                                                .record_totp_failure(sender_id);
-                                            return "Invalid recovery code.".into();
-                                        }
-                                        Err(e) => return format!("Recovery code error: {e}"),
+                            // Atomic redeem: read + verify + consume under
+                            // the kernel's recovery-code mutex.  The
+                            // earlier vault_get → verify → vault_set
+                            // triple let two concurrent channel approvals
+                            // both consume the same code (#3560 / #3943),
+                            // because nothing serialised the write.
+                            match self.kernel.vault_redeem_recovery_code(code) {
+                                Ok(true) => true,
+                                Ok(false) => {
+                                    // Fail-secure: if recording the failure
+                                    // hits a wedged audit DB, refuse the
+                                    // attempt rather than handing the
+                                    // attacker unlimited tries.  The HTTP
+                                    // path already does this.
+                                    if self
+                                        .kernel
+                                        .approvals()
+                                        .record_totp_failure(sender_id)
+                                        .is_err()
+                                    {
+                                        return "TOTP service temporarily unavailable.".into();
                                     }
+                                    return "Invalid recovery code.".into();
                                 }
-                                None => return "No recovery codes configured.".into(),
+                                Err(e) => return format!("Recovery code error: {e}"),
                             }
                         }
                         Some(code) => {
@@ -1498,10 +1499,17 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                             ) {
                                 Ok(true) => true,
                                 Ok(false) => {
-                                    let _ = self
+                                    // Fail-secure parity with the HTTP path:
+                                    // a wedged audit DB must not silently
+                                    // grant unlimited TOTP attempts.
+                                    if self
                                         .kernel
                                         .approvals()
-                                        .record_totp_failure(sender_id);
+                                        .record_totp_failure(sender_id)
+                                        .is_err()
+                                    {
+                                        return "TOTP service temporarily unavailable.".into();
+                                    }
                                     return "Invalid TOTP code.".into();
                                 }
                                 Err(e) => return format!("TOTP error: {e}"),


### PR DESCRIPTION
Follow-up to #3943 (atomic TOTP / recovery-code operations).

## Problem 1 — channel bridge bypasses the new atomic API

#3943 introduced `vault_redeem_recovery_code` as the atomic read-verify-consume primitive (`crates/librefang-kernel/src/kernel/mod.rs:1435`), guarded by `vault_recovery_codes_mutex`.  Every HTTP approval path was migrated to it.

`channel_bridge.rs` was not.  The chat-channel approval handler still does the unsafe triple:

```rust
match self.kernel.vault_get("totp_recovery_codes") {        // step 1 — read
    Some(stored) => match ApprovalManager::verify_recovery_code(&stored, code) {  // step 2 — verify
        Ok((true, updated)) => {
            let _ = self.kernel.vault_set("totp_recovery_codes", &updated);  // step 3 — write
            true
        }
        ...
```

Two concurrent channel approvals racing on the same recovery code can both pass step 2 before either reaches step 3, so both succeed.  `vault_recovery_codes_mutex` is only acquired by `vault_redeem_recovery_code`, never by this triple — bypassing the mutex defeats the entire #3943 fix.

The chat channels are the most exposed entry point: a Telegram bot retry, a Slack message replay, or any fan-out platform can re-trigger the same approval payload with sub-second timing.

### Fix

Replace the triple with `self.kernel.vault_redeem_recovery_code(code)`.  Same atomicity contract as the HTTP path; same `Result<bool, String>` shape.

## Problem 2 — record_totp_failure errors silently swallowed

The TOTP and recovery-code branches both drop the `record_totp_failure` error with `let _ = …`.  The HTTP path returns 500 in this case (fail-secure: a wedged audit DB must not let an attacker keep guessing).  The channel path returns the same `"Invalid …"` string and continues, letting the attacker grind through codes uncapped.

### Fix

Mirror the HTTP fail-secure: if `record_totp_failure` errors, return `"TOTP service temporarily unavailable."` instead of the generic invalid-code reply.

## Tests

No new unit tests — the unsafe pattern is reachable only through a live channel adapter and the timing race is not deterministically reproducible without a fault-injection harness.  The atomic API itself already has regression coverage in `scheduler.rs` / `approval.rs` from #3943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)