### PR TITLE
fix(cli): repair TUI daemon_client() refs and missing api_key arg in chat_runner

### DIFF
--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -249,6 +249,7 @@ impl StandaloneChat {
                     base_url.clone(),
                     self.agent_id_daemon.as_ref().unwrap().clone(),
                     message,
+                    None,
                     self.event_tx.clone(),
                 );
             }
@@ -626,6 +627,7 @@ impl StandaloneChat {
                 event::spawn_daemon_agent(
                     base_url.to_string(),
                     t.content.clone(),
+                    None,
                     self.event_tx.clone(),
                 );
                 self.chat.status_msg = Some(format!("Spawning '{}' agent\u{2026}", t.name));

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -2956,7 +2956,7 @@ pub fn spawn_fetch_agent_model_label(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || {
-        let client = daemon_client();
+        let client = make_daemon_client(None);
         if let Ok(resp) = client
             .get(format!("{base_url}/api/agents/{agent_id}"))
             .send()
@@ -2976,7 +2976,7 @@ pub fn spawn_fetch_agent_model_label(
 /// without blocking the render/input thread.
 pub fn spawn_fetch_models_for_picker(base_url: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || {
-        let client = daemon_client();
+        let client = make_daemon_client(None);
         if let Ok(resp) = client.get(format!("{base_url}/api/models")).send() {
             if let Ok(body) = resp.json::<serde_json::Value>() {
                 let models: Vec<super::screens::chat::ModelEntry> = body["models"]
@@ -3004,7 +3004,7 @@ pub fn spawn_fetch_models_for_picker(base_url: String, tx: mpsc::Sender<AppEvent
 /// without blocking the render/input thread.
 pub fn spawn_fetch_agents_for_chat(base_url: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || {
-        let client = daemon_client();
+        let client = make_daemon_client(None);
         if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
             if let Ok(body) = resp.json::<serde_json::Value>() {
                 let arr = if let Some(arr) = body.as_array() {


### PR DESCRIPTION
## Summary

`main` currently fails to compile in `librefang-cli` with five errors:

- 3× `cannot find function daemon_client in this scope` in `tui/event.rs` (lines 2959, 2979, 3007)
- 2× `this function takes N arguments but N-1 arguments were supplied` in `tui/chat_runner.rs` (lines 248, 626)

### Root cause

#3959 added three new TUI helpers (`spawn_fetch_agent_model_label`, `spawn_fetch_models_for_picker`, `spawn_fetch_agents_for_chat`) that call `daemon_client()` — a function that does not exist. Every other call site in the file uses `make_daemon_client(api_key.as_deref())` / `make_daemon_client_with_timeout(...)`.

#3966 then added an `api_key: Option<String>` parameter to `spawn_daemon_stream` and `spawn_daemon_agent`, but the two callers in `tui/chat_runner.rs` were not updated to pass it.

### Fix

- Replace the three `daemon_client()` calls with `make_daemon_client(None)`. These helpers don't currently have an api_key in scope; passing `None` matches the pre-existing behaviour of the unauthenticated TUI HTTP path and is consistent with how every nearby helper handles the same parameter.
- Pass `None` for `api_key` at the two `chat_runner.rs` call sites so the signatures line up.

After this `cargo build -p librefang-cli` succeeds.

## Test plan

- [x] `cargo build -p librefang-cli` (was failing on `main`, now passes)
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] TUI chat smoke test: enter chat, send a message, open `/agents`, open the model picker — verify the three async fetches still complete (these were the helpers from #3959 that needed the http client fix).