### PR TITLE
fix(dashboard): fetch workflows after template instantiate (don't read stale closure)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -1730,15 +1730,23 @@ function CanvasPageInner() {
   const handleTemplateInstantiate = useCallback(async (workflowId: string) => {
     setShowTemplateBrowser(false);
     try {
-      // Invalidate the workflows cache so the list refreshes
-      await queryClient.invalidateQueries({ queryKey: workflowQueries.list().queryKey });
-      const created = workflows.find(w => w.id === workflowId);
+      // Fetch the fresh list synchronously to this scope rather than
+      // invalidate-then-read-closure.  #3958 swapped pre-PR's
+      // `await listWorkflows()` for `invalidateQueries()` plus a
+      // closure read of `workflows` — but that closure value is the
+      // pre-invalidation snapshot, which for a just-instantiated
+      // template doesn't contain the new id yet, so `created` is
+      // undefined and the canvas header falls back to "" name and
+      // description until the next 30s poll.  fetchQuery awaits the
+      // network round-trip and returns the up-to-date list directly.
+      const fresh = await queryClient.fetchQuery(workflowQueries.list());
+      const created = fresh.find((w) => w.id === workflowId);
       await loadWorkflowIntoCanvas(workflowId, created ?? null);
       navigate({ to: "/canvas", search: { t: undefined, wf: workflowId }, replace: true });
     } catch (e: unknown) {
       showError(toErrorMessage(e, t("canvas.template_instantiate_error")));
     }
-  }, [queryClient, workflows, loadWorkflowIntoCanvas, navigate, showError, t, toErrorMessage]);
+  }, [queryClient, loadWorkflowIntoCanvas, navigate, showError, t, toErrorMessage]);
 
   // Valid agent step count
   const agentStepCount = useMemo(() => buildSteps(nodes).length, [nodes, buildSteps]);


### PR DESCRIPTION
Follow-up to #3958 (CanvasPage React Query migration).

## Stale closure read

`handleTemplateInstantiate` invalidates the workflows cache, then immediately reads `workflows` from the closure:

```ts
await queryClient.invalidateQueries({ queryKey: workflowQueries.list().queryKey });
const created = workflows.find(w => w.id === workflowId);   // ← pre-invalidation snapshot
```

`invalidateQueries` marks the entry stale but doesn't refetch in this scope.  The closure-captured `workflows` is still the pre-invalidation snapshot, which for the just-instantiated template doesn't contain the new id.  `created` resolves to `undefined` and the canvas header falls back to `""` name / `""` description until the next 30s poll cycle paints the real values.

Pre-#3958 the handler awaited `listWorkflows()` and used the fresh result.

## Fix

Switch to `queryClient.fetchQuery(workflowQueries.list())` — same cache key as `useWorkflows`, but the call awaits the network round-trip and returns the up-to-date list synchronously to this scope.  Drop `workflows` from the `useCallback` deps since we no longer read it.