### PR TITLE
fix(channels,api): rename misleading trait method + wire roster_upsert that #4079 left dead

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -856,19 +856,16 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Ok(agent_id)
     }
 
-    async fn get_agent_aliases(&self, agent_id: AgentId) -> Vec<String> {
+    async fn get_agent_group_trigger_patterns(&self, agent_id: AgentId) -> Vec<String> {
         self.kernel
             .agent_registry()
             .get(agent_id)
-            .map(|entry| {
-                // Collect aliases from channel_overrides.group_trigger_patterns
-                // which serve as the agent's known names/aliases in group chats.
+            .and_then(|entry| {
                 entry
                     .manifest
                     .channel_overrides
                     .as_ref()
                     .map(|ov| ov.group_trigger_patterns.clone())
-                    .unwrap_or_default()
             })
             .unwrap_or_default()
     }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -241,9 +241,15 @@ pub trait ChannelBridgeHandle: Send + Sync {
         None
     }
 
-    /// Return the aliases configured for an agent (from agent.toml `aliases` field).
-    /// Used to build trigger patterns and enrich the reply-intent classifier.
-    async fn get_agent_aliases(&self, _agent_id: AgentId) -> Vec<String> {
+    /// Return the agent's `group_trigger_patterns` (already-escaped regex
+    /// patterns), drawn from `manifest.channel_overrides.group_trigger_patterns`.
+    ///
+    /// The previous name `get_agent_aliases` was misleading: callers reading
+    /// "aliases" expected plain names like `"Rodelo"` and would re-escape
+    /// the result — but the `KernelBridgeAdapter` impl returns regex patterns
+    /// like `(?i)\bRodelo\b`, so re-escaping would corrupt them. Renaming
+    /// surfaces the actual return contract.
+    async fn get_agent_group_trigger_patterns(&self, _agent_id: AgentId) -> Vec<String> {
         Vec::new()
     }
 
@@ -1475,19 +1481,6 @@ fn text_content(message: &ChannelMessage) -> Option<&str> {
     }
 }
 
-/// Convert agent aliases (plain names) into case-insensitive word-boundary
-/// regex patterns suitable for `group_trigger_patterns`.
-///
-/// Each alias `"foo"` becomes `(?i)\bfoo\b`. Special regex characters in
-/// the alias are escaped so user-supplied names are safe.
-pub fn aliases_to_trigger_patterns(aliases: &[String]) -> Vec<String> {
-    aliases
-        .iter()
-        .filter(|a| !a.is_empty())
-        .map(|a| format!(r"(?i)\b{}\b", regex::escape(a)))
-        .collect()
-}
-
 fn matches_group_trigger_pattern(
     ct_str: &str,
     message: &ChannelMessage,
@@ -1897,6 +1890,60 @@ fn sender_user_id(message: &ChannelMessage) -> &str {
         .get(SENDER_USER_ID_KEY)
         .and_then(|v| v.as_str())
         .unwrap_or(&message.sender.platform_id)
+}
+
+/// Record this message's sender into the persistent group roster.
+///
+/// #4079 added `RosterStore` and the `roster_upsert` trait method but never
+/// wired it up — `RosterStore` stayed empty for every install. Without a
+/// channel adapter providing a full participant list (which only the
+/// WhatsApp gateway does, via `sock.groupMetadata`), the next-best signal
+/// we have is "this user just spoke", so we accumulate the roster from
+/// the senders we observe over time. DM senders are skipped — there's no
+/// useful "group" to record them under.
+///
+/// We require `metadata[SENDER_USER_ID_KEY]` to be explicitly set so we
+/// don't accidentally store the group's own platform_id (which is what
+/// `message.sender.platform_id` is for group messages — see
+/// `parse_telegram_message`). Adapters that don't yet plumb the sender's
+/// real user id silently no-op here.
+async fn upsert_sender_into_roster(handle: &dyn ChannelBridgeHandle, message: &ChannelMessage) {
+    if !message.is_group {
+        return;
+    }
+    let Some(user_id) = message
+        .metadata
+        .get(SENDER_USER_ID_KEY)
+        .and_then(|v| v.as_str())
+    else {
+        return;
+    };
+    if user_id.is_empty() || message.sender.platform_id.is_empty() {
+        return;
+    }
+    let username = message
+        .metadata
+        .get("sender_username")
+        .and_then(|v| v.as_str());
+    let channel_str = channel_type_str(&message.channel);
+    if let Err(e) = handle
+        .roster_upsert(
+            channel_str,
+            &message.sender.platform_id,
+            user_id,
+            &message.sender.display_name,
+            username,
+        )
+        .await
+    {
+        warn!(
+            channel = channel_str,
+            chat_id = %message.sender.platform_id,
+            user_id = %user_id,
+            error = %e,
+            "roster_upsert failed; group member will not be remembered for this turn"
+        );
+    }
 }
 
 /// Wrap an outbound message with the responding agent's name according to
@@ -3355,6 +3402,10 @@ async fn dispatch_message(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
+    // Accumulate group senders into RosterStore (no-op for DMs / adapters
+    // that don't plumb sender_user_id). See #4079 follow-up.
+    upsert_sender_into_roster(handle, message).await;
+
     // Build sender context to propagate identity to the agent
     let sender_ctx = build_sender_context(message, overrides.as_ref());
 
@@ -4393,6 +4444,10 @@ async fn dispatch_with_blocks(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
+    // Accumulate group senders into RosterStore (no-op for DMs / adapters
+    // that don't plumb sender_user_id). See #4079 follow-up.
+    upsert_sender_into_roster(handle, message).await;
+
     // Build sender context to propagate identity to the agent
     let sender_ctx = build_sender_context(message, overrides);
 
@@ -5273,36 +5328,6 @@ mod tests {
                 "telegram", &overrides, &message
             ));
         });
-    }
-
-    #[test]
-    fn test_aliases_to_trigger_patterns_basic() {
-        let aliases = vec!["Rodelo".to_string(), "bot".to_string()];
-        let patterns = aliases_to_trigger_patterns(&aliases);
-        assert_eq!(patterns.len(), 2);
-        assert!(patterns[0].contains("Rodelo"));
-        assert!(patterns[1].contains("bot"));
-        // Each should be a valid regex
-        for p in &patterns {
-            assert!(regex::Regex::new(p).is_ok(), "Invalid regex: {p}");
-        }
-    }
-
-    #[test]
-    fn test_aliases_to_trigger_patterns_escapes_special() {
-        let aliases = vec!["c++".to_string(), "a.b".to_string()];
-        let patterns = aliases_to_trigger_patterns(&aliases);
-        // Special chars should be escaped so they match literally
-        for p in &patterns {
-            assert!(regex::Regex::new(p).is_ok(), "Invalid regex: {p}");
-        }
-    }
-
-    #[test]
-    fn test_aliases_to_trigger_patterns_empty_filtered() {
-        let aliases = vec!["".to_string(), "valid".to_string()];
-        let patterns = aliases_to_trigger_patterns(&aliases);
-        assert_eq!(patterns.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Post-merge follow-up to #4079. The takeover PR added the interface skeleton + persistent SQLite store + migration ladder entry but left three things that need fixing now (rather than waiting for a separate group-roster wiring PR):

## 1. Rename `get_agent_aliases` → `get_agent_group_trigger_patterns`

The trait method's name said "aliases" (raw plain names like `"Rodelo"`) but the `KernelBridgeAdapter` implementation returns `manifest.channel_overrides.group_trigger_patterns` — already-escaped regex like `(?i)\bRodelo\b`. A future caller reading the name would feed the result through `aliases_to_trigger_patterns(...)` and double-escape the regex into garbage that matches nothing.

The rename surfaces the actual return contract. The implementation also collapsed from `match { Some => Some, None => None }` into `and_then` since both branches reduced to `unwrap_or_default()`.

## 2. Delete `aliases_to_trigger_patterns` (and its 3 unit tests)

The helper had no callers — it lived as a #4079 trait skeleton. The `channel_overrides.group_trigger_patterns` source field is **already** a regex pattern, so this `(?i)\bfoo\b` conversion has no place to live until/unless a separate `aliases` field gets added to the manifest. Re-add the 6-line helper then.

## 3. Actually call `roster_upsert` from the bridge dispatch path

#4079 added the trait method, the `KernelBridgeAdapter` implementation, the `RosterStore` SQLite-backed store, and `migrate_v28` — but never invoked `roster_upsert` from anywhere in the bridge. `RosterStore` was guaranteed empty on every install of every operator on every platform.

New `upsert_sender_into_roster` helper accumulates one row per group sender on every group message. It short-circuits for DMs and for adapters that haven't plumbed `metadata[SENDER_USER_ID_KEY]` (so we never accidentally store the group's own `platform_id` — which is what `message.sender.platform_id` *is* for group messages, e.g. telegram's `parse_telegram_message` sets `sender.platform_id = chat_id.to_string()` for group chats and stuffs the real user id under `SENDER_USER_ID_KEY`). The helper is called at both `build_sender_context` sites (streaming and non-streaming dispatch paths).

`roster_upsert` failures log a warn and continue — a roster miss should never block message handling.

## Still missing (out of scope here)

Channel adapters need to populate three message-metadata keys for the corresponding `SenderContext` fields to be anything other than `None` / empty `Vec`:

- `metadata["bot_username"]` — `SenderContext.bot_username` (#4079:bridge.rs:1873)
- `metadata["sender_username"]` — `SenderContext.sender_username` (#4079:bridge.rs:1878)  
- `metadata["group_members"]` — `SenderContext.group_members` via `extract_group_members` (#4079:bridge.rs:1883)

Each of these needs a per-adapter change (telegram / discord / whatsapp / matrix / etc.) and is best done as a separate PR per adapter. The current followup at least lets `RosterStore` accumulate from observed senders so the persistent layer isn't dead either way.

## Test plan

- [x] `aliases_to_trigger_patterns` removal — 0 callers in tree, 0 doc references after rename
- [x] `get_agent_aliases` → `get_agent_group_trigger_patterns` rename consistent across trait def + impl
- [x] `upsert_sender_into_roster` short-circuits when `is_group=false` or `SENDER_USER_ID_KEY` absent (so no accidental "group is its own member" entries)
- [ ] CI green — workspace build + clippy + test