### PR TITLE
fix(dashboard): stop polling protected endpoints before login

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -605,6 +605,24 @@ export function App() {
     },
   ]; }, [t, terminalEnabled]);
 
+  // Until auth is confirmed, do NOT mount the shell — `<Outlet />` and
+  // `<NotificationCenter />` both fire `useDashboardSnapshot` /
+  // `useApprovalCount` (5s refetchInterval) the moment they render.
+  // Those endpoints sit behind the auth gate, so polling them before the
+  // user logs in (or after a token expiry) produces an endless 401 storm
+  // in server logs.  Render only the AuthDialog here, then fall through
+  // to the full layout once authentication is established.
+  if (!isNoAuthRoute && authChecked && authNeeded) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-main text-slate-900 dark:text-slate-100">
+        <AuthDialog
+          mode={authMode}
+          onAuthenticated={() => { setAuthNeeded(false); window.location.hash = "#/overview"; }}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-screen flex-col bg-main text-slate-900 dark:text-slate-100 lg:flex-row transition-colors duration-300 overflow-hidden">
       <a
@@ -860,9 +878,6 @@ export function App() {
       <CommandPalette isOpen={isPaletteOpen} onClose={() => setPaletteOpen(false)} />
       <ShortcutsHelp isOpen={showShortcuts} onClose={() => setShowShortcuts(false)} />
       {showChangePassword && <ChangePasswordModal onClose={() => setShowChangePassword(false)} />}
-      {authChecked && authNeeded && !isNoAuthRoute && (
-        <AuthDialog mode={authMode} onAuthenticated={() => { setAuthNeeded(false); window.location.hash = "#/overview"; }} />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Symptom

After enabling auth (api_key or dashboard credentials), server logs fill with this every few seconds, indefinitely:

```
INFO API request method=GET path=/api/dashboard/snapshot status=401 latency_ms=2
INFO API request method=GET path=/api/approvals/count status=401 latency_ms=2
INFO API request method=GET path=/api/dashboard/snapshot status=401 latency_ms=3
INFO API request method=GET path=/api/approvals/count status=401 latency_ms=1
...
```

## Root cause

`crates/librefang-api/dashboard/src/App.tsx` renders the AuthDialog as a *modal layered on top* of the full layout. The header keeps `<NotificationCenter />` mounted and `<main>` keeps `<Outlet />` mounted at all times.

- `NotificationCenter` calls `useApprovalCount({ refetchInterval: 5000 })` (no `enabled` guard) — polls `/api/approvals/count`.
- Every page rendered through `<Outlet />` (e.g. `OverviewPage`) calls `useDashboardSnapshot()` with `refetchInterval: 5000` (no `enabled` guard) — polls `/api/dashboard/snapshot`.

Neither endpoint is in the public allowlist when auth is configured (`/api/dashboard/snapshot` is never public; `/api/approvals/count` becomes private once `require_auth_for_reads` is on). So before the user logs in, or after a token expiry:

1. Components mount → React Query fires the request → server returns 401.
2. `parseError` calls `_onUnauthorized` once and sets `_unauthorizedFired=true`, so subsequent 401s do not re-trigger the dialog logic.
3. React Query's `refetchInterval` keeps firing every 5s — the requests still go out, the server still rejects them, the log keeps growing.

## Fix

When `authChecked && authNeeded && !isNoAuthRoute`, return early from `App` and render only the AuthDialog inside a minimal centered container. The full shell (sidebar, header with `NotificationCenter`, main with `Outlet`) does not mount until authentication succeeds, so no polling hook is alive to fire requests.

After `setAuthNeeded(false)` the full layout mounts. The token is already in `sessionStorage`, so the first request from each query is authenticated. The `/connect` mobile pairing route already had its own bypass via `NO_AUTH_ROUTES` and is unaffected.

Token-expiry path is preserved: the global `_onUnauthorized` callback sets `authNeeded=true`, the next render unmounts the shell, React Query observers detach, and the refetchInterval stops — no more 401 spam.

## Test plan

- [ ] Boot daemon with dashboard credentials configured, open `/` in a fresh tab. Confirm AuthDialog renders and server log stays quiet (no `/api/dashboard/snapshot` or `/api/approvals/count` 401s).
- [ ] Log in. Confirm Overview page loads, NotificationCenter badge updates, and snapshot refresh works on the 5s cadence.
- [ ] Open dev tools, manually delete the `librefang-api-key` from sessionStorage, wait for the next 5s tick. Confirm AuthDialog re-appears and polling stops (server log no longer shows 401s for those paths).
- [ ] Visit `/connect` directly without a token — confirm the pairing wizard still loads (NO_AUTH_ROUTES bypass intact).