### PR TITLE
fix(cli): repair daemon-token shadowing in spawn_save_provider_key

### DIFF
--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -2096,8 +2096,11 @@ pub fn spawn_save_provider_key(
     tx: mpsc::Sender<AppEvent>,
 ) {
     std::thread::spawn(move || match backend {
-        BackendRef::Daemon { base_url, api_key } => {
-            let client = make_daemon_client(api_key.as_deref());
+        BackendRef::Daemon {
+            base_url,
+            api_key: daemon_api_key,
+        } => {
+            let client = make_daemon_client(daemon_api_key.as_deref());
             match client
                 .post(format!("{base_url}/api/providers/{name}/key"))
                 .json(&serde_json::json!({"key": api_key}))


### PR DESCRIPTION
## Summary

Follow-up to #4076. The unused-variable warning surfaced once main built clean; investigating revealed it was a real value swap, not just a lint nit.

`spawn_save_provider_key` takes `api_key: String` (the **provider** key the user wants to save) but immediately shadows it inside the match arm:

```rust
pub fn spawn_save_provider_key(backend: BackendRef, name: String, api_key: String, tx: ...) {
    std::thread::spawn(move || match backend {
        BackendRef::Daemon { base_url, api_key } => {           // ← shadows outer api_key
            let client = make_daemon_client(api_key.as_deref());
            match client
                .post(format!("{base_url}/api/providers/{name}/key"))
                .json(&serde_json::json!({"key": api_key}))     // ← daemon bearer token, NOT user's key
                .send()
```

Effect: every "save provider key" action from the TUI silently POSTed the daemon's bearer token to `/api/providers/{name}/key` instead of the user-typed provider key. The vault row would store the wrong value and the provider would never authenticate. The compiler's `unused variable: api_key` was the symptom; the value swap is the bug.

## Fix

Rebind the destructure as `daemon_api_key` so the outer `api_key` parameter stays in scope for the JSON body:

```rust
BackendRef::Daemon {
    base_url,
    api_key: daemon_api_key,
} => {
    let client = make_daemon_client(daemon_api_key.as_deref());
    ...
    .json(&serde_json::json!({"key": api_key}))
```

The other `spawn_save_*` / `spawn_delete_*` helpers don't take an extra string parameter, so they have no shadowing risk — only this one site needed the fix.

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] TUI smoke test: open Settings → Providers, paste an OpenAI key, save, then `librefang vault get openai_api_key` (or equivalent) — must equal what was typed, not the daemon bearer token