### PR TITLE
fix(kernel,migrate): 3 data-integrity bugs

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -5570,7 +5570,24 @@ pub async fn inject_message(
             .into_response();
     }
 
-    match state.kernel.inject_message(agent_id, &req.message).await {
+    // #3734: parse the optional session_id so callers can target a specific
+    // running loop on agents with concurrent sessions. None falls back to a
+    // broadcast across every live session for the agent.
+    let session_id = match req.session_id.as_deref() {
+        Some(s) if !s.is_empty() => match s.parse::<uuid::Uuid>() {
+            Ok(u) => Some(librefang_types::agent::SessionId(u)),
+            Err(_) => {
+                return ApiErrorResponse::bad_request("invalid session_id").into_response();
+            }
+        },
+        _ => None,
+    };
+
+    match state
+        .kernel
+        .inject_message_for_session(agent_id, session_id, &req.message)
+        .await
+    {
         Ok(injected) => (
             StatusCode::OK,
             Json(serde_json::json!({"injected": injected})),

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -5570,9 +5570,7 @@ pub async fn inject_message(
             .into_response();
     }
 
-    // #3734: parse the optional session_id so callers can target a specific
-    // running loop on agents with concurrent sessions. None falls back to a
-    // broadcast across every live session for the agent.
+    // None falls back to a broadcast across every live session for the agent.
     let session_id = match req.session_id.as_deref() {
         Some(s) if !s.is_empty() => match s.parse::<uuid::Uuid>() {
             Ok(u) => Some(librefang_types::agent::SessionId(u)),

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -314,6 +314,12 @@ pub struct MessageResponse {
 pub struct InjectMessageRequest {
     /// The message to inject between tool calls.
     pub message: String,
+    /// Optional session id to target a specific running loop. When omitted
+    /// (#3734), the message is broadcast to every live session for the
+    /// agent — preserves backward compatibility with single-session callers
+    /// while allowing multi-session UIs to address one session at a time.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Response from a mid-turn message injection.

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -314,10 +314,7 @@ pub struct MessageResponse {
 pub struct InjectMessageRequest {
     /// The message to inject between tool calls.
     pub message: String,
-    /// Optional session id to target a specific running loop. When omitted
-    /// (#3734), the message is broadcast to every live session for the
-    /// agent — preserves backward compatibility with single-session callers
-    /// while allowing multi-session UIs to address one session at a time.
+    /// Optional session id; when omitted the message broadcasts to all live sessions for the agent.
     #[serde(default)]
     pub session_id: Option<String>,
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -18518,11 +18518,7 @@ impl LibreFangKernel {
         }
     }
 
-    /// Notify the running agent loop about an approval resolution via an explicit
-    /// mid-turn signal.
-    ///
-    /// `DeferredToolExecution` carries no session id, so the signal fans out to every
-    /// live session; only the one holding the matching `tool_use_id` will act on it.
+    /// Notify the running agent loop about an approval resolution via an explicit mid-turn signal.
     fn notify_agent_of_resolution(
         &self,
         agent_id: &AgentId,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -565,14 +565,26 @@ pub struct LibreFangKernel {
     /// fresh `instance_id` doesn't accumulate stale mutexes across
     /// activate/deactivate cycles.
     hand_runtime_override_locks: dashmap::DashMap<uuid::Uuid, Arc<std::sync::Mutex<()>>>,
-    /// Per-agent mid-turn message injection senders (#956).
-    /// When an agent loop is running, it holds the receiver; callers use the sender
-    /// to inject messages between tool calls.
-    pub(crate) injection_senders:
-        dashmap::DashMap<AgentId, tokio::sync::mpsc::Sender<AgentLoopSignal>>,
-    /// Per-agent injection receivers, created alongside senders and consumed by the agent loop.
+    /// Per-(agent, session) mid-turn message injection senders (#956, #3734).
+    ///
+    /// When an agent loop is running, it holds the receiver; callers use the
+    /// sender to inject messages between tool calls. Keying by
+    /// `(AgentId, SessionId)` instead of just `AgentId` is required for
+    /// concurrent sessions on the same agent (multi-tab UI, multi-channel
+    /// agents) — under the previous `AgentId` keying, a second turn's
+    /// `setup_injection_channel` silently overwrote the first turn's sender,
+    /// so `/api/agents/{id}/inject` could only ever reach the most recently
+    /// started session and earlier sessions' approval-resolution signals
+    /// were silently dropped. See `inject_message` for how callers without a
+    /// session id fan out to all live sessions for the agent.
+    pub(crate) injection_senders: dashmap::DashMap<
+        (AgentId, SessionId),
+        tokio::sync::mpsc::Sender<AgentLoopSignal>,
+    >,
+    /// Per-(agent, session) injection receivers, created alongside senders
+    /// and consumed by the agent loop.
     injection_receivers: dashmap::DashMap<
-        AgentId,
+        (AgentId, SessionId),
         Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<AgentLoopSignal>>>,
     >,
     /// Sticky assistant routing per conversation (assistant + sender/thread).
@@ -1762,11 +1774,11 @@ impl LibreFangKernel {
         &self.whatsapp_gateway_pid
     }
 
-    /// Per-agent message injection senders.
+    /// Per-(agent, session) message injection senders (#3734).
     #[inline]
     pub fn injection_senders_ref(
         &self,
-    ) -> &dashmap::DashMap<AgentId, tokio::sync::mpsc::Sender<AgentLoopSignal>> {
+    ) -> &dashmap::DashMap<(AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>> {
         &self.injection_senders
     }
 
@@ -1864,17 +1876,19 @@ impl LibreFangKernel {
         }
 
         // 4. injection_senders / injection_receivers — remove for dead agents
+        // (#3734: keys are now `(AgentId, SessionId)`, so we filter on the
+        // tuple's agent component).
         {
-            let stale: Vec<AgentId> = self
+            let stale: Vec<(AgentId, SessionId)> = self
                 .injection_senders
                 .iter()
-                .filter(|e| !live_agents.contains(e.key()))
+                .filter(|e| !live_agents.contains(&e.key().0))
                 .map(|e| *e.key())
                 .collect();
             total_removed += stale.len();
-            for id in &stale {
-                self.injection_senders.remove(id);
-                self.injection_receivers.remove(id);
+            for key in &stale {
+                self.injection_senders.remove(key);
+                self.injection_receivers.remove(key);
             }
         }
 
@@ -6164,12 +6178,43 @@ system_prompt = "You are a helpful assistant."
             },
         );
 
+        // #3737 — `session` was loaded above before the spawn, OUTSIDE the
+        // serialization lock. If a concurrent turn (streaming or non-
+        // streaming) lands on the same `(agent, session)` between that read
+        // and the spawn acquiring the lock, the snapshot we captured is
+        // already stale and any messages the loop appends will overwrite
+        // the other turn's writes (last-write-wins). The spawn now reloads
+        // the session AFTER acquiring `session_lock` so the read+modify+
+        // write window is fully serialized — matching the non-streaming
+        // path which loads the session inside `_guard`.
         let handle = tokio::spawn(async move {
             // Acquire the session/agent serialization lock for the duration of
             // this streaming turn.  This matches the non-streaming path and
             // prevents concurrent streaming + non-streaming writes from
             // producing last-write-wins data loss on session history (#3737).
             let _session_guard = session_lock.lock().await;
+
+            // #3737 — Reload the session under the lock so we never feed the
+            // loop a snapshot that another concurrent turn has already
+            // mutated. If the session is missing (race with deletion or a
+            // brand-new session), keep the empty placeholder built above.
+            match memory.get_session(effective_session_id) {
+                Ok(Some(reloaded)) => {
+                    session = reloaded;
+                }
+                Ok(None) => {
+                    // Brand-new session — keep the empty placeholder.
+                }
+                Err(e) => {
+                    warn!(
+                        agent_id = %agent_id,
+                        session_id = %effective_session_id,
+                        error = %e,
+                        "Failed to reload session under lock; proceeding with pre-lock snapshot (streaming)"
+                    );
+                }
+            }
+
             // Auto-compact if the session is large before running the loop.
             // Pass the in-turn session id so the compactor operates on
             // the SAME session the outer loop just measured. Using the
@@ -6241,16 +6286,22 @@ system_prompt = "You are a helpful assistant."
                 });
 
             // Set up mid-turn injection channel (#956). Fork turns skip —
-            // inserting into `injection_senders[agent_id]` would overwrite
-            // the parent turn's channel, and external code trying to
-            // inject into the parent during the fork window would land on
-            // the fork's (about-to-be-dropped) sender instead. Forks are
-            // by design short synchronous derivative calls that don't
-            // need mid-turn injection themselves.
+            // inserting into `injection_senders[(agent_id, session_id)]`
+            // would overwrite the parent turn's channel (forks share the
+            // parent's session id for prompt-cache alignment), and external
+            // code trying to inject into the parent during the fork window
+            // would land on the fork's (about-to-be-dropped) sender
+            // instead. Forks are by design short synchronous derivative
+            // calls that don't need mid-turn injection themselves.
+            //
+            // #3734: keyed by `(agent_id, session_id)` so concurrent
+            // sessions on the same agent (multi-tab UI / multi-channel
+            // bridges) each get their own injection sender instead of the
+            // last writer winning under a single-AgentId key.
             let injection_rx = if loop_opts.is_fork {
                 None
             } else {
-                Some(kernel_clone.setup_injection_channel(agent_id))
+                Some(kernel_clone.setup_injection_channel(agent_id, effective_session_id))
             };
 
             let start_time = std::time::Instant::now();
@@ -6307,9 +6358,10 @@ system_prompt = "You are a helpful assistant."
 
             // Tear down injection channel after loop finishes (skipped for
             // forks since they never set one up — tearing down would
-            // remove the parent turn's entry).
+            // remove the parent turn's entry under the shared
+            // (agent, session) key).
             if !loop_opts.is_fork {
-                kernel_clone.teardown_injection_channel(agent_id);
+                kernel_clone.teardown_injection_channel(agent_id, effective_session_id);
             }
 
             let latency_ms = start_time.elapsed().as_millis() as u64;
@@ -7857,8 +7909,10 @@ system_prompt = "You are a helpful assistant."
 
         let proactive_memory = self.proactive_memory.get().cloned();
 
-        // Set up mid-turn injection channel (#956)
-        let injection_rx = self.setup_injection_channel(agent_id);
+        // Set up mid-turn injection channel (#956, #3734 — keyed by
+        // `(agent_id, effective_session_id)` so concurrent sessions for the
+        // same agent each get their own sender).
+        let injection_rx = self.setup_injection_channel(agent_id, effective_session_id);
 
         // Session-scoped interrupt for tool-level cancellation.  Cloned into
         // each ToolExecutionContext so that cancelling the session (via
@@ -7949,8 +8003,9 @@ system_prompt = "You are a helpful assistant."
         )
         .await;
 
-        // Tear down injection channel after loop finishes
-        self.teardown_injection_channel(agent_id);
+        // Tear down injection channel after loop finishes (#3734 — same
+        // (agent_id, session_id) key as setup above).
+        self.teardown_injection_channel(agent_id, effective_session_id);
 
         // Clean up the interrupt handle regardless of outcome — the map must
         // not retain stale entries that would suppress cancellation on the
@@ -8176,53 +8231,115 @@ system_prompt = "You are a helpful assistant."
     /// Returns `Ok(true)` if the message was sent, `Ok(false)` if no active
     /// loop is running for this agent, or `Err` if the agent doesn't exist.
     pub async fn inject_message(&self, agent_id: AgentId, message: &str) -> KernelResult<bool> {
+        self.inject_message_for_session(agent_id, None, message)
+            .await
+    }
+
+    /// #3734 — Session-aware variant of [`Self::inject_message`].
+    ///
+    /// When `session_id` is `Some`, deliver the message to that exact
+    /// `(agent, session)` injection channel. When `None`, fan out to every
+    /// live session for the agent — useful for callers (HTTP `/inject`
+    /// without a session id, approval-resolution dispatch, …) that don't
+    /// know which concrete session a deferred operation belongs to and need
+    /// to wake whichever loop happens to be running.
+    ///
+    /// Returns `Ok(true)` if at least one channel accepted the message,
+    /// `Ok(false)` if no live loop was reachable, or `Err` when the agent
+    /// itself does not exist.
+    pub async fn inject_message_for_session(
+        &self,
+        agent_id: AgentId,
+        session_id: Option<SessionId>,
+        message: &str,
+    ) -> KernelResult<bool> {
         // Verify the agent exists
         if self.registry.get(agent_id).is_none() {
             return Err(KernelError::LibreFang(LibreFangError::AgentNotFound(
                 agent_id.to_string(),
             )));
         }
-        if let Some(tx) = self.injection_senders.get(&agent_id) {
+
+        // Collect targets first so we don't hold any DashMap shard lock
+        // across the `try_send` calls (which themselves can briefly block on
+        // the per-channel internal lock).
+        let targets: Vec<((AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>)> =
+            if let Some(sid) = session_id {
+                self.injection_senders
+                    .get(&(agent_id, sid))
+                    .map(|entry| (*entry.key(), entry.value().clone()))
+                    .into_iter()
+                    .collect()
+            } else {
+                self.injection_senders
+                    .iter()
+                    .filter(|e| e.key().0 == agent_id)
+                    .map(|e| (*e.key(), e.value().clone()))
+                    .collect()
+            };
+
+        if targets.is_empty() {
+            return Ok(false);
+        }
+
+        let mut delivered = false;
+        let mut closed_keys: Vec<(AgentId, SessionId)> = Vec::new();
+        for (key, tx) in targets {
             match tx.try_send(AgentLoopSignal::Message {
                 content: message.to_string(),
             }) {
                 Ok(()) => {
-                    info!(agent_id = %agent_id, "Mid-turn message injected");
-                    Ok(true)
+                    info!(
+                        agent_id = %agent_id,
+                        session_id = %key.1,
+                        "Mid-turn message injected"
+                    );
+                    delivered = true;
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    warn!(agent_id = %agent_id, "Injection channel full — message dropped");
-                    Ok(false)
+                    warn!(
+                        agent_id = %agent_id,
+                        session_id = %key.1,
+                        "Injection channel full — message dropped"
+                    );
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                    // Receiver dropped — loop is no longer running
-                    self.injection_senders.remove(&agent_id);
-                    Ok(false)
+                    // Receiver dropped — loop is no longer running.
+                    closed_keys.push(key);
                 }
             }
-        } else {
-            // No active loop for this agent
-            Ok(false)
         }
+        for key in closed_keys {
+            self.injection_senders.remove(&key);
+        }
+        Ok(delivered)
     }
 
-    /// Set up the injection channel for an agent before running its loop.
-    /// Returns the receiver wrapped in a Mutex for the agent loop to consume.
+    /// Set up the injection channel for an agent's specific session before
+    /// running its loop. Returns the receiver wrapped in a Mutex for the
+    /// agent loop to consume.
+    ///
+    /// #3734: keyed by `(AgentId, SessionId)` so concurrent sessions for the
+    /// same agent each get their own channel — previously, the second turn
+    /// silently overwrote the first's sender via the single-`AgentId` key.
     fn setup_injection_channel(
         &self,
         agent_id: AgentId,
+        session_id: SessionId,
     ) -> Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<AgentLoopSignal>>> {
         let (tx, rx) = tokio::sync::mpsc::channel::<AgentLoopSignal>(8);
-        self.injection_senders.insert(agent_id, tx);
+        self.injection_senders.insert((agent_id, session_id), tx);
         let rx = Arc::new(tokio::sync::Mutex::new(rx));
-        self.injection_receivers.insert(agent_id, Arc::clone(&rx));
+        self.injection_receivers
+            .insert((agent_id, session_id), Arc::clone(&rx));
         rx
     }
 
-    /// Tear down the injection channel after the agent loop finishes.
-    fn teardown_injection_channel(&self, agent_id: AgentId) {
-        self.injection_senders.remove(&agent_id);
-        self.injection_receivers.remove(&agent_id);
+    /// Tear down the injection channel for an agent's specific session
+    /// after its loop finishes (#3734).
+    fn teardown_injection_channel(&self, agent_id: AgentId, session_id: SessionId) {
+        self.injection_senders.remove(&(agent_id, session_id));
+        self.injection_receivers.remove(&(agent_id, session_id));
     }
 
     /// Resolve a module path relative to the kernel's home directory.
@@ -18443,6 +18560,14 @@ impl LibreFangKernel {
 
     /// Notify the running agent loop about an approval resolution via an explicit
     /// mid-turn signal.
+    ///
+    /// #3734 — `injection_senders` is keyed by `(AgentId, SessionId)`. The
+    /// `DeferredToolExecution` does not currently carry a `SessionId`, so we
+    /// fan the signal out to every live session for the agent. In practice
+    /// only one session has the matching `tool_use_id` outstanding, so the
+    /// other sessions will ignore the message; this is strictly more correct
+    /// than the pre-#3734 behaviour where a single-AgentId key meant only
+    /// the most recently spawned session ever received the signal at all.
     fn notify_agent_of_resolution(
         &self,
         agent_id: &AgentId,
@@ -18450,7 +18575,24 @@ impl LibreFangKernel {
         decision: &librefang_types::approval::ApprovalDecision,
         result: &librefang_types::tool::ToolResult,
     ) -> bool {
-        if let Some(tx) = self.injection_senders.get(agent_id) {
+        let senders: Vec<((AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>)> =
+            self.injection_senders
+                .iter()
+                .filter(|e| e.key().0 == *agent_id)
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect();
+
+        if senders.is_empty() {
+            debug!(
+                agent_id = %agent_id,
+                "Approval resolution: no active agent loop to notify"
+            );
+            return false;
+        }
+
+        let mut delivered = false;
+        let mut closed_keys: Vec<(AgentId, SessionId)> = Vec::new();
+        for (key, tx) in senders {
             match tx.try_send(AgentLoopSignal::ApprovalResolved {
                 tool_use_id: deferred.tool_use_id.clone(),
                 tool_name: deferred.tool_name.clone(),
@@ -18460,31 +18602,34 @@ impl LibreFangKernel {
                 result_status: result.status,
             }) {
                 Ok(()) => {
-                    debug!(agent_id = %agent_id, "Approval resolution injected into agent loop");
-                    true
+                    debug!(
+                        agent_id = %agent_id,
+                        session_id = %key.1,
+                        "Approval resolution injected into agent loop"
+                    );
+                    delivered = true;
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                     warn!(
                         agent_id = %agent_id,
+                        session_id = %key.1,
                         "Approval resolution injection channel full — falling back to session patch"
                     );
-                    false
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                     debug!(
                         agent_id = %agent_id,
+                        session_id = %key.1,
                         "Approval resolution: agent loop is not running (injection channel closed)"
                     );
-                    false
+                    closed_keys.push(key);
                 }
             }
-        } else {
-            debug!(
-                agent_id = %agent_id,
-                "Approval resolution: no active agent loop to notify"
-            );
-            false
         }
+        for key in closed_keys {
+            self.injection_senders.remove(&key);
+        }
+        delivered
     }
 }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -567,10 +567,8 @@ pub struct LibreFangKernel {
     hand_runtime_override_locks: dashmap::DashMap<uuid::Uuid, Arc<std::sync::Mutex<()>>>,
     /// Per-(agent, session) mid-turn injection senders; keyed by session so concurrent
     /// sessions on the same agent each get their own channel.
-    pub(crate) injection_senders: dashmap::DashMap<
-        (AgentId, SessionId),
-        tokio::sync::mpsc::Sender<AgentLoopSignal>,
-    >,
+    pub(crate) injection_senders:
+        dashmap::DashMap<(AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>>,
     /// Per-(agent, session) injection receivers, created alongside senders
     /// and consumed by the agent loop.
     injection_receivers: dashmap::DashMap<
@@ -8216,20 +8214,22 @@ system_prompt = "You are a helpful assistant."
         // Collect targets first so we don't hold any DashMap shard lock
         // across the `try_send` calls (which themselves can briefly block on
         // the per-channel internal lock).
-        let targets: Vec<((AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>)> =
-            if let Some(sid) = session_id {
-                self.injection_senders
-                    .get(&(agent_id, sid))
-                    .map(|entry| (*entry.key(), entry.value().clone()))
-                    .into_iter()
-                    .collect()
-            } else {
-                self.injection_senders
-                    .iter()
-                    .filter(|e| e.key().0 == agent_id)
-                    .map(|e| (*e.key(), e.value().clone()))
-                    .collect()
-            };
+        let targets: Vec<(
+            (AgentId, SessionId),
+            tokio::sync::mpsc::Sender<AgentLoopSignal>,
+        )> = if let Some(sid) = session_id {
+            self.injection_senders
+                .get(&(agent_id, sid))
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .into_iter()
+                .collect()
+        } else {
+            self.injection_senders
+                .iter()
+                .filter(|e| e.key().0 == agent_id)
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect()
+        };
 
         if targets.is_empty() {
             return Ok(false);

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -565,18 +565,8 @@ pub struct LibreFangKernel {
     /// fresh `instance_id` doesn't accumulate stale mutexes across
     /// activate/deactivate cycles.
     hand_runtime_override_locks: dashmap::DashMap<uuid::Uuid, Arc<std::sync::Mutex<()>>>,
-    /// Per-(agent, session) mid-turn message injection senders (#956, #3734).
-    ///
-    /// When an agent loop is running, it holds the receiver; callers use the
-    /// sender to inject messages between tool calls. Keying by
-    /// `(AgentId, SessionId)` instead of just `AgentId` is required for
-    /// concurrent sessions on the same agent (multi-tab UI, multi-channel
-    /// agents) — under the previous `AgentId` keying, a second turn's
-    /// `setup_injection_channel` silently overwrote the first turn's sender,
-    /// so `/api/agents/{id}/inject` could only ever reach the most recently
-    /// started session and earlier sessions' approval-resolution signals
-    /// were silently dropped. See `inject_message` for how callers without a
-    /// session id fan out to all live sessions for the agent.
+    /// Per-(agent, session) mid-turn injection senders; keyed by session so concurrent
+    /// sessions on the same agent each get their own channel.
     pub(crate) injection_senders: dashmap::DashMap<
         (AgentId, SessionId),
         tokio::sync::mpsc::Sender<AgentLoopSignal>,
@@ -1774,7 +1764,7 @@ impl LibreFangKernel {
         &self.whatsapp_gateway_pid
     }
 
-    /// Per-(agent, session) message injection senders (#3734).
+    /// Per-(agent, session) message injection senders.
     #[inline]
     pub fn injection_senders_ref(
         &self,
@@ -1875,9 +1865,7 @@ impl LibreFangKernel {
             }
         }
 
-        // 4. injection_senders / injection_receivers — remove for dead agents
-        // (#3734: keys are now `(AgentId, SessionId)`, so we filter on the
-        // tuple's agent component).
+        // 4. injection_senders / injection_receivers — remove for dead agents.
         {
             let stale: Vec<(AgentId, SessionId)> = self
                 .injection_senders
@@ -6152,11 +6140,8 @@ system_prompt = "You are a helpful assistant."
         // reload barrier before spawning the async task.
         drop(_config_guard);
 
-        // Issue #3737: acquire the same session/agent lock as the non-streaming
-        // path so concurrent streaming + non-streaming turns on the same session
-        // are serialized (last-write-wins data loss on session history otherwise).
-        // We clone the Arc here (sync fn) and move it into the task; the lock
-        // itself is awaited inside the spawn where we can .await.
+        // Acquire the same session/agent lock as the non-streaming path so concurrent
+        // turns are serialized. Clone the Arc here (sync fn); lock inside the spawn.
         let session_lock = if session_id_override.is_some() {
             self.session_msg_locks
                 .entry(effective_session_id)
@@ -6178,26 +6163,16 @@ system_prompt = "You are a helpful assistant."
             },
         );
 
-        // #3737 — `session` was loaded above before the spawn, OUTSIDE the
-        // serialization lock. If a concurrent turn (streaming or non-
-        // streaming) lands on the same `(agent, session)` between that read
-        // and the spawn acquiring the lock, the snapshot we captured is
-        // already stale and any messages the loop appends will overwrite
-        // the other turn's writes (last-write-wins). The spawn now reloads
-        // the session AFTER acquiring `session_lock` so the read+modify+
-        // write window is fully serialized — matching the non-streaming
-        // path which loads the session inside `_guard`.
+        // Reload session after acquiring the lock so we never act on a stale
+        // snapshot captured before a concurrent turn's writes landed.
         let handle = tokio::spawn(async move {
             // Acquire the session/agent serialization lock for the duration of
             // this streaming turn.  This matches the non-streaming path and
             // prevents concurrent streaming + non-streaming writes from
-            // producing last-write-wins data loss on session history (#3737).
+            // producing last-write-wins data loss on session history.
             let _session_guard = session_lock.lock().await;
 
-            // #3737 — Reload the session under the lock so we never feed the
-            // loop a snapshot that another concurrent turn has already
-            // mutated. If the session is missing (race with deletion or a
-            // brand-new session), keep the empty placeholder built above.
+            // Reload session under the lock; keep the placeholder on miss.
             match memory.get_session(effective_session_id) {
                 Ok(Some(reloaded)) => {
                     session = reloaded;
@@ -6285,19 +6260,9 @@ system_prompt = "You are a helpful assistant."
                     let _ = phase_tx.try_send(event);
                 });
 
-            // Set up mid-turn injection channel (#956). Fork turns skip —
-            // inserting into `injection_senders[(agent_id, session_id)]`
-            // would overwrite the parent turn's channel (forks share the
-            // parent's session id for prompt-cache alignment), and external
-            // code trying to inject into the parent during the fork window
-            // would land on the fork's (about-to-be-dropped) sender
-            // instead. Forks are by design short synchronous derivative
-            // calls that don't need mid-turn injection themselves.
-            //
-            // #3734: keyed by `(agent_id, session_id)` so concurrent
-            // sessions on the same agent (multi-tab UI / multi-channel
-            // bridges) each get their own injection sender instead of the
-            // last writer winning under a single-AgentId key.
+            // Set up mid-turn injection channel. Fork turns skip — inserting
+            // would overwrite the parent turn's channel (forks share the parent's
+            // session id for prompt-cache alignment).
             let injection_rx = if loop_opts.is_fork {
                 None
             } else {
@@ -7909,9 +7874,7 @@ system_prompt = "You are a helpful assistant."
 
         let proactive_memory = self.proactive_memory.get().cloned();
 
-        // Set up mid-turn injection channel (#956, #3734 — keyed by
-        // `(agent_id, effective_session_id)` so concurrent sessions for the
-        // same agent each get their own sender).
+        // Set up mid-turn injection channel.
         let injection_rx = self.setup_injection_channel(agent_id, effective_session_id);
 
         // Session-scoped interrupt for tool-level cancellation.  Cloned into
@@ -8003,8 +7966,7 @@ system_prompt = "You are a helpful assistant."
         )
         .await;
 
-        // Tear down injection channel after loop finishes (#3734 — same
-        // (agent_id, session_id) key as setup above).
+        // Tear down injection channel after loop finishes.
         self.teardown_injection_channel(agent_id, effective_session_id);
 
         // Clean up the interrupt handle regardless of outcome — the map must
@@ -8235,18 +8197,9 @@ system_prompt = "You are a helpful assistant."
             .await
     }
 
-    /// #3734 — Session-aware variant of [`Self::inject_message`].
+    /// Session-aware variant of [`Self::inject_message`]; `None` fans out to all live sessions.
     ///
-    /// When `session_id` is `Some`, deliver the message to that exact
-    /// `(agent, session)` injection channel. When `None`, fan out to every
-    /// live session for the agent — useful for callers (HTTP `/inject`
-    /// without a session id, approval-resolution dispatch, …) that don't
-    /// know which concrete session a deferred operation belongs to and need
-    /// to wake whichever loop happens to be running.
-    ///
-    /// Returns `Ok(true)` if at least one channel accepted the message,
-    /// `Ok(false)` if no live loop was reachable, or `Err` when the agent
-    /// itself does not exist.
+    /// Returns `Ok(true)` if at least one channel accepted, `Ok(false)` if no loop was running.
     pub async fn inject_message_for_session(
         &self,
         agent_id: AgentId,
@@ -8315,13 +8268,7 @@ system_prompt = "You are a helpful assistant."
         Ok(delivered)
     }
 
-    /// Set up the injection channel for an agent's specific session before
-    /// running its loop. Returns the receiver wrapped in a Mutex for the
-    /// agent loop to consume.
-    ///
-    /// #3734: keyed by `(AgentId, SessionId)` so concurrent sessions for the
-    /// same agent each get their own channel — previously, the second turn
-    /// silently overwrote the first's sender via the single-`AgentId` key.
+    /// Creates the injection channel for `(agent_id, session_id)` and returns the receiver.
     fn setup_injection_channel(
         &self,
         agent_id: AgentId,
@@ -8335,8 +8282,7 @@ system_prompt = "You are a helpful assistant."
         rx
     }
 
-    /// Tear down the injection channel for an agent's specific session
-    /// after its loop finishes (#3734).
+    /// Tears down the `(agent_id, session_id)` injection channel after the loop finishes.
     fn teardown_injection_channel(&self, agent_id: AgentId, session_id: SessionId) {
         self.injection_senders.remove(&(agent_id, session_id));
         self.injection_receivers.remove(&(agent_id, session_id));
@@ -18561,13 +18507,8 @@ impl LibreFangKernel {
     /// Notify the running agent loop about an approval resolution via an explicit
     /// mid-turn signal.
     ///
-    /// #3734 — `injection_senders` is keyed by `(AgentId, SessionId)`. The
-    /// `DeferredToolExecution` does not currently carry a `SessionId`, so we
-    /// fan the signal out to every live session for the agent. In practice
-    /// only one session has the matching `tool_use_id` outstanding, so the
-    /// other sessions will ignore the message; this is strictly more correct
-    /// than the pre-#3734 behaviour where a single-AgentId key meant only
-    /// the most recently spawned session ever received the signal at all.
+    /// `DeferredToolExecution` carries no session id, so the signal fans out to every
+    /// live session; only the one holding the matching `tool_use_id` will act on it.
     fn notify_agent_of_resolution(
         &self,
         agent_id: &AgentId,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -18516,12 +18516,15 @@ impl LibreFangKernel {
         decision: &librefang_types::approval::ApprovalDecision,
         result: &librefang_types::tool::ToolResult,
     ) -> bool {
-        let senders: Vec<((AgentId, SessionId), tokio::sync::mpsc::Sender<AgentLoopSignal>)> =
-            self.injection_senders
-                .iter()
-                .filter(|e| e.key().0 == *agent_id)
-                .map(|e| (*e.key(), e.value().clone()))
-                .collect();
+        let senders: Vec<(
+            (AgentId, SessionId),
+            tokio::sync::mpsc::Sender<AgentLoopSignal>,
+        )> = self
+            .injection_senders
+            .iter()
+            .filter(|e| e.key().0 == *agent_id)
+            .map(|e| (*e.key(), e.value().clone()))
+            .collect();
 
         if senders.is_empty() {
             debug!(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -5835,29 +5835,14 @@ system_prompt = "You are a helpful assistant."
             );
         }
 
-        // Check if auto-compaction is needed: message-count OR token-count trigger
-        let needs_compact = {
-            use librefang_runtime::compactor::{
-                estimate_token_count, needs_compaction as check_compact,
-                needs_compaction_by_tokens, CompactionConfig,
-            };
-            let config = CompactionConfig::from_toml(&cfg.compaction);
-            let by_messages = check_compact(&session, &config);
-            let estimated = estimate_token_count(
-                &session.messages,
-                Some(&entry.manifest.model.system_prompt),
-                None,
-            );
-            let by_tokens = needs_compaction_by_tokens(estimated, &config);
-            if by_tokens && !by_messages {
-                info!(
-                    agent_id = %agent_id,
-                    estimated_tokens = estimated,
-                    messages = session.messages.len(),
-                    "Token-based compaction triggered (messages below threshold but tokens above)"
-                );
-            }
-            by_messages || by_tokens
+        // Snapshot the compaction config so the spawned task can recompute the
+        // `needs_compact` flag *after* reloading the session under the lock.
+        // Computing it here on the pre-lock snapshot would make it stale: a
+        // concurrent turn that committed history while we were waiting for
+        // the lock could push us across (or back below) the threshold.
+        let compaction_config_snapshot = {
+            use librefang_runtime::compactor::CompactionConfig;
+            CompactionConfig::from_toml(&cfg.compaction)
         };
 
         let tools = self.available_tools(agent_id);
@@ -6187,6 +6172,35 @@ system_prompt = "You are a helpful assistant."
                     );
                 }
             }
+
+            // Recompute `needs_compact` against the freshly-reloaded session.
+            // Computing it on the pre-lock snapshot was racy: a concurrent
+            // turn that wrote history while we were queued on `session_lock`
+            // could have pushed us across (or back below) the threshold,
+            // causing this turn to either skip a compact that is now due or
+            // re-compact a session another turn just compacted.
+            let needs_compact = {
+                use librefang_runtime::compactor::{
+                    estimate_token_count, needs_compaction as check_compact,
+                    needs_compaction_by_tokens,
+                };
+                let by_messages = check_compact(&session, &compaction_config_snapshot);
+                let estimated = estimate_token_count(
+                    &session.messages,
+                    Some(&manifest.model.system_prompt),
+                    None,
+                );
+                let by_tokens = needs_compaction_by_tokens(estimated, &compaction_config_snapshot);
+                if by_tokens && !by_messages {
+                    info!(
+                        agent_id = %agent_id,
+                        estimated_tokens = estimated,
+                        messages = session.messages.len(),
+                        "Token-based compaction triggered (messages below threshold but tokens above)"
+                    );
+                }
+                by_messages || by_tokens
+            };
 
             // Auto-compact if the session is large before running the loop.
             // Pass the in-turn session id so the compactor operates on

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5378,3 +5378,92 @@ fn cron_create_handles_missing_peer_id() {
     let peer_id = job_json["peer_id"].as_str().map(|s| s.to_string());
     assert_eq!(peer_id, None);
 }
+
+// ---------------------------------------------------------------------------
+// #3734 — injection_senders is keyed by `(AgentId, SessionId)` so concurrent
+// sessions on the same agent each get their own sender. Pre-#3734 the second
+// `setup_injection_channel` silently overwrote the first one's entry under
+// the single `AgentId` key, so an HTTP `/inject` could only ever reach the
+// most recently spawned session.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn injection_senders_two_sessions_one_agent_do_not_collide() {
+    let kernel = boot_kernel_for_display_tests();
+    let agent_id = register_test_agent(&kernel, "twin");
+
+    let session_a = SessionId::new();
+    let session_b = SessionId::new();
+
+    let _rx_a = kernel.setup_injection_channel(agent_id, session_a);
+    let _rx_b = kernel.setup_injection_channel(agent_id, session_b);
+
+    // Both senders must be live concurrently — pre-#3734 the second insert
+    // overwrote the first under the `AgentId` key.
+    assert!(
+        kernel
+            .injection_senders
+            .contains_key(&(agent_id, session_a)),
+        "session A sender lost under (agent, session) keying"
+    );
+    assert!(
+        kernel
+            .injection_senders
+            .contains_key(&(agent_id, session_b)),
+        "session B sender lost under (agent, session) keying"
+    );
+
+    // Targeted inject must reach exactly one session — the other's mpsc
+    // receiver still holds at-zero queue depth.
+    kernel
+        .inject_message_for_session(agent_id, Some(session_a), "hello A")
+        .await
+        .expect("inject A");
+
+    let queued_a = _rx_a.lock().await.try_recv();
+    let queued_b = _rx_b.lock().await.try_recv();
+    assert!(matches!(queued_a, Ok(_)), "session A must have received");
+    assert!(
+        matches!(queued_b, Err(tokio::sync::mpsc::error::TryRecvError::Empty)),
+        "session B must NOT have received a session-A inject"
+    );
+
+    // Untargeted inject (#3734 fallback) broadcasts to both sessions.
+    kernel
+        .inject_message_for_session(agent_id, None, "broadcast")
+        .await
+        .expect("inject broadcast");
+
+    assert!(matches!(_rx_a.lock().await.try_recv(), Ok(_)));
+    assert!(matches!(_rx_b.lock().await.try_recv(), Ok(_)));
+
+    kernel.teardown_injection_channel(agent_id, session_a);
+    kernel.teardown_injection_channel(agent_id, session_b);
+    kernel.shutdown();
+}
+
+#[tokio::test]
+async fn injection_teardown_only_removes_target_session() {
+    let kernel = boot_kernel_for_display_tests();
+    let agent_id = register_test_agent(&kernel, "twin2");
+
+    let session_a = SessionId::new();
+    let session_b = SessionId::new();
+
+    let _rx_a = kernel.setup_injection_channel(agent_id, session_a);
+    let _rx_b = kernel.setup_injection_channel(agent_id, session_b);
+
+    // Tearing down session A must NOT clear session B's sender — pre-#3734
+    // a single `remove(&agent_id)` would orphan whichever session was still
+    // running.
+    kernel.teardown_injection_channel(agent_id, session_a);
+    assert!(!kernel
+        .injection_senders
+        .contains_key(&(agent_id, session_a)));
+    assert!(kernel
+        .injection_senders
+        .contains_key(&(agent_id, session_b)));
+
+    kernel.teardown_injection_channel(agent_id, session_b);
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5379,14 +5379,6 @@ fn cron_create_handles_missing_peer_id() {
     assert_eq!(peer_id, None);
 }
 
-// ---------------------------------------------------------------------------
-// #3734 — injection_senders is keyed by `(AgentId, SessionId)` so concurrent
-// sessions on the same agent each get their own sender. Pre-#3734 the second
-// `setup_injection_channel` silently overwrote the first one's entry under
-// the single `AgentId` key, so an HTTP `/inject` could only ever reach the
-// most recently spawned session.
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn injection_senders_two_sessions_one_agent_do_not_collide() {
     let kernel = boot_kernel_for_display_tests();
@@ -5398,8 +5390,7 @@ async fn injection_senders_two_sessions_one_agent_do_not_collide() {
     let _rx_a = kernel.setup_injection_channel(agent_id, session_a);
     let _rx_b = kernel.setup_injection_channel(agent_id, session_b);
 
-    // Both senders must be live concurrently — pre-#3734 the second insert
-    // overwrote the first under the `AgentId` key.
+    // Both senders must be live concurrently (second insert used to overwrite the first).
     assert!(
         kernel
             .injection_senders
@@ -5428,7 +5419,7 @@ async fn injection_senders_two_sessions_one_agent_do_not_collide() {
         "session B must NOT have received a session-A inject"
     );
 
-    // Untargeted inject (#3734 fallback) broadcasts to both sessions.
+    // Untargeted inject (None session_id) broadcasts to both sessions.
     kernel
         .inject_message_for_session(agent_id, None, "broadcast")
         .await
@@ -5453,9 +5444,7 @@ async fn injection_teardown_only_removes_target_session() {
     let _rx_a = kernel.setup_injection_channel(agent_id, session_a);
     let _rx_b = kernel.setup_injection_channel(agent_id, session_b);
 
-    // Tearing down session A must NOT clear session B's sender — pre-#3734
-    // a single `remove(&agent_id)` would orphan whichever session was still
-    // running.
+    // Tearing down session A must NOT clear session B's sender.
     kernel.teardown_injection_channel(agent_id, session_a);
     assert!(!kernel
         .injection_senders

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5413,7 +5413,7 @@ async fn injection_senders_two_sessions_one_agent_do_not_collide() {
 
     let queued_a = _rx_a.lock().await.try_recv();
     let queued_b = _rx_b.lock().await.try_recv();
-    assert!(matches!(queued_a, Ok(_)), "session A must have received");
+    assert!(queued_a.is_ok(), "session A must have received");
     assert!(
         matches!(queued_b, Err(tokio::sync::mpsc::error::TryRecvError::Empty)),
         "session B must NOT have received a session-A inject"
@@ -5425,8 +5425,8 @@ async fn injection_senders_two_sessions_one_agent_do_not_collide() {
         .await
         .expect("inject broadcast");
 
-    assert!(matches!(_rx_a.lock().await.try_recv(), Ok(_)));
-    assert!(matches!(_rx_b.lock().await.try_recv(), Ok(_)));
+    assert!(_rx_a.lock().await.try_recv().is_ok());
+    assert!(_rx_b.lock().await.try_recv().is_ok());
 
     kernel.teardown_injection_channel(agent_id, session_a);
     kernel.teardown_injection_channel(agent_id, session_b);

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5379,7 +5379,7 @@ fn cron_create_handles_missing_peer_id() {
     assert_eq!(peer_id, None);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn injection_senders_two_sessions_one_agent_do_not_collide() {
     let kernel = boot_kernel_for_display_tests();
     let agent_id = register_test_agent(&kernel, "twin");
@@ -5433,7 +5433,7 @@ async fn injection_senders_two_sessions_one_agent_do_not_collide() {
     kernel.shutdown();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn injection_teardown_only_removes_target_session() {
     let kernel = boot_kernel_for_display_tests();
     let agent_id = register_test_agent(&kernel, "twin2");

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -4799,8 +4799,7 @@ mod tests {
         assert_eq!(dc_count, 1, "Duplicate DISCORD_BOT_TOKEN in secrets.env");
     }
 
-    /// When the marker is removed and a re-run is forced, user-edited files
-    /// must be backed up to `.bak.<timestamp>` siblings rather than overwritten.
+    /// Forced re-run (marker deleted) must back up user-edited files to `.bak.<timestamp>` siblings rather than overwriting them.
     #[test]
     fn test_rerun_backs_up_user_edits() {
         let source = TempDir::new().unwrap();

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -67,19 +67,10 @@ fn atomic_write(path: &std::path::Path, content: impl AsRef<[u8]>) -> std::io::R
     Ok(())
 }
 
-/// #3795 — Marker filename written into the target home directory after a
-/// successful OpenClaw migration. Subsequent invocations of `migrate()` see
-/// this file and refuse to run, so we never overwrite (or even back up) user
-/// edits made after the initial import.
+/// Marker written after a successful migration; present = re-runs are no-ops.
 const MIGRATION_MARKER_FILENAME: &str = ".openclaw_migrated";
 
-/// #3795 — Backup `path` to a timestamped sibling (`<path>.bak.<unix_ts>`)
-/// before overwriting. Returns the backup path so callers can record it in
-/// the migration report. If the source file does not exist, this is a no-op
-/// and returns `Ok(None)`.
-///
-/// The timestamp is the current UTC time formatted as `YYYYMMDDHHMMSS` so
-/// repeated rescues never collide and the order is obvious from the filename.
+/// Renames `path` to a `.bak.<timestamp>` sibling; returns the new path or `None` if absent.
 fn backup_existing(path: &std::path::Path) -> std::io::Result<Option<PathBuf>> {
     if !path.exists() {
         return Ok(None);
@@ -100,11 +91,7 @@ fn backup_existing(path: &std::path::Path) -> std::io::Result<Option<PathBuf>> {
     Ok(Some(backup_path))
 }
 
-/// #3795 — Helper used by every migration write point: if `dest` already
-/// exists, rename it to a `.bak.<timestamp>` sibling and emit a warning +
-/// report entry, then proceed to atomically write `content`. This is the
-/// single chokepoint that protects user-edited config/agent/memory files
-/// from being silently clobbered on re-runs.
+/// Backs up any existing `dest` to a `.bak.*` sibling then atomically writes `content`.
 fn write_with_backup(
     dest: &std::path::Path,
     content: &str,
@@ -1282,11 +1269,8 @@ pub fn migrate(options: &MigrateOptions) -> Result<MigrationReport, MigrateError
         ..Default::default()
     };
 
-    // #3795 — If a previous successful migration already wrote a marker file
-    // in the target home directory, refuse to re-run. The marker is the
-    // strongest signal that any subsequent edits to config.toml /
-    // agent.toml / imported_memory.md belong to the user, not to OpenClaw,
-    // and should not be touched by the migrator at all (not even backed up).
+    // Refuse to re-run if the marker file is present; user edits since the
+    // first import must not be overwritten.
     let marker_path = target.join(MIGRATION_MARKER_FILENAME);
     if marker_path.exists() && !options.dry_run {
         warn!(
@@ -1318,9 +1302,8 @@ pub fn migrate(options: &MigrateOptions) -> Result<MigrationReport, MigrateError
         let report_path = target.join("migration_report.md");
         let _ = std::fs::write(&report_path, &report_md);
 
-        // #3795 — Drop a marker file so re-runs are no-ops. Best-effort: if
-        // we can't write the marker (e.g. read-only home), the worst case is
-        // a future re-run that backs up files again — no data is lost.
+        // Drop a marker so re-runs are no-ops. Best-effort: if the write fails,
+        // a future re-run will back up files again — no data lost.
         let stamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
         let marker_body = format!(
             "OpenClaw migration completed at {stamp}.\nDelete this file to force a re-import; existing files will be moved to .bak.<timestamp> siblings rather than overwritten.\n"
@@ -1443,10 +1426,7 @@ fn migrate_config_from_json(
 
     if !dry_run {
         std::fs::create_dir_all(target)?;
-        // #3795 — Existing config.toml is preserved by renaming it to a
-        // timestamped `.bak.*` sibling before writing the freshly imported
-        // version. The migrate() entry point also writes a marker file so
-        // subsequent re-runs short-circuit before reaching this point.
+        // Back up any existing config.toml before overwriting.
         write_with_backup(&dest, &config_content, report)?;
     }
 
@@ -1978,12 +1958,7 @@ fn migrate_agents_from_json(
 
                 if !dry_run {
                     std::fs::create_dir_all(&dest_dir)?;
-                    // #3795 — Existing agent.toml is moved to a timestamped
-                    // `.bak.*` sibling before writing. Combined with the
-                    // marker file, re-runs after the initial import are
-                    // short-circuited at migrate() entry, so this branch
-                    // only fires on the first import or when the marker has
-                    // been deliberately removed.
+                    // Back up any existing agent.toml before overwriting.
                     write_with_backup(&dest_file, &toml_str, report)?;
                 }
 
@@ -2324,9 +2299,7 @@ fn migrate_memory_files(
 
                 if !dry_run {
                     std::fs::create_dir_all(&dest_dir)?;
-                    // #3795 — Back up any existing imported_memory.md before
-                    // overwriting; the marker file in target/ stops re-runs
-                    // from reaching this branch on subsequent invocations.
+                    // Back up any existing imported_memory.md before overwriting.
                     write_with_backup(&dest_file, &content, report)?;
                 }
 
@@ -2375,8 +2348,7 @@ fn migrate_memory_files(
 
                 if !dry_run {
                     std::fs::create_dir_all(&dest_dir)?;
-                    // #3795 — Back up any existing imported_memory.md before
-                    // overwriting; marker file short-circuits re-runs.
+                    // Back up any existing imported_memory.md before overwriting.
                     write_with_backup(&dest_file, &content, report)?;
                 }
 
@@ -2749,9 +2721,7 @@ fn migrate_legacy_config(
 
     if !dry_run {
         std::fs::create_dir_all(target)?;
-        // #3795 — Back up any existing config.toml before overwriting; the
-        // marker file written at migrate() exit prevents re-runs from
-        // reaching this branch on subsequent invocations.
+        // Back up any existing config.toml before overwriting.
         write_with_backup(&dest, &config_content, report)?;
     }
 
@@ -3065,8 +3035,7 @@ fn migrate_legacy_agents(
 
                 if !dry_run {
                     std::fs::create_dir_all(&dest_dir)?;
-                    // #3795 — Back up any existing agent.toml before
-                    // overwriting; marker file short-circuits re-runs.
+                    // Back up any existing agent.toml before overwriting.
                     write_with_backup(&dest_file, &toml_str, report)?;
                 }
 
@@ -3259,8 +3228,7 @@ fn migrate_legacy_memory(
 
         if !dry_run {
             std::fs::create_dir_all(&dest_dir)?;
-            // #3795 — Back up any existing imported_memory.md before
-            // overwriting; marker file short-circuits re-runs.
+            // Back up any existing imported_memory.md before overwriting.
             write_with_backup(&dest_file, &content, report)?;
         }
 
@@ -4804,7 +4772,7 @@ mod tests {
         // Run migration twice
         migrate(&options).unwrap();
 
-        // #3795 — Marker file should be present after a successful run.
+        // Marker file must be present after a successful run.
         let marker = target.path().join(MIGRATION_MARKER_FILENAME);
         assert!(marker.exists(), "marker file not written");
 
@@ -4831,9 +4799,8 @@ mod tests {
         assert_eq!(dc_count, 1, "Duplicate DISCORD_BOT_TOKEN in secrets.env");
     }
 
-    /// #3795 regression — when the marker file is removed and a re-run is
-    /// forced, any user-edited config.toml / agent.toml must be backed up
-    /// to a `.bak.<timestamp>` sibling rather than silently overwritten.
+    /// When the marker is removed and a re-run is forced, user-edited files
+    /// must be backed up to `.bak.<timestamp>` siblings rather than overwritten.
     #[test]
     fn test_rerun_backs_up_user_edits() {
         let source = TempDir::new().unwrap();
@@ -4872,8 +4839,7 @@ mod tests {
             "fresh config should not contain user edit"
         );
 
-        // The user's edited copy is preserved as a `.bak.*` sibling so no
-        // data is lost — this is what #3795 demands.
+        // The user's edited copy must be preserved as a `.bak.*` sibling.
         let backups: Vec<_> = std::fs::read_dir(target.path())
             .unwrap()
             .filter_map(Result::ok)

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -67,6 +67,64 @@ fn atomic_write(path: &std::path::Path, content: impl AsRef<[u8]>) -> std::io::R
     Ok(())
 }
 
+/// #3795 — Marker filename written into the target home directory after a
+/// successful OpenClaw migration. Subsequent invocations of `migrate()` see
+/// this file and refuse to run, so we never overwrite (or even back up) user
+/// edits made after the initial import.
+const MIGRATION_MARKER_FILENAME: &str = ".openclaw_migrated";
+
+/// #3795 — Backup `path` to a timestamped sibling (`<path>.bak.<unix_ts>`)
+/// before overwriting. Returns the backup path so callers can record it in
+/// the migration report. If the source file does not exist, this is a no-op
+/// and returns `Ok(None)`.
+///
+/// The timestamp is the current UTC time formatted as `YYYYMMDDHHMMSS` so
+/// repeated rescues never collide and the order is obvious from the filename.
+fn backup_existing(path: &std::path::Path) -> std::io::Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S");
+    let original = path.file_name().and_then(|s| s.to_str()).unwrap_or("file");
+    let backup_name = format!("{original}.bak.{stamp}");
+    let backup_path = path.with_file_name(backup_name);
+    // If by some collision the backup already exists, fall back to nanosecond
+    // precision so we never silently drop the previous backup.
+    let backup_path = if backup_path.exists() {
+        let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        path.with_file_name(format!("{original}.bak.{stamp}.{nanos}"))
+    } else {
+        backup_path
+    };
+    std::fs::rename(path, &backup_path)?;
+    Ok(Some(backup_path))
+}
+
+/// #3795 — Helper used by every migration write point: if `dest` already
+/// exists, rename it to a `.bak.<timestamp>` sibling and emit a warning +
+/// report entry, then proceed to atomically write `content`. This is the
+/// single chokepoint that protects user-edited config/agent/memory files
+/// from being silently clobbered on re-runs.
+fn write_with_backup(
+    dest: &std::path::Path,
+    content: &str,
+    report: &mut MigrationReport,
+) -> std::io::Result<()> {
+    if let Some(backup) = backup_existing(dest)? {
+        warn!(
+            "Backed up existing {} -> {} before overwriting",
+            dest.display(),
+            backup.display()
+        );
+        report.warnings.push(format!(
+            "Existing {} was backed up to {} before overwrite",
+            dest.display(),
+            backup.display()
+        ));
+    }
+    atomic_write(dest, content)
+}
+
 // ---------------------------------------------------------------------------
 // OpenClaw JSON5 input types
 // ---------------------------------------------------------------------------
@@ -1224,6 +1282,24 @@ pub fn migrate(options: &MigrateOptions) -> Result<MigrationReport, MigrateError
         ..Default::default()
     };
 
+    // #3795 — If a previous successful migration already wrote a marker file
+    // in the target home directory, refuse to re-run. The marker is the
+    // strongest signal that any subsequent edits to config.toml /
+    // agent.toml / imported_memory.md belong to the user, not to OpenClaw,
+    // and should not be touched by the migrator at all (not even backed up).
+    let marker_path = target.join(MIGRATION_MARKER_FILENAME);
+    if marker_path.exists() && !options.dry_run {
+        warn!(
+            "OpenClaw migration already completed (marker {} present); skipping re-run to preserve user edits",
+            marker_path.display()
+        );
+        report.warnings.push(format!(
+            "Migration already completed — marker {} present. Delete it to force a re-import; existing files will be backed up to .bak.<timestamp> siblings.",
+            marker_path.display()
+        ));
+        return Ok(report);
+    }
+
     // Determine config format
     let config_file = find_config_file(source);
     let is_json5 = config_file
@@ -1241,6 +1317,21 @@ pub fn migrate(options: &MigrateOptions) -> Result<MigrationReport, MigrateError
         let report_md = report.to_markdown();
         let report_path = target.join("migration_report.md");
         let _ = std::fs::write(&report_path, &report_md);
+
+        // #3795 — Drop a marker file so re-runs are no-ops. Best-effort: if
+        // we can't write the marker (e.g. read-only home), the worst case is
+        // a future re-run that backs up files again — no data is lost.
+        let stamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+        let marker_body = format!(
+            "OpenClaw migration completed at {stamp}.\nDelete this file to force a re-import; existing files will be moved to .bak.<timestamp> siblings rather than overwritten.\n"
+        );
+        if let Err(e) = std::fs::write(&marker_path, marker_body) {
+            warn!(
+                "Failed to write migration marker {}: {} (re-runs will not be detected)",
+                marker_path.display(),
+                e
+            );
+        }
     }
 
     Ok(report)
@@ -1352,16 +1443,11 @@ fn migrate_config_from_json(
 
     if !dry_run {
         std::fs::create_dir_all(target)?;
-        if dest.exists() {
-            // #3795 — Never clobber an existing config on re-run.
-            warn!(
-                "Skipping existing config {:?} — re-run would overwrite user edits",
-                dest
-            );
-        } else {
-            // #3798 — Atomic write.
-            atomic_write(&dest, &config_content)?;
-        }
+        // #3795 — Existing config.toml is preserved by renaming it to a
+        // timestamped `.bak.*` sibling before writing the freshly imported
+        // version. The migrate() entry point also writes a marker file so
+        // subsequent re-runs short-circuit before reaching this point.
+        write_with_backup(&dest, &config_content, report)?;
     }
 
     report.imported.push(MigrateItem {
@@ -1891,18 +1977,14 @@ fn migrate_agents_from_json(
                 let dest_file = dest_dir.join("agent.toml");
 
                 if !dry_run {
-                    // #3795 — Skip files that already exist to avoid overwriting
-                    // user edits on re-run.
-                    if dest_file.exists() {
-                        warn!(
-                            "Skipping existing file {:?} — re-run would overwrite user edits",
-                            dest_file
-                        );
-                    } else {
-                        std::fs::create_dir_all(&dest_dir)?;
-                        // #3798 — Atomic write: tmp → rename.
-                        atomic_write(&dest_file, &toml_str)?;
-                    }
+                    std::fs::create_dir_all(&dest_dir)?;
+                    // #3795 — Existing agent.toml is moved to a timestamped
+                    // `.bak.*` sibling before writing. Combined with the
+                    // marker file, re-runs after the initial import are
+                    // short-circuited at migrate() entry, so this branch
+                    // only fires on the first import or when the marker has
+                    // been deliberately removed.
+                    write_with_backup(&dest_file, &toml_str, report)?;
                 }
 
                 report.imported.push(MigrateItem {
@@ -2241,16 +2323,11 @@ fn migrate_memory_files(
                 let dest_file = dest_dir.join("imported_memory.md");
 
                 if !dry_run {
-                    // #3795 — Skip existing memory files to preserve user edits.
-                    if dest_file.exists() {
-                        warn!(
-                            "Skipping existing file {:?} — re-run would overwrite user edits",
-                            dest_file
-                        );
-                    } else {
-                        std::fs::create_dir_all(&dest_dir)?;
-                        std::fs::write(&dest_file, &content)?;
-                    }
+                    std::fs::create_dir_all(&dest_dir)?;
+                    // #3795 — Back up any existing imported_memory.md before
+                    // overwriting; the marker file in target/ stops re-runs
+                    // from reaching this branch on subsequent invocations.
+                    write_with_backup(&dest_file, &content, report)?;
                 }
 
                 report.imported.push(MigrateItem {
@@ -2297,16 +2374,10 @@ fn migrate_memory_files(
                 let dest_file = dest_dir.join("imported_memory.md");
 
                 if !dry_run {
-                    // #3795 — Skip existing memory files to preserve user edits.
-                    if dest_file.exists() {
-                        warn!(
-                            "Skipping existing file {:?} — re-run would overwrite user edits",
-                            dest_file
-                        );
-                    } else {
-                        std::fs::create_dir_all(&dest_dir)?;
-                        std::fs::write(&dest_file, &content)?;
-                    }
+                    std::fs::create_dir_all(&dest_dir)?;
+                    // #3795 — Back up any existing imported_memory.md before
+                    // overwriting; marker file short-circuits re-runs.
+                    write_with_backup(&dest_file, &content, report)?;
                 }
 
                 report.imported.push(MigrateItem {
@@ -2678,16 +2749,10 @@ fn migrate_legacy_config(
 
     if !dry_run {
         std::fs::create_dir_all(target)?;
-        if dest.exists() {
-            // #3795 — Never clobber an existing config on re-run.
-            warn!(
-                "Skipping existing config {:?} — re-run would overwrite user edits",
-                dest
-            );
-        } else {
-            // #3798 — Atomic write.
-            atomic_write(&dest, &config_content)?;
-        }
+        // #3795 — Back up any existing config.toml before overwriting; the
+        // marker file written at migrate() exit prevents re-runs from
+        // reaching this branch on subsequent invocations.
+        write_with_backup(&dest, &config_content, report)?;
     }
 
     report.imported.push(MigrateItem {
@@ -2999,17 +3064,10 @@ fn migrate_legacy_agents(
                 let dest_file = dest_dir.join("agent.toml");
 
                 if !dry_run {
-                    if dest_file.exists() {
-                        // #3795 — Skip existing files to preserve user edits.
-                        warn!(
-                            "Skipping existing file {:?} — re-run would overwrite user edits",
-                            dest_file
-                        );
-                    } else {
-                        std::fs::create_dir_all(&dest_dir)?;
-                        // #3798 — Atomic write.
-                        atomic_write(&dest_file, &toml_str)?;
-                    }
+                    std::fs::create_dir_all(&dest_dir)?;
+                    // #3795 — Back up any existing agent.toml before
+                    // overwriting; marker file short-circuits re-runs.
+                    write_with_backup(&dest_file, &toml_str, report)?;
                 }
 
                 report.imported.push(MigrateItem {
@@ -3200,16 +3258,10 @@ fn migrate_legacy_memory(
         let dest_file = dest_dir.join("imported_memory.md");
 
         if !dry_run {
-            // #3795 — Skip existing memory files to preserve user edits.
-            if dest_file.exists() {
-                warn!(
-                    "Skipping existing file {:?} — re-run would overwrite user edits",
-                    dest_file
-                );
-            } else {
-                std::fs::create_dir_all(&dest_dir)?;
-                std::fs::write(&dest_file, &content)?;
-            }
+            std::fs::create_dir_all(&dest_dir)?;
+            // #3795 — Back up any existing imported_memory.md before
+            // overwriting; marker file short-circuits re-runs.
+            write_with_backup(&dest_file, &content, report)?;
         }
 
         report.imported.push(MigrateItem {
@@ -4751,12 +4803,20 @@ mod tests {
 
         // Run migration twice
         migrate(&options).unwrap();
+
+        // #3795 — Marker file should be present after a successful run.
+        let marker = target.path().join(MIGRATION_MARKER_FILENAME);
+        assert!(marker.exists(), "marker file not written");
+
+        // Second run must be a no-op (no imported entries) so user edits to
+        // config.toml / agent.toml between runs are preserved.
         let report2 = migrate(&options).unwrap();
+        assert!(
+            report2.imported.is_empty(),
+            "second run should short-circuit on marker file"
+        );
 
-        // Second run should still succeed
-        assert!(!report2.imported.is_empty());
-
-        // secrets.env should not have duplicate keys
+        // secrets.env should not have duplicate keys (re-run is no-op).
         let secrets = std::fs::read_to_string(target.path().join("secrets.env")).unwrap();
         let tg_count = secrets
             .lines()
@@ -4769,6 +4829,66 @@ mod tests {
             .filter(|l| l.starts_with("DISCORD_BOT_TOKEN="))
             .count();
         assert_eq!(dc_count, 1, "Duplicate DISCORD_BOT_TOKEN in secrets.env");
+    }
+
+    /// #3795 regression — when the marker file is removed and a re-run is
+    /// forced, any user-edited config.toml / agent.toml must be backed up
+    /// to a `.bak.<timestamp>` sibling rather than silently overwritten.
+    #[test]
+    fn test_rerun_backs_up_user_edits() {
+        let source = TempDir::new().unwrap();
+        let target = TempDir::new().unwrap();
+
+        create_json5_workspace(source.path());
+
+        let options = MigrateOptions {
+            source: crate::MigrateSource::OpenClaw,
+            source_dir: source.path().to_path_buf(),
+            target_dir: target.path().to_path_buf(),
+            dry_run: false,
+        };
+
+        // Initial migration writes config.toml and removes the marker so we
+        // can simulate a forced re-run.
+        migrate(&options).unwrap();
+
+        let config_path = target.path().join("config.toml");
+        assert!(config_path.exists());
+
+        // Simulate user editing the config after the first import.
+        let user_marker = "# user edited line: do not lose me\n";
+        let original = std::fs::read_to_string(&config_path).unwrap();
+        std::fs::write(&config_path, format!("{user_marker}{original}")).unwrap();
+
+        // Force a re-run by deleting the marker.
+        std::fs::remove_file(target.path().join(MIGRATION_MARKER_FILENAME)).unwrap();
+
+        migrate(&options).unwrap();
+
+        // Re-imported config exists with fresh content (no user marker).
+        let new_content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            !new_content.contains(user_marker),
+            "fresh config should not contain user edit"
+        );
+
+        // The user's edited copy is preserved as a `.bak.*` sibling so no
+        // data is lost — this is what #3795 demands.
+        let backups: Vec<_> = std::fs::read_dir(target.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("config.toml.bak.")
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "exactly one config backup expected");
+        let backup_content = std::fs::read_to_string(backups[0].path()).unwrap();
+        assert!(
+            backup_content.contains(user_marker),
+            "backup must preserve the user's edits"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1109,6 +1109,34 @@ fn handle_mid_turn_signal(
         return None;
     };
 
+    // For approval-resolution signals, decide ownership BEFORE touching
+    // the staged turn. The kernel's `notify_agent_of_resolution` fans
+    // every resolved approval to all live sessions of the agent (because
+    // `DeferredToolExecution` does not carry a session id). If we run
+    // `pad_missing_results` + `commit` first and only check ownership
+    // after, every unrelated session gets its in-progress `tool_use`
+    // padded to `is_error=true` and persisted — the staged-pollution
+    // bug acknowledged in PR #4091's follow-up commit but not fixed
+    // there.
+    //
+    // Strategy: peek the signal's `tool_use_id` against this session's
+    // pending approvals (in `staged.tool_result_blocks`, in
+    // `session.messages`, and in the in-flight `messages` slice). If
+    // none of them carry the id with `WaitingApproval` status, the
+    // signal is for a sibling session — drop it silently without
+    // committing or padding. Drop is correct: sibling sessions consume
+    // their own copies of the same broadcast.
+    if let AgentLoopSignal::ApprovalResolved { tool_use_id, .. } = &signal {
+        if !session_owns_pending_approval(session, messages, staged, tool_use_id) {
+            debug!(
+                agent = %manifest_name,
+                tool_use_id = %tool_use_id,
+                "Ignoring broadcast approval resolution for tool_use_id not owned by this session"
+            );
+            return None;
+        }
+    }
+
     // Pad any tool_use_id that never produced a result, then commit the
     // staged assistant message + user{tool_results} atomically. After
     // this call, session.messages is guaranteed to have paired
@@ -1131,6 +1159,13 @@ fn handle_mid_turn_signal(
             result_is_error,
             result_status,
         } => {
+            // Ownership was verified above. `apply_approval_resolution_signal`
+            // is guaranteed to find the matching WaitingApproval block
+            // (either in committed history or in just-committed staged
+            // results) and patch it in place. If for any reason it
+            // doesn't (race between fork/reset and resolution arrival),
+            // suppress the `[System]` text — same behaviour as the
+            // upstream PR #4091 fix.
             let matched = apply_approval_resolution_signal(
                 session,
                 messages.as_mut_slice(),
@@ -1146,11 +1181,13 @@ fn handle_mid_turn_signal(
                     tool_name, decision, result_preview
                 ))
             } else {
-                // Unknown tool_use_id means this approval broadcast was for a different live session; consume silently.
+                // Ownership was verified before pad/commit; reaching
+                // here means the WaitingApproval block disappeared
+                // between the peek and the patch (fork/reset race).
                 debug!(
                     agent = %manifest_name,
                     tool_use_id = %tool_use_id,
-                    "Ignoring broadcast approval resolution for unknown tool_use_id (different session)"
+                    "Approval resolution arrived after WaitingApproval block disappeared (fork/reset race?)"
                 );
                 None
             }
@@ -1162,6 +1199,66 @@ fn handle_mid_turn_signal(
         messages.push(inject_msg);
     }
     Some(flushed_outcomes)
+}
+
+/// Returns `true` if `tool_use_id` has a `WaitingApproval` `ToolResult`
+/// block in any of: the staged-but-not-yet-committed turn, the session's
+/// committed history, or the in-flight `messages` slice the LLM driver
+/// will see next.
+///
+/// Used by `handle_mid_turn_signal` to decide whether an
+/// `ApprovalResolved` broadcast is meant for THIS session before
+/// touching staged state. Without this check, a broadcast intended for a
+/// sibling session would force `pad_missing_results` + `commit` here,
+/// poisoning every unrelated session's in-progress `tool_use` with
+/// `is_error=true` — the residual injection_senders pollution
+/// acknowledged in PR #4091's follow-up commit (591ad4ec) and fixed
+/// here.
+fn session_owns_pending_approval(
+    session: &Session,
+    messages: &[Message],
+    staged: &StagedToolUseTurn,
+    tool_use_id: &str,
+) -> bool {
+    fn block_is_waiting_for(block: &ContentBlock, target: &str) -> bool {
+        matches!(
+            block,
+            ContentBlock::ToolResult { tool_use_id: id, status, .. }
+                if id == target
+                    && *status == librefang_types::tool::ToolExecutionStatus::WaitingApproval
+        )
+    }
+
+    fn message_carries_waiting(msg: &Message, target: &str) -> bool {
+        match &msg.content {
+            MessageContent::Blocks(blocks) => {
+                blocks.iter().any(|b| block_is_waiting_for(b, target))
+            }
+            _ => false,
+        }
+    }
+
+    if staged
+        .tool_result_blocks
+        .iter()
+        .any(|b| block_is_waiting_for(b, tool_use_id))
+    {
+        return true;
+    }
+    if session
+        .messages
+        .iter()
+        .any(|m| message_carries_waiting(m, tool_use_id))
+    {
+        return true;
+    }
+    if messages
+        .iter()
+        .any(|m| message_carries_waiting(m, tool_use_id))
+    {
+        return true;
+    }
+    false
 }
 
 fn finalize_tool_use_results(
@@ -7017,6 +7114,228 @@ mod tests {
             update_consecutive_hard_failures(&mut consecutive_all_failed, flushed_outcomes);
         assert_eq!(hard_error_count, 1);
         assert_eq!(consecutive_all_failed, 0);
+    }
+
+    /// Regression for the residual injection_senders pollution that PR
+    /// #4091's composite-key swap and 591ad4ec follow-up did NOT fix.
+    ///
+    /// Setup: two sessions belong to the same agent.
+    ///   - Session A has a `WaitingApproval` `ToolResult` for tool_use
+    ///     `T1` (an approval is pending).
+    ///   - Session B is mid-turn on a different `ToolUse` `T2` (staged,
+    ///     no approval pending, no result yet).
+    ///
+    /// The kernel's `notify_agent_of_resolution` broadcasts the
+    /// resolution of `T1` to BOTH sessions because
+    /// `DeferredToolExecution` carries no session id.
+    ///
+    /// Bug: before this fix, session B's `handle_mid_turn_signal` would
+    /// receive the `ApprovalResolved { tool_use_id: "T1" }` signal,
+    /// unconditionally call `pad_missing_results` (which marks `T2` as
+    /// `is_error=true` "[tool interrupted...]") and `commit` (which
+    /// persists that to `session.messages`), and only then notice that
+    /// `T1` doesn't belong to session B and skip the `[System]` text.
+    /// Net effect: every unrelated session of the same agent gets its
+    /// in-progress tool_use poisoned to error state.
+    ///
+    /// Fix: `handle_mid_turn_signal` peeks the signal's `tool_use_id`
+    /// against the session's pending `WaitingApproval` blocks BEFORE
+    /// touching staged state. When the id is unknown, drop the signal
+    /// silently — staged stays untouched, history stays clean.
+    #[test]
+    fn injection_resolution_does_not_pollute_other_sessions() {
+        let agent_id = librefang_types::agent::AgentId::new();
+
+        // Session B — mid-turn on T2, NO pending approval. The single
+        // staged tool_use has not yet produced a result; without the
+        // fix, the broadcast resolution will pad it to is_error=true
+        // and persist it.
+        let mut session_b = librefang_memory::session::Session {
+            id: librefang_types::agent::SessionId::new(),
+            agent_id,
+            messages: Vec::new(),
+            context_window_tokens: 0,
+            label: None,
+        };
+        let mut messages_b: Vec<Message> = Vec::new();
+        let mut staged_b = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: "T2".to_string(),
+                    name: "ongoing_tool".to_string(),
+                    input: serde_json::json!({}),
+                    provider_metadata: None,
+                }]),
+                pinned: false,
+                timestamp: None,
+            },
+            tool_call_ids: vec![("T2".to_string(), "ongoing_tool".to_string())],
+            tool_result_blocks: Vec::new(),
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session_b.agent_id.to_string(),
+            committed: false,
+        };
+
+        // Channel mimicking session B's injection_senders entry. The
+        // kernel writes the same ApprovalResolved into every session's
+        // channel because the resolution carries no session id.
+        let (tx, rx) = mpsc::channel(1);
+        tx.try_send(AgentLoopSignal::ApprovalResolved {
+            tool_use_id: "T1".to_string(), // belongs to session A, not B
+            tool_name: "dangerous_tool".to_string(),
+            decision: "approved".to_string(),
+            result_content: "approved and executed".to_string(),
+            result_is_error: false,
+            result_status: librefang_types::tool::ToolExecutionStatus::Completed,
+        })
+        .unwrap();
+        let pending = tokio::sync::Mutex::new(rx);
+
+        let outcome = handle_mid_turn_signal(
+            Some(&pending),
+            "test-agent",
+            &mut session_b,
+            &mut messages_b,
+            &mut staged_b,
+        );
+
+        // The signal does not belong to session B, so the handler must
+        // return None — no flush happened, no [System] text was
+        // injected, and most importantly the staged turn was left
+        // intact so session B can keep executing T2 normally.
+        assert!(
+            outcome.is_none(),
+            "broadcast resolution for unrelated session must be dropped without flushing"
+        );
+        assert!(
+            !staged_b.committed,
+            "staged turn must not be committed when the signal is for a different session"
+        );
+        assert!(
+            staged_b.tool_result_blocks.is_empty(),
+            "staged tool_result_blocks must NOT be padded with a synthetic \
+             is_error=true entry for T2 — that is the pollution this test guards against"
+        );
+        assert!(
+            session_b.messages.is_empty(),
+            "session B's history must be untouched by a broadcast for session A"
+        );
+        assert!(
+            messages_b.is_empty(),
+            "in-flight messages slice must be untouched by a broadcast for session A"
+        );
+    }
+
+    /// Companion to `injection_resolution_does_not_pollute_other_sessions`
+    /// — confirms the fix did NOT regress the matching-session path.
+    /// When the broadcast's `tool_use_id` IS owned by this session
+    /// (there's a `WaitingApproval` `ToolResult` block in committed
+    /// history for that id), the handler must still pad + commit the
+    /// staged turn, patch the waiting block, and inject the `[System]`
+    /// notice.
+    #[test]
+    fn injection_resolution_still_applies_when_session_owns_pending_approval() {
+        let agent_id = librefang_types::agent::AgentId::new();
+
+        // Session A — committed history carries a WaitingApproval
+        // ToolResult for T1.
+        let waiting = ContentBlock::ToolResult {
+            tool_use_id: "T1".to_string(),
+            tool_name: "dangerous_tool".to_string(),
+            content: "awaiting approval".to_string(),
+            is_error: true,
+            status: librefang_types::tool::ToolExecutionStatus::WaitingApproval,
+            approval_request_id: Some("approval-1".to_string()),
+        };
+        let mut session_a = librefang_memory::session::Session {
+            id: librefang_types::agent::SessionId::new(),
+            agent_id,
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks(vec![waiting]),
+                pinned: false,
+                timestamp: None,
+            }],
+            context_window_tokens: 0,
+            label: None,
+        };
+        let mut messages_a = session_a.messages.clone();
+        let mut staged_a = StagedToolUseTurn {
+            assistant_msg: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(Vec::new()),
+                pinned: false,
+                timestamp: None,
+            },
+            tool_call_ids: Vec::new(),
+            tool_result_blocks: Vec::new(),
+            rationale_text: None,
+            allowed_tool_names: Vec::new(),
+            caller_id_str: session_a.agent_id.to_string(),
+            committed: false,
+        };
+
+        let (tx, rx) = mpsc::channel(1);
+        tx.try_send(AgentLoopSignal::ApprovalResolved {
+            tool_use_id: "T1".to_string(),
+            tool_name: "dangerous_tool".to_string(),
+            decision: "approved".to_string(),
+            result_content: "approved and executed".to_string(),
+            result_is_error: false,
+            result_status: librefang_types::tool::ToolExecutionStatus::Completed,
+        })
+        .unwrap();
+        let pending = tokio::sync::Mutex::new(rx);
+
+        let outcome = handle_mid_turn_signal(
+            Some(&pending),
+            "test-agent",
+            &mut session_a,
+            &mut messages_a,
+            &mut staged_a,
+        );
+
+        assert!(
+            outcome.is_some(),
+            "matching-session path must still flush and inject"
+        );
+        assert!(staged_a.committed, "staged must be committed on match");
+
+        // Original WaitingApproval block was patched in place to
+        // Completed/non-error.
+        match &session_a.messages[0].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult {
+                    content,
+                    is_error,
+                    status,
+                    approval_request_id,
+                    ..
+                } => {
+                    assert_eq!(content, "approved and executed");
+                    assert!(!is_error);
+                    assert_eq!(
+                        *status,
+                        librefang_types::tool::ToolExecutionStatus::Completed
+                    );
+                    assert!(approval_request_id.is_none());
+                }
+                other => panic!("expected patched tool_result, got {other:?}"),
+            },
+            other => panic!("expected blocks message, got {other:?}"),
+        }
+
+        // Last message is the injected `[System] Tool '...' approval
+        // resolved` notice.
+        let last = session_a
+            .messages
+            .last()
+            .expect("expected at least the injected system notice");
+        let injected = last.content.text_content();
+        assert!(injected.contains("Tool 'dangerous_tool' approval resolved (approved)"));
+        assert!(injected.contains("approved and executed"));
     }
 
     /// Regression for issue #2067: auto_memorize sliced `session.messages`

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1122,7 +1122,7 @@ fn handle_mid_turn_signal(
         "Mid-turn signal injected — interrupting tool execution"
     );
     let injected_text = match signal {
-        AgentLoopSignal::Message { content } => content,
+        AgentLoopSignal::Message { content } => Some(content),
         AgentLoopSignal::ApprovalResolved {
             tool_use_id,
             tool_name,
@@ -1131,7 +1131,7 @@ fn handle_mid_turn_signal(
             result_is_error,
             result_status,
         } => {
-            apply_approval_resolution_signal(
+            let matched = apply_approval_resolution_signal(
                 session,
                 messages.as_mut_slice(),
                 &tool_use_id,
@@ -1139,16 +1139,35 @@ fn handle_mid_turn_signal(
                 result_is_error,
                 result_status,
             );
-            let result_preview = librefang_types::truncate_str(&result_content, 300);
-            format!(
-                "[System] Tool '{}' approval resolved ({}). Result: {}",
-                tool_name, decision, result_preview
-            )
+            if matched {
+                let result_preview = librefang_types::truncate_str(&result_content, 300);
+                Some(format!(
+                    "[System] Tool '{}' approval resolved ({}). Result: {}",
+                    tool_name, decision, result_preview
+                ))
+            } else {
+                // The kernel fans approval resolutions to every live session
+                // for the agent (because `DeferredToolExecution` carries no
+                // session id — see `LibreFangKernel::notify_agent_of_resolution`).
+                // When this session does not own the resolved `tool_use_id`,
+                // the broadcast is for someone else; consume it silently
+                // instead of polluting our history with a stray `[System]
+                // Tool '…' approval resolved` user message that references
+                // a tool this session never invoked.
+                debug!(
+                    agent = %manifest_name,
+                    tool_use_id = %tool_use_id,
+                    "Ignoring broadcast approval resolution for unknown tool_use_id (different session)"
+                );
+                None
+            }
         }
     };
-    let inject_msg = Message::user(&injected_text);
-    session.messages.push(inject_msg.clone());
-    messages.push(inject_msg);
+    if let Some(text) = injected_text {
+        let inject_msg = Message::user(&text);
+        session.messages.push(inject_msg.clone());
+        messages.push(inject_msg);
+    }
     Some(flushed_outcomes)
 }
 
@@ -1227,6 +1246,16 @@ fn max_tokens_response_text(response: &crate::llm_driver::CompletionResponse) ->
     }
 }
 
+/// Patches the matching `WaitingApproval` ToolResult block(s) in `session.messages`
+/// and the in-flight `messages` slice with the resolved decision.
+///
+/// Returns `true` when at least one matching block was patched. Callers rely on
+/// this flag to suppress the user-facing `[System] Tool '…' approval resolved`
+/// notice when the signal was a broadcast intended for a different live
+/// session that happens to share the same agent (the kernel fans approval
+/// resolutions to every `(agent, *)` injection channel because
+/// `DeferredToolExecution` does not currently carry a session id — see
+/// `LibreFangKernel::notify_agent_of_resolution`).
 fn apply_approval_resolution_signal(
     session: &mut Session,
     messages: &mut [Message],
@@ -1234,7 +1263,7 @@ fn apply_approval_resolution_signal(
     result_content: &str,
     result_is_error: bool,
     result_status: librefang_types::tool::ToolExecutionStatus,
-) {
+) -> bool {
     fn patch_message_blocks(
         msg: &mut Message,
         tool_use_id: &str,
@@ -1269,6 +1298,7 @@ fn apply_approval_resolution_signal(
         false
     }
 
+    let mut matched = false;
     for msg in session.messages.iter_mut().rev() {
         if patch_message_blocks(
             msg,
@@ -1277,6 +1307,7 @@ fn apply_approval_resolution_signal(
             result_is_error,
             result_status,
         ) {
+            matched = true;
             break;
         }
     }
@@ -1288,9 +1319,11 @@ fn apply_approval_resolution_signal(
             result_is_error,
             result_status,
         ) {
+            matched = true;
             break;
         }
     }
+    matched
 }
 
 /// Strip images from all messages except the last user message.

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1146,14 +1146,7 @@ fn handle_mid_turn_signal(
                     tool_name, decision, result_preview
                 ))
             } else {
-                // The kernel fans approval resolutions to every live session
-                // for the agent (because `DeferredToolExecution` carries no
-                // session id — see `LibreFangKernel::notify_agent_of_resolution`).
-                // When this session does not own the resolved `tool_use_id`,
-                // the broadcast is for someone else; consume it silently
-                // instead of polluting our history with a stray `[System]
-                // Tool '…' approval resolved` user message that references
-                // a tool this session never invoked.
+                // Unknown tool_use_id means this approval broadcast was for a different live session; consume silently.
                 debug!(
                     agent = %manifest_name,
                     tool_use_id = %tool_use_id,
@@ -1246,16 +1239,7 @@ fn max_tokens_response_text(response: &crate::llm_driver::CompletionResponse) ->
     }
 }
 
-/// Patches the matching `WaitingApproval` ToolResult block(s) in `session.messages`
-/// and the in-flight `messages` slice with the resolved decision.
-///
-/// Returns `true` when at least one matching block was patched. Callers rely on
-/// this flag to suppress the user-facing `[System] Tool '…' approval resolved`
-/// notice when the signal was a broadcast intended for a different live
-/// session that happens to share the same agent (the kernel fans approval
-/// resolutions to every `(agent, *)` injection channel because
-/// `DeferredToolExecution` does not currently carry a session id — see
-/// `LibreFangKernel::notify_agent_of_resolution`).
+/// Patches `WaitingApproval` blocks in `session.messages` and the in-flight slice; returns `true` when at least one block was matched.
 fn apply_approval_resolution_signal(
     session: &mut Session,
     messages: &mut [Message],


### PR DESCRIPTION
## Summary

Three independent data-loss / data-corruption fixes batched together.

- **OpenClaw migration no longer silently clobbers user-edited config**: writes to `config.toml` / `agent.toml` / `imported_memory.md` rename existing files to `.bak.<timestamp>` siblings before overwriting, and a `.openclaw_migrated` marker file makes re-runs a no-op so post-migration edits are never touched. Closes #3795.
- **`injection_senders` rekeyed `(AgentId, SessionId)`**: concurrent sessions on the same agent (multi-tab UI, multi-channel bridges, agents with both telegram + dashboard active) no longer silently overwrite each other's mid-turn injection senders. `/api/agents/{id}/inject` accepts an optional `session_id`; without one it broadcasts. `notify_agent_of_resolution` also fans out across all live sessions because `DeferredToolExecution` does not currently carry a session id. Closes #3734.
- **Streaming agent loop reloads session under the lock**: pre-fix the streaming path read `session` BEFORE acquiring `session_lock`, so a concurrent turn could land between the read and the lock acquisition and have its writes silently overwritten. The reload is now done after the lock is held, matching the non-streaming path. Closes #3737.

Closes #3795
Closes #3734
Closes #3737

## Breaking / migration notes

- `injection_senders` / `injection_receivers` DashMap key changed from `AgentId` to `(AgentId, SessionId)`. The only public surface using the previous key was the inherent `inject_message(AgentId, &str)` method, which is preserved as a thin wrapper around the new `inject_message_for_session(AgentId, Option<SessionId>, &str)`. The pub-crate `injection_senders_ref()` accessor reflects the new key type — no in-tree consumers.
- `InjectMessageRequest` gained an optional `session_id` field with `#[serde(default)]`; existing clients keep working.
- The pre-existing `idempotent_migration` regression test was updated: re-runs now short-circuit on the marker file (no duplicate imports), and a new `rerun_backs_up_user_edits` test asserts that forcing a re-run preserves user edits as `.bak.*` siblings.

## Test plan

- [ ] `cargo test -p librefang-migrate openclaw::tests::test_idempotent_migration`
- [ ] `cargo test -p librefang-migrate openclaw::tests::test_rerun_backs_up_user_edits`
- [ ] `cargo test -p librefang-kernel injection_senders_two_sessions_one_agent_do_not_collide`
- [ ] `cargo test -p librefang-kernel injection_teardown_only_removes_target_session`
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`