### PR TITLE
fix(runtime): repair tool pairs before saving on failure paths (#4029)

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -181,6 +181,19 @@ fn clamp_max_history(requested: usize, agent: &str) -> usize {
     }
 }
 
+/// Run session repair on `session.messages` before persisting on failure paths.
+///
+/// When the agent loop exits via circuit breaker, max iterations, or timeout,
+/// the session history may contain orphaned `ToolUse` blocks with no matching
+/// `ToolResult`.  Providers that enforce strict pairing (Moonshot, OpenAI)
+/// then return 400 on next load, making the session permanently broken.
+///
+/// This helper replaces `session.messages` with the repaired copy so the
+/// persisted history is always well-formed.
+fn repair_session_before_save(session: &mut Session) {
+    session.messages = crate::session_repair::validate_and_repair(&session.messages);
+}
+
 /// Maximum consecutive iterations where every executed tool failed before
 /// the loop exits with `RepeatedToolFailures`. Catches expensive wheel-spinning
 /// when the LLM cannot fix a tool call (bad auth, permanent 404, etc.).
@@ -799,6 +812,7 @@ async fn execute_single_tool_call(
                 warn!(tool = %tool_call.name, "Circuit breaker triggered");
             }
             if !ctx.opts.is_fork {
+                repair_session_before_save(ctx.session);
                 if let Err(e) = ctx.memory.save_session_async(ctx.session).await {
                     warn!("Failed to save session on circuit break: {e}");
                 }
@@ -3860,6 +3874,7 @@ pub async fn run_agent_loop(
     // Fork turns skip — they're ephemeral and must not pollute canonical
     // session history even when the loop bailed out.
     if !opts.is_fork {
+        repair_session_before_save(session);
         if let Err(e) = memory.save_session_async(session).await {
             warn!("Failed to save session on max iterations: {e}");
         }
@@ -5286,6 +5301,7 @@ pub async fn run_agent_loop_streaming(
     }
 
     if !opts.is_fork {
+        repair_session_before_save(session);
         if let Err(e) = memory.save_session_async(session).await {
             warn!("Failed to save session on max iterations: {e}");
         }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -190,8 +190,25 @@ fn clamp_max_history(requested: usize, agent: &str) -> usize {
 ///
 /// This helper replaces `session.messages` with the repaired copy so the
 /// persisted history is always well-formed.
-fn repair_session_before_save(session: &mut Session) {
-    session.messages = crate::session_repair::validate_and_repair(&session.messages);
+fn repair_session_before_save(session: &mut Session, agent_id: &str, reason: &str) {
+    let (repaired, stats) =
+        crate::session_repair::validate_and_repair_with_stats(&session.messages);
+    if stats != crate::session_repair::RepairStats::default() {
+        tracing::warn!(
+            agent_id,
+            reason,
+            orphaned_results_removed = stats.orphaned_results_removed,
+            empty_messages_removed = stats.empty_messages_removed,
+            messages_merged = stats.messages_merged,
+            results_reordered = stats.results_reordered,
+            synthetic_results_inserted = stats.synthetic_results_inserted,
+            duplicates_removed = stats.duplicates_removed,
+            misplaced_results_rescued = stats.misplaced_results_rescued,
+            positional_synthetic_inserted = stats.positional_synthetic_inserted,
+            "Session repair applied before save"
+        );
+    }
+    session.messages = repaired;
 }
 
 /// Maximum consecutive iterations where every executed tool failed before
@@ -811,8 +828,8 @@ async fn execute_single_tool_call(
             } else {
                 warn!(tool = %tool_call.name, "Circuit breaker triggered");
             }
+            repair_session_before_save(ctx.session, ctx.agent_id_str, "circuit_breaker");
             if !ctx.opts.is_fork {
-                repair_session_before_save(ctx.session);
                 if let Err(e) = ctx.memory.save_session_async(ctx.session).await {
                     warn!("Failed to save session on circuit break: {e}");
                 }
@@ -3873,8 +3890,8 @@ pub async fn run_agent_loop(
     // Save session before failing so conversation history is preserved.
     // Fork turns skip — they're ephemeral and must not pollute canonical
     // session history even when the loop bailed out.
+    repair_session_before_save(session, agent_id_str.as_str(), "max_iterations");
     if !opts.is_fork {
-        repair_session_before_save(session);
         if let Err(e) = memory.save_session_async(session).await {
             warn!("Failed to save session on max iterations: {e}");
         }
@@ -4755,6 +4772,7 @@ pub async fn run_agent_loop_streaming(
                          Any partial output was already sent to the user.]"
                     );
                     session.messages.push(Message::assistant(note));
+                    repair_session_before_save(session, agent_id_str.as_str(), "streaming_timeout");
                     if !opts.is_fork {
                         if let Err(save_err) = memory.save_session_async(session).await {
                             warn!(
@@ -5300,8 +5318,8 @@ pub async fn run_agent_loop_streaming(
         }
     }
 
+    repair_session_before_save(session, agent_id_str.as_str(), "streaming_max_iterations");
     if !opts.is_fork {
-        repair_session_before_save(session);
         if let Err(e) = memory.save_session_async(session).await {
             warn!("Failed to save session on max iterations: {e}");
         }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3927,11 +3927,6 @@ fn default_max_upload_size_bytes() -> usize {
     10 * 1024 * 1024
 }
 
-/// Default workflow stale timeout: 60 minutes.
-fn default_workflow_stale_timeout_minutes() -> u64 {
-    60
-}
-
 /// Default maximum concurrent background LLM calls.
 fn default_max_concurrent_bg_llm() -> usize {
     5
@@ -5161,7 +5156,7 @@ pub struct NetworkConfig {
     pub max_messages_per_peer_per_minute: u32,
     /// SECURITY (#3876): Optional cumulative LLM token budget per OFP peer per hour.
     ///
-    /// When set, the node tracks how many tokens each peer's 
+    /// When set, the node tracks how many tokens each peer's
     /// requests have consumed in the current hour window. If a peer exceeds
     /// this budget the request is rejected with a 429 error.
     ///
@@ -5201,8 +5196,14 @@ impl std::fmt::Debug for NetworkConfig {
                     "<redacted>"
                 },
             )
-            .field("max_messages_per_peer_per_minute", &self.max_messages_per_peer_per_minute)
-            .field("max_llm_tokens_per_peer_per_hour", &self.max_llm_tokens_per_peer_per_hour)
+            .field(
+                "max_messages_per_peer_per_minute",
+                &self.max_messages_per_peer_per_minute,
+            )
+            .field(
+                "max_llm_tokens_per_peer_per_hour",
+                &self.max_llm_tokens_per_peer_per_hour,
+            )
             .finish()
     }
 }


### PR DESCRIPTION
## Summary

- Agent loop failure paths (circuit breaker, max iterations, timeout) save session history without repairing orphaned ToolUse blocks
- Providers enforcing strict tool-use/tool-result pairing (Moonshot, OpenAI) then permanently 400 on next session load
- Add `repair_session_before_save()` that runs `validate_and_repair` before each failure-path save
- Covers all three failure-path save sites: circuit breaker, non-streaming max iterations, streaming max iterations

Closes #4029

## Test plan
- [ ] Existing session repair tests still pass
- [ ] Interrupt a tool call mid-execution, verify session loads cleanly on next conversation
- [ ] Circuit breaker exit produces valid session history