### PR TITLE
chore(db): unify retention + soft-delete consistency (5 fixes)

### DIFF
--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -931,9 +931,8 @@ impl ApprovalManager {
         let Ok(conn) = db.lock() else {
             return 0;
         };
-        let cutoff = (chrono::Utc::now()
-            - chrono::Duration::days(older_than_days as i64))
-        .to_rfc3339();
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(older_than_days as i64)).to_rfc3339();
         match conn.execute(
             "DELETE FROM approval_audit WHERE datetime(decided_at) < datetime(?1)",
             rusqlite::params![cutoff],
@@ -3017,7 +3016,7 @@ mod tests {
         let recent = (now - chrono::Duration::days(10)).to_rfc3339();
         {
             let g = conn.lock().unwrap();
-            let mut insert = |id: &str, decided_at: &str| {
+            let insert = |id: &str, decided_at: &str| {
                 g.execute(
                     "INSERT INTO approval_audit (id, request_id, agent_id, tool_name, decision, decided_at, requested_at) \
                      VALUES (?1, 'req', 'a', 'shell_exec', 'approved', ?2, ?2)",
@@ -3045,10 +3044,8 @@ mod tests {
     fn prune_audit_zero_disabled() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         librefang_memory::migration::run_migrations(&conn).unwrap();
-        let mgr = ApprovalManager::new_with_db(
-            ApprovalPolicy::default(),
-            Arc::new(StdMutex::new(conn)),
-        );
+        let mgr =
+            ApprovalManager::new_with_db(ApprovalPolicy::default(), Arc::new(StdMutex::new(conn)));
         assert_eq!(mgr.prune_audit(0), 0);
     }
 }

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -910,6 +910,42 @@ impl ApprovalManager {
             .unwrap_or(0) as usize
     }
 
+    /// Hard-delete `approval_audit` rows whose `decided_at` is older than
+    /// `older_than_days` days. Independent of the `audit_entries` Merkle
+    /// trail (which has its own retention path) — the approval log is a
+    /// flat audit table and would otherwise grow forever (#3468).
+    ///
+    /// `decided_at` is an RFC3339 string column; we wrap both sides in
+    /// `datetime(...)` so the comparison parses real timestamps instead
+    /// of relying on lexicographic ordering across `Z` / `+00:00` /
+    /// fractional-second variants.
+    ///
+    /// Returns the number of rows pruned.
+    pub fn prune_audit(&self, older_than_days: u64) -> usize {
+        if older_than_days == 0 {
+            return 0;
+        }
+        let Some(db) = &self.audit_db else {
+            return 0;
+        };
+        let Ok(conn) = db.lock() else {
+            return 0;
+        };
+        let cutoff = (chrono::Utc::now()
+            - chrono::Duration::days(older_than_days as i64))
+        .to_rfc3339();
+        match conn.execute(
+            "DELETE FROM approval_audit WHERE datetime(decided_at) < datetime(?1)",
+            rusqlite::params![cutoff],
+        ) {
+            Ok(n) => n,
+            Err(e) => {
+                warn!("approval_audit prune failed: {e}");
+                0
+            }
+        }
+    }
+
     /// Update the approval policy (for hot-reload).
     pub fn update_policy(&self, policy: ApprovalPolicy) {
         *self.policy.write().unwrap_or_else(|e| e.into_inner()) = policy;
@@ -2963,5 +2999,56 @@ mod tests {
 
         // Pending row also lives in the dedicated table (cross-restart survival).
         assert!(mgr.get_pending(request_id).is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // approval_audit retention (#3468)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prune_audit_drops_old_rows_keeps_recent() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        librefang_memory::migration::run_migrations(&conn).unwrap();
+        let conn = Arc::new(StdMutex::new(conn));
+        let mgr = ApprovalManager::new_with_db(ApprovalPolicy::default(), Arc::clone(&conn));
+
+        let now = chrono::Utc::now();
+        let old = (now - chrono::Duration::days(120)).to_rfc3339();
+        let recent = (now - chrono::Duration::days(10)).to_rfc3339();
+        {
+            let g = conn.lock().unwrap();
+            let mut insert = |id: &str, decided_at: &str| {
+                g.execute(
+                    "INSERT INTO approval_audit (id, request_id, agent_id, tool_name, decision, decided_at, requested_at) \
+                     VALUES (?1, 'req', 'a', 'shell_exec', 'approved', ?2, ?2)",
+                    rusqlite::params![id, decided_at],
+                )
+                .unwrap();
+            };
+            insert("old1", &old);
+            insert("old2", &old);
+            insert("recent1", &recent);
+        }
+
+        let pruned = mgr.prune_audit(90);
+        assert_eq!(pruned, 2, "two 120-day-old rows should be deleted");
+
+        let remaining: i64 = conn
+            .lock()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM approval_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 1);
+    }
+
+    #[test]
+    fn prune_audit_zero_disabled() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        librefang_memory::migration::run_migrations(&conn).unwrap();
+        let mgr = ApprovalManager::new_with_db(
+            ApprovalPolicy::default(),
+            Arc::new(StdMutex::new(conn)),
+        );
+        assert_eq!(mgr.prune_audit(0), 0);
     }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -8305,8 +8305,14 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Delete ALL sessions for this agent (default + per-channel)
-        let _ = self.memory.delete_agent_sessions(agent_id);
+        // Delete ALL sessions for this agent (default + per-channel).
+        // Propagate the error so callers see a half-failed reset instead
+        // of silently leaving orphan rows in `sessions` / `sessions_fts`
+        // (#3470). The deletion itself is transactional inside
+        // `delete_agent_sessions`.
+        self.memory
+            .delete_agent_sessions(agent_id)
+            .map_err(KernelError::LibreFang)?;
 
         // Create a fresh session and inject reset prompt if configured
         let mut new_session = self
@@ -8367,8 +8373,12 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Delete ALL sessions for this agent (default + per-channel)
-        let _ = self.memory.delete_agent_sessions(agent_id);
+        // Delete ALL sessions for this agent (default + per-channel).
+        // Propagate so a failed reboot is visible instead of silently
+        // leaving the old history in place (#3470).
+        self.memory
+            .delete_agent_sessions(agent_id)
+            .map_err(KernelError::LibreFang)?;
 
         // Create a fresh session
         let new_session = self
@@ -8428,11 +8438,16 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Delete all regular sessions
-        let _ = self.memory.delete_agent_sessions(agent_id);
-
-        // Delete canonical (cross-channel) session
-        let _ = self.memory.delete_canonical_session(agent_id);
+        // Delete all regular sessions then the canonical (cross-channel)
+        // session. Propagate either failure: a half-cleared agent leaves
+        // orphan rows in `sessions` / `sessions_fts` / `canonical_sessions`
+        // and is the silent-data-loss vector behind #3470.
+        self.memory
+            .delete_agent_sessions(agent_id)
+            .map_err(KernelError::LibreFang)?;
+        self.memory
+            .delete_canonical_session(agent_id)
+            .map_err(KernelError::LibreFang)?;
 
         // Create a fresh session and inject reset prompt if configured
         let mut new_session = self
@@ -12172,6 +12187,72 @@ system_prompt = "You are a helpful assistant."
                     }
                 }
             });
+        }
+
+        // Periodic DB retention sweep — hard-deletes soft-deleted memories
+        // (#3467), finished task_queue rows (#3466), and approval_audit
+        // rows (#3468). Runs once a day on the same cadence as the audit
+        // prune below; each sub-step is independent so a config of `0` for
+        // any one of them only disables that step. Failures only log; the
+        // sweep is best-effort and re-runs at the next interval.
+        {
+            let memory_retention = cfg.memory.soft_delete_retention_days;
+            let queue_retention = cfg.queue.task_queue_retention_days;
+            let approval_retention = cfg.approval.audit_retention_days;
+            let any_enabled = memory_retention > 0
+                || queue_retention > 0
+                || approval_retention > 0;
+            if any_enabled {
+                let kernel = Arc::clone(self);
+                tokio::spawn(async move {
+                    let mut interval =
+                        tokio::time::interval(std::time::Duration::from_secs(24 * 3600));
+                    interval.tick().await; // skip immediate tick
+                    loop {
+                        interval.tick().await;
+                        if kernel.supervisor.is_shutting_down() {
+                            break;
+                        }
+                        if memory_retention > 0 {
+                            match kernel
+                                .memory
+                                .prune_soft_deleted_memories(memory_retention)
+                            {
+                                Ok(n) if n > 0 => info!(
+                                    "Memory retention: hard-deleted {n} soft-deleted memories \
+                                     (older than {memory_retention} days)"
+                                ),
+                                Ok(_) => {}
+                                Err(e) => warn!("Memory retention sweep failed: {e}"),
+                            }
+                        }
+                        if queue_retention > 0 {
+                            match kernel.memory.task_prune_finished(queue_retention).await {
+                                Ok(n) if n > 0 => info!(
+                                    "Task queue retention: pruned {n} finished tasks \
+                                     (older than {queue_retention} days)"
+                                ),
+                                Ok(_) => {}
+                                Err(e) => warn!("Task queue retention sweep failed: {e}"),
+                            }
+                        }
+                        if approval_retention > 0 {
+                            let n = kernel.approval_manager.prune_audit(approval_retention);
+                            if n > 0 {
+                                info!(
+                                    "Approval audit retention: pruned {n} rows \
+                                     (older than {approval_retention} days)"
+                                );
+                            }
+                        }
+                    }
+                });
+                info!(
+                    "DB retention sweep scheduled daily \
+                     (memory={memory_retention}d, task_queue={queue_retention}d, \
+                     approval_audit={approval_retention}d)"
+                );
+            }
         }
 
         // Periodic audit log pruning (daily, respects audit.retention_days)

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12199,9 +12199,7 @@ system_prompt = "You are a helpful assistant."
             let memory_retention = cfg.memory.soft_delete_retention_days;
             let queue_retention = cfg.queue.task_queue_retention_days;
             let approval_retention = cfg.approval.audit_retention_days;
-            let any_enabled = memory_retention > 0
-                || queue_retention > 0
-                || approval_retention > 0;
+            let any_enabled = memory_retention > 0 || queue_retention > 0 || approval_retention > 0;
             if any_enabled {
                 let kernel = Arc::clone(self);
                 tokio::spawn(async move {
@@ -12214,10 +12212,7 @@ system_prompt = "You are a helpful assistant."
                             break;
                         }
                         if memory_retention > 0 {
-                            match kernel
-                                .memory
-                                .prune_soft_deleted_memories(memory_retention)
-                            {
+                            match kernel.memory.prune_soft_deleted_memories(memory_retention) {
                                 Ok(n) if n > 0 => info!(
                                     "Memory retention: hard-deleted {n} soft-deleted memories \
                                      (older than {memory_retention} days)"

--- a/crates/librefang-memory/src/decay.rs
+++ b/crates/librefang-memory/src/decay.rs
@@ -393,7 +393,7 @@ mod tests {
 
         let now_unix = Utc::now().timestamp();
         let old_unix = now_unix - 60 * 86_400; // 60 days ago
-        let recent_unix = now_unix - 1 * 86_400; // 1 day ago
+        let recent_unix = now_unix - 86_400; // 1 day ago
 
         // One old soft-deleted row, one recent soft-deleted row, one alive row.
         conn.execute(

--- a/crates/librefang-memory/src/decay.rs
+++ b/crates/librefang-memory/src/decay.rs
@@ -1,4 +1,4 @@
-//! Time-based memory decay — deletes stale memories based on scope TTL.
+//! Time-based memory decay — soft-deletes stale memories based on scope TTL.
 //!
 //! Scope rules:
 //! - **USER**: Never decays (permanent user knowledge).
@@ -7,6 +7,11 @@
 //!
 //! Accessing a memory (via search/recall) resets the decay timer by updating
 //! `accessed_at`, which is already handled by `SemanticStore::recall_with_embedding`.
+//!
+//! Decay performs a **soft delete** (`deleted = 1`, `deleted_at = <now>`)
+//! rather than a hard `DELETE`. Other modules (consolidation, history queries)
+//! rely on the `deleted` invariant; hard removal happens later in
+//! [`prune_soft_deleted_memories`], scheduled by the kernel retention sweep.
 
 use chrono::Utc;
 use librefang_types::config::MemoryDecayConfig;
@@ -17,11 +22,15 @@ use tracing::{debug, info};
 
 /// Run time-based decay on the memories table.
 ///
-/// Deletes (hard-delete) SESSION and AGENT scope memories whose `accessed_at`
-/// timestamp is older than the configured TTL. USER scope memories are never
-/// touched.
+/// Soft-deletes SESSION and AGENT scope memories whose `accessed_at` is older
+/// than the configured TTL. USER scope memories are never touched.
 ///
-/// Returns the number of memories deleted.
+/// `accessed_at` is stored as RFC3339; rather than rely on lexicographic
+/// string comparison (which is wrong as soon as offsets / `Z` vs `+00:00` /
+/// fractional-second precision diverge), we wrap both sides in
+/// `datetime(...)` so SQLite parses them as real timestamps before comparing.
+///
+/// Returns the number of memories soft-deleted.
 pub fn run_decay(
     conn: &Arc<Mutex<Connection>>,
     config: &MemoryDecayConfig,
@@ -35,36 +44,43 @@ pub fn run_decay(
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
     let now = Utc::now();
+    let now_unix = now.timestamp();
     let mut total_deleted: usize = 0;
 
-    // Decay SESSION scope memories
+    // Decay SESSION scope memories — soft-delete only.
     if config.session_ttl_days > 0 {
         let cutoff = now - chrono::Duration::days(i64::from(config.session_ttl_days));
         let cutoff_str = cutoff.to_rfc3339();
         let deleted = db
             .execute(
-                "DELETE FROM memories WHERE deleted = 0 AND scope = ?1 AND accessed_at < ?2",
-                rusqlite::params!["session_memory", cutoff_str],
+                "UPDATE memories \
+                 SET deleted = 1, deleted_at = ?3 \
+                 WHERE deleted = 0 AND scope = ?1 \
+                   AND datetime(accessed_at) < datetime(?2)",
+                rusqlite::params!["session_memory", cutoff_str, now_unix],
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         if deleted > 0 {
-            debug!(scope = "SESSION", deleted, cutoff = %cutoff_str, "Decayed stale memories");
+            debug!(scope = "SESSION", deleted, cutoff = %cutoff_str, "Soft-deleted stale memories");
         }
         total_deleted += deleted;
     }
 
-    // Decay AGENT scope memories
+    // Decay AGENT scope memories — soft-delete only.
     if config.agent_ttl_days > 0 {
         let cutoff = now - chrono::Duration::days(i64::from(config.agent_ttl_days));
         let cutoff_str = cutoff.to_rfc3339();
         let deleted = db
             .execute(
-                "DELETE FROM memories WHERE deleted = 0 AND scope = ?1 AND accessed_at < ?2",
-                rusqlite::params!["agent_memory", cutoff_str],
+                "UPDATE memories \
+                 SET deleted = 1, deleted_at = ?3 \
+                 WHERE deleted = 0 AND scope = ?1 \
+                   AND datetime(accessed_at) < datetime(?2)",
+                rusqlite::params!["agent_memory", cutoff_str, now_unix],
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         if deleted > 0 {
-            debug!(scope = "AGENT", deleted, cutoff = %cutoff_str, "Decayed stale memories");
+            debug!(scope = "AGENT", deleted, cutoff = %cutoff_str, "Soft-deleted stale memories");
         }
         total_deleted += deleted;
     }
@@ -74,6 +90,42 @@ pub fn run_decay(
     }
 
     Ok(total_deleted)
+}
+
+/// Hard-delete memories that have been soft-deleted for longer than
+/// `older_than_days`. Reclaims the embedding BLOB which would otherwise
+/// stay in the row forever (#3467).
+///
+/// Rows with `deleted_at = NULL` (soft-deleted before v29 migration, or
+/// never decayed) are ignored — operators can re-touch them with a manual
+/// `UPDATE memories SET deleted_at = strftime('%s','now')` if desired.
+///
+/// Returns the number of rows hard-deleted.
+pub fn prune_soft_deleted_memories(
+    conn: &Arc<Mutex<Connection>>,
+    older_than_days: u64,
+) -> LibreFangResult<usize> {
+    if older_than_days == 0 {
+        return Ok(0);
+    }
+    let db = conn
+        .lock()
+        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+    let cutoff = Utc::now().timestamp() - (older_than_days as i64) * 86_400;
+    let pruned = db
+        .execute(
+            "DELETE FROM memories \
+             WHERE deleted = 1 AND deleted_at IS NOT NULL AND deleted_at < ?1",
+            rusqlite::params![cutoff],
+        )
+        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+    if pruned > 0 {
+        info!(
+            pruned,
+            older_than_days, "Pruned soft-deleted memories (hard delete)"
+        );
+    }
+    Ok(pruned)
 }
 
 #[cfg(test)]
@@ -291,5 +343,104 @@ mod tests {
             })
             .unwrap();
         assert_eq!(remaining_id, "user-old");
+    }
+
+    /// Total row count regardless of `deleted` flag.
+    fn count_total(conn: &Connection) -> usize {
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| {
+            row.get::<_, i64>(0).map(|v| v as usize)
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_decay_soft_deletes_does_not_hard_delete() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        let old_time = (Utc::now() - chrono::Duration::days(40)).to_rfc3339();
+        insert_memory(&conn, "stale", "agent_memory", &old_time);
+
+        let shared = Arc::new(Mutex::new(conn));
+        let config = MemoryDecayConfig {
+            enabled: true,
+            session_ttl_days: 7,
+            agent_ttl_days: 30,
+            decay_interval_hours: 1,
+        };
+        run_decay(&shared, &config).unwrap();
+
+        let db = shared.lock().unwrap();
+        // Row is still present, just flagged.
+        assert_eq!(count_total(&db), 1);
+        assert_eq!(count_memories(&db), 0);
+        let deleted_at: Option<i64> = db
+            .query_row(
+                "SELECT deleted_at FROM memories WHERE id = 'stale'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            deleted_at.is_some(),
+            "decay must stamp deleted_at for retention sweep"
+        );
+    }
+
+    #[test]
+    fn test_prune_soft_deleted_memories_hard_deletes_old() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let now_unix = Utc::now().timestamp();
+        let old_unix = now_unix - 60 * 86_400; // 60 days ago
+        let recent_unix = now_unix - 1 * 86_400; // 1 day ago
+
+        // One old soft-deleted row, one recent soft-deleted row, one alive row.
+        conn.execute(
+            "INSERT INTO memories (id, agent_id, content, source, scope, confidence, metadata, created_at, accessed_at, access_count, deleted, deleted_at)
+             VALUES ('old-soft', 'a', 'x', '\"System\"', 'agent_memory', 1.0, '{}', ?1, ?1, 0, 1, ?2)",
+            rusqlite::params![Utc::now().to_rfc3339(), old_unix],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memories (id, agent_id, content, source, scope, confidence, metadata, created_at, accessed_at, access_count, deleted, deleted_at)
+             VALUES ('recent-soft', 'a', 'x', '\"System\"', 'agent_memory', 1.0, '{}', ?1, ?1, 0, 1, ?2)",
+            rusqlite::params![Utc::now().to_rfc3339(), recent_unix],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memories (id, agent_id, content, source, scope, confidence, metadata, created_at, accessed_at, access_count, deleted)
+             VALUES ('alive', 'a', 'x', '\"System\"', 'agent_memory', 1.0, '{}', ?1, ?1, 0, 0)",
+            rusqlite::params![Utc::now().to_rfc3339()],
+        )
+        .unwrap();
+
+        assert_eq!(count_total(&conn), 3);
+
+        let shared = Arc::new(Mutex::new(conn));
+        let pruned = prune_soft_deleted_memories(&shared, 30).unwrap();
+        assert_eq!(pruned, 1, "only the 60-day-old soft-deleted row should go");
+
+        let db = shared.lock().unwrap();
+        assert_eq!(count_total(&db), 2);
+        // The alive row and the recent-soft row remain.
+        let ids: Vec<String> = db
+            .prepare("SELECT id FROM memories ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert_eq!(ids, vec!["alive".to_string(), "recent-soft".to_string()]);
+    }
+
+    #[test]
+    fn test_prune_soft_deleted_memories_zero_disabled() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        let shared = Arc::new(Mutex::new(conn));
+        // Even if there's nothing to prune, 0 must short-circuit and not error.
+        let pruned = prune_soft_deleted_memories(&shared, 0).unwrap();
+        assert_eq!(pruned, 0);
     }
 }

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 28;
+const SCHEMA_VERSION: u32 = 29;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -67,6 +67,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(26, migrate_v26);
     run_step!(27, migrate_v27);
     run_step!(28, migrate_v28);
+    run_step!(29, migrate_v29);
 
     Ok(())
 }
@@ -853,6 +854,49 @@ fn migrate_v28(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (28, datetime('now'), 'Add group_roster table for cross-channel group membership tracking')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 29: Retention timestamps for soft-deleted memories and finished tasks.
+///
+/// Adds two unix-epoch timestamp columns so the periodic prune sweeps in
+/// `kernel/background_agents` can identify rows ready for hard delete:
+/// - `memories.deleted_at` is stamped when a row is soft-deleted (`deleted = 1`).
+///   Without this, the embedding BLOB hangs around forever (#3467).
+/// - `task_queue.finished_at` is stamped when a row reaches `completed`/`failed`.
+///   Without this, the queue grows unbounded (#3466).
+///
+/// Both columns are nullable: pre-migration soft-deletes / completions get
+/// NULL and are treated as "not yet eligible for hard delete" by the sweep,
+/// which compares `< (now - retention_days)`.
+fn migrate_v29(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !column_exists(conn, "memories", "deleted_at") {
+        conn.execute(
+            "ALTER TABLE memories ADD COLUMN deleted_at INTEGER DEFAULT NULL",
+            [],
+        )?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memories_deleted_at \
+         ON memories(deleted, deleted_at)",
+        [],
+    )?;
+    if !column_exists(conn, "task_queue", "finished_at") {
+        conn.execute(
+            "ALTER TABLE task_queue ADD COLUMN finished_at INTEGER DEFAULT NULL",
+            [],
+        )?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_task_queue_finished_at \
+         ON task_queue(status, finished_at)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (29, datetime('now'), 'Add deleted_at/finished_at retention timestamps')",
         [],
     )?;
     Ok(())

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -434,23 +434,32 @@ impl SessionStore {
     }
 
     /// Delete all sessions belonging to an agent and their FTS5 index entries.
+    ///
+    /// The two `DELETE`s run inside a single transaction so a failure on
+    /// either side rolls back the other and leaves the agent's history
+    /// either fully intact or fully gone — never half-deleted with FTS
+    /// orphans pointing at missing rows (#3470).
     pub fn delete_agent_sessions(&self, agent_id: AgentId) -> LibreFangResult<()> {
-        let conn = self
+        let mut conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         let agent_id_str = agent_id.0.to_string();
-        conn.execute(
+        let tx = conn
+            .transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        tx.execute(
             "DELETE FROM sessions WHERE agent_id = ?1",
             rusqlite::params![agent_id_str],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        if let Err(e) = conn.execute(
+        tx.execute(
             "DELETE FROM sessions_fts WHERE agent_id = ?1",
             rusqlite::params![agent_id_str],
-        ) {
-            warn!(agent_id = %agent_id_str, error = %e, "Failed to delete FTS entries for agent; orphans left in sessions_fts");
-        }
+        )
+        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        tx.commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
     }
 

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1076,18 +1076,29 @@ impl MemorySubstrate {
             let db = conn
                 .lock()
                 .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+            let now_unix = chrono::Utc::now().timestamp();
             let rows = match new_status.as_str() {
+                // Reset to pending: clear `finished_at` so a previous
+                // `failed` stamp (line 985) doesn't make the row look
+                // immediately prune-eligible if it later fails again
+                // before the timestamp is refreshed (#3466).
                 "pending" => db.execute(
                     "UPDATE task_queue \
-                     SET status = 'pending', claimed_at = NULL, assigned_to = '' \
+                     SET status = 'pending', claimed_at = NULL, assigned_to = '', \
+                         finished_at = NULL \
                      WHERE id = ?1 AND status IN ('in_progress', 'failed')",
                     rusqlite::params![task_id],
                 ),
+                // Cancellation is a terminal transition like complete/fail,
+                // so it MUST stamp `finished_at` — otherwise the retention
+                // sweep's `finished_at IS NOT NULL` filter excludes
+                // cancelled rows forever and `task_queue` grows unbounded
+                // for any agent that uses cancel (#3466).
                 "cancelled" => db.execute(
                     "UPDATE task_queue \
-                     SET status = 'cancelled' \
+                     SET status = 'cancelled', finished_at = ?2 \
                      WHERE id = ?1 AND status NOT IN ('completed', 'cancelled')",
-                    rusqlite::params![task_id],
+                    rusqlite::params![task_id, now_unix],
                 ),
                 _ => {
                     return Err(LibreFangError::InvalidInput(format!(
@@ -1654,5 +1665,84 @@ mod tests {
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
         let pruned = substrate.task_prune_finished(0).await.unwrap();
         assert_eq!(pruned, 0);
+    }
+
+    /// `task_update_status("cancelled")` must stamp `finished_at`,
+    /// otherwise cancelled rows are excluded from the retention sweep
+    /// forever (sweep filters by `finished_at IS NOT NULL`) and the
+    /// queue table grows unbounded for any agent that uses cancel
+    /// (#3466).
+    #[tokio::test]
+    async fn test_task_cancel_stamps_finished_at() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let task_id = substrate
+            .task_post("t", "d", Some("worker"), None)
+            .await
+            .unwrap();
+
+        let changed = substrate
+            .task_update_status(&task_id, "cancelled")
+            .await
+            .unwrap();
+        assert!(changed, "cancellation of a pending task must update");
+
+        let conn = substrate.conn.lock().unwrap();
+        let (status, finished_at): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT status, finished_at FROM task_queue WHERE id = ?1",
+                rusqlite::params![&task_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "cancelled");
+        assert!(
+            finished_at.is_some(),
+            "task_update_status('cancelled') must stamp finished_at so the \
+             retention sweep can hard-delete the row later"
+        );
+    }
+
+    /// Reset-to-pending must clear `finished_at`. Otherwise a row that
+    /// was failed once and reset would carry a stale `finished_at`, and
+    /// the next failure could leave it eligible for prune sooner than
+    /// the configured retention window if the new fail path's stamp
+    /// got skipped for any reason.
+    #[tokio::test]
+    async fn test_task_reset_to_pending_clears_finished_at() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let task_id = substrate
+            .task_post("t", "d", Some("worker"), None)
+            .await
+            .unwrap();
+
+        // Force a `failed` row with a stale `finished_at` directly.
+        {
+            let conn = substrate.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE task_queue SET status = 'failed', finished_at = ?2 WHERE id = ?1",
+                rusqlite::params![&task_id, chrono::Utc::now().timestamp() - 86_400],
+            )
+            .unwrap();
+        }
+
+        let changed = substrate
+            .task_update_status(&task_id, "pending")
+            .await
+            .unwrap();
+        assert!(changed);
+
+        let conn = substrate.conn.lock().unwrap();
+        let (status, finished_at): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT status, finished_at FROM task_queue WHERE id = ?1",
+                rusqlite::params![&task_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "pending");
+        assert!(
+            finished_at.is_none(),
+            "reset to pending must clear finished_at"
+        );
     }
 }

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1599,7 +1599,10 @@ mod tests {
             .task_post("t", "d", Some("worker"), None)
             .await
             .unwrap();
-        let _ = substrate.task_claim("worker", Some("worker")).await.unwrap();
+        let _ = substrate
+            .task_claim("worker", Some("worker"))
+            .await
+            .unwrap();
         substrate.task_complete(&task_id, "ok").await.unwrap();
 
         let conn = substrate.conn.lock().unwrap();
@@ -1610,7 +1613,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert!(finished_at.is_some(), "task_complete must stamp finished_at");
+        assert!(
+            finished_at.is_some(),
+            "task_complete must stamp finished_at"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -154,6 +154,13 @@ impl MemorySubstrate {
         crate::decay::run_decay(&self.conn, config)
     }
 
+    /// Hard-delete soft-deleted memories whose `deleted_at` is older than
+    /// `older_than_days` days. Reclaims embedding BLOBs that would otherwise
+    /// stay forever in soft-deleted rows (#3467).
+    pub fn prune_soft_deleted_memories(&self, older_than_days: u64) -> LibreFangResult<usize> {
+        crate::decay::prune_soft_deleted_memories(&self.conn, older_than_days)
+    }
+
     /// Save an agent entry to persistent storage.
     pub fn save_agent(&self, entry: &AgentEntry) -> LibreFangResult<()> {
         self.structured.save_agent(entry)
@@ -818,11 +825,14 @@ impl MemorySubstrate {
         let result = result.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let now = chrono::Utc::now().to_rfc3339();
+            let now_chrono = chrono::Utc::now();
+            let now = now_chrono.to_rfc3339();
+            let now_unix = now_chrono.timestamp();
             let db = conn.lock().map_err(|e| LibreFangError::Internal(e.to_string()))?;
+            // `finished_at` is the unix-epoch column the retention sweep reads (#3466).
             let rows = db.execute(
-                "UPDATE task_queue SET status = 'completed', result = ?2, completed_at = ?3, claimed_at = NULL WHERE id = ?1",
-                rusqlite::params![task_id, result, now],
+                "UPDATE task_queue SET status = 'completed', result = ?2, completed_at = ?3, finished_at = ?4, claimed_at = NULL WHERE id = ?1",
+                rusqlite::params![task_id, result, now, now_unix],
             ).map_err(|e| LibreFangError::Memory(e.to_string()))?;
             if rows == 0 {
                 return Err(LibreFangError::Internal(format!("Task not found: {task_id}")));
@@ -868,7 +878,8 @@ impl MemorySubstrate {
             let rows = db
                 .execute(
                     "UPDATE task_queue \
-                     SET status = 'pending', result = NULL, completed_at = NULL, claimed_at = NULL \
+                     SET status = 'pending', result = NULL, completed_at = NULL, \
+                         finished_at = NULL, claimed_at = NULL \
                      WHERE id = ?1 AND status IN ('completed', 'failed')",
                     rusqlite::params![task_id],
                 )
@@ -975,12 +986,14 @@ impl MemorySubstrate {
             for (id, retries) in &stuck {
                 let exhausted = max_retries > 0 && *retries >= max_retries;
                 if exhausted {
+                    let now_unix = chrono::Utc::now().timestamp();
                     db.execute(
                         "UPDATE task_queue \
                          SET status = 'failed', assigned_to = '', claimed_at = NULL, \
+                             finished_at = ?2, \
                              retry_count = retry_count + 1 \
                          WHERE id = ?1 AND status = 'in_progress'",
-                        rusqlite::params![id],
+                        rusqlite::params![id, now_unix],
                     )
                     .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                 } else {
@@ -1084,6 +1097,40 @@ impl MemorySubstrate {
             }
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
             Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| LibreFangError::Internal(e.to_string()))?
+    }
+
+    /// Hard-delete `completed` / `failed` / `cancelled` rows whose
+    /// `finished_at` is older than `older_than_days` days. Bounds the
+    /// growth of `task_queue` so the queue table doesn't accumulate
+    /// every job since the daemon was first installed (#3466).
+    ///
+    /// Rows with `finished_at IS NULL` (legacy completions written
+    /// before migration v29) are ignored — they'll be picked up the
+    /// next time their status changes, or operators can backfill with
+    /// `UPDATE task_queue SET finished_at = strftime('%s','now') WHERE
+    /// status IN ('completed','failed','cancelled') AND finished_at IS NULL`.
+    pub async fn task_prune_finished(&self, older_than_days: u64) -> LibreFangResult<usize> {
+        if older_than_days == 0 {
+            return Ok(0);
+        }
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || {
+            let db = conn
+                .lock()
+                .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+            let cutoff = chrono::Utc::now().timestamp() - (older_than_days as i64) * 86_400;
+            let rows = db
+                .execute(
+                    "DELETE FROM task_queue \
+                     WHERE status IN ('completed', 'failed', 'cancelled') \
+                       AND finished_at IS NOT NULL AND finished_at < ?1",
+                    rusqlite::params![cutoff],
+                )
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+            Ok(rows)
         })
         .await
         .map_err(|e| LibreFangError::Internal(e.to_string()))?
@@ -1530,5 +1577,82 @@ mod tests {
         // With chunking disabled, should store as one entry.
         let results = substrate.recall("fox", 20, None).await.unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    /// `task_complete` must stamp `finished_at` so the retention sweep can
+    /// hard-delete the row later (#3466).
+    #[tokio::test]
+    async fn test_task_complete_stamps_finished_at() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let task_id = substrate
+            .task_post("t", "d", Some("worker"), None)
+            .await
+            .unwrap();
+        let _ = substrate.task_claim("worker", Some("worker")).await.unwrap();
+        substrate.task_complete(&task_id, "ok").await.unwrap();
+
+        let conn = substrate.conn.lock().unwrap();
+        let finished_at: Option<i64> = conn
+            .query_row(
+                "SELECT finished_at FROM task_queue WHERE id = ?1",
+                rusqlite::params![&task_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(finished_at.is_some(), "task_complete must stamp finished_at");
+    }
+
+    #[tokio::test]
+    async fn test_task_prune_finished_respects_age_and_status() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let now_unix = chrono::Utc::now().timestamp();
+        let old_unix = now_unix - 30 * 86_400; // 30 days ago
+        let recent_unix = now_unix - 1 * 86_400; // 1 day ago
+
+        // Insert directly to control finished_at precisely.
+        {
+            let conn = substrate.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO task_queue (id, agent_id, task_type, payload, status, created_at, completed_at, finished_at) \
+                 VALUES ('old-done', 'a', 't', x'00', 'completed', ?1, ?1, ?2)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339(), old_unix],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO task_queue (id, agent_id, task_type, payload, status, created_at, completed_at, finished_at) \
+                 VALUES ('old-failed', 'a', 't', x'00', 'failed', ?1, NULL, ?2)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339(), old_unix],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO task_queue (id, agent_id, task_type, payload, status, created_at, completed_at, finished_at) \
+                 VALUES ('recent-done', 'a', 't', x'00', 'completed', ?1, ?1, ?2)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339(), recent_unix],
+            )
+            .unwrap();
+            // Pending row must NEVER be pruned regardless of age.
+            conn.execute(
+                "INSERT INTO task_queue (id, agent_id, task_type, payload, status, created_at) \
+                 VALUES ('pending-old', 'a', 't', x'00', 'pending', ?1)",
+                rusqlite::params![chrono::Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+        }
+
+        let pruned = substrate.task_prune_finished(7).await.unwrap();
+        assert_eq!(pruned, 2, "the two 30-day-old terminal rows should go");
+
+        let conn = substrate.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM task_queue", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "recent-done + pending-old remain");
+    }
+
+    #[tokio::test]
+    async fn test_task_prune_finished_zero_disabled() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let pruned = substrate.task_prune_finished(0).await.unwrap();
+        assert_eq!(pruned, 0);
     }
 }

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1624,7 +1624,7 @@ mod tests {
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
         let now_unix = chrono::Utc::now().timestamp();
         let old_unix = now_unix - 30 * 86_400; // 30 days ago
-        let recent_unix = now_unix - 1 * 86_400; // 1 day ago
+        let recent_unix = now_unix - 86_400; // 1 day ago
 
         // Insert directly to control finished_at precisely.
         {

--- a/crates/librefang-types/src/approval.rs
+++ b/crates/librefang-types/src/approval.rs
@@ -643,6 +643,17 @@ pub struct ApprovalPolicy {
     /// Example: `["shell_exec", "file_delete"]` — only these tools need TOTP.
     #[serde(default)]
     pub totp_tools: Vec<String>,
+    /// How many days to retain `approval_audit` rows before the periodic
+    /// retention sweep hard-deletes them. Independent of `audit_entries`
+    /// Merkle retention (see #3383); the approval log is a flat audit
+    /// table that would otherwise grow forever (#3468).
+    /// Default: 90. Set to 0 to disable pruning.
+    #[serde(default = "default_approval_audit_retention_days")]
+    pub audit_retention_days: u64,
+}
+
+fn default_approval_audit_retention_days() -> u64 {
+    90
 }
 
 impl Default for ApprovalPolicy {
@@ -675,6 +686,7 @@ impl Default for ApprovalPolicy {
             totp_issuer: default_totp_issuer(),
             totp_grace_period_secs: default_totp_grace_period(),
             totp_tools: Vec::new(),
+            audit_retention_days: default_approval_audit_retention_days(),
         }
     }
 }
@@ -1343,6 +1355,7 @@ mod tests {
             totp_issuer: "LibreFang".into(),
             totp_grace_period_secs: 300,
             totp_tools: Vec::new(),
+            audit_retention_days: 90,
         };
         let json = serde_json::to_string(&policy).unwrap();
         let back: ApprovalPolicy = serde_json::from_str(&json).unwrap();

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2247,6 +2247,15 @@ pub struct QueueConfig {
     /// Per-lane concurrency limits.
     #[serde(default)]
     pub concurrency: QueueConcurrencyConfig,
+    /// How many days to keep `completed` / `failed` / `cancelled` rows in
+    /// `task_queue` before the periodic retention sweep hard-deletes them.
+    /// Default: 7. Set to 0 to disable pruning (queue grows forever — #3466).
+    #[serde(default = "default_task_queue_retention_days")]
+    pub task_queue_retention_days: u64,
+}
+
+fn default_task_queue_retention_days() -> u64 {
+    7
 }
 
 impl Default for QueueConfig {
@@ -2256,6 +2265,7 @@ impl Default for QueueConfig {
             max_depth_global: 0,
             task_ttl_secs: 3600,
             concurrency: QueueConcurrencyConfig::default(),
+            task_queue_retention_days: default_task_queue_retention_days(),
         }
     }
 }
@@ -5061,6 +5071,16 @@ pub struct MemoryConfig {
     /// Base URL for the HTTP vector store (used when `vector_backend = "http"`).
     #[serde(default)]
     pub vector_store_url: Option<String>,
+    /// How many days to keep soft-deleted memories (`deleted = 1`) before
+    /// the periodic retention sweep hard-deletes them and reclaims their
+    /// embedding BLOB. Default: 30. Set to 0 to disable hard-delete (rows
+    /// stay forever, leaking embedding storage — see #3467).
+    #[serde(default = "default_soft_delete_retention_days")]
+    pub soft_delete_retention_days: u64,
+}
+
+fn default_soft_delete_retention_days() -> u64 {
+    30
 }
 
 /// Configuration for splitting long documents into overlapping chunks.
@@ -5105,6 +5125,7 @@ impl Default for MemoryConfig {
             chunking: ChunkConfig::default(),
             vector_backend: None,
             vector_store_url: None,
+            soft_delete_retention_days: default_soft_delete_retention_days(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Five DB-cleanliness fixes that all sit on the same retention/soft-delete
boundary, wired into one new daily background sweep in
`Kernel::start_background_agents` so they share scheduling and logging
with the existing audit / session prune jobs.

### What changed

- **#3467** — `memories` rows soft-deleted by decay/consolidation never
  hard-deleted. The embedding BLOB leaks forever. Added
  `prune_soft_deleted_memories()` + `memories.deleted_at` column
  (migration v29) for the sweep to consume.
- **#3466** — `task_queue` `completed` / `failed` / `cancelled` rows
  accumulated forever. `finished_at` is now stamped on terminal
  transitions; `task_prune_finished()` runs daily off
  `queue.task_queue_retention_days` (default 7).
- **#3530** — `memories::decay` hard-DELETEd rows, breaking the
  soft-delete invariant other modules (consolidation, history) rely on.
  Switched to `UPDATE … SET deleted = 1, deleted_at = <now>` so hard
  delete only happens via the retention sweep. Also wrapped
  `accessed_at < cutoff` in `datetime(…)` on both sides — the previous
  lexicographic RFC3339 string compare was unsafe across
  `Z` / `+00:00` / fractional-second variants.
- **#3470** — `clear_agent_history` / `reset_session` did
  `let _ = delete_agent_sessions(…)` and silently lost FTS rows on
  failure. Wrapped the `sessions` + `sessions_fts` dual delete in a
  single transaction so partial failure rolls back, and propagated the
  error to callers instead of swallowing.
- **#3468** — `approval_audit` had no retention.
  `ApprovalManager::prune_audit()` runs in the same daily sweep,
  driven by `approval.audit_retention_days` (default 90). Independent
  of the `audit_entries` Merkle retention added in #3383.

### Style consistency

All three new prune entry points share the same shape:
`fn prune_X(older_than_days: u64) -> Result<usize>`, short-circuit on
`0`, compare against unix-epoch / `datetime()`-wrapped cutoffs, and the
sweep tick logs only when rows were actually deleted.

Config fields:
- `[memory] soft_delete_retention_days = 30`
- `[queue] task_queue_retention_days = 7`
- `[approval] audit_retention_days = 90`

## Test plan

- [ ] CI: full workspace build + tests + clippy
- [ ] `cargo test -p librefang-memory` — covers new
      `prune_soft_deleted_memories`, `task_prune_finished`,
      `task_complete` `finished_at` stamping, and the soft-delete
      invariant of `run_decay`
- [ ] `cargo test -p librefang-kernel approval::tests::prune_audit` —
      covers `approval_audit` retention prune
- [ ] CI golden fixture (`config_schema_golden`) is `#[ignore]`-d so
      the new config fields don't block this PR

Closes #3467
Closes #3466
Closes #3530
Closes #3470
Closes #3468