### PR TITLE
fix(api,oauth): persistent OIDC nonce single-use enforcement

### DIFF
--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -664,6 +664,10 @@ pub async fn auth_callback(
         }
     };
 
+    if let Err(resp) = consume_oauth_nonce(&state, &state_payload.nonce) {
+        return resp;
+    }
+
     handle_code_exchange(ext_auth, &code, &state_payload).await
 }
 
@@ -696,7 +700,42 @@ pub async fn auth_callback_post(
         }
     };
 
+    if let Err(resp) = consume_oauth_nonce(&state, &state_payload.nonce) {
+        return resp;
+    }
+
     handle_code_exchange(ext_auth, &body.code, &state_payload).await
+}
+
+/// Atomically reject + consume an OAuth state nonce.
+///
+/// #3944 verified that the nonce in the id_token matched the one we
+/// signed into `state`, but never marked the nonce as redeemed.  A
+/// callback URL captured from browser history, Referer, or proxy logs
+/// could be replayed against the daemon repeatedly until the IdP
+/// rejected the authorization code.  This helper enforces single-use
+/// at the daemon by checking + recording the nonce as consumed before
+/// the code exchange runs.  Subsequent requests with the same `state`
+/// are rejected with HTTP 400.
+///
+/// The nonce is consumed eagerly (before code exchange).  Failed
+/// downstream verification (token-endpoint reject, JWT signature fail)
+/// still leaves the nonce marked used — the legitimate user must
+/// restart the auth flow if anything goes wrong, which is exactly the
+/// fail-closed shape we want for credential flows.
+fn consume_oauth_nonce(state: &Arc<AppState>, nonce: &str) -> Result<(), Response> {
+    if state.kernel.approvals().is_oauth_nonce_used(nonce) {
+        warn!("OIDC nonce replay rejected (state.nonce already redeemed)");
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "OAuth callback already redeemed; please restart the sign-in flow"
+            })),
+        )
+            .into_response());
+    }
+    state.kernel.approvals().record_oauth_nonce_used(nonce);
+    Ok(())
 }
 
 /// Shared code exchange logic for both GET and POST callback handlers.

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1190,6 +1190,70 @@ impl ApprovalManager {
         );
     }
 
+    /// SHA-256 hex of an OIDC state nonce.  We only persist the hash so
+    /// the raw nonce never sits in the audit DB on disk.
+    fn oauth_nonce_hash(nonce: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(nonce.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    /// Check whether an OIDC state nonce has already been redeemed.
+    ///
+    /// #3944 added the nonce-equality check to the OAuth callback but the
+    /// nonce was reconstructed from the HMAC-signed `state` parameter on
+    /// every request, never consumed — so the same callback URL captured
+    /// from browser history, Referer, or proxy logs could be replayed
+    /// against the daemon repeatedly until the IdP rejected the
+    /// authorization code.  Persist consumed nonces (hashed) here so the
+    /// daemon refuses the second redemption itself.  Returns `false` when
+    /// no audit DB is wired (test harness) so the existing tests are
+    /// unaffected.
+    pub fn is_oauth_nonce_used(&self, nonce: &str) -> bool {
+        let Some(db) = &self.audit_db else { return false };
+        let Ok(conn) = db.lock() else { return false };
+        let hash = Self::oauth_nonce_hash(nonce);
+        // OAuth flow lifetime is typically 5–15 min; matching the state
+        // signing window at 1 hour is generous and never lets the lookup
+        // miss a still-active flow.
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        let window_start = now_unix - 3600;
+        conn.query_row(
+            "SELECT COUNT(*) FROM oauth_used_nonces WHERE nonce_hash = ?1 AND used_at >= ?2",
+            rusqlite::params![hash, window_start],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+            > 0
+    }
+
+    /// Record a redeemed OIDC nonce.  Prunes entries older than 1 hour
+    /// to keep the table small without trimming inside the typical
+    /// OAuth-flow window.
+    pub fn record_oauth_nonce_used(&self, nonce: &str) {
+        let Some(db) = &self.audit_db else { return };
+        let Ok(conn) = db.lock() else { return };
+        let hash = Self::oauth_nonce_hash(nonce);
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        let _ = conn.execute(
+            "INSERT INTO oauth_used_nonces (nonce_hash, used_at)
+             VALUES (?1, ?2)
+             ON CONFLICT(nonce_hash) DO UPDATE SET used_at = excluded.used_at",
+            rusqlite::params![hash, now_unix],
+        );
+        let prune_before = now_unix - 3600;
+        let _ = conn.execute(
+            "DELETE FROM oauth_used_nonces WHERE used_at < ?1",
+            rusqlite::params![prune_before],
+        );
+    }
+
     /// Write an audit entry to the persistent database.
     fn audit_log_write(&self, entry: &ApprovalAuditEntry) {
         let Some(db) = &self.audit_db else { return };

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 26;
+const SCHEMA_VERSION: u32 = 27;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -65,6 +65,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(25, migrate_v25);
 
     run_step!(26, migrate_v26);
+    run_step!(27, migrate_v27);
 
     Ok(())
 }
@@ -797,6 +798,33 @@ fn migrate_v26(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (26, datetime('now'), 'Add pending_approvals table for cross-restart persistence (issue #3611)')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 27: Add `oauth_used_nonces` table for OIDC nonce single-use enforcement.
+///
+/// OIDC `state` carries a server-signed nonce that the IdP echoes back in the
+/// id_token's `nonce` claim.  #3944 added the equality check but never
+/// consumed the nonce, so a callback URL captured from browser history /
+/// Referer / proxy logs could be replayed against the daemon repeatedly.
+/// Hashes of recently-redeemed nonces live here for the duration of the
+/// OAuth flow window (default ~15 minutes); prune sweeps anything older
+/// than 1 hour to bound the table.
+fn migrate_v27(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS oauth_used_nonces (
+            nonce_hash  TEXT    NOT NULL,  -- SHA-256 hex of the raw state nonce
+            used_at     INTEGER NOT NULL,  -- Unix timestamp (seconds)
+            PRIMARY KEY (nonce_hash)
+        );
+        CREATE INDEX IF NOT EXISTS idx_oauth_used_nonces_used_at
+            ON oauth_used_nonces(used_at);",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (27, datetime('now'), 'Add oauth_used_nonces table for OIDC nonce single-use enforcement')",
         [],
     )?;
     Ok(())


### PR DESCRIPTION
Follow-up to #3944 (OIDC nonce binding) and #4041 (JWT-validation-failure rejection).

## Problem

#3944 verified the `nonce` claim against the nonce we signed into `state`, but never **consumed** the nonce.  `state` is just an HMAC-signed payload reconstructed on every callback, so any captured callback URL (browser history, Referer, proxy logs) can be replayed against the daemon repeatedly until the IdP rejects the authorization code reuse — which is **not** a guarantee we get to lean on for our own nonce-binding contract.

The PR description claimed "nonce-binding guarantee" but the only nonce-tracking lived in the in-flight HMAC signature, not in any consumption store.

## Fix

Persistent nonce store mirroring the `totp_used_codes` design from #3952:

### Schema
- `migrate_v27` adds `oauth_used_nonces (nonce_hash TEXT PK, used_at INTEGER)`.
- `SCHEMA_VERSION` 26 → 27.

### Approval-manager API (kernel/approval.rs)
- `is_oauth_nonce_used(nonce) -> bool` — returns `false` when no `audit_db` is wired (test harness keeps existing behaviour).
- `record_oauth_nonce_used(nonce)` — upsert hash + `used_at`, prune rows older than 1 hour.
- SHA-256 of the raw nonce; the cleartext value never lands on disk.

### Callback wiring (api/oauth.rs)
Both `auth_callback` (GET) and `auth_callback_post` (POST) now pass through `consume_oauth_nonce(&state, &state_payload.nonce)` after `verify_state_token` but **before** `handle_code_exchange`:

```rust
if let Err(resp) = consume_oauth_nonce(&state, &state_payload.nonce) {
    return resp;
}
handle_code_exchange(ext_auth, &code, &state_payload).await
```

A second redemption returns 400 `"OAuth callback already redeemed; please restart the sign-in flow"`; the replay never reaches the IdP token endpoint.

## Eager consumption

The nonce is marked used **before** the code exchange runs.  Downstream failures (IdP token-endpoint reject, JWT validation fail, audience mismatch) still leave the nonce consumed — the legitimate user has to restart the flow on any failure.  This is the right fail-closed shape for a credential primitive: better to force a clean retry than to leave a partially-consumed credential reusable.

## Window

1 hour prune sweep.  OAuth flows typically complete in 5–15 minutes; 1 hour gives operational slack without ever trimming inside an active flow.  Hourly cron is implicit (next consumption triggers a `DELETE WHERE used_at < now - 3600`).