### PR TITLE
fix(ci): gate Dependabot auto-merge on patch/minor update-type only

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,10 +13,41 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge for Dependabot PRs
+      # Inspect the dependabot PR's metadata so we can gate auto-merge
+      # on update-type.  Without this gate, a malicious major-version
+      # release in any watched ecosystem auto-lands on green CI — the
+      # supply-chain blast radius the post-merge audit of #3938 flagged
+      # (npm + pip ecosystems newly added by that PR widened the surface).
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-merge only patch + minor bumps.  Major bumps still open
+      # the PR for review.  Pass values via env so the gh command
+      # never interpolates anything attacker-controlled into the run
+      # block (consistent with the #3938 hardening pattern and #4046).
+      - name: Enable auto-merge for safe Dependabot bumps
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_NAME: ${{ steps.meta.outputs.dependency-names }}
         run: |
-          gh pr merge ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --auto --squash
+          echo "Auto-merging $DEP_NAME ($UPDATE_TYPE)"
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+
+      - name: Skip auto-merge for major bumps
+        if: |
+          steps.meta.outputs.update-type != 'version-update:semver-patch' &&
+          steps.meta.outputs.update-type != 'version-update:semver-minor'
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_NAME: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          echo "Refusing to auto-merge $DEP_NAME ($UPDATE_TYPE) — manual review required."


### PR DESCRIPTION
Follow-up to #3938 (workflow shell-injection hardening / dependabot ecosystem expansion).

## Problem

`auto-merge-dependabot.yml` ran `gh pr merge --auto --squash` on **every** `dependabot[bot]` PR with no metadata gate.  After CI passes, ANY dependabot bump auto-lands — including a major-version release that just shipped a malicious payload (eslint-config typosquats, left-pad-style takeovers, post-install npm scripts).

#3938 widened the watched ecosystems to npm + pip without tightening this policy, maximising the supply-chain blast radius.

## Fix

Add the standard `dependabot/fetch-metadata` step (pinned to v2.4.0 SHA `d7267f60`, matching the #3905 "pin all GitHub Actions to commit SHAs" commitment) and split the merge step in two:

| update-type | action |
|---|---|
| `version-update:semver-patch` | `--auto --squash` |
| `version-update:semver-minor` | `--auto --squash` |
| anything else (major / security with cross-cutting changes / unknown) | log notice, leave PR open for manual review |

All values pass through env vars (`PR_NUMBER`, `REPO`, `UPDATE_TYPE`, `DEP_NAME`) instead of inline `${{ … }}` expansion in the run block — matches the #3938 hardening pattern and the deploy-web/docs fix in #4046.

## Out of scope

The audit also flagged that `dependabot.yml` itself doesn't constrain to direct dependencies, so transitive bumps (which Dependabot won't currently emit by default but could be configured to) would also auto-merge.  The current behaviour is direct-only, so this isn't reachable today; tightening the policy further is a separate dependabot.yml change.