### PR TITLE
perf(kernel): batch hot-path allocations on every LLM turn

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -460,6 +460,18 @@ pub struct LibreFangKernel {
         Arc<dyn librefang_runtime::mcp_oauth::McpOAuthProvider + Send + Sync>,
     /// MCP tool definitions cache (populated after connections are established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
+    /// Cached rendered MCP summary strings, keyed by the agent's
+    /// `mcp_servers` allowlist. Each entry stores the
+    /// `mcp_generation` it was rendered under so we cheaply detect
+    /// staleness on the next read.
+    ///
+    /// Lets the per-LLM-turn prompt build skip re-extracting tool
+    /// names under the `mcp_tools` `Mutex` and re-running the
+    /// `BTreeMap`-based render when nothing has changed since the
+    /// previous turn — the common case between rare MCP
+    /// connect/disconnect events. See #3687.
+    pub(crate) mcp_summary_cache:
+        dashmap::DashMap<String, (u64, std::sync::Arc<String>)>,
     /// A2A task store for tracking task lifecycle.
     pub a2a_task_store: librefang_runtime::a2a::A2aTaskStore,
     /// Discovered external A2A agent cards.
@@ -3101,6 +3113,7 @@ impl LibreFangKernel {
                 oauth_home_dir,
             )),
             mcp_tools: std::sync::Mutex::new(Vec::new()),
+            mcp_summary_cache: dashmap::DashMap::new(),
             a2a_task_store: librefang_runtime::a2a::A2aTaskStore::with_persistence(
                 1000,
                 &a2a_db_path,
@@ -4596,21 +4609,12 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use list_arcs() so the per-LLM-turn peer-agent snapshot only
-            // incurs one Arc::new() per entry instead of a full AgentEntry
-            // deep-clone. See #3685.
-            let peer_agents: Vec<(String, String, String)> = self
-                .registry
-                .list_arcs()
-                .iter()
-                .map(|a| {
-                    (
-                        a.name.clone(),
-                        format!("{:?}", a.state),
-                        a.manifest.model.model.clone(),
-                    )
-                })
-                .collect();
+            // Use peer_agents_summary() so the per-LLM-turn peer-agent
+            // snapshot projects directly to the three short strings the
+            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
+            // allocation. See #3685.
+            let peer_agents: Vec<(String, String, String)> =
+                self.registry.peer_agents_summary();
 
             let ws_meta = manifest
                 .workspace
@@ -5934,21 +5938,12 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use list_arcs() so the per-LLM-turn peer-agent snapshot only
-            // incurs one Arc::new() per entry instead of a full AgentEntry
-            // deep-clone. See #3685.
-            let peer_agents: Vec<(String, String, String)> = self
-                .registry
-                .list_arcs()
-                .iter()
-                .map(|a| {
-                    (
-                        a.name.clone(),
-                        format!("{:?}", a.state),
-                        a.manifest.model.model.clone(),
-                    )
-                })
-                .collect();
+            // Use peer_agents_summary() so the per-LLM-turn peer-agent
+            // snapshot projects directly to the three short strings the
+            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
+            // allocation. See #3685.
+            let peer_agents: Vec<(String, String, String)> =
+                self.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
             let ws_meta = manifest
@@ -7496,21 +7491,12 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use list_arcs() so the per-LLM-turn peer-agent snapshot only
-            // incurs one Arc::new() per entry instead of a full AgentEntry
-            // deep-clone. See #3685.
-            let peer_agents: Vec<(String, String, String)> = self
-                .registry
-                .list_arcs()
-                .iter()
-                .map(|a| {
-                    (
-                        a.name.clone(),
-                        format!("{:?}", a.state),
-                        a.manifest.model.model.clone(),
-                    )
-                })
-                .collect();
+            // Use peer_agents_summary() so the per-LLM-turn peer-agent
+            // snapshot projects directly to the three short strings the
+            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
+            // allocation. See #3685.
+            let peer_agents: Vec<(String, String, String)> =
+                self.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
             let ws_meta = manifest
@@ -13761,9 +13747,15 @@ system_prompt = "You are a helpful assistant."
             .cloned()
             .collect();
 
-        // 4. Update effective list
+        // 4. Update effective list. Bump mcp_generation so any cached
+        //    `build_mcp_summary` entries that read `effective_mcp_servers`
+        //    invalidate immediately, even before per-server connect bumps
+        //    fire below — otherwise the prompt could briefly show a stale
+        //    server set after a hot-reload. See #3687.
         if let Ok(mut effective) = self.effective_mcp_servers.write() {
             *effective = new_configs;
+            self.mcp_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
         // 5. Connect new servers
@@ -15294,14 +15286,38 @@ system_prompt = "You are a helpful assistant."
     /// Build a compact MCP server/tool summary for the system prompt so the
     /// agent knows what external tool servers are connected.
     ///
-    /// The sync Mutex is held for the minimum time possible: only the tool
-    /// names are extracted while the guard is live. All serialization and
-    /// rendering happens after the lock is released so we never block MCP
-    /// tool-update operations on string formatting work. See #3687.
+    /// Hot-path (~1 LLM turn for any agent with MCP servers): we cache the
+    /// rendered string per allowlist + `mcp_generation`. On a hit we skip
+    /// the `mcp_tools` `Mutex` acquisition and the `BTreeMap`-based render
+    /// entirely — both of which used to run unconditionally on every turn
+    /// even though the MCP tool registry only changes on connect /
+    /// disconnect / reload (which all bump `mcp_generation`). See #3687.
+    ///
+    /// Determinism is preserved: `render_mcp_summary` already sorts servers
+    /// (`BTreeMap`) and each server's tool list before joining, so the
+    /// cached `String` is byte-identical to a freshly rendered one for the
+    /// same `(allowlist, generation)` pair. The cache key normalises the
+    /// allowlist by sorting + joining so different insertion orders share
+    /// a single entry, matching the determinism guarantee in #3298.
     fn build_mcp_summary(&self, mcp_allowlist: &[String]) -> String {
-        // Extract only the names we need while holding the lock, then drop it
-        // immediately. Cloning the entire Vec<ToolDefinition> (which may hold
-        // 60KB+ of JSON schema values) under the Mutex was the original bug.
+        let mcp_gen = self
+            .mcp_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let cache_key = mcp_summary_cache_key(mcp_allowlist);
+
+        // Cache hit on the current generation: just clone the Arc<String>.
+        if let Some(entry) = self.mcp_summary_cache.get(&cache_key) {
+            let (cached_gen, cached_str) = entry.value();
+            if *cached_gen == mcp_gen {
+                return (**cached_str).clone();
+            }
+        }
+
+        // Cache miss / stale: re-render. Extract only the names we need
+        // while holding the lock, then drop it immediately. Cloning the
+        // entire `Vec<ToolDefinition>` (which may hold 60KB+ of JSON
+        // schema values) under the Mutex was the original bug fixed in
+        // an earlier pass on this issue.
         let tool_names: Vec<String> = match self.mcp_tools.lock() {
             Ok(t) => {
                 if t.is_empty() {
@@ -15319,7 +15335,10 @@ system_prompt = "You are a helpful assistant."
             .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
             .unwrap_or_default();
 
-        render_mcp_summary(&tool_names, &configured_servers, mcp_allowlist)
+        let rendered = render_mcp_summary(&tool_names, &configured_servers, mcp_allowlist);
+        let arc = std::sync::Arc::new(rendered.clone());
+        self.mcp_summary_cache.insert(cache_key, (mcp_gen, arc));
+        rendered
     }
 
     // inject_user_personalization() — logic moved to prompt_builder::build_user_section()
@@ -15408,6 +15427,22 @@ enum ReviewError {
     /// Parse / validation / security-blocked; retry would be
     /// non-idempotent (fresh LLM call, different output each time).
     Permanent(String),
+}
+
+/// Build a deterministic cache key for the per-agent MCP allowlist.
+///
+/// The render output only depends on the *set* of allowed servers, so we
+/// sort + join with a separator that cannot appear inside an MCP server
+/// name (`\x1f`, ASCII Unit Separator). Two manifests with the same set
+/// of `mcp_servers` in different listed orders share one cache entry,
+/// preserving the determinism guarantee in #3298 / #3687.
+fn mcp_summary_cache_key(mcp_allowlist: &[String]) -> String {
+    if mcp_allowlist.is_empty() {
+        return String::from("*");
+    }
+    let mut sorted = mcp_allowlist.to_vec();
+    sorted.sort();
+    sorted.join("\x1f")
 }
 
 /// Render the MCP-server tool summary that lands in the system prompt.

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -460,16 +460,7 @@ pub struct LibreFangKernel {
         Arc<dyn librefang_runtime::mcp_oauth::McpOAuthProvider + Send + Sync>,
     /// MCP tool definitions cache (populated after connections are established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
-    /// Cached rendered MCP summary strings, keyed by the agent's
-    /// `mcp_servers` allowlist. Each entry stores the
-    /// `mcp_generation` it was rendered under so we cheaply detect
-    /// staleness on the next read.
-    ///
-    /// Lets the per-LLM-turn prompt build skip re-extracting tool
-    /// names under the `mcp_tools` `Mutex` and re-running the
-    /// `BTreeMap`-based render when nothing has changed since the
-    /// previous turn — the common case between rare MCP
-    /// connect/disconnect events. See #3687.
+    /// Rendered MCP summary cache keyed by allowlist + mcp_generation; skips Mutex + re-render on hit.
     pub(crate) mcp_summary_cache:
         dashmap::DashMap<String, (u64, std::sync::Arc<String>)>,
     /// A2A task store for tracking task lifecycle.
@@ -4609,10 +4600,6 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use peer_agents_summary() so the per-LLM-turn peer-agent
-            // snapshot projects directly to the three short strings the
-            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
-            // allocation. See #3685.
             let peer_agents: Vec<(String, String, String)> =
                 self.registry.peer_agents_summary();
 
@@ -5938,10 +5925,6 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use peer_agents_summary() so the per-LLM-turn peer-agent
-            // snapshot projects directly to the three short strings the
-            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
-            // allocation. See #3685.
             let peer_agents: Vec<(String, String, String)> =
                 self.registry.peer_agents_summary();
 
@@ -7491,10 +7474,6 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            // Use peer_agents_summary() so the per-LLM-turn peer-agent
-            // snapshot projects directly to the three short strings the
-            // prompt builder consumes, skipping every `AgentEntry`/`Arc`
-            // allocation. See #3685.
             let peer_agents: Vec<(String, String, String)> =
                 self.registry.peer_agents_summary();
 
@@ -13747,11 +13726,7 @@ system_prompt = "You are a helpful assistant."
             .cloned()
             .collect();
 
-        // 4. Update effective list. Bump mcp_generation so any cached
-        //    `build_mcp_summary` entries that read `effective_mcp_servers`
-        //    invalidate immediately, even before per-server connect bumps
-        //    fire below — otherwise the prompt could briefly show a stale
-        //    server set after a hot-reload. See #3687.
+        // 4. Update effective list; bump mcp_generation inside the same write lock so cached summaries invalidate atomically.
         if let Ok(mut effective) = self.effective_mcp_servers.write() {
             *effective = new_configs;
             self.mcp_generation
@@ -15283,22 +15258,7 @@ system_prompt = "You are a helpful assistant."
         summary
     }
 
-    /// Build a compact MCP server/tool summary for the system prompt so the
-    /// agent knows what external tool servers are connected.
-    ///
-    /// Hot-path (~1 LLM turn for any agent with MCP servers): we cache the
-    /// rendered string per allowlist + `mcp_generation`. On a hit we skip
-    /// the `mcp_tools` `Mutex` acquisition and the `BTreeMap`-based render
-    /// entirely — both of which used to run unconditionally on every turn
-    /// even though the MCP tool registry only changes on connect /
-    /// disconnect / reload (which all bump `mcp_generation`). See #3687.
-    ///
-    /// Determinism is preserved: `render_mcp_summary` already sorts servers
-    /// (`BTreeMap`) and each server's tool list before joining, so the
-    /// cached `String` is byte-identical to a freshly rendered one for the
-    /// same `(allowlist, generation)` pair. The cache key normalises the
-    /// allowlist by sorting + joining so different insertion orders share
-    /// a single entry, matching the determinism guarantee in #3298.
+    /// Build a compact MCP server/tool summary for the system prompt; caches per allowlist + mcp_generation to skip Mutex and re-render on hit.
     fn build_mcp_summary(&self, mcp_allowlist: &[String]) -> String {
         let mcp_gen = self
             .mcp_generation
@@ -15313,11 +15273,7 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Cache miss / stale: re-render. Extract only the names we need
-        // while holding the lock, then drop it immediately. Cloning the
-        // entire `Vec<ToolDefinition>` (which may hold 60KB+ of JSON
-        // schema values) under the Mutex was the original bug fixed in
-        // an earlier pass on this issue.
+        // Cache miss / stale: extract only names under the lock, then release before rendering.
         let tool_names: Vec<String> = match self.mcp_tools.lock() {
             Ok(t) => {
                 if t.is_empty() {
@@ -15429,13 +15385,7 @@ enum ReviewError {
     Permanent(String),
 }
 
-/// Build a deterministic cache key for the per-agent MCP allowlist.
-///
-/// The render output only depends on the *set* of allowed servers, so we
-/// sort + join with a separator that cannot appear inside an MCP server
-/// name (`\x1f`, ASCII Unit Separator). Two manifests with the same set
-/// of `mcp_servers` in different listed orders share one cache entry,
-/// preserving the determinism guarantee in #3298 / #3687.
+/// Build a deterministic cache key for the per-agent MCP allowlist; sorts and joins with `\x1f` so insertion-order variants share one entry.
 fn mcp_summary_cache_key(mcp_allowlist: &[String]) -> String {
     if mcp_allowlist.is_empty() {
         return String::from("*");

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -461,8 +461,7 @@ pub struct LibreFangKernel {
     /// MCP tool definitions cache (populated after connections are established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
     /// Rendered MCP summary cache keyed by allowlist + mcp_generation; skips Mutex + re-render on hit.
-    pub(crate) mcp_summary_cache:
-        dashmap::DashMap<String, (u64, std::sync::Arc<String>)>,
+    pub(crate) mcp_summary_cache: dashmap::DashMap<String, (u64, std::sync::Arc<String>)>,
     /// A2A task store for tracking task lifecycle.
     pub a2a_task_store: librefang_runtime::a2a::A2aTaskStore,
     /// Discovered external A2A agent cards.
@@ -4600,8 +4599,7 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            let peer_agents: Vec<(String, String, String)> =
-                self.registry.peer_agents_summary();
+            let peer_agents: Vec<(String, String, String)> = self.registry.peer_agents_summary();
 
             let ws_meta = manifest
                 .workspace
@@ -5925,8 +5923,7 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            let peer_agents: Vec<(String, String, String)> =
-                self.registry.peer_agents_summary();
+            let peer_agents: Vec<(String, String, String)> = self.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
             let ws_meta = manifest
@@ -7474,8 +7471,7 @@ system_prompt = "You are a helpful assistant."
                 .flatten()
                 .and_then(|v| v.as_str().map(String::from));
 
-            let peer_agents: Vec<(String, String, String)> =
-                self.registry.peer_agents_summary();
+            let peer_agents: Vec<(String, String, String)> = self.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
             let ws_meta = manifest

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -461,7 +461,8 @@ pub struct LibreFangKernel {
     /// MCP tool definitions cache (populated after connections are established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
     /// Rendered MCP summary cache keyed by allowlist + mcp_generation; skips Mutex + re-render on hit.
-    pub(crate) mcp_summary_cache: dashmap::DashMap<String, (u64, std::sync::Arc<String>)>,
+    /// Stale entries from old generations are never evicted; bounded by distinct allowlists in practice.
+    pub(crate) mcp_summary_cache: dashmap::DashMap<String, (u64, String)>,
     /// A2A task store for tracking task lifecycle.
     pub a2a_task_store: librefang_runtime::a2a::A2aTaskStore,
     /// Discovered external A2A agent cards.
@@ -15261,11 +15262,11 @@ system_prompt = "You are a helpful assistant."
             .load(std::sync::atomic::Ordering::Relaxed);
         let cache_key = mcp_summary_cache_key(mcp_allowlist);
 
-        // Cache hit on the current generation: just clone the Arc<String>.
+        // Cache hit on the current generation: clone the cached String.
         if let Some(entry) = self.mcp_summary_cache.get(&cache_key) {
             let (cached_gen, cached_str) = entry.value();
             if *cached_gen == mcp_gen {
-                return (**cached_str).clone();
+                return cached_str.clone();
             }
         }
 
@@ -15288,8 +15289,8 @@ system_prompt = "You are a helpful assistant."
             .unwrap_or_default();
 
         let rendered = render_mcp_summary(&tool_names, &configured_servers, mcp_allowlist);
-        let arc = std::sync::Arc::new(rendered.clone());
-        self.mcp_summary_cache.insert(cache_key, (mcp_gen, arc));
+        self.mcp_summary_cache
+            .insert(cache_key, (mcp_gen, rendered.clone()));
         rendered
     }
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4748,6 +4748,35 @@ fn mcp_summary_inner_tool_list_is_sorted() {
     );
 }
 
+#[test]
+fn mcp_summary_cache_key_is_order_independent() {
+    // Determinism contract for the #3687 cache: two manifests listing
+    // the same `mcp_servers` set in different declaration orders must
+    // hash to the SAME cache entry, otherwise we'd silently double the
+    // cache footprint and (worse) double-render an identical string.
+    // This dovetails with #3298 — a sorted key here is the cache-side
+    // counterpart of the sorted `BTreeMap` inside `render_mcp_summary`.
+    let order_a = vec![
+        "filesystem".to_string(),
+        "github".to_string(),
+        "weather".to_string(),
+    ];
+    let order_b = vec![
+        "weather".to_string(),
+        "filesystem".to_string(),
+        "github".to_string(),
+    ];
+
+    assert_eq!(
+        super::mcp_summary_cache_key(&order_a),
+        super::mcp_summary_cache_key(&order_b),
+        "cache key must be insertion-order-independent (#3687 / #3298)"
+    );
+    // Empty allowlist (= "all servers") gets its own well-known key
+    // so it never collides with a server literally named "*".
+    assert_eq!(super::mcp_summary_cache_key(&[]), "*");
+}
+
 // ─── resolve_dispatch_session_id ──────────────────────────────────────────
 //
 // Backstop for the session-id-in-failure-log change: ensures the kernel

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4750,12 +4750,6 @@ fn mcp_summary_inner_tool_list_is_sorted() {
 
 #[test]
 fn mcp_summary_cache_key_is_order_independent() {
-    // Determinism contract for the #3687 cache: two manifests listing
-    // the same `mcp_servers` set in different declaration orders must
-    // hash to the SAME cache entry, otherwise we'd silently double the
-    // cache footprint and (worse) double-render an identical string.
-    // This dovetails with #3298 — a sorted key here is the cache-side
-    // counterpart of the sorted `BTreeMap` inside `render_mcp_summary`.
     let order_a = vec![
         "filesystem".to_string(),
         "github".to_string(),
@@ -4770,10 +4764,8 @@ fn mcp_summary_cache_key_is_order_independent() {
     assert_eq!(
         super::mcp_summary_cache_key(&order_a),
         super::mcp_summary_cache_key(&order_b),
-        "cache key must be insertion-order-independent (#3687 / #3298)"
+        "cache key must be insertion-order-independent"
     );
-    // Empty allowlist (= "all servers") gets its own well-known key
-    // so it never collides with a server literally named "*".
     assert_eq!(super::mcp_summary_cache_key(&[]), "*");
 }
 

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -140,6 +140,34 @@ impl AgentRegistry {
         entries
     }
 
+    /// Project a peer-agents summary `(name, state_debug, model)` for the
+    /// per-LLM-turn system prompt without cloning a single `AgentEntry`.
+    ///
+    /// Sorted by name so the resulting prompt section is byte-identical
+    /// across runs (provider prompt-cache stability — see #3298).
+    ///
+    /// This is the cheapest path: only the three short strings the prompt
+    /// builder actually consumes are cloned out. With 50 agents that's
+    /// ~150 small string allocations per turn instead of 50 full
+    /// `AgentEntry`s (each with a fat `AgentManifest` of ~6 nested
+    /// `Vec`/`HashMap` allocations). See #3685.
+    pub fn peer_agents_summary(&self) -> Vec<(String, String, String)> {
+        let mut entries: Vec<(String, String, String)> = self
+            .agents
+            .iter()
+            .map(|e| {
+                let v = e.value();
+                (
+                    v.name.clone(),
+                    format!("{:?}", v.state),
+                    v.manifest.model.model.clone(),
+                )
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
     /// Add a child agent ID to a parent's children list.
     pub fn add_child(&self, parent_id: AgentId, child_id: AgentId) {
         if let Some(mut entry) = self.agents.get_mut(&parent_id) {
@@ -674,6 +702,33 @@ mod tests {
 
         let names: Vec<String> = registry.list().iter().map(|e| e.name.clone()).collect();
         assert_eq!(names, vec!["alpha", "mu", "zeta"]);
+    }
+
+    #[test]
+    fn test_peer_agents_summary_is_sorted_and_projects_three_fields() {
+        // Determinism contract for #3685 / #3298: the per-LLM-turn
+        // peer-agents projection must be sorted by name regardless of
+        // insertion order so the resulting prompt section is byte-stable
+        // across processes (provider prompt-cache friendly).
+        let registry = AgentRegistry::new();
+        registry.register(test_entry("zeta")).unwrap();
+        registry.register(test_entry("alpha")).unwrap();
+        registry.register(test_entry("mu")).unwrap();
+
+        let summary = registry.peer_agents_summary();
+        let names: Vec<&str> = summary.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mu", "zeta"]);
+        // Each entry projects exactly the (name, state-debug, model)
+        // tuple the prompt builder consumes — no extra fat from the
+        // underlying `AgentEntry`/`AgentManifest`.
+        for (name, state_debug, model) in &summary {
+            assert!(!name.is_empty());
+            assert!(!state_debug.is_empty());
+            // Whatever the default model is, every entry projects the
+            // same field — the contract is "no panic, three short
+            // strings per entry".
+            assert!(!model.is_empty());
+        }
     }
 
     #[test]

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -140,17 +140,7 @@ impl AgentRegistry {
         entries
     }
 
-    /// Project a peer-agents summary `(name, state_debug, model)` for the
-    /// per-LLM-turn system prompt without cloning a single `AgentEntry`.
-    ///
-    /// Sorted by name so the resulting prompt section is byte-identical
-    /// across runs (provider prompt-cache stability — see #3298).
-    ///
-    /// This is the cheapest path: only the three short strings the prompt
-    /// builder actually consumes are cloned out. With 50 agents that's
-    /// ~150 small string allocations per turn instead of 50 full
-    /// `AgentEntry`s (each with a fat `AgentManifest` of ~6 nested
-    /// `Vec`/`HashMap` allocations). See #3685.
+    /// Projects `(name, state_debug, model)` per agent, sorted by name for prompt-cache stability.
     pub fn peer_agents_summary(&self) -> Vec<(String, String, String)> {
         let mut entries: Vec<(String, String, String)> = self
             .agents
@@ -706,10 +696,6 @@ mod tests {
 
     #[test]
     fn test_peer_agents_summary_is_sorted_and_projects_three_fields() {
-        // Determinism contract for #3685 / #3298: the per-LLM-turn
-        // peer-agents projection must be sorted by name regardless of
-        // insertion order so the resulting prompt section is byte-stable
-        // across processes (provider prompt-cache friendly).
         let registry = AgentRegistry::new();
         registry.register(test_entry("zeta")).unwrap();
         registry.register(test_entry("alpha")).unwrap();
@@ -718,15 +704,9 @@ mod tests {
         let summary = registry.peer_agents_summary();
         let names: Vec<&str> = summary.iter().map(|(n, _, _)| n.as_str()).collect();
         assert_eq!(names, vec!["alpha", "mu", "zeta"]);
-        // Each entry projects exactly the (name, state-debug, model)
-        // tuple the prompt builder consumes — no extra fat from the
-        // underlying `AgentEntry`/`AgentManifest`.
         for (name, state_debug, model) in &summary {
             assert!(!name.is_empty());
             assert!(!state_debug.is_empty());
-            // Whatever the default model is, every entry projects the
-            // same field — the contract is "no panic, three short
-            // strings per entry".
             assert!(!model.is_empty());
         }
     }


### PR DESCRIPTION
## Summary

Three independent allocation hot spots on the per-LLM-turn prompt build path. All preserve the deterministic-prompt guarantee from #3298 and are covered by regression tests.

- **`peer_agents_summary()`** on `AgentRegistry` — projects directly to `(name, state_debug, model)` so the three call sites in `execute_llm_agent` / `send_message_streaming_resolved` / `send_message_with_blocks_and_sender` skip every `AgentEntry` / `Arc<AgentEntry>` deep clone per turn.
- **`build_mcp_summary` `Arc<String>` cache** keyed by `(sorted allowlist, mcp_generation)` — the common case between rare connect/disconnect events skips both the `mcp_tools` `Mutex` acquisition and the `BTreeMap`-based render. Bumps `mcp_generation` immediately after `effective_mcp_servers` is replaced during hot-reload to close a stale-server-set window.
- **`/api/budget/agents`** N+1 SUM was already collapsed into a single `GROUP BY agent_id` via `query_all_agents_daily()`. No code change needed; the issue is closed by the existing implementation.

Closes #3685
Closes #3684
Closes #3687

## Test plan

- [ ] `cargo test -p librefang-kernel registry::tests::test_peer_agents_summary_is_sorted_and_projects_three_fields`
- [ ] `cargo test -p librefang-kernel kernel::tests::mcp_summary_cache_key_is_order_independent`
- [ ] `cargo test -p librefang-kernel kernel::tests::mcp_summary_is_byte_identical_across_input_orders` (existing — must still pass)
- [ ] `cargo test -p librefang-kernel kernel::tests::mcp_summary_inner_tool_list_is_sorted` (existing — must still pass)
- [ ] Live: send a message to an agent twice in a row, confirm prompt cache hit on second turn (no re-render of MCP summary, no `AgentEntry` allocations in flame graph)