### PR TITLE
fix(docker): unbreak docker build (#3948 added duplicate user creation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,17 @@ COPY --from=builder /usr/local/bin/librefang /usr/local/bin/
 COPY --from=builder /build/packages /opt/librefang/packages
 COPY deploy/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-# CIS Docker Benchmark §4.1: run the service as a dedicated non-root user with
-# no login shell. The entrypoint starts as root (to chown /data on first boot)
-# and then drops privileges with `gosu librefang` before exec'ing the binary.
-RUN groupadd -r librefang && useradd -r -g librefang -s /sbin/nologin librefang
+# CIS Docker Benchmark §4.1: run the service as a dedicated non-root
+# user with no login shell.  The user `librefang` (uid/gid 1001) is
+# already created above via addgroup/adduser; the redundant
+# `groupadd -r librefang && useradd -r ...` block introduced by #3948
+# collides with that user — `groupadd` exits with code 9 ('group
+# already exists'), breaking `docker build` on every clean tree.
+# Apply the CIS shell-restriction with `usermod` instead, then chown
+# /opt/librefang/packages so the runtime user can read its own asset
+# tree (the COPYs above land as root:root by default).
+RUN usermod -s /sbin/nologin librefang && \
+    chown -R librefang:librefang /opt/librefang/packages
 EXPOSE 4545
 ENV LIBREFANG_HOME=/data
 # docker-entrypoint.sh uses gosu to exec as the librefang user, so we


### PR DESCRIPTION
Follow-up to #3948.

## Build break

#3948 appended at `Dockerfile:67`:

```dockerfile
RUN groupadd -r librefang && useradd -r -g librefang -s /sbin/nologin librefang
```

The `librefang` user already exists at lines 58-59 (uid/gid 1001):

```dockerfile
RUN addgroup --system --gid 1001 librefang && \
    adduser  --system --uid 1001 --ingroup librefang librefang
```

`groupadd` exits with code 9 ("group librefang already exists") the moment it tries to add the same group a second time, failing the `RUN`, which fails `docker build`.  **Every clean `docker build` of main has been broken since #3948 was merged.**

## Fix

Replace the duplicate creation with a `usermod` that applies the CIS Docker Benchmark §4.1 login-shell restriction (`/sbin/nologin`) to the existing user, plus a `chown` of `/opt/librefang/packages` so the runtime user can read its own asset tree (the `COPY` at line 61 lands files at `root:root` by default — the entrypoint then drops privileges via `gosu librefang` and can't read its own packages dir without this chown).

The original commit message claimed the entrypoint was also updated to reference `librefang` instead of `node`; verified by `git show` that `deploy/docker-entrypoint.sh` was **not** in the merge diff — the entrypoint already used `librefang` and didn't need the change.