### PR TITLE
fix(api,approvals): list full in-memory window so pagination total matches reality

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1616,7 +1616,15 @@ pub async fn list_approvals(
     Query(pagination): Query<PaginationParams>,
 ) -> impl IntoResponse {
     let pending = state.kernel.approvals().list_pending();
-    let recent = state.kernel.approvals().list_recent(50);
+    // Pull the full in-memory recent buffer (capped at
+    // MAX_RECENT_APPROVALS = 100 by approval.rs), not a hard-coded 50.
+    // The earlier limit meant `total` reported pending + 50 even when
+    // the buffer held more, so a frontend asking for `offset=50` got
+    // an empty page despite `total > offset` — pagination contract
+    // broken (audit of #3958).  The buffer cap is the real bound;
+    // surfacing the full set here lets the skip/take below paginate
+    // over the actual window the server can serve.
+    let recent = state.kernel.approvals().list_recent(usize::MAX);
 
     let registry_agents = state.kernel.agent_registry().list();
     let agent_name_for = |agent_id: &str| {


### PR DESCRIPTION
Follow-up to #3958 (paginate sessions/approvals).

`list_approvals` hard-codes the recent-history fetch at 50 and reports `total = approvals.len()`:

```rust
let pending = state.kernel.approvals().list_pending();
let recent = state.kernel.approvals().list_recent(50);
…
let total = approvals.len();   // reports pending + 50
```

The in-memory buffer actually holds up to `MAX_RECENT_APPROVALS = 100` (`approval.rs:23`).  A frontend asking for `offset=50` gets back an empty page despite `total > offset` — pagination contract is wrong on the wire.  Audit of #3958 flagged this as latent because the dashboard hasn't shipped a "page 2" UI yet, but any new consumer hits the bug immediately.

## Fix

`list_recent(usize::MAX)` so the full buffer is materialised and the `skip`/`take` paginates over the entire server-serveable window.  The buffer's own `MAX_RECENT_APPROVALS` cap remains the only real bound.

Cost: per-request clone of the full recent buffer (~100 records).  Bounded, small, low-frequency dashboard endpoint — fine.