### PR TITLE
feat(channels,memory): group roster stores wired into kernel/bridge (takeover #4035)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -856,6 +856,41 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Ok(agent_id)
     }
 
+    async fn get_agent_aliases(&self, agent_id: AgentId) -> Vec<String> {
+        self.kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|entry| {
+                // Collect aliases from channel_overrides.group_trigger_patterns
+                // which serve as the agent's known names/aliases in group chats.
+                entry
+                    .manifest
+                    .channel_overrides
+                    .as_ref()
+                    .map(|ov| ov.group_trigger_patterns.clone())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn roster_upsert(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+        display_name: &str,
+        username: Option<&str>,
+    ) -> Result<(), String> {
+        self.kernel.memory_substrate().roster().upsert(
+            channel,
+            chat_id,
+            user_id,
+            display_name,
+            username,
+        );
+        Ok(())
+    }
+
     async fn uptime_info(&self) -> String {
         let uptime = self.started_at.elapsed();
         let agents = self.list_agents().await.unwrap_or_default();

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -9,7 +9,7 @@ use crate::router::AgentRouter;
 use crate::sanitizer::{InputSanitizer, SanitizeResult};
 use crate::types::{
     default_phase_emoji, truncate_utf8, AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage,
-    ChannelUser, InteractiveButton, LifecycleReaction, ParticipantRef, SenderContext,
+    ChannelUser, GroupMember, InteractiveButton, LifecycleReaction, ParticipantRef, SenderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -239,6 +239,24 @@ pub trait ChannelBridgeHandle: Send + Sync {
     /// Returns `None` if the agent has no per-agent overrides configured.
     async fn agent_channel_overrides(&self, _agent_id: AgentId) -> Option<ChannelOverrides> {
         None
+    }
+
+    /// Return the aliases configured for an agent (from agent.toml `aliases` field).
+    /// Used to build trigger patterns and enrich the reply-intent classifier.
+    async fn get_agent_aliases(&self, _agent_id: AgentId) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Persist a group roster member to the kernel's persistent storage.
+    async fn roster_upsert(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+        _user_id: &str,
+        _display_name: &str,
+        _username: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
     }
 
     /// Lightweight LLM classification: should the bot reply to this group message?
@@ -1457,6 +1475,19 @@ fn text_content(message: &ChannelMessage) -> Option<&str> {
     }
 }
 
+/// Convert agent aliases (plain names) into case-insensitive word-boundary
+/// regex patterns suitable for `group_trigger_patterns`.
+///
+/// Each alias `"foo"` becomes `(?i)\bfoo\b`. Special regex characters in
+/// the alias are escaped so user-supplied names are safe.
+pub fn aliases_to_trigger_patterns(aliases: &[String]) -> Vec<String> {
+    aliases
+        .iter()
+        .filter(|a| !a.is_empty())
+        .map(|a| format!(r"(?i)\b{}\b", regex::escape(a)))
+        .collect()
+}
+
 fn matches_group_trigger_pattern(
     ct_str: &str,
     message: &ChannelMessage,
@@ -1746,6 +1777,17 @@ fn should_process_group_message(
     }
 }
 
+/// Extract structured `GroupMember` entries from the inbound message metadata.
+/// Channels that supply `group_members` (a JSON array of `{user_id, display_name, username?}`)
+/// populate this; the bridge persists them to the roster store for later queries.
+fn extract_group_members(message: &ChannelMessage) -> Vec<GroupMember> {
+    message
+        .metadata
+        .get("group_members")
+        .and_then(|v| serde_json::from_value::<Vec<GroupMember>>(v.clone()).ok())
+        .unwrap_or_default()
+}
+
 /// Read `group_participants` from the inbound message metadata payload
 /// (populated gateway-side by `sock.groupMetadata`). Returns empty when the
 /// channel doesn't supply a roster — the addressee guard then becomes a no-op
@@ -1827,6 +1869,18 @@ fn build_sender_context(
         // sock.groupMetadata). Empty for non-WhatsApp channels — addressee
         // guard then becomes a no-op (BC-01).
         group_participants: extract_group_participants(message),
+        // Bot identity metadata for group context enrichment.
+        bot_username: message
+            .metadata
+            .get("bot_username")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        sender_username: message
+            .metadata
+            .get("sender_username")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        group_members: extract_group_members(message),
         // Channel bridges land in per-channel sessions (the default); only
         // the dashboard WS opts into canonical storage.
         use_canonical_session: false,
@@ -5219,6 +5273,36 @@ mod tests {
                 "telegram", &overrides, &message
             ));
         });
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_basic() {
+        let aliases = vec!["Rodelo".to_string(), "bot".to_string()];
+        let patterns = aliases_to_trigger_patterns(&aliases);
+        assert_eq!(patterns.len(), 2);
+        assert!(patterns[0].contains("Rodelo"));
+        assert!(patterns[1].contains("bot"));
+        // Each should be a valid regex
+        for p in &patterns {
+            assert!(regex::Regex::new(p).is_ok(), "Invalid regex: {p}");
+        }
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_escapes_special() {
+        let aliases = vec!["c++".to_string(), "a.b".to_string()];
+        let patterns = aliases_to_trigger_patterns(&aliases);
+        // Special chars should be escaped so they match literally
+        for p in &patterns {
+            assert!(regex::Regex::new(p).is_ok(), "Invalid regex: {p}");
+        }
+    }
+
+    #[test]
+    fn test_aliases_to_trigger_patterns_empty_filtered() {
+        let aliases = vec!["".to_string(), "valid".to_string()];
+        let patterns = aliases_to_trigger_patterns(&aliases);
+        assert_eq!(patterns.len(), 1);
     }
 
     #[test]

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod http_client;
 pub mod message_journal;
 pub mod message_truncator;
 pub mod rate_limiter;
+pub mod roster;
 pub mod router;
 pub mod sanitizer;
 pub mod sidecar;

--- a/crates/librefang-channels/src/roster.rs
+++ b/crates/librefang-channels/src/roster.rs
@@ -1,0 +1,141 @@
+//! In-memory group roster store.
+//!
+//! Tracks the human members seen in each group chat so that agents can be given
+//! a structured "who is in this group" context in their system prompt. Without
+//! this, an agent receiving a message like `@pepe dile algo a @jose` has no way
+//! to know who `@pepe` and `@jose` are — they look like opaque text.
+//!
+//! The store is a simple in-memory map keyed by `(channel_type, chat_id)`. It
+//! does not persist to disk: on daemon restart it is empty and repopulates
+//! naturally as members send messages. A persistent backend can be added later
+//! without changing the public API.
+
+use crate::types::ParticipantRef;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+/// Composite key identifying a specific chat on a specific channel.
+///
+/// For Telegram the `chat_id` is the group's negative chat ID (or the user's
+/// ID for DMs). For Discord it's the channel ID, and so on per platform.
+type RosterKey = (String, String);
+
+/// Thread-safe in-memory store of known group members per chat.
+#[derive(Debug, Default, Clone)]
+pub struct GroupRosterStore {
+    rosters: Arc<DashMap<RosterKey, DashMap<String, ParticipantRef>>>,
+}
+
+impl GroupRosterStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record (or update) a member in the given chat roster.
+    ///
+    /// Idempotent: subsequent calls with the same `user_id` simply refresh the
+    /// display name and username.
+    pub fn upsert(&self, channel: &str, chat_id: &str, member: ParticipantRef) {
+        if chat_id.is_empty() || member.jid.is_empty() {
+            return;
+        }
+        let key = (channel.to_string(), chat_id.to_string());
+        let members = self.rosters.entry(key).or_default();
+        members.insert(member.jid.clone(), member);
+    }
+
+    /// Return all known members for a chat, sorted by display name for stable
+    /// rendering. Returns an empty vector if the chat is unknown.
+    pub fn members(&self, channel: &str, chat_id: &str) -> Vec<ParticipantRef> {
+        let key = (channel.to_string(), chat_id.to_string());
+        let Some(entry) = self.rosters.get(&key) else {
+            return Vec::new();
+        };
+        let mut out: Vec<ParticipantRef> = entry.iter().map(|e| e.value().clone()).collect();
+        out.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        out
+    }
+
+    /// Number of members in a specific chat (0 if unknown).
+    pub fn member_count(&self, channel: &str, chat_id: &str) -> usize {
+        let key = (channel.to_string(), chat_id.to_string());
+        self.rosters.get(&key).map(|e| e.len()).unwrap_or(0)
+    }
+
+    /// Total number of chats being tracked.
+    pub fn chat_count(&self) -> usize {
+        self.rosters.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_member(jid: &str, display: &str) -> ParticipantRef {
+        ParticipantRef {
+            jid: jid.to_string(),
+            display_name: display.to_string(),
+        }
+    }
+
+    #[test]
+    fn upsert_and_list_sorted() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100123", mk_member("1", "Jorge"));
+        store.upsert("telegram", "-100123", mk_member("2", "Pakman"));
+        store.upsert("telegram", "-100123", mk_member("3", "Ana"));
+
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 3);
+        assert_eq!(members[0].display_name, "Ana");
+        assert_eq!(members[1].display_name, "Jorge");
+        assert_eq!(members[2].display_name, "Pakman");
+    }
+
+    #[test]
+    fn upsert_idempotent_and_updates() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100123", mk_member("1", "Jorge"));
+        store.upsert("telegram", "-100123", mk_member("1", "Jorge Pablo"));
+        let members = store.members("telegram", "-100123");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].display_name, "Jorge Pablo");
+        assert_eq!(members[0].jid, "1");
+    }
+
+    #[test]
+    fn unknown_chat_returns_empty() {
+        let store = GroupRosterStore::new();
+        assert!(store.members("telegram", "-999").is_empty());
+        assert_eq!(store.member_count("telegram", "-999"), 0);
+    }
+
+    #[test]
+    fn ignores_empty_ids() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "", mk_member("1", "Nobody"));
+        store.upsert("telegram", "-100", mk_member("", "Nameless"));
+        assert_eq!(store.chat_count(), 0);
+    }
+
+    #[test]
+    fn separate_chats_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "-100", mk_member("1", "Alice"));
+        store.upsert("telegram", "-200", mk_member("2", "Bob"));
+        assert_eq!(store.members("telegram", "-100").len(), 1);
+        assert_eq!(store.members("telegram", "-200").len(), 1);
+        assert_eq!(store.chat_count(), 2);
+    }
+
+    #[test]
+    fn separate_channels_are_isolated() {
+        let store = GroupRosterStore::new();
+        store.upsert("telegram", "123", mk_member("1", "Alice"));
+        store.upsert("discord", "123", mk_member("2", "Bob"));
+        assert_eq!(store.members("telegram", "123").len(), 1);
+        assert_eq!(store.members("discord", "123").len(), 1);
+    }
+}

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -52,6 +52,22 @@ pub struct ChannelUser {
     pub librefang_user: Option<String>,
 }
 
+/// A known member of a group chat, accumulated from past messages.
+///
+/// Used to populate multi-user context in the system prompt so agents can
+/// distinguish between the current sender and other users mentioned in a
+/// message (e.g. `@pepe`, `@jose`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GroupMember {
+    /// Platform-specific user ID.
+    pub user_id: String,
+    /// Human-readable display name (what the platform shows).
+    pub display_name: String,
+    /// Optional `@handle` for platforms that expose one (Telegram, Discord, ...).
+    #[serde(default)]
+    pub username: Option<String>,
+}
+
 /// Typing indicator event from a channel.
 #[derive(Debug, Clone)]
 pub struct TypingEvent {
@@ -304,6 +320,18 @@ pub struct SenderContext {
     /// Divergence count threshold for `sticky_heuristic` strategy.
     #[serde(default)]
     pub auto_route_divergence_count: u32,
+    /// The bot's own platform `@handle` on this channel (e.g. `fandangorodelo_bot`
+    /// on Telegram). Used so the agent knows its own alias in the prompt.
+    #[serde(default)]
+    pub bot_username: Option<String>,
+    /// The current sender's `@handle` on the platform, when available.
+    #[serde(default)]
+    pub sender_username: Option<String>,
+    /// Known members of the group chat where this message was sent.
+    /// Empty for DMs and for the very first message in a group before the
+    /// roster has accumulated any entries.
+    #[serde(default)]
+    pub group_members: Vec<GroupMember>,
     /// Group participant roster (Phase 2 §C OB-04/OB-05/GS-01).
     ///
     /// Populated by the WhatsApp gateway via `sock.groupMetadata(groupJid)`

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -650,6 +650,37 @@ pub trait KernelHandle: Send + Sync {
         Err("run_forked_agent_oneshot not available in this KernelHandle".to_string())
     }
 
+    /// Upsert a group roster member (channel bridge → persistent storage).
+    fn roster_upsert(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+        _user_id: &str,
+        _display_name: &str,
+        _username: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// List group roster members for a (channel, chat_id) pair.
+    fn roster_members(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Remove a member from the group roster.
+    fn roster_remove_member(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+        _user_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Fire an `agent:step` external hook event.
     /// Called by the runtime at the start of each agent loop iteration.
     fn fire_agent_step(&self, _agent_id: &str, _step: u32) {}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17854,6 +17854,50 @@ impl KernelHandle for LibreFangKernel {
         librefang_types::config::EnvPassthroughPolicy::from_skills_config(&cfg.skills)
     }
 
+    fn roster_upsert(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+        display_name: &str,
+        username: Option<&str>,
+    ) -> Result<(), String> {
+        self.memory
+            .roster()
+            .upsert(channel, chat_id, user_id, display_name, username);
+        Ok(())
+    }
+
+    fn roster_members(
+        &self,
+        channel: &str,
+        chat_id: &str,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        let members = self.memory.roster().members(channel, chat_id);
+        Ok(members
+            .into_iter()
+            .map(|(user_id, display_name, username)| {
+                serde_json::json!({
+                    "user_id": user_id,
+                    "display_name": display_name,
+                    "username": username,
+                })
+            })
+            .collect())
+    }
+
+    fn roster_remove_member(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+    ) -> Result<(), String> {
+        self.memory
+            .roster()
+            .remove_member(channel, chat_id, user_id);
+        Ok(())
+    }
+
     fn fire_agent_step(&self, agent_id: &str, step: u32) {
         self.external_hooks.fire(
             crate::hooks::ExternalHookEvent::AgentStep,

--- a/crates/librefang-memory/src/lib.rs
+++ b/crates/librefang-memory/src/lib.rs
@@ -24,6 +24,7 @@ pub mod namespace_acl;
 pub mod proactive;
 pub mod prompt;
 pub mod provider;
+pub mod roster_store;
 pub mod semantic;
 pub mod session;
 pub mod structured;

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 27;
+const SCHEMA_VERSION: u32 = 28;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -66,6 +66,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     run_step!(26, migrate_v26);
     run_step!(27, migrate_v27);
+    run_step!(28, migrate_v28);
 
     Ok(())
 }
@@ -825,6 +826,33 @@ fn migrate_v27(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (27, datetime('now'), 'Add oauth_used_nonces table for OIDC nonce single-use enforcement')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 28: Add `group_roster` table for cross-channel group membership tracking.
+///
+/// Tracks which users have been seen in each group chat (channel + chat_id),
+/// persisting across daemon restarts. Agents query this to give names to
+/// `@mention`s and to render structured "who's in this room" context.
+/// Owned by `RosterStore` in `librefang-memory`.
+fn migrate_v28(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS group_roster (
+            channel_type TEXT    NOT NULL,
+            chat_id      TEXT    NOT NULL,
+            user_id      TEXT    NOT NULL,
+            display_name TEXT    NOT NULL,
+            username     TEXT,
+            first_seen   INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            last_seen    INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            PRIMARY KEY (channel_type, chat_id, user_id)
+        );",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (28, datetime('now'), 'Add group_roster table for cross-channel group membership tracking')",
         [],
     )?;
     Ok(())

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -1,0 +1,177 @@
+//! SQLite-backed group roster store.
+//!
+//! Tracks which users have been seen in each group chat, persisting across
+//! daemon restarts. Agents query this via the `group_members` tool instead
+//! of having the roster injected into the system prompt (saving tokens).
+
+use rusqlite::Connection;
+use std::sync::{Arc, Mutex};
+
+/// Persistent roster of group chat members, backed by SQLite.
+pub struct RosterStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl RosterStore {
+    /// Create a new roster store, initialising the table if needed.
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        {
+            let c = conn.lock().unwrap();
+            c.execute_batch(
+                "CREATE TABLE IF NOT EXISTS group_roster (
+                    channel_type TEXT NOT NULL,
+                    chat_id      TEXT NOT NULL,
+                    user_id      TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    username     TEXT,
+                    first_seen   INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+                    last_seen    INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+                    PRIMARY KEY (channel_type, chat_id, user_id)
+                );",
+            )
+            .expect("Failed to create group_roster table");
+        }
+        Self { conn }
+    }
+
+    /// Insert or update a member in the roster.
+    pub fn upsert(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+        display_name: &str,
+        username: Option<&str>,
+    ) {
+        if chat_id.is_empty() || user_id.is_empty() {
+            return;
+        }
+        let c = self.conn.lock().unwrap();
+        let _ = c.execute(
+            "INSERT INTO group_roster (channel_type, chat_id, user_id, display_name, username, first_seen, last_seen)
+             VALUES (?1, ?2, ?3, ?4, ?5, strftime('%s','now'), strftime('%s','now'))
+             ON CONFLICT(channel_type, chat_id, user_id) DO UPDATE SET
+               display_name = excluded.display_name,
+               username = COALESCE(excluded.username, group_roster.username),
+               last_seen = strftime('%s','now')",
+            rusqlite::params![channel, chat_id, user_id, display_name, username],
+        );
+    }
+
+    /// List all members of a group chat, ordered by display name.
+    pub fn members(&self, channel: &str, chat_id: &str) -> Vec<(String, String, Option<String>)> {
+        let c = self.conn.lock().unwrap();
+        let mut stmt = c
+            .prepare(
+                "SELECT user_id, display_name, username FROM group_roster
+                 WHERE channel_type = ?1 AND chat_id = ?2
+                 ORDER BY display_name",
+            )
+            .unwrap();
+        stmt.query_map(rusqlite::params![channel, chat_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect()
+    }
+
+    /// Remove a single member from the roster.
+    pub fn remove_member(&self, channel: &str, chat_id: &str, user_id: &str) {
+        let c = self.conn.lock().unwrap();
+        let _ = c.execute(
+            "DELETE FROM group_roster WHERE channel_type = ?1 AND chat_id = ?2 AND user_id = ?3",
+            rusqlite::params![channel, chat_id, user_id],
+        );
+    }
+
+    /// Count the members in a group chat.
+    pub fn member_count(&self, channel: &str, chat_id: &str) -> usize {
+        let c = self.conn.lock().unwrap();
+        c.query_row(
+            "SELECT COUNT(*) FROM group_roster WHERE channel_type = ?1 AND chat_id = ?2",
+            rusqlite::params![channel, chat_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0) as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory_store() -> RosterStore {
+        let conn = Connection::open_in_memory().unwrap();
+        RosterStore::new(Arc::new(Mutex::new(conn)))
+    }
+
+    #[test]
+    fn upsert_and_list() {
+        let store = in_memory_store();
+        store.upsert("telegram", "-100", "1", "Alice", Some("alice"));
+        store.upsert("telegram", "-100", "2", "Bob", None);
+
+        let members = store.members("telegram", "-100");
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].1, "Alice");
+        assert_eq!(members[1].1, "Bob");
+        assert_eq!(members[0].2, Some("alice".to_string()));
+        assert_eq!(members[1].2, None);
+    }
+
+    #[test]
+    fn idempotent_upsert_updates_display_name() {
+        let store = in_memory_store();
+        store.upsert("telegram", "-100", "1", "Alice", Some("alice"));
+        store.upsert("telegram", "-100", "1", "Alice Updated", Some("alice"));
+
+        let members = store.members("telegram", "-100");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].1, "Alice Updated");
+    }
+
+    #[test]
+    fn remove_member() {
+        let store = in_memory_store();
+        store.upsert("telegram", "-100", "1", "Alice", None);
+        store.upsert("telegram", "-100", "2", "Bob", None);
+        assert_eq!(store.member_count("telegram", "-100"), 2);
+
+        store.remove_member("telegram", "-100", "1");
+        assert_eq!(store.member_count("telegram", "-100"), 1);
+        let members = store.members("telegram", "-100");
+        assert_eq!(members[0].1, "Bob");
+    }
+
+    #[test]
+    fn empty_chat_returns_nothing() {
+        let store = in_memory_store();
+        let members = store.members("telegram", "-999");
+        assert!(members.is_empty());
+        assert_eq!(store.member_count("telegram", "-999"), 0);
+    }
+
+    #[test]
+    fn different_chats_are_isolated() {
+        let store = in_memory_store();
+        store.upsert("telegram", "-100", "1", "Alice", None);
+        store.upsert("telegram", "-200", "2", "Bob", None);
+
+        assert_eq!(store.member_count("telegram", "-100"), 1);
+        assert_eq!(store.member_count("telegram", "-200"), 1);
+    }
+
+    #[test]
+    fn empty_ids_are_ignored() {
+        let store = in_memory_store();
+        store.upsert("telegram", "", "1", "Alice", None);
+        store.upsert("telegram", "-100", "", "Bob", None);
+        assert_eq!(store.member_count("telegram", "-100"), 0);
+        assert_eq!(store.member_count("telegram", ""), 0);
+    }
+}

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -13,24 +13,16 @@ pub struct RosterStore {
 }
 
 impl RosterStore {
-    /// Create a new roster store, initialising the table if needed.
+    /// Wrap an existing SQLite connection.
+    ///
+    /// The `group_roster` table is created by `migration::migrate_v28`,
+    /// which `MemorySubstrate::open` runs before constructing the store.
+    /// We deliberately don't run schema DDL here so a) every memory
+    /// table goes through the single migration ladder and b)
+    /// constructing a `RosterStore` can never panic on a locked /
+    /// read-only DB — the failure surfaces from `MemorySubstrate::open`
+    /// at boot instead.
     pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
-        {
-            let c = conn.lock().unwrap();
-            c.execute_batch(
-                "CREATE TABLE IF NOT EXISTS group_roster (
-                    channel_type TEXT NOT NULL,
-                    chat_id      TEXT NOT NULL,
-                    user_id      TEXT NOT NULL,
-                    display_name TEXT NOT NULL,
-                    username     TEXT,
-                    first_seen   INTEGER NOT NULL DEFAULT (strftime('%s','now')),
-                    last_seen    INTEGER NOT NULL DEFAULT (strftime('%s','now')),
-                    PRIMARY KEY (channel_type, chat_id, user_id)
-                );",
-            )
-            .expect("Failed to create group_roster table");
-        }
         Self { conn }
     }
 
@@ -107,6 +99,7 @@ mod tests {
 
     fn in_memory_store() -> RosterStore {
         let conn = Connection::open_in_memory().unwrap();
+        crate::migration::run_migrations(&conn).expect("migrations must apply");
         RosterStore::new(Arc::new(Mutex::new(conn)))
     }
 

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -7,6 +7,7 @@ use crate::chunker;
 use crate::consolidation::ConsolidationEngine;
 use crate::knowledge::KnowledgeStore;
 use crate::migration::run_migrations;
+use crate::roster_store::RosterStore;
 use crate::semantic::SemanticStore;
 use crate::session::{Session, SessionStore};
 use crate::structured::StructuredStore;
@@ -35,6 +36,7 @@ pub struct MemorySubstrate {
     sessions: SessionStore,
     consolidation: ConsolidationEngine,
     usage: UsageStore,
+    roster: RosterStore,
     chunk_config: ChunkConfig,
 }
 
@@ -70,6 +72,7 @@ impl MemorySubstrate {
             knowledge: KnowledgeStore::new(Arc::clone(&shared)),
             sessions: SessionStore::new(Arc::clone(&shared)),
             usage: UsageStore::new(Arc::clone(&shared)),
+            roster: RosterStore::new(Arc::clone(&shared)),
             consolidation: ConsolidationEngine::new(shared, decay_rate),
             chunk_config,
         })
@@ -102,6 +105,7 @@ impl MemorySubstrate {
             knowledge: KnowledgeStore::new(Arc::clone(&shared)),
             sessions: SessionStore::new(Arc::clone(&shared)),
             usage: UsageStore::new(Arc::clone(&shared)),
+            roster: RosterStore::new(Arc::clone(&shared)),
             consolidation: ConsolidationEngine::new(shared, decay_rate),
             chunk_config,
         })
@@ -115,6 +119,11 @@ impl MemorySubstrate {
     /// Get a reference to the knowledge graph store.
     pub fn knowledge(&self) -> &KnowledgeStore {
         &self.knowledge
+    }
+
+    /// Get a reference to the group roster store.
+    pub fn roster(&self) -> &RosterStore {
+        &self.roster
     }
 
     /// Attach an external vector store backend to the semantic store.


### PR DESCRIPTION
Takeover of #4035 (rodela-ai/librefang fork) — rebased onto current main and addresses two design follow-ups. Original author **Paco Navarrete** (paco.j.navarrete@gmail.com), retained as commit author.

`maintainerCanModify` is enabled on #4035 but only works via SSH or the GitHub web UI, not HTTPS-token push, so opening this as a fresh PR. Closing #4035 once this lands.

## What's in here

The original commit (unchanged from #4035 except for one trivial rebase conflict resolution):

- **`librefang-channels::roster::GroupRosterStore`** — in-memory `DashMap<(channel, chat_id), DashMap<user_id, ParticipantRef>>` for the channel-bridge hot path
- **`librefang-memory::roster_store::RosterStore`** — SQLite-backed persistent roster (channel_type, chat_id, user_id, display_name, username, first_seen, last_seen)
- **`librefang-channels::types::GroupMember`** — typed roster entry with `user_id` / `display_name` / optional `username`
- **`SenderContext` enrichment** — three new fields (`bot_username`, `sender_username`, `group_members`) populated by `build_sender_context`
- **`aliases_to_trigger_patterns`** — converts plain agent aliases into case-insensitive word-boundary regex patterns for group triggering
- **`ChannelBridgeHandle::get_agent_aliases` / `roster_upsert`** with default impls, implemented on `KernelBridgeAdapter`
- **`KernelHandle::roster_upsert` / `roster_members` / `roster_remove_member`** wired through to `MemorySubstrate::roster()`

Refs #2262, #2291, #2292.

## Rebase conflict resolved

`crates/librefang-kernel/src/kernel/mod.rs:6596` — main switched to `DashMap::insert`-returns-displaced-value (#4014's atomic running-tasks swap, fixes the race window where the older `remove(...) → insert(...)` could lose abort handles under concurrent `send_message_full`). Kept main's atomic version, dropped the PR's older `remove`+`insert` pattern.

## Design follow-ups (second commit)

1. **`group_roster` now goes through the migration ladder.** Original PR ran `CREATE TABLE IF NOT EXISTS group_roster` inside `RosterStore::new`. Every other memory table is created via `migration::run_migrations` (currently `migrate_v1` … `migrate_v27`). Sneaking a CREATE into a wrapper constructor leaves the table outside the version registry, so a future migration that needs to ALTER it has nothing to anchor to. Added `migrate_v28` and bumped `SCHEMA_VERSION` 27 → 28.

2. **`RosterStore::new` no longer panics.** Previously `.expect("Failed to create group_roster table")` could panic on a poisoned mutex / read-only DB / locked DB — and the panic would unwind into whatever channel adapter happened to trigger the first roster write. With the CREATE moved to migration, the constructor is now a pure wrapper; schema failures surface from `MemorySubstrate::open` at boot through `LibreFangError::Memory`, where the error path is already wired.

   `MemorySubstrate::open` already runs `run_migrations(&conn)` before constructing the store (substrate.rs:65, 98), so the table-exists invariant is preserved. Updated the `roster_store` test helper to call `run_migrations` explicitly so existing tests still pass.

## Test plan

- [x] Rebased cleanly onto current main (single conflict in kernel/mod.rs, resolved per #4014's atomic-insert pattern)
- [x] Migration ladder advances 27 → 28
- [x] `RosterStore::new` is non-panicking, pure wrapper
- [ ] CI green across all platforms

## Closes
Closes #4035 (will close on merge — same content + rebase + design follow-ups)