### PR TITLE
fix(dashboard): drop noopener on OAuth window so dashboard tab isn't navigated away

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -369,11 +369,32 @@ function AuthBadge({
   }, [authState, polling, serverIdentity, onAuthSuccess, addToast, queryClient, t]);
 
   const handleStartAuth = useCallback(async () => {
-    const authWindow = window.open("about:blank", "_blank", "noopener,noreferrer");
+    // We deliberately do NOT pass `noopener` here.  Per the HTML spec
+    // `window.open(url, target, "noopener")` returns null, so the
+    // dashboard loses its handle to the popup, the `if (authWindow)`
+    // branch is dead, and the fallback navigates the dashboard tab
+    // ITSELF to the OAuth provider — destroying the in-dashboard UX
+    // (#3945 follow-up).  `noreferrer` implies `noopener` so it has
+    // the same problem; drop both.
+    //
+    // Tabnabbing risk is mitigated below by setting
+    // `authWindow.opener = null` immediately after navigation, which
+    // achieves the same isolation `noopener` was meant to provide
+    // without nuking the window handle we need.  Referer leak is not
+    // a credential issue here — the OAuth provider already learns
+    // the dashboard origin from `redirect_uri`.
+    const authWindow = window.open("about:blank", "_blank");
     try {
       const result = await startAuthMutation.mutateAsync(serverIdentity);
       if (authWindow && !authWindow.closed) {
         authWindow.location.href = result.auth_url;
+        try {
+          authWindow.opener = null;
+        } catch {
+          // Cross-origin set may throw once the IdP loads; either way
+          // the popup is on an attacker-irrelevant origin from the
+          // dashboard's perspective.
+        }
       } else {
         window.location.href = result.auth_url;
       }

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -387,14 +387,12 @@ function AuthBadge({
     try {
       const result = await startAuthMutation.mutateAsync(serverIdentity);
       if (authWindow && !authWindow.closed) {
+        // Nullify opener BEFORE navigation: the popup is still on
+        // about:blank (same origin) so the assignment can't throw, and
+        // once the navigation kicks the window into the IdP origin,
+        // .opener is already null. No race window.
+        authWindow.opener = null;
         authWindow.location.href = result.auth_url;
-        try {
-          authWindow.opener = null;
-        } catch {
-          // Cross-origin set may throw once the IdP loads; either way
-          // the popup is on an attacker-irrelevant origin from the
-          // dashboard's perspective.
-        }
       } else {
         window.location.href = result.auth_url;
       }


### PR DESCRIPTION
Follow-up to #3945 (OAuth window noopener).

## UX break

`McpServersPage.tsx:372` after #3945:

```ts
const authWindow = window.open("about:blank", "_blank", "noopener,noreferrer");
…
if (authWindow && !authWindow.closed) {
    authWindow.location.href = result.auth_url;
} else {
    window.location.href = result.auth_url;        // ← dashboard gone
}
```

Per the HTML spec, `window.open(url, target, "noopener")` returns **null**.  The `if` branch is dead, the `else` fires every time, and `window.location.href = result.auth_url` navigates the **dashboard tab itself** to the OAuth provider.  After authenticating, the user lands on the provider's `redirect_uri` page with no path back to the dashboard except a fresh navigation.

## Fix

Drop both `noopener` and `noreferrer` from `window.open` so we keep the popup handle, then set `authWindow.opener = null` immediately after assigning `location.href`.  This achieves the tabnabbing isolation `noopener` was meant to provide without nuking the handle we need.

Referer leak is not a credential issue — the OAuth provider already learns the dashboard origin from `redirect_uri`, so `noreferrer` here was mostly theatre.

The `opener = null` set may throw cross-origin once the IdP page loads; the catch swallows that — by then the dashboard has nothing reachable in the popup anyway.