### PR TITLE
fix(quality,api): main CI green — clippy doc/collapsible-if + openapi regen

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1693,16 +1693,15 @@ impl LlmDriver for OpenAIDriver {
                                     // Arguments delta
                                     if let Some(args) = func["arguments"].as_str() {
                                         tool_accum[idx].2.push_str(args);
-                                        if !args.is_empty() {
-                                            if tx
+                                        if !args.is_empty()
+                                            && tx
                                                 .send(StreamEvent::ToolInputDelta {
                                                     text: args.to_string(),
                                                 })
                                                 .await
                                                 .is_err()
-                                            {
-                                                receiver_dropped = true;
-                                            }
+                                        {
+                                            receiver_dropped = true;
                                         }
                                     }
                                 }

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -195,6 +195,7 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
     /// that route packets to an IPv4 endpoint on the wire:
     ///   * IPv4-mapped: `::ffff:x.x.x.x` (RFC 4291 §2.5.5.2)
     ///   * NAT64:       `64:ff9b::x.x.x.x` (RFC 6052)
+    ///
     /// Without these, `http://[::ffff:7f00:0001]/` bypasses the V4
     /// loopback check entirely — the daemon happily connects to
     /// 127.0.0.1 over an IPv6 socket.

--- a/openapi.json
+++ b/openapi.json
@@ -140,6 +140,7 @@
           "a2a"
         ],
         "summary": "GET /api/a2a/agents — List discovered external A2A agents.",
+        "description": "Returns both `trusted` agents (approved and able to receive tasks) and\n`pending` agents (discovered but not yet approved by the operator).",
         "operationId": "a2a_list_external_agents",
         "responses": {
           "200": {
@@ -2168,15 +2169,34 @@
         "summary": "GET /api/approvals — List pending and recent approval requests.",
         "description": "Transforms field names to match the dashboard template expectations:\n`action_summary` → `action`, `agent_id` → `agent_name`, `requested_at` → `created_at`.",
         "operationId": "list_approvals",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max items (default 100, max 500)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Items to skip",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "List pending and recent approvals",
+            "description": "Paginated list of pending and recent approvals",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {}
-                }
+                "schema": {}
               }
             }
           }
@@ -3003,6 +3023,7 @@
           "budget"
         ],
         "summary": "GET /api/budget/agents — Per-agent cost ranking (top spenders).",
+        "description": "Uses a single `GROUP BY agent_id` query instead of one `SUM` per agent to\neliminate the N+1 SQLite pattern that caused ~1200 queries/min under normal\ndashboard polling at 100 agents. See #3684.",
         "operationId": "agent_budget_ranking",
         "responses": {
           "200": {
@@ -6850,15 +6871,34 @@
         ],
         "summary": "GET /api/sessions — List all sessions with metadata.",
         "operationId": "list_sessions",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max items (default 100, max 500)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Items to skip",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "List sessions",
+            "description": "Paginated list of sessions",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {}
-                }
+                "schema": {}
               }
             }
           }
@@ -8088,7 +8128,7 @@
           "openai"
         ],
         "summary": "GET /v1/models — List available agents as OpenAI model objects.",
-        "operationId": "list_models",
+        "operationId": "list_openai_models",
         "responses": {
           "200": {
             "description": "OpenAI-compatible model list",

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -466,8 +466,8 @@ func (r *AgentsResource) ServeUpload(file_id string) (interface{}, error) {
 
 type ApprovalsResource struct{ client *Client }
 
-func (r *ApprovalsResource) ListApprovals() (interface{}, error) {
-	return r.client.request("GET", "/api/approvals", nil, nil)
+func (r *ApprovalsResource) ListApprovals(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/approvals", nil, query)
 }
 
 func (r *ApprovalsResource) CreateApproval(data map[string]interface{}) (interface{}, error) {
@@ -1006,8 +1006,8 @@ func (r *SessionsResource) FindSessionByLabel(id string, label string) (interfac
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/sessions/by-label/%s", id, label), nil, nil)
 }
 
-func (r *SessionsResource) ListSessions() (interface{}, error) {
-	return r.client.request("GET", "/api/sessions", nil, nil)
+func (r *SessionsResource) ListSessions(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/sessions", nil, query)
 }
 
 func (r *SessionsResource) SessionCleanup() (interface{}, error) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -335,8 +335,8 @@ class AgentsResource {
 class ApprovalsResource {
   constructor(client) { this._c = client; }
 
-  async listApprovals() {
-    return this._c._request("GET", "/api/approvals");
+  async listApprovals(query) {
+    return this._c._request("GET", "/api/approvals", undefined, query);
   }
 
   async createApproval(data) {
@@ -901,8 +901,8 @@ class SessionsResource {
     return this._c._request("GET", `/api/agents/${id}/sessions/by-label/${label}`);
   }
 
-  async listSessions() {
-    return this._c._request("GET", "/api/sessions");
+  async listSessions(query) {
+    return this._c._request("GET", "/api/sessions", undefined, query);
   }
 
   async sessionCleanup() {

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -294,8 +294,8 @@ class _AgentsResource(_Resource):
 
 class _ApprovalsResource(_Resource):
 
-    def list_approvals(self):
-        return self._c._request("GET", "/api/approvals")
+    def list_approvals(self, limit: Any = None, offset: Any = None):
+        return self._c._request("GET", "/api/approvals", None, query={"limit": limit, "offset": offset})
 
     def create_approval(self, **data):
         return self._c._request("POST", "/api/approvals", data)
@@ -725,8 +725,8 @@ class _SessionsResource(_Resource):
     def find_session_by_label(self, id: str, label: str):
         return self._c._request("GET", f"/api/agents/{id}/sessions/by-label/{label}")
 
-    def list_sessions(self):
-        return self._c._request("GET", "/api/sessions")
+    def list_sessions(self, limit: Any = None, offset: Any = None):
+        return self._c._request("GET", "/api/sessions", None, query={"limit": limit, "offset": offset})
 
     def session_cleanup(self):
         return self._c._request("POST", "/api/sessions/cleanup")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -452,8 +452,8 @@ impl ApprovalsResource {
         Self { base_url, client }
     }
 
-    pub async fn list_approvals(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/approvals".to_string(), None, &[]).await
+    pub async fn list_approvals(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/approvals".to_string(), None, &[("limit", limit), ("offset", offset)]).await
     }
 
     pub async fn create_approval(&self, data: Value) -> Result<Value> {
@@ -1122,8 +1122,8 @@ impl SessionsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/by-label/{}", id, label), None, &[]).await
     }
 
-    pub async fn list_sessions(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/sessions".to_string(), None, &[]).await
+    pub async fn list_sessions(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/sessions".to_string(), None, &[("limit", limit), ("offset", offset)]).await
     }
 
     pub async fn session_cleanup(&self) -> Result<Value> {


### PR DESCRIPTION
## Summary

Main CI is failing on every PR after #4021 landed. Two distinct issues, both root-caused to commits already in main:

### 1. Quality / Test/* / Install Smoke — clippy errors under \`-D warnings\`

* \`crates/librefang-runtime-mcp/src/mcp_oauth.rs:198-200\` — three \`doc-lazy-continuation\` errors. The explanation paragraph after the bulleted list at lines 196-197 wasn't separated by a blank line, so clippy parsed the next three sentences as un-indented list continuations. Added the blank line.
* \`crates/librefang-llm-drivers/src/drivers/openai.rs:1696\` — \`collapsible-if\`: nested \`if !args.is_empty() { if tx.send(...).await.is_err() { ... } }\` collapsed to \`if !args.is_empty() && tx.send(...).await.is_err()\` per the lint's auto-fix.

### 2. OpenAPI Drift — out-of-sync openapi.json + SDKs

\`\`\`
##[error]openapi.json or generated SDKs are out of sync with the source code.
Reproduce locally:
  cargo xtask codegen --openapi
  python3 scripts/codegen-sdks.py
\`\`\`

Recent merges (notably #4022 \`/api/approvals\` pagination + #4019 a2a description tweak) shipped operation changes without regenerating. Ran both commands. Result: 269 endpoints across 22 tags, all four SDKs (python, js, go, rust) updated.

## Verification

\`\`\`
$ cargo clippy -p librefang-runtime-mcp -p librefang-llm-drivers --all-targets --all-features -- -D warnings
    Finished 'dev' profile [unoptimized + debuginfo] target(s)
$ cargo xtask codegen --openapi  # 269 endpoints
$ python3 scripts/codegen-sdks.py # 261 ops across 22 tags
\`\`\`

## Test plan

- [ ] CI on this PR turns green for Quality, OpenAPI Drift, Test/Ubuntu, Test/macOS
- [ ] After merge, all 28 open follow-up PRs (#3949, #4013, #4018, #4020, #4022-#4026, #4040-#4056) have CI unblocked