### PR TITLE
ci: harden release supply chain (sha256, --ignore-scripts, OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -791,22 +791,34 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v'))
     needs: [cli_mac, cli_linux, cli_musl, cli_windows]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC trusted publishing to PyPI
+      contents: read   # actions/checkout (job-level permissions block fully overrides top-level)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
-      - name: Publish CLI binaries to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Build CLI wheels (no upload)
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
+          mkdir -p "${{ runner.temp }}/cli-pypi-dist"
           cargo xtask publish-pypi-binaries \
             --version "$VERSION" \
             --repo "${{ github.repository }}" \
-            --tag "${{ github.ref_name }}"
+            --tag "${{ github.ref_name }}" \
+            --build-only \
+            --dist-dir "${{ runner.temp }}/cli-pypi-dist"
+
+      - name: Publish CLI wheels to PyPI (OIDC)
+        # OIDC trusted publishing — configure at:
+        # pypi.org/manage/project/librefang/settings/publishing
+        # workflow filename: release.yml, environment: (none)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: ${{ runner.temp }}/cli-pypi-dist
+          skip-existing: true
 
   sync_homebrew:
     name: Sync to Homebrew Tap

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -122,15 +122,7 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
     Err(format!("Failed to download {}", url).into())
 }
 
-/// Download and verify the .sha256 checksum file for an asset.
-///
-/// Downloads `{asset_url}.sha256`, parses the expected hash, then computes
-/// sha256 of the already-downloaded `asset_path` and compares. Returns an
-/// error if the download fails or the hashes do not match.
-///
-/// Note: the `.sha256` sidecar lives in the same GitHub Release as the
-/// binary, so this guards against transport corruption / partial downloads,
-/// not against an attacker who has write access to the release assets.
+/// Downloads `{asset}.sha256` from the release and returns an error if the hash does not match.
 fn verify_asset_sha256(
     repo: &str,
     tag: &str,

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -278,8 +278,17 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
         if args.dry_run {
             println!("  [dry-run] Would publish {}@{}", pkg_name, args.version);
         } else {
+            // --ignore-scripts blocks lifecycle hooks (prepublishOnly,
+            // prepack, postpublish) from running during publish, so a
+            // future malicious dep cannot exfiltrate NODE_AUTH_TOKEN.
             let mut cmd = Command::new("npm");
-            cmd.args(["publish", &pkg_dir.to_string_lossy(), "--access", "public"]);
+            cmd.args([
+                "publish",
+                &pkg_dir.to_string_lossy(),
+                "--access",
+                "public",
+                "--ignore-scripts",
+            ]);
             for a in &npm_tag_args {
                 cmd.arg(a);
             }
@@ -339,8 +348,9 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
             }
             fs::write(&pkg_path, serde_json::to_string_pretty(&pkg)? + "\n")?;
 
+            // --ignore-scripts: see comment in per-target publish above.
             let mut cmd = Command::new("npm");
-            cmd.args(["publish", "--access", "public"])
+            cmd.args(["publish", "--access", "public", "--ignore-scripts"])
                 .current_dir(&wrapper_dir);
             for a in &npm_tag_args {
                 cmd.arg(a);

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -348,7 +348,6 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
             }
             fs::write(&pkg_path, serde_json::to_string_pretty(&pkg)? + "\n")?;
 
-            // --ignore-scripts: see comment in per-target publish above.
             let mut cmd = Command::new("npm");
             cmd.args(["publish", "--access", "public", "--ignore-scripts"])
                 .current_dir(&wrapper_dir);

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -123,6 +123,12 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
 }
 
 /// Downloads `{asset}.sha256` from the release and returns an error if the hash does not match.
+///
+/// Note: this only defends against transport corruption / mirror tampering.
+/// The `.sha256` is fetched from the same GitHub Release as the binary, so an
+/// attacker with release-write access can swap both. Real release-write defence
+/// needs OIDC artifact attestations (`actions/attest-build-provenance` +
+/// `gh attestation verify`) — out of scope for this PR.
 fn verify_asset_sha256(
     repo: &str,
     tag: &str,

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -278,9 +278,7 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
         if args.dry_run {
             println!("  [dry-run] Would publish {}@{}", pkg_name, args.version);
         } else {
-            // --ignore-scripts blocks lifecycle hooks (prepublishOnly,
-            // prepack, postpublish) from running during publish, so a
-            // future malicious dep cannot exfiltrate NODE_AUTH_TOKEN.
+            // --ignore-scripts blocks lifecycle hooks so a malicious dep cannot exfiltrate NODE_AUTH_TOKEN.
             let mut cmd = Command::new("npm");
             cmd.args([
                 "publish",

--- a/xtask/src/publish_pypi_binaries.rs
+++ b/xtask/src/publish_pypi_binaries.rs
@@ -20,6 +20,18 @@ pub struct PublishPypiBinariesArgs {
     /// Dry run — show what would be published
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Build wheels only; do not run `twine upload`.
+    /// When set, wheels are written to `--dist-dir` (or a temp dir if unset)
+    /// and the workflow is expected to upload them via OIDC trusted
+    /// publishing (`pypa/gh-action-pypi-publish`).
+    #[arg(long)]
+    pub build_only: bool,
+
+    /// Output directory for built wheels (used with `--build-only`).
+    /// If unset, a temp directory is used.
+    #[arg(long)]
+    pub dist_dir: Option<PathBuf>,
 }
 
 struct PyTarget {
@@ -97,6 +109,50 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
     Err(format!("Failed to download {}", url).into())
 }
 
+/// Download and verify the .sha256 sidecar for an asset.
+///
+/// Mirrors `publish_npm_binaries::verify_asset_sha256`. Fails fast if the
+/// sidecar is missing or the hash mismatches — we refuse to repackage a
+/// binary into a wheel without confirming what the GitHub Release
+/// actually served us.
+fn verify_asset_sha256(
+    repo: &str,
+    tag: &str,
+    asset_name: &str,
+    asset_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sha_url = format!(
+        "https://github.com/{}/releases/download/{}/{}.sha256",
+        repo, tag, asset_name
+    );
+    let tmp_sha = asset_path.with_extension("sha256");
+    download_asset(&sha_url, &tmp_sha)?;
+
+    let sha_content = fs::read_to_string(&tmp_sha)?;
+    let expected = sha_content
+        .split_whitespace()
+        .next()
+        .ok_or("empty .sha256 file")?
+        .to_ascii_lowercase();
+
+    let data = fs::read(asset_path)?;
+    let actual = sha256_hex(&data);
+    fs::remove_file(&tmp_sha).ok();
+
+    if actual != expected {
+        return Err(
+            format!("SHA256 mismatch for {asset_name}: expected {expected}, got {actual}").into(),
+        );
+    }
+    println!("  ✓ SHA256 verified: {expected}");
+    Ok(())
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(data))
+}
+
 /// Convert version for PEP 440: -beta1 → b1, -rc1 → rc1
 fn pypi_version(version: &str) -> String {
     version.replace("-beta", "b").replace("-rc", "rc")
@@ -131,6 +187,10 @@ fn build_wheel(
     if !dry_run {
         let asset_path = wheel_dir.join(&asset);
         download_asset(&url, &asset_path)?;
+
+        // Verify SHA256 against the .sha256 sidecar uploaded alongside the
+        // release asset. Refuse to repackage on mismatch.
+        verify_asset_sha256(repo, tag, &asset, &asset_path)?;
 
         let scripts_dir = wheel_dir.join(&data_dir);
         if target.ext == "tar.gz" {
@@ -277,13 +337,19 @@ fn sha256_base64url(data: &[u8]) -> String {
 pub fn run(args: PublishPypiBinariesArgs) -> Result<(), Box<dyn std::error::Error>> {
     let pypi_ver = pypi_version(&args.version);
     let work = std::env::temp_dir().join(format!("xtask-pypi-{}", std::process::id()));
-    let dist = work.join("dist");
+    let dist = match &args.dist_dir {
+        Some(p) => p.clone(),
+        None => work.join("dist"),
+    };
     fs::create_dir_all(&dist)?;
 
     println!(
         "Publishing PyPI wheels for v{} (PEP 440: {})",
         args.version, pypi_ver
     );
+    if args.build_only {
+        println!("  --build-only set: wheels → {}", dist.display());
+    }
 
     for target in TARGETS {
         println!("\n=== {} ({}) ===", target.rust_target, target.platform_tag);
@@ -298,8 +364,11 @@ pub fn run(args: PublishPypiBinariesArgs) -> Result<(), Box<dyn std::error::Erro
         )?;
     }
 
-    if !args.dry_run {
-        println!("\n=== Uploading to PyPI ===");
+    if !args.dry_run && !args.build_only {
+        // Legacy path: twine + long-lived API token. Prefer `--build-only`
+        // and let the workflow upload via OIDC trusted publishing
+        // (`pypa/gh-action-pypi-publish`) — see `cli_pypi` in release.yml.
+        println!("\n=== Uploading to PyPI (twine, legacy) ===");
         let _ = Command::new("pip")
             .args(["install", "--quiet", "twine"])
             .status();
@@ -315,9 +384,17 @@ pub fn run(args: PublishPypiBinariesArgs) -> Result<(), Box<dyn std::error::Erro
         if !status.success() {
             return Err("twine upload failed".into());
         }
+    } else if args.build_only {
+        println!(
+            "\n=== Build complete; {} wheels in {} ===",
+            TARGETS.len(),
+            dist.display()
+        );
     }
 
     println!("\nDone.");
+    // Always clean up the temp working dir. When --dist-dir is explicit,
+    // wheels live outside `work` so they survive this cleanup.
     fs::remove_dir_all(&work).ok();
     Ok(())
 }

--- a/xtask/src/publish_pypi_binaries.rs
+++ b/xtask/src/publish_pypi_binaries.rs
@@ -109,12 +109,6 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
     Err(format!("Failed to download {}", url).into())
 }
 
-/// Download and verify the .sha256 sidecar for an asset.
-///
-/// Mirrors `publish_npm_binaries::verify_asset_sha256`. Fails fast if the
-/// sidecar is missing or the hash mismatches — we refuse to repackage a
-/// binary into a wheel without confirming what the GitHub Release
-/// actually served us.
 fn verify_asset_sha256(
     repo: &str,
     tag: &str,
@@ -188,8 +182,6 @@ fn build_wheel(
         let asset_path = wheel_dir.join(&asset);
         download_asset(&url, &asset_path)?;
 
-        // Verify SHA256 against the .sha256 sidecar uploaded alongside the
-        // release asset. Refuse to repackage on mismatch.
         verify_asset_sha256(repo, tag, &asset, &asset_path)?;
 
         let scripts_dir = wheel_dir.join(&data_dir);
@@ -365,9 +357,6 @@ pub fn run(args: PublishPypiBinariesArgs) -> Result<(), Box<dyn std::error::Erro
     }
 
     if !args.dry_run && !args.build_only {
-        // Legacy path: twine + long-lived API token. Prefer `--build-only`
-        // and let the workflow upload via OIDC trusted publishing
-        // (`pypa/gh-action-pypi-publish`) — see `cli_pypi` in release.yml.
         println!("\n=== Uploading to PyPI (twine, legacy) ===");
         let _ = Command::new("pip")
             .args(["install", "--quiet", "twine"])
@@ -393,8 +382,7 @@ pub fn run(args: PublishPypiBinariesArgs) -> Result<(), Box<dyn std::error::Erro
     }
 
     println!("\nDone.");
-    // Always clean up the temp working dir. When --dist-dir is explicit,
-    // wheels live outside `work` so they survive this cleanup.
+    // --dist-dir wheels live outside `work` and survive this cleanup.
     fs::remove_dir_all(&work).ok();
     Ok(())
 }

--- a/xtask/src/publish_pypi_binaries.rs
+++ b/xtask/src/publish_pypi_binaries.rs
@@ -109,6 +109,13 @@ fn download_asset(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Erro
     Err(format!("Failed to download {}", url).into())
 }
 
+/// Downloads `{asset}.sha256` from the release and returns an error if the hash does not match.
+///
+/// Note: this only defends against transport corruption / mirror tampering.
+/// The `.sha256` is fetched from the same GitHub Release as the binary, so an
+/// attacker with release-write access can swap both. Real release-write defence
+/// needs OIDC artifact attestations (`actions/attest-build-provenance` +
+/// `gh attestation verify`) — out of scope for this PR.
 fn verify_asset_sha256(
     repo: &str,
     tag: &str,

--- a/xtask/src/publish_sdks.rs
+++ b/xtask/src/publish_sdks.rs
@@ -46,7 +46,11 @@ fn publish_js(root: &Path, dry_run: bool) -> Result<(), Box<dyn std::error::Erro
 
     println!("Publishing JavaScript SDK...");
 
-    let mut args = vec!["publish", "--access", "public"];
+    // --ignore-scripts: block lifecycle hooks (prepublishOnly, prepack,
+    // postpublish) during publish so a future malicious dep cannot
+    // exfiltrate NODE_AUTH_TOKEN. Matches publish_npm_binaries.rs and
+    // the inline `npm publish` calls in release.yml.
+    let mut args = vec!["publish", "--access", "public", "--ignore-scripts"];
     if dry_run {
         args.push("--dry-run");
     }

--- a/xtask/src/publish_sdks.rs
+++ b/xtask/src/publish_sdks.rs
@@ -46,10 +46,7 @@ fn publish_js(root: &Path, dry_run: bool) -> Result<(), Box<dyn std::error::Erro
 
     println!("Publishing JavaScript SDK...");
 
-    // --ignore-scripts: block lifecycle hooks (prepublishOnly, prepack,
-    // postpublish) during publish so a future malicious dep cannot
-    // exfiltrate NODE_AUTH_TOKEN. Matches publish_npm_binaries.rs and
-    // the inline `npm publish` calls in release.yml.
+    // --ignore-scripts blocks lifecycle hooks so a malicious dep cannot exfiltrate NODE_AUTH_TOKEN.
     let mut args = vec!["publish", "--access", "public", "--ignore-scripts"];
     if dry_run {
         args.push("--dry-run");


### PR DESCRIPTION
## Summary

Three small follow-ups to the in-flight CI supply-chain hardening, plus
verification that the action SHA-pinning issue is already covered.

| # | Issue | Status before | Change |
|---|-------|---------------|--------|
| 1 | #3868 | `publish_npm_binaries.rs` already verifies `.sha256`; `publish_pypi_binaries.rs` did not | Mirror the same `verify_asset_sha256()` helper before repackaging into wheels; refuse on mismatch / missing sidecar |
| 2 | #3808 | All 32 workflow files already use `uses: foo/bar@<40-char-sha> # vN` | No-op — verified `grep -r 'uses:' .github/workflows/` returns zero unpinned refs. Closing as already-fixed |
| 3 | #3809 | `release.yml` inline `npm publish` already uses `--ignore-scripts`; the `xtask` publisher (used by `cli_npm`) did not | Add `--ignore-scripts` to both `npm publish` calls in `xtask/src/publish_npm_binaries.rs` (per-target packages + `@librefang/cli` wrapper) |
| 4 | #3869 | `sdk_python` already on OIDC; `cli_pypi` still used `PYPI_API_TOKEN` + twine | Add `--build-only`/`--dist-dir` to `publish-pypi-binaries`, build wheels in a token-less step, upload via `pypa/gh-action-pypi-publish` with `id-token: write`. Drop `PYPI_API_TOKEN`/`TWINE_*` from the workflow |

Closes #3868
Closes #3808
Closes #3809
Closes #3869

## Reviewer action required (blocking before next tag)

#3869 is half manual: PyPI trusted-publisher config cannot be set from a
workflow. Before the next `v*` tag is cut, somebody with PyPI admin on
the `librefang` project must visit

  https://pypi.org/manage/project/librefang/settings/publishing/

and add a trusted publisher matching:

  - **PyPI Project Name**: `librefang`
  - **Owner**: `librefang`
  - **Repository name**: `librefang`
  - **Workflow filename**: `release.yml`
  - **Environment name**: *(leave blank — the `cli_pypi` job has no `environment:` set)*

Without this, the next release will fail at the upload step. The
companion `sdk_python` job (`librefang-sdk` PyPI project) is already
configured per the comment that exists in the workflow today.

`secrets.PYPI_API_TOKEN` can be removed from repo settings after the
first OIDC-only release succeeds.

## Test plan

- [ ] CI green on PR (lint / actionlint / xtask compile)
- [ ] PyPI trusted publisher configured for `librefang` project (manual, owner)
- [ ] Cut a pre-release tag (e.g. `vX.Y.Z-rc1`) and confirm `cli_pypi` and `sdk_python` both publish via OIDC
- [ ] Confirm `cli_npm` publishes per-target packages without lifecycle scripts running (check `npm view @librefang/cli-linux-x64 dist.tarball` and verify the published tarball does not include built artifacts from a `prepublishOnly` script that wasn't run)