### PR TITLE
fix(extensions): atomic .env save closes #3944 truncation + perms TOCTOU

### DIFF
--- a/crates/librefang-extensions/src/dotenv.rs
+++ b/crates/librefang-extensions/src/dotenv.rs
@@ -219,13 +219,42 @@ fn write_env_file(path: &Path, entries: &BTreeMap<String, String>) -> Result<(),
         }
     }
 
-    std::fs::write(path, &content).map_err(|e| format!("Failed to write .env file: {e}"))?;
+    // Atomic save: open <path>.tmp.<pid> with mode 0600 (Unix) at open
+    // time, write_all + flush + sync_all + rename(tmp, final).  Closes
+    // three #3944 holes left by the bare std::fs::write:
+    //   * Crash mid-write no longer leaves a truncated/empty .env
+    //     (the loader silently accepts that, so the API key the user
+    //     just configured vanishes on next boot).
+    //   * Default-perms TOCTOU window is gone: the file is created
+    //     0600 instead of 0644-then-tightened, so a parallel local
+    //     reader can't grab the key during the open syscall.
+    //   * Two concurrent saves no longer share the same staging path
+    //     because the tmp filename is uniquified by PID.
+    let tmp_path = path.with_extension(format!(
+        "env.tmp.{}",
+        std::process::id()
+    ));
+    let result = (|| -> std::io::Result<()> {
+        use std::io::Write as _;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp_path)?;
+        f.write_all(content.as_bytes())?;
+        f.flush()?;
+        f.sync_all()?;
+        drop(f);
+        std::fs::rename(&tmp_path, path)
+    })();
 
-    // Set 0600 permissions on Unix
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    if let Err(e) = result {
+        // Clean up an abandoned tmp on either write or rename failure.
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Failed to write .env file: {e}"));
     }
 
     Ok(())


### PR DESCRIPTION
Follow-up to #3944 (atomic init write).

`write_env_file` (called by `save_env_key` during the init wizard / provider configuration flow) used `std::fs::write` + post-write `set_permissions(0o600)`.  That shape leaves three real failure modes:

1. **Crash mid-write** — the file lands at 0 bytes or partial content.  The dotenv loader's `parse_env_line` silently skips malformed lines, so the API key the user just configured disappears on next boot with no error.
2. **Default-perms TOCTOU** — the file is created at 0644 minus umask and only tightened to 0600 by a separate syscall.  A parallel reader on the same host can read the credential during the gap.
3. **Concurrent saves on the same final path** — both processes truncate the same file before either finishes writing.

PR description claimed "atomic init write" but the underlying write is exactly the non-atomic `std::fs::write`.

## Fix

Same atomic-write pattern used by `cron.rs` / `triggers.rs` (after #3954 + #4018):

```rust
opts.write(true).create_new(true);
#[cfg(unix)] opts.mode(0o600);
let mut f = opts.open(&tmp_path)?;
f.write_all(...)?;
f.flush()?;
f.sync_all()?;
drop(f);
std::fs::rename(&tmp_path, path)
```

- O_EXCL + per-PID tmp name → concurrent writers stage independently.
- mode(0o600) at open time → no default-perms window.
- sync_all + rename → no partial-file visible state.
- Errors clean up the tmp before returning so a failed save doesn't leave debris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)