### PR TITLE
docs: Update README with new crates counts new Hands, channels replacing closed PR [#3437]

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Build your own: define a `HAND.toml` + system prompt + `SKILL.md`. [Guide](https
 
 ## Architecture
 
-14 Rust crates + xtask, modular kernel design.
+24 Rust crates + xtask, modular kernel design.
 
 ```
 librefang-kernel            Orchestration, workflows, metering, RBAC, scheduler, budget
@@ -145,7 +145,7 @@ xtask                       Build automation
 
 ## Key Features
 
-**57 Channel Adapters** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky, and 44 more. [Full list](https://docs.librefang.ai/integrations/channels)
+**45 Channel Adapters** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky, and 32 more. [Full list](https://docs.librefang.ai/integrations/channels)
 
 **28 LLM Providers** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama, Alibaba Coding Plan, and 20 more. Intelligent routing, automatic fallback, cost tracking. [Details](https://docs.librefang.ai/configuration/providers)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <h3 align="center">Libre Agent Operating System — Free as in Freedom</h3>
 
 <p align="center">
-  Open-source Agent OS built in Rust. 14 crates. 2,100+ tests. Zero clippy warnings.
+  Open-source Agent OS built in Rust. 24 crates. 2,100+ tests. Zero clippy warnings.
 </p>
 
 <p align="center">
@@ -94,7 +94,7 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 **Hands** are autonomous capability packages that run independently, on schedules, without prompting. Each Hand is defined by a `HAND.toml` manifest, a system prompt, and optional `SKILL.md` files loaded from your configured `hands_dir`.
 
-Example Hand definitions (Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps) are available in the [community hands repository](https://github.com/librefang/hands).
+Example Hand definitions (Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps) are available in the [community hands repository](https://github.com/librefang-registry/hands).
 
 ```bash
 # Install a community Hand, then:
@@ -107,23 +107,34 @@ Build your own: define a `HAND.toml` + system prompt + `SKILL.md`. [Guide](https
 
 ## Architecture
 
-14 Rust crates, modular kernel design.
+14 Rust crates + xtask, modular kernel design.
 
 ```
-librefang-kernel      Orchestration, workflows, metering, RBAC, scheduler, budget
-librefang-runtime     Agent loop, 3 LLM drivers, 53 tools, WASM sandbox, MCP, A2A
-librefang-api         140+ REST/WS/SSE endpoints, OpenAI-compatible API, dashboard
-librefang-channels    40 messaging adapters with rate limiting, DM/group policies
-librefang-memory      SQLite persistence, vector embeddings, sessions, compaction
-librefang-types       Core types, taint tracking, Ed25519 signing, model catalog
-librefang-skills      60 bundled skills, SKILL.md parser, FangHub marketplace
-librefang-hands       HAND.toml parser, Hand registry, lifecycle management
-librefang-extensions  25 MCP templates, AES-256-GCM vault, OAuth2 PKCE
-librefang-wire        OFP P2P protocol, HMAC-SHA256 mutual auth (see note)
-librefang-cli         CLI, daemon management, TUI dashboard, MCP server mode
-librefang-desktop     Tauri 2.0 native app (tray, notifications, shortcuts)
-librefang-migrate     OpenClaw, LangChain, AutoGPT migration engine
-xtask                 Build automation
+librefang-kernel            Orchestration, workflows, metering, RBAC, scheduler, budget
+librefang-runtime           Agent loop, 3 LLM drivers, 53 tools, WASM sandbox, MCP, A2A
+librefang-api               140+ REST/WS/SSE endpoints, OpenAI-compatible API, dashboard
+librefang-channels          40 messaging adapters with rate limiting, DM/group policies
+librefang-memory            SQLite persistence, vector embeddings, sessions, compaction
+librefang-types             Core types, taint tracking, Ed25519 signing, model catalog
+librefang-skills            60 bundled skills, SKILL.md parser, FangHub marketplace
+librefang-hands             HAND.toml parser, Hand registry, lifecycle management
+librefang-extensions        25 MCP templates, AES-256-GCM vault, OAuth2 PKCE
+librefang-wire              OFP P2P protocol, HMAC-SHA256 mutual auth (see note)
+librefang-cli               CLI, daemon management, TUI dashboard, MCP server mode
+librefang-desktop           Tauri 2.0 native app (tray, notifications, shortcuts)
+librefang-migrate           OpenClaw, LangChain, AutoGPT migration engine
+librefang-http              Shared HTTP client builder, proxy, TLS fallback
+librefang-testing           Test infrastructure: mock kernel, mock LLM driver and API route test utilities
+librefang-telemetry         OpenTelemetry + Prometheus metrics instrumentation for LibreFang
+librefang-llm-driver        LLM driver trait and shared types for LibreFang
+librefang-llm-drivers       Concrete LLM provider drivers (anthropic, openai, gemini, …) implementing librefang-llm-driver trait
+librefang-runtime-mcp       MCP (Model Context Protocol) client for LibreFang runtime
+librefang-kernel-handle     KernelHandle trait for in-process callers into the LibreFang kernel
+librefang-runtime-wasm      WASM skill sandbox for LibreFang runtime
+librefang-kernel-router     Hand/Template routing engine for the LibreFang kernel
+librefang-runtime-oauth     OAuth flows (ChatGPT, GitHub Copilot) for LibreFang runtime drivers
+librefang-kernel-metering   Cost metering, quota enforcement for the LibreFang kernel
+xtask                       Build automation
 ```
 
 > **OFP wire is plaintext-by-design.** HMAC-SHA256 mutual auth + per-message
@@ -134,7 +145,7 @@ xtask                 Build automation
 
 ## Key Features
 
-**40 Channel Adapters** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky, and 26 more. [Full list](https://docs.librefang.ai/integrations/channels)
+**57 Channel Adapters** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky, and 44 more. [Full list](https://docs.librefang.ai/integrations/channels)
 
 **28 LLM Providers** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama, Alibaba Coding Plan, and 20 more. Intelligent routing, automatic fallback, cost tracking. [Details](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -143,7 +143,7 @@ xtask                       Build-Automatisierung
 
 ## Hauptfunktionen
 
-**57 Kanaladapter** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, E-Mail, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky und 44 weitere. [Vollständige Liste](https://docs.librefang.ai/integrations/channels)
+**45 Kanaladapter** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, E-Mail, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky und 32 weitere. [Vollständige Liste](https://docs.librefang.ai/integrations/channels)
 
 **28 LLM-Anbieter** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama und 20 weitere. Intelligentes Routing, automatisches Fallback, Kostenverfolgung. [Details](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -106,7 +106,7 @@ Eigene Hands erstellen: `HAND.toml` + System-Prompt + `SKILL.md` definieren. [An
 
 ## Architektur
 
-24 Rust-Crates, modulares Kernel-Design.
+24 Rust-Crates + xtask, modulares Kernel-Design.
 
 ```
 librefang-kernel            Orchestrierung, Workflows, Metering, RBAC, Scheduler, Budget

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -6,7 +6,7 @@
 <h3 align="center">Freies Agenten-Betriebssystem — Libre bedeutet Freiheit</h3>
 
 <p align="center">
-  Open-Source Agent OS in Rust. 14 Crates. 2.100+ Tests. Null Clippy-Warnungen.
+  Open-Source Agent OS in Rust. 24 Crates. 2.100+ Tests. Null Clippy-Warnungen.
 </p>
 
 <p align="center">
@@ -53,11 +53,11 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # Oder per Cargo installieren
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# Initialisieren (führt durch die Provider-Einrichtung)
-librefang init
-
-# Starten — Dashboard unter http://localhost:4545
+# Starten — initialisiert sich beim ersten Ausführen automatisch, Dashboard unter http://localhost:4545
 librefang start
+
+# Oder führen Sie den Setup-Assistenten für eine interaktive Anbieterauswahl manuell aus
+# librefang init
 ```
 
 <details>
@@ -92,26 +92,11 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands: Agenten, die für Sie arbeiten
 
-**Hands** sind vorgefertigte autonome Fähigkeitspakete, die unabhängig nach Zeitplan arbeiten. 14 integriert:
+**Hands** sind autonome Fähigkeitspakete, die unabhängig, nach Zeitplänen und ohne Prompting ausgeführt werden. Jeder Hand wird durch ein HAND.toml-Manifest, einen System-Prompt und optionale SKILL.md-Dateien definiert, die geladen werden aus Ihrer konfigurierten `hands_dir`.
 
-| Hand | Funktion |
-|------|----------|
-| **Researcher** | Tiefenrecherche — Mehrquellen-Kreuzreferenz, CRAAP-Glaubwürdigkeitsbewertung, zitierte Berichte |
-| **Collector** | OSINT-Überwachung — Änderungserkennung, Sentimentverfolgung, Wissensgraph |
-| **Predictor** | Superprognose — kalibrierte Vorhersagen mit Konfidenzintervallen |
-| **Strategist** | Strategieanalyse — Marktforschung, Wettbewerbsintelligenz, Geschäftsplanung |
-| **Analytics** | Datenanalyse — Erfassung, Analyse, Visualisierung, automatische Berichte |
-| **Trader** | Marktintelligenz — Multi-Signal-Analyse, Risikomanagement, Portfolioanalyse |
-| **Lead** | Interessentensuche — Webrecherche, Scoring, Deduplizierung, Lead-Lieferung |
-| **Twitter** | Autonomes X/Twitter — Content-Erstellung, Terminplanung, Genehmigungswarteschlange |
-| **Reddit** | Reddit-Management — Subreddit-Überwachung, Posting, Engagement-Tracking |
-| **LinkedIn** | LinkedIn-Management — Content-Erstellung, Networking, professionelle Interaktion |
-| **Clip** | YouTube zu Shorts — Beste Momente schneiden, Untertitel, KI-Sprecherstimme |
-| **Browser** | Web-Automatisierung — Playwright-basiert, obligatorisches Kaufgenehmigungsgate |
-| **API Tester** | API-Tests — Endpunkt-Erkennung, Validierung, Lasttests, Regressionserkennung |
-| **DevOps** | DevOps-Automatisierung — CI/CD, Infrastrukturüberwachung, Incident Response |
-
+Beispielhafte Hand-Definitionen (Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps) sind im [community hands repository](https://github.com/librefang-registry/hands).
 ```bash
+# Einen Community-Hand installieren, dann:
 librefang hand activate researcher   # Beginnt sofort zu arbeiten
 librefang hand status researcher     # Fortschritt prüfen
 librefang hand list                  # Alle Hands anzeigen
@@ -121,30 +106,46 @@ Eigene Hands erstellen: `HAND.toml` + System-Prompt + `SKILL.md` definieren. [An
 
 ## Architektur
 
-14 Rust-Crates, modulares Kernel-Design.
+24 Rust-Crates, modulares Kernel-Design.
 
 ```
-librefang-kernel      Orchestrierung, Workflows, Metering, RBAC, Scheduler, Budget
-librefang-runtime     Agenten-Loop, 3 LLM-Treiber, 53 Tools, WASM-Sandbox, MCP, A2A
-librefang-api         140+ REST/WS/SSE-Endpunkte, OpenAI-kompatible API, Dashboard
-librefang-channels    40 Messaging-Adapter, Rate Limiting, DM/Gruppen-Policies
-librefang-memory      SQLite-Persistenz, Vektor-Embeddings, Sessions, Komprimierung
-librefang-types       Kerntypen, Taint-Tracking, Ed25519-Signierung, Modellkatalog
-librefang-skills      60 gebündelte Skills, SKILL.md-Parser, FangHub-Marktplatz
-librefang-hands       14 autonome Hands, HAND.toml-Parser, Lifecycle-Management
-librefang-extensions  25 MCP-Templates, AES-256-GCM-Vault, OAuth2 PKCE
-librefang-wire        OFP P2P-Protokoll, HMAC-SHA256 gegenseitige Authentifizierung
-librefang-cli         CLI, Daemon-Management, TUI-Dashboard, MCP-Servermodus
-librefang-desktop     Tauri 2.0 native App (Tray, Benachrichtigungen, Shortcuts)
-librefang-migrate     OpenClaw, LangChain, AutoGPT Migrationsengine
-xtask                 Build-Automatisierung
+librefang-kernel            Orchestrierung, Workflows, Metering, RBAC, Scheduler, Budget
+librefang-runtime           Agenten-Loop, 3 LLM-Treiber, 53 Tools, WASM-Sandbox, MCP, A2A
+librefang-api               140+ REST/WS/SSE-Endpunkte, OpenAI-kompatible API, Dashboard
+librefang-channels          40 Messaging-Adapter, Rate Limiting, DM/Gruppen-Policies
+librefang-memory            SQLite-Persistenz, Vektor-Embeddings, Sessions, Komprimierung
+librefang-types             Kerntypen, Taint-Tracking, Ed25519-Signierung, Modellkatalog
+librefang-skills            60 gebündelte Skills, SKILL.md-Parser, FangHub-Marktplatz
+librefang-hands             autonome Hands, HAND.toml-Parser, Lifecycle-Management
+librefang-extensions        25 MCP-Templates, AES-256-GCM-Vault, OAuth2 PKCE
+librefang-wire              OFP P2P-Protokoll, HMAC-SHA256 gegenseitige Authentifizierung
+librefang-cli               CLI, Daemon-Management, TUI-Dashboard, MCP-Servermodus
+librefang-desktop           Tauri 2.0 native App (Tray, Benachrichtigungen, Shortcuts)
+librefang-migrate           OpenClaw, LangChain, AutoGPT Migrationsengine
+librefang-http              Gemeinsamer HTTP-Client-Builder, Proxy, TLS-Fallback
+librefang-testing           Testinfrastruktur: Mock-Kernel, Mock-LLM-Driver und Testdienstprogramme für API-Routen
+librefang-telemetry         OpenTelemetry + Prometheus Metrik-Instrumentierung für LibreFang
+librefang-llm-driver        LLM-Driver-Trait und gemeinsame Typen für LibreFang
+librefang-llm-drivers       Konkrete LLM-Provider-Driver (Anthropic, OpenAI, Gemini, …), die das librefang-llm-driver Trait implementieren
+librefang-runtime-mcp       MCP (Model Context Protocol) Client für die LibreFang-Runtime
+librefang-kernel-handle     KernelHandle-Trait für In-Process-Aufrufer in den LibreFang-Kernel
+librefang-runtime-wasm      WASM-Skill-Sandbox für die LibreFang-Runtime
+librefang-kernel-router     Hand/Template-Routing-Engine für den LibreFang-Kernel
+librefang-runtime-oauth     OAuth-Flows (ChatGPT, GitHub Copilot) für LibreFang-Runtime-Driver
+librefang-kernel-metering   Kostenmessung und Durchsetzung von Quoten für den LibreFang-Kernel
+xtask                       Build-Automatisierung
 ```
+> **OFP wire is plaintext-by-design.** HMAC-SHA256 mutual auth + per-message
+> HMAC + nonce replay protection cover *active* attackers, but frame contents
+> are not encrypted. For cross-network federation, run OFP behind a private
+> overlay (WireGuard, Tailscale, SSH tunnel) or a service-mesh mTLS layer.
+> Details: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
 
 ## Hauptfunktionen
 
-**40 Kanaladapter** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, E-Mail, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky und 26 weitere. [Vollständige Liste](https://docs.librefang.ai/integrations/channels)
+**57 Kanaladapter** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, E-Mail, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky und 44 weitere. [Vollständige Liste](https://docs.librefang.ai/integrations/channels)
 
-**27 LLM-Anbieter** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama und 20 weitere. Intelligentes Routing, automatisches Fallback, Kostenverfolgung. [Details](https://docs.librefang.ai/configuration/providers)
+**28 LLM-Anbieter** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama und 20 weitere. Intelligentes Routing, automatisches Fallback, Kostenverfolgung. [Details](https://docs.librefang.ai/configuration/providers)
 
 **16 Sicherheitsschichten** — WASM-Sandbox, Merkle-Auditpfad, Taint-Tracking, Ed25519-Signierung, SSRF-Schutz, Secret-Zeroization und mehr. [Details](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -137,6 +137,12 @@ librefang-kernel-metering   Medición de costos y aplicación de cuotas para el 
 xtask                       Automatización de build
 ```
 
+> **OFP wire es plaintext-by-design.** Autenticación mutua HMAC-SHA256 + HMAC
+> por mensaje + protección contra repetición nonce cubren a los atacantes *activos*, pero los contenidos de los frames
+> no están encriptados. Para cross-network federation, ejecute OFP detrás de un overlay
+> privado (WireGuard, Tailscale, túnel SSH) o una capa mTLS de service-mesh.
+> Detalles: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
+
 ## Características Principales
 
 **57 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky y 44 más. [Lista completa](https://docs.librefang.ai/integrations/channels)

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -109,7 +109,7 @@ Crea el tuyo: define un `HAND.toml` + prompt de sistema + `SKILL.md`. [Guía](ht
 
 24 crates de Rust + xtask, diseño de kernel modular.
 
-```
+```bash
 librefang-kernel            Orquestación, workflows, medición, RBAC, planificador, presupuesto
 librefang-runtime           Bucle de agente, 3 drivers LLM, 53 herramientas, sandbox WASM, MCP, A2A
 librefang-api               140+ endpoints REST/WS/SSE, API compatible con OpenAI, dashboard
@@ -136,7 +136,6 @@ librefang-runtime-oauth     Flujos OAuth (ChatGPT, GitHub Copilot) para los driv
 librefang-kernel-metering   Medición de costos y aplicación de cuotas para el kernel de LibreFang
 xtask                       Automatización de build
 ```
-
 > **OFP wire es plaintext-by-design.** Autenticación mutua HMAC-SHA256 + HMAC
 > por mensaje + protección contra repetición nonce cubren a los atacantes *activos*, pero los contenidos de los frames
 > no están encriptados. Para cross-network federation, ejecute OFP detrás de un overlay
@@ -145,7 +144,7 @@ xtask                       Automatización de build
 
 ## Características Principales
 
-**57 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky y 44 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
+**57 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 44 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
 
 **28 Proveedores LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama y 20 más. Enrutamiento inteligente, fallback automático, seguimiento de costos. [Detalles](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -144,7 +144,7 @@ xtask                       Automatización de build
 
 ## Características Principales
 
-**57 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 44 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
+**45 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 32 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
 
 **28 Proveedores LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama y 20 más. Enrutamiento inteligente, fallback automático, seguimiento de costos. [Detalles](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -53,11 +53,11 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # O instalar con Cargo
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# Inicializar (te guía en la configuración del proveedor)
-librefang init
-
-# Iniciar — dashboard en http://localhost:4545
+# Iniciar — se inicializa automáticamente en la primera ejecución, panel de control en http://localhost:4545
 librefang start
+
+# O ejecute el asistente de configuración manualmente para la selección interactiva de proveedores
+# librefang init
 ```
 
 <details>
@@ -92,26 +92,12 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands: Agentes que Trabajan para Ti
 
-**Hands** son paquetes de capacidades autónomas preconstruidos que funcionan de forma independiente, según horarios. 14 incluidos:
+**Hands** son paquetes de capacidades autónomas que se ejecutan de forma independiente, en horarios programados y sin necesidad de prompts. Cada Hand se define mediante un manifiesto HAND.toml, un prompt del sistema y archivos SKILL.md opcionales cargados desde su configurada `hands_dir`.
 
-| Hand | Función |
-|------|---------|
-| **Researcher** | Investigación profunda — referencias cruzadas, evaluación de credibilidad CRAAP, informes citados |
-| **Collector** | Monitorización OSINT — detección de cambios, seguimiento de sentimiento, grafo de conocimiento |
-| **Predictor** | Superpredicción — predicciones calibradas con intervalos de confianza |
-| **Strategist** | Análisis estratégico — investigación de mercado, inteligencia competitiva, planificación empresarial |
-| **Analytics** | Análisis de datos — recopilación, análisis, visualización, informes automáticos |
-| **Trader** | Inteligencia de mercado — análisis multi-señal, gestión de riesgos, análisis de cartera |
-| **Lead** | Descubrimiento de prospectos — investigación web, scoring, deduplicación, entrega de leads |
-| **Twitter** | X/Twitter autónomo — creación de contenido, programación, cola de aprobación |
-| **Reddit** | Gestión de Reddit — monitorización de subreddits, publicación, seguimiento de engagement |
-| **LinkedIn** | Gestión de LinkedIn — creación de contenido, networking, interacción profesional |
-| **Clip** | YouTube a shorts — corta mejores momentos, subtítulos, narración IA |
-| **Browser** | Automatización web — basado en Playwright, puerta de aprobación de compras obligatoria |
-| **API Tester** | Testing de APIs — descubrimiento de endpoints, validación, pruebas de carga, detección de regresiones |
-| **DevOps** | Automatización DevOps — CI/CD, monitorización de infraestructura, respuesta a incidentes |
+Ejemplos de definiciones de Hands (Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps) están disponibles en el [repositorio de Hands de la comunidad](https://github.com/librefang/hands).
 
 ```bash
+# Instala un Hand de la comunidad, luego:
 librefang hand activate researcher   # Comienza a trabajar inmediatamente
 librefang hand status researcher     # Ver progreso
 librefang hand list                  # Ver todos los Hands
@@ -121,30 +107,41 @@ Crea el tuyo: define un `HAND.toml` + prompt de sistema + `SKILL.md`. [Guía](ht
 
 ## Arquitectura
 
-14 crates de Rust, diseño de kernel modular.
+24 crates de Rust + xtask, diseño de kernel modular.
 
 ```
-librefang-kernel      Orquestación, workflows, medición, RBAC, planificador, presupuesto
-librefang-runtime     Bucle de agente, 3 drivers LLM, 53 herramientas, sandbox WASM, MCP, A2A
-librefang-api         140+ endpoints REST/WS/SSE, API compatible con OpenAI, dashboard
-librefang-channels    40 adaptadores de mensajería, limitación de tasa, políticas DM/grupo
-librefang-memory      Persistencia SQLite, embeddings vectoriales, sesiones, compactación
-librefang-types       Tipos core, seguimiento de taint, firma Ed25519, catálogo de modelos
-librefang-skills      60 skills incluidos, parser SKILL.md, marketplace FangHub
-librefang-hands       14 Hands autónomos, parser HAND.toml, gestión de ciclo de vida
-librefang-extensions  25 plantillas MCP, vault AES-256-GCM, OAuth2 PKCE
-librefang-wire        Protocolo P2P OFP, autenticación mutua HMAC-SHA256
-librefang-cli         CLI, gestión de daemon, dashboard TUI, modo servidor MCP
-librefang-desktop     App nativa Tauri 2.0 (bandeja, notificaciones, atajos)
-librefang-migrate     Motor de migración OpenClaw, LangChain, AutoGPT
-xtask                 Automatización de build
+librefang-kernel            Orquestación, workflows, medición, RBAC, planificador, presupuesto
+librefang-runtime           Bucle de agente, 3 drivers LLM, 53 herramientas, sandbox WASM, MCP, A2A
+librefang-api               140+ endpoints REST/WS/SSE, API compatible con OpenAI, dashboard
+librefang-channels          40 adaptadores de mensajería, limitación de tasa, políticas DM/grupo
+librefang-memory            Persistencia SQLite, embeddings vectoriales, sesiones, compactación
+librefang-types             Tipos core, seguimiento de taint, firma Ed25519, catálogo de modelos
+librefang-skills            60 skills incluidos, parser SKILL.md, marketplace FangHub
+librefang-hands             Hands autónomos, parser HAND.toml, gestión de ciclo de vida
+librefang-extensions        25 plantillas MCP, vault AES-256-GCM, OAuth2 PKCE
+librefang-wire              Protocolo P2P OFP, autenticación mutua HMAC-SHA256
+librefang-cli               CLI, gestión de daemon, dashboard TUI, modo servidor MCP
+librefang-desktop           App nativa Tauri 2.0 (bandeja, notificaciones, atajos)
+librefang-migrate           Motor de migración OpenClaw, LangChain, AutoGPT
+librefang-http              Constructor de cliente HTTP compartido, proxy, respaldo TLS (TLS fallback)
+librefang-testing           Infraestructura de pruebas: kernel simulado (mock), driver de LLM simulado y utilidades de prueba de rutas API
+librefang-telemetry         Instrumentación de métricas de OpenTelemetry + Prometheus para LibreFang
+librefang-llm-driver        Trait de driver LLM y tipos compartidos para LibreFang
+librefang-llm-drivers       Drivers concretos de proveedores de LLM (anthropic, openai, gemini, …) que implementan el trait librefang-llm-driver
+librefang-runtime-mcp       Cliente MCP (Model Context Protocol) para el runtime de LibreFang
+librefang-kernel-handle     Trait KernelHandle para llamadores en proceso (in-process) hacia el kernel de LibreFang
+librefang-runtime-wasm      Sandbox de habilidades (skills) WASM para el runtime de LibreFang
+librefang-kernel-router     Motor de enrutamiento de Hand/Template para el kernel de LibreFang
+librefang-runtime-oauth     Flujos OAuth (ChatGPT, GitHub Copilot) para los drivers del runtime de LibreFang
+librefang-kernel-metering   Medición de costos y aplicación de cuotas para el kernel de LibreFang
+xtask                       Automatización de build
 ```
 
 ## Características Principales
 
-**40 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky y 26 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
+**57 Adaptadores de Canal** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky y 44 más. [Lista completa](https://docs.librefang.ai/integrations/channels)
 
-**27 Proveedores LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama y 20 más. Enrutamiento inteligente, fallback automático, seguimiento de costos. [Detalles](https://docs.librefang.ai/configuration/providers)
+**28 Proveedores LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama y 20 más. Enrutamiento inteligente, fallback automático, seguimiento de costos. [Detalles](https://docs.librefang.ai/configuration/providers)
 
 **16 Capas de Seguridad** — Sandbox WASM, auditoría Merkle, seguimiento de taint, firma Ed25519, protección SSRF, zeroización de secretos y más. [Detalles](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -144,7 +144,7 @@ xtask                       ビルド自動化
 
 ## 主な機能
 
-**57 チャネルアダプター** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、Feishu、LINE、Mastodon、Bluesky 他。[完全リスト](https://docs.librefang.ai/integrations/channels)
+**45 チャネルアダプター** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、Feishu、LINE、Mastodon、Bluesky 他。[完全リスト](https://docs.librefang.ai/integrations/channels)
 
 **28 LLM プロバイダー** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 他。インテリジェントルーティング、自動フォールバック、コスト追跡。[詳細](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -6,7 +6,7 @@
 <h3 align="center">自由なエージェントオペレーティングシステム — Libre は自由を意味する</h3>
 
 <p align="center">
-  Rust で構築されたオープンソース Agent OS。14 クレート。2,100+ テスト。clippy 警告ゼロ。
+  Rust で構築されたオープンソース Agent OS。24 クレート。2,100+ テスト。clippy 警告ゼロ。
 </p>
 
 <p align="center">
@@ -53,11 +53,11 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # または Cargo でインストール
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# 初期化（プロバイダー設定をガイド）
-librefang init
-
-# 起動 — ダッシュボード http://localhost:4545
+# 起動 — 初回実行時に自動初期化されます。ダッシュボードは http://localhost:4545
 librefang start
+
+# または、セットアップウィザードを手動で実行して、対話式でプロバイダーを選択します
+# librefang init
 ```
 
 <details>
@@ -92,26 +92,12 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands：あなたのために働くエージェント
 
-**Hands** はプリビルトの自律型機能パッケージで、スケジュールに従い独立して動作します。14 個バンドル：
+**Hands** は、プロンプトなしでスケジュールに従って独立して実行される、自律的な機能パッケージです。各Handは、`HAND.toml`マニフェスト、システムプロンプト、および設定された環境からロードされるオプションの`SKILL.md`ファイルによって定義されます `hands_dir`。
 
-| Hand | 機能 |
-|------|------|
-| **Researcher** | 深い調査 — 複数ソースの相互参照、CRAAP 信頼性評価、引用付きレポート |
-| **Collector** | OSINT 監視 — 変更検出、感情追跡、ナレッジグラフ |
-| **Predictor** | 超予測 — 信頼区間付きのキャリブレーション済み予測 |
-| **Strategist** | 戦略分析 — 市場調査、競合インテリジェンス、事業計画 |
-| **Analytics** | データ分析 — 収集、分析、可視化、自動レポート |
-| **Trader** | 市場インテリジェンス — マルチシグナル分析、リスク管理、ポートフォリオ分析 |
-| **Lead** | 見込み客発見 — ウェブ調査、スコアリング、重複排除、リード配信 |
-| **Twitter** | 自律型 X/Twitter — コンテンツ作成、スケジューリング、承認キュー |
-| **Reddit** | Reddit 管理 — サブレディット監視、投稿、エンゲージメント追跡 |
-| **LinkedIn** | LinkedIn 管理 — コンテンツ作成、ネットワーキング、プロフェッショナル交流 |
-| **Clip** | YouTube からショート動画 — ベストモーメント切り出し、字幕、AI ナレーション |
-| **Browser** | Web 自動化 — Playwright ベース、購入承認ゲート必須 |
-| **API Tester** | API テスト — エンドポイント発見、検証、負荷テスト、回帰検出 |
-| **DevOps** | DevOps 自動化 — CI/CD、インフラ監視、インシデント対応 |
+Handの定義例（Researcher、Collector、Predictor、Strategist、Analytics、Trader、Lead、Twitter、Reddit、LinkedIn、Clip、Browser、API Tester、DevOps）は、コミュニティの[Handsリポジトリで入手できます](https://github.com/librefang/hands).。
 
 ```bash
+# コミュニティのHandをインストールしてから：
 librefang hand activate researcher   # すぐに作業開始
 librefang hand status researcher     # 進捗確認
 librefang hand list                  # 全 Hands を表示
@@ -121,30 +107,46 @@ librefang hand list                  # 全 Hands を表示
 
 ## アーキテクチャ
 
-14 の Rust クレート、モジュラーカーネル設計。
+24 の Rust クレート + xtask、モジュラーカーネル設計。
 
 ```
-librefang-kernel      オーケストレーション、ワークフロー、計量、RBAC、スケジューラ、予算
-librefang-runtime     エージェントループ、3 LLM ドライバ、53 ツール、WASM サンドボックス、MCP、A2A
-librefang-api         140+ REST/WS/SSE エンドポイント、OpenAI 互換 API、ダッシュボード
-librefang-channels    40 メッセージングアダプター、レート制限、DM/グループポリシー
-librefang-memory      SQLite 永続化、ベクトル埋め込み、セッション、圧縮
-librefang-types       コア型、テイント追跡、Ed25519 署名、モデルカタログ
-librefang-skills      60 バンドルスキル、SKILL.md パーサー、FangHub マーケットプレイス
-librefang-hands       14 自律 Hands、HAND.toml パーサー、ライフサイクル管理
-librefang-extensions  25 MCP テンプレート、AES-256-GCM ボールト、OAuth2 PKCE
-librefang-wire        OFP P2P プロトコル、HMAC-SHA256 相互認証
-librefang-cli         CLI、デーモン管理、TUI ダッシュボード、MCP サーバーモード
-librefang-desktop     Tauri 2.0 ネイティブアプリ（トレイ、通知、ショートカット）
-librefang-migrate     OpenClaw、LangChain、AutoGPT マイグレーションエンジン
-xtask                 ビルド自動化
+librefang-kernel            オーケストレーション、ワークフロー、計量、RBAC、スケジューラ、予算
+librefang-runtime           エージェントループ、3 LLM ドライバ、53 ツール、WASM サンドボックス、MCP、A2A
+librefang-api               140+ REST/WS/SSE エンドポイント、OpenAI 互換 API、ダッシュボード
+librefang-channels          40 メッセージングアダプター、レート制限、DM/グループポリシー
+librefang-memory            SQLite 永続化、ベクトル埋め込み、セッション、圧縮
+librefang-types             コア型、テイント追跡、Ed25519 署名、モデルカタログ
+librefang-skills            60 バンドルスキル、SKILL.md パーサー、FangHub マーケットプレイス
+librefang-hands             自律 Hands、HAND.toml パーサー、ライフサイクル管理
+librefang-extensions        25 MCP テンプレート、AES-256-GCM ボールト、OAuth2 PKCE
+librefang-wire              OFP P2P プロトコル、HMAC-SHA256 相互認証
+librefang-cli               CLI、デーモン管理、TUI ダッシュボード、MCP サーバーモード
+librefang-desktop           Tauri 2.0 ネイティブアプリ（トレイ、通知、ショートカット）
+librefang-migrate           OpenClaw、LangChain、AutoGPT マイグレーションエンジン
+librefang-http              共有HTTPクライアントビルダー、プロキシ、TLSフォールバック
+librefang-testing           テストインフラ：モックカーネル、モックLLMドライバー、APIルートテストユーティリティ
+librefang-telemetry         向けのOpenTelemetry + Prometheusメトリクス計装
+librefang-llm-driver        向けのLLMドライバーtraitおよび共有型
+librefang-llm-drivers       traitを実装する具体的なLLMプロバイダードライバー（anthropic、openai、geminiなど）
+librefang-runtime-mcp       ランタイム向けのMCP（Model Context Protocol）クライアント
+librefang-kernel-handle     カーネルへのインプロセス呼び出し元のためのKernelHandle trait
+librefang-runtime-wasm      ランタイム向けのWASMスキルサンドボックス
+librefang-kernel-router     カーネル向けのHand/Templateルーティングエンジン
+librefang-runtime-oauth     ランタイムドライバー向けのOAuthフロー（ChatGPT、GitHub Copilot）
+librefang-kernel-metering   カーネル向けのコスト計量、クォータ適用
+xtask                       ビルド自動化
 ```
+> **OFP wire は plaintext-by-design です。** HMAC-SHA256 相互認証 + メッセージごとの
+> HMAC + nonceリプレイ攻撃対策により、*アクティブ* な攻撃者はカバーされますが、フレームの内容は
+> 暗号化されません。クロスネットワークのフェデレーションを行う場合は、プライベート
+> オーバーレイ（WireGuard、Tailscale、SSHトンネル）またはサービスメッシュのmTLSレイヤーの背後でOFPを実行してください。
+> 詳細: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
 
 ## 主な機能
 
-**40 チャネルアダプター** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、Feishu、LINE、Mastodon、Bluesky 他。[完全リスト](https://docs.librefang.ai/integrations/channels)
+**57 チャネルアダプター** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、Feishu、LINE、Mastodon、Bluesky 他。[完全リスト](https://docs.librefang.ai/integrations/channels)
 
-**27 LLM プロバイダー** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 他。インテリジェントルーティング、自動フォールバック、コスト追跡。[詳細](https://docs.librefang.ai/configuration/providers)
+**28 LLM プロバイダー** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 他。インテリジェントルーティング、自動フォールバック、コスト追跡。[詳細](https://docs.librefang.ai/configuration/providers)
 
 **16 セキュリティレイヤー** — WASM サンドボックス、Merkle 監査証跡、テイント追跡、Ed25519 署名、SSRF 保護、シークレットゼロ化他。[詳細](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -6,7 +6,7 @@
 <h3 align="center">자유로운 에이전트 운영체제 — Libre는 자유를 의미합니다</h3>
 
 <p align="center">
-  Rust로 구축된 오픈소스 Agent OS. 14개 크레이트. 2,100+ 테스트. clippy 경고 제로.
+  Rust로 구축된 오픈소스 Agent OS. 24개 크레이트. 2,100+ 테스트. clippy 경고 제로.
 </p>
 
 <p align="center">
@@ -53,11 +53,11 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # 또는 Cargo로 설치
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# 초기화 (프로바이더 설정 안내)
-librefang init
-
-# 시작 — 대시보드 http://localhost:4545
+# 시작 — 첫 실행 시 자동 초기화되며, 대시보드는 http://localhost:4545 에 있습니다
 librefang start
+
+# 또는 대화형 제공자 선택을 위해 설정 마법사를 수동으로 실행합니다
+# librefang init
 ```
 
 <details>
@@ -92,26 +92,12 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands: 당신을 위해 일하는 에이전트
 
-**Hands**는 사전 구축된 자율형 기능 패키지로, 스케줄에 따라 독립적으로 작동합니다. 14개 내장:
+**Hands** 는 프롬프트 없이 일정에 따라 독립적으로 실행되는 자율 기능 패키지입니다. 각 Hand는 `HAND.toml` 매니페스트, 시스템 프롬프트 및 구성된 환경에서 로드되는 선택적 `SKILL.md` 파일에 의해 정의됩니다 `hands_dir`.
 
-| Hand | 기능 |
-|------|------|
-| **Researcher** | 심층 조사 — 다중 소스 교차 참조, CRAAP 신뢰도 평가, 인용 보고서 |
-| **Collector** | OSINT 모니터링 — 변경 감지, 감정 추적, 지식 그래프 |
-| **Predictor** | 초예측 — 신뢰 구간이 포함된 교정된 예측 |
-| **Strategist** | 전략 분석 — 시장 조사, 경쟁 인텔리전스, 사업 계획 |
-| **Analytics** | 데이터 분석 — 수집, 분석, 시각화, 자동 보고 |
-| **Trader** | 시장 인텔리전스 — 다중 신호 분석, 리스크 관리, 포트폴리오 분석 |
-| **Lead** | 잠재 고객 발굴 — 웹 조사, 스코어링, 중복 제거, 리드 전달 |
-| **Twitter** | 자율형 X/Twitter — 콘텐츠 생성, 스케줄링, 승인 큐 |
-| **Reddit** | Reddit 관리 — 서브레딧 모니터링, 게시, 참여 추적 |
-| **LinkedIn** | LinkedIn 관리 — 콘텐츠 생성, 네트워킹, 전문적 교류 |
-| **Clip** | YouTube 쇼츠 변환 — 베스트 모먼트 컷, 자막, AI 내레이션 |
-| **Browser** | 웹 자동화 — Playwright 기반, 구매 승인 게이트 필수 |
-| **API Tester** | API 테스트 — 엔드포인트 발견, 검증, 부하 테스트, 회귀 감지 |
-| **DevOps** | DevOps 자동화 — CI/CD, 인프라 모니터링, 인시던트 대응 |
+예제 Hand 정의(Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps)는 커뮤니티 [Hands 리포지토리에서 확인할 수 있습니다](https://github.com/librefang/hands).
 
 ```bash
+# 커뮤니티 Hand를 설치한 후:
 librefang hand activate researcher   # 즉시 작업 시작
 librefang hand status researcher     # 진행 상황 확인
 librefang hand list                  # 모든 Hands 보기
@@ -121,30 +107,46 @@ librefang hand list                  # 모든 Hands 보기
 
 ## 아키텍처
 
-14개 Rust 크레이트, 모듈러 커널 설계.
+24개 Rust 크레이트 + xtask, 모듈러 커널 설계.
 
 ```
-librefang-kernel      오케스트레이션, 워크플로, 미터링, RBAC, 스케줄러, 예산
-librefang-runtime     에이전트 루프, 3 LLM 드라이버, 53 도구, WASM 샌드박스, MCP, A2A
-librefang-api         140+ REST/WS/SSE 엔드포인트, OpenAI 호환 API, 대시보드
-librefang-channels    40 메시징 어댑터, 레이트 리미팅, DM/그룹 정책
-librefang-memory      SQLite 영속화, 벡터 임베딩, 세션, 압축
-librefang-types       코어 타입, 테인트 추적, Ed25519 서명, 모델 카탈로그
-librefang-skills      60 번들 스킬, SKILL.md 파서, FangHub 마켓플레이스
-librefang-hands       14 자율 Hands, HAND.toml 파서, 라이프사이클 관리
-librefang-extensions  25 MCP 템플릿, AES-256-GCM 볼트, OAuth2 PKCE
-librefang-wire        OFP P2P 프로토콜, HMAC-SHA256 상호 인증
-librefang-cli         CLI, 데몬 관리, TUI 대시보드, MCP 서버 모드
-librefang-desktop     Tauri 2.0 네이티브 앱 (트레이, 알림, 단축키)
-librefang-migrate     OpenClaw, LangChain, AutoGPT 마이그레이션 엔진
-xtask                 빌드 자동화
+librefang-kernel            오케스트레이션, 워크플로, 미터링, RBAC, 스케줄러, 예산
+librefang-runtime           에이전트 루프, 3 LLM 드라이버, 53 도구, WASM 샌드박스, MCP, A2A
+librefang-api               140+ REST/WS/SSE 엔드포인트, OpenAI 호환 API, 대시보드
+librefang-channels          40 메시징 어댑터, 레이트 리미팅, DM/그룹 정책
+librefang-memory            SQLite 영속화, 벡터 임베딩, 세션, 압축
+librefang-types             코어 타입, 테인트 추적, Ed25519 서명, 모델 카탈로그
+librefang-skills            60 번들 스킬, SKILL.md 파서, FangHub 마켓플레이스
+librefang-hands             자율 Hands, HAND.toml 파서, 라이프사이클 관리
+librefang-extensions        25 MCP 템플릿, AES-256-GCM 볼트, OAuth2 PKCE
+librefang-wire              OFP P2P 프로토콜, HMAC-SHA256 상호 인증
+librefang-cli               CLI, 데몬 관리, TUI 대시보드, MCP 서버 모드
+librefang-desktop           Tauri 2.0 네이티브 앱 (트레이, 알림, 단축키)
+librefang-migrate           OpenClaw, LangChain, AutoGPT 마이그레이션 엔진
+librefang-http              공유 HTTP 클라이언트 빌더, 프록시, TLS 폴백
+librefang-testing           테스트 인프라: 모의(mock) 커널, 모의 LLM 드라이버 및 API 라우트 테스트 유틸리티
+librefang-telemetry         용 OpenTelemetry + Prometheus 메트릭 계측
+librefang-llm-driver        용 LLM 드라이버 trait 및 공유 타입
+librefang-llm-drivers       trait를 구현하는 구체적인 LLM 제공자 드라이버(anthropic, openai, gemini 등)
+librefang-runtime-mcp       런타임용 MCP(Model Context Protocol) 클라이언트
+librefang-kernel-handle     커널로의 인프로세스(in-process) 호출자를 위한 KernelHandle trait
+librefang-runtime-wasm      런타임용 WASM 스킬 샌드박스
+librefang-kernel-router     커널용 Hand/Template 라우팅 엔진
+librefang-runtime-oauth     런타임 드라이버용 OAuth 플로우(ChatGPT, GitHub Copilot)
+librefang-kernel-metering   커널에 대한 비용 측정 및 할당량(quota) 적용
+xtask                       빌드 자동화
 ```
+> **OFP wire는 plaintext-by-design입니다.** HMAC-SHA256 상호 인증 + 메시지별
+> HMAC + nonce 리플레이 방지 기능이 *활성* 공격자를 방어하지만, 프레임 콘텐츠는
+> 암호화되지 않습니다. 교차 네트워크 페더레이션의 경우 프라이빗
+> 오버레이(WireGuard, Tailscale, SSH 터널) 또는 서비스 메시 mTLS 계층 뒤에서 OFP를 실행하세요.
+> 세부 정보: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
 
 ## 주요 기능
 
-**40 채널 어댑터** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 등. [전체 목록](https://docs.librefang.ai/integrations/channels)
+**57 채널 어댑터** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 등. [전체 목록](https://docs.librefang.ai/integrations/channels)
 
-**27 LLM 프로바이더** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama 등. 지능형 라우팅, 자동 폴백, 비용 추적. [상세](https://docs.librefang.ai/configuration/providers)
+**28 LLM 프로바이더** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama 등. 지능형 라우팅, 자동 폴백, 비용 추적. [상세](https://docs.librefang.ai/configuration/providers)
 
 **16 보안 레이어** — WASM 샌드박스, Merkle 감사 추적, 테인트 추적, Ed25519 서명, SSRF 보호, 시크릿 제로화 등. [상세](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -144,7 +144,7 @@ xtask                       빌드 자동화
 
 ## 주요 기능
 
-**57 채널 어댑터** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 등. [전체 목록](https://docs.librefang.ai/integrations/channels)
+**45 채널 어댑터** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky 등. [전체 목록](https://docs.librefang.ai/integrations/channels)
 
 **28 LLM 프로바이더** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama 등. 지능형 라우팅, 자동 폴백, 비용 추적. [상세](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.pl.md
+++ b/i18n/README.pl.md
@@ -144,7 +144,7 @@ xtask                       Automatyzacja budowania
 
 ## Kluczowe Funkcje
 
-**57 Adapterów Kanałów** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky i 44 innych. [Pełna lista](https://docs.librefang.ai/integrations/channels)
+**45 Adapterów Kanałów** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky i 32 innych. [Pełna lista](https://docs.librefang.ai/integrations/channels)
 
 **28 Dostawców LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama i 20 innych. Inteligentny routing, automatyczny fallback, śledzenie kosztów. [Szczegóły](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.pl.md
+++ b/i18n/README.pl.md
@@ -6,7 +6,7 @@
 <h3 align="center">Wolnościowy System Operacyjny Agentów — Wolny, a nie tylko darmowy (Free as in Freedom)</h3>
 
 <p align="center">
-  Agentowy system operacyjny (Agent OS) typu open-source napisany w języku Rust. 14 paczek (crates). Ponad 2100 testów. Zero ostrzeżeń lintera Clippy.
+  Agentowy system operacyjny (Agent OS) typu open-source napisany w języku Rust. 24 paczek (crates). Ponad 2100 testów. Zero ostrzeżeń lintera Clippy.
 </p>
 
 <p align="center">
@@ -53,10 +53,10 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # # Lub zainstaluj przez Cargo
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# Start — automatyczna inicjalizacja przy pierwszym uruchomieniu, dashboard pod adresem
+# Start — automatyczna inicjalizacja przy pierwszym uruchomieniu, panel nawigacyjny pod adresem http://localhost:4545
 librefang start
 
-# # Lub uruchom kreator konfiguracji ręcznie w celu wyboru dostawcy
+# Lub uruchom kreatora konfiguracji ręcznie w celu interaktywnego wyboru dostawcy
 # librefang init
 ```
 
@@ -92,26 +92,12 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands: Agenci, którzy pracują dla Ciebie
 
-**Hands** to wbudowane, autonomiczne pakiety możliwości, które działają niezależnie, zgodnie z harmonogramami i bez konieczności ciągłego promptowania. W zestawie znajduje się ich 14:
+**Hands** to pakiety autonomicznych możliwości, które działają niezależnie, zgodnie z harmonogramami, bez konieczności wprowadzania promptów. Każdy Hand jest definiowany przez manifest `HAND.toml`, prompt systemowy oraz opcjonalne pliki `SKILL.md` ładowane z Twojego skonfigurowanego `hands_dir`.
 
-| Hand | Co robi |
-|------|-------------|
-| **Researcher** | Dogłębny research — wieloźródłowy, ocena wiarygodności (CRAAP), raporty z cytowaniami |
-| **Collector** | Monitorowanie OSINT — wykrywanie zmian, śledzenie sentymentu, graf wiedzy |
-| **Predictor** | Superprognozowanie — skalibrowane predykcje z przedziałami ufności |
-| **Strategist** | Analiza strategii — badania rynku, wywiad konkurencji, planowanie biznesowe |
-| **Analytics** | Analityka danych — zbieranie, analiza, wizualizacja, zautomatyzowane raportowanie |
-| **Trader** | Inteligencja rynkowa — analiza wielu sygnałów, zarządzanie ryzykiem, analityka portfelowa |
-| **Lead** | Odkrywanie prospektów — research w sieci, scoring, deduplikacja, dostarczanie zakwalifikowanych leadów |
-| **Twitter** | Autonomiczny X/Twitter — tworzenie treści, harmonogramowanie, kolejka zatwierdzania |
-| **Reddit** | Menedżer Reddit — monitorowanie subredditów, postowanie, śledzenie zaangażowania |
-| **LinkedIn** | Menedżer LinkedIn — tworzenie treści, networking, zaangażowanie profesjonalne |
-| **Clip** | YouTube na pionowe shorty — wycinanie najlepszych momentów, napisy, lektor (voice-over) |
-| **Browser** | Automatyzacja przeglądarki — oparta na Playwright, obowiązkowa bramka zatwierdzania zakupów |
-| **API Tester** | Testowanie API — odkrywanie endpointów, walidacja, testy obciążeniowe, wykrywanie regresji |
-| **DevOps** | Automatyzacja DevOps — CI/CD, monitorowanie infrastruktury, reagowanie na incydenty |
+Przykładowe definicje Hand (Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps) są dostępne w [repozytorium społecznościowym dla Hands](https://github.com/librefang/hands).
 
 ```bash
+# Zainstaluj społecznościowy Hand, a następnie:
 librefang hand activate researcher   # Rozpoczyna pracę natychmiast
 librefang hand status researcher     # Sprawdź postęp
 librefang hand list                  # Wyświetl wszystkie Hands
@@ -121,30 +107,46 @@ Zbuduj własnego: zdefiniuj `HAND.toml` + prompt systemowy + `SKILL.md`. [Przewo
 
 ## Architektura
 
-14 paczek (crates) w Rust, modułowa architektura jądra (kernel).
+24 paczek (crates) w Rust + xtask, modułowa architektura jądra (kernel).
 
 ```
-librefang-kernel      Orkiestracja, przepływy pracy, opomiarowanie, RBAC, scheduler, budżet
-librefang-runtime     Pętla agenta, 3 sterowniki LLM, 53 narzędzia, piaskownica WASM, MCP, A2A
-librefang-api         140+ endpointów REST/WS/SSE, API kompatybilne z OpenAI, dashboard
-librefang-channels    40 adapterów komunikacyjnych z limitowaniem liczby żądań, polityki DM/grupowe
-librefang-memory      Persystencja SQLite, osadzenia wektorowe, sesje, kompakcja
-librefang-types       Typy podstawowe, taint tracking, podpisywanie Ed25519, katalog modeli
-librefang-skills      60 wbudowanych umiejętności, parser SKILL.md, marketplace FangHub
-librefang-hands       14 autonomicznych Hands, parser HAND.toml, zarządzanie cyklem życia
-librefang-extensions  25 szablonów MCP, skarbiec AES-256-GCM, OAuth2 PKCE
-librefang-wire        Protokół OFP P2P, wzajemne uwierzytelnianie HMAC-SHA256
-librefang-cli         CLI, zarządzanie demonem, dashboard TUI, tryb serwera MCP
-librefang-desktop     Natywna aplikacja Tauri 2.0 (zasobnik systemowy, powiadomienia, skróty)
-librefang-migrate     Silnik migracji OpenClaw, LangChain i AutoGPT
-xtask                 Automatyzacja budowania
+librefang-kernel            Orkiestracja, przepływy pracy, opomiarowanie, RBAC, scheduler, budżet
+librefang-runtime           Pętla agenta, 3 sterowniki LLM, 53 narzędzia, piaskownica WASM, MCP, A2A
+librefang-api               140+ endpointów REST/WS/SSE, API kompatybilne z OpenAI, dashboard
+librefang-channels          40 adapterów komunikacyjnych z limitowaniem liczby żądań, polityki DM/grupowe
+librefang-memory            Persystencja SQLite, osadzenia wektorowe, sesje, kompakcja
+librefang-types             Typy podstawowe, taint tracking, podpisywanie Ed25519, katalog modeli
+librefang-skills            60 wbudowanych umiejętności, parser SKILL.md, marketplace FangHub
+librefang-hands             autonomicznych Hands, parser HAND.toml, zarządzanie cyklem życia
+librefang-extensions        25 szablonów MCP, skarbiec AES-256-GCM, OAuth2 PKCE
+librefang-wire              Protokół OFP P2P, wzajemne uwierzytelnianie HMAC-SHA256
+librefang-cli               CLI, zarządzanie demonem, dashboard TUI, tryb serwera MCP
+librefang-desktop           Natywna aplikacja Tauri 2.0 (zasobnik systemowy, powiadomienia, skróty)
+librefang-migrate           Silnik migracji OpenClaw, LangChain i AutoGPT
+librefang-http              Współdzielony kreator klienta HTTP, proxy, fallback TLS
+librefang-testing           Infrastruktura testowa: mockowany kernel, mockowany driver LLM i narzędzia do testowania tras API
+librefang-telemetry         Instrumentacja metryk OpenTelemetry + Prometheus dla LibreFang
+librefang-llm-driver        Trait drivera LLM i współdzielone typy dla LibreFang
+librefang-llm-drivers       Konkretne drivery dostawców LLM (anthropic, openai, gemini, …) implementujące trait librefang-llm-driver
+librefang-runtime-mcp       Klient MCP (Model Context Protocol) dla środowiska uruchomieniowego (runtime) LibreFang
+librefang-kernel-handle     Trait KernelHandle dla wywołań wewnątrzprocesowych (in-process) do kernela LibreFang
+librefang-runtime-wasm      Sandbox umiejętności (skills) WASM dla środowiska uruchomieniowego LibreFang
+librefang-kernel-router     Silnik routingu Hand/Template dla kernela LibreFang
+librefang-runtime-oauth     Przepływy OAuth (ChatGPT, GitHub Copilot) dla driverów środowiska uruchomieniowego LibreFang
+librefang-kernel-metering   Pomiar kosztów i egzekwowanie limitów (quota) dla kernela LibreFang
+xtask                       Automatyzacja budowania
 ```
+> **OFP wire to plaintext-by-design.** Wzajemne uwierzytelnianie HMAC-SHA256 + HMAC
+> dla każdej wiadomości + ochrona przed atakami typu replay (nonce) zabezpieczają przed *aktywnymi* atakującymi, ale zawartość ramek
+> nie jest szyfrowana. W przypadku cross-network federation, uruchamiaj OFP za prywatnym
+> overlayem (WireGuard, Tailscale, tunel SSH) lub warstwą mTLS typu service-mesh.
+> Szczegóły: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
 
 ## Kluczowe Funkcje
 
-**40 Adapterów Kanałów** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky i 26 innych. [Pełna lista](https://docs.librefang.ai/integrations/channels)
+**57 Adapterów Kanałów** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, Teams, Google Chat, Feishu, LINE, Mastodon, Bluesky i 44 innych. [Pełna lista](https://docs.librefang.ai/integrations/channels)
 
-**27 Dostawców LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama i 20 innych. Inteligentny routing, automatyczny fallback, śledzenie kosztów. [Szczegóły](https://docs.librefang.ai/configuration/providers)
+**28 Dostawców LLM** — Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Ollama i 20 innych. Inteligentny routing, automatyczny fallback, śledzenie kosztów. [Szczegóły](https://docs.librefang.ai/configuration/providers)
 
 **16 Warstw Zabezpieczeń** — Piaskownica (sandbox) WASM, ścieżka audytu Merkle, śledzenie skażenia (taint tracking), podpisywanie Ed25519, ochrona przed SSRF, zerowanie sekretów (secret zeroization) i wiele więcej. [Szczegóły](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -144,7 +144,7 @@ xtask                       构建自动化
 
 ## 核心特性
 
-**57 个渠道适配器** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、飞书、LINE、Mastodon、Bluesky 等。[完整列表](https://docs.librefang.ai/integrations/channels)
+**45 个渠道适配器** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、飞书、LINE、Mastodon、Bluesky 等。[完整列表](https://docs.librefang.ai/integrations/channels)
 
 **28 个 LLM 服务商** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 等。智能路由、自动回退、成本追踪。[详情](https://docs.librefang.ai/configuration/providers)
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -6,7 +6,7 @@
 <h3 align="center">自由的 Agent 操作系统 — Libre 意味着自由</h3>
 
 <p align="center">
-  使用 Rust 构建的开源 Agent OS。14 个 crate。2,100+ 测试。零 clippy 警告。
+  使用 Rust 构建的开源 Agent OS。24 个 crate。2,100+ 测试。零 clippy 警告。
 </p>
 
 <p align="center">
@@ -53,11 +53,11 @@ curl -fsSL https://librefang.ai/install.sh | sh
 # 或通过 Cargo 安装
 cargo install --git https://github.com/librefang/librefang librefang-cli
 
-# 初始化（引导你完成服务商配置）
-librefang init
-
-# 启动 — 控制台 http://localhost:4545
+# 启动 — 首次运行时自动初始化，仪表盘位于 http://localhost:4545
 librefang start
+
+# 或者手动运行设置向导以进行交互式的提供商选择
+# librefang init
 ```
 
 <details>
@@ -92,26 +92,12 @@ docker run -p 4545:4545 ghcr.io/librefang/librefang
 
 ## Hands：为你工作的智能体
 
-**Hands** 是预置的自主能力包，按计划独立运行，无需提示。内置 14 个：
+**Hands** 是一种自主的能力包，无需输入提示词即可按计划独立运行。每个 Hand 由一个 `HAND.toml` 清单、一个系统提示词（system prompt）以及从您配置的环境中加载的可选 `SKILL.md` 文件来定义 `hands_dir`。
 
-| Hand | 功能 |
-|------|------|
-| **Researcher** | 深度研究 — 多源交叉引用、CRAAP 可信度评估、带引用的报告 |
-| **Collector** | OSINT 监控 — 变化检测、情感追踪、知识图谱 |
-| **Predictor** | 超级预测 — 带置信区间的校准预测 |
-| **Strategist** | 战略分析 — 市场研究、竞争情报、商业规划 |
-| **Analytics** | 数据分析 — 数据采集、分析、可视化、自动报告 |
-| **Trader** | 市场情报 — 多信号分析、风险管理、投资组合分析 |
-| **Lead** | 潜客发现 — 网络研究、评分、去重、合格线索交付 |
-| **Twitter** | 自主 X/Twitter — 内容创作、定时发布、审批队列 |
-| **Reddit** | Reddit 管理 — 子版块监控、发帖、互动追踪 |
-| **LinkedIn** | LinkedIn 管理 — 内容创作、社交拓展、职业互动 |
-| **Clip** | YouTube 转短视频 — 裁剪精华、字幕、AI 配音 |
-| **Browser** | Web 自动化 — 基于 Playwright，购买操作强制审批 |
-| **API Tester** | API 测试 — 端点发现、验证、负载测试、回归检测 |
-| **DevOps** | DevOps 自动化 — CI/CD、基础设施监控、事件响应 |
+Hand 的定义示例（Researcher, Collector, Predictor, Strategist, Analytics, Trader, Lead, Twitter, Reddit, LinkedIn, Clip, Browser, API Tester, DevOps）可以在[社区的 Hands 仓库](https://github.com/librefang-registry/hands)中找到。
 
 ```bash
+# 安装一个社区 Hand，然后：
 librefang hand activate researcher   # 立即开始工作
 librefang hand status researcher     # 查看进度
 librefang hand list                  # 查看所有 Hands
@@ -121,30 +107,46 @@ librefang hand list                  # 查看所有 Hands
 
 ## 架构
 
-14 个 Rust crate，模块化内核设计。
+24 个 Rust crate + xtask，模块化内核设计。
 
 ```
-librefang-kernel      编排、工作流、计量、RBAC、调度、预算
-librefang-runtime     智能体循环、3 个 LLM 驱动器、53 个工具、WASM 沙箱、MCP、A2A
-librefang-api         140+ REST/WS/SSE 端点、OpenAI 兼容 API、控制台
-librefang-channels    40 个消息适配器，速率限制、DM/群组策略
-librefang-memory      SQLite 持久化、向量嵌入、会话、压缩
-librefang-types       核心类型、污点追踪、Ed25519 签名、模型目录
-librefang-skills      60 个内置技能、SKILL.md 解析器、FangHub 市场
-librefang-hands       14 个自主 Hands、HAND.toml 解析器、生命周期管理
-librefang-extensions  25 个 MCP 模板、AES-256-GCM 保险库、OAuth2 PKCE
-librefang-wire        OFP P2P 协议、HMAC-SHA256 双向认证
-librefang-cli         CLI、守护进程管理、TUI 控制台、MCP 服务器模式
-librefang-desktop     Tauri 2.0 原生应用（托盘、通知、快捷键）
-librefang-migrate     OpenClaw、LangChain、AutoGPT 迁移引擎
-xtask                 构建自动化
+librefang-kernel            编排、工作流、计量、RBAC、调度、预算
+librefang-runtime           智能体循环、3 个 LLM 驱动器、53 个工具、WASM 沙箱、MCP、A2A
+librefang-api               140+ REST/WS/SSE 端点、OpenAI 兼容 API、控制台
+librefang-channels          40 个消息适配器，速率限制、DM/群组策略
+librefang-memory            SQLite 持久化、向量嵌入、会话、压缩
+librefang-types             核心类型、污点追踪、Ed25519 签名、模型目录
+librefang-skills            60 个内置技能、SKILL.md 解析器、FangHub 市场
+librefang-hands             个自主 Hands、HAND.toml 解析器、生命周期管理
+librefang-extensions        25 个 MCP 模板、AES-256-GCM 保险库、OAuth2 PKCE
+librefang-wire              OFP P2P 协议、HMAC-SHA256 双向认证
+librefang-cli               CLI、守护进程管理、TUI 控制台、MCP 服务器模式
+librefang-desktop           Tauri 2.0 原生应用（托盘、通知、快捷键）
+librefang-migrate           OpenClaw、LangChain、AutoGPT 迁移引擎
+librefang-http              共享 HTTP 客户端构建器、代理、TLS 回退（fallback）
+librefang-testing           测试基础设施：模拟（mock）内核、模拟 LLM 驱动程序以及 API 路由测试工具
+librefang-telemetry         的 OpenTelemetry + Prometheus 指标埋点（instrumentation）
+librefang-llm-driver        的 LLM 驱动程序 trait 及共享类型
+librefang-llm-drivers       trait 的具体 LLM 提供商驱动程序（anthropic、openai、gemini 等）
+librefang-runtime-mcp       运行时的 MCP（Model Context Protocol）客户端
+librefang-kernel-handle     内核进行进程内调用的 KernelHandle trait
+librefang-runtime-wasm      运行时的 WASM 技能沙盒（sandbox）
+librefang-kernel-router     内核的 Hand/Template 路由引擎
+librefang-runtime-oauth     运行时驱动程序的 OAuth 流程（ChatGPT、GitHub Copilot）
+librefang-kernel-metering   内核的成本计量和配额执行
+xtask                       构建自动化
 ```
+> **OFP wire 是 plaintext-by-design。** HMAC-SHA256 双向认证 + 每条消息的
+> HMAC + nonce 重放保护涵盖了针对 *主动* 攻击者的防御，但帧的内容
+> 未经加密。对于跨网络联邦，请在私有
+> 覆盖网络（如 WireGuard、Tailscale、SSH 隧道）或服务网格 mTLS 层之后运行 OFP。
+> 详情: [docs.librefang.ai/architecture/ofp-wire](https://docs.librefang.ai/architecture/ofp-wire)
 
 ## 核心特性
 
-**40 个渠道适配器** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、飞书、LINE、Mastodon、Bluesky 等。[完整列表](https://docs.librefang.ai/integrations/channels)
+**57 个渠道适配器** — Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Email、Teams、Google Chat、飞书、LINE、Mastodon、Bluesky 等。[完整列表](https://docs.librefang.ai/integrations/channels)
 
-**27 个 LLM 服务商** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 等。智能路由、自动回退、成本追踪。[详情](https://docs.librefang.ai/configuration/providers)
+**28 个 LLM 服务商** — Anthropic、Gemini、OpenAI、Groq、DeepSeek、OpenRouter、Ollama 等。智能路由、自动回退、成本追踪。[详情](https://docs.librefang.ai/configuration/providers)
 
 **16 层安全体系** — WASM 沙箱、Merkle 审计链、污点追踪、Ed25519 签名、SSRF 防护、密钥清零等。[详情](https://docs.librefang.ai/getting-started/comparison#16-security-systems--defense-in-depth)
 


### PR DESCRIPTION
This replaces closed PR [#3437](https://github.com/librefang/librefang/pull/3437). It updates the README and syncs the crate/driver counts across all i18n translation files as requested by the reviewer previously

<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [ ] Bug fix
- [ ] Feature (Rust)
- [x] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

<!-- What does this PR do? Link related issues with "Fixes #123". -->

## Changes

<!-- Brief list of what changed. -->

## Attribution

- [ ] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
