### PR TITLE
fix(dashboard): normalize workflow_id to id in createWorkflow response

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1743,7 +1743,10 @@ export async function createWorkflow(payload: {
   }>;
   layout?: unknown;
 }): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>("/api/workflows", payload);
+  return post<ApiActionResponse>("/api/workflows", payload).then((r) => ({
+    ...r,
+    id: r.id ?? (r as { workflow_id?: string }).workflow_id,
+  }));
 }
 
 export async function getWorkflow(workflowId: string): Promise<WorkflowItem> {


### PR DESCRIPTION
## Summary

- `POST /api/workflows` returns `{"workflow_id": "..."}` but `CanvasPage.tsx:1536` reads `created?.id`
- Since `id` is always `undefined`, every workflow creation throws "Failed to create workflow"
- The workflow IS created server-side but the frontend can't read the ID back
- Fix: normalize at the API boundary in `createWorkflow()` so the frontend sees a consistent `id` field

Closes #4037

## Test plan

- [ ] Create a workflow via Canvas page — should succeed instead of throwing
- [ ] Verify existing workflow list/get/delete operations still work
- [ ] Verify the unit test mock (`{ id: "wf-1" }`) still passes (unchanged)