### PR TITLE
test(api): lock auth gate on /api/logs/stream + close stale a2a/logs issues

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2075,7 +2075,7 @@ mod tests {
     // ---- Bug #3680: GET /api/logs/stream must require auth even when
     // ---- require_auth_for_reads = false -------------------------------
     //
-    // Before #3939 the SSE endpoint was unconditionally appended to
+    // Before #3909 the SSE endpoint was unconditionally appended to
     // `dashboard_read_public` (`|| path == "/api/logs/stream"`) so any
     // operator who explicitly set `require_auth_for_reads = false` (the
     // documented escape hatch for an external auth proxy) lost auth on

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2072,6 +2072,98 @@ mod tests {
         );
     }
 
+    // ---- Bug #3680: GET /api/logs/stream must require auth even when
+    // ---- require_auth_for_reads = false -------------------------------
+    //
+    // Before #3939 the SSE endpoint was unconditionally appended to
+    // `dashboard_read_public` (`|| path == "/api/logs/stream"`) so any
+    // operator who explicitly set `require_auth_for_reads = false` (the
+    // documented escape hatch for an external auth proxy) lost auth on
+    // the log stream. The stream emits real-time tracing fields that can
+    // contain prompts, OAuth callback codes, MCP stderr, and bearer
+    // prefixes — a continuous credential leak. The fix removed the
+    // path from every public allowlist; this test locks that contract
+    // so a future refactor cannot silently re-introduce it.
+
+    /// GET /api/logs/stream must return 401 when `require_auth_for_reads`
+    /// is OFF — the SSE log stream is sensitive enough that the
+    /// "loosen reads" escape hatch must NOT apply to it.
+    #[tokio::test]
+    async fn logs_stream_requires_auth_even_when_reads_are_loosened() {
+        // Reproduce the deployment posture that exposed the bug:
+        // an api_key is configured, but the operator has opted out of
+        // auth-gating dashboard reads (e.g. fronting with an external
+        // auth proxy). /api/logs/stream MUST still require auth.
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            require_auth_for_reads: false,
+            allow_no_auth: false,
+            audit_log: None,
+        };
+
+        let app = Router::new()
+            .route("/api/logs/stream", get(|| async { "sse stream" }))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        // Simulate a remote (non-loopback) caller so the loopback
+        // short-circuit cannot mask the bug.
+        let addr: std::net::SocketAddr = "203.0.113.5:53000".parse().unwrap();
+        let mut req = Request::builder()
+            .uri("/api/logs/stream")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(addr));
+
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "GET /api/logs/stream must require auth — SSE leaks tracing \
+             fields with prompts, OAuth codes, and bearer prefixes"
+        );
+    }
+
+    /// Sanity check: /api/logs/stream with a valid bearer DOES go through.
+    /// Without this counter-test the regression test above could pass by
+    /// accident (e.g. if the route were globally blocked).
+    #[tokio::test]
+    async fn logs_stream_allows_authenticated_caller() {
+        let auth_state = AuthState {
+            api_key_lock: Arc::new(tokio::sync::RwLock::new("secret".to_string())),
+            active_sessions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            dashboard_auth_enabled: false,
+            user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            require_auth_for_reads: false,
+            allow_no_auth: false,
+            audit_log: None,
+        };
+
+        let app = Router::new()
+            .route("/api/logs/stream", get(|| async { "sse stream" }))
+            .layer(axum::middleware::from_fn_with_state(auth_state, auth));
+
+        let addr: std::net::SocketAddr = "203.0.113.5:53000".parse().unwrap();
+        let mut req = Request::builder()
+            .uri("/api/logs/stream")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(addr));
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid bearer token must allow access to /api/logs/stream"
+        );
+    }
+
     /// Regression: #3367 — GET /api/approvals/session/{id} used to be
     /// publicly readable via the `/api/approvals/` prefix in
     /// `dashboard_read_prefix`. That endpoint returns pending approval


### PR DESCRIPTION
## Summary

The two endpoint-auth holes the title issues describe were fixed weeks ago, but
the PRs that landed the fixes used \`**#3781**\` / \`#3680\` in their bodies
instead of \`Closes #3781\` / \`Closes #3680\`, so GitHub never auto-closed the
issues. They have been sitting open and showing up on the security tracker
ever since. This PR:

1. Adds a regression test for #3680 — there was no test gating
   \`/api/logs/stream\` against the \`require_auth_for_reads = false\`
   deployment posture that originally exposed the SSE log stream. A future
   refactor of \`dashboard_read_public\` could silently re-introduce the leak;
   the new \`logs_stream_requires_auth_even_when_reads_are_loosened\` +
   \`logs_stream_allows_authenticated_caller\` pair locks both directions of
   the contract.
2. Pulls #3781 forward into the closing-issues set — the fix already shipped
   in #3909 (\`middleware.rs:572\`, \`path == "/a2a/agents"\` replacing the
   blanket \`/a2a/\` prefix) and is covered by the existing tests at
   \`middleware.rs:1990\` / \`:2018\` / \`:2047\`.

## What this does NOT do — #3712 punts to follow-up

#3712 asks for a structural fix: declare auth posture inline with the route
in \`server.rs\` (split \`public_router()\` / \`authed_router()\`) so the
compiler — not a hand-maintained string list in \`middleware.rs\` — enforces
that every new endpoint picks a side. That is a 200+ line refactor touching
50+ route declarations across \`server.rs\` and every file under
\`crates/librefang-api/src/routes/\`, and would also need a router
enumeration test to act as the regression gate the issue describes. It does
not belong in a PR scoped to closing two stale security issues — sending it
as a follow-up so the structural change can be reviewed on its own merits.

Closes #3781
Closes #3680

Punts root cause #3712 to follow-up.

## Test plan

- [ ] \`cargo test -p librefang-api middleware::tests::logs_stream\` — both
  new tests pass
- [ ] \`cargo test -p librefang-api middleware::tests::a2a_tasks\` — existing
  #3781 tests still pass (no behaviour change to \`is_public\`)