### PR TITLE
fix(channels,api,runtime): repair main — sanitizer field, dingtalk test args, rustfmt diff

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2114,12 +2114,7 @@ mod tests {
         ] {
             let resp = app
                 .clone()
-                .oneshot(
-                    Request::builder()
-                        .uri(*path)
-                        .body(Body::empty())
-                        .unwrap(),
-                )
+                .oneshot(Request::builder().uri(*path).body(Body::empty()).unwrap())
                 .await
                 .unwrap();
             assert_eq!(

--- a/crates/librefang-api/src/rate_limiter.rs
+++ b/crates/librefang-api/src/rate_limiter.rs
@@ -996,12 +996,12 @@ mod tests {
         ] {
             let limiter = Arc::new(AuthLoginLimiter::new());
             let max_attempts: u32 = 1;
-            let app = Router::new()
-                .route(path, post(|| async { "ok" }))
-                .layer(axum::middleware::from_fn_with_state(
+            let app = Router::new().route(path, post(|| async { "ok" })).layer(
+                axum::middleware::from_fn_with_state(
                     (limiter, max_attempts),
                     auth_rate_limit_layer,
-                ));
+                ),
+            );
 
             let mut saw_429 = false;
             for _ in 0..5 {
@@ -1020,10 +1020,7 @@ mod tests {
                     break;
                 }
             }
-            assert!(
-                saw_429,
-                "endpoint {path} must be rate-limited but was not"
-            );
+            assert!(saw_429, "endpoint {path} must be rate-limited but was not");
         }
     }
 }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1459,7 +1459,8 @@ mod tests {
     /// when it added the 4xx mapping.
     #[test]
     fn map_memory_error_does_not_leak_internal_message_on_500() {
-        let (status, body) = map_memory_error("connection refused: /home/foo/.librefang/memory.db".to_string());
+        let (status, body) =
+            map_memory_error("connection refused: /home/foo/.librefang/memory.db".to_string());
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         let v: serde_json::Value = serde_json::to_value(body.0).unwrap();
         let echoed = v["error"].as_str().unwrap_or("");
@@ -1499,8 +1500,7 @@ mod tests {
         let (status, _) = map_memory_error("Capability denied: shell_exec".to_string());
         assert_eq!(status, StatusCode::FORBIDDEN);
 
-        let (status, _) =
-            map_memory_error("Resource quota exceeded: 1500 / 1000".to_string());
+        let (status, _) = map_memory_error("Resource quota exceeded: 1500 / 1000".to_string());
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
     }
 

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -943,11 +943,13 @@ mod tests {
     fn test_dingtalk_verify_signature_rejects_wrong_timestamp() {
         let secret = "test-secret";
         let ts: i64 = 1700000000000;
-        let good_sig = DingTalkAdapter::compute_signature(secret, ts);
+        let body: &[u8] = b"{\"msgtype\":\"text\"}";
+        let good_sig = DingTalkAdapter::compute_signature(secret, ts, body);
         // Different timestamp → signature mismatch
         assert!(!DingTalkAdapter::verify_signature(
             secret,
             ts + 1,
+            body,
             &good_sig
         ));
     }

--- a/crates/librefang-channels/src/sanitizer.rs
+++ b/crates/librefang-channels/src/sanitizer.rs
@@ -195,6 +195,7 @@ mod tests {
             mode: SanitizeMode::Warn,
             max_message_length: 32768,
             custom_block_patterns: Vec::new(),
+            disable_input_sanitizer: false,
         }
     }
 
@@ -203,6 +204,7 @@ mod tests {
             mode: SanitizeMode::Block,
             max_message_length: 32768,
             custom_block_patterns: Vec::new(),
+            disable_input_sanitizer: false,
         }
     }
 
@@ -211,6 +213,7 @@ mod tests {
             mode: SanitizeMode::Off,
             max_message_length: 32768,
             custom_block_patterns: Vec::new(),
+            disable_input_sanitizer: false,
         }
     }
 

--- a/crates/librefang-runtime/src/media/mod.rs
+++ b/crates/librefang-runtime/src/media/mod.rs
@@ -175,9 +175,7 @@ impl MediaDriverCache {
     ///
     /// Accepts any map type that can be iterated as `(String, String)` pairs,
     /// including both `HashMap` and `BTreeMap`.
-    pub fn new_with_urls(
-        provider_urls: impl IntoIterator<Item = (String, String)>,
-    ) -> Self {
+    pub fn new_with_urls(provider_urls: impl IntoIterator<Item = (String, String)>) -> Self {
         Self {
             cache: DashMap::new(),
             provider_urls: RwLock::new(provider_urls.into_iter().collect()),
@@ -282,10 +280,7 @@ impl MediaDriverCache {
     ///
     /// Accepts any map type that can be iterated as `(String, String)` pairs,
     /// including both `HashMap` and `BTreeMap`.
-    pub fn update_provider_urls(
-        &self,
-        urls: impl IntoIterator<Item = (String, String)>,
-    ) {
+    pub fn update_provider_urls(&self, urls: impl IntoIterator<Item = (String, String)>) {
         if let Ok(mut map) = self.provider_urls.write() {
             *map = urls.into_iter().collect();
         }


### PR DESCRIPTION
## Emergency

Main HEAD `d9dc3536` is failing CI on every platform (`Test/macOS`, `Test/Ubuntu`, `Test/Windows`, `Quality`) — has been failing for the last 5 commits.

## Compile errors

### `librefang-channels/src/sanitizer.rs:194,202,210`

`SanitizeConfig` literal in three test helpers (`config_warn` / `config_block` / `config_off`) is missing the `disable_input_sanitizer` field that #3936 added to the struct.

```
error[E0063]: missing field `disable_input_sanitizer` in initializer of `librefang_types::config::SanitizeConfig`
```

### `librefang-channels/src/dingtalk.rs:946,948`

`test_dingtalk_verify_signature_rejects_wrong_timestamp` calls:

- `compute_signature(secret, ts)` — but the body-binding fix bumped the signature to `(secret, ts, body)` (3 args).
- `verify_signature(secret, ts+1, &good_sig)` — the new signature is `(secret, ts, body, signature)` (4 args).

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
```

## rustfmt diff

`Quality` job fails on:
- `middleware.rs:2114`
- `rate_limiter.rs:996,1020`
- `memory.rs:1459,1499`
- `media/mod.rs:175,282`

All fmt-noncanonical layouts that `cargo fmt` rewrites.

## Why this slipped in

Both classes of error landed because the squash merges of the underlying PRs went through without re-running `fmt + test` on the post-squash tree.  Per-PR CI runs on the unsquashed branch tip; the squash commit can introduce diff-induced fmt drift or expose API skew between two PRs that both merged based on different versions of the API surface (here: sanitizer struct vs. dingtalk signature).

## Repair

1. Add `disable_input_sanitizer: false` to all three test config literals.
2. Pass body bytes through `compute_signature` / `verify_signature` in the wrong-timestamp test (any non-empty body — the test only asserts that a different timestamp produces a mismatch).
3. Apply `cargo fmt --all` to the 6 fmt-diff files.