### PR TITLE
fix(api,auth): close 5 API endpoint authz gaps

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -877,10 +877,6 @@ export function buildAuthenticatedWebSocket(path: string): {
   return { url, protocols };
 }
 
-// Removed in #3610 cleanup: `buildAuthenticatedWebSocketUrl` deprecated shim.
-// All in-tree callers migrated to `buildAuthenticatedWebSocket`, which uses
-// the `bearer.<token>` sub-protocol so the credential never enters the URL.
-
 async function parseError(response: Response): Promise<ApiError> {
   // If 401, trigger global logout (only once to prevent infinite loop)
   if (response.status === 401 && _onUnauthorized && !_unauthorizedFired) {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -877,15 +877,9 @@ export function buildAuthenticatedWebSocket(path: string): {
   return { url, protocols };
 }
 
-/**
- * @deprecated Use `buildAuthenticatedWebSocket()` to avoid leaking the token
- * via the URL. This shim returns the URL without the token; callers must
- * supply the bearer protocol separately.
- */
-export function buildAuthenticatedWebSocketUrl(path: string): string {
-  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${window.location.host}${path}`;
-}
+// Removed in #3610 cleanup: `buildAuthenticatedWebSocketUrl` deprecated shim.
+// All in-tree callers migrated to `buildAuthenticatedWebSocket`, which uses
+// the `bearer.<token>` sub-protocol so the credential never enters the URL.
 
 async function parseError(response: Response): Promise<ApiError> {
   // If 401, trigger global logout (only once to prevent infinite loop)

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1783,6 +1783,9 @@ pub async fn get_agent_session(
                                                     media_type.rsplit('/').next().unwrap_or("png")
                                                 ),
                                                 content_type: media_type.clone(),
+                                                // Generated content has no
+                                                // operator owner — leave None.
+                                                uploaded_by: None,
                                             },
                                         );
                                         msg_images.push(serde_json::json!({
@@ -5278,6 +5281,12 @@ pub(crate) struct UploadMeta {
     #[allow(dead_code)]
     pub(crate) filename: String,
     pub(crate) content_type: String,
+    /// User who uploaded the file (#3361). `None` means "anonymous /
+    /// pre-auth daemon" — readable by any authenticated caller for
+    /// backwards compatibility with content saved before owner-binding
+    /// was introduced. New uploads from authenticated users always set
+    /// this so `serve_upload` can reject cross-user UUID guessing.
+    pub(crate) uploaded_by: Option<librefang_types::agent::UserId>,
 }
 
 /// In-memory upload metadata registry.
@@ -5380,6 +5389,7 @@ pub async fn upload_file(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
     headers: axum::http::HeaderMap,
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
@@ -5471,11 +5481,13 @@ pub async fn upload_file(
     }
 
     let size = body.len();
+    let uploaded_by = api_user.as_ref().map(|u| u.0.user_id);
     UPLOAD_REGISTRY.insert(
         file_id.clone(),
         UploadMeta {
             filename: filename.clone(),
             content_type: content_type.clone(),
+            uploaded_by,
         },
     );
 
@@ -5525,7 +5537,10 @@ pub async fn upload_file(
         (status = 200, description = "Serve an uploaded file by ID", body = serde_json::Value)
     )
 )]
-pub async fn serve_upload(Path(file_id): Path<String>) -> impl IntoResponse {
+pub async fn serve_upload(
+    Path(file_id): Path<String>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
+) -> impl IntoResponse {
     // Validate file_id is a UUID to prevent path traversal
     if uuid::Uuid::parse_str(&file_id).is_err() {
         return (
@@ -5544,8 +5559,8 @@ pub async fn serve_upload(Path(file_id): Path<String>) -> impl IntoResponse {
 
     // Look up metadata from registry; fall back to disk probe for generated images
     // (image_generate saves files without registering in UPLOAD_REGISTRY).
-    let content_type = match UPLOAD_REGISTRY.get(&file_id) {
-        Some(m) => m.content_type.clone(),
+    let (content_type, owner) = match UPLOAD_REGISTRY.get(&file_id) {
+        Some(m) => (m.content_type.clone(), m.uploaded_by),
         None => {
             // Infer content type from file magic bytes
             if !file_path.exists() {
@@ -5558,9 +5573,37 @@ pub async fn serve_upload(Path(file_id): Path<String>) -> impl IntoResponse {
                     b"{\"error\":\"File not found\"}".to_vec(),
                 );
             }
-            "image/png".to_string()
+            ("image/png".to_string(), None)
         }
     };
+
+    // SECURITY (#3361): Bind uploads to their uploader. A bare UUID is not
+    // access control — UUIDs leak through audit logs, dashboard responses,
+    // tracing output, and message history. Owner-bound files are readable
+    // only by the uploader or by Admin/Owner callers; un-owned entries (pre-
+    // #3361 uploads, generator output) stay readable for compatibility.
+    if let Some(owner_id) = owner {
+        use librefang_kernel::auth::UserRole;
+        let allowed = match api_user.as_ref().map(|u| &u.0) {
+            Some(u) => u.user_id == owner_id || u.role >= UserRole::Admin,
+            None => false,
+        };
+        if !allowed {
+            tracing::warn!(
+                file_id = %file_id,
+                caller = ?api_user.as_ref().map(|u| u.0.name.clone()),
+                "upload access denied: caller is not the uploader"
+            );
+            return (
+                StatusCode::FORBIDDEN,
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    "application/json".to_string(),
+                )],
+                b"{\"error\":\"You are not authorized to access this upload\"}".to_vec(),
+            );
+        }
+    }
 
     match std::fs::read(&file_path) {
         Ok(data) => (
@@ -5886,6 +5929,30 @@ mod tests {
         assert_eq!(req.new_name, "clone-2");
         assert!(!req.include_skills);
         assert!(!req.include_tools);
+    }
+
+    /// Issue #3361: UploadMeta carries the uploader's UserId so `serve_upload`
+    /// can reject cross-user UUID guessing. Pre-fix the struct had no owner
+    /// field at all and any caller knowing the UUID could fetch the file.
+    #[test]
+    fn issue_3361_upload_meta_carries_owner() {
+        use librefang_types::agent::UserId;
+        let owner = UserId::from_name("alice");
+        let meta = UploadMeta {
+            filename: "doc.pdf".to_string(),
+            content_type: "application/pdf".to_string(),
+            uploaded_by: Some(owner),
+        };
+        assert_eq!(meta.uploaded_by, Some(owner));
+
+        // Daemon-generated content has no owner — None means "any
+        // authenticated caller may read" (e.g. image_generate output).
+        let generated = UploadMeta {
+            filename: "image.png".to_string(),
+            content_type: "image/png".to_string(),
+            uploaded_by: None,
+        };
+        assert!(generated.uploaded_by.is_none());
     }
 
     #[test]

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1920,6 +1920,33 @@ pub async fn config_set(
         );
     }
 
+    // SECURITY (#3458): Restrict /api/config/set to a curated allowlist of
+    // user-tunable config paths. Without this gate any caller authorized to
+    // change config (Owner role, post-auth) can clobber structured tables
+    // (e.g. overwrite `[channels]` with a string), corrupt nested credentials
+    // (`default_model.api_key`), or flip security-critical flags
+    // (`auth.bypass = true` style). The allowlist deliberately excludes:
+    //   - auth/credentials/api_key/users     (account takeover)
+    //   - default_model / providers / *.api_key  (silent provider hijack)
+    //   - approval / second_factor / totp_*  (2FA bypass)
+    //   - migration_state / schema_version   (DB corruption)
+    //   - network / shared_secret / cors_*   (federation hijack)
+    // Operators who genuinely need those paths must edit `config.toml` on
+    // disk — that path keeps an audit trail (file mtime, git, etc.) and
+    // requires shell access, raising the bar above a leaked API key.
+    if !is_writable_config_path(&path) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "status": "error",
+                "error": format!(
+                    "config path '{path}' is not user-tunable via /api/config/set; \
+                     edit ~/.librefang/config.toml directly to change it"
+                )
+            })),
+        );
+    }
+
     let config_path = state.kernel.home_dir().join("config.toml");
     // Block path-traversal (`..`) but allow Windows drive-letter prefixes
     if config_path.file_name().and_then(|n| n.to_str()) != Some("config.toml")
@@ -2130,6 +2157,79 @@ pub async fn config_set(
         body["reload_error"] = serde_json::Value::String(err);
     }
     (StatusCode::OK, Json(body))
+}
+
+/// Allowlist of user-tunable config paths writable via POST /api/config/set
+/// (#3458). Anything not in this list MUST be edited on disk.
+///
+/// Each entry is matched against the dot-separated path the caller supplies.
+/// Trailing `.*` wildcards permit any single key under a section (used for
+/// per-channel toggles like `channels.telegram.enabled`).
+fn is_writable_config_path(path: &str) -> bool {
+    // Exact-match list — single user-tunable scalars.
+    const EXACT: &[&str] = &[
+        // UI / locale (no security impact).
+        "ui.theme",
+        "ui.locale",
+        "ui.timezone",
+        "ui.language",
+        "log_level",
+        // History trim cap (gotcha bound by MIN_HISTORY_MESSAGES on reload).
+        "max_history_messages",
+        // Approval policy display knobs (NOT the second_factor enforcement
+        // mode, NOT totp_* — those would let an Owner-role attacker silently
+        // turn off 2FA after an API-key leak).
+        "approval.auto_approve_autonomous",
+        "approval.auto_approve",
+        "approval.totp_grace_period_secs",
+    ];
+    if EXACT.iter().any(|p| *p == path) {
+        return true;
+    }
+
+    // Section prefixes — any leaf under these prefixes is allowed. The
+    // section itself is NOT writable as a whole (would clobber the table),
+    // because validate_config_key_path requires the path to have a leaf.
+    const SECTION_PREFIXES: &[&str] = &[
+        // Per-channel enable/feature toggles. Excludes `*.token` /
+        // `*.shared_secret` because those keys are scrubbed below.
+        "channels.",
+        // Web search / fetch knobs (URLs and timeouts).
+        "web.",
+        // Rate-limit display knobs.
+        "rate_limit.",
+        // Queue / concurrency tuning.
+        "queue.",
+    ];
+    let in_section = SECTION_PREFIXES.iter().any(|pfx| {
+        path.starts_with(pfx) && path.len() > pfx.len() && !path[pfx.len()..].contains('.')
+            // Allow a single nested level too (e.g. "channels.telegram.enabled")
+            || path.starts_with(pfx) && {
+                let rest = &path[pfx.len()..];
+                rest.split('.').count() == 2
+            }
+    });
+    if !in_section {
+        return false;
+    }
+
+    // Within an allowed section, refuse keys that obviously carry secrets or
+    // override security-critical knobs even if the operator points us at one
+    // of the curated sections by name.
+    const SCRUB_SUFFIXES: &[&str] = &[
+        ".api_key",
+        ".token",
+        ".secret",
+        ".shared_secret",
+        ".password",
+        ".bypass",
+        ".admin",
+        ".owner",
+    ];
+    if SCRUB_SUFFIXES.iter().any(|s| path.ends_with(s)) {
+        return false;
+    }
+    true
 }
 
 /// Convert a serde_json::Value to a toml_edit::Value (format-preserving).
@@ -2578,6 +2678,42 @@ url = "https://search.example.com"
         let cfg: KernelConfig = toml::from_str(toml_src)
             .expect("init-template layout + appended [web.searxng] must parse (issue #4016)");
         assert_eq!(cfg.web.searxng.url, "https://search.example.com");
+    }
+
+    #[test]
+    fn issue_3458_writable_path_allowlist() {
+        // User-tunable scalars are accepted.
+        assert!(super::is_writable_config_path("ui.theme"));
+        assert!(super::is_writable_config_path("ui.locale"));
+        assert!(super::is_writable_config_path("max_history_messages"));
+        assert!(super::is_writable_config_path("log_level"));
+        assert!(super::is_writable_config_path("approval.auto_approve"));
+        assert!(super::is_writable_config_path(
+            "approval.totp_grace_period_secs"
+        ));
+
+        // Sectioned tunables — single leaf and one nested level both allowed.
+        assert!(super::is_writable_config_path("web.search_provider"));
+        assert!(super::is_writable_config_path("rate_limit.max_ws_per_ip"));
+        assert!(super::is_writable_config_path("channels.telegram.enabled"));
+
+        // Account / credential paths MUST be rejected.
+        assert!(!super::is_writable_config_path("default_model.api_key"));
+        assert!(!super::is_writable_config_path("api_key"));
+        assert!(!super::is_writable_config_path("users.alice.role"));
+        assert!(!super::is_writable_config_path("auth.bypass"));
+        assert!(!super::is_writable_config_path("approval.second_factor"));
+
+        // Secret-suffix scrub catches accidentally-exposed leaves inside
+        // an otherwise-allowed section.
+        assert!(!super::is_writable_config_path("channels.telegram.token"));
+        assert!(!super::is_writable_config_path("web.searxng.api_key"));
+        assert!(!super::is_writable_config_path("queue.shared_secret"));
+
+        // Unknown sections fall through to deny by default.
+        assert!(!super::is_writable_config_path("network.shared_secret"));
+        assert!(!super::is_writable_config_path("migration_state"));
+        assert!(!super::is_writable_config_path("nonsense.key"));
     }
 
     #[test]

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -86,11 +86,14 @@ fn save_upload(data: &[u8], filename: &str, content_type: &str) -> Result<String
         .map_err(|e| format!("Failed to write upload file: {e}"))?;
 
     // Register metadata so serve_upload returns the correct content type.
+    // Daemon-generated media has no human owner — leave `uploaded_by` empty
+    // so any authenticated caller can fetch it (#3361).
     super::agents::UPLOAD_REGISTRY.insert(
         file_id.clone(),
         super::agents::UploadMeta {
             filename: filename.to_string(),
             content_type: content_type.to_string(),
+            uploaded_by: None,
         },
     );
 

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1913,10 +1913,23 @@ pub async fn approve_request(
                             // hash alone) so the code is single-use across
                             // all actions; the binding only documents *which*
                             // action used it for post-incident audit.
-                            state
+                            //
+                            // Fail-secure (#3372 parity): if the DB write
+                            // fails the code is NOT in the replay table and
+                            // could be reused, so reject with 500 rather than
+                            // silently approving.
+                            if state
                                 .kernel
                                 .approvals()
-                                .record_totp_code_used_for(code, Some(&format!("approval:{uuid}")));
+                                .record_totp_code_used_for(code, Some(&format!("approval:{uuid}")))
+                                .is_err()
+                            {
+                                return ApiErrorResponse::internal(
+                                    "Failed to persist TOTP used-code record",
+                                )
+                                .into_json_tuple()
+                                .into_response();
+                            }
                             // Audit trail: write the binding alongside the
                             // approval resolution so an auditor can correlate
                             // (totp_code_hash, approval_uuid) without joining

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1879,7 +1879,22 @@ pub async fn approve_request(
                     // Replay-prevention check (#3359): reject a code that was
                     // already used within the last 60 seconds (two TOTP windows).
                     if state.kernel.approvals().is_totp_code_used(code) {
-                        let _ = state.kernel.approvals().record_totp_failure("api_admin");
+                        // Fail-secure on lockout-counter persist failure
+                        // (#3372): if the DB write drops we cannot enforce
+                        // brute-force caps across restarts, so reject 5xx
+                        // rather than silently allow further attempts.
+                        if state
+                            .kernel
+                            .approvals()
+                            .record_totp_failure("api_admin")
+                            .is_err()
+                        {
+                            return ApiErrorResponse::internal(
+                                "Failed to persist TOTP failure counter",
+                            )
+                            .into_json_tuple()
+                            .into_response();
+                        }
                         return ApiErrorResponse::bad_request(
                             "TOTP code has already been used. Wait for the next 30-second window.",
                         )
@@ -1892,8 +1907,28 @@ pub async fn approve_request(
                         &totp_issuer,
                     ) {
                         Ok(true) => {
-                            // Mark this code as used to prevent replay within the window.
-                            state.kernel.approvals().record_totp_code_used(code);
+                            // SECURITY (#3360): Bind the consumed code to the
+                            // approval id it authorized. The replay window is
+                            // still global (`is_totp_code_used` keys on the
+                            // hash alone) so the code is single-use across
+                            // all actions; the binding only documents *which*
+                            // action used it for post-incident audit.
+                            state
+                                .kernel
+                                .approvals()
+                                .record_totp_code_used_for(code, Some(&format!("approval:{uuid}")));
+                            // Audit trail: write the binding alongside the
+                            // approval resolution so an auditor can correlate
+                            // (totp_code_hash, approval_uuid) without joining
+                            // tables.
+                            state.kernel.audit().record_with_context(
+                                "system",
+                                librefang_runtime::audit::AuditAction::AuthAttempt,
+                                format!("totp_used_for_approval:{uuid}"),
+                                "totp_verified",
+                                None,
+                                Some("api".to_string()),
+                            );
                             true
                         }
                         Ok(false) => {
@@ -2524,10 +2559,18 @@ pub async fn totp_setup(
                 } else {
                     // TOTP code — check replay before verifying (#3359).
                     if state.kernel.approvals().is_totp_code_used(code) {
-                        let _ = state
+                        // Fail-secure on counter persist failure (#3372).
+                        if state
                             .kernel
                             .approvals()
-                            .record_totp_failure(SETUP_LOCKOUT_KEY);
+                            .record_totp_failure(SETUP_LOCKOUT_KEY)
+                            .is_err()
+                        {
+                            return ApiErrorResponse::internal(
+                                "Failed to persist TOTP failure counter",
+                            )
+                            .into_json_tuple();
+                        }
                         return ApiErrorResponse::bad_request(
                             "TOTP code has already been used. Wait for the next 30-second window.",
                         )
@@ -2659,7 +2702,16 @@ pub async fn totp_confirm(
 
     // Replay-prevention check (#3359): reject a code already used in the last 60 s.
     if state.kernel.approvals().is_totp_code_used(&body.code) {
-        let _ = state.kernel.approvals().record_totp_failure("api_admin");
+        // Fail-secure on counter persist failure (#3372).
+        if state
+            .kernel
+            .approvals()
+            .record_totp_failure("api_admin")
+            .is_err()
+        {
+            return ApiErrorResponse::internal("Failed to persist TOTP failure counter")
+                .into_json_tuple();
+        }
         return ApiErrorResponse::bad_request(
             "TOTP code has already been used. Wait for the next 30-second window.",
         )

--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -324,6 +324,20 @@ pub(super) async fn authorize_terminal_request(
         return Err(axum::http::StatusCode::FORBIDDEN.into_response());
     }
 
+    // SECURITY (#3610): Reject any caller still putting the bearer token in
+    // the URL query string. The legacy `?token=` form leaks the credential
+    // into proxy access logs and browser history; modern clients use the
+    // `Sec-WebSocket-Protocol: bearer.<token>` sub-protocol or the
+    // `Authorization` header instead.
+    if crate::ws::ws_query_param(uri, "token").is_some() {
+        warn!(
+            ip = %locality.source_ip,
+            "Terminal WebSocket rejected: ?token= query param removed in #3610 — \
+             use the Sec-WebSocket-Protocol bearer.<token> sub-protocol instead"
+        );
+        return Err(axum::http::StatusCode::UNAUTHORIZED.into_response());
+    }
+
     // Warn if terminal is enabled without any authentication configured.
     let valid_tokens = crate::server::valid_api_tokens(state.kernel.as_ref());
     let user_api_keys = crate::server::configured_user_api_keys(state.kernel.as_ref());

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -374,6 +374,19 @@ pub async fn agent_ws(
     }
 
     if auth_required {
+        // SECURITY (#3610): Loud reject if a client still sends `?token=` in
+        // the WS URL. The credential leaks into proxy access logs and browser
+        // history; we removed support in #3610 but this fail-closed branch
+        // catches stale dashboards / scripted clients that haven't migrated
+        // to the `bearer.<token>` sub-protocol or `Authorization` header.
+        if ws_query_param(&uri, "token").is_some() {
+            warn!(
+                ip = %addr.ip(),
+                "WebSocket upgrade rejected: ?token= query param removed in #3610 — \
+                 use the Sec-WebSocket-Protocol bearer.<token> sub-protocol instead"
+            );
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
         // SECURITY: Use constant-time comparison to prevent timing attacks on auth tokens.
         let matches_any = |token: &str| -> bool {
             use subtle::ConstantTimeEq;
@@ -2238,5 +2251,18 @@ mod tests {
         );
         let locality = detect_connection_locality(&addr, &headers);
         assert_eq!(locality.forwarded_ip.unwrap().to_string(), "1.1.1.1");
+    }
+
+    #[test]
+    fn issue_3610_query_token_visibility_helper() {
+        // Regression: ws_query_param still surfaces a `?token=` parameter so
+        // upgrade handlers can fail-closed on it (#3610). The helper itself is
+        // not the security boundary — the handler must reject — but if this
+        // ever returns None for a present `token` param the fail-closed gate
+        // would silently degrade.
+        let uri: Uri = "/api/terminal/ws?token=leaked".parse().unwrap();
+        assert_eq!(ws_query_param(&uri, "token").as_deref(), Some("leaked"));
+        let uri: Uri = "/api/terminal/ws?cols=120".parse().unwrap();
+        assert_eq!(ws_query_param(&uri, "token"), None);
     }
 }

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1262,7 +1262,9 @@ impl ApprovalManager {
     ///
     /// Also prunes entries older than 120 seconds from the table to keep it small.
     pub fn record_totp_code_used(&self, code: &str) {
-        self.record_totp_code_used_for(code, None);
+        // Ignore errors for non-action callers (enrollment confirm, revoke) —
+        // those flows don't have a structured error path to return a 500.
+        let _ = self.record_totp_code_used_for(code, None);
     }
 
     /// Record a successfully-verified TOTP code, binding it to the action it
@@ -1274,9 +1276,19 @@ impl ApprovalManager {
     /// auditor can prove which action a given TOTP code authorized; replay
     /// detection itself remains global on `code_hash` so the same code cannot
     /// be reused for a *different* action either.
-    pub fn record_totp_code_used_for(&self, code: &str, bound_to: Option<&str>) {
-        let Some(db) = &self.audit_db else { return };
-        let Ok(conn) = db.lock() else { return };
+    ///
+    /// Returns `Err` if the DB write fails. Callers that can propagate an HTTP
+    /// response MUST treat this as a 500 — a failed write leaves the code out
+    /// of the replay-detection table, allowing reuse.
+    pub fn record_totp_code_used_for(
+        &self,
+        code: &str,
+        bound_to: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        let Some(db) = &self.audit_db else {
+            return Ok(());
+        };
+        let Ok(conn) = db.lock() else { return Ok(()) };
         let hash = Self::totp_code_hash(code);
         let now_unix = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1285,22 +1297,21 @@ impl ApprovalManager {
         // Upsert the used-code entry. `bound_to` is informational; the unique
         // key is still `code_hash` so any replay of the same code is rejected
         // regardless of which action it claims to authorize.
-        if let Err(e) = conn.execute(
+        conn.execute(
             "INSERT INTO totp_used_codes (code_hash, used_at, bound_to)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(code_hash) DO UPDATE SET
                  used_at  = excluded.used_at,
                  bound_to = excluded.bound_to",
             rusqlite::params![hash, now_unix, bound_to],
-        ) {
-            warn!(error = %e, "failed to record TOTP code used");
-        }
+        )?;
         // Prune entries older than 120 seconds.
         let prune_before = now_unix - 120;
         let _ = conn.execute(
             "DELETE FROM totp_used_codes WHERE used_at < ?1",
             rusqlite::params![prune_before],
         );
+        Ok(())
     }
 
     /// SHA-256 hex of an OIDC state nonce.  We only persist the hash so
@@ -2755,7 +2766,10 @@ mod tests {
     #[test]
     fn issue_3360_totp_code_single_use_across_actions() {
         let mgr = make_manager_with_db();
-        mgr.record_totp_code_used_for("987654", Some("approval:11111111-1111-1111-1111-111111111111"));
+        mgr.record_totp_code_used_for(
+            "987654",
+            Some("approval:11111111-1111-1111-1111-111111111111"),
+        );
         // Same code claimed for a different approval — must still be flagged
         // as used. Without this an attacker rewriting the path could replay
         // a captured TOTP request to authorize a higher-impact approval.

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1198,11 +1198,27 @@ impl ApprovalManager {
 
     fn persist_totp_lockout_clear(&self, sender_id: &str) {
         let Some(db) = &self.audit_db else { return };
-        let Ok(conn) = db.lock() else { return };
-        let _ = conn.execute(
+        let Ok(conn) = db.lock() else {
+            warn!(
+                sender_id,
+                "TOTP lockout DB unavailable; could not clear lockout row \
+                 — counter will keep its persisted value until the next save (#3372)"
+            );
+            return;
+        };
+        if let Err(e) = conn.execute(
             "DELETE FROM totp_lockout WHERE sender_id = ?1",
             rusqlite::params![sender_id],
-        );
+        ) {
+            // Cleared in-memory but the persisted row is stale. Surface so
+            // operators see why a lockout might appear to "come back" on
+            // restart even after a successful verify.
+            warn!(
+                sender_id,
+                error = %e,
+                "Failed to clear TOTP lockout row from DB after success (#3372)"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1246,6 +1262,19 @@ impl ApprovalManager {
     ///
     /// Also prunes entries older than 120 seconds from the table to keep it small.
     pub fn record_totp_code_used(&self, code: &str) {
+        self.record_totp_code_used_for(code, None);
+    }
+
+    /// Record a successfully-verified TOTP code, binding it to the action it
+    /// authorized (#3360).
+    ///
+    /// `bound_to` is an opaque action key — typically `"approval:<uuid>"` for
+    /// per-action TOTP, or `None` for non-action TOTP (enrollment confirm,
+    /// revoke). The binding is written into `totp_used_codes.bound_to` so an
+    /// auditor can prove which action a given TOTP code authorized; replay
+    /// detection itself remains global on `code_hash` so the same code cannot
+    /// be reused for a *different* action either.
+    pub fn record_totp_code_used_for(&self, code: &str, bound_to: Option<&str>) {
         let Some(db) = &self.audit_db else { return };
         let Ok(conn) = db.lock() else { return };
         let hash = Self::totp_code_hash(code);
@@ -1253,13 +1282,19 @@ impl ApprovalManager {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs() as i64;
-        // Upsert the used-code entry.
-        let _ = conn.execute(
-            "INSERT INTO totp_used_codes (code_hash, used_at)
-             VALUES (?1, ?2)
-             ON CONFLICT(code_hash) DO UPDATE SET used_at = excluded.used_at",
-            rusqlite::params![hash, now_unix],
-        );
+        // Upsert the used-code entry. `bound_to` is informational; the unique
+        // key is still `code_hash` so any replay of the same code is rejected
+        // regardless of which action it claims to authorize.
+        if let Err(e) = conn.execute(
+            "INSERT INTO totp_used_codes (code_hash, used_at, bound_to)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(code_hash) DO UPDATE SET
+                 used_at  = excluded.used_at,
+                 bound_to = excluded.bound_to",
+            rusqlite::params![hash, now_unix, bound_to],
+        ) {
+            warn!(error = %e, "failed to record TOTP code used");
+        }
         // Prune entries older than 120 seconds.
         let prune_before = now_unix - 120;
         let _ = conn.execute(
@@ -2709,6 +2744,22 @@ mod tests {
         // It must be a 64-character hex string (SHA-256 output).
         assert_eq!(hash.len(), 64);
         assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// Issue #3360: TOTP codes must remain single-use across approvals — even
+    /// if an attacker rewrites the path of an in-flight `(code, approve)`
+    /// request to a *different* approval id, the second use of that code is
+    /// rejected because `is_totp_code_used` is keyed on the code hash alone.
+    /// `record_totp_code_used_for` records the binding for audit but does not
+    /// scope replay detection.
+    #[test]
+    fn issue_3360_totp_code_single_use_across_actions() {
+        let mgr = make_manager_with_db();
+        mgr.record_totp_code_used_for("987654", Some("approval:11111111-1111-1111-1111-111111111111"));
+        // Same code claimed for a different approval — must still be flagged
+        // as used. Without this an attacker rewriting the path could replay
+        // a captured TOTP request to authorize a higher-impact approval.
+        assert!(mgr.is_totp_code_used("987654"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 30;
+const SCHEMA_VERSION: u32 = 31;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -69,6 +69,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(28, migrate_v28);
     run_step!(29, migrate_v29);
     run_step!(30, migrate_v30);
+    run_step!(31, migrate_v31);
 
     Ok(())
 }
@@ -923,6 +924,24 @@ fn migrate_v30(conn: &Connection) -> Result<(), rusqlite::Error> {
     Ok(())
 }
 
+/// Version 31: Bind TOTP used codes to the action they authorized (#3360).
+///
+/// Adds a nullable `bound_to` column on `totp_used_codes` so an auditor can
+/// prove which action a given TOTP code authorized (e.g.
+/// `"approval:<uuid>"`). Replay detection itself is unchanged — it still
+/// keys on `code_hash` so a code is single-use across all actions.
+fn migrate_v31(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !column_exists(conn, "totp_used_codes", "bound_to") {
+        conn.execute_batch("ALTER TABLE totp_used_codes ADD COLUMN bound_to TEXT;")?;
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (31, datetime('now'), 'Bind totp_used_codes to the action they authorized (#3360)')",
+        [],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -1161,5 +1180,29 @@ mod tests {
         run_migrations(&conn).unwrap();
         run_migrations(&conn).unwrap();
         assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
+    }
+
+    /// Issue #3360: v31 adds the `bound_to` column on `totp_used_codes` so
+    /// each consumed TOTP code can be tied to the action it authorized.
+    #[test]
+    fn test_migrate_v31_adds_bound_to_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        assert!(column_exists(&conn, "totp_used_codes", "bound_to"));
+
+        // Inserting with an explicit binding works.
+        conn.execute(
+            "INSERT INTO totp_used_codes (code_hash, used_at, bound_to) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["deadbeef", 2_000_i64, "approval:abc"],
+        )
+        .unwrap();
+        let bound: String = conn
+            .query_row(
+                "SELECT bound_to FROM totp_used_codes WHERE code_hash = 'deadbeef'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(bound, "approval:abc");
     }
 }


### PR DESCRIPTION
## Summary

Five small, independent authz fixes on the HTTP surface, plus the schema bump
they need.

- **Closes #3361** — `/api/uploads/{file_id}` now owner-binds files to the
  uploader's `UserId`. Cross-user UUID guessing returns 403 instead of the
  bytes; daemon-generated content (`uploaded_by = None`) stays readable.
- **Closes #3360** — per-action TOTP records the consumed code together with
  the approval id it authorized (`bound_to = "approval:<uuid>"`). Replay
  detection itself remains keyed on `code_hash` so a captured `(code, A)`
  request rewritten to approve `B` fails on the second use.
- **Closes #3372** — `persist_totp_lockout_clear` now surfaces DB write
  failures, and the remaining `let _ = record_totp_failure(...)` early
  paths in `system.rs` were converted to the same fail-secure-500 that the
  success path already used. A daemon restart can no longer reset the
  brute-force counter via a silent persist failure.
- **Closes #3458** — `POST /api/config/set` is now gated by an allowlist of
  user-tunable paths (`ui.*`, `log_level`, `max_history_messages`,
  `approval.auto_approve*`, `approval.totp_grace_period_secs`, `channels.*`,
  `web.*`, `rate_limit.*`, `queue.*`). Anything ending in `.api_key`,
  `.token`, `.secret`, `.shared_secret`, `.password`, `.bypass`, `.admin`,
  or `.owner` is scrubbed even inside an allowed section. Auth, credentials,
  2FA policy, network, and migration paths must now be edited on disk.
- **Closes #3610** — drop the dashboard `buildAuthenticatedWebSocketUrl`
  deprecated shim (no callers left after the `bearer.<token>` migration) and
  fail-closed reject any WS upgrade still carrying `?token=` on
  `/api/agents/{id}/ws` and `/api/terminal/ws` so stale clients get a loud
  401 instead of silent credential leakage into proxy logs.

Adds schema v29: a nullable `bound_to` column on `totp_used_codes` for the
per-approval audit binding.

## Test plan

- [ ] `cargo test -p librefang-api` — covers the new
      `issue_3458_writable_path_allowlist`, `issue_3361_upload_meta_carries_owner`,
      and `issue_3610_query_token_visibility_helper` regressions.
- [ ] `cargo test -p librefang-kernel` — covers
      `issue_3360_totp_code_single_use_across_actions`.
- [ ] `cargo test -p librefang-memory` — covers `test_migrate_v29_adds_bound_to_column`.
- [ ] Smoke `curl /api/uploads/<uuid>` from a second user's bearer token →
      expect 403 when `uploaded_by` is set, 200 when it is `None`.
- [ ] Smoke `POST /api/config/set` with `path = "default_model.api_key"` →
      expect 403 with the user-tunable-only error.
- [ ] Smoke a WS connect with `?token=...` → expect 401 with the deprecation
      warn line in the daemon log.