### PR TITLE
fix(cli,wasm,mcp,kernel): preserve TUI api_key auth + repair main build

### DIFF
--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -249,7 +249,7 @@ impl StandaloneChat {
                     base_url.clone(),
                     self.agent_id_daemon.as_ref().unwrap().clone(),
                     message,
-                    None,
+                    crate::read_api_key(),
                     self.event_tx.clone(),
                 );
             }
@@ -627,7 +627,7 @@ impl StandaloneChat {
                 event::spawn_daemon_agent(
                     base_url.to_string(),
                     t.content.clone(),
-                    None,
+                    crate::read_api_key(),
                     self.event_tx.clone(),
                 );
                 self.chat.status_msg = Some(format!("Spawning '{}' agent\u{2026}", t.name));

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -2953,10 +2953,11 @@ pub fn spawn_comms_task(
 pub fn spawn_fetch_agent_model_label(
     base_url: String,
     agent_id: String,
+    api_key: Option<String>,
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || {
-        let client = make_daemon_client(None);
+        let client = make_daemon_client(api_key.as_deref());
         if let Ok(resp) = client
             .get(format!("{base_url}/api/agents/{agent_id}"))
             .send()
@@ -2974,9 +2975,13 @@ pub fn spawn_fetch_agent_model_label(
 /// Fetch the model list from the daemon for the chat model picker.
 /// Sends `ChatModelsForPicker` so the event loop can open the picker
 /// without blocking the render/input thread.
-pub fn spawn_fetch_models_for_picker(base_url: String, tx: mpsc::Sender<AppEvent>) {
+pub fn spawn_fetch_models_for_picker(
+    base_url: String,
+    api_key: Option<String>,
+    tx: mpsc::Sender<AppEvent>,
+) {
     std::thread::spawn(move || {
-        let client = make_daemon_client(None);
+        let client = make_daemon_client(api_key.as_deref());
         if let Ok(resp) = client.get(format!("{base_url}/api/models")).send() {
             if let Ok(body) = resp.json::<serde_json::Value>() {
                 let models: Vec<super::screens::chat::ModelEntry> = body["models"]
@@ -3002,9 +3007,13 @@ pub fn spawn_fetch_models_for_picker(base_url: String, tx: mpsc::Sender<AppEvent
 /// Fetch the agent list from the daemon for the /agents chat command.
 /// Sends `ChatAgentListLoaded` so the event loop can push the reply
 /// without blocking the render/input thread.
-pub fn spawn_fetch_agents_for_chat(base_url: String, tx: mpsc::Sender<AppEvent>) {
+pub fn spawn_fetch_agents_for_chat(
+    base_url: String,
+    api_key: Option<String>,
+    tx: mpsc::Sender<AppEvent>,
+) {
     std::thread::spawn(move || {
-        let client = make_daemon_client(None);
+        let client = make_daemon_client(api_key.as_deref());
         if let Ok(resp) = client.get(format!("{base_url}/api/agents")).send() {
             if let Ok(body) = resp.json::<serde_json::Value>() {
                 let arr = if let Some(arr) = body.as_array() {

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -1826,10 +1826,15 @@ impl App {
         self.chat.mode_label = "daemon".to_string();
 
         // Fetch model label asynchronously — avoids blocking the TUI event loop.
-        if let Backend::Daemon { ref base_url, .. } = self.backend {
+        if let Backend::Daemon {
+            ref base_url,
+            ref api_key,
+        } = self.backend
+        {
             event::spawn_fetch_agent_model_label(
                 base_url.clone(),
                 id.clone(),
+                api_key.clone(),
                 self.event_tx.clone(),
             );
         }
@@ -1957,10 +1962,14 @@ impl App {
 
     fn open_model_picker(&mut self) {
         match &self.backend {
-            Backend::Daemon { base_url, .. } => {
+            Backend::Daemon { base_url, api_key } => {
                 // Fetch model list asynchronously — avoids blocking the TUI event loop.
                 // The `ChatModelsForPicker` event handler will open the picker once loaded.
-                event::spawn_fetch_models_for_picker(base_url.clone(), self.event_tx.clone());
+                event::spawn_fetch_models_for_picker(
+                    base_url.clone(),
+                    api_key.clone(),
+                    self.event_tx.clone(),
+                );
             }
             Backend::InProcess { kernel } => {
                 let models = {
@@ -2128,10 +2137,14 @@ impl App {
             }
             "/agents" => {
                 match &self.backend {
-                    Backend::Daemon { base_url, .. } => {
+                    Backend::Daemon { base_url, api_key } => {
                         // Fetch agent list asynchronously — avoids blocking the TUI event loop.
                         // The `ChatAgentListLoaded` event handler will push the reply.
-                        event::spawn_fetch_agents_for_chat(base_url.clone(), self.event_tx.clone());
+                        event::spawn_fetch_agents_for_chat(
+                            base_url.clone(),
+                            api_key.clone(),
+                            self.event_tx.clone(),
+                        );
                     }
                     Backend::InProcess { kernel } => {
                         let lines: Vec<String> = kernel

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -17,7 +17,10 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::path::PathBuf;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
+// `error!` is used only in non-test keyring code paths.
+#[cfg(not(test))]
+use tracing::error;
 use zeroize::Zeroizing;
 
 /// Env var fallback for vault key.
@@ -791,10 +794,8 @@ fn machine_fingerprint() -> Vec<u8> {
     // umask defaults.  `O_EXCL` makes the first-run race deterministic:
     // if two daemons start concurrently, only one wins the create; the
     // loser falls back to reading the winner's file.
-    let tmp_path = fingerprint_path.with_extension(format!(
-        "machine-id.tmp.{}",
-        std::process::id()
-    ));
+    let tmp_path =
+        fingerprint_path.with_extension(format!("machine-id.tmp.{}", std::process::id()));
     let persisted = (|| -> std::io::Result<()> {
         use std::io::Write as _;
         let mut opts = std::fs::OpenOptions::new();
@@ -854,6 +855,7 @@ fn machine_fingerprint() -> Vec<u8> {
 /// persisted.  Same security level as the pre-#3944 code; documented so
 /// operators know that on this path the vault is only as secret as the
 /// hostname + username.
+#[cfg(not(test))]
 fn predictable_machine_fingerprint() -> Vec<u8> {
     use sha2::Digest;
     let mut hasher = Sha256::new();

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1046,6 +1046,7 @@ impl ApprovalManager {
     /// treat `Err(())` as a rejection — if we cannot persist the counter we
     /// cannot enforce the brute-force cap across restarts, so the safest
     /// course is to deny the request (fail-secure, fix for #3372 / #3584).
+    #[allow(clippy::result_unit_err)]
     pub fn record_totp_failure(&self, sender_id: &str) -> Result<(), ()> {
         let mut failures = self.totp_failures.lock().unwrap_or_else(|e| e.into_inner());
         let entry = failures.entry(sender_id.to_string()).or_insert((0, None));
@@ -1210,7 +1211,9 @@ impl ApprovalManager {
     /// no audit DB is wired (test harness) so the existing tests are
     /// unaffected.
     pub fn is_oauth_nonce_used(&self, nonce: &str) -> bool {
-        let Some(db) = &self.audit_db else { return false };
+        let Some(db) = &self.audit_db else {
+            return false;
+        };
         let Ok(conn) = db.lock() else { return false };
         let hash = Self::oauth_nonce_hash(nonce);
         // OAuth flow lifetime is typically 5–15 min; matching the state

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1735,7 +1735,7 @@ impl McpConnection {
             // close as a real risk.
             const CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
             match tokio::time::timeout(CLOSE_TIMEOUT, client.close()).await {
-                Ok(Ok(())) => {}
+                Ok(Ok(_reason)) => {}
                 Ok(Err(e)) => {
                     warn!(server = %name, error = ?e, "MCP stdio client close error on disconnect");
                 }
@@ -1803,7 +1803,7 @@ impl Drop for McpConnection {
                         const CLOSE_TIMEOUT: std::time::Duration =
                             std::time::Duration::from_secs(10);
                         match tokio::time::timeout(CLOSE_TIMEOUT, client.close()).await {
-                            Ok(Ok(())) => {}
+                            Ok(Ok(_reason)) => {}
                             Ok(Err(e)) => {
                                 debug!(
                                     server = %name,

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -712,12 +712,12 @@ mod tests {
     use super::*;
 
     fn test_state(capabilities: Vec<Capability>) -> GuestState {
-        GuestState {
+        GuestState::for_test(
             capabilities,
-            kernel: None,
-            agent_id: "test-agent".to_string(),
-            tokio_handle: tokio::runtime::Handle::current(),
-        }
+            None,
+            "test-agent".to_string(),
+            tokio::runtime::Handle::current(),
+        )
     }
 
     /// Word-boundary blocklist: real secret-shaped names match, benign
@@ -1073,12 +1073,12 @@ mod tests {
         capabilities: Vec<Capability>,
         kernel: std::sync::Arc<RecordingKernel>,
     ) -> GuestState {
-        GuestState {
+        GuestState::for_test(
             capabilities,
-            kernel: Some(kernel),
-            agent_id: agent_id.to_string(),
-            tokio_handle: tokio::runtime::Handle::current(),
-        }
+            Some(kernel),
+            agent_id.to_string(),
+            tokio::runtime::Handle::current(),
+        )
     }
 
     /// Regression test for Bug #3837: kv_get must namespace the key with
@@ -1195,32 +1195,6 @@ mod tests {
         assert!(safe_resolve_path("../etc/passwd").is_err());
         assert!(safe_resolve_path("/tmp/../../etc/passwd").is_err());
         assert!(safe_resolve_path("foo/../bar").is_err());
-    }
-
-    /// Regression for #3814: capability check must run AFTER canonicalization.
-    ///
-    /// A capability granting access to `/tmp/allowed` must NOT permit a guest
-    /// that passes `../allowed` when the working directory is `/tmp/sub` —
-    /// the raw string does not literally match `/tmp/allowed`, but
-    /// canonicalization would resolve it to the same inode. Conversely, a
-    /// traversal attempt aimed at a path outside any granted capability must
-    /// be denied even if the raw string superficially matches a prefix.
-    ///
-    /// We test the deny path here: a FileRead("*") wildcard is granted but
-    /// the path `../etc/passwd` is rejected during canonicalization (contains
-    /// `..`), so the capability check is never even reached. This validates
-    /// that canonicalization is the first gate.
-    #[tokio::test]
-    async fn test_fs_read_traversal_rejected_before_capability_check() {
-        // Even with a wildcard capability, ".." in the path must be caught by
-        // safe_resolve_path before we ever consult the capability list.
-        let state = test_state(vec![Capability::FileRead("*".to_string())]);
-        let result = host_fs_read(&state, &json!({"path": "../etc/passwd"}));
-        let err = result["error"].as_str().unwrap_or("");
-        assert!(
-            err.contains("traversal") || err.contains("resolve") || err.contains("Cannot"),
-            "Expected path-traversal or resolution error, got: {err}"
-        );
     }
 
     #[test]

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -108,6 +108,29 @@ pub struct GuestState {
     limiter: MemoryLimiter,
 }
 
+#[cfg(test)]
+impl GuestState {
+    /// Build a `GuestState` for unit tests in sibling modules. The host_functions
+    /// tests don't exercise WASM memory growth, so the limiter is set to
+    /// effectively unbounded.
+    pub(crate) fn for_test(
+        capabilities: Vec<Capability>,
+        kernel: Option<Arc<dyn KernelHandle>>,
+        agent_id: String,
+        tokio_handle: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            capabilities,
+            kernel,
+            agent_id,
+            tokio_handle,
+            limiter: MemoryLimiter {
+                max_bytes: usize::MAX,
+            },
+        }
+    }
+}
+
 /// Result of executing a WASM module.
 #[derive(Debug)]
 pub struct ExecutionResult {
@@ -691,9 +714,9 @@ mod tests {
 
     #[test]
     fn test_sandbox_engine_creation() {
-        let sandbox = WasmSandbox::new().unwrap();
-        // Engine should be created successfully
-        drop(sandbox);
+        // Constructing the sandbox eagerly validates the engine config; the
+        // assertion is simply that `new()` returns Ok.
+        let _sandbox = WasmSandbox::new().unwrap();
     }
 
     /// Regression: max_memory_bytes must be enforced at runtime, not just
@@ -706,19 +729,17 @@ mod tests {
             max_bytes: 1024 * 1024,
         };
         // Within limit → allowed
-        assert_eq!(
+        assert!(
             limiter
                 .memory_growing(0, 64 * 1024, None)
                 .expect("should not error"),
-            true,
             "growth within cap must be permitted"
         );
         // Exceeds limit → denied
-        assert_eq!(
-            limiter
+        assert!(
+            !limiter
                 .memory_growing(0, 2 * 1024 * 1024, None)
                 .expect("should not error"),
-            false,
             "growth beyond cap must be denied"
         );
     }


### PR DESCRIPTION
## Summary

Two-part fix: (1) close the TUI api_key auth regression that #4071 introduced, and (2) repair the cascade of main-branch build/clippy failures that surfaced once `cargo clippy --workspace --all-targets -- -D warnings` and `cargo build --workspace` were re-run after the recent rmcp / wasm churn.

### TUI standalone chat — restore api_key auth (the original review item from #4071)

`StandaloneChat` (`librefang chat`) routes every other HTTP call through `crate::daemon_client()`, which auto-attaches `Authorization: Bearer <key>` from `config.toml`. After #4071, two new spawn paths bypassed that:

- `chat_runner.rs` calls to `spawn_daemon_stream` / `spawn_daemon_agent` passed `None` for `api_key`, so message send (`POST /api/agents/{id}/message/stream`) and template spawn (`POST /api/agents`) silently failed with 401 when an api_key was configured. Now passes `crate::read_api_key()`.
- The three new fetch helpers in `event.rs` (`spawn_fetch_agent_model_label` / `spawn_fetch_models_for_picker` / `spawn_fetch_agents_for_chat`) called `make_daemon_client(None)` and didn't accept an `api_key` parameter at all — out of step with the 25+ surrounding helpers. They now take `api_key: Option<String>` and `mod.rs` forwards it from `Backend::Daemon { base_url, api_key }`.

### main build / clippy repairs

After rebasing onto `origin/main` (`996f7ce6`), the workspace failed both `cargo build` and `cargo clippy --workspace --all-targets -- -D warnings`. The fixes:

| Crate / file | Issue | Fix |
|---|---|---|
| `librefang-extensions/src/vault.rs` | unused `use sha2::Digest` inside `machine_fingerprint`; `predictable_machine_fingerprint` referenced `Sha256::new()` but the file-level `use sha2::{Digest as _, Sha256}` is `#[cfg(not(test))]`, so lib-test couldn't resolve it; `tracing::error` imported but only used inside `cfg(not(test))` code | dropped the inner `use`, gated the fn with `#[cfg(not(test))]` (both callers are already `cfg(not(test))`), gated `tracing::error` import |
| `librefang-runtime-wasm/src/sandbox.rs` | `GuestState`'s `limiter` is a private field; tests in sibling `host_functions.rs` couldn't construct it via struct literal; lint errors on `drop(unit-struct)` and `assert_eq!(.., bool, ..)` | added `#[cfg(test)] impl GuestState { pub(crate) fn for_test(...) }`; replaced `drop(_)` with `let _bind`; rewrote two `assert_eq!` as `assert!` |
| `librefang-runtime-wasm/src/host_functions.rs` | both test factories built `GuestState` directly; duplicate `#[tokio::test] async fn test_fs_read_traversal_rejected_before_capability_check` (E0428 — defined at lines 1214 and 1304) | both factories now go through `GuestState::for_test`; removed the older duplicate (kept the one paired with `test_fs_write_traversal_rejected_before_capability_check`) |
| `librefang-runtime-mcp/src/lib.rs` | rmcp upgrade made `client.close()` return `Result<QuitReason, JoinError>` instead of `Result<(), JoinError>`; both close paths added in #4052 still pattern-matched `Ok(Ok(()))` | matched `Ok(Ok(_reason))` instead — the value is informational and we already log success implicitly |
| `librefang-kernel/src/approval.rs` | `record_totp_failure -> Result<(), ()>` triggered `clippy::result_unit_err` | added local `#[allow(clippy::result_unit_err)]` — the unit-err shape is the documented fail-secure contract for #3372 / #3584, not a typing oversight |

## Test plan

- [x] `cargo xtask dev` (locally) — daemon boots cleanly off this branch
- [ ] `cargo build --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] TUI smoke test with `api_key` set in `config.toml`: enter chat, send a message, run `/agents`, open the model picker — all four paths must hit a 200 (not 401)