### PR TITLE
fix(llm,ollama): repair model lookup + capability detection for HF-imported models (close #4034)

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -110,17 +110,7 @@ pub async fn list_models(
     //   - Custom-tier models (user-added via /api/models/custom) always pass
     //     through — they're explicit user intent, not catalog inheritance.
     use std::collections::HashSet;
-    // Both sides may or may not carry the `:latest` Ollama tag suffix:
-    // - Static catalog entries for Ollama models are sometimes shipped as
-    //   bare names (`llama3.2`) and sometimes as tagged names (`llama3.2:latest`).
-    // - Ollama's `/api/tags` always returns the tagged form. Lemonade /
-    //   LM Studio / vLLM (which all share this provider slot per #3191)
-    //   return the bare ID with no tag.
-    // We therefore index every discovered name twice — once verbatim, once
-    // with a trailing `:latest` stripped — and look up catalog IDs the
-    // same way. Pre-fix, a static `llama3.2` entry was hidden when the
-    // probe returned `llama3.2:latest`, even though both refer to the
-    // same model on the same server.
+    // Index each discovered name both verbatim and with `:latest` stripped so static entries survive whether Ollama returns `llama3.2` or `llama3.2:latest`.
     fn strip_latest(s: &str) -> &str {
         s.strip_suffix(":latest").unwrap_or(s)
     }
@@ -166,8 +156,6 @@ pub async fn list_models(
                 }
             }
             // Live-discovered filter for local providers (see comment above).
-            // Compare both verbatim and `:latest`-stripped to bridge the
-            // Ollama-tag vs OpenAI-shape (Lemonade/LM Studio/vLLM) gap.
             if m.tier != librefang_types::model_catalog::ModelTier::Custom {
                 if let Some(live_set) = live_models_per_provider.get(&m.provider.to_lowercase()) {
                     let lower = m.id.to_lowercase();

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -110,6 +110,20 @@ pub async fn list_models(
     //   - Custom-tier models (user-added via /api/models/custom) always pass
     //     through — they're explicit user intent, not catalog inheritance.
     use std::collections::HashSet;
+    // Both sides may or may not carry the `:latest` Ollama tag suffix:
+    // - Static catalog entries for Ollama models are sometimes shipped as
+    //   bare names (`llama3.2`) and sometimes as tagged names (`llama3.2:latest`).
+    // - Ollama's `/api/tags` always returns the tagged form. Lemonade /
+    //   LM Studio / vLLM (which all share this provider slot per #3191)
+    //   return the bare ID with no tag.
+    // We therefore index every discovered name twice — once verbatim, once
+    // with a trailing `:latest` stripped — and look up catalog IDs the
+    // same way. Pre-fix, a static `llama3.2` entry was hidden when the
+    // probe returned `llama3.2:latest`, even though both refer to the
+    // same model on the same server.
+    fn strip_latest(s: &str) -> &str {
+        s.strip_suffix(":latest").unwrap_or(s)
+    }
     let live_models_per_provider: std::collections::HashMap<String, HashSet<String>> = catalog
         .list_providers()
         .iter()
@@ -119,11 +133,12 @@ pub async fn list_models(
             if !probe.reachable || probe.discovered_models.is_empty() {
                 return None;
             }
-            let set: HashSet<String> = probe
-                .discovered_models
-                .iter()
-                .map(|s| s.to_lowercase())
-                .collect();
+            let mut set: HashSet<String> = HashSet::new();
+            for s in &probe.discovered_models {
+                let lower = s.to_lowercase();
+                set.insert(strip_latest(&lower).to_string());
+                set.insert(lower);
+            }
             Some((p.id.to_lowercase(), set))
         })
         .collect();
@@ -151,9 +166,13 @@ pub async fn list_models(
                 }
             }
             // Live-discovered filter for local providers (see comment above).
+            // Compare both verbatim and `:latest`-stripped to bridge the
+            // Ollama-tag vs OpenAI-shape (Lemonade/LM Studio/vLLM) gap.
             if m.tier != librefang_types::model_catalog::ModelTier::Custom {
                 if let Some(live_set) = live_models_per_provider.get(&m.provider.to_lowercase()) {
-                    if !live_set.contains(&m.id.to_lowercase()) {
+                    let lower = m.id.to_lowercase();
+                    let bare = strip_latest(&lower);
+                    if !live_set.contains(&lower) && !live_set.contains(bare) {
                         return false;
                     }
                 }

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -58,6 +58,48 @@ fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, b
     (supports_vision, true, supports_thinking)
 }
 
+/// Resolve `(supports_vision, supports_tools, supports_thinking)` for a model
+/// discovered via a local provider's listing endpoint.
+///
+/// When the probe carried an explicit `capabilities` array (Ollama ≥0.7
+/// `/api/tags` exposes one per model), we trust those tags verbatim — they are
+/// the authoritative signal for HuggingFace-imported models whose names carry
+/// no recognisable substring (e.g. `Gemma-4-26B-A4B-it-GGUF`). The previous
+/// code only honoured `vision`/`embedding` from the array and silently fell
+/// back to name-heuristics for `thinking`/`tools`, which dropped capabilities
+/// that the model server explicitly reported.
+///
+/// Falls back to [`infer_capabilities`] only when the array is empty
+/// (Ollama <0.7 or non-Ollama OpenAI-compat probes that omit it).
+fn resolve_discovered_capabilities(
+    name: &str,
+    families: Option<&[String]>,
+    capabilities: &[String],
+) -> (bool, bool, bool) {
+    if capabilities.is_empty() {
+        return infer_capabilities(name, families);
+    }
+    let is_embedding = capabilities
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case("embedding"));
+    if is_embedding {
+        return (false, false, false);
+    }
+    let has_vision = capabilities
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case("vision"));
+    let has_thinking = capabilities
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case("thinking"));
+    // `tools`/`completion` is the default for any non-embedding chat model.
+    // Ollama ≥0.7 emits an explicit `tools` capability for tool-aware models;
+    // older daemons just emit `completion`. We treat any non-embedding model
+    // as tool-capable to preserve the prior behaviour (`!is_embedding`) and
+    // because most modern chat models expose tool calls via the OpenAI shape.
+    let supports_tools = true;
+    (has_vision, supports_tools, has_thinking)
+}
+
 #[cfg(test)]
 impl ModelCatalog {
     /// Test-only constructor: build a catalog directly from owned entries
@@ -781,30 +823,63 @@ impl ModelCatalog {
         provider: &str,
         model_info: &[crate::provider_health::DiscoveredModelInfo],
     ) {
-        let existing_ids: std::collections::HashSet<String> = self
-            .models
-            .iter()
-            .filter(|m| m.provider == provider)
-            .map(|m| m.id.to_lowercase())
-            .collect();
+        // Index existing entries for this provider by lowercase ID so we can
+        // both skip duplicates and selectively upgrade Local-tier entries
+        // whose capability flags were inferred from a stale signal (e.g.
+        // a previous probe before the user upgraded to Ollama ≥0.7, or a
+        // first probe that lacked the explicit `capabilities` array).
+        let mut existing_local: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        let mut existing_non_local: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for (idx, m) in self.models.iter().enumerate() {
+            if m.provider != provider {
+                continue;
+            }
+            let key = m.id.to_lowercase();
+            if m.tier == ModelTier::Local {
+                existing_local.insert(key, idx);
+            } else {
+                existing_non_local.insert(key);
+            }
+        }
 
         let mut added = 0usize;
         for info in model_info {
-            if existing_ids.contains(&info.name.to_lowercase()) {
+            let key = info.name.to_lowercase();
+            // A registry-shipped (non-Local) entry already covers this ID —
+            // its curated metadata (pricing, context window, tested caps)
+            // takes precedence over what a local probe reports.
+            if existing_non_local.contains(&key) {
                 continue;
             }
-            // Use capabilities from probe when available (Ollama ≥0.7 native or
-            // heuristic fallback). Fall back to local name/families heuristics.
             let (supports_vision, supports_tools, supports_thinking) =
-                if !info.capabilities.is_empty() {
-                    let is_embedding = info.capabilities.iter().any(|c| c == "embedding");
-                    let has_vision = info.capabilities.iter().any(|c| c == "vision");
-                    let (_, _, supports_thinking) =
-                        infer_capabilities(&info.name, info.families.as_deref());
-                    (has_vision, !is_embedding, supports_thinking)
-                } else {
-                    infer_capabilities(&info.name, info.families.as_deref())
-                };
+                resolve_discovered_capabilities(
+                    &info.name,
+                    info.families.as_deref(),
+                    &info.capabilities,
+                );
+            // Upgrade the previously-discovered Local entry in place when the
+            // current probe reports stronger capabilities. We never downgrade:
+            // a transient probe that drops the `capabilities` array (e.g. an
+            // older proxy in front of an upgraded Ollama) must not flip a
+            // vision-capable model back to non-vision.
+            if let Some(&idx) = existing_local.get(&key) {
+                let entry = &mut self.models[idx];
+                if supports_vision {
+                    entry.supports_vision = true;
+                }
+                if supports_thinking {
+                    entry.supports_thinking = true;
+                }
+                if supports_tools {
+                    entry.supports_tools = true;
+                    if !entry.supports_streaming {
+                        entry.supports_streaming = true;
+                    }
+                }
+                continue;
+            }
             let display = format!("{} ({})", info.name, provider);
             self.models.push(ModelCatalogEntry {
                 id: info.name.clone(),
@@ -1723,6 +1798,147 @@ id = "acme"
         assert!(!llama.supports_vision);
         assert!(llama.supports_tools);
         assert!(!llama.supports_thinking);
+    }
+
+    /// Regression test for #4034: HuggingFace-imported models like
+    /// `Gemma-4-26B-A4B-it-GGUF` carry no recognisable substring in their
+    /// name, so capability inference must fall through to the explicit
+    /// `capabilities` array Ollama ≥0.7 reports in `/api/tags`. The pre-fix
+    /// code only honoured `vision`/`embedding` and silently dropped the
+    /// `thinking`/`tools` tags, causing the dashboard to show such models
+    /// as plain chat models.
+    #[test]
+    fn test_merge_honours_explicit_thinking_and_vision_capabilities() {
+        let mut catalog = test_catalog();
+        let models = vec![DiscoveredModelInfo {
+            // No `vision`/`r1`/`qwen3` in the name — the heuristic alone
+            // would return (false, true, false). The explicit capabilities
+            // array must override that.
+            name: "Gemma-4-26B-A4B-it-GGUF:latest".to_string(),
+            families: Some(vec!["gemma".to_string()]),
+            family: Some("gemma".to_string()),
+            parameter_size: None,
+            quantization_level: None,
+            size: None,
+            capabilities: vec![
+                "completion".to_string(),
+                "vision".to_string(),
+                "thinking".to_string(),
+                "tools".to_string(),
+            ],
+        }];
+        catalog.merge_discovered_models("ollama", &models);
+
+        let entry = catalog
+            .find_model("Gemma-4-26B-A4B-it-GGUF:latest")
+            .expect("HF-imported model must be added");
+        assert!(
+            entry.supports_vision,
+            "explicit `vision` capability must propagate"
+        );
+        assert!(
+            entry.supports_thinking,
+            "explicit `thinking` capability must propagate (pre-fix this was dropped)"
+        );
+        assert!(entry.supports_tools);
+    }
+
+    /// Regression test for #4034 (part 2): a re-probe that newly reports
+    /// `vision`/`thinking` for an existing Local-tier entry must upgrade
+    /// the catalog in place rather than silently `continue`-ing past it.
+    /// This handles the case where the user upgrades Ollama from <0.7 to
+    /// ≥0.7 — the first probe stored capability=false, the second probe
+    /// must repair the entry.
+    #[test]
+    fn test_merge_upgrades_existing_local_entry_capabilities() {
+        let mut catalog = test_catalog();
+
+        // First probe: no explicit capabilities, plain chat model.
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModelInfo {
+                name: "Gemma-4-26B-A4B-it-GGUF:latest".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+                capabilities: vec![],
+            }],
+        );
+        let pre = catalog
+            .find_model("Gemma-4-26B-A4B-it-GGUF:latest")
+            .unwrap();
+        assert!(!pre.supports_vision);
+        assert!(!pre.supports_thinking);
+
+        // Second probe: now carries explicit capabilities.
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModelInfo {
+                name: "Gemma-4-26B-A4B-it-GGUF:latest".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+                capabilities: vec![
+                    "vision".to_string(),
+                    "thinking".to_string(),
+                    "tools".to_string(),
+                ],
+            }],
+        );
+        let post = catalog
+            .find_model("Gemma-4-26B-A4B-it-GGUF:latest")
+            .unwrap();
+        assert!(
+            post.supports_vision,
+            "second probe must upgrade vision flag"
+        );
+        assert!(
+            post.supports_thinking,
+            "second probe must upgrade thinking flag"
+        );
+        assert!(post.supports_tools);
+    }
+
+    /// Capability upgrades are monotonic — a transient probe that loses the
+    /// `capabilities` array (e.g. an older proxy in front of an upgraded
+    /// daemon) must not flip a previously-detected vision model back to
+    /// non-vision. Downgrades silently corrupt agent prompts.
+    #[test]
+    fn test_merge_never_downgrades_capabilities() {
+        let mut catalog = test_catalog();
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModelInfo {
+                name: "vlm-model:latest".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+                capabilities: vec!["vision".to_string(), "thinking".to_string()],
+            }],
+        );
+        // Re-probe with empty capabilities — must NOT clear the previously
+        // detected `vision`/`thinking` flags.
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModelInfo {
+                name: "vlm-model:latest".to_string(),
+                families: None,
+                family: None,
+                parameter_size: None,
+                quantization_level: None,
+                size: None,
+                capabilities: vec![],
+            }],
+        );
+        let entry = catalog.find_model("vlm-model:latest").unwrap();
+        assert!(entry.supports_vision, "must not downgrade vision");
+        assert!(entry.supports_thinking, "must not downgrade thinking");
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -58,19 +58,7 @@ fn infer_capabilities(name: &str, families: Option<&[String]>) -> (bool, bool, b
     (supports_vision, true, supports_thinking)
 }
 
-/// Resolve `(supports_vision, supports_tools, supports_thinking)` for a model
-/// discovered via a local provider's listing endpoint.
-///
-/// When the probe carried an explicit `capabilities` array (Ollama ≥0.7
-/// `/api/tags` exposes one per model), we trust those tags verbatim — they are
-/// the authoritative signal for HuggingFace-imported models whose names carry
-/// no recognisable substring (e.g. `Gemma-4-26B-A4B-it-GGUF`). The previous
-/// code only honoured `vision`/`embedding` from the array and silently fell
-/// back to name-heuristics for `thinking`/`tools`, which dropped capabilities
-/// that the model server explicitly reported.
-///
-/// Falls back to [`infer_capabilities`] only when the array is empty
-/// (Ollama <0.7 or non-Ollama OpenAI-compat probes that omit it).
+/// Resolve capabilities from the explicit Ollama ≥0.7 `capabilities` array, falling back to name heuristics when empty.
 fn resolve_discovered_capabilities(
     name: &str,
     families: Option<&[String]>,
@@ -1800,20 +1788,11 @@ id = "acme"
         assert!(!llama.supports_thinking);
     }
 
-    /// Regression test for #4034: HuggingFace-imported models like
-    /// `Gemma-4-26B-A4B-it-GGUF` carry no recognisable substring in their
-    /// name, so capability inference must fall through to the explicit
-    /// `capabilities` array Ollama ≥0.7 reports in `/api/tags`. The pre-fix
-    /// code only honoured `vision`/`embedding` and silently dropped the
-    /// `thinking`/`tools` tags, causing the dashboard to show such models
-    /// as plain chat models.
+    /// Regression #4034: explicit `thinking`/`vision` capabilities from Ollama ≥0.7 must propagate for HF-imported models with opaque names.
     #[test]
     fn test_merge_honours_explicit_thinking_and_vision_capabilities() {
         let mut catalog = test_catalog();
         let models = vec![DiscoveredModelInfo {
-            // No `vision`/`r1`/`qwen3` in the name — the heuristic alone
-            // would return (false, true, false). The explicit capabilities
-            // array must override that.
             name: "Gemma-4-26B-A4B-it-GGUF:latest".to_string(),
             families: Some(vec!["gemma".to_string()]),
             family: Some("gemma".to_string()),
@@ -1843,12 +1822,7 @@ id = "acme"
         assert!(entry.supports_tools);
     }
 
-    /// Regression test for #4034 (part 2): a re-probe that newly reports
-    /// `vision`/`thinking` for an existing Local-tier entry must upgrade
-    /// the catalog in place rather than silently `continue`-ing past it.
-    /// This handles the case where the user upgrades Ollama from <0.7 to
-    /// ≥0.7 — the first probe stored capability=false, the second probe
-    /// must repair the entry.
+    /// Regression #4034 part 2: a re-probe with explicit capabilities must upgrade an existing Local-tier entry in place (handles Ollama <0.7 → ≥0.7 upgrades).
     #[test]
     fn test_merge_upgrades_existing_local_entry_capabilities() {
         let mut catalog = test_catalog();
@@ -1903,10 +1877,7 @@ id = "acme"
         assert!(post.supports_tools);
     }
 
-    /// Capability upgrades are monotonic — a transient probe that loses the
-    /// `capabilities` array (e.g. an older proxy in front of an upgraded
-    /// daemon) must not flip a previously-detected vision model back to
-    /// non-vision. Downgrades silently corrupt agent prompts.
+    /// Capability upgrades are monotonic — a transient probe with empty capabilities must not downgrade previously-detected vision/thinking flags.
     #[test]
     fn test_merge_never_downgrades_capabilities() {
         let mut catalog = test_catalog();


### PR DESCRIPTION
## Summary

Repairs three Ollama-provider regressions reported in #4034 by FrantaNautilus.

The reporter pulled `Gemma-4-26B-A4B-it-GGUF` (a HuggingFace vision+thinking
model) into a Lemonade Server fronted by the `ollama` provider slot, and saw
both wrong capabilities in the Models page and `Model not found` errors at
chat time.

### Root causes

1. **`merge_discovered_models` ignored `thinking`/`tools` from the explicit
   capabilities array.** When Ollama ≥0.7 emits an explicit `capabilities`
   list per model, the merge code only honoured `vision`/`embedding` and fell
   back to name-heuristics (`qwq`, `deepseek-r1`, `qwen3`, ...) for
   `thinking`. HF-imported models whose names carry no recognisable substring
   were therefore listed as plain chat models even when the server advertised
   `thinking`.

2. **`merge_discovered_models` `continue`-d past existing entries.** A user
   who upgraded Ollama from <0.7 to ≥0.7 was stuck with stale capability
   flags forever — the second probe never updated the catalog entry.

3. **`:latest` tag asymmetry hid models from the dashboard.** Static catalog
   entries are shipped as bare names (`llama3.2`); Ollama returns
   `llama3.2:latest`; Lemonade returns the bare name. The dashboard's
   live-discovered filter compared exact lowercase strings, so static entries
   for tagged Ollama servers were hidden — and tagged catalog IDs paired
   with bare-name backends were hidden the other way.

### Fix

- New helper `resolve_discovered_capabilities` trusts the explicit Ollama
  capabilities array verbatim for `vision`/`thinking`/`embedding`. Only falls
  through to `infer_capabilities` (the name-heuristic) when the array is
  empty.
- `merge_discovered_models` now distinguishes Local-tier from registry/builtin
  entries. Local-tier entries are **monotonically upgraded** when a fresh
  probe reports stronger capabilities (vision/thinking/tools). Downgrades are
  refused so a transient probe that drops the array can't flip a vision
  model back to non-vision. Registry-shipped entries are still left
  untouched so curated pricing/context isn't clobbered.
- The dashboard's live-discovered filter (`/api/models`) now indexes both
  the verbatim name and the `:latest`-stripped form on both sides, so a
  static `llama3.2` entry survives whether the probe reported `llama3.2` or
  `llama3.2:latest`.

### Notes for reviewers

- This PR doesn't touch the `Model not found` error from the chat path
  itself — that error originates from Lemonade rejecting the literal model
  name the user has in their agent config (`Gemma-4-26B-A4B-it-GGUF:latest`
  vs Lemonade's `Gemma-4-26B-A4B-it-GGUF`). The dashboard `:latest` filter
  fix is a prerequisite for the user to re-pick the right model from the
  Models page once it stops being hidden; once they re-pick, the chat path
  sends the correct name.
- I don't have an Ollama instance with this exact HF model, so the
  capability-detection fix is verified by the new unit tests rather than
  end-to-end against a live daemon.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: `cargo test --workspace` passes (3 new regression tests added)
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Manual: with Ollama ≥0.7 and a HF-imported vision/thinking model, the
      Models page shows the correct vision/thinking badges
- [ ] Manual: a static `llama3.2` catalog entry stays visible when the user's
      Ollama returns `llama3.2:latest`

Closes #4034