### PR TITLE
fix(cli): init wizard saves API key only after successful validation

### DIFF
--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -617,15 +617,32 @@ pub fn run() -> InitResult {
         // initial Enter press (fixes #3629: write-before-validate).
         if state.key_test == KeyTestState::Testing {
             if let Ok(ok) = test_rx.try_recv() {
-                // Persist the key now that we have a test result. We write for
-                // both Ok (verified) and Warn (unverified but user confirmed)
-                // so the daemon can pick it up either way.
-                if let Some(p) = state.provider() {
-                    if !p.env_var.is_empty() {
-                        let _ = dotenv::save_env_key(p.env_var, &state.api_key_input);
-                    }
-                }
+                // Persist ONLY when the validation succeeded.  The
+                // pre-fix comment claimed the Warn path was "unverified
+                // but user confirmed", but the wizard auto-advances
+                // 600 ms after either Ok or Warn (see the matches!
+                // block below) — there is no explicit confirmation
+                // step.  Writing a failing key still landed it in
+                // .env, so the daemon booted with a key the wizard
+                // had just told the user was bad.  Now Warn keeps the
+                // user-typed value in `state.api_key_input` only, the
+                // UI surfaces the validation message, and nothing
+                // hits disk until the user retries with a key that
+                // actually authenticates.
                 state.key_test = if ok {
+                    if let Some(p) = state.provider() {
+                        if !p.env_var.is_empty() {
+                            if let Err(e) =
+                                dotenv::save_env_key(p.env_var, &state.api_key_input)
+                            {
+                                tracing::warn!(
+                                    provider = ?p.name,
+                                    error = %e,
+                                    "init wizard: failed to persist verified API key"
+                                );
+                            }
+                        }
+                    }
                     KeyTestState::Ok
                 } else {
                     KeyTestState::Warn


### PR DESCRIPTION
Follow-up to #3944 (init wizard write-before-validate fix).

#3944 moved the `save_env_key` call to the test-result branch — but persisted on **both** outcomes:

```rust
if let Ok(ok) = test_rx.try_recv() {
    // Persist for both Ok and Warn 'so the daemon can pick it up'
    let _ = dotenv::save_env_key(p.env_var, &state.api_key_input);
    state.key_test = if ok { Ok } else { Warn };
}
```

The comment claimed `Warn` was "unverified but user confirmed", but the wizard **auto-advances 600 ms** after either Ok or Warn (the `matches!(state.key_test, KeyTestState::Ok | KeyTestState::Warn)` block right below).  There is no explicit confirmation step.  A failing key is written to `.env`, the daemon picks it up on next boot, and every subsequent LLM call dies on a 401.  Issue #3629 (write-before-validate) is reintroduced one frame later as write-on-validation-failed.

## Fix

Move the save inside the `Ok` arm.  On `Warn` the typed value lives in `state.api_key_input` only; the UI surfaces the validation message; the user retries.

Also stop swallowing `save_env_key` errors with `let _ =` — a perms/truncation/atomic-write failure should land in the daemon log via `tracing::warn!` so an operator notices, not vanish.