### PR TITLE
fix(quality): cargo fmt --all to clear accumulated main drift

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2751,10 +2751,8 @@ pub async fn totp_revoke(
             // Don't count toward the lockout — the code itself isn't
             // wrong, it's already-spent.  Return the same 400 shape so
             // the caller can't distinguish "already used" from "wrong".
-            return ApiErrorResponse::bad_request(
-                "TOTP code already used. Wait for a new code.",
-            )
-            .into_json_tuple();
+            return ApiErrorResponse::bad_request("TOTP code already used. Wait for a new code.")
+                .into_json_tuple();
         }
         match state.kernel.vault_get("totp_secret") {
             Some(secret) => {

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -800,10 +800,7 @@ fn save_sessions(
             // the bearer tokens during the gap.  open(mode 0600 +
             // truncate) + write_all + flush + sync_all + rename keeps
             // the file at owner-only mode for its entire lifetime.
-            let tmp_path = path.with_extension(format!(
-                "json.tmp.{}",
-                std::process::id()
-            ));
+            let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
             let result = (|| -> std::io::Result<()> {
                 use std::io::Write as _;
                 let mut opts = std::fs::OpenOptions::new();

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1886,7 +1886,10 @@ fn sender_user_id(message: &ChannelMessage) -> &str {
 }
 
 /// Persists the observed group sender; skips DMs and messages without SENDER_USER_ID_KEY to avoid storing the group's own platform_id.
-async fn upsert_sender_into_roster(handle: &Arc<dyn ChannelBridgeHandle>, message: &ChannelMessage) {
+async fn upsert_sender_into_roster(
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    message: &ChannelMessage,
+) {
     if !message.is_group {
         return;
     }

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -632,9 +632,7 @@ pub fn run() -> InitResult {
                 state.key_test = if ok {
                     if let Some(p) = state.provider() {
                         if !p.env_var.is_empty() {
-                            if let Err(e) =
-                                dotenv::save_env_key(p.env_var, &state.api_key_input)
-                            {
+                            if let Err(e) = dotenv::save_env_key(p.env_var, &state.api_key_input) {
                                 tracing::warn!(
                                     provider = ?p.name,
                                     error = %e,

--- a/crates/librefang-extensions/src/dotenv.rs
+++ b/crates/librefang-extensions/src/dotenv.rs
@@ -230,10 +230,7 @@ fn write_env_file(path: &Path, entries: &BTreeMap<String, String>) -> Result<(),
     //     reader can't grab the key during the open syscall.
     //   * Two concurrent saves no longer share the same staging path
     //     because the tmp filename is uniquified by PID.
-    let tmp_path = path.with_extension(format!(
-        "env.tmp.{}",
-        std::process::id()
-    ));
+    let tmp_path = path.with_extension(format!("env.tmp.{}", std::process::id()));
     let result = (|| -> std::io::Result<()> {
         use std::io::Write as _;
         let mut opts = std::fs::OpenOptions::new();

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -11422,62 +11422,60 @@ system_prompt = "You are a helpful assistant."
                 // the scope inside the spawn so trigger chains
                 // accumulate correctly.
                 let parent_depth = PUBLISH_EVENT_DEPTH.try_with(|c| c.get()).unwrap_or(0);
-                let task = PUBLISH_EVENT_DEPTH.scope(
-                    std::cell::Cell::new(parent_depth),
-                    async move {
-                    // Execute trigger dispatches sequentially to preserve
-                    // the order in which the trigger engine evaluated them.
-                    // Each dispatch still acquires its semaphore permits
-                    // (global trigger-lane + per-agent) before calling
-                    // send_message_full, so back-pressure and concurrency
-                    // caps continue to apply correctly.
-                    for d in dispatches {
-                        let TriggerDispatch {
-                            kernel,
-                            aid,
-                            msg,
-                            mode_override,
-                            session_id_override,
-                            trigger_sem,
-                            agent_sem,
-                        } = d;
-
-                        // (1) Global trigger lane permit.
-                        let _lane_permit = match trigger_sem.acquire_owned().await {
-                            Ok(p) => p,
-                            Err(_) => return, // lane closed during shutdown
-                        };
-                        // (2) Per-agent permit.
-                        let _agent_permit = match agent_sem.acquire_owned().await {
-                            Ok(p) => p,
-                            Err(_) => continue,
-                        };
-                        // (3) Inner per-session mutex applies inside
-                        //     send_message_full when session_id_override is Some.
-                        let handle: Option<Arc<dyn KernelHandle>> = kernel
-                            .self_handle
-                            .get()
-                            .and_then(|w| w.upgrade())
-                            .map(|arc| arc as Arc<dyn KernelHandle>);
-                        let home_channel = kernel.resolve_agent_home_channel(aid);
-                        if let Err(e) = kernel
-                            .send_message_full(
+                let task =
+                    PUBLISH_EVENT_DEPTH.scope(std::cell::Cell::new(parent_depth), async move {
+                        // Execute trigger dispatches sequentially to preserve
+                        // the order in which the trigger engine evaluated them.
+                        // Each dispatch still acquires its semaphore permits
+                        // (global trigger-lane + per-agent) before calling
+                        // send_message_full, so back-pressure and concurrency
+                        // caps continue to apply correctly.
+                        for d in dispatches {
+                            let TriggerDispatch {
+                                kernel,
                                 aid,
-                                &msg,
-                                handle,
-                                None,
-                                home_channel.as_ref(),
+                                msg,
                                 mode_override,
-                                None,
                                 session_id_override,
-                            )
-                            .await
-                        {
-                            warn!(agent = %aid, "Trigger dispatch failed: {e}");
+                                trigger_sem,
+                                agent_sem,
+                            } = d;
+
+                            // (1) Global trigger lane permit.
+                            let _lane_permit = match trigger_sem.acquire_owned().await {
+                                Ok(p) => p,
+                                Err(_) => return, // lane closed during shutdown
+                            };
+                            // (2) Per-agent permit.
+                            let _agent_permit = match agent_sem.acquire_owned().await {
+                                Ok(p) => p,
+                                Err(_) => continue,
+                            };
+                            // (3) Inner per-session mutex applies inside
+                            //     send_message_full when session_id_override is Some.
+                            let handle: Option<Arc<dyn KernelHandle>> = kernel
+                                .self_handle
+                                .get()
+                                .and_then(|w| w.upgrade())
+                                .map(|arc| arc as Arc<dyn KernelHandle>);
+                            let home_channel = kernel.resolve_agent_home_channel(aid);
+                            if let Err(e) = kernel
+                                .send_message_full(
+                                    aid,
+                                    &msg,
+                                    handle,
+                                    None,
+                                    home_channel.as_ref(),
+                                    mode_override,
+                                    None,
+                                    session_id_override,
+                                )
+                                .await
+                            {
+                                warn!(agent = %aid, "Trigger dispatch failed: {e}");
+                            }
                         }
-                    }
-                    },
-                );
+                    });
                 spawn_logged("trigger_dispatch", task);
             }
         }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4116,7 +4116,12 @@ async fn test_push_notification_health_check_failed_falls_back_to_alert_channels
     kernel.channel_adapters.insert("test".to_string(), adapter);
 
     kernel
-        .push_notification("agent-xyz", "health_check_failed", "agent unresponsive", None)
+        .push_notification(
+            "agent-xyz",
+            "health_check_failed",
+            "agent unresponsive",
+            None,
+        )
         .await;
 
     let recorded = sent.lock().unwrap().clone();
@@ -4165,7 +4170,12 @@ async fn test_push_notification_health_check_failed_agent_rule_overrides_alert_c
     kernel.channel_adapters.insert("test".to_string(), adapter);
 
     kernel
-        .push_notification("worker-7", "health_check_failed", "agent unresponsive", None)
+        .push_notification(
+            "worker-7",
+            "health_check_failed",
+            "agent unresponsive",
+            None,
+        )
         .await;
 
     let recorded = sent.lock().unwrap().clone();
@@ -4199,7 +4209,12 @@ async fn test_push_notification_health_check_failed_no_targets_when_unconfigured
     kernel.channel_adapters.insert("test".to_string(), adapter);
 
     kernel
-        .push_notification("agent-xyz", "health_check_failed", "agent unresponsive", None)
+        .push_notification(
+            "agent-xyz",
+            "health_check_failed",
+            "agent unresponsive",
+            None,
+        )
         .await;
 
     assert!(
@@ -4245,7 +4260,12 @@ async fn test_push_notification_unknown_event_type_yields_no_targets() {
     kernel.channel_adapters.insert("test".to_string(), adapter);
 
     kernel
-        .push_notification("agent-xyz", "totally_made_up_event", "should not deliver", None)
+        .push_notification(
+            "agent-xyz",
+            "totally_made_up_event",
+            "should not deliver",
+            None,
+        )
         .await;
 
     assert!(
@@ -4299,9 +4319,8 @@ async fn test_push_notification_appends_session_suffix_when_provided() {
 
     let recorded = sent.lock().unwrap().clone();
     assert_eq!(recorded.len(), 1, "exactly one alert delivered");
-    let expected = format!(
-        "ops:Agent \"x\" exited after 3 consecutive tool failures [session={session_id}]"
-    );
+    let expected =
+        format!("ops:Agent \"x\" exited after 3 consecutive tool failures [session={session_id}]");
     assert_eq!(
         recorded[0], expected,
         "session-scoped alert must include [session=<uuid>] suffix"

--- a/crates/librefang-runtime/src/audit.rs
+++ b/crates/librefang-runtime/src/audit.rs
@@ -635,8 +635,7 @@ impl AuditLog {
             let overflow = entries.len() - MAX_AUDIT_ENTRIES;
             let new_anchor = entries[overflow - 1].hash.clone();
             {
-                let mut anchor =
-                    self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+                let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
                 *anchor = Some(new_anchor);
             }
             entries.drain(..overflow);


### PR DESCRIPTION
Mechanical \`cargo fmt --all\` to clear the Quality job's red across every recent main commit. 8 files drifted across the #4019 → #4082 merge wave.

\`\`\`
crates/librefang-api/src/routes/system.rs              | 6 +-
crates/librefang-api/src/server.rs                     | 5 +-
crates/librefang-channels/src/bridge.rs                | 5 +-
crates/librefang-cli/src/tui/screens/init_wizard.rs    | 4 +-
crates/librefang-extensions/src/dotenv.rs              | 5 +-
crates/librefang-kernel/src/kernel/mod.rs              | 102 ++++++++++-----------
crates/librefang-kernel/src/kernel/tests.rs            | 33 +++++--
crates/librefang-runtime/src/audit.rs                  | 3 +-
\`\`\`

No logic changes — line wraps, closure indents, test argument wraps. Each diff hunk is what \`cargo fmt --all\` produced verbatim.

The Quality job will go green once this lands; it's the same recurring pattern that #4074 / #4076 addressed in earlier waves.