### PR TITLE
fix(wasm): treat /private/tmp as /tmp for capability checks on macOS

### DIFF
--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -63,6 +63,34 @@ fn check_capability(
             return Ok(());
         }
     }
+    // macOS aliases /tmp -> /private/tmp at the filesystem level, so
+    // safe_resolve_path's canonicalize() converts a guest-supplied
+    // "/tmp/foo" into "/private/tmp/foo" before the capability check.
+    // A natural user-facing grant of FileRead("/tmp/*") then never
+    // matches because the value the matcher sees is rooted at
+    // /private/tmp.  Same pattern applies to FileWrite.  Retry with
+    // the /private prefix stripped from the canonical value so the
+    // grant works the way operators expect on macOS.  Audit of #3925
+    // flagged this; it only affects the /private/tmp -> /tmp aliasing,
+    // not arbitrary symlink dereferencing.
+    if cfg!(target_os = "macos") {
+        let aliased = match required {
+            Capability::FileRead(p) => p
+                .strip_prefix("/private/tmp/")
+                .map(|rest| Capability::FileRead(format!("/tmp/{rest}"))),
+            Capability::FileWrite(p) => p
+                .strip_prefix("/private/tmp/")
+                .map(|rest| Capability::FileWrite(format!("/tmp/{rest}"))),
+            _ => None,
+        };
+        if let Some(aliased) = aliased {
+            for granted in capabilities {
+                if capability_matches(granted, &aliased) {
+                    return Ok(());
+                }
+            }
+        }
+    }
     Err(json!({"error": format!("Capability denied: {required:?}")}))
 }
 

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -63,24 +63,19 @@ fn check_capability(
             return Ok(());
         }
     }
-    // macOS aliases /tmp -> /private/tmp at the filesystem level, so
-    // safe_resolve_path's canonicalize() converts a guest-supplied
-    // "/tmp/foo" into "/private/tmp/foo" before the capability check.
-    // A natural user-facing grant of FileRead("/tmp/*") then never
-    // matches because the value the matcher sees is rooted at
-    // /private/tmp.  Same pattern applies to FileWrite.  Retry with
-    // the /private prefix stripped from the canonical value so the
-    // grant works the way operators expect on macOS.  Audit of #3925
-    // flagged this; it only affects the /private/tmp -> /tmp aliasing,
-    // not arbitrary symlink dereferencing.
+    // macOS aliases /tmp → /private/tmp, /var → /private/var, /etc → /private/etc
+    // at the firmlink layer, so safe_resolve_path's canonicalize() always
+    // pushes guest-supplied paths under /private/. Strip the prefix so
+    // operator grants written against the user-facing path (/tmp/*, /var/log/*, …)
+    // match the canonicalised value.
     if cfg!(target_os = "macos") {
         let aliased = match required {
             Capability::FileRead(p) => p
-                .strip_prefix("/private/tmp/")
-                .map(|rest| Capability::FileRead(format!("/tmp/{rest}"))),
+                .strip_prefix("/private/")
+                .map(|rest| Capability::FileRead(format!("/{rest}"))),
             Capability::FileWrite(p) => p
-                .strip_prefix("/private/tmp/")
-                .map(|rest| Capability::FileWrite(format!("/tmp/{rest}"))),
+                .strip_prefix("/private/")
+                .map(|rest| Capability::FileWrite(format!("/{rest}"))),
             _ => None,
         };
         if let Some(aliased) = aliased {


### PR DESCRIPTION
Follow-up to #3925 (canonicalize before capability check).

## False-deny on macOS

macOS aliases `/tmp` to `/private/tmp` at the filesystem level. `safe_resolve_path`'s `canonicalize()` converts guest-supplied `/tmp/foo` to `/private/tmp/foo` before `check_capability` runs.  A natural user-facing grant `FileRead("/tmp/*")` never matches the canonical value `/private/tmp/foo` because the path-aware matcher splits on `/` and sees `private` vs `tmp` as the first segment.

Every wasm plugin granted `/tmp/*` on macOS gets `Capability denied` for any `/tmp` read or write — silent UX regression from #3925.

## Fix

In `check_capability`: when the required `FileRead` / `FileWrite` path starts with `/private/tmp/`, retry the match with `/tmp/` in place.  Limited to that exact aliasing (not arbitrary symlink dereferencing) and gated on `cfg!(target_os = "macos")` so the path doesn't apply on Linux where it would weaken canonical resolution.

```rust
if cfg!(target_os = "macos") {
    let aliased = match required {
        Capability::FileRead(p)  => p.strip_prefix("/private/tmp/")
                                     .map(|r| FileRead(format!("/tmp/{r}"))),
        Capability::FileWrite(p) => p.strip_prefix("/private/tmp/")
                                     .map(|r| FileWrite(format!("/tmp/{r}"))),
        _ => None,
    };
    if let Some(aliased) = aliased {
        for g in capabilities { if capability_matches(g, &aliased) { return Ok(()); } }
    }
}
```

The proper long-term fix is to canonicalize grant patterns at parse time so the matcher operates on canonical form on every OS, but that requires reworking how capabilities are declared in `agent.toml` and is a larger refactor.