### PR TITLE
fix(api): WS auth via Sec-WebSocket-Protocol + status-class log levels

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -238,12 +238,7 @@ pub async fn request_logging(request: Request<Body>, next: Next) -> Response<Bod
     let elapsed = start.elapsed();
     let status = response.status().as_u16();
 
-    // Route by status class so the level reflects severity:
-    //   5xx → error  (server fault — must surface)
-    //   4xx → warn   (client error — auth storms / bad requests should not
-    //                 hide in INFO; ops needs to spot 401 reconnect loops)
-    //   GET 2xx/3xx → debug (routine polling would otherwise drown the log)
-    //   default → info (state-changing 2xx/3xx)
+    // 4xx/5xx elevated so auth storms and server faults surface; GET successes suppressed to avoid poll noise.
     if status >= 500 {
         error!(
             request_id = %request_id,

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -162,17 +162,22 @@ fn user_role_allows_request(role: UserRole, method: &axum::http::Method, path: &
 }
 
 /// Pull a caller-provided token from the standard locations the auth path
-/// understands: `Authorization: Bearer <x>` or `X-API-Key: <x>`. Bearer wins
-/// over X-API-Key — same precedence as the non-loopback flow at
-/// `auth(...)` line ~528. Returns `None` if no shape is present.
+/// understands. Precedence (matches the non-loopback flow at `auth(...)`):
+///   1. `Authorization: Bearer <x>`
+///   2. `X-API-Key: <x>`
+///   3. `Sec-WebSocket-Protocol: bearer.<x>` — WS upgrade fallback.
+///      Browsers cannot set custom headers on the WebSocket handshake, so
+///      the dashboard encodes the token as a sub-protocol entry that starts
+///      with `bearer.`. Without this branch the auth middleware (which runs
+///      before any WS handler) would 401-storm every dashboard ws (terminal,
+///      chat, agent stream). The matching ws handler echoes the protocol
+///      back via `WebSocketUpgrade::protocols(...)` so the browser accepts
+///      the handshake — see `ws::ws_bearer_protocol`.
 ///
-/// SECURITY: `?token=` query-string auth is intentionally NOT supported here.
+/// SECURITY: `?token=` query-string auth is intentionally NOT supported.
 /// Query parameters appear in server access logs, browser history, and HTTP
 /// Referer headers forwarded to third parties, making them unsuitable for
-/// carrying credentials on regular HTTP routes. WebSocket upgrades are the
-/// sole exception — browsers cannot set custom headers on WebSocket
-/// connections — and they handle `?token=` in `crate::ws::ws_auth_token`
-/// rather than going through this middleware path.
+/// carrying credentials.
 fn extract_request_token(request: &Request<Body>) -> Option<String> {
     let bearer = request
         .headers()
@@ -183,11 +188,27 @@ fn extract_request_token(request: &Request<Body>) -> Option<String> {
     if bearer.is_some() {
         return bearer;
     }
-    request
+    if let Some(key) = request
         .headers()
         .get("x-api-key")
         .and_then(|v| v.to_str().ok())
-        .map(str::to_string)
+    {
+        return Some(key.to_string());
+    }
+    // WebSocket upgrade: sub-protocol entry of the form `bearer.<token>`.
+    // Multiple sub-protocols may be comma-separated; pick the first that
+    // starts with `bearer.`.
+    request
+        .headers()
+        .get("sec-websocket-protocol")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            v.split(',')
+                .map(str::trim)
+                .find(|p| p.starts_with("bearer."))
+                .and_then(|p| p.strip_prefix("bearer."))
+                .map(str::to_string)
+        })
 }
 
 /// Request ID header name (standard).

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -16,7 +16,7 @@ use librefang_types::i18n;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{debug, info};
+use tracing::{debug, error, info, warn};
 
 use librefang_telemetry::metrics;
 
@@ -238,8 +238,31 @@ pub async fn request_logging(request: Request<Body>, next: Next) -> Response<Bod
     let elapsed = start.elapsed();
     let status = response.status().as_u16();
 
-    // GET 2xx — routine polling, keep out of INFO to reduce noise
-    if method == axum::http::Method::GET && status < 300 {
+    // Route by status class so the level reflects severity:
+    //   5xx → error  (server fault — must surface)
+    //   4xx → warn   (client error — auth storms / bad requests should not
+    //                 hide in INFO; ops needs to spot 401 reconnect loops)
+    //   GET 2xx/3xx → debug (routine polling would otherwise drown the log)
+    //   default → info (state-changing 2xx/3xx)
+    if status >= 500 {
+        error!(
+            request_id = %request_id,
+            method = %method,
+            path = %uri,
+            status = status,
+            latency_ms = elapsed.as_millis() as u64,
+            "API request"
+        );
+    } else if status >= 400 {
+        warn!(
+            request_id = %request_id,
+            method = %method,
+            path = %uri,
+            status = status,
+            latency_ms = elapsed.as_millis() as u64,
+            "API request"
+        );
+    } else if method == axum::http::Method::GET {
         debug!(
             request_id = %request_id,
             method = %method,


### PR DESCRIPTION
## Summary

Two related middleware bugs surfaced together, both in `crates/librefang-api/src/middleware.rs`. Splitting them is more churn than value because the second one (log levels) is what made the first one (ws auth) visible enough to diagnose — under the old INFO-everything routing the 401 storm was just noise, not a signal.

## Bug 1 — dashboard WebSocket 401-storm

**Symptom**: after dashboard login, `/api/terminal/ws` returns 401 in a tight reconnect loop. `ChatPage` and any other caller of `buildAuthenticatedWebSocket()` are affected the same way.

**Root cause**: `extract_request_token()` reads tokens from `Authorization: Bearer …` and `X-API-Key: …`, but **not** from `Sec-WebSocket-Protocol: bearer.<token>`. Browsers can't set custom headers on the WS handshake, so the dashboard encodes the bearer token as a sub-protocol. The auth middleware runs *before* any WS handler, so it 401-rejects the upgrade before `ws::ws_auth_token` (which does parse the sub-protocol) ever runs. The handler-side `WebSocketUpgrade::protocols(...)` echo is already wired correctly — only the middleware's token extractor was missing this source.

**Fix**: add a third fallback branch to `extract_request_token` that scans comma-separated sub-protocols for the first `bearer.<x>` entry and returns `<x>`. Precedence stays Authorization > X-API-Key > Sec-WebSocket-Protocol. No handler changes needed.

## Bug 2 — request log noise hides 4xx/5xx

**Symptom**: a 401 reconnect storm or a 5xx fault renders at the same `INFO` level as a normal `POST 200`, so ops can't visually pick them out.

**Root cause**: `request_logging` only branched on `GET 2xx → debug, everything else → info`. No status-class routing.

**Fix**: classify by status class, matching the standard middleware convention (tower-http / nginx / most stacks):

| Status | Level | Why |
|---|---|---|
| 5xx | `error` | Server fault — must surface |
| 4xx | `warn` | Client error / auth — visible above INFO baseline |
| `GET` 2xx/3xx | `debug` | Routine polling stays quiet (unchanged) |
| Other 2xx/3xx | `info` | State-changing requests |

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test -p librefang-api`
- [ ] Smoke: open `/dashboard/#/terminal` after logging in — terminal should connect, no `WARN status=401` storm
- [ ] Smoke: hit a real bad-auth endpoint without a token — single line, now `WARN`, not `INFO`
- [ ] Smoke: hit `GET /api/health` — stays at `DEBUG` (not promoted)