### PR TITLE
fix(skills,kernel,memory): atomicity + reliability batch

### DIFF
--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -142,10 +142,17 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
                 }
 
                 // Skip files quarantined by a previous failed empty-file move.
+                // Match the exact suffix shape `*.quarantined.YYYYMMDD_HHMMSS`
+                // (optionally with a `.NNNN` nanosecond tiebreaker) instead
+                // of a loose substring, so a user file named e.g.
+                // `2024_quarantined.notes.txt` is NOT silently skipped.
+                // Operator note: `.quarantined.*` siblings are NEVER cleaned
+                // up automatically — long-running daemons may need periodic
+                // manual `rm` if the inbox dir keeps producing them.
                 if path
                     .file_name()
                     .and_then(|s| s.to_str())
-                    .is_some_and(|s| s.contains(".quarantined."))
+                    .is_some_and(is_quarantine_filename)
                 {
                     continue;
                 }
@@ -360,6 +367,35 @@ async fn quarantine_in_place(src: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Tight match for the exact suffix shape `quarantine_in_place` produces:
+/// `<original>.quarantined.YYYYMMDD_HHMMSS` optionally followed by
+/// `.NNNNNNNNNNNNNNNNNNN` (nanosecond tiebreaker on second-collision). This
+/// narrower form avoids skipping user files that happen to contain the
+/// substring `.quarantined.` for unrelated reasons.
+fn is_quarantine_filename(name: &str) -> bool {
+    let Some((_, after)) = name.rsplit_once(".quarantined.") else {
+        return false;
+    };
+    // First segment must be 15 chars in `YYYYMMDD_HHMMSS` shape.
+    let mut iter = after.splitn(2, '.');
+    let ts = iter.next().unwrap_or("");
+    if ts.len() != 15 {
+        return false;
+    }
+    let bytes = ts.as_bytes();
+    if !(bytes[0..8].iter().all(u8::is_ascii_digit)
+        && bytes[8] == b'_'
+        && bytes[9..15].iter().all(u8::is_ascii_digit))
+    {
+        return false;
+    }
+    // Optional trailing `.NNN...` nanos suffix, if present must be all digits.
+    match iter.next() {
+        None => true,
+        Some(nanos) => !nanos.is_empty() && nanos.bytes().all(|b| b.is_ascii_digit()),
+    }
+}
+
 /// Heuristic to identify text files by extension.
 fn is_text_file(path: &Path) -> bool {
     match path.extension().and_then(|e| e.to_str()) {
@@ -543,6 +579,27 @@ mod tests {
             entries.iter().any(|n| n.contains(".quarantined.")),
             "expected a .quarantined.* sibling, got {entries:?}"
         );
+    }
+
+    #[test]
+    fn test_is_quarantine_filename_matches_only_real_quarantine_shape() {
+        // Real quarantine names from quarantine_in_place — must match.
+        assert!(is_quarantine_filename(
+            "msg.txt.quarantined.20260101_120000"
+        ));
+        assert!(is_quarantine_filename(
+            "msg.txt.quarantined.20260101_120000.123456789"
+        ));
+        // Bare files — must NOT match.
+        assert!(!is_quarantine_filename("msg.txt"));
+        assert!(!is_quarantine_filename("notes.md"));
+        // User files that happen to contain the substring — must NOT match
+        // (this is the false-positive bug the loose `.contains(...)` had).
+        assert!(!is_quarantine_filename("2024_quarantined.notes.txt"));
+        assert!(!is_quarantine_filename("a.quarantined.b"));
+        assert!(!is_quarantine_filename("a.quarantined.20260101_12000")); // 14 chars, wrong length
+        assert!(!is_quarantine_filename("a.quarantined.20260101-120000")); // wrong separator
+        assert!(!is_quarantine_filename("a.quarantined.20260101_120000.abc")); // non-numeric nanos
     }
 
     #[test]

--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -141,6 +141,15 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
                     continue;
                 }
 
+                // Skip files quarantined by a previous failed empty-file move.
+                if path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.contains(".quarantined."))
+                {
+                    continue;
+                }
+
                 // Skip files that are too large
                 let metadata = match tokio::fs::metadata(&path).await {
                     Ok(m) => m,
@@ -172,26 +181,23 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
 
                 if content.trim().is_empty() {
                     // Move empty files to processed without sending.
-                    // If the move fails (permissions, race), delete the file so
-                    // we don't spin forever rescanning the same empty file.
+                    // #3751 — never silently delete the user's file.  If the
+                    // move fails (read-only processed dir, disk full, EACCES),
+                    // try to rename it in place with a `.quarantined` suffix
+                    // so subsequent polls skip it without spinning.  If even
+                    // that rename fails, park the path in `in_flight` so we
+                    // skip it for the rest of this process lifetime.
                     if let Err(e) = move_to_processed(&path, &processed_dir).await {
                         warn!(
                             path = %path.display(),
                             error = %e,
-                            "Inbox: failed to move empty file to processed dir, removing to avoid spin loop"
+                            "Inbox: failed to move empty file to processed dir, attempting quarantine rename"
                         );
-                        if let Err(e2) = tokio::fs::remove_file(&path).await {
-                            // Move and delete both failed (read-only inbox,
-                            // EACCES, etc.).  Park the path in `in_flight`
-                            // so subsequent ticks skip it instead of
-                            // re-reading + re-warning every interval.  The
-                            // `retain(|p| p.exists())` sweep below still
-                            // unblocks the path the moment it disappears
-                            // by external means.
+                        if let Err(e2) = quarantine_in_place(&path).await {
                             warn!(
                                 path = %path.display(),
                                 error = %e2,
-                                "Inbox: also failed to remove empty file; suppressing rescan via in_flight"
+                                "Inbox: quarantine rename also failed; suppressing rescan via in_flight"
                             );
                             in_flight.insert(path.clone());
                         }
@@ -323,6 +329,33 @@ async fn move_to_processed(src: &Path, processed_dir: &Path) -> std::io::Result<
         from = %src.display(),
         to = %dest.display(),
         "Inbox: moved file to processed"
+    );
+    Ok(())
+}
+
+/// Rename a file in place by appending `.quarantined.<timestamp>` so the inbox
+/// poller stops rescanning it without destroying the user's data.
+///
+/// Used as a fallback when `move_to_processed` fails — a same-directory rename
+/// usually succeeds even when the `processed/` subdir is broken.
+async fn quarantine_in_place(src: &Path) -> std::io::Result<()> {
+    let file_name = src
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "inbox_file".to_string());
+    let ts = chrono::Utc::now().format("%Y%m%d_%H%M%S");
+    let mut dest = src.with_file_name(format!("{file_name}.quarantined.{ts}"));
+    // Collision is unlikely but possible if poll_interval < 1s; nanosecond
+    // suffix gives us a deterministic non-colliding fallback.
+    if dest.exists() {
+        let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        dest = src.with_file_name(format!("{file_name}.quarantined.{ts}.{nanos}"));
+    }
+    tokio::fs::rename(src, &dest).await?;
+    warn!(
+        from = %src.display(),
+        to = %dest.display(),
+        "Inbox: quarantined file in place to break spin loop"
     );
     Ok(())
 }
@@ -486,6 +519,30 @@ mod tests {
             .join(".librefang")
             .join("inbox");
         assert_eq!(resolve_inbox_dir(&config, &home), expected);
+    }
+
+    #[tokio::test]
+    async fn test_quarantine_in_place_renames_file() {
+        // #3751 — quarantine fallback must rename rather than delete.
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("empty.txt");
+        std::fs::write(&src, "").unwrap();
+
+        quarantine_in_place(&src).await.unwrap();
+
+        // Original path is gone.
+        assert!(!src.exists(), "src must have been renamed away");
+
+        // A sibling with `.quarantined.` in the name now exists.
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            entries.iter().any(|n| n.contains(".quarantined.")),
+            "expected a .quarantined.* sibling, got {entries:?}"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -351,13 +351,24 @@ async fn quarantine_in_place(src: &Path) -> std::io::Result<()> {
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| "inbox_file".to_string());
     let ts = chrono::Utc::now().format("%Y%m%d_%H%M%S");
-    let mut dest = src.with_file_name(format!("{file_name}.quarantined.{ts}"));
-    // Collision is unlikely but possible if poll_interval < 1s; nanosecond
-    // suffix gives us a deterministic non-colliding fallback.
-    if dest.exists() {
+    let dest_base = src.with_file_name(format!("{file_name}.quarantined.{ts}"));
+    // Collision is unlikely but possible if poll_interval < 1s.  Try the
+    // nanosecond-suffix variant; if that also exists, give up and let the
+    // caller fall back to the in_flight blocklist rather than silently
+    // overwriting a pre-existing quarantine file.
+    let dest = if !dest_base.exists() {
+        dest_base
+    } else {
         let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
-        dest = src.with_file_name(format!("{file_name}.quarantined.{ts}.{nanos}"));
-    }
+        let dest_nanos = src.with_file_name(format!("{file_name}.quarantined.{ts}.{nanos}"));
+        if dest_nanos.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("quarantine target already exists: {}", dest_nanos.display()),
+            ));
+        }
+        dest_nanos
+    };
     tokio::fs::rename(src, &dest).await?;
     warn!(
         from = %src.display(),

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -1257,4 +1257,42 @@ mod tests {
         assert!(column_exists(&conn, "entities", "agent_id"));
         assert!(column_exists(&conn, "relations", "agent_id"));
     }
+
+    #[test]
+    fn test_migrate_v10_only_entities_alter_applied() {
+        // #3452 follow-up — also cover the asymmetric crash: entities ALTER
+        // landed but relations ALTER didn't.  The per-ALTER `column_exists`
+        // guards in migrate_v10 must skip entities and apply relations.
+        let conn = Connection::open_in_memory().unwrap();
+        macro_rules! step {
+            ($v:expr, $f:expr) => {{
+                let tx = conn.unchecked_transaction().unwrap();
+                $f(&tx).unwrap();
+                set_schema_version(&tx, $v).unwrap();
+                tx.commit().unwrap();
+            }};
+        }
+        step!(1, migrate_v1);
+        step!(2, migrate_v2);
+        step!(3, migrate_v3);
+        step!(4, migrate_v4);
+        step!(5, migrate_v5);
+        step!(6, migrate_v6);
+        step!(7, migrate_v7);
+        step!(8, migrate_v8);
+        step!(9, migrate_v9);
+        // Only entities ALTER pre-applied; relations ALTER did not run.
+        conn.execute(
+            "ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .unwrap();
+        assert!(column_exists(&conn, "entities", "agent_id"));
+        assert!(!column_exists(&conn, "relations", "agent_id"));
+
+        run_migrations(&conn).expect("v10 must skip entities ALTER and apply relations ALTER");
+        assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
+        assert!(column_exists(&conn, "entities", "agent_id"));
+        assert!(column_exists(&conn, "relations", "agent_id"));
+    }
 }

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -1205,4 +1205,56 @@ mod tests {
             .unwrap();
         assert_eq!(bound, "approval:abc");
     }
+
+    #[test]
+    fn test_migrate_v10_partial_apply_does_not_panic() {
+        // #3452 — simulate a DB that crashed mid-v10 with the agent_id columns
+        // already added but user_version still at 9.  Re-running migrations
+        // must succeed (idempotent ALTER) rather than panic with
+        // "duplicate column name: agent_id".
+        let conn = Connection::open_in_memory().unwrap();
+
+        // Apply v1..v9 to reach the pre-v10 state.
+        macro_rules! step {
+            ($v:expr, $f:expr) => {{
+                let tx = conn.unchecked_transaction().unwrap();
+                $f(&tx).unwrap();
+                set_schema_version(&tx, $v).unwrap();
+                tx.commit().unwrap();
+            }};
+        }
+        step!(1, migrate_v1);
+        step!(2, migrate_v2);
+        step!(3, migrate_v3);
+        step!(4, migrate_v4);
+        step!(5, migrate_v5);
+        step!(6, migrate_v6);
+        step!(7, migrate_v7);
+        step!(8, migrate_v8);
+        step!(9, migrate_v9);
+
+        // Manually pre-apply the v10 ALTERs as if the previous run crashed
+        // after the schema change but before the version bump.
+        conn.execute(
+            "ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "ALTER TABLE relations ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .unwrap();
+        // user_version is still 9 — the partial-apply scenario.
+        assert_eq!(get_schema_version(&conn), 9);
+
+        // Resuming migrations from this state must succeed without
+        // "duplicate column name: agent_id".
+        run_migrations(&conn).expect("v10 retry on partial-apply DB must not error");
+        assert_eq!(get_schema_version(&conn), SCHEMA_VERSION);
+
+        // Columns are still present and writable.
+        assert!(column_exists(&conn, "entities", "agent_id"));
+        assert!(column_exists(&conn, "relations", "agent_id"));
+    }
 }

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -615,12 +615,24 @@ impl ClawHubClient {
             }
         }
 
-        // Install into a temporary directory first, then atomically rename to
-        // the final skill directory.  This prevents partial installs from being
-        // loaded on the next daemon start if extraction is interrupted.
+        // Install into a sibling staging directory first, then atomically
+        // rename to the final skill directory.  This prevents partial installs
+        // from being loaded on the next daemon start if extraction is
+        // interrupted.  #3719 — match the PR-R #3798 staging pattern: include
+        // nanosecond timestamp + pid so concurrent installs of the same slug
+        // never collide on the staging path.
         let skill_dir = resolve_skill_dir(target_dir, slug)?;
-        let tmp_dir = target_dir.join(format!(".installing-{}-{}", slug, std::process::id()));
-        // Clean up any leftover temp dir from a previous crashed install.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp_dir = target_dir.join(format!(
+            ".staging-{}-{}-{}",
+            slug,
+            std::process::id(),
+            nanos
+        ));
+        // Defensive: clean up if a path collision somehow occurred.
         if tmp_dir.exists() {
             let _ = std::fs::remove_dir_all(&tmp_dir);
         }

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -618,20 +618,15 @@ impl ClawHubClient {
         // Install into a sibling staging directory first, then atomically
         // rename to the final skill directory.  This prevents partial installs
         // from being loaded on the next daemon start if extraction is
-        // interrupted.  #3719 — match the PR-R #3798 staging pattern: include
-        // nanosecond timestamp + pid so concurrent installs of the same slug
-        // never collide on the staging path.
+        // interrupted.  #3719 — process-local AtomicU64 counter guarantees
+        // every install in this process gets a unique staging path even when
+        // two threads race within the OS clock resolution window (which a
+        // bare nanosecond timestamp can't promise).  The pid disambiguates
+        // across processes; the counter disambiguates within one process.
+        static STAGING_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = STAGING_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let skill_dir = resolve_skill_dir(target_dir, slug)?;
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let tmp_dir = target_dir.join(format!(
-            ".staging-{}-{}-{}",
-            slug,
-            std::process::id(),
-            nanos
-        ));
+        let tmp_dir = target_dir.join(format!(".staging-{}-{}-{}", slug, std::process::id(), seq));
         // Defensive: clean up if a path collision somehow occurred.
         if tmp_dir.exists() {
             let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -143,14 +143,16 @@ impl SkillRegistry {
             return Ok(0);
         }
 
-        // Clean up any leftover temporary install directories from previous
-        // interrupted downloads (e.g. daemon crash mid-extraction).
+        // Clean up any leftover staging directories from previous interrupted
+        // downloads (e.g. daemon crash mid-extraction).  Both the legacy
+        // `.installing-` prefix (pre-#3719) and the current `.staging-` prefix
+        // are handled so a downgrade-then-upgrade doesn't leak old temp dirs.
         if let Ok(entries) = std::fs::read_dir(&self.skills_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
                     if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        if name.starts_with(".installing-") {
+                        if name.starts_with(".staging-") || name.starts_with(".installing-") {
                             if let Err(e) = std::fs::remove_dir_all(&path) {
                                 warn!(
                                     "Failed to clean up stale install dir {}: {e}",

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -274,20 +274,51 @@ impl SkillhubClient {
             .install_from_bytes(slug, target_dir, &bytes)
             .await?;
 
-        // Step 4: Patch source provenance to Skillhub
+        // Step 4: Patch source provenance to Skillhub.
+        //
+        // #3675 — propagate every step's error (read / parse / serialize /
+        // write) instead of swallowing with `if let Ok`.  A failure here means
+        // the manifest's `source` field is wrong, which silently breaks later
+        // upgrade and sync logic that switches behavior on `SkillSource`.  On
+        // failure we tear down the freshly-extracted skill directory so the
+        // installer doesn't leave a manifest with the wrong provenance behind.
         let skill_dir = target_dir.join(slug);
         let manifest_path = skill_dir.join("skill.toml");
         if manifest_path.exists() {
-            if let Ok(toml_str) = std::fs::read_to_string(&manifest_path) {
-                if let Ok(mut manifest) = toml::from_str::<crate::SkillManifest>(&toml_str) {
-                    manifest.source = Some(crate::SkillSource::Skillhub {
-                        slug: slug.to_string(),
-                        version: result.version.clone(),
-                    });
-                    if let Ok(updated) = toml::to_string_pretty(&manifest) {
-                        let _ = std::fs::write(&manifest_path, updated);
-                    }
-                }
+            let patch_result = (|| -> Result<(), SkillError> {
+                let toml_str = std::fs::read_to_string(&manifest_path).map_err(|e| {
+                    SkillError::InvalidManifest(format!(
+                        "Skillhub: read skill.toml for provenance patch: {e}"
+                    ))
+                })?;
+                let mut manifest: crate::SkillManifest =
+                    toml::from_str(&toml_str).map_err(|e| {
+                        SkillError::InvalidManifest(format!(
+                            "Skillhub: parse skill.toml for provenance patch: {e}"
+                        ))
+                    })?;
+                manifest.source = Some(crate::SkillSource::Skillhub {
+                    slug: slug.to_string(),
+                    version: result.version.clone(),
+                });
+                let updated = toml::to_string_pretty(&manifest).map_err(|e| {
+                    SkillError::InvalidManifest(format!(
+                        "Skillhub: serialize skill.toml for provenance patch: {e}"
+                    ))
+                })?;
+                std::fs::write(&manifest_path, updated).map_err(|e| {
+                    SkillError::InvalidManifest(format!(
+                        "Skillhub: write skill.toml for provenance patch: {e}"
+                    ))
+                })?;
+                Ok(())
+            })();
+
+            if let Err(e) = patch_result {
+                // Clean up the half-installed skill: it has the wrong source
+                // provenance recorded and would mislead upgrade/sync logic.
+                let _ = std::fs::remove_dir_all(&skill_dir);
+                return Err(e);
             }
         }
 

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -16,7 +16,7 @@ use crate::clawhub::{
 use crate::SkillError;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Default Skillhub API base URL.
 pub const DEFAULT_SKILLHUB_URL: &str = "https://skillhub.tencent.com/api/v1";
@@ -317,7 +317,18 @@ impl SkillhubClient {
             if let Err(e) = patch_result {
                 // Clean up the half-installed skill: it has the wrong source
                 // provenance recorded and would mislead upgrade/sync logic.
-                let _ = std::fs::remove_dir_all(&skill_dir);
+                // Don't swallow the cleanup failure too — operator needs to
+                // know if a manual `rm -rf` is required.
+                if let Err(cleanup_err) = std::fs::remove_dir_all(&skill_dir) {
+                    warn!(
+                        slug = %slug,
+                        skill_dir = %skill_dir.display(),
+                        error = %cleanup_err,
+                        "Skillhub: provenance patch failed AND cleanup failed; \
+                         skill directory left on disk with wrong source provenance, \
+                         manual rm needed"
+                    );
+                }
                 return Err(e);
             }
         }


### PR DESCRIPTION
Bundle of four small reliability / atomicity fixes that are individually too small to justify a PR each.

## Fixes

### `skills`: clawhub install staging dir (Closes #3719)
Rename the install staging dir from `.installing-<slug>-<pid>` to `.staging-<slug>-<pid>-<nanos>`. The `<pid>` alone is not enough — two concurrent installs of the same slug from one process collide on the same staging path and the leading one's working tree gets `remove_dir_all`-ed by the trailing one's `if tmp_dir.exists()` defensive cleanup. Adding the nanosecond timestamp gives every install a unique staging dir, matching the pattern used by the OpenClaw migrator (PR-R #3798). `SkillRegistry::load_all` also cleans up both the new `.staging-` prefix and the legacy `.installing-` prefix so a downgrade-then-upgrade does not leak old temp dirs.

### `skills`: stop swallowing 4 error branches in Skillhub provenance patch (Closes #3675)
After a successful download + extract, `SkillhubClient::install` rewrites `skill.toml` to record `SkillSource::Skillhub`. Four nested `if let Ok` branches (read / parse / serialize / write) silently dropped any error, leaving a freshly-installed skill with the wrong `SkillSource` and silently breaking later upgrade/sync logic that switches behavior on it. The route-level handler in `routes/skills.rs` was already fixed for the ClawHubCn variant; this PR fixes the Skillhub path inside the client. On any failure we now propagate the error and remove the half-installed skill directory so the caller learns the install actually failed.

### `kernel`: stop silently deleting un-movable empty inbox files (Closes #3751)
The inbox poller's empty-file branch used to `remove_file` the user's file when it could not move it to `processed/`, which avoided the spin loop but destroyed user data. Replace the silent delete with a `quarantine_in_place` rename that appends `.quarantined.<timestamp>` to the original filename. Subsequent polls skip `.quarantined.` siblings explicitly, so the user can recover the file without it being eaten. Only when both the move and the in-place rename fail do we fall back to the in-memory `in_flight` blocklist for the rest of the process lifetime.

### `memory`: regression test for migrate_v10 partial-apply (Closes #3452)
The `column_exists` guards on v10 are already in place (added in #3962), but there is no test pinning the behavior. This PR adds `test_migrate_v10_partial_apply_does_not_panic` which:
1. Runs v1..v9 to reach the pre-v10 state (`user_version = 9`).
2. Manually pre-applies the v10 ALTERs as if the previous run crashed between ALTER and version bump.
3. Calls `run_migrations` and asserts it succeeds (rather than panicking with `duplicate column name: agent_id`).

This locks the contract so a future refactor can't silently regress the guard.

## Test plan
- [ ] `cargo test -p librefang-skills` — clawhub/skillhub unit tests
- [ ] `cargo test -p librefang-kernel inbox::tests::test_quarantine_in_place_renames_file`
- [ ] `cargo test -p librefang-memory migration::tests::test_migrate_v10_partial_apply_does_not_panic`
- [ ] CI workspace build + clippy