### PR TITLE
fix(mcp,ssrf): strip [ ] brackets from IPv6 host_str before IpAddr parse

### DIFF
--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -222,15 +222,7 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
         return true;
     }
 
-    // `Url::host_str()` returns IPv6 literals WITH `[ ]` brackets per the
-    // url crate docs ("IPv6 addresses are given between [ and ] brackets"),
-    // but `IpAddr::from_str` rejects bracketed forms.  Without stripping,
-    // every IPv6 host falls through to `false` here — that's the exact
-    // SSRF bypass the IPv4-mapped/NAT64/loopback IPv6 tests catch:
-    // `well_known_url("http://[::ffff:7f00:0001]/mcp")` hands us
-    // `[::ffff:7f00:0001]`, parse fails, function says "not blocked", and
-    // the daemon happily fetches OAuth metadata over the V6 socket that
-    // routes to 127.0.0.1.  Strip exactly one matching bracket pair.
+    // `Url::host_str()` returns IPv6 as "[::1]"; strip brackets before IpAddr::from_str rejects them.
     let ip_str = host
         .strip_prefix('[')
         .and_then(|s| s.strip_suffix(']'))

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -222,7 +222,21 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
         return true;
     }
 
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    // `Url::host_str()` returns IPv6 literals WITH `[ ]` brackets per the
+    // url crate docs ("IPv6 addresses are given between [ and ] brackets"),
+    // but `IpAddr::from_str` rejects bracketed forms.  Without stripping,
+    // every IPv6 host falls through to `false` here — that's the exact
+    // SSRF bypass the IPv4-mapped/NAT64/loopback IPv6 tests catch:
+    // `well_known_url("http://[::ffff:7f00:0001]/mcp")` hands us
+    // `[::ffff:7f00:0001]`, parse fails, function says "not blocked", and
+    // the daemon happily fetches OAuth metadata over the V6 socket that
+    // routes to 127.0.0.1.  Strip exactly one matching bracket pair.
+    let ip_str = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = ip_str.parse::<IpAddr>() {
         return match ip {
             IpAddr::V4(v4) => blocked_v4(v4),
             IpAddr::V6(v6) => {


### PR DESCRIPTION
**Real SSRF bypass** that #4019 introduced and its own regression tests caught — but the tests have been red on every Test/{Ubuntu,Windows,macOS} run since #4019 merged, and nobody noticed because main has been red on other things in parallel.

## The bug

\`Url::host_str()\` returns IPv6 literals WITH \`[ ]\` brackets per the url crate's documented contract:

> Returns the string representation of the host (domain or IP address) for this URL, if any. Non-ASCII domains are punycode-encoded per IDNA. **IPv6 addresses are given between [ and ] brackets.**

But \`IpAddr::from_str\` rejects bracketed forms — \`"[::ffff:7f00:0001]".parse::<IpAddr>()\` is \`Err\`. So \`is_ssrf_blocked_host\` saw the \`Err\`, fell through past the IPv6 branch entirely, and returned \`false\` (not blocked).

Net result: **every IPv6 host string passed the SSRF check unconditionally**, including:
- \`http://[::ffff:7f00:0001]/\` → routes to V4 loopback 127.0.0.1
- \`http://[::ffff:a9fe:a9fe]/\` → routes to V4 IMDS 169.254.169.254 (AWS / Azure metadata)
- \`http://[64:ff9b::7f00:1]/\` → NAT64 to V4 loopback
- \`http://[::1]/\`, \`http://[fe80::1]/\`, \`http://[fc00::1]/\` (the IPv6 native blocks)

The daemon would happily fetch OAuth metadata from any of these.

## The fix

Strip exactly one matching \`[\` ... \`]\` bracket pair before \`IpAddr::from_str\`. One-direction strip (only when both prefix AND suffix match) so a malformed host with stray brackets doesn't get silently coerced.

\`\`\`rust
let ip_str = host
    .strip_prefix('[')
    .and_then(|s| s.strip_suffix(']'))
    .unwrap_or(host);
\`\`\`

After this, the existing #4019 tests pass and the SSRF check actually does what its docstring says.

## Why now

This bug has been there since #4019 (~2026-04-28). Every Test job has flagged it. It got mistaken for either a flaky test or "main is broken on something else, will fix later". Today's main repair wave (#4082, #4083, #4084) is clearing the unrelated noise and exposing this one as the actual remaining failure on Test.

## Test plan

- [x] Existing #4019 tests should pass (they assert the exact bypass shapes this fix closes)
- [ ] CI Test (Ubuntu/Windows/macOS) green