### PR TITLE
fix(extensions): drop dead sha2::Digest import in machine_fingerprint

### DIFF
--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -742,8 +742,6 @@ fn load_keyring_key() -> Result<Zeroizing<String>, String> {
 /// degraded security as before, but only as a last resort.
 #[cfg(not(test))]
 fn machine_fingerprint() -> Vec<u8> {
-    use sha2::Digest;
-
     let fingerprint_path = dirs::data_local_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join("librefang")


### PR DESCRIPTION
## Summary

After #4040 refactored \`machine_fingerprint()\` to store a raw 32-byte random id on disk (atomic \`O_EXCL + mode(0o600)\`) instead of hashing anything in that scope, the function-local \`use sha2::Digest;\` became unreachable. Every Test platform on main is currently failing with:

\`\`\`
error: unused import: sha2::Digest
   --> crates/librefang-extensions/src/vault.rs:745:9
    |
745 |     use sha2::Digest;
    |         ^^^^^^^^^^^^
    |
    = note: -D unused-imports implied by -D warnings
\`\`\`

The other \`use sha2::Digest;\` inside \`predictable_machine_fingerprint()\` is genuine — that path still calls \`Sha256::new\` / \`update\` / \`finalize\` — so it stays.

## Test plan

- [x] grep confirms only one \`Sha256::new()\` call remains in vault.rs (inside \`predictable_machine_fingerprint\`)
- [ ] CI Test (Ubuntu/macOS/Windows) and Quality (clippy -D warnings) all green