### PR TITLE
fix(vault): stop swallowing vault write errors in 3 security paths

### DIFF
--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -717,22 +717,26 @@ pub async fn auth_revoke(
         }
     };
 
-    // Clear tokens via provider (keyed by server URL, not name)
-    let provider = state.kernel.oauth_provider_ref();
-    if let Err(e) = provider.clear_tokens(&server_url).await {
-        tracing::warn!(server = %name, error = %e, "Failed to clear OAuth tokens");
-    }
-
-    // Set auth state to NeedsAuth so the dashboard shows the Authorize button
+    // #3369: clear in-memory state first so the current process can no longer
+    // use the cached tokens, even if the persistent vault wipe fails. Then
+    // attempt the vault wipe; if that fails, surface the error so the UI can
+    // tell the user the sign-out is incomplete on disk and prompt a retry.
     {
         let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
         auth_states.insert(name.clone(), McpAuthState::NeedsAuth);
     }
-
-    // Remove from MCP connections so next reconnect is clean
     {
         let mut conns = state.kernel.mcp_connections_ref().lock().await;
         conns.retain(|c| c.name() != name);
+    }
+
+    let provider = state.kernel.oauth_provider_ref();
+    if let Err(e) = provider.clear_tokens(&server_url).await {
+        tracing::error!(server = %name, error = %e, "auth_revoke: vault clear failed");
+        return ApiErrorResponse::internal(format!(
+            "Sign-out partially failed: in-memory session cleared but stored tokens may remain in the vault. Retry. Details: {e}"
+        ))
+        .into_json_tuple();
     }
 
     (

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2797,27 +2797,41 @@ pub async fn totp_revoke(
         .into_json_tuple();
     }
 
-    // #3633: clearing must not be best-effort. If any vault_set fails, the
-    // secret / recovery codes can still verify and the caller would see a
-    // "revoked" response while 2FA remains active. Fail the request instead.
-    if let Err(e) = state.kernel.vault_set("totp_confirmed", "false") {
-        tracing::error!("totp_revoke: failed to clear totp_confirmed: {e}");
-        return ApiErrorResponse::internal(format!(
-            "TOTP revocation failed to persist: {e}. TOTP is still active — retry."
-        ))
-        .into_json_tuple();
-    }
+    // #3633: clearing must not be best-effort and must avoid creating a
+    // partial state that BYPASSES 2FA on login. The login gate
+    // (server.rs ~334) reads `if totp_enrolled && totp_confirmed` to decide
+    // whether to prompt for a TOTP code, so:
+    //   * `totp_confirmed=false` alone is enough to disable 2FA on login,
+    //     even if `totp_secret` is still present.
+    // An earlier fail-fast version cleared `totp_confirmed` first and
+    // returned 500 if `totp_secret` then failed to wipe — that
+    // simultaneously told the user "TOTP is still active, retry" while
+    // actually disabling 2FA. To prevent that, we:
+    //   1. Wipe `totp_secret` and `totp_recovery_codes` FIRST so the
+    //      verify path is dead before we ever flip the `totp_confirmed`
+    //      flag. Even if writing the flag later fails, secret/recovery are
+    //      already gone, so a retry is purely a state-flag fix and 2FA is
+    //      effectively disabled either way.
+    //   2. Attempt every write (collect-all, not fail-fast) so a transient
+    //      failure on field N doesn't leave fields >N untouched on retry.
+    //   3. Aggregate failures into a single 500 with all field errors.
+    let mut failures: Vec<String> = Vec::new();
     if let Err(e) = state.kernel.vault_set("totp_secret", "") {
         tracing::error!("totp_revoke: failed to clear totp_secret: {e}");
-        return ApiErrorResponse::internal(format!(
-            "TOTP revocation partially failed: {e}. Retry to fully clear stored secret."
-        ))
-        .into_json_tuple();
+        failures.push(format!("totp_secret: {e}"));
     }
     if let Err(e) = state.kernel.vault_set("totp_recovery_codes", "[]") {
         tracing::error!("totp_revoke: failed to clear totp_recovery_codes: {e}");
+        failures.push(format!("totp_recovery_codes: {e}"));
+    }
+    if let Err(e) = state.kernel.vault_set("totp_confirmed", "false") {
+        tracing::error!("totp_revoke: failed to clear totp_confirmed: {e}");
+        failures.push(format!("totp_confirmed: {e}"));
+    }
+    if !failures.is_empty() {
         return ApiErrorResponse::internal(format!(
-            "TOTP revocation partially failed: {e}. Recovery codes may still be valid — retry."
+            "TOTP revocation partially failed; the secret and recovery codes have been wiped first so 2FA is no longer verifiable, but vault state is inconsistent. Retry. Details: {}",
+            failures.join("; ")
         ))
         .into_json_tuple();
     }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2797,16 +2797,29 @@ pub async fn totp_revoke(
         .into_json_tuple();
     }
 
-    // Remove TOTP data from vault
-    // vault_set to empty/false markers (vault doesn't expose remove via kernel helper)
+    // #3633: clearing must not be best-effort. If any vault_set fails, the
+    // secret / recovery codes can still verify and the caller would see a
+    // "revoked" response while 2FA remains active. Fail the request instead.
     if let Err(e) = state.kernel.vault_set("totp_confirmed", "false") {
-        tracing::warn!("Failed to clear totp_confirmed in vault during TOTP revocation: {e}");
+        tracing::error!("totp_revoke: failed to clear totp_confirmed: {e}");
+        return ApiErrorResponse::internal(format!(
+            "TOTP revocation failed to persist: {e}. TOTP is still active — retry."
+        ))
+        .into_json_tuple();
     }
     if let Err(e) = state.kernel.vault_set("totp_secret", "") {
-        tracing::warn!("Failed to clear totp_secret in vault during TOTP revocation: {e}");
+        tracing::error!("totp_revoke: failed to clear totp_secret: {e}");
+        return ApiErrorResponse::internal(format!(
+            "TOTP revocation partially failed: {e}. Retry to fully clear stored secret."
+        ))
+        .into_json_tuple();
     }
     if let Err(e) = state.kernel.vault_set("totp_recovery_codes", "[]") {
-        tracing::warn!("Failed to clear totp_recovery_codes in vault during TOTP revocation: {e}");
+        tracing::error!("totp_revoke: failed to clear totp_recovery_codes: {e}");
+        return ApiErrorResponse::internal(format!(
+            "TOTP revocation partially failed: {e}. Recovery codes may still be valid — retry."
+        ))
+        .into_json_tuple();
     }
 
     (

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -2452,14 +2452,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn save_failed_blocks_input_until_user_acks() {
-        // The ApiKey step uses `matches!(state.key_test, Ok | Warn)` to short-
-        // circuit input handling and let the auto-advance timer fire. SaveFailed
-        // must fall through that guard so Esc can still bring the user back to
-        // the provider step (where they can retry from a clean state).
-        let s = KeyTestState::SaveFailed("io error".to_string());
-        let auto_advance_match = matches!(s, KeyTestState::Ok | KeyTestState::Warn);
-        assert!(!auto_advance_match);
-    }
 }

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -2494,5 +2494,4 @@ mod tests {
             "SaveFailed must NOT match the auto-advance arm"
         );
     }
-
 }

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -818,6 +818,49 @@ pub fn run() -> InitResult {
                             continue;
                         }
 
+                        // #3629 follow-up: from SaveFailed the user has an
+                        // already-validated key in `api_key_input` — Enter
+                        // should retry ONLY the disk write (no re-validate, no
+                        // rate-limit hit), and Esc should preserve the key
+                        // text so the user is not forced to retype it after a
+                        // transient disk error. Other input (typing /
+                        // backspace) stays disabled to avoid mutating the
+                        // already-verified value.
+                        if let KeyTestState::SaveFailed(_) = &state.key_test {
+                            match key.code {
+                                KeyCode::Enter => {
+                                    let mut new_err: Option<String> = None;
+                                    if let Some(p) = state.provider() {
+                                        if !p.env_var.is_empty() {
+                                            if let Err(e) = dotenv::save_env_key(
+                                                p.env_var,
+                                                &state.api_key_input,
+                                            ) {
+                                                tracing::error!(
+                                                    provider = ?p.name,
+                                                    error = %e,
+                                                    "init wizard: retry of save_env_key failed"
+                                                );
+                                                new_err = Some(e);
+                                            }
+                                        }
+                                    }
+                                    state.key_test = match new_err {
+                                        Some(e) => KeyTestState::SaveFailed(e),
+                                        None => KeyTestState::Ok,
+                                    };
+                                    state.key_test_started = Some(Instant::now());
+                                }
+                                KeyCode::Esc => {
+                                    // Keep `api_key_input` so the user can
+                                    // retry without re-typing or re-validating.
+                                    state.key_test = KeyTestState::Idle;
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
+
                         match key.code {
                             KeyCode::Esc => {
                                 state.key_test = KeyTestState::Idle;
@@ -1949,7 +1992,7 @@ fn draw_api_key(f: &mut Frame, area: Rect, state: &mut State) {
             );
             f.render_widget(
                 Paragraph::new(Line::from(vec![Span::styled(
-                    "    Press [Esc] to go back and retry. Nothing was written.",
+                    "    [Enter] retry save  ·  [Esc] edit key  (key already verified — nothing on disk)",
                     theme::dim_style(),
                 )])),
                 chunks[4],

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -238,12 +238,15 @@ enum RoutingPhase {
     PickTier(usize),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 enum KeyTestState {
     Idle,
     Testing,
     Ok,
     Warn,
+    // #3629: validation succeeded but persisting to .env failed. Surface this
+    // explicitly so the user sees the disk error instead of a fake "Verified".
+    SaveFailed(String),
 }
 
 /// A model entry for list display.
@@ -617,31 +620,28 @@ pub fn run() -> InitResult {
         // initial Enter press (fixes #3629: write-before-validate).
         if state.key_test == KeyTestState::Testing {
             if let Ok(ok) = test_rx.try_recv() {
-                // Persist ONLY when the validation succeeded.  The
-                // pre-fix comment claimed the Warn path was "unverified
-                // but user confirmed", but the wizard auto-advances
-                // 600 ms after either Ok or Warn (see the matches!
-                // block below) — there is no explicit confirmation
-                // step.  Writing a failing key still landed it in
-                // .env, so the daemon booted with a key the wizard
-                // had just told the user was bad.  Now Warn keeps the
-                // user-typed value in `state.api_key_input` only, the
-                // UI surfaces the validation message, and nothing
-                // hits disk until the user retries with a key that
-                // actually authenticates.
+                // #3629: never advance silently. If the disk save fails after a
+                // verified key, surface it as SaveFailed so the user retries
+                // instead of seeing a fake "Verified" while ~/.librefang/.env
+                // is still empty.
                 state.key_test = if ok {
+                    let mut save_err: Option<String> = None;
                     if let Some(p) = state.provider() {
                         if !p.env_var.is_empty() {
                             if let Err(e) = dotenv::save_env_key(p.env_var, &state.api_key_input) {
-                                tracing::warn!(
+                                tracing::error!(
                                     provider = ?p.name,
                                     error = %e,
                                     "init wizard: failed to persist verified API key"
                                 );
+                                save_err = Some(e);
                             }
                         }
                     }
-                    KeyTestState::Ok
+                    match save_err {
+                        Some(e) => KeyTestState::SaveFailed(e),
+                        None => KeyTestState::Ok,
+                    }
                 } else {
                     KeyTestState::Warn
                 };
@@ -1871,7 +1871,7 @@ fn draw_api_key(f: &mut Frame, area: Rect, state: &mut State) {
     ))]));
     f.render_widget(prompt, chunks[0]);
 
-    match state.key_test {
+    match &state.key_test {
         KeyTestState::Idle => {
             let masked: String = "\u{2022}".repeat(state.api_key_input.len());
             let input = Paragraph::new(Line::from(vec![
@@ -1930,6 +1930,29 @@ fn draw_api_key(f: &mut Frame, area: Rect, state: &mut State) {
                     theme::dim_style(),
                 )])),
                 chunks[3],
+            );
+        }
+        KeyTestState::SaveFailed(err) => {
+            f.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("  \u{2716} ", Style::default().fg(theme::YELLOW)),
+                    Span::raw("Verified, but saving to .env failed"),
+                ])),
+                chunks[1],
+            );
+            f.render_widget(
+                Paragraph::new(Line::from(vec![Span::styled(
+                    format!("    {err}"),
+                    theme::dim_style(),
+                )])),
+                chunks[3],
+            );
+            f.render_widget(
+                Paragraph::new(Line::from(vec![Span::styled(
+                    "    Press [Esc] to go back and retry. Nothing was written.",
+                    theme::dim_style(),
+                )])),
+                chunks[4],
             );
         }
     }
@@ -2411,4 +2434,32 @@ fn draw_complete(f: &mut Frame, area: Rect, state: &mut State) {
         widgets::hint_bar("  [\u{2191}\u{2193}/jk] Navigate  [Enter] Launch  [1/2/3] Quick select"),
         chunks[15],
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #3629: SaveFailed must not be treated as a successful key state. Pre-fix,
+    /// a failed .env write was logged-then-ignored and the wizard auto-advanced
+    /// while the key was never on disk.
+    #[test]
+    fn save_failed_does_not_auto_advance() {
+        let s = KeyTestState::SaveFailed("disk full".to_string());
+        assert!(
+            !matches!(s, KeyTestState::Ok | KeyTestState::Warn),
+            "SaveFailed must NOT match the auto-advance arm"
+        );
+    }
+
+    #[test]
+    fn save_failed_blocks_input_until_user_acks() {
+        // The ApiKey step uses `matches!(state.key_test, Ok | Warn)` to short-
+        // circuit input handling and let the auto-advance timer fire. SaveFailed
+        // must fall through that guard so Esc can still bring the user back to
+        // the provider step (where they can retry from a clean state).
+        let s = KeyTestState::SaveFailed("io error".to_string());
+        let auto_advance_match = matches!(s, KeyTestState::Ok | KeyTestState::Warn);
+        assert!(!auto_advance_match);
+    }
 }

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -266,8 +266,23 @@ impl McpOAuthProvider for KernelOAuthProvider {
     }
 
     async fn clear_tokens(&self, server_url: &str) -> Result<(), String> {
+        // #3369: aggregate per-field failures and surface them. Returning Ok
+        // when vault_remove failed lets the UI display "logged out" while the
+        // refresh/access tokens still sit in the vault — daemon keeps using
+        // them on the next request.
+        let mut failures: Vec<String> = Vec::new();
         for field in ALL_VAULT_FIELDS {
-            let _ = self.vault_remove(&Self::vault_key(server_url, field));
+            let key = Self::vault_key(server_url, field);
+            if let Err(e) = self.vault_remove(&key) {
+                warn!(server = %server_url, field = %field, error = %e, "MCP OAuth clear_tokens: vault_remove failed");
+                failures.push(format!("{field}: {e}"));
+            }
+        }
+        if !failures.is_empty() {
+            return Err(format!(
+                "Sign-out failed to fully clear vault for {server_url}; tokens may still be valid. Retry. Details: {}",
+                failures.join("; ")
+            ));
         }
         debug!(server = %server_url, "MCP OAuth tokens cleared from vault");
         Ok(())
@@ -330,6 +345,44 @@ mod tests {
         assert_ne!(
             key_a, key_b,
             "Different servers should have different vault keys"
+        );
+    }
+
+    /// #3369: when vault_remove fails, clear_tokens MUST return Err so the
+    /// API layer can tell the user sign-out is incomplete. Pre-fix, this
+    /// returned Ok(()) and the UI showed "logged out" while the access token
+    /// stayed in the vault.
+    #[tokio::test]
+    async fn clear_tokens_returns_err_when_vault_unlock_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        // Write a garbage vault.enc so unlock() fails for every vault_remove call.
+        std::fs::write(home.join("vault.enc"), b"not-a-real-vault").expect("seed bad vault");
+        // Provide a syntactically valid master key so unlock() reaches the
+        // decrypt step and fails on the corrupt ciphertext rather than on a
+        // missing key.
+        unsafe {
+            std::env::set_var(
+                "LIBREFANG_VAULT_KEY",
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            );
+        }
+
+        let provider = KernelOAuthProvider::new(home);
+        let result = provider.clear_tokens("https://example.com/mcp").await;
+        unsafe {
+            std::env::remove_var("LIBREFANG_VAULT_KEY");
+        }
+
+        assert!(
+            result.is_err(),
+            "clear_tokens must propagate vault failures (#3369), got {:?}",
+            result
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_lowercase().contains("retry") || err.to_lowercase().contains("sign-out"),
+            "error message should prompt the caller to retry, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

Three security-critical paths called `vault_set` / `vault_remove` and silently swallowed the error, returning success to the caller while the persisted state was wrong. This PR makes each call site fail loud.

### #3633 — `totp_revoke` returned 200 \"revoked\" while 2FA still active
`crates/librefang-api/src/routes/system.rs:2802-2810` cleared `totp_confirmed`, `totp_secret`, and `totp_recovery_codes` with `tracing::warn!` on `vault_set` failure, then returned `{\"status\":\"revoked\"}`. The user saw revocation succeed while the secret could still verify and every recovery code remained valid.

Fix: each `vault_set` failure now returns a 500 telling the user TOTP is still active and to retry.

### #3369 — MCP OAuth `clear_tokens` returned `Ok(())` despite vault write failure
`crates/librefang-kernel/src/mcp_oauth_provider.rs:268-274` looped over `ALL_VAULT_FIELDS` and discarded every `vault_remove` result with `let _ = ...`. The dashboard showed \"logged out\" while access/refresh tokens still sat in the vault — the daemon kept using them on subsequent requests.

Fix: aggregate per-field failures and propagate as `Err`. `auth_revoke` (route) now clears the in-memory `mcp_auth_states` and `mcp_connections` **first** so the current process drops the session even if the persistent vault wipe later fails, then surfaces any vault failure as a 500 so the UI can prompt the user to retry.

### #3629 — Init wizard ignored `.env` write failure, daemon booted with no key
`crates/librefang-cli/src/tui/screens/init_wizard.rs:632-647` validated the API key first (an earlier fix for the write-before-validate bug), but if the post-validate `dotenv::save_env_key` failed it was logged at warn level and the wizard still set `KeyTestState::Ok` and auto-advanced. The daemon then booted with `~/.librefang/.env` empty.

Fix: a new `KeyTestState::SaveFailed(String)` branch keeps the wizard on the API-key step, surfaces the disk error in the UI, and is excluded from the `Ok | Warn` auto-advance match. Atomic write (tmp + rename) and validate-before-write were already in place — this closes the last \"silent ignore\" hole. Cancel / Ctrl-C while still in `Testing` continues to leave `.env` untouched.

## Tests

- `clear_tokens_returns_err_when_vault_unlock_fails` (kernel): seeds a corrupt `vault.enc` in a tempdir and asserts `clear_tokens` returns `Err`, locking the #3369 fix.
- `save_failed_does_not_auto_advance` / `save_failed_blocks_input_until_user_acks` (init_wizard): pin the contract that `SaveFailed` does not match the auto-advance arm, locking the #3629 fix.
- `vault_redeem_recovery_code` (already in tree) propagates `vault_set` errors via `?`, and the three approval call sites already match on its `Result` — no behaviour change there. The new `totp_revoke` branches are covered by the route-level changes; full handler-level integration coverage would need a kernel mock that does not exist in this crate yet.

## Backward compat / user-facing

- `DELETE /api/mcp/servers/{name}/auth/revoke`: was 200 with `\"state\":\"not_required\"` even on partial failure; now returns 500 + an explanatory message when the vault wipe fails. In-memory session is still cleared so the daemon won't keep using the cached token.
- `POST /api/approvals/totp/revoke`: was 200 with `\"status\":\"revoked\"` even on partial failure; now returns 500 with a retry prompt. Same revocation gates.
- Init wizard: a new \"Verified, but saving to .env failed\" screen instead of silently advancing. No CLI flags or config changes.
- All three changes only add error paths — the success path response shape is unchanged.

Closes #3633
Closes #3369
Closes #3629