### PR TITLE
fix(api,oauth): reject OIDC callback when id_token validation fails (no userinfo fallback)

### DIFF
--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -764,16 +764,25 @@ async fn handle_code_exchange(
         }
     };
 
-    // Try to validate the ID token if present.
+    // Validate the ID token if the provider supplies one.  Three rules,
+    // all hard rejects:
+    //   1. Provider sent an id_token AND we have a jwks_uri to verify it
+    //      against → JWT validation MUST succeed.  A malformed / forged /
+    //      expired id_token is a strong signal of replay or token swap;
+    //      falling through to userinfo (which carries no nonce) lets
+    //      the attack succeed.  This was the path #3944 left open.
+    //   2. id_token validates → nonce claim MUST be present and equal
+    //      to the nonce we signed into `state`.
+    //   3. id_token validates with mismatched nonce → reject.
+    //
+    // The "no id_token at all" path (some OAuth2 providers genuinely
+    // don't emit one for non-OIDC flows) still falls through to
+    // userinfo by design; that path was always nonce-less.
     let claims = if let Some(ref id_token) = token_resp.id_token {
         if !id_token.is_empty() && !provider.jwks_uri.is_empty() {
             match validate_jwt_cached(id_token, &provider.jwks_uri, &provider.audience).await {
                 Ok(c) => {
                     // Verify nonce claim against the nonce we sent in the auth request.
-                    // Two failure cases must both be rejected:
-                    //   1. Nonce claim present but doesn't match (replay / token swap).
-                    //   2. Nonce claim absent even though we sent a nonce (provider
-                    //      non-compliance that could be used to bypass nonce binding).
                     match c.nonce {
                         Some(ref token_nonce) if token_nonce != &state_payload.nonce => {
                             warn!("Nonce mismatch in ID token");
@@ -802,11 +811,36 @@ async fn handle_code_exchange(
                     Some(c)
                 }
                 Err(e) => {
-                    debug!(error = %e, "ID token validation failed, falling back to userinfo");
-                    None
+                    // The provider sent an id_token AND we had keys to
+                    // verify it — verification must succeed or the
+                    // request is rejected.  Returning the error message
+                    // as-is is fine: it's our own validation diagnostic
+                    // (kid mismatch, expired, sig fail), not provider
+                    // body.
+                    warn!(error = %e, "ID token validation failed — rejecting OAuth callback");
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": "ID token signature or expiry validation failed"
+                        })),
+                    )
+                        .into_response();
                 }
             }
         } else {
+            // Provider sent a non-empty id_token but no jwks_uri configured
+            // for this provider, OR the id_token field came back empty.
+            // The empty-token case is benign (no token to verify); the
+            // missing-jwks-uri case means this provider was added to the
+            // config without OIDC keys, which only makes sense for pure
+            // OAuth2 — accept and rely on userinfo.
+            if !id_token.is_empty() {
+                warn!(
+                    "Provider supplied id_token but jwks_uri is unset; \
+                     skipping JWT validation and falling back to userinfo. \
+                     Configure jwks_uri to enforce OIDC nonce binding."
+                );
+            }
             None
         }
     } else {


### PR DESCRIPTION
Follow-up to #3944 (OIDC nonce binding).

## Bypass

#3944 verified the `nonce` claim **only on the success arm** of `validate_jwt_cached`:

```rust
match validate_jwt_cached(id_token, &provider.jwks_uri, …).await {
    Ok(c) => {
        match c.nonce { … nonce checks … }
        Some(c)
    }
    Err(e) => {
        debug!(error = %e, "ID token validation failed, falling back to userinfo");
        None     // ← falls through to userinfo, which has no nonce check
    }
}
```

When the provider supplies an `id_token` AND we have a `jwks_uri` to verify it against, **failure** (forged signature, expired, kid mismatch, malformed) is a strong signal of replay or token swap.  The userinfo branch then fetches identity claims off the access token without ever checking the nonce, so:

1. Attacker injects any unverifiable `id_token` in the token response (or recycles one from a different audience).
2. `validate_jwt_cached` returns `Err`.
3. Code logs at `debug` level, sets `claims = None`.
4. Userinfo branch happily reads identity from `/userinfo`.
5. Identity is consumed; nonce binding bypassed.

## Fix

`Err` from JWT validation is now a hard reject with HTTP 400.  The underlying validation error is logged at `warn!` for ops; the response carries a generic `"ID token signature or expiry validation failed"` so internal diagnostics don't leak (same fail-secure shape as #4015's memory-route fix).

The id-token-absent path (pure-OAuth2 providers that don't emit one) is unchanged — still falls through to userinfo by design.  The id-token-present-but-no-`jwks_uri` path now logs a `warn!` so an operator notices an OIDC provider was configured without keys.

## Out of scope

The audit also flagged that nonce is reconstructed from HMAC-signed `state` on every callback and never consumed (replay protection only via the IdP rejecting code reuse).  That's a separate fix — adding server-side nonce consumption requires either a sqlite migration or a per-flow vault key.  Filed as a TODO for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)