### PR TITLE
fix(wasm): use word-boundary check in env-var blocklist to stop false positives

### DIFF
--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -533,11 +533,18 @@ fn is_blocked_env_var(name: &str) -> bool {
         .any(|sub| has_word_boundary_substring(&upper, sub))
 }
 
-/// `true` iff `needle` appears in `haystack` with a non-alphanumeric
-/// boundary on at least one side.  Boundary = string edge or any char
-/// that is not ASCII letter / digit (env-var convention separates words
-/// with `_`, but covering all non-alphanumerics defends against odd
-/// names like `MY-API-KEY` or `KEY.PRIVATE`).
+/// `true` iff `needle` appears in `haystack` as its own word —
+/// i.e. with a non-alphanumeric boundary (string edge or any char that
+/// is not an ASCII letter / digit) on **both** sides.  Env-var
+/// convention separates words with `_`; `-` / `.` are also covered for
+/// odd names like `MY-API-KEY` or `KEY.PRIVATE`.
+///
+/// Both-sides matters: a single-side rule would still flag
+/// `KEYBOARD_LAYOUT` (left edge = start-of-string is a boundary, but
+/// right edge = `'B'` is alphanumeric, so it isn't actually a `KEY`
+/// word).  Real secret names always have a boundary on the side
+/// closest to the credential token: `OPENAI_API_KEY`, `MY_PASSWORD`,
+/// `FOO_TOKEN`, `KEY_FOO` all satisfy both-sides.
 fn has_word_boundary_substring(haystack: &str, needle: &str) -> bool {
     let bytes = haystack.as_bytes();
     let n = needle.len();
@@ -547,7 +554,7 @@ fn has_word_boundary_substring(haystack: &str, needle: &str) -> bool {
         let before_ok = idx == 0 || !bytes[idx - 1].is_ascii_alphanumeric();
         let end = idx + n;
         let after_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
-        if before_ok || after_ok {
+        if before_ok && after_ok {
             return true;
         }
         // Advance past this occurrence to find any later one with a

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -516,13 +516,48 @@ const BLOCKED_ENV_EXACT: &[&str] = &[
 /// returned to a WASM guest.
 fn is_blocked_env_var(name: &str) -> bool {
     let upper = name.to_uppercase();
-    // Exact-name check (belt-and-suspenders — all of these also match a
-    // substring below, but an explicit list is easier to audit).
+    // Exact-name check (belt-and-suspenders — all of these also match the
+    // boundary check below, but an explicit list is easier to audit).
     if BLOCKED_ENV_EXACT.contains(&upper.as_str()) {
         return true;
     }
-    // Substring check — catches any var that smells like a credential.
-    BLOCKED_ENV_SUBSTRINGS.iter().any(|sub| upper.contains(sub))
+    // Word-boundary substring check.  Plain `contains` flagged
+    // `MONKEYHOUSE`, `KEYBOARD_LAYOUT`, `TOKENIZER_OPTS`,
+    // `PRIVATELABEL_NAME` and similar non-secret config vars, leaving
+    // `EnvRead("*")` plugins unable to read benign settings.  Require a
+    // non-alphanumeric boundary on at least one side of the match
+    // (start/end of string counts), so e.g. `AWS_API_KEY` and
+    // `MY_PASSWORD_HASH` still match while `MONKEYHOUSE` does not.
+    BLOCKED_ENV_SUBSTRINGS
+        .iter()
+        .any(|sub| has_word_boundary_substring(&upper, sub))
+}
+
+/// `true` iff `needle` appears in `haystack` with a non-alphanumeric
+/// boundary on at least one side.  Boundary = string edge or any char
+/// that is not ASCII letter / digit (env-var convention separates words
+/// with `_`, but covering all non-alphanumerics defends against odd
+/// names like `MY-API-KEY` or `KEY.PRIVATE`).
+fn has_word_boundary_substring(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let n = needle.len();
+    let mut start = 0;
+    while let Some(rel) = haystack[start..].find(needle) {
+        let idx = start + rel;
+        let before_ok = idx == 0 || !bytes[idx - 1].is_ascii_alphanumeric();
+        let end = idx + n;
+        let after_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+        if before_ok || after_ok {
+            return true;
+        }
+        // Advance past this occurrence to find any later one with a
+        // boundary.  Stop if we'd loop on a zero-length needle.
+        start = idx + n.max(1);
+        if start >= bytes.len() {
+            break;
+        }
+    }
+    false
 }
 
 fn host_env_read(state: &GuestState, params: &serde_json::Value) -> serde_json::Value {
@@ -676,6 +711,50 @@ mod tests {
             agent_id: "test-agent".to_string(),
             tokio_handle: tokio::runtime::Handle::current(),
         }
+    }
+
+    /// Word-boundary blocklist: real secret-shaped names match, benign
+    /// names that merely embed the substring don't.
+    #[test]
+    fn test_is_blocked_env_var_word_boundary() {
+        // Real secrets — must block.
+        for name in &[
+            "OPENAI_API_KEY",
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
+            "MY_PASSWORD",
+            "DB_PRIVATE_KEY",
+            "API_CREDENTIAL_FILE",
+            // Standalone tokens at string start/end.
+            "KEY",
+            "SECRET_FOO",
+            "FOO_TOKEN",
+        ] {
+            assert!(
+                is_blocked_env_var(name),
+                "{name} must be blocked (real secret)"
+            );
+        }
+
+        // Benign config — must NOT block.  These were all false positives
+        // under the old plain `contains` check.
+        for name in &[
+            "MONKEYHOUSE",
+            "KEYBOARD_LAYOUT",
+            "TOKENIZER_OPTS",
+            "PRIVATELABEL_NAME",
+            "PASSWORDLIST_FILE",
+            "MASTERKEYBOARD",
+        ] {
+            assert!(
+                !is_blocked_env_var(name),
+                "{name} must NOT be blocked (benign config)"
+            );
+        }
+
+        // Boundary punctuation other than `_` is also a boundary.
+        assert!(is_blocked_env_var("MY-API-KEY"));
+        assert!(is_blocked_env_var("KEY.PRIVATE"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #3941 (#3548 — WASM env-var blocklist).

## Problem

The blocklist used plain `upper.contains(sub)`:

```rust
const BLOCKED_ENV_SUBSTRINGS: &[&str] = &[
    "KEY", "SECRET", "TOKEN", "PASSWORD", "CREDENTIAL", "PRIVATE",
];

BLOCKED_ENV_SUBSTRINGS.iter().any(|sub| upper.contains(sub))
```

Any var name that *embeds* one of those words was rejected — including a long tail of perfectly innocuous config names:

| Name | Falsely blocked because |
|---|---|
| `MONKEYHOUSE` | contains `KEY` |
| `KEYBOARD_LAYOUT` | contains `KEY` |
| `TOKENIZER_OPTS` | contains `TOKEN` |
| `PRIVATELABEL_NAME` | contains `PRIVATE` |
| `PASSWORDLIST_FILE` | contains `PASSWORD` |
| `MASTERKEYBOARD` | contains `KEY` |

A wildcard-permitted (`EnvRead("*")`) plugin can't read them, with no escape hatch and no log line — they come back as `null`, indistinguishable from "not set".

## Fix

Word-boundary substring check: a needle matches only when it has a non-alphanumeric character (or string edge) on **both** sides.  Env-var convention separates words with `_`, but `-` and `.` are also covered.

- `AWS_API_KEY` → `KEY` between `_` and end-of-string → match ✅
- `MY_PASSWORD_HASH` → `PASSWORD` between two `_` → match ✅
- `KEY` alone → both edges → match ✅
- `KEY_FOO` → `KEY` between start-of-string and `_` → match ✅
- `MONKEYHOUSE` → `KEY` between `N` and `H` → no match ✅
- `KEYBOARD_LAYOUT` → `KEY` between start-of-string (boundary) and `B` (not boundary) → fails the both-sides check → no match ✅

The both-sides rule (vs. either-side) was added in the second commit after a review pass caught that `KEYBOARD_LAYOUT` slipped through with `||`.

## Test

`test_is_blocked_env_var_word_boundary` pins the new contract:
- 9 real secrets (all blocked).
- 6 known false positives from the audit (all unblocked).
- 2 odd-punctuation cases (`MY-API-KEY`, `KEY.PRIVATE`) covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)