### PR TITLE
fix(vault): chmod 0600, AAD schema binding, dotenv newline escape

### DIFF
--- a/crates/librefang-extensions/src/dotenv.rs
+++ b/crates/librefang-extensions/src/dotenv.rs
@@ -109,11 +109,7 @@ fn load_env_file(path: &Path) {
     }
 }
 
-/// Parse a single `KEY=VALUE` line. Handles optional quotes and undoes
-/// the `\\` / `\n` / `\r` / `\"` escape sequences emitted by
-/// [`escape_env_value`] so values written by the dashboard round-trip
-/// byte-identically (#3790). Single-quoted values are taken literally,
-/// matching shell semantics.
+/// Parses a `KEY=VALUE` line; undoes double-quote escape sequences, single-quoted values are literal.
 fn parse_env_line(line: &str) -> Option<(String, String)> {
     let eq_pos = line.find('=')?;
     let key = line[..eq_pos].trim().to_string();
@@ -142,24 +138,17 @@ fn parse_env_line(line: &str) -> Option<(String, String)> {
     Some((key, value))
 }
 
-/// Escape a `.env` value so that newlines, carriage returns, backslashes
-/// and double quotes survive a write→read round-trip without splitting
-/// the value across lines or being misread as escape sequences (#3790).
-///
-/// Backslash MUST be replaced first, otherwise the `\n` inserted by the
-/// newline replacement gets a leading `\\` and decodes back as a literal
-/// `\n` instead of a newline.
+/// Escapes `\`, `\n`, `\r`, `"` for writing inside double-quoted `.env` values.
 fn escape_env_value(value: &str) -> String {
     value
+        // Backslash must come first; otherwise the \n replacement produces \\n which decodes back as a newline.
         .replace('\\', "\\\\")
         .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('"', "\\\"")
 }
 
-/// Inverse of [`escape_env_value`]. Walks the input once so we never
-/// double-decode an embedded `\\` (e.g. the input `\\n` must decode to
-/// the literal two-character `\n`, not a real newline).
+/// Inverse of [`escape_env_value`]; single-pass to avoid double-decoding `\\n`.
 fn unescape_env_value(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     let mut chars = value.chars();
@@ -266,11 +255,6 @@ fn write_env_file(path: &Path, entries: &BTreeMap<String, String>) -> Result<(),
     content.push_str("# Do not edit while the daemon is running.\n\n");
 
     for (key, value) in entries {
-        // A value needs quoting if it contains ANY character that would
-        // confuse a dotenv reader, including newline / CR (which would
-        // otherwise split the value into bogus extra `KEY=...` lines —
-        // #3790). Always escape inside the quotes so backslash, double
-        // quote, newline and CR round-trip via [`parse_env_line`].
         let needs_quoting = value.contains(' ')
             || value.contains('#')
             || value.contains('"')

--- a/crates/librefang-extensions/src/dotenv.rs
+++ b/crates/librefang-extensions/src/dotenv.rs
@@ -109,7 +109,11 @@ fn load_env_file(path: &Path) {
     }
 }
 
-/// Parse a single `KEY=VALUE` line. Handles optional quotes.
+/// Parse a single `KEY=VALUE` line. Handles optional quotes and undoes
+/// the `\\` / `\n` / `\r` / `\"` escape sequences emitted by
+/// [`escape_env_value`] so values written by the dashboard round-trip
+/// byte-identically (#3790). Single-quoted values are taken literally,
+/// matching shell semantics.
 fn parse_env_line(line: &str) -> Option<(String, String)> {
     let eq_pos = line.find('=')?;
     let key = line[..eq_pos].trim().to_string();
@@ -119,15 +123,65 @@ fn parse_env_line(line: &str) -> Option<(String, String)> {
         return None;
     }
 
-    // Strip matching quotes
-    if ((value.starts_with('"') && value.ends_with('"'))
-        || (value.starts_with('\'') && value.ends_with('\'')))
-        && value.len() >= 2
-    {
-        value = value[1..value.len() - 1].to_string();
+    // Strip matching quotes and remember which kind we stripped, so we
+    // only undo escapes inside double quotes (single-quoted = literal).
+    let mut was_double_quoted = false;
+    if value.len() >= 2 {
+        if value.starts_with('"') && value.ends_with('"') {
+            value = value[1..value.len() - 1].to_string();
+            was_double_quoted = true;
+        } else if value.starts_with('\'') && value.ends_with('\'') {
+            value = value[1..value.len() - 1].to_string();
+        }
+    }
+
+    if was_double_quoted {
+        value = unescape_env_value(&value);
     }
 
     Some((key, value))
+}
+
+/// Escape a `.env` value so that newlines, carriage returns, backslashes
+/// and double quotes survive a write→read round-trip without splitting
+/// the value across lines or being misread as escape sequences (#3790).
+///
+/// Backslash MUST be replaced first, otherwise the `\n` inserted by the
+/// newline replacement gets a leading `\\` and decodes back as a literal
+/// `\n` instead of a newline.
+fn escape_env_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('"', "\\\"")
+}
+
+/// Inverse of [`escape_env_value`]. Walks the input once so we never
+/// double-decode an embedded `\\` (e.g. the input `\\n` must decode to
+/// the literal two-character `\n`, not a real newline).
+fn unescape_env_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            // Unknown escape: keep both chars verbatim so we don't lose data.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Upsert a key in `$LIBREFANG_HOME/.env`.
@@ -212,8 +266,23 @@ fn write_env_file(path: &Path, entries: &BTreeMap<String, String>) -> Result<(),
     content.push_str("# Do not edit while the daemon is running.\n\n");
 
     for (key, value) in entries {
-        if value.contains(' ') || value.contains('#') || value.contains('"') {
-            content.push_str(&format!("{key}=\"{}\"\n", value.replace('"', "\\\"")));
+        // A value needs quoting if it contains ANY character that would
+        // confuse a dotenv reader, including newline / CR (which would
+        // otherwise split the value into bogus extra `KEY=...` lines —
+        // #3790). Always escape inside the quotes so backslash, double
+        // quote, newline and CR round-trip via [`parse_env_line`].
+        let needs_quoting = value.contains(' ')
+            || value.contains('#')
+            || value.contains('"')
+            || value.contains('\\')
+            || value.contains('\n')
+            || value.contains('\r')
+            || value.contains('\'')
+            || value.contains('=')
+            || value.contains('$');
+        if needs_quoting {
+            let escaped = escape_env_value(value);
+            content.push_str(&format!("{key}=\"{escaped}\"\n"));
         } else {
             content.push_str(&format!("{key}={value}\n"));
         }
@@ -310,6 +379,57 @@ mod tests {
     fn test_load_env_file_nonexistent() {
         // Should not panic
         load_env_file(&PathBuf::from("/nonexistent/.env"));
+    }
+
+    /// Regression for #3790: a value containing a literal newline must
+    /// be written as a single `KEY="..."` line (escaped) and must round
+    /// trip back to the original bytes via `parse_env_line`.
+    #[test]
+    fn write_env_file_escapes_newlines_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".env");
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "PEM_KEY".to_string(),
+            "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----".to_string(),
+        );
+        entries.insert("PLAIN".to_string(), "simple".to_string());
+        entries.insert("BACKSLASH".to_string(), r"a\b\c".to_string());
+        entries.insert("QUOTED".to_string(), r#"has "quotes""#.to_string());
+        write_env_file(&path, &entries).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        // Header is two comment lines + blank line; every entry must occupy
+        // exactly one line (no embedded newline leaks).
+        let key_lines: Vec<&str> = raw.lines().filter(|l| l.contains('=')).collect();
+        assert_eq!(
+            key_lines.len(),
+            entries.len(),
+            "expected one line per key; raw:\n{raw}"
+        );
+
+        // Round-trip: re-parse and ensure values match exactly.
+        let parsed = read_env_file(&path);
+        for (k, v) in &entries {
+            assert_eq!(
+                parsed.get(k).map(String::as_str),
+                Some(v.as_str()),
+                "round-trip mismatch for {k}: wrote {v:?}, read {:?}",
+                parsed.get(k)
+            );
+        }
+    }
+
+    /// Backslash MUST round-trip correctly — the escape ordering bug from
+    /// #3790 caused `\\\n` to decode as a real newline.
+    #[test]
+    fn escape_unescape_backslash_then_newline() {
+        let raw = "\\\n";
+        let escaped = escape_env_value(raw);
+        // \  →  \\, \n → \n  ⇒  \\\n
+        assert_eq!(escaped, r"\\\n");
+        assert!(!escaped.contains('\n'));
+        assert_eq!(unescape_env_value(&escaped), raw);
     }
 
     /// `load_env_file` must not override existing process env vars —

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -120,10 +120,16 @@ const NONCE_LEN: usize = 12;
 /// Magic bytes for vault file format versioning.
 const VAULT_MAGIC: &[u8; 4] = b"OFV1";
 
+/// Current vault schema version. Bumped when the AAD layout or on-disk
+/// format changes. Version 0 = legacy (no AAD or path-only AAD); version 1
+/// = `(schema_version_le_bytes || path_bytes)` AAD which prevents both
+/// file-swap and downgrade attacks (#3788).
+const VAULT_SCHEMA_VERSION: u32 = 1;
+
 /// On-disk vault format (encrypted).
 #[derive(Serialize, Deserialize)]
 struct VaultFile {
-    /// Version marker.
+    /// File-format version marker (always 1; not the AAD schema version).
     version: u8,
     /// Argon2 salt (base64).
     salt: String,
@@ -131,6 +137,11 @@ struct VaultFile {
     nonce: String,
     /// Encrypted data (base64).
     ciphertext: String,
+    /// AAD schema version. Missing on legacy files (deserializes to 0,
+    /// which selects the path-only AAD decrypt path for backward compat).
+    /// Files written by this binary are always `VAULT_SCHEMA_VERSION`.
+    #[serde(default)]
+    schema_version: u32,
 }
 
 /// Decrypted vault entries.
@@ -345,12 +356,28 @@ impl CredentialVault {
         Err(ExtensionError::VaultLocked)
     }
 
+    /// Build the AAD bytes used to bind a ciphertext to both this vault's
+    /// canonical path AND the current schema version. Layout:
+    ///   `schema_version (u32 little-endian) || path_bytes`
+    /// A different path or a downgraded `schema_version` field will cause
+    /// AES-GCM authentication to fail on decrypt (#3788).
+    fn aad_bytes(path: &std::path::Path, schema_version: u32) -> Vec<u8> {
+        let path_str = path.to_string_lossy();
+        let path_bytes = path_str.as_bytes();
+        let mut buf = Vec::with_capacity(4 + path_bytes.len());
+        buf.extend_from_slice(&schema_version.to_le_bytes());
+        buf.extend_from_slice(path_bytes);
+        buf
+    }
+
     /// Save encrypted vault to disk.
     ///
-    /// The vault file path is used as AES-GCM Additional Associated Data (AAD)
-    /// so that a ciphertext blob cannot be silently transplanted to a different
-    /// path or a different install's vault file — decryption will fail with an
-    /// authentication error if the path recorded at encryption time differs.
+    /// Binds the AES-GCM Additional Associated Data (AAD) to both the vault
+    /// file's canonical path AND the current schema version so that a
+    /// ciphertext blob cannot be silently transplanted to a different path,
+    /// a different install's vault file, or downgraded to an older AAD
+    /// layout (#3788) — decryption will fail with an authentication error
+    /// if either differs.
     fn save(&self, master_key: &[u8; 32]) -> ExtensionResult<()> {
         // Serialize entries to JSON
         let plain_entries: HashMap<String, String> = self
@@ -376,19 +403,21 @@ impl CredentialVault {
         let derived_key = derive_key(master_key, &salt)?;
 
         // Encrypt with AES-256-GCM, binding the ciphertext to this vault's
-        // canonical path via AAD. An adversary who copies the raw vault file to
-        // a different path (or to another install) will receive an authentication
-        // error on decrypt rather than silently obtaining a valid plaintext.
+        // canonical path AND the current schema version via AAD. An
+        // adversary who copies the raw vault file to a different path,
+        // splices it from another install, or rewrites `schema_version`
+        // will receive an authentication error on decrypt rather than
+        // silently obtaining a valid plaintext (#3788).
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let aad = self.path.to_string_lossy();
+        let aad = Self::aad_bytes(&self.path, VAULT_SCHEMA_VERSION);
         let ciphertext = cipher
             .encrypt(
                 nonce,
                 Payload {
                     msg: plaintext.as_slice(),
-                    aad: aad.as_bytes(),
+                    aad: &aad,
                 },
             )
             .map_err(|e| ExtensionError::Vault(format!("Encryption failed: {e}")))?;
@@ -402,6 +431,7 @@ impl CredentialVault {
                 &base64::engine::general_purpose::STANDARD,
                 &ciphertext,
             ),
+            schema_version: VAULT_SCHEMA_VERSION,
         };
         let content = serde_json::to_string_pretty(&vault_file)
             .map_err(|e| ExtensionError::Vault(format!("Vault file serialization failed: {e}")))?;
@@ -418,17 +448,36 @@ impl CredentialVault {
         // Atomic write: write to a sibling .tmp file (same filesystem guarantees
         // rename is atomic), fsync to flush to disk, then rename over the target.
         // A crash mid-write leaves only the .tmp file; the vault is never corrupt.
+        // The tmp file is created with mode 0600 on Unix so the secret
+        // ciphertext is never world-readable, even briefly (#3724).
         let temp_path = self.path.with_extension("tmp");
         {
-            let mut f = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&temp_path)?;
+            let mut opts = OpenOptions::new();
+            opts.write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut f = opts.open(&temp_path)?;
             f.write_all(&output)?;
             f.sync_all()?;
         }
         std::fs::rename(&temp_path, &self.path)?;
+        // Belt-and-braces: if the file already existed before the rename
+        // with looser permissions, the rename inherits the tmp file's mode
+        // on POSIX. On non-Unix this is a no-op.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(meta) = std::fs::metadata(&self.path) {
+                let mut perms = meta.permissions();
+                if perms.mode() & 0o777 != 0o600 {
+                    perms.set_mode(0o600);
+                    let _ = std::fs::set_permissions(&self.path, perms);
+                }
+            }
+        }
         Ok(())
     }
 
@@ -480,20 +529,31 @@ impl CredentialVault {
         // Derive key
         let derived_key = derive_key(master_key, &salt)?;
 
-        // Decrypt, supplying the vault path as AAD so the authentication tag
-        // covers both the ciphertext and the path. A file swapped from a
-        // different path will fail here with "Decryption failed".
+        // Decrypt, supplying AAD that matches the schema version recorded
+        // in the file. Files written by this binary use schema_version=1
+        // (path + version bound); legacy files have schema_version=0
+        // (default), which selects the path-only AAD compat path so users
+        // upgrading from a pre-#3788 vault can still unlock without a
+        // forced re-init. The next save() will rewrite at v1 automatically.
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let aad = self.path.to_string_lossy();
+        let aad: Vec<u8> = match vault_file.schema_version {
+            0 => self.path.to_string_lossy().as_bytes().to_vec(),
+            v if v == VAULT_SCHEMA_VERSION => Self::aad_bytes(&self.path, v),
+            other => {
+                return Err(ExtensionError::Vault(format!(
+                    "Unsupported vault AAD schema version: {other}"
+                )));
+            }
+        };
         let plaintext = Zeroizing::new(
             cipher
                 .decrypt(
                     nonce,
                     Payload {
                         msg: ciphertext.as_slice(),
-                        aad: aad.as_bytes(),
+                        aad: &aad,
                     },
                 )
                 .map_err(|e| ExtensionError::Vault(format!("Decryption failed: {e}")))?,
@@ -618,7 +678,49 @@ fn store_keyring_key(key_b64: &str) -> Result<(), String> {
         };
         let content =
             serde_json::to_string_pretty(&keyring_file).map_err(|e| format!("json: {e}"))?;
-        std::fs::write(&keyring_path, content).map_err(|e| format!("write: {e}"))?;
+
+        // Atomic write with mode 0600 on Unix so the wrapped master key is
+        // never world-readable, even briefly between `write` and a
+        // separate `set_permissions` call (#3724). On non-Unix the create
+        // is plain; ACLs apply at the OS level.
+        let tmp_path =
+            keyring_path.with_extension(format!("keyring.tmp.{}", std::process::id()));
+        let result = (|| -> std::io::Result<()> {
+            use std::io::Write as _;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut f = opts.open(&tmp_path)?;
+            f.write_all(content.as_bytes())?;
+            f.flush()?;
+            f.sync_all()?;
+            drop(f);
+            std::fs::rename(&tmp_path, &keyring_path)
+        })();
+
+        if let Err(e) = result {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("write: {e}"));
+        }
+
+        // Belt-and-braces tighten on Unix in case the destination
+        // pre-existed with looser perms (rename inherits source mode on
+        // POSIX, but enforce explicitly).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(meta) = std::fs::metadata(&keyring_path) {
+                let mut perms = meta.permissions();
+                if perms.mode() & 0o777 != 0o600 {
+                    perms.set_mode(0o600);
+                    let _ = std::fs::set_permissions(&keyring_path, perms);
+                }
+            }
+        }
         Ok(())
     }
     #[cfg(test)]
@@ -1020,6 +1122,113 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{:?}", result.unwrap_err());
         assert!(msg.contains("Unrecognized vault file format"));
+    }
+
+    /// Regression test for #3788: a file with schema_version=0 (legacy
+    /// path-only AAD) must still decrypt with the path-only AAD path so
+    /// pre-#3788 vaults keep working after upgrade.
+    #[test]
+    fn vault_legacy_schema_version_zero_decrypts_with_path_only_aad() {
+        use aes_gcm::aead::{Aead, KeyInit, Payload};
+        use aes_gcm::Aes256Gcm;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault.enc");
+        let key = random_key();
+
+        // Hand-roll a legacy v0 ciphertext blob using the path as the only
+        // AAD (the pre-#3788 layout) so we exercise the compat decode
+        // branch without depending on git history.
+        let plain = serde_json::to_vec(&VaultEntries {
+            secrets: {
+                let mut m = HashMap::new();
+                m.insert("LEGACY_KEY".to_string(), "legacy_value".to_string());
+                m
+            },
+        })
+        .unwrap();
+
+        let mut salt = [0u8; SALT_LEN];
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut salt);
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let derived = derive_key(&key, &salt).unwrap();
+        let cipher = Aes256Gcm::new_from_slice(derived.as_ref()).unwrap();
+        let path_only_aad = path.to_string_lossy();
+        let ct = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: plain.as_slice(),
+                    aad: path_only_aad.as_bytes(),
+                },
+            )
+            .unwrap();
+
+        let legacy_file = VaultFile {
+            version: 1,
+            salt: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, salt),
+            nonce: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, nonce_bytes),
+            ciphertext: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &ct),
+            schema_version: 0, // ← legacy
+        };
+        let json = serde_json::to_string(&legacy_file).unwrap();
+        let mut out = Vec::with_capacity(VAULT_MAGIC.len() + json.len());
+        out.extend_from_slice(VAULT_MAGIC);
+        out.extend_from_slice(json.as_bytes());
+        std::fs::write(&path, &out).unwrap();
+
+        let mut vault = CredentialVault::new(path);
+        vault.unlock_with_key(key).unwrap();
+        assert_eq!(vault.get("LEGACY_KEY").unwrap().as_str(), "legacy_value");
+    }
+
+    /// Regression test for #3788: a file written at schema_version=1 must
+    /// fail to decrypt if an attacker downgrades the field to 0 because
+    /// the AAD recorded at encryption time included the version bytes.
+    #[test]
+    fn vault_rejects_schema_version_downgrade() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault.enc");
+        let key = random_key();
+
+        let mut vault = CredentialVault::new(path.clone());
+        vault.init_with_key(key.clone()).unwrap();
+        vault
+            .set("K".to_string(), Zeroizing::new("v".to_string()))
+            .unwrap();
+        drop(vault);
+
+        // Tamper with schema_version on disk: 1 → 0
+        let raw = std::fs::read(&path).unwrap();
+        let json_start = VAULT_MAGIC.len();
+        let mut file: VaultFile = serde_json::from_slice(&raw[json_start..]).unwrap();
+        assert_eq!(file.schema_version, VAULT_SCHEMA_VERSION);
+        file.schema_version = 0;
+        let mut tampered = Vec::with_capacity(raw.len());
+        tampered.extend_from_slice(VAULT_MAGIC);
+        tampered.extend_from_slice(serde_json::to_string_pretty(&file).unwrap().as_bytes());
+        std::fs::write(&path, &tampered).unwrap();
+
+        let mut vault2 = CredentialVault::new(path);
+        let res = vault2.unlock_with_key(key);
+        assert!(
+            res.is_err(),
+            "schema_version downgrade must fail authentication"
+        );
+    }
+
+    /// Regression test for #3724: vault.enc must be created with mode 0600
+    /// on Unix so the encrypted blob is never world-readable.
+    #[cfg(unix)]
+    #[test]
+    fn vault_file_is_chmod_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key).unwrap();
+        let mode = std::fs::metadata(&vault.path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "vault.enc must be 0600, got {mode:o}");
     }
 
     /// Regression test for #3788: copying a vault file to a different path

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -647,8 +647,7 @@ fn store_keyring_key(key_b64: &str) -> Result<(), String> {
             serde_json::to_string_pretty(&keyring_file).map_err(|e| format!("json: {e}"))?;
 
         // Atomic write with mode 0600 on Unix; non-Unix relies on OS ACLs.
-        let tmp_path =
-            keyring_path.with_extension(format!("keyring.tmp.{}", std::process::id()));
+        let tmp_path = keyring_path.with_extension(format!("keyring.tmp.{}", std::process::id()));
         let result = (|| -> std::io::Result<()> {
             use std::io::Write as _;
             let mut opts = std::fs::OpenOptions::new();

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -120,10 +120,7 @@ const NONCE_LEN: usize = 12;
 /// Magic bytes for vault file format versioning.
 const VAULT_MAGIC: &[u8; 4] = b"OFV1";
 
-/// Current vault schema version. Bumped when the AAD layout or on-disk
-/// format changes. Version 0 = legacy (no AAD or path-only AAD); version 1
-/// = `(schema_version_le_bytes || path_bytes)` AAD which prevents both
-/// file-swap and downgrade attacks (#3788).
+/// AAD schema version; 0 = legacy path-only AAD, 1 = schema_version_le_bytes || path_bytes.
 const VAULT_SCHEMA_VERSION: u32 = 1;
 
 /// On-disk vault format (encrypted).
@@ -137,9 +134,7 @@ struct VaultFile {
     nonce: String,
     /// Encrypted data (base64).
     ciphertext: String,
-    /// AAD schema version. Missing on legacy files (deserializes to 0,
-    /// which selects the path-only AAD decrypt path for backward compat).
-    /// Files written by this binary are always `VAULT_SCHEMA_VERSION`.
+    /// AAD schema version; defaults to 0 on legacy files (path-only AAD compat).
     #[serde(default)]
     schema_version: u32,
 }
@@ -356,11 +351,7 @@ impl CredentialVault {
         Err(ExtensionError::VaultLocked)
     }
 
-    /// Build the AAD bytes used to bind a ciphertext to both this vault's
-    /// canonical path AND the current schema version. Layout:
-    ///   `schema_version (u32 little-endian) || path_bytes`
-    /// A different path or a downgraded `schema_version` field will cause
-    /// AES-GCM authentication to fail on decrypt (#3788).
+    /// Returns `schema_version_le_bytes || path_bytes` as AES-GCM AAD.
     fn aad_bytes(path: &std::path::Path, schema_version: u32) -> Vec<u8> {
         let path_str = path.to_string_lossy();
         let path_bytes = path_str.as_bytes();
@@ -370,14 +361,7 @@ impl CredentialVault {
         buf
     }
 
-    /// Save encrypted vault to disk.
-    ///
-    /// Binds the AES-GCM Additional Associated Data (AAD) to both the vault
-    /// file's canonical path AND the current schema version so that a
-    /// ciphertext blob cannot be silently transplanted to a different path,
-    /// a different install's vault file, or downgraded to an older AAD
-    /// layout (#3788) — decryption will fail with an authentication error
-    /// if either differs.
+    /// Save encrypted vault to disk; AAD binds ciphertext to path + schema version.
     fn save(&self, master_key: &[u8; 32]) -> ExtensionResult<()> {
         // Serialize entries to JSON
         let plain_entries: HashMap<String, String> = self
@@ -402,12 +386,6 @@ impl CredentialVault {
         // Derive encryption key from master key + salt using Argon2
         let derived_key = derive_key(master_key, &salt)?;
 
-        // Encrypt with AES-256-GCM, binding the ciphertext to this vault's
-        // canonical path AND the current schema version via AAD. An
-        // adversary who copies the raw vault file to a different path,
-        // splices it from another install, or rewrites `schema_version`
-        // will receive an authentication error on decrypt rather than
-        // silently obtaining a valid plaintext (#3788).
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
@@ -445,11 +423,7 @@ impl CredentialVault {
         output.extend_from_slice(VAULT_MAGIC);
         output.extend_from_slice(content.as_bytes());
 
-        // Atomic write: write to a sibling .tmp file (same filesystem guarantees
-        // rename is atomic), fsync to flush to disk, then rename over the target.
-        // A crash mid-write leaves only the .tmp file; the vault is never corrupt.
-        // The tmp file is created with mode 0600 on Unix so the secret
-        // ciphertext is never world-readable, even briefly (#3724).
+        // Atomic write to .tmp (mode 0600 on Unix) then rename over target.
         let temp_path = self.path.with_extension("tmp");
         {
             let mut opts = OpenOptions::new();
@@ -464,9 +438,7 @@ impl CredentialVault {
             f.sync_all()?;
         }
         std::fs::rename(&temp_path, &self.path)?;
-        // Belt-and-braces: if the file already existed before the rename
-        // with looser permissions, the rename inherits the tmp file's mode
-        // on POSIX. On non-Unix this is a no-op.
+        // Enforce 0600 if a pre-existing file had looser perms.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -529,12 +501,7 @@ impl CredentialVault {
         // Derive key
         let derived_key = derive_key(master_key, &salt)?;
 
-        // Decrypt, supplying AAD that matches the schema version recorded
-        // in the file. Files written by this binary use schema_version=1
-        // (path + version bound); legacy files have schema_version=0
-        // (default), which selects the path-only AAD compat path so users
-        // upgrading from a pre-#3788 vault can still unlock without a
-        // forced re-init. The next save() will rewrite at v1 automatically.
+        // schema_version=0 on disk means path-only AAD (legacy compat); save() rewrites at v1.
         let cipher = Aes256Gcm::new_from_slice(derived_key.as_ref())
             .map_err(|e| ExtensionError::Vault(format!("Cipher init failed: {e}")))?;
         let nonce = Nonce::from_slice(&nonce_bytes);
@@ -679,10 +646,7 @@ fn store_keyring_key(key_b64: &str) -> Result<(), String> {
         let content =
             serde_json::to_string_pretty(&keyring_file).map_err(|e| format!("json: {e}"))?;
 
-        // Atomic write with mode 0600 on Unix so the wrapped master key is
-        // never world-readable, even briefly between `write` and a
-        // separate `set_permissions` call (#3724). On non-Unix the create
-        // is plain; ACLs apply at the OS level.
+        // Atomic write with mode 0600 on Unix; non-Unix relies on OS ACLs.
         let tmp_path =
             keyring_path.with_extension(format!("keyring.tmp.{}", std::process::id()));
         let result = (|| -> std::io::Result<()> {
@@ -707,9 +671,7 @@ fn store_keyring_key(key_b64: &str) -> Result<(), String> {
             return Err(format!("write: {e}"));
         }
 
-        // Belt-and-braces tighten on Unix in case the destination
-        // pre-existed with looser perms (rename inherits source mode on
-        // POSIX, but enforce explicitly).
+        // Enforce 0600 if destination pre-existed with looser perms.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary
Three backward-compatible hardening fixes on the secret/vault write paths:

- **chmod 0600 (#3724)** — `vault.enc` and the file-fallback `.keyring` are now created mode `0600` on Unix at `open` time (atomic `create_new` + `OpenOptions::mode`). Closes the world-readable window where any local user could read the wrapped master key on shared hosts.
- **AAD schema-version binding (#3788)** — AES-GCM AAD is now `(schema_version_le_bytes || vault_path_bytes)` instead of just the path. A new `schema_version: u32` field on `VaultFile` defaults to `0` on deserialise, so pre-existing vaults still decrypt via a path-only AAD compat branch and are transparently rewritten at v1 on the next save. Downgrading `schema_version` from 1 to 0 on disk now fails authentication.
- **dotenv newline escape (#3790)** — `write_env_file` escapes `\\`, `\n`, `\r`, `\"` inside double quotes; `parse_env_line` undoes the escape symmetrically. PEM keys / JWTs / service-account JSON pasted via the dashboard no longer corrupt `.env` or inject bogus `KEY=` lines. Single-quoted values stay literal.

## Backward compat
- **Legacy vaults**: `schema_version` defaults to `0` when missing on disk → path-only AAD decrypt path → existing files keep unlocking. The very next `save()` rewrites at `schema_version=1` automatically.
- **Legacy `.env` files**: existing `.env` lines are unchanged when re-read; only newly-written values pass through the escape function. `parse_env_line` only undoes escapes inside double quotes, so untouched legacy values remain literal.
- **Legacy `.keyring` v1 (XOR)**: untouched migration path still triggers and re-stores in the new format with 0600.

## Test plan
- [x] `vault_legacy_schema_version_zero_decrypts_with_path_only_aad` — pre-#3788 file unlocks
- [x] `vault_rejects_schema_version_downgrade` — tampering 1→0 fails
- [x] `vault_file_is_chmod_0600` (unix) — newly created vault is 0600
- [x] `vault_path_binding_rejects_file_swap` — pre-existing swap defence still holds
- [x] `write_env_file_escapes_newlines_round_trip` — multi-line PEM survives write→read
- [x] `escape_unescape_backslash_then_newline` — escape ordering bug regression
- [ ] CI: `cargo test -p librefang-extensions`
- [ ] CI: `cargo clippy --all-targets -- -D warnings`

Closes #3724
Closes #3788
Closes #3790