### PR TITLE
fix(mcp): bound rmcp client close() with a 10s timeout (cap shutdown stall)

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1721,8 +1721,33 @@ impl McpConnection {
             },
         );
         if let McpInner::Rmcp(mut client) = inner {
-            if let Err(e) = client.close().await {
-                warn!(server = %name, error = ?e, "MCP stdio client close error on disconnect");
+            // Bound the rmcp close() call so a stuck stdio child or a
+            // wedged shutdown path can never block the caller (typically
+            // hot-reload or daemon shutdown) indefinitely.  rmcp's close
+            // sends a CancellationToken and waits for its transport loop
+            // + the underlying ChildWithCleanup drop; tokio's
+            // kill_on_drop(true) follows up with SIGKILL but does NOT
+            // call wait(), so the OS-level reap depends on the tokio
+            // child reaper still being alive.  A 10s timeout is generous
+            // enough that a healthy server completes shutdown but tight
+            // enough that a wedged transport doesn't stall the next
+            // hot-reload — the audit of #3926 flagged the unbounded
+            // close as a real risk.
+            const CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+            match tokio::time::timeout(CLOSE_TIMEOUT, client.close()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    warn!(server = %name, error = ?e, "MCP stdio client close error on disconnect");
+                }
+                Err(_) => {
+                    warn!(
+                        server = %name,
+                        timeout_secs = CLOSE_TIMEOUT.as_secs(),
+                        "MCP stdio client close timed out — relying on kill_on_drop \
+                         to reap the subprocess (may leave a transient zombie until \
+                         the tokio child reaper runs)"
+                    );
+                }
             }
         }
         // SSE and HttpCompat hold no persistent connection; nothing to close.
@@ -1769,12 +1794,30 @@ impl Drop for McpConnection {
                 // entered.
                 if let Ok(handle) = tokio::runtime::Handle::try_current() {
                     handle.spawn(async move {
-                        if let Err(e) = client.close().await {
-                            debug!(
-                                server = %name,
-                                error = ?e,
-                                "MCP stdio client close error on implicit drop (#3800)"
-                            );
+                        // Bound the implicit close just like the explicit
+                        // path above so a wedged transport doesn't stall
+                        // a runtime worker indefinitely (the spawn
+                        // itself is fire-and-forget so we can't await
+                        // the join handle, but the timeout still caps
+                        // the worker's commitment).
+                        const CLOSE_TIMEOUT: std::time::Duration =
+                            std::time::Duration::from_secs(10);
+                        match tokio::time::timeout(CLOSE_TIMEOUT, client.close()).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(e)) => {
+                                debug!(
+                                    server = %name,
+                                    error = ?e,
+                                    "MCP stdio client close error on implicit drop (#3800)"
+                                );
+                            }
+                            Err(_) => {
+                                debug!(
+                                    server = %name,
+                                    timeout_secs = CLOSE_TIMEOUT.as_secs(),
+                                    "MCP stdio client close timed out on implicit drop"
+                                );
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Follow-up to #3926 (kill stdio child on drop).

## Two real properties from the post-merge audit

1. tokio's `Command::kill_on_drop(true)` sends SIGKILL but **does not call `wait()`**.  The child becomes a zombie until tokio's internal child-reaper task runs.  If the reaper is starved (runtime spinning down) or already dropped (synchronous drop on a runtime that's been ejected), the zombie persists until the daemon process itself exits.

2. `McpConnection::close()` awaits `client.close()` unconditionally — a wedged rmcp transport loop blocks the caller forever.  Hot-reload (which awaits this) and daemon graceful shutdown both accumulate stalls there.

A full fix for the `kill_on_drop` / no-`wait` gap means hijacking the child handle out of rmcp's `RunningService` — either patching rmcp upstream or replacing the transport.  Far outside follow-up scope.

## Contained fix

Bound both close paths with a 10s timeout so the daemon stops betting on the tokio reaper to finish in time:

- **Explicit close** (`McpConnection::close()`): wrap `client.close()` in `tokio::time::timeout(10s, ...)`.  Healthy servers complete easily; a stuck one stops blocking hot-reload.
- **Implicit close** (`Drop`): same 10s timeout inside the spawn so a wedged transport doesn't pin a tokio worker.

10s is generous enough that a normally-shutting child finishes without a warning, tight enough that "still running 10 seconds after kill" is the right signal that something failed.  Past the timeout the path falls back to relying on `kill_on_drop` + OS-level reap-on-process-exit; the daemon log carries a `warn!` so an operator notices.

## What this does NOT fix

The underlying zombie-until-runtime-shutdown property of `kill_on_drop` without `wait`.  That requires owning the child handle, which means restructuring how rmcp consumes the spawned process.  Filed as out-of-scope for now.