### PR TITLE
fix(channels): close 3 inbound-safety holes (LINE/Teams/email)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2479,15 +2479,37 @@ pub async fn start_channel_bridge_with_config(
                 read_token(&tm_config.security_token_env, "Teams (security_token)")
                     .unwrap_or_default();
             // Default-deny: unsigned webhooks let anyone forge Teams activities.
-            if tm_config.signature_required && security_token.is_empty() {
-                tracing::error!(
-                    "Teams adapter for app_id={} refused: signature_required=true \
-                     but security_token_env '{}' is unset/empty. Set the env var or \
-                     explicitly set signature_required=false (NOT recommended).",
-                    tm_config.app_id,
-                    tm_config.security_token_env
-                );
-                continue;
+            // Also reject when the token is present but cannot be base64-decoded
+            // or decodes to empty bytes — TeamsAdapter::new would otherwise
+            // silently fall back to security_token_key=None and skip
+            // signature verification at the webhook handler.
+            if tm_config.signature_required {
+                use base64::Engine;
+                let decoded = if security_token.is_empty() {
+                    Err("missing".to_string())
+                } else {
+                    base64::engine::general_purpose::STANDARD
+                        .decode(security_token.as_bytes())
+                        .map_err(|e| format!("invalid base64: {e}"))
+                        .and_then(|b| {
+                            if b.is_empty() {
+                                Err("decodes to empty key".to_string())
+                            } else {
+                                Ok(b)
+                            }
+                        })
+                };
+                if let Err(reason) = decoded {
+                    tracing::error!(
+                        "Teams adapter for app_id={} refused: signature_required=true \
+                         but security_token_env '{}' is {reason}. Set the env var to a \
+                         valid base64-encoded outgoing-webhook token, or explicitly \
+                         set signature_required=false (NOT recommended).",
+                        tm_config.app_id,
+                        tm_config.security_token_env
+                    );
+                    continue;
+                }
             }
             let adapter = Arc::new(
                 TeamsAdapter::new(

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2478,6 +2478,17 @@ pub async fn start_channel_bridge_with_config(
             let security_token =
                 read_token(&tm_config.security_token_env, "Teams (security_token)")
                     .unwrap_or_default();
+            // Default-deny: unsigned webhooks let anyone forge Teams activities.
+            if tm_config.signature_required && security_token.is_empty() {
+                tracing::error!(
+                    "Teams adapter for app_id={} refused: signature_required=true \
+                     but security_token_env '{}' is unset/empty. Set the env var or \
+                     explicitly set signature_required=false (NOT recommended).",
+                    tm_config.app_id,
+                    tm_config.security_token_env
+                );
+                continue;
+            }
             let adapter = Arc::new(
                 TeamsAdapter::new(
                     tm_config.app_id.clone(),

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -8521,8 +8521,13 @@
             },
             "security_token_env": {
               "default": "",
-              "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. If the env var is absent or empty, verification is skipped with a warning.",
+              "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. Required by default; setting `signature_required = false` opts out (dev only).",
               "type": "string"
+            },
+            "signature_required": {
+              "default": true,
+              "description": "Reject adapter startup unless a security token is configured (default `true`). Setting to `false` is strongly discouraged — webhook becomes a public endpoint.",
+              "type": "boolean"
             },
             "webhook_port": {
               "default": 3978,
@@ -11688,8 +11693,13 @@
         },
         "security_token_env": {
           "default": "",
-          "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. If the env var is absent or empty, verification is skipped with a warning.",
+          "description": "Env var name holding the outgoing webhook security token (base64-encoded). Used for HMAC-SHA256 verification of inbound webhook requests. Required by default; setting `signature_required = false` opts out (dev only).",
           "type": "string"
+        },
+        "signature_required": {
+          "default": true,
+          "description": "Reject adapter startup unless a security token is configured (default `true`). Setting to `false` is strongly discouraged — webhook becomes a public endpoint.",
+          "type": "boolean"
         },
         "webhook_port": {
           "default": 3978,

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -115,7 +115,10 @@ impl EmailAdapter {
     /// Check if a sender is in the allowlist (empty = allow all). Used in tests.
     #[allow(dead_code)]
     fn is_allowed_sender(&self, sender: &str) -> bool {
-        self.allowed_senders.is_empty() || self.allowed_senders.iter().any(|s| sender.contains(s))
+        if self.allowed_senders.is_empty() {
+            return true;
+        }
+        sender_matches_allowlist(sender, &self.allowed_senders)
     }
 
     /// Extract agent name from subject line brackets, e.g., "[coder] Fix the bug" -> Some("coder")
@@ -178,6 +181,33 @@ fn extract_email_addr(raw: &str) -> String {
         }
     }
     raw.to_string()
+}
+
+/// Exact-address or `@domain` allowlist match (no substring — fixes #3463).
+fn sender_matches_allowlist(sender: &str, allowed: &[String]) -> bool {
+    let addr = extract_email_addr(sender);
+    let addr = addr.trim();
+    let Some(at_idx) = addr.rfind('@') else {
+        return false;
+    };
+    let domain = &addr[at_idx + 1..];
+    if domain.is_empty() {
+        return false;
+    }
+    for entry in allowed {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some(allowed_domain) = entry.strip_prefix('@') {
+            if !allowed_domain.is_empty() && domain.eq_ignore_ascii_case(allowed_domain) {
+                return true;
+            }
+        } else if addr.eq_ignore_ascii_case(entry) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Get a specific header value from a parsed email.
@@ -383,9 +413,9 @@ impl ChannelAdapter for EmailAdapter {
                 };
 
                 for (from_addr, subject, message_id, body) in emails {
-                    // Check allowed senders
+                    // Exact-match allowlist (substring match would let evil-trusted.com bypass).
                     if !allowed_senders.is_empty()
-                        && !allowed_senders.iter().any(|s| from_addr.contains(s))
+                        && !sender_matches_allowlist(&from_addr, &allowed_senders)
                     {
                         debug!(from = %from_addr, "Email from non-allowed sender, skipping");
                         continue;
@@ -577,6 +607,64 @@ mod tests {
             vec![],
         );
         assert!(open.is_allowed_sender("anyone@anywhere.com"));
+    }
+
+    #[test]
+    fn test_allowed_senders_domain_exact_match() {
+        let allowed = vec!["@example.com".to_string()];
+        // Exact domain match passes
+        assert!(sender_matches_allowlist("alice@example.com", &allowed));
+        assert!(sender_matches_allowlist("ALICE@EXAMPLE.COM", &allowed));
+        assert!(sender_matches_allowlist(
+            "Alice <alice@example.com>",
+            &allowed
+        ));
+        // Sibling-domain spoofing is rejected (the original substring bug).
+        assert!(!sender_matches_allowlist(
+            "attacker@example.com.evil.com",
+            &allowed
+        ));
+        assert!(!sender_matches_allowlist(
+            "attacker@notexample.com",
+            &allowed
+        ));
+        assert!(!sender_matches_allowlist(
+            "attacker@evil.com",
+            &allowed
+        ));
+        assert!(!sender_matches_allowlist("malformed", &allowed));
+        assert!(!sender_matches_allowlist("trailing@", &allowed));
+    }
+
+    #[test]
+    fn test_allowed_senders_full_address_exact_match() {
+        let allowed = vec!["alice@example.com".to_string()];
+        assert!(sender_matches_allowlist("alice@example.com", &allowed));
+        assert!(sender_matches_allowlist("ALICE@example.com", &allowed));
+        assert!(!sender_matches_allowlist(
+            "alice@example.com.evil.com",
+            &allowed
+        ));
+        assert!(!sender_matches_allowlist("bob@example.com", &allowed));
+        assert!(!sender_matches_allowlist(
+            "alice+spoof@example.com",
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn test_allowed_senders_mixed_entries() {
+        let allowed = vec![
+            "@example.com".to_string(),
+            "bob@partner.com".to_string(),
+        ];
+        assert!(sender_matches_allowlist("anyone@example.com", &allowed));
+        assert!(sender_matches_allowlist("bob@partner.com", &allowed));
+        assert!(!sender_matches_allowlist("alice@partner.com", &allowed));
+        assert!(!sender_matches_allowlist(
+            "bob@partner.com.evil.com",
+            &allowed
+        ));
     }
 
     #[test]

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -628,10 +628,7 @@ mod tests {
             "attacker@notexample.com",
             &allowed
         ));
-        assert!(!sender_matches_allowlist(
-            "attacker@evil.com",
-            &allowed
-        ));
+        assert!(!sender_matches_allowlist("attacker@evil.com", &allowed));
         assert!(!sender_matches_allowlist("malformed", &allowed));
         assert!(!sender_matches_allowlist("trailing@", &allowed));
     }
@@ -654,10 +651,7 @@ mod tests {
 
     #[test]
     fn test_allowed_senders_mixed_entries() {
-        let allowed = vec![
-            "@example.com".to_string(),
-            "bob@partner.com".to_string(),
-        ];
+        let allowed = vec!["@example.com".to_string(), "bob@partner.com".to_string()];
         assert!(sender_matches_allowlist("anyone@example.com", &allowed));
         assert!(sender_matches_allowlist("bob@partner.com", &allowed));
         assert!(!sender_matches_allowlist("alice@partner.com", &allowed));

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -703,4 +703,14 @@ mod tests {
         assert!(msg.is_group);
         assert_eq!(msg.sender.platform_id, "R1234567890");
     }
+
+    /// Regression for #3439: empty / non-base64 sig must never pass HMAC.
+    #[test]
+    fn test_verify_line_signature_rejects_empty_signature() {
+        let secret = b"channel-secret-bytes";
+        let body = br#"{"events":[]}"#;
+        assert!(!verify_line_signature(secret, body, ""));
+        assert!(!verify_line_signature(secret, body, "   "));
+        assert!(!verify_line_signature(secret, body, "not-base64!@#"));
+    }
 }

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -1687,6 +1687,12 @@ fn migrate_channels_from_json(
                 "teams".to_string(),
                 build_channel_table(fields, tm.dm_policy.as_deref(), None),
             );
+            report.warnings.push(
+                "Teams: signature_required defaults to true. Set TEAMS_SECURITY_TOKEN \
+                 (base64 outgoing-webhook token from the Teams portal) before \
+                 starting the daemon, or the adapter will refuse to register."
+                    .to_string(),
+            );
             report.imported.push(MigrateItem {
                 kind: ItemKind::Channel,
                 name: "teams".to_string(),

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -446,6 +446,7 @@ admin_role = "admin"
         assert_eq!(t.app_password_env, "TEAMS_APP_PASSWORD");
         assert_eq!(t.webhook_port, 3978);
         assert!(t.allowed_tenants.is_empty());
+        assert!(t.signature_required, "default-deny on Teams webhook");
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5730,9 +5730,13 @@ pub struct TeamsConfig {
     pub app_password_env: String,
     /// Env var name holding the outgoing webhook security token (base64-encoded).
     /// Used for HMAC-SHA256 verification of inbound webhook requests.
-    /// If the env var is absent or empty, verification is skipped with a warning.
+    /// Required by default; setting `signature_required = false` opts out (dev only).
     #[serde(default)]
     pub security_token_env: String,
+    /// Reject adapter startup unless a security token is configured (default `true`).
+    /// Setting to `false` is strongly discouraged — webhook becomes a public endpoint.
+    #[serde(default = "default_true")]
+    pub signature_required: bool,
     /// Port for the incoming webhook.
     pub webhook_port: u16,
     /// Allowed tenant IDs (empty = allow all).
@@ -5754,6 +5758,7 @@ impl Default for TeamsConfig {
             app_id: String::new(),
             app_password_env: "TEAMS_APP_PASSWORD".to_string(),
             security_token_env: "TEAMS_SECURITY_TOKEN".to_string(),
+            signature_required: true,
             webhook_port: 3978,
             allowed_tenants: vec![],
             account_id: None,


### PR DESCRIPTION
## Summary

Three independent inbound-side input-safety bypasses on channel adapters,
batched into one PR per request.

### LINE — empty signature defense in depth (#3439)

The webhook handler already rejects requests missing the
`X-Line-Signature` header (handler short-circuits to `400`), but added a
verifier-level regression test that pins the invariant: an empty or
non-base64 signature string MUST NOT satisfy HMAC. This guards against
someone reverting to the historical `unwrap_or("")` shape.

### Teams — default-deny webhook (#3440)

The Teams webhook quietly disabled signature verification when
`security_token_env` was unset (`security_token_key = None` → handler
skips the verify branch entirely). An attacker on the internet could
forge `Activity` envelopes with arbitrary `from.aadObjectId` and
`tenant`, bypassing `allowed_tenants`.

* New `TeamsConfig.signature_required: bool`, **default `true`**.
* Wiring in `channel_bridge.rs` now refuses to register the adapter
  when the flag is on and no token is decoded — fails loudly in logs
  rather than silently accepting forged inbound activities.
* Backward-compat: operators can set `signature_required = false` for
  dev, but the daemon logs an `error` and the schema description marks
  it dev-only.
* OpenClaw migrate emits a warning so imported configs do not silently
  regress on first start.

> The Viber half of #3440 was already addressed by the prior
> `mandatory webhook HMAC verification` PRs (`cd3d1ceb`, `bca800c8`):
> Viber today demands `X-Viber-Content-Signature` + HMAC-SHA256(token)
> and rejects missing/invalid headers with 400/401 before parsing.

### Email — exact-match allowlist (#3463)

`allowed_senders.iter().any(|s| from_addr.contains(s))` lets an attacker
register a sibling domain and bypass: `attacker@example.com.evil.com`
contains the substring `@example.com`. Replaced with a parse-and-anchor
matcher:

* `@example.com` matches if the parsed sender domain equals
  `example.com` (case-insensitive).
* `alice@example.com` matches only if the full address is identical.
* Malformed addresses (`malformed`, `trailing@`) and the documented
  spoofs are rejected by tests.

## Test plan

- [x] `cargo test -p librefang-channels` (unit tests for
      `sender_matches_allowlist`, LINE empty-sig regression, existing
      Teams/Viber sig tests)
- [x] `cargo test -p librefang-types` (TeamsConfig default invariant)
- [ ] Reviewer: confirm OpenClaw migration warning appears for
      imported Teams configs
- [ ] Reviewer: confirm new schema field round-trips through golden

Closes #3439
Closes #3440
Closes #3463