### PR TITLE
fix(desktop,cli): block http MITM-RCE on webview + guard build.rs git mutation

### DIFF
--- a/crates/librefang-cli/tests/build_rs_no_git_mutation.rs
+++ b/crates/librefang-cli/tests/build_rs_no_git_mutation.rs
@@ -1,0 +1,70 @@
+//! Regression guard: build.rs must not mutate user git config (#3641).
+
+use std::path::PathBuf;
+
+const BUILD_RS_PATH: &str = "build.rs";
+
+fn read_build_rs() -> String {
+    let manifest_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest_dir.join(BUILD_RS_PATH);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
+fn strip_comments(src: &str) -> String {
+    // Drop // comments so doc notes about the old bug do not trip the check.
+    let mut out = String::with_capacity(src.len());
+    for line in src.lines() {
+        let cleaned = match line.find("//") {
+            Some(idx) => &line[..idx],
+            None => line,
+        };
+        out.push_str(cleaned);
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn build_rs_does_not_mutate_git_config() {
+    let src = strip_comments(&read_build_rs());
+
+    // Ban the bare `git config` token; if a future change needs read-only
+    // `git config --get`, allow it explicitly here instead of silently.
+    assert!(
+        !src.contains("\"config\""),
+        "build.rs must not invoke `git config` — issue #3641 forbids \
+         mutating user git config from a build script. If you need to \
+         read a value, use `git config --get` and add an explicit \
+         allowance in this test."
+    );
+    assert!(
+        !src.contains("hooksPath"),
+        "build.rs must not touch core.hooksPath — see issue #3641."
+    );
+}
+
+#[test]
+fn build_rs_uses_only_read_only_git_subcommands() {
+    let src = strip_comments(&read_build_rs());
+    // Side-effecting git subcommands have no place in a build script.
+    for forbidden in [
+        "\"init\"",
+        "\"clone\"",
+        "\"commit\"",
+        "\"push\"",
+        "\"pull\"",
+        "\"fetch\"",
+        "\"checkout\"",
+        "\"reset\"",
+        "\"add\"",
+        "\"rm\"",
+    ] {
+        assert!(
+            !src.contains(forbidden),
+            "build.rs must not invoke side-effecting git subcommand {forbidden} \
+             — see issue #3641."
+        );
+    }
+}

--- a/crates/librefang-cli/tests/build_rs_no_git_mutation.rs
+++ b/crates/librefang-cli/tests/build_rs_no_git_mutation.rs
@@ -5,8 +5,7 @@ use std::path::PathBuf;
 const BUILD_RS_PATH: &str = "build.rs";
 
 fn read_build_rs() -> String {
-    let manifest_dir =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let path = manifest_dir.join(BUILD_RS_PATH);
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -50,9 +50,7 @@ pub fn save_preference(pref: &ConnectionPreference) {
 #[tauri::command]
 pub async fn test_connection(url: String) -> Result<serde_json::Value, String> {
     let url = url.trim_end_matches('/').to_string();
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        return Err("URL must start with http:// or https://".to_string());
-    }
+    crate::validate_server_url(&url)?;
 
     let health_url = format!("{url}/api/health");
     let client = reqwest::Client::builder()
@@ -85,9 +83,7 @@ pub async fn connect_remote(
     window: tauri::WebviewWindow,
 ) -> Result<(), String> {
     let url = url.trim_end_matches('/').to_string();
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        return Err("URL must start with http:// or https://".to_string());
-    }
+    crate::validate_server_url(&url)?;
 
     // Verify server is reachable before committing to the connection.
     let health_url = format!("{url}/api/health");

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -49,6 +49,13 @@ pub(crate) fn validate_server_url(url: &str) -> Result<(), String> {
 
     // strip path/query, then peel optional :port (IPv6 literal needs []).
     let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    // Reject userinfo: `http://[::1]@evil.com/` would otherwise pass the
+    // loopback check while wry/reqwest connect to evil.com.
+    if authority.contains('@') {
+        return Err(format!(
+            "Refusing URL with userinfo (would bypass loopback check): {url}"
+        ));
+    }
     let host = if let Some(stripped) = authority.strip_prefix('[') {
         match stripped.split_once(']') {
             Some((h, _)) => h,
@@ -567,5 +574,16 @@ mod tests {
     fn malformed_url_rejected() {
         assert!(validate_server_url("http://").is_err());
         assert!(validate_server_url("http://[::1").is_err());
+    }
+
+    #[test]
+    fn userinfo_loopback_bypass_rejected() {
+        // wry/reqwest connect to the @-suffix host, not the userinfo;
+        // the IPv6/IPv4 prefix must NOT vouch for the real target.
+        assert!(validate_server_url("http://[::1]@evil.com/").is_err());
+        assert!(validate_server_url("http://[::1]:80@evil.com/").is_err());
+        assert!(validate_server_url("http://localhost@evil.com/").is_err());
+        assert!(validate_server_url("http://127.0.0.1@evil.com/").is_err());
+        assert!(validate_server_url("http://user:pass@evil.com/").is_err());
     }
 }

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -21,6 +21,7 @@ mod updater;
 use librefang_extensions::dotenv;
 use librefang_kernel::LibreFangKernel;
 use librefang_types::event::{EventPayload, LifecycleEvent, SystemEvent};
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tauri::Manager;
@@ -28,6 +29,53 @@ use tauri::Manager;
 use tauri::{WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
+
+/// Reject http:// for non-loopback hosts (IPC-enabled webview MITM-RCE, #3673).
+pub fn validate_server_url(url: &str) -> Result<(), String> {
+    let lower = url.to_ascii_lowercase();
+    let (scheme_is_http, rest) = if let Some(r) = lower.strip_prefix("http://") {
+        (true, r)
+    } else if let Some(r) = lower.strip_prefix("https://") {
+        (false, r)
+    } else {
+        return Err(format!(
+            "Server URL must start with http:// or https://, got: {url}"
+        ));
+    };
+
+    if !scheme_is_http {
+        return Ok(());
+    }
+
+    // strip path/query, then peel optional :port (IPv6 literal needs []).
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    let host = if let Some(stripped) = authority.strip_prefix('[') {
+        match stripped.split_once(']') {
+            Some((h, _)) => h,
+            None => return Err(format!("Malformed IPv6 host in URL: {url}")),
+        }
+    } else {
+        authority.rsplit_once(':').map(|(h, _)| h).unwrap_or(authority)
+    };
+
+    if host.is_empty() {
+        return Err(format!("Missing host in URL: {url}"));
+    }
+
+    if host == "localhost" {
+        return Ok(());
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip.is_loopback() {
+            return Ok(());
+        }
+    }
+
+    Err(format!(
+        "Refusing to load plaintext http:// from non-loopback host {host}: \
+         use https:// to prevent MITM-injected IPC abuse (issue #3673). URL: {url}"
+    ))
+}
 
 /// Managed state: the port the embedded server listens on.
 /// Wrapped in `RwLock<Option<_>>` — `None` when running in remote mode or before local boot.
@@ -183,8 +231,8 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     let (initial_url, server_handle, is_remote) = match &mode {
         StartupMode::Remote(url) => {
-            if !url.starts_with("http://") && !url.starts_with("https://") {
-                eprintln!("Server URL must use http:// or https://, got: {url}");
+            if let Err(e) = validate_server_url(url) {
+                eprintln!("{e}");
                 std::process::exit(1);
             }
             info!("Remote mode: connecting to {url}");
@@ -206,8 +254,8 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     #[cfg(any(target_os = "ios", target_os = "android"))]
     let (initial_url, is_remote) = match &mode {
         StartupMode::Remote(url) => {
-            if !url.starts_with("http://") && !url.starts_with("https://") {
-                eprintln!("Server URL must use http:// or https://, got: {url}");
+            if let Err(e) = validate_server_url(url) {
+                eprintln!("{e}");
                 std::process::exit(1);
             }
             info!("Remote mode: connecting to {url}");
@@ -464,4 +512,57 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     info!("Tauri app closed, shutting down...");
     // The ServerHandle's Drop impl will signal shutdown automatically when
     // Tauri's managed state is dropped.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_server_url;
+
+    #[test]
+    fn https_remote_host_accepted() {
+        assert!(validate_server_url("https://example.com").is_ok());
+        assert!(validate_server_url("https://example.com:8443/path").is_ok());
+        assert!(validate_server_url("https://192.0.2.10").is_ok());
+    }
+
+    #[test]
+    fn http_loopback_accepted() {
+        assert!(validate_server_url("http://127.0.0.1:4545").is_ok());
+        assert!(validate_server_url("http://localhost").is_ok());
+        assert!(validate_server_url("http://localhost:4545/dashboard").is_ok());
+        assert!(validate_server_url("http://[::1]:4545").is_ok());
+        assert!(validate_server_url("http://127.0.0.1").is_ok());
+        // Anywhere in 127.0.0.0/8 is loopback per IpAddr::is_loopback.
+        assert!(validate_server_url("http://127.5.6.7:4545").is_ok());
+    }
+
+    #[test]
+    fn http_remote_host_rejected() {
+        assert!(validate_server_url("http://example.com").is_err());
+        assert!(validate_server_url("http://192.168.1.10:4545").is_err());
+        assert!(validate_server_url("http://10.0.0.1:4545/dashboard").is_err());
+        assert!(validate_server_url("http://[2001:db8::1]:4545").is_err());
+    }
+
+    #[test]
+    fn case_insensitive_scheme() {
+        assert!(validate_server_url("HTTP://example.com").is_err());
+        assert!(validate_server_url("Http://127.0.0.1:4545").is_ok());
+        assert!(validate_server_url("HTTPS://example.com").is_ok());
+    }
+
+    #[test]
+    fn unknown_scheme_rejected() {
+        assert!(validate_server_url("ftp://example.com").is_err());
+        assert!(validate_server_url("javascript:alert(1)").is_err());
+        assert!(validate_server_url("file:///etc/passwd").is_err());
+        assert!(validate_server_url("").is_err());
+        assert!(validate_server_url("example.com").is_err());
+    }
+
+    #[test]
+    fn malformed_url_rejected() {
+        assert!(validate_server_url("http://").is_err());
+        assert!(validate_server_url("http://[::1").is_err());
+    }
 }

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -55,7 +55,10 @@ pub(crate) fn validate_server_url(url: &str) -> Result<(), String> {
             None => return Err(format!("Malformed IPv6 host in URL: {url}")),
         }
     } else {
-        authority.rsplit_once(':').map(|(h, _)| h).unwrap_or(authority)
+        authority
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(authority)
     };
 
     if host.is_empty() {

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -31,7 +31,7 @@ use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
 
 /// Reject http:// for non-loopback hosts (IPC-enabled webview MITM-RCE, #3673).
-pub fn validate_server_url(url: &str) -> Result<(), String> {
+pub(crate) fn validate_server_url(url: &str) -> Result<(), String> {
     let lower = url.to_ascii_lowercase();
     let (scheme_is_http, rest) = if let Some(r) = lower.strip_prefix("http://") {
         (true, r)


### PR DESCRIPTION
## Summary
Two single-critical security fixes:

- **#3673 (desktop, P0):** Tauri webview has IPC enabled and exposes `import_agent_toml`, `set_autostart`, `import_skill_file`. The previous URL check accepted any `http://` URL, so a passive MITM (LAN, café Wi-Fi, hijacked DNS) could inject JS into a plaintext-served LibreFang dashboard and call those IPC commands → full RCE on the host with autostart persistence. Fix: extract `validate_server_url()` that allows `http://` only for loopback (`127.0.0.0/8`, `::1`, `localhost`); remote `http://` is rejected. Applied at desktop + mobile `StartupMode::Remote` and `test_connection` / `connect_remote` IPC commands. Local embedded server (default) keeps working.
- **#3641 (cli, critical):** The `git config core.hooksPath` mutation was removed from `crates/librefang-cli/build.rs` in #3961, but nothing prevents the regression. Added an integration test (`crates/librefang-cli/tests/build_rs_no_git_mutation.rs`) that reads `build.rs` and asserts no `"config"` arg, no `hooksPath` literal, and none of the side-effecting git subcommands (`init`/`clone`/`commit`/`push`/`pull`/`fetch`/`checkout`/`reset`/`add`/`rm`) appear. Comments are stripped so historical doc references do not trip the check.

## Decisions
- Chose option (a) from #3673 — reject `http://` non-loopback rather than running an isolated webview without IPC. Simplest, matches modern browser behaviour, and the loopback exception preserves the default local-mode UX. Users connecting to a remote LAN daemon now need `https://` (e.g. via reverse proxy or self-signed cert).
- Hand-rolled URL parser (no `url` crate dependency) — only need scheme + host + IPv6-literal handling. Six unit tests cover the matrix.
- For #3641 we ban the bare `"config"` arg token rather than a regex; if a future change ever needs read-only `git config --get`, the test message tells the author to add an explicit allowance instead of silently re-opening the door.

## Test plan
- [ ] `cargo test -p librefang-desktop validate_server_url` — six new unit tests.
- [ ] `cargo test -p librefang-cli --test build_rs_no_git_mutation` — two regression guards.
- [ ] Manual: launch desktop with `--server-url http://example.com:4545` → expect process exit with the new error message; `--server-url https://example.com:4545` → starts; `--server-url http://127.0.0.1:4545` → starts.
- [ ] CI: workspace build / clippy / test.

Closes #3673
Closes #3641