### PR TITLE
fix(mcp): stream MCP response body with running cap (no 16 MiB pre-rejection allocation)

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -796,9 +796,17 @@ const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
 
 /// Read an HTTP response body up to [`MAX_RESPONSE_BYTES`].
 ///
-/// Rejects based on `Content-Length` header first (fast path), then reads
-/// the full body and errors if it exceeds the cap.
-async fn read_response_bytes_capped(response: reqwest::Response) -> Result<Vec<u8>, String> {
+/// Rejects based on `Content-Length` header first (fast path), then
+/// **streams** the body chunk-by-chunk and aborts mid-read once the
+/// running total would breach the cap.
+///
+/// The previous shape (`response.bytes().await` followed by a length
+/// check) happily allocated up to ~16 MiB before rejecting — a server
+/// omitting `Content-Length` (chunked transfer) forces that allocation
+/// per request and creates memory pressure under concurrent abuse.
+/// The audit of #3926 flagged this; fix is a streaming reader with a
+/// running byte counter.
+async fn read_response_bytes_capped(mut response: reqwest::Response) -> Result<Vec<u8>, String> {
     // Fast-path: reject via Content-Length before reading a single byte.
     if let Some(content_length) = response.content_length() {
         if content_length as usize > MAX_RESPONSE_BYTES {
@@ -808,19 +816,39 @@ async fn read_response_bytes_capped(response: reqwest::Response) -> Result<Vec<u
             ));
         }
     }
-    // Read the full body and enforce the cap.
-    let b = response
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to read response body: {e}"))?;
-    if b.len() > MAX_RESPONSE_BYTES {
-        return Err(format!(
-            "MCP response body ({} bytes) exceeds the {MAX_RESPONSE_BYTES}-byte cap \
-             — response rejected",
-            b.len()
-        ));
+
+    // Streaming-path: consume chunks via reqwest's `chunk()` async API
+    // and bail out the moment the running total would breach the cap.
+    // No 16 MiB buffering for chunked-transfer servers that omit
+    // Content-Length.
+    let mut buf: Vec<u8> = Vec::new();
+    if let Some(hint) = response.content_length() {
+        // Pre-allocate when Content-Length is honest; clamp to avoid a
+        // malicious large hint forcing the allocation we're trying to
+        // avoid.
+        let cap_hint = (hint as usize).min(MAX_RESPONSE_BYTES);
+        buf.reserve(cap_hint);
     }
-    Ok(b.to_vec())
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                if buf.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+                    return Err(format!(
+                        "MCP response body exceeds the {MAX_RESPONSE_BYTES}-byte cap \
+                         (streamed {} + next chunk {}) — response aborted",
+                        buf.len(),
+                        chunk.len()
+                    ));
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(None) => break, // end of body
+            Err(e) => {
+                return Err(format!("Failed to read response body: {e}"));
+            }
+        }
+    }
+    Ok(buf)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -809,7 +809,7 @@ const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
 async fn read_response_bytes_capped(mut response: reqwest::Response) -> Result<Vec<u8>, String> {
     // Fast-path: reject via Content-Length before reading a single byte.
     if let Some(content_length) = response.content_length() {
-        if content_length as usize > MAX_RESPONSE_BYTES {
+        if content_length > MAX_RESPONSE_BYTES as u64 {
             return Err(format!(
                 "MCP response Content-Length ({content_length}) exceeds \
                  the {MAX_RESPONSE_BYTES}-byte cap — response rejected"
@@ -826,7 +826,7 @@ async fn read_response_bytes_capped(mut response: reqwest::Response) -> Result<V
         // Pre-allocate when Content-Length is honest; clamp to avoid a
         // malicious large hint forcing the allocation we're trying to
         // avoid.
-        let cap_hint = (hint as usize).min(MAX_RESPONSE_BYTES);
+        let cap_hint = hint.min(MAX_RESPONSE_BYTES as u64) as usize;
         buf.reserve(cap_hint);
     }
     loop {


### PR DESCRIPTION
Follow-up to #3926 (cap SSE body).

## Problem

`read_response_bytes_capped` used `response.bytes().await` — which buffers the **full** body in memory before the length check:

```rust
let b = response.bytes().await?;
if b.len() > MAX_RESPONSE_BYTES { return Err(...); }
```

A server omitting `Content-Length` (HTTP/1.1 chunked transfer) forces a fresh ~16 MiB allocation per request before rejection.  Under concurrent abuse this creates real memory pressure — the audit of #3926 flagged it as a MEDIUM exploitation surface.

## Fix

Stream via `reqwest::Response::chunk()` (already available in the crate's reqwest version, no new feature flag):

```rust
loop {
    match response.chunk().await {
        Ok(Some(chunk)) if buf.len() + chunk.len() > MAX_RESPONSE_BYTES => {
            return Err("...response aborted");
        }
        Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
        Ok(None) => break,
        Err(e) => return Err(...),
    }
}
```

- Pre-allocate `Vec` capacity from `Content-Length` when present, clamped to `MAX_RESPONSE_BYTES` so a malicious large hint can't bypass the streaming fix.
- When `Content-Length` is missing the `Vec` grows organically; the running counter aborts the moment the next chunk would breach the cap.
- Worst-case allocation is now `MAX_RESPONSE_BYTES + 1 chunk size` regardless of header presence — not the unconditional 16 MiB ceiling.