### PR TITLE
fix(mcp): keep draining stderr after log cap to prevent child pipe stall

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1119,9 +1119,30 @@ impl McpConnection {
                 let mut lines_read: u32 = 0;
                 const MAX_LINE_BYTES: usize = 256;
                 const MAX_LINES: u32 = 100;
-                while lines_read < MAX_LINES {
+                loop {
                     match reader.next_line().await {
                         Ok(Some(line)) => {
+                            // Past the log cap we KEEP READING but stop
+                            // logging.  CRITICAL: we must continue to
+                            // drain the pipe — if the loop exits on
+                            // line 101, the kernel stderr pipe buffer
+                            // (64 KiB on Linux) fills and the child's
+                            // next `write(stderr)` blocks forever,
+                            // hanging the MCP server.  #3926 introduced
+                            // a `break` here that reintroduced exactly
+                            // the pipe-stall failure mode the PR title
+                            // claimed to fix.
+                            if lines_read >= MAX_LINES {
+                                if lines_read == MAX_LINES {
+                                    debug!(
+                                        server = %server_name_for_log,
+                                        "MCP stdio stderr drain reached {MAX_LINES}-line log cap; \
+                                         continuing to discard further output to keep the pipe drained"
+                                    );
+                                }
+                                lines_read = lines_read.saturating_add(1);
+                                continue;
+                            }
                             let truncated = if line.len() > MAX_LINE_BYTES {
                                 // Find the last valid UTF-8 character boundary at
                                 // or before MAX_LINE_BYTES so we don't panic on
@@ -1142,15 +1163,9 @@ impl McpConnection {
                             );
                             lines_read += 1;
                         }
-                        Ok(None) => break, // EOF
-                        Err(_) => break,   // pipe closed or read error
+                        Ok(None) => break, // EOF — child closed stderr.
+                        Err(_) => break,   // read error — pipe is unusable.
                     }
-                }
-                if lines_read >= MAX_LINES {
-                    debug!(
-                        server = %server_name_for_log,
-                        "MCP stdio stderr drain reached {MAX_LINES}-line cap; suppressing further output"
-                    );
                 }
             });
         }


### PR DESCRIPTION
Follow-up to #3926 (pipe stderr).

#3926's stderr drain loop terminated at line 101:

```rust
while lines_read < MAX_LINES {
    match reader.next_line().await {
        Ok(Some(line)) => { … debug!(…); lines_read += 1; }
        Ok(None) => break,
        Err(_) => break,
    }
}
```

After the 100th line the task exits and stops reading.  Once the kernel pipe buffer fills (64 KiB on Linux), the child's next `write(stderr)` blocks forever — recreating exactly the pipe-stall failure mode #3926 claimed to close.  Any moderately chatty MCP server (banner + per-request log line) hits this within seconds.

## Fix

Switch to an unconditional `loop {}` that keeps reading after `MAX_LINES` but stops formatting / logging:

- `lines_read < MAX_LINES` → format + `debug!` as before.
- `lines_read == MAX_LINES` (boundary) → emit a single "capped, still draining" notice so an operator can correlate.
- `lines_read > MAX_LINES` → `next_line()`, discard, `continue`.

The pipe stays drained indefinitely.  The only `break` paths are now EOF (child closed stderr) and a real I/O error (pipe unusable) — the only correct shutdown signals.