### PR TITLE
fix(kernel,triggers): evaluate triggers in deterministic id order

### DIFF
--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -651,7 +651,25 @@ impl TriggerEngine {
         let mut state_mutated = false;
         let now = Utc::now();
 
-        for mut entry in self.triggers.iter_mut() {
+        // Iterate in deterministic order.  DashMap's native iterator
+        // is order-by-shard-and-hash, so the same trigger set produces
+        // a different evaluation order on every event — and when the
+        // per-event budget caps the matches, the *set* of triggers
+        // that fire is also non-deterministic.  #3923's existing
+        // "ordered triggers" wording (and the CLAUDE.md determinism
+        // rule for anything that ultimately reaches an LLM prompt
+        // through TaskPosted / agent dispatch) calls for a stable
+        // order; the audit caught that the evaluator itself was the
+        // remaining gap.  Sorting the snapshot of trigger IDs before
+        // taking each shard write-lock keeps storm prevention intact
+        // (still drops excess matches at the budget) while making
+        // *which* matches drop deterministic.
+        let mut ids: Vec<TriggerId> = self.triggers.iter().map(|e| *e.key()).collect();
+        ids.sort();
+        for id in ids {
+            let Some(mut entry) = self.triggers.get_mut(&id) else {
+                continue;
+            };
             let trigger = entry.value_mut();
 
             if !trigger.enabled {

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -26,7 +26,7 @@ const DEFAULT_MAX_TRIGGERS_PER_EVENT: usize = 10;
 // from TriggersConfig via `TriggerEngine::with_config`.
 
 /// Unique identifier for a trigger.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct TriggerId(pub Uuid);
 
 impl TriggerId {

--- a/crates/librefang-kernel/tests/audit_retention_test.rs
+++ b/crates/librefang-kernel/tests/audit_retention_test.rs
@@ -1,3 +1,11 @@
+// `start_background_agents()` spawns 17 closures whose async-block layouts
+// the compiler folds into a single type-resolution query.  After
+// `TriggerId` gained `PartialOrd, Ord` (#4067), one of those layouts
+// exceeded the default recursion limit of 128.  The compiler explicitly
+// suggests this attribute; bumping to 256 leaves headroom for further
+// trait-bound additions on kernel-internal types.
+#![recursion_limit = "256"]
+
 //! Audit retention M7: kernel boot wires the periodic trim task and the
 //! self-audit `RetentionTrim` row lands when a trim cycle actually drops
 //! entries.


### PR DESCRIPTION
Follow-up to #3923 (ordered triggers).

## Problem

#3923 advertised "ordered triggers" but `evaluate_with_resolver` still iterated `self.triggers` (a `DashMap`) in shard-and-hash order:

```rust
for mut entry in self.triggers.iter_mut() {
    let trigger = entry.value_mut();
    …
}
```

When the per-event budget caps matches, **which** matches survive is non-deterministic.  Downstream consumers — `TaskPosted` dispatches, LLM prompts that reference the triggered task list — see a different set on a re-evaluation of the same event, breaking the determinism rule for inputs that reach the prompt cache.

The pre-existing comment acknowledged the gap and pointed at an "explicit priority field" as the eventual fix; that's a larger schema change.  A stable-but-arbitrary id order is enough to make the matched set stable across processes.

## Fix

Snapshot trigger ids, sort, then take each shard write-lock in order:

```rust
let mut ids: Vec<TriggerId> = self.triggers.iter().map(|e| *e.key()).collect();
ids.sort();
for id in ids {
    let Some(mut entry) = self.triggers.get_mut(&id) else { continue };
    …
}
```

No deadlock risk — each `get_mut` is an independent shard lock.  Storm prevention still bites at the same budget threshold; only **which** matches drop changes (now: highest-id; before: whichever shard hashed last).