### PR TITLE
🚨 EMERGENCY fix(api): resolve unresolved git conflict markers shipped to main by #3927

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -714,45 +714,15 @@ pub async fn auth(
     // SECURITY: Use constant-time comparison to prevent timing attacks.
     let header_auth = api_token.map(&matches_any);
 
-<<<<<<< HEAD
     // SECURITY: ?token= query-string auth is deliberately NOT checked here.
     // Query parameters are written to server access logs, retained in browser
     // history, and forwarded in HTTP Referer headers to third parties. Tokens
     // must only arrive via Authorization: Bearer or X-API-Key headers, or via
     // the session cookie. WebSocket upgrades are the sole exception (browsers
     // cannot set custom headers on WebSocket connections); they authenticate
-    // via crate::ws::ws_auth_token, which never passes through this middleware.
-=======
-    // SECURITY: ?token= query parameter is ONLY accepted for WebSocket upgrade
-    // requests and SSE streaming endpoints where browsers cannot send custom
-    // headers. For all other REST routes the token must come from an
-    // Authorization: Bearer or X-API-Key header — query params appear in
-    // access logs, Referer headers, and browser history, making them easy to
-    // accidentally leak.
-    //
-    // Allowed path prefixes:
-    //   /api/agents/{id}/ws           — WebSocket upgrade (can't set headers)
-    //   /ws/                          — any future top-level WS endpoint
-    //   /api/agents/{id}/sessions/*/stream — SSE session attach
-    //   /api/agents/{id}/message/stream   — SSE message stream
-    //   /api/logs/stream              — SSE log tail
-    //
-    // Percent-decode (but NOT form-urlencoded) so literal `+` characters in
-    // base64-derived tokens are preserved instead of being turned into spaces.
-    // See issue #962 (ported from openfang).
-    let is_ws_or_sse_path =
-        path.ends_with("/ws") || path.starts_with("/ws/") || path.ends_with("/stream");
-
-    let query_token_decoded = if is_ws_or_sse_path {
-        request
-            .uri()
-            .query()
-            .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
-            .map(crate::percent_decode)
-    } else {
-        None
-    };
->>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
+    // via crate::ws::ws_auth_token, which uses Authorization: Bearer or the
+    // Sec-WebSocket-Protocol bearer.<token> sub-protocol (#3963), never the
+    // query string — and never passes through this middleware.
 
     // Accept if header auth matches a static API key or legacy token
     if header_auth == Some(true) {

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3681,64 +3681,36 @@ pub async fn update_agent(
         }
     };
 
-<<<<<<< HEAD
-    drop(t);
-
-    match state.kernel.update_manifest(agent_id, manifest) {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "ok",
-                "agent_id": id,
-            })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e.to_string()})),
-        ),
-=======
-    // Apply the new manifest to the in-memory registry (preserves runtime-only
-    // fields like workspace path and tags).
-    if let Err(e) = state
-        .kernel
-        .agent_registry()
-        .replace_manifest(agent_id, manifest)
-    {
+    // `update_manifest` already runs the same replace_manifest +
+    // memory.save_agent + persist_manifest_to_disk sequence the
+    // earlier draft of this handler did inline (kernel/mod.rs ~9131),
+    // plus capability re-grant, quota update, and prompt-cache flush.
+    // Use the kernel API instead of duplicating the steps here.
+    if let Err(e) = state.kernel.update_manifest(agent_id, manifest) {
+        let msg = e.to_string();
+        drop(t);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
-            ),
+            Json(serde_json::json!({"error": msg})),
         );
     }
 
-    // Persist updated entry to SQLite so it survives a restart.
-    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
-        if let Err(e) = state.kernel.memory_substrate().save_agent(&entry) {
-            tracing::warn!("Failed to persist agent manifest update: {e}");
-        }
-    }
-
-    // Write updated manifest to agent.toml on disk so the file matches the
-    // in-memory state and doesn't override changes on next boot.
-    state.kernel.persist_manifest_to_disk(agent_id);
-
-    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
-        (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "ok",
-                "agent_id": entry.id.to_string(),
-                "name": entry.name,
-            })),
-        )
+    // Resolve the post-update entry so the response carries the agent name
+    // alongside the id (the contract documented in PR #3927 / #3824).
+    let response = if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
+        Json(serde_json::json!({
+            "status": "ok",
+            "agent_id": entry.id.to_string(),
+            "name": entry.name,
+        }))
     } else {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": t.t("api-error-agent-vanished")})),
-        )
->>>>>>> b9c55db9 (fix(api): channel body limit, remove ?token= from non-WS routes, implement PUT agents, deduplicate operationIds)
-    }
+        Json(serde_json::json!({
+            "status": "ok",
+            "agent_id": id,
+        }))
+    };
+    drop(t);
+    (StatusCode::OK, response)
 }
 
 #[utoipa::path(


### PR DESCRIPTION
## Emergency

PR #3927 (squash commit `42038f9b`) shipped **unresolved git conflict markers** to main:

- `crates/librefang-api/src/middleware.rs` lines 717–755
- `crates/librefang-api/src/routes/agents.rs` lines 3684–3740

Each file contains literal `<<<<<<< HEAD` / `=======` / `>>>>>>> b9c55db9` markers in the middle of a `pub async fn`.  `rustc` parses them as syntax errors.  `cargo build --workspace` against main HEAD `545ff239` fails with no other changes.

CI must have skipped, fast-merged, or otherwise not actually compiled these files since the merge — every PR that landed on top of #3927 was building against a tree that did not actually compile.

## Resolution

### middleware.rs — adopt HEAD

`ws_auth_token` (`ws.rs:144`) deliberately no longer reads the query string at all — #3963 introduced the `Sec-WebSocket-Protocol: bearer.<token>` sub-protocol path so the token never leaves the handshake.  The b9c55db9 branch's `is_ws_or_sse_path` + `query_token_decoded` variables therefore end up **dead** — defined but never consumed (no `query_auth` use anywhere).  Drop them and keep the HEAD comment documenting why `?token=` is rejected universally.

### agents.rs — adopt HEAD, restore `name` in response

`kernel.update_manifest` (`kernel/mod.rs:9131`) already runs the full `replace_manifest` + `memory.save_agent` + `persist_manifest_to_disk` sequence the b9c55db9 branch was open-coding inline, plus capability re-grant, quota update, and prompt-cache flush.  Use the kernel API instead of duplicating the steps in the route handler.

Restore the `name` field in the response body — the documented PR #3927 / #3824 contract is "returns 200 with `agent_id` + `name` on success".

## No semantic change

Beyond completing the merge that should have happened before the squash, no behavioural change.  ?token= handling matches the documented post-#3963 design; PUT /api/agents/{id}/update contract matches what the PR description claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)