### PR TITLE
fix(kernel,api): approval audit, disconnect cancel, MCP tool order

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1319,6 +1319,31 @@ fn mime_from_url(url: &str) -> Option<String> {
     }
 }
 
+/// RAII guard that aborts a spawned task when dropped. Used so client
+/// disconnect cancels the kernel call and releases per-agent locks +
+/// LLM bandwidth instead of letting the round-trip finish unobserved
+/// (#3464).
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if !self.0.is_finished() {
+            self.0.abort();
+        }
+    }
+}
+
+/// Run `fut` in a spawned task; abort it if the awaiting future is dropped.
+async fn run_cancel_on_disconnect<F, T>(fut: F) -> Result<T, tokio::task::JoinError>
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let handle = tokio::spawn(fut);
+    let _guard = AbortOnDrop(handle.abort_handle());
+    handle.await
+}
+
 /// POST /api/agents/:id/message — Send a message to an agent.
 #[utoipa::path(
     post,
@@ -1450,24 +1475,55 @@ pub async fn send_message(
 
     let result = if is_ephemeral {
         // Ephemeral "side question" — use a temp session, no persistence
-        state
-            .kernel
-            .send_message_ephemeral(agent_id, &effective_message)
-            .await
+        let kernel = state.kernel.clone();
+        let msg = effective_message.clone();
+        match run_cancel_on_disconnect(async move {
+            kernel.send_message_ephemeral(agent_id, &msg).await
+        })
+        .await
+        {
+            Ok(r) => r,
+            Err(join_err) if join_err.is_cancelled() => {
+                tracing::info!("send_message cancelled: client disconnected");
+                return StatusCode::from_u16(499)
+                    .unwrap_or(StatusCode::BAD_REQUEST)
+                    .into_response();
+            }
+            Err(e) => Err(librefang_kernel::error::KernelError::LibreFang(
+                librefang_types::error::LibreFangError::Internal(format!("task panicked: {e}")),
+            )),
+        }
     } else {
         let sender_context = request_sender_context(&req);
-        let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
-        state
-            .kernel
-            .send_message_with_session_override(
-                agent_id,
-                &effective_message,
-                Some(kernel_handle),
-                sender_context.as_ref(),
-                thinking_override,
-                session_id_override,
-            )
-            .await
+        let kernel = state.kernel.clone();
+        let kernel_handle: Arc<dyn KernelHandle> = kernel.clone() as Arc<dyn KernelHandle>;
+        let msg = effective_message.clone();
+        let sc = sender_context;
+        match run_cancel_on_disconnect(async move {
+            kernel
+                .send_message_with_session_override(
+                    agent_id,
+                    &msg,
+                    Some(kernel_handle),
+                    sc.as_ref(),
+                    thinking_override,
+                    session_id_override,
+                )
+                .await
+        })
+        .await
+        {
+            Ok(r) => r,
+            Err(join_err) if join_err.is_cancelled() => {
+                tracing::info!("send_message cancelled: client disconnected");
+                return StatusCode::from_u16(499)
+                    .unwrap_or(StatusCode::BAD_REQUEST)
+                    .into_response();
+            }
+            Err(e) => Err(librefang_kernel::error::KernelError::LibreFang(
+                librefang_types::error::LibreFangError::Internal(format!("task panicked: {e}")),
+            )),
+        }
     };
 
     match result {
@@ -2187,7 +2243,7 @@ pub async fn send_message_stream(
     };
 
     let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
-    let (rx, _handle) = match state
+    let (rx, handle) = match state
         .kernel
         .send_message_streaming_with_routing_and_session_override(
             agent_id,
@@ -2206,63 +2262,72 @@ pub async fn send_message_stream(
         }
     };
 
+    // Tie the agent loop's lifetime to the SSE stream — when the client
+    // disconnects, axum drops the SSE response future, which drops the
+    // unfold state and this guard, aborting the spawned LLM task and
+    // releasing per-agent locks immediately (#3464).
+    let abort_guard = AbortOnDrop(handle.abort_handle());
+
     // Defense against the agent loop emitting the same text span twice in a
     // single streaming turn (observed when multi-iteration loops re-assert a
     // final sentence after a tool step). The dedup window is per-request, so
     // legitimate repetitions across turns stay unaffected.
-    let sse_stream = stream::unfold((rx, StreamDedup::new()), |(mut rx, mut dedup)| async move {
-        loop {
-            let event = rx.recv().await?;
-            let sse_event: Result<Event, std::convert::Infallible> = Ok(match event {
-                StreamEvent::TextDelta { text } => {
-                    if dedup.is_duplicate(&text) {
-                        tracing::debug!(
-                            len = text.len(),
-                            preview = %text.chars().take(40).collect::<String>(),
-                            "stream dedup: dropping duplicate TextDelta",
-                        );
-                        continue;
-                    }
-                    dedup.record_sent(&text);
-                    Event::default()
-                        .event("chunk")
-                        .json_data(serde_json::json!({"content": text, "done": false}))
-                        .unwrap_or_else(|_| Event::default().data("error"))
-                }
-                StreamEvent::ToolUseStart { name, .. } => Event::default()
-                    .event("tool_use")
-                    .json_data(serde_json::json!({"tool": name}))
-                    .unwrap_or_else(|_| Event::default().data("error")),
-                StreamEvent::ToolUseEnd { name, input, .. } => Event::default()
-                    .event("tool_result")
-                    .json_data(serde_json::json!({"tool": name, "input": input}))
-                    .unwrap_or_else(|_| Event::default().data("error")),
-                StreamEvent::ContentComplete { usage, .. } => Event::default()
-                    .event("done")
-                    .json_data(serde_json::json!({
-                        "done": true,
-                        "usage": {
-                            "input_tokens": usage.input_tokens,
-                            "output_tokens": usage.output_tokens,
+    let sse_stream = stream::unfold(
+        (rx, StreamDedup::new(), abort_guard),
+        |(mut rx, mut dedup, abort_guard)| async move {
+            loop {
+                let event = rx.recv().await?;
+                let sse_event: Result<Event, std::convert::Infallible> = Ok(match event {
+                    StreamEvent::TextDelta { text } => {
+                        if dedup.is_duplicate(&text) {
+                            tracing::debug!(
+                                len = text.len(),
+                                preview = %text.chars().take(40).collect::<String>(),
+                                "stream dedup: dropping duplicate TextDelta",
+                            );
+                            continue;
                         }
-                    }))
-                    .unwrap_or_else(|_| Event::default().data("error")),
-                StreamEvent::PhaseChange { phase, detail } => Event::default()
-                    .event("phase")
-                    .json_data(serde_json::json!({
-                        "phase": phase,
-                        "detail": detail,
-                    }))
-                    .unwrap_or_else(|_| Event::default().data("error")),
-                StreamEvent::OwnerNotice { text } => Event::default()
-                    .event("owner_notice")
-                    .json_data(serde_json::json!({ "text": text }))
-                    .unwrap_or_else(|_| Event::default().data("error")),
-                _ => Event::default().comment("skip"),
-            });
-            return Some((sse_event, (rx, dedup)));
-        }
-    });
+                        dedup.record_sent(&text);
+                        Event::default()
+                            .event("chunk")
+                            .json_data(serde_json::json!({"content": text, "done": false}))
+                            .unwrap_or_else(|_| Event::default().data("error"))
+                    }
+                    StreamEvent::ToolUseStart { name, .. } => Event::default()
+                        .event("tool_use")
+                        .json_data(serde_json::json!({"tool": name}))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::ToolUseEnd { name, input, .. } => Event::default()
+                        .event("tool_result")
+                        .json_data(serde_json::json!({"tool": name, "input": input}))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::ContentComplete { usage, .. } => Event::default()
+                        .event("done")
+                        .json_data(serde_json::json!({
+                            "done": true,
+                            "usage": {
+                                "input_tokens": usage.input_tokens,
+                                "output_tokens": usage.output_tokens,
+                            }
+                        }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::PhaseChange { phase, detail } => Event::default()
+                        .event("phase")
+                        .json_data(serde_json::json!({
+                            "phase": phase,
+                            "detail": detail,
+                        }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::OwnerNotice { text } => Event::default()
+                        .event("owner_notice")
+                        .json_data(serde_json::json!({ "text": text }))
+                        .unwrap_or_else(|_| Event::default().data("error")),
+                    _ => Event::default().comment("skip"),
+                });
+                return Some((sse_event, (rx, dedup, abort_guard)));
+            }
+        },
+    );
 
     Sse::new(sse_stream)
         .keep_alive(
@@ -6072,6 +6137,51 @@ mod tests {
         let req: PatchAgentConfigRequest = serde_json::from_str(json).unwrap();
         assert!(req.temperature.is_none());
         assert_eq!(req.max_tokens, Some(4096));
+    }
+
+    /// #3464 — when the awaiting future is dropped (simulates client
+    /// disconnect), the spawned task is aborted within ~10ms so the kernel
+    /// stops doing work for a vanished caller.
+    #[tokio::test]
+    async fn run_cancel_on_disconnect_aborts_inner_task_when_caller_drops() {
+        let observed_progress = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let observed_completion = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let progress = observed_progress.clone();
+        let completion = observed_completion.clone();
+        let inner = async move {
+            for _ in 0..200 {
+                progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            completion.store(true, std::sync::atomic::Ordering::Relaxed);
+        };
+
+        // Spawn the helper, drop the join future after a short delay to
+        // simulate the axum response future being dropped.
+        let helper = run_cancel_on_disconnect(inner);
+        let join = tokio::spawn(helper);
+
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        join.abort();
+        let _ = join.await; // Reaping the JoinHandle drops the helper future.
+
+        // Give the abort signal time to propagate.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let snapshot = observed_progress.load(std::sync::atomic::Ordering::Relaxed);
+
+        // Wait further; if cancellation works the inner task stopped.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let later = observed_progress.load(std::sync::atomic::Ordering::Relaxed);
+
+        assert_eq!(
+            snapshot, later,
+            "inner task must stop counting after caller drops (got {snapshot} → {later})"
+        );
+        assert!(
+            !observed_completion.load(std::sync::atomic::Ordering::Relaxed),
+            "inner task must not run to completion after cancellation"
+        );
     }
 }
 

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1323,12 +1323,33 @@ fn mime_from_url(url: &str) -> Option<String> {
 /// disconnect cancels the kernel call and releases per-agent locks +
 /// LLM bandwidth instead of letting the round-trip finish unobserved
 /// (#3464).
-struct AbortOnDrop(tokio::task::AbortHandle);
+///
+/// `disarm()` releases the abort handle without aborting — call it when
+/// the spawned task has already produced its observable output and the
+/// remaining work (metering settle, canonical session append, audit log
+/// write) MUST run to completion. The streaming path uses this once
+/// `ContentComplete` has reached the client, so the natural end of the
+/// SSE stream (which drops the unfold state and hence the guard) does
+/// not race-cancel post-stream cleanup.
+struct AbortOnDrop(Option<tokio::task::AbortHandle>);
+
+impl AbortOnDrop {
+    fn new(handle: tokio::task::AbortHandle) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Release the abort permission without aborting.
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
 
 impl Drop for AbortOnDrop {
     fn drop(&mut self) {
-        if !self.0.is_finished() {
-            self.0.abort();
+        if let Some(handle) = self.0.take() {
+            if !handle.is_finished() {
+                handle.abort();
+            }
         }
     }
 }
@@ -1340,7 +1361,7 @@ where
     T: Send + 'static,
 {
     let handle = tokio::spawn(fut);
-    let _guard = AbortOnDrop(handle.abort_handle());
+    let _guard = AbortOnDrop::new(handle.abort_handle());
     handle.await
 }
 
@@ -2266,7 +2287,18 @@ pub async fn send_message_stream(
     // disconnects, axum drops the SSE response future, which drops the
     // unfold state and this guard, aborting the spawned LLM task and
     // releasing per-agent locks immediately (#3464).
-    let abort_guard = AbortOnDrop(handle.abort_handle());
+    //
+    // CRITICAL: the kernel task does substantial post-stream work AFTER
+    // the agent loop emits `ContentComplete` — token-reservation settle,
+    // canonical session append, JSONL mirror, metering record, audit
+    // log, lifecycle bus publish, experiment recording. We MUST disarm
+    // the guard the moment we observe `ContentComplete`, otherwise the
+    // natural end of the SSE stream (sender drained → caller_rx returns
+    // None → unfold ends → guard drops) races against the post-stream
+    // cleanup and silently aborts settle/audit/canonical writes,
+    // leaking token reservations and dropping the user's last turn from
+    // history.
+    let abort_guard = AbortOnDrop::new(handle.abort_handle());
 
     // Defense against the agent loop emitting the same text span twice in a
     // single streaming turn (observed when multi-iteration loops re-assert a
@@ -2274,7 +2306,7 @@ pub async fn send_message_stream(
     // legitimate repetitions across turns stay unaffected.
     let sse_stream = stream::unfold(
         (rx, StreamDedup::new(), abort_guard),
-        |(mut rx, mut dedup, abort_guard)| async move {
+        |(mut rx, mut dedup, mut abort_guard)| async move {
             loop {
                 let event = rx.recv().await?;
                 let sse_event: Result<Event, std::convert::Infallible> = Ok(match event {
@@ -2301,16 +2333,25 @@ pub async fn send_message_stream(
                         .event("tool_result")
                         .json_data(serde_json::json!({"tool": name, "input": input}))
                         .unwrap_or_else(|_| Event::default().data("error")),
-                    StreamEvent::ContentComplete { usage, .. } => Event::default()
-                        .event("done")
-                        .json_data(serde_json::json!({
-                            "done": true,
-                            "usage": {
-                                "input_tokens": usage.input_tokens,
-                                "output_tokens": usage.output_tokens,
-                            }
-                        }))
-                        .unwrap_or_else(|_| Event::default().data("error")),
+                    StreamEvent::ContentComplete { usage, .. } => {
+                        // The LLM stream is done — every byte the client
+                        // cares about has been emitted. Release the abort
+                        // permission BEFORE we yield the `done` event so
+                        // the kernel task is free to finish settle /
+                        // canonical / audit work even if the SSE stream
+                        // ends a few milliseconds later (#3464).
+                        abort_guard.disarm();
+                        Event::default()
+                            .event("done")
+                            .json_data(serde_json::json!({
+                                "done": true,
+                                "usage": {
+                                    "input_tokens": usage.input_tokens,
+                                    "output_tokens": usage.output_tokens,
+                                }
+                            }))
+                            .unwrap_or_else(|_| Event::default().data("error"))
+                    }
                     StreamEvent::PhaseChange { phase, detail } => Event::default()
                         .event("phase")
                         .json_data(serde_json::json!({
@@ -6181,6 +6222,39 @@ mod tests {
         assert!(
             !observed_completion.load(std::sync::atomic::Ordering::Relaxed),
             "inner task must not run to completion after cancellation"
+        );
+    }
+
+    /// #3464 — once `disarm()` has been called, dropping the guard MUST
+    /// NOT abort the spawned task. This is the streaming path's
+    /// invariant: after `ContentComplete` reaches the client, the
+    /// kernel still runs settle-reservation / canonical-append / audit
+    /// writes; if the SSE stream ends a few ms later and the guard
+    /// drops, those side-effects must complete instead of being
+    /// silently cancelled.
+    #[tokio::test]
+    async fn abort_on_drop_after_disarm_does_not_abort_task() {
+        let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let completed_inner = completed.clone();
+
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            completed_inner.store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        let mut guard = AbortOnDrop::new(handle.abort_handle());
+        // Simulate observing `ContentComplete`: release abort permission.
+        guard.disarm();
+        // Drop the guard immediately, simulating SSE stream end racing
+        // ahead of the kernel post-stream cleanup.
+        drop(guard);
+
+        // The task must still be allowed to finish.
+        let _ = handle.await;
+        assert!(
+            completed.load(std::sync::atomic::Ordering::Relaxed),
+            "disarmed guard must NOT abort the task on drop — \
+             post-stream settle/audit work would be silently cancelled"
         );
     }
 }

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -180,6 +180,9 @@ impl ApprovalManager {
     }
 
     /// Persist a new pending approval to the database so it survives restarts.
+    ///
+    /// Also writes a `pending` audit row so submission is observable even when
+    /// the daemon dies before resolution (#3611).
     fn db_insert_pending(&self, req: &ApprovalRequest) {
         let Some(db) = &self.audit_db else { return };
         let Ok(conn) = db.lock() else { return };
@@ -198,6 +201,45 @@ impl ApprovalManager {
             ],
         ) {
             warn!(request_id = %req.id, error = %e, "Failed to persist pending approval to database");
+        }
+        // Audit row at submission so a crash mid-flight still shows the request.
+        let entry = ApprovalAuditEntry {
+            id: Uuid::new_v4().to_string(),
+            request_id: req.id.to_string(),
+            agent_id: req.agent_id.clone(),
+            tool_name: req.tool_name.clone(),
+            description: req.description.clone(),
+            action_summary: req.action_summary.clone(),
+            risk_level: serde_json::to_string(&req.risk_level)
+                .unwrap_or_default()
+                .trim_matches('"')
+                .to_string(),
+            decision: "pending".to_string(),
+            decided_by: None,
+            decided_at: req.requested_at.to_rfc3339(),
+            requested_at: req.requested_at.to_rfc3339(),
+            feedback: None,
+            second_factor_used: false,
+        };
+        if let Err(e) = conn.execute(
+            "INSERT OR IGNORE INTO approval_audit (id, request_id, agent_id, tool_name, description, action_summary, risk_level, decision, decided_by, decided_at, requested_at, feedback, second_factor_used) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            rusqlite::params![
+                entry.id,
+                entry.request_id,
+                entry.agent_id,
+                entry.tool_name,
+                entry.description,
+                entry.action_summary,
+                entry.risk_level,
+                entry.decision,
+                entry.decided_by,
+                entry.decided_at,
+                entry.requested_at,
+                entry.feedback,
+                entry.second_factor_used,
+            ],
+        ) {
+            warn!(request_id = %req.id, error = %e, "Failed to write pending audit entry");
         }
     }
 
@@ -2886,5 +2928,40 @@ mod tests {
         // Cleanup.
         let _ = mgr.resolve(id1, ApprovalDecision::Denied, None, false, None);
         let _ = mgr.resolve(id3, ApprovalDecision::Denied, None, false, None);
+    }
+
+    #[tokio::test]
+    async fn submission_writes_pending_audit_row_and_persists_pending_table() {
+        // #3611: a daemon crash mid-flight must not erase the audit trail.
+        // Submission writes a `pending` row immediately so the request is
+        // observable even if resolve / expire never runs.
+        let mgr = Arc::new(make_manager_with_db());
+        let deferred = DeferredToolExecution {
+            agent_id: "agent-3611".to_string(),
+            tool_use_id: "tool-3611".to_string(),
+            tool_name: "shell_exec".to_string(),
+            input: serde_json::json!({"cmd": "echo hi"}),
+            allowed_tools: None,
+            allowed_env_vars: None,
+            exec_policy: None,
+            sender_id: None,
+            channel: None,
+            workspace_root: None,
+            force_human: false,
+        };
+        let req = make_session_request("agent-3611", "sess-3611");
+        let request_id = mgr.submit_request(req, deferred).unwrap();
+
+        // Audit row exists with `pending` decision before any resolve.
+        let audit = mgr.query_audit(50, 0, Some("agent-3611"), None);
+        assert!(
+            audit
+                .iter()
+                .any(|e| e.request_id == request_id.to_string() && e.decision == "pending"),
+            "submission must write a pending audit row, got: {audit:?}"
+        );
+
+        // Pending row also lives in the dedicated table (cross-restart survival).
+        assert!(mgr.get_pending(request_id).is_some());
     }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -14238,7 +14238,7 @@ system_prompt = "You are a helpful assistant."
                 .read()
                 .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
                 .unwrap_or_default();
-            let mcp_candidates: Vec<ToolDefinition> = if mcp_allowlist.is_empty() {
+            let mut mcp_candidates: Vec<ToolDefinition> = if mcp_allowlist.is_empty() {
                 mcp_tools.iter().cloned().collect()
             } else {
                 let normalized: Vec<String> = mcp_allowlist
@@ -14261,6 +14261,9 @@ system_prompt = "You are a helpful assistant."
                     .cloned()
                     .collect()
             };
+            // Sort MCP tools by name so connect / hot-reload order does not
+            // mutate the prompt prefix and invalidate provider cache (#3765).
+            mcp_candidates.sort_by(|a, b| a.name.cmp(&b.name));
             for t in mcp_candidates {
                 // MCP tools are NOT filtered by capabilities.tools.
                 // mcp_candidates is already scoped to the agent's allowed servers

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4769,6 +4769,107 @@ fn mcp_summary_cache_key_is_order_independent() {
     assert_eq!(super::mcp_summary_cache_key(&[]), "*");
 }
 
+#[test]
+fn available_tools_mcp_section_is_sorted_across_connect_orders() {
+    // Regression for #3765: connect / hot-reload order of MCP servers must
+    // not mutate the LLM tool definition list, otherwise provider prompt
+    // caches miss on every daemon restart.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("librefang-mcp-order-test");
+    std::fs::create_dir_all(home.join("data")).unwrap();
+    let cfg = KernelConfig {
+        home_dir: home.clone(),
+        data_dir: home.join("data"),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(cfg).expect("kernel should boot");
+    let manifest = AgentManifest {
+        name: "mcp-order".to_string(),
+        description: "agent for mcp order regression".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+
+    // Order A: connect filesystem before github before weather.
+    {
+        let mut tools = kernel.mcp_tools_ref().lock().unwrap();
+        tools.clear();
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_filesystem_read_file".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_github_create_issue".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_weather_forecast".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+    }
+    kernel
+        .mcp_generation
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let names_a: Vec<String> = kernel
+        .available_tools(agent_id)
+        .iter()
+        .filter(|t| t.name.starts_with("mcp_"))
+        .map(|t| t.name.clone())
+        .collect();
+
+    // Order B: same set, scrambled connect order.
+    {
+        let mut tools = kernel.mcp_tools_ref().lock().unwrap();
+        tools.clear();
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_weather_forecast".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_github_create_issue".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_filesystem_read_file".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+    }
+    kernel
+        .mcp_generation
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let names_b: Vec<String> = kernel
+        .available_tools(agent_id)
+        .iter()
+        .filter(|t| t.name.starts_with("mcp_"))
+        .map(|t| t.name.clone())
+        .collect();
+
+    assert_eq!(
+        names_a, names_b,
+        "MCP tool list must be byte-identical across connect orders (#3765)"
+    );
+    assert_eq!(
+        names_a,
+        vec![
+            "mcp_filesystem_read_file".to_string(),
+            "mcp_github_create_issue".to_string(),
+            "mcp_weather_forecast".to_string(),
+        ],
+        "MCP tools must be sorted lexicographically by name"
+    );
+
+    kernel.shutdown();
+}
+
 // ─── resolve_dispatch_session_id ──────────────────────────────────────────
 //
 // Backstop for the session-id-in-failure-log change: ensures the kernel


### PR DESCRIPTION
## Summary
Three independent kernel fixes that share regression-test plumbing in `librefang-kernel` and `librefang-api`.

- **#3611** — approval audit on submit: `db_insert_pending` now writes a `pending` row to `approval_audit` alongside the `pending_approvals` table. A daemon crash before resolve/expire still leaves an observable audit trail.
- **#3464** — cancel on client disconnect: `send_message` (JSON) and `send_message_stream` (SSE) now spawn the kernel call inside an `AbortOnDrop` RAII guard. When axum drops the response future (client gone), the spawned task is aborted and per-agent / per-session locks release in milliseconds instead of holding for the full LLM round-trip.
- **#3765** — deterministic MCP tool injection: `available_tools` now sorts MCP candidates by name before pushing into the LLM tool list, so config reload / hot reconnect order does not flip the prompt prefix and invalidate provider caches.

## Test plan
- [x] New unit test `submission_writes_pending_audit_row_and_persists_pending_table` (approval.rs) confirms the `pending` row is queryable immediately after `submit_request`.
- [x] New unit test `available_tools_mcp_section_is_sorted_across_connect_orders` (kernel/tests.rs) injects two scrambled `mcp_tools` orderings and asserts byte-identical output.
- [x] New tokio test `run_cancel_on_disconnect_aborts_inner_task_when_caller_drops` (agents.rs) simulates the axum-drop scenario and asserts the inner task stops progressing.
- [ ] Live disconnect test: `curl -N` against `/api/agents/{id}/message`, drop mid-flight, watch per-agent semaphore release in logs.
- [ ] Live cache test: configure 2 MCP servers, restart daemon, send turn, verify Anthropic cache_read_input_tokens is non-zero.

Closes #3611
Closes #3464
Closes #3765