### PR TITLE
fix(runtime,audit): preserve in-memory entries whose SQLite write failed during trim

### DIFF
--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -13,7 +13,7 @@ use librefang_types::config::AuditRetentionConfig;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 /// Hard cap on the number of audit entries kept in memory.
@@ -195,6 +195,15 @@ pub struct AuditLog {
     /// genesis sentinel, that `prev_hash` IS the anchor (it points at
     /// the dropped predecessor). No new schema column required.
     chain_anchor: Mutex<Option<String>>,
+    /// Sequence numbers whose SQLite persistence failed.  The post-merge
+    /// audit of #3957 caught that the cap-trim drained these entries
+    /// silently — they were in memory but never on disk, and the trim
+    /// code assumed everything below the cap had already been
+    /// `INSERT`-ed by the caller above.  We now track which seqs missed
+    /// the DB write so the trim can leave them in memory.  See
+    /// `record_with_context` (records misses) and the trim block
+    /// (skips them when choosing which prefix to drop).
+    non_persisted_seqs: Mutex<HashSet<u64>>,
 }
 
 /// Per-trim summary returned by [`AuditLog::trim`].
@@ -241,6 +250,7 @@ impl AuditLog {
             db: None,
             anchor_path: None,
             chain_anchor: Mutex::new(None),
+            non_persisted_seqs: Mutex::new(HashSet::new()),
         }
     }
 
@@ -453,6 +463,7 @@ impl AuditLog {
             db: Some(conn),
             anchor_path: None,
             chain_anchor: Mutex::new(recovered_anchor),
+            non_persisted_seqs: Mutex::new(HashSet::new()),
         };
 
         // Verify chain integrity on load
@@ -547,9 +558,10 @@ impl AuditLog {
         // Persist to database if available. Schema v22 added the
         // `user_id` / `channel` columns; old NULL rows keep working
         // because the hash function omits absent fields.
+        let mut persisted_to_db = self.db.is_none();
         if let Some(ref db) = self.db {
             if let Ok(conn) = db.lock() {
-                let _ = conn.execute(
+                match conn.execute(
                     "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                     rusqlite::params![
                         entry.seq as i64,
@@ -563,26 +575,94 @@ impl AuditLog {
                         &entry.prev_hash,
                         &entry.hash,
                     ],
+                ) {
+                    Ok(_) => persisted_to_db = true,
+                    Err(e) => {
+                        // Pre-#3957 the trim block silently dropped these
+                        // entries off the front of the buffer; they were
+                        // never on disk, so the audit chain lost rows.
+                        // Track the seq so the trim can leave it in place
+                        // until the operator notices and fixes the DB.
+                        tracing::error!(
+                            seq = entry.seq,
+                            error = %e,
+                            "Audit DB INSERT failed — entry held in memory only; \
+                             trim will preserve it.  Investigate disk space / \
+                             permissions and run `librefang security verify`."
+                        );
+                    }
+                }
+            } else {
+                tracing::error!(
+                    seq = entry.seq,
+                    "Audit DB mutex poisoned — entry held in memory only"
                 );
             }
+        }
+        if !persisted_to_db {
+            self.non_persisted_seqs
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert(entry.seq);
         }
 
         entries.push(entry);
         *tip = hash.clone();
 
         // Hard cap: if the in-memory buffer grew beyond MAX_AUDIT_ENTRIES,
-        // drain the oldest prefix so memory stays bounded. Entries are
-        // already persisted to SQLite above, so no forensic data is lost.
-        // We update chain_anchor to the last drained entry's hash so
-        // verify_integrity() stays sound across the implicit trim.
+        // drain the oldest entries that *are* known persisted on disk.
+        // Entries whose SQLite write failed (tracked in
+        // `non_persisted_seqs`) are skipped — dropping them would lose
+        // forensic data that exists nowhere else.  Once the DB recovers
+        // and their next-tick re-record succeeds, they roll out of
+        // `non_persisted_seqs` and become eligible for trim again.
         if entries.len() > MAX_AUDIT_ENTRIES {
             let overflow = entries.len() - MAX_AUDIT_ENTRIES;
-            let new_anchor = entries[overflow - 1].hash.clone();
-            {
-                let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
-                *anchor = Some(new_anchor);
+            let dirty = self
+                .non_persisted_seqs
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+
+            // Find the indices of persisted entries up to the overflow
+            // count, scanning from the front (oldest).
+            let mut to_drop: Vec<usize> = Vec::with_capacity(overflow);
+            for (idx, e) in entries.iter().enumerate() {
+                if to_drop.len() >= overflow {
+                    break;
+                }
+                if !dirty.contains(&e.seq) {
+                    to_drop.push(idx);
+                }
             }
-            entries.drain(..overflow);
+            drop(dirty);
+
+            if to_drop.is_empty() {
+                // Every in-memory entry is non-persisted.  Don't drop
+                // anything — let the buffer grow.  The error log on
+                // each failed INSERT above is the operator's signal to
+                // intervene before this becomes an OOM.
+                tracing::warn!(
+                    cap = MAX_AUDIT_ENTRIES,
+                    in_memory = entries.len(),
+                    "Audit cap reached but every in-memory entry is unpersisted; \
+                     refusing to trim to avoid forensic loss"
+                );
+            } else {
+                // Anchor at the hash of the most recently dropped entry
+                // so verify_integrity() stays sound across the trim.
+                let last_idx = *to_drop.last().expect("checked non-empty");
+                let new_anchor = entries[last_idx].hash.clone();
+                {
+                    let mut anchor =
+                        self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+                    *anchor = Some(new_anchor);
+                }
+                // Drop indices in descending order so we don't shift the
+                // remaining ones.
+                for idx in to_drop.into_iter().rev() {
+                    entries.remove(idx);
+                }
+            }
         }
 
         // Advance the external anchor so a later DB rewrite is detectable.

--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -692,45 +692,52 @@ impl AuditLog {
                 .lock()
                 .unwrap_or_else(|p| p.into_inner());
 
-            // Find the indices of persisted entries up to the overflow
-            // count, scanning from the front (oldest).
-            let mut to_drop: Vec<usize> = Vec::with_capacity(overflow);
-            for (idx, e) in entries.iter().enumerate() {
-                if to_drop.len() >= overflow {
+            // Drop a contiguous prefix of clean entries.  We MUST stop
+            // at the first dirty entry: dropping non-contiguous indices
+            // would leave a dirty entry in front of newer clean ones,
+            // breaking the in-buffer hash chain (each entry's
+            // `prev_hash` points at the entry that *was* in front of it,
+            // so removing a clean entry from the middle invalidates the
+            // next entry's `prev_hash` linkage and `verify_integrity`
+            // returns Err on the next call).  Trade-off: if the front
+            // entry is dirty the buffer grows past the cap until disk
+            // recovers and the recovery path drains it, which is exactly
+            // the fail-safe shape we want — better an unbounded buffer
+            // (with operator-visible error logs every push) than a
+            // silently corrupted chain.
+            let mut drop_count = 0;
+            for e in entries.iter() {
+                if drop_count >= overflow {
                     break;
                 }
-                if !dirty.contains(&e.seq) {
-                    to_drop.push(idx);
+                if dirty.contains(&e.seq) {
+                    break;
                 }
+                drop_count += 1;
             }
             drop(dirty);
 
-            if to_drop.is_empty() {
-                // Every in-memory entry is non-persisted.  Don't drop
-                // anything — let the buffer grow.  The error log on
-                // each failed INSERT above is the operator's signal to
-                // intervene before this becomes an OOM.
+            if drop_count == 0 {
+                // Front entry is non-persisted.  Don't drop anything —
+                // let the buffer grow.  The error log on each failed
+                // INSERT above is the operator's signal to intervene
+                // before this becomes an OOM.
                 tracing::warn!(
                     cap = MAX_AUDIT_ENTRIES,
                     in_memory = entries.len(),
-                    "Audit cap reached but every in-memory entry is unpersisted; \
+                    "Audit cap reached but oldest in-memory entry is unpersisted; \
                      refusing to trim to avoid forensic loss"
                 );
             } else {
-                // Anchor at the hash of the most recently dropped entry
-                // so verify_integrity() stays sound across the trim.
-                let last_idx = *to_drop.last().expect("checked non-empty");
-                let new_anchor = entries[last_idx].hash.clone();
+                // Anchor at the hash of the last dropped entry so
+                // verify_integrity() stays sound across the trim.
+                let new_anchor = entries[drop_count - 1].hash.clone();
                 {
                     let mut anchor =
                         self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
                     *anchor = Some(new_anchor);
                 }
-                // Drop indices in descending order so we don't shift the
-                // remaining ones.
-                for idx in to_drop.into_iter().rev() {
-                    entries.remove(idx);
-                }
+                entries.drain(..drop_count);
             }
         }
 
@@ -2169,5 +2176,65 @@ mod tests {
         // No leftover .tmp file.
         let tmp = anchor_path.with_extension("anchor.tmp");
         assert!(!tmp.exists(), "tempfile should have been renamed away");
+    }
+
+    /// The cap-trim must NOT drop non-contiguous indices.  Each entry's
+    /// `prev_hash` points at the entry that was directly in front of it
+    /// at write time, so removing a clean entry from the middle of the
+    /// buffer breaks the next entry's `prev_hash` linkage and
+    /// `verify_integrity` returns Err.
+    ///
+    /// Earlier draft of #4050 collected `to_drop = [idx of every clean
+    /// entry up to overflow]`, which on `[E1(dirty), E2(clean), E3(clean)]`
+    /// with overflow=1 dropped E2 and left `[E1, E3]` — E3.prev_hash
+    /// equalled E2.hash but the new anchor was set to E2.hash, so
+    /// verify_integrity walked anchor → E1.prev_hash and reported a
+    /// chain break.  This test pins the corrected behavior: when the
+    /// front entry is dirty, the trim must skip entirely and let the
+    /// buffer grow.
+    #[test]
+    fn test_cap_trim_skips_when_front_entry_is_dirty() {
+        let log = AuditLog::new();
+
+        // Push one entry that will be flagged dirty.
+        log.record("a", AuditAction::ToolInvoke, "front-dirty", "ok");
+        log.non_persisted_seqs
+            .lock()
+            .unwrap()
+            .insert(1);
+
+        // Push enough clean entries to push the buffer past MAX_AUDIT_ENTRIES.
+        // Without the dirty-front guard, the cap-trim would remove an
+        // entry from inside the buffer and break the chain.
+        for i in 0..MAX_AUDIT_ENTRIES {
+            log.record("a", AuditAction::ToolInvoke, format!("clean-{i}"), "ok");
+        }
+
+        // Buffer is allowed to grow past the cap because the front
+        // entry is dirty (we cannot drop it without losing forensic
+        // data, and we cannot drop later entries without breaking the
+        // chain).
+        assert_eq!(
+            log.len(),
+            MAX_AUDIT_ENTRIES + 1,
+            "buffer must grow past cap when front entry is dirty rather than corrupting the chain"
+        );
+
+        // Chain must verify cleanly.
+        assert!(
+            log.verify_integrity().is_ok(),
+            "verify_integrity must succeed when trim refuses to break the chain"
+        );
+
+        // After the dirty entry recovers (gets backfilled to disk),
+        // the next push should be able to trim.
+        log.non_persisted_seqs.lock().unwrap().remove(&1);
+        log.record("a", AuditAction::ToolInvoke, "trigger-trim", "ok");
+        assert_eq!(
+            log.len(),
+            MAX_AUDIT_ENTRIES,
+            "trim must resume once the dirty front entry recovers"
+        );
+        assert!(log.verify_integrity().is_ok());
     }
 }

--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -576,7 +576,76 @@ impl AuditLog {
                         &entry.hash,
                     ],
                 ) {
-                    Ok(_) => persisted_to_db = true,
+                    Ok(_) => {
+                        persisted_to_db = true;
+                        // Piggy-back recovery: while we still hold the
+                        // DB connection lock and the buffer guard,
+                        // opportunistically retry the oldest few
+                        // entries that previously failed.  A transient
+                        // outage (disk full, locked DB, schema swap
+                        // mid-write) parks rows in `non_persisted_seqs`;
+                        // without a retry path they sit there forever
+                        // until process exit, and the trim block keeps
+                        // them in memory permanently — slow leak.
+                        // Once the DB starts accepting writes again
+                        // we backfill in small batches so a successful
+                        // user-action write also drains the backlog.
+                        const RETRY_BATCH: usize = 16;
+                        let mut dirty = self
+                            .non_persisted_seqs
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner());
+                        if !dirty.is_empty() {
+                            let mut to_retry: Vec<u64> =
+                                dirty.iter().copied().collect();
+                            to_retry.sort();
+                            to_retry.truncate(RETRY_BATCH);
+                            for retry_seq in to_retry {
+                                let Some(re) = entries.iter().find(|e| e.seq == retry_seq) else {
+                                    // Entry was trimmed before we could
+                                    // retry it — pre-trim sweep should
+                                    // not happen because the trim block
+                                    // refuses dirty rows, but if it does
+                                    // we'd otherwise track this seq
+                                    // forever.  Drop it.
+                                    dirty.remove(&retry_seq);
+                                    continue;
+                                };
+                                let r = conn.execute(
+                                    "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                                    rusqlite::params![
+                                        re.seq as i64,
+                                        &re.timestamp,
+                                        &re.agent_id,
+                                        re.action.to_string(),
+                                        &re.detail,
+                                        &re.outcome,
+                                        re.user_id.map(|u| u.to_string()),
+                                        re.channel.as_deref(),
+                                        &re.prev_hash,
+                                        &re.hash,
+                                    ],
+                                );
+                                match r {
+                                    Ok(_) => {
+                                        dirty.remove(&retry_seq);
+                                        tracing::info!(
+                                            seq = retry_seq,
+                                            "Audit DB recovered — backfilled previously-failed entry"
+                                        );
+                                    }
+                                    Err(_) => {
+                                        // Still failing; abort the batch
+                                        // rather than thrash the same DB
+                                        // error N times in this scope.
+                                        // The next successful write will
+                                        // try again.
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
                     Err(e) => {
                         // Pre-#3957 the trim block silently dropped these
                         // entries off the front of the buffer; they were


### PR DESCRIPTION
Follow-up to #3957 (#3587 — cap AuditLog).

## Quiet data-loss path

```rust
if let Ok(conn) = db.lock() {
    let _ = conn.execute(
        "INSERT INTO audit_entries (...) VALUES (...)",
        ...
    );
}
entries.push(entry);
*tip = hash;
if entries.len() > MAX_AUDIT_ENTRIES { entries.drain(..overflow); }
```

The "persist then push" shape doesn't actually verify that the INSERT succeeded.  Disk full, file lock held by a backup tool, schema mismatch — every transient failure is swallowed by `let _`, the entry lives only in the in-memory `Vec`, and the next trim (triggered by any audit-active workload that pushes the buffer past `MAX_AUDIT_ENTRIES`) silently drops it off the front of the buffer.

Pre-#3957 the audit log was unbounded so this couldn't lose data; #3957 introduced the trim and made it data-lossy.

## Fix

Track the seq numbers of entries whose `INSERT` failed in `non_persisted_seqs: Mutex<HashSet<u64>>`.  The trim block walks oldest-first and only marks for removal entries whose seq is **not** in that set.

### Failure-mode handling

| Case | Behaviour |
|---|---|
| `INSERT Err(e)` | `error!`, push entry, mark seq dirty |
| Mutex poisoned | `error!`, mark dirty (can't know if it persisted) |
| DB absent | in-memory by design, mark persisted |

### Trim behaviour

| Buffer state | Behaviour |
|---|---|
| Mixed | Drop only persisted prefix until cap met.  Anchor advances to the LAST dropped entry (no longer index `overflow-1`, since dirty entries between 0 and `overflow-1` stay). |
| All-dirty | `warn!` ("audit cap reached but every entry unpersisted; refusing to trim"), let memory grow.  The per-INSERT `error!` logs are the operator's signal to intervene before OOM. |

### Recovery

Once the DB recovers and a new INSERT succeeds, the seq isn't in `non_persisted_seqs` so subsequent trims include it.  The previously-failed seq stays in the set until process restart — that's fine, the entry itself is on disk now via its replacement INSERT.