### PR TITLE
fix(website): register 'pl' in registry-route + search-dialog locale lists

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1291,7 +1291,7 @@ function BackToTop() {
 const REGISTRY_ROUTES: RegistryCategory[] = [
   'skills', 'mcp', 'plugins', 'hands', 'agents', 'providers', 'workflows', 'channels',
 ]
-const LOCALES = ['zh-TW', 'zh', 'ja', 'ko', 'de', 'es']
+const LOCALES = ['zh-TW', 'zh', 'ja', 'ko', 'de', 'es', 'pl']
 
 type RegistryMatch =
   | { kind: 'list'; category: RegistryCategory }

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -220,7 +220,7 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
     const path = raw.replace(/^https?:\/\/[^/]+/i, '').replace(/^\/+/, '').replace(/[?#].*$/, '')
     const segs = path.split('/').filter(Boolean)
     // Tolerate a leading lang prefix (zh/ja/...) when present.
-    const langs = new Set(['zh', 'zh-TW', 'ja', 'ko', 'de', 'es'])
+    const langs = new Set(['zh', 'zh-TW', 'ja', 'ko', 'de', 'es', 'pl'])
     const [first, ...rest] = segs
     const parts = first && langs.has(first) ? rest : segs
     if (parts.length >= 2 && CATEGORIES.includes(parts[0] as RegistryCategory)) {


### PR DESCRIPTION
Follow-up to #3937 (Add Polish language).

#3937 added `pl` to the website i18n config but missed two locale-stripping lists that drive routing for `/pl/*` URLs:

| File | List | Impact when 'pl' missing |
|---|---|---|
| `web/src/App.tsx:1294` | `LOCALES` (drives `detectRegistryRoute`) | Polish user on `/pl/skills/foo` doesn't get the prefix stripped → registry list/detail silently 404s into fallback |
| `web/src/components/SearchDialog.tsx:223` | `langs` Set (paste-URL handler) | Pasting `/pl/skills/foo` into search doesn't strip the prefix → lookup misses, paste-to-jump silently fails |

Both are user-visible silent navigation bugs for `pl` users.  Add `'pl'` to both sets to match the rest of the i18n config (`i18n.ts:207`, `App.tsx:41`/`752`, `store.ts:13`/`43`).