### PR TITLE
fix(cli,kernel): drop stale chat label; suppress inbox spin on un-removable empty file

### DIFF
--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -632,8 +632,20 @@ impl App {
             }
 
             // ── Async chat helpers (previously blocked the event-loop thread) ──
-            AppEvent::ChatModelLabelLoaded { agent_id: _, label } => {
-                self.chat.model_label = label;
+            AppEvent::ChatModelLabelLoaded { agent_id, label } => {
+                // The variant carries the agent id specifically so a late
+                // response from a previously-entered chat target can't
+                // clobber the current header.  Drop labels that don't
+                // match the current daemon target.
+                let still_current = self
+                    .chat_target
+                    .as_ref()
+                    .and_then(|t| t.agent_id_daemon.as_deref())
+                    .map(|cur| cur == agent_id.as_str())
+                    .unwrap_or(false);
+                if still_current {
+                    self.chat.model_label = label;
+                }
             }
             AppEvent::ChatModelsForPicker(models) => {
                 if models.is_empty() {

--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -180,7 +180,21 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
                             error = %e,
                             "Inbox: failed to move empty file to processed dir, removing to avoid spin loop"
                         );
-                        let _ = tokio::fs::remove_file(&path).await;
+                        if let Err(e2) = tokio::fs::remove_file(&path).await {
+                            // Move and delete both failed (read-only inbox,
+                            // EACCES, etc.).  Park the path in `in_flight`
+                            // so subsequent ticks skip it instead of
+                            // re-reading + re-warning every interval.  The
+                            // `retain(|p| p.exists())` sweep below still
+                            // unblocks the path the moment it disappears
+                            // by external means.
+                            warn!(
+                                path = %path.display(),
+                                error = %e2,
+                                "Inbox: also failed to remove empty file; suppressing rescan via in_flight"
+                            );
+                            in_flight.insert(path.clone());
+                        }
                     }
                     continue;
                 }


### PR DESCRIPTION
Two follow-ups from the post-merge audit of #3959.

## TUI stale label clobber

`AppEvent::ChatModelLabelLoaded { agent_id, label }` carries `agent_id` *specifically* so a late HTTP response from a previously-entered chat target can be discarded.  The handler ignored it (`agent_id: _`).

Repro: enter chat for agent A, quickly switch to agent B before A's model-label HTTP request returns.  A's response writes `chat.model_label = "anthropic/claude-..."` and clobbers B's header.

Compare against `chat_target.agent_id_daemon` and drop mismatches.

## Inbox spin on un-removable empty file

`inbox.rs` walks `~/.librefang/inbox/`, moves empty files to `processed/`, deletes them on move failure.  The PR documented that the delete is the spin-loop guard:

```rust
if let Err(e) = move_to_processed(&path, &processed_dir).await {
    warn!(... "removing to avoid spin loop");
    let _ = tokio::fs::remove_file(&path).await;   // ← swallowed
}
continue;
```

But `remove_file` can fail too (read-only inbox dir, EACCES on the file).  On that double failure the file stays in place; every subsequent poll re-reads it, re-fails the move, re-warns, and re-fails the delete.  The "spin loop" the comment claims to prevent is exactly what happens.

Insert the path into `in_flight` (already used to skip in-progress files) after the second failure.  The existing `in_flight.retain(|p| p.exists())` sweep at line 269 releases the entry the moment the file is removed by any external means, so this doesn't permanently strand state.

## No new tests

Both bugs surface only under timing or fs-fault fixtures that the existing test harness doesn't provide.  The fixes are small and localised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)