### PR TITLE
fix(kernel): propagate PUBLISH_EVENT_DEPTH scope across trigger_dispatch spawn

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -11399,8 +11399,22 @@ system_prompt = "You are a helpful assistant."
             }
 
             if !dispatches.is_empty() {
-                // #3740: spawn_logged so panics in dispatch surface in logs.
-                spawn_logged("trigger_dispatch", async move {
+                // CRITICAL: tokio task-locals do NOT propagate across
+                // tokio::spawn.  Without re-establishing the
+                // PUBLISH_EVENT_DEPTH scope inside the spawned task,
+                // every send_message_full -> publish_event chain
+                // started from a triggered dispatch would observe an
+                // unscoped depth, fall into the "top-level scope"
+                // branch, and reset depth=0 — the exact path that
+                // breaks circular trigger detection across the spawn
+                // boundary (audit of #3929 / #3780).  Capture the
+                // parent depth here on the caller's task and rebuild
+                // the scope inside the spawn so trigger chains
+                // accumulate correctly.
+                let parent_depth = PUBLISH_EVENT_DEPTH.try_with(|c| c.get()).unwrap_or(0);
+                let task = PUBLISH_EVENT_DEPTH.scope(
+                    std::cell::Cell::new(parent_depth),
+                    async move {
                     // Execute trigger dispatches sequentially to preserve
                     // the order in which the trigger engine evaluated them.
                     // Each dispatch still acquires its semaphore permits
@@ -11452,7 +11466,9 @@ system_prompt = "You are a helpful assistant."
                             warn!(agent = %aid, "Trigger dispatch failed: {e}");
                         }
                     }
-                });
+                    },
+                );
+                spawn_logged("trigger_dispatch", task);
             }
         }
 


### PR DESCRIPTION
Follow-up to #3929 (per-task trigger depth, observable event bus drops).

## Critical regression

#3929 replaced the global `AtomicU32` trigger-depth counter with a `tokio::task::LocalKey<Cell<u32>>` (`PUBLISH_EVENT_DEPTH`).  But **tokio task-locals do NOT propagate to spawned tasks**.

The trigger dispatcher uses `spawn_logged` (bare `tokio::spawn` under the hood) to fire the actual dispatches:

```rust
spawn_logged("trigger_dispatch", async move {
    for d in dispatches {
        … kernel.send_message_full(…) …
    }
});
```

Inside that spawn, every `send_message_full → publish_event` call:

1. Hits `PUBLISH_EVENT_DEPTH.try_with(|_| ())` → `Err` (no scope active in the spawned task).
2. Takes the "top-level scope" branch at line 11258 of `mod.rs`.
3. Resets `depth = 0`.

Circular-trigger detection across the spawn boundary is silently broken.  This is the same bug pattern as #3735/#3960 which #3929 was supposed to close — the audit caught that the fix didn't actually cross the only spawn boundary that matters.

## Fix

Capture `PUBLISH_EVENT_DEPTH` on the caller's task *before* the spawn, then rebuild the scope inside the spawned future:

```rust
let parent_depth = PUBLISH_EVENT_DEPTH.try_with(|c| c.get()).unwrap_or(0);
let task = PUBLISH_EVENT_DEPTH.scope(
    Cell::new(parent_depth),
    async move { …dispatches loop… },
);
spawn_logged("trigger_dispatch", task);
```

`publish_event_inner` increments + decrements off the inherited depth, so a chain that already passed depth N before being spawned starts at depth N inside the spawn and trips `max_trigger_depth` on the next nested fire — instead of on every Nth fire forever.