### PR TITLE
fix(kernel): harden task lifecycle (panics, locks, races)

### DIFF
--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -798,7 +798,7 @@ pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
         return;
     }
 
-    tokio::spawn(async move {
+    crate::supervised_spawn::spawn_supervised("auto_dream_dispatch", async move {
         // Re-check all three gates inside the task. The operator could have
         // flipped the global switch, toggled this agent off, or started a
         // shutdown in the microseconds between the synchronous pre-filter
@@ -909,7 +909,7 @@ impl librefang_runtime::hooks::HookHandler for AutoDreamTurnEndHook {
 }
 
 pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
-    tokio::spawn(async move {
+    crate::supervised_spawn::spawn_supervised("auto_dream_scheduler", async move {
         {
             let cfg = kernel.config_snapshot();
             if cfg.auto_dream.enabled {
@@ -1164,7 +1164,7 @@ pub async fn trigger_manual(kernel: Arc<LibreFangKernel>, agent_id: AgentId) -> 
             let slot = Arc::new(Mutex::new(Some(abort_tx)));
             ABORT_HANDLES.insert(agent_id, slot);
             let k = Arc::clone(&kernel);
-            tokio::spawn(async move {
+            crate::supervised_spawn::spawn_supervised("auto_dream_run", async move {
                 run_dream(k, agent_id, prior_mtime, Some(abort_rx)).await;
             });
             // task_id becomes available once run_dream installs the

--- a/crates/librefang-kernel/src/inbox.rs
+++ b/crates/librefang-kernel/src/inbox.rs
@@ -105,7 +105,7 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
         "Inbox watcher started"
     );
 
-    tokio::spawn(async move {
+    crate::supervised_spawn::spawn_supervised("inbox_watcher", async move {
         let mut interval = tokio::time::interval(poll_interval);
         // Track files we have already queued so a slow send_message doesn't
         // cause double-processing before the file is moved.
@@ -252,7 +252,7 @@ pub fn start_inbox_watcher(kernel: Arc<LibreFangKernel>) {
                     .to_string_lossy()
                     .to_string();
 
-                tokio::spawn(async move {
+                crate::supervised_spawn::spawn_supervised("inbox_dispatch", async move {
                     let inbox_prompt = format!("[INBOX FILE: {file_name}]\n{message}");
 
                     info!(

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -474,6 +474,10 @@ fn resolve_dispatch_session_id(
 pub(crate) struct RunningTask {
     pub(crate) abort: tokio::task::AbortHandle,
     pub(crate) started_at: chrono::DateTime<chrono::Utc>,
+    /// Unique id for this turn — used by cleanup to ensure a task only
+    /// removes its OWN entry from `running_tasks`, never a successor's
+    /// (#3445 stale-entry guard). Compared with `Uuid` equality.
+    pub(crate) task_id: uuid::Uuid,
 }
 
 pub struct LibreFangKernel {
@@ -914,23 +918,14 @@ use workspace_setup::*;
 /// `tokio::spawn` drops panics when the returned `JoinHandle` is not awaited.
 /// This wrapper catches any panic from the inner future and logs it at `error`
 /// level so it surfaces in traces and structured logs.
+///
+/// Thin alias over [`crate::supervised_spawn::spawn_supervised`] (#3740) — kept
+/// for the existing `spawn_logged(tag, fut)` call sites in this file.
 fn spawn_logged(
     tag: &'static str,
     fut: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> tokio::task::JoinHandle<()> {
-    use futures::FutureExt as _;
-    tokio::spawn(async move {
-        if let Err(e) = std::panic::AssertUnwindSafe(fut).catch_unwind().await {
-            let msg = if let Some(s) = e.downcast_ref::<&str>() {
-                (*s).to_string()
-            } else if let Some(s) = e.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "(non-string panic payload)".to_string()
-            };
-            tracing::error!(tag, "spawned task panicked: {msg}");
-        }
-    })
+    crate::supervised_spawn::spawn_supervised(tag, fut)
 }
 
 // ── Public Facade Getters ────────────────────────────────────────────
@@ -956,9 +951,16 @@ impl LibreFangKernel {
     /// runtime via [`update_budget_config`], so callers always see the
     /// latest values set through the API.
     pub fn budget_config(&self) -> librefang_types::config::BudgetConfig {
+        // Recover from poisoning instead of panicking — a panic here would
+        // kill every LLM turn that needs a budget check (#3447).
         self.budget_config
             .read()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(|p| {
+                tracing::warn!(
+                    "budget_config read lock was poisoned, recovering with last-known state"
+                );
+                p.into_inner()
+            })
             .clone()
     }
 
@@ -971,7 +973,12 @@ impl LibreFangKernel {
         let mut guard = self
             .budget_config
             .write()
-            .unwrap_or_else(|p| p.into_inner());
+            .unwrap_or_else(|p| {
+                tracing::warn!(
+                    "budget_config write lock was poisoned, recovering with last-known state"
+                );
+                p.into_inner()
+            });
         f(&mut guard);
     }
 
@@ -5390,7 +5397,7 @@ system_prompt = "You are a helpful assistant."
                     let review_agent_id = agent_id;
                     let audit_log_success = audit_log.clone();
                     let agent_id_for_success = agent_id_str.clone();
-                    let review_handle = tokio::spawn(async move {
+                    let review_handle = spawn_logged("auto_memorize", async move {
                         // Move the permit into the task so it's released
                         // on task exit. Binding it to `_permit` keeps
                         // clippy happy (dropped at end of scope).
@@ -6339,6 +6346,11 @@ system_prompt = "You are a helpful assistant."
             },
         );
 
+        // Unique id for this turn — used by cleanup-side `remove_if` so a
+        // late-finishing predecessor never wipes out a successor's entry
+        // (#3445 stale-entry guard).
+        let turn_task_id = uuid::Uuid::new_v4();
+
         // Reload session after acquiring the lock so we never act on a stale
         // snapshot captured before a concurrent turn's writes landed.
         let handle = tokio::spawn(async move {
@@ -6771,9 +6783,14 @@ system_prompt = "You are a helpful assistant."
                         kernel_clone
                             .session_interrupts
                             .remove(&(agent_id, effective_session_id));
+                        // #3445: only remove if THIS turn's entry is still
+                        // present — a faster successor turn may have already
+                        // swapped it for its own RunningTask.
                         kernel_clone
                             .running_tasks
-                            .remove(&(agent_id, effective_session_id));
+                            .remove_if(&(agent_id, effective_session_id), |_, v| {
+                                v.task_id == turn_task_id
+                            });
                     }
                     Ok(result)
                 }
@@ -6798,9 +6815,13 @@ system_prompt = "You are a helpful assistant."
                         kernel_clone
                             .session_interrupts
                             .remove(&(agent_id, effective_session_id));
+                        // #3445: only remove if THIS turn's entry is still
+                        // present — see Ok branch above.
                         kernel_clone
                             .running_tasks
-                            .remove(&(agent_id, effective_session_id));
+                            .remove_if(&(agent_id, effective_session_id), |_, v| {
+                                v.task_id == turn_task_id
+                            });
                     }
                     Err(KernelError::LibreFang(e))
                 }
@@ -6823,20 +6844,43 @@ system_prompt = "You are a helpful assistant."
             // can never both observe an empty slot and lose one of the
             // abort handles.  The earlier `remove(...) → insert(...)`
             // sequence had exactly that race window.
-            let new_task = RunningTask {
-                abort: handle.abort_handle(),
-                started_at: chrono::Utc::now(),
-            };
-            if let Some(old_task) = self
-                .running_tasks
-                .insert((agent_id, effective_session_id), new_task)
-            {
+            //
+            // #3445: skip insert if the task already finished while we
+            // were preparing to register it. The task's own cleanup
+            // path uses `remove_if(... task_id matches ...)`, but if it
+            // ran before our insert, the cleanup found nothing to
+            // remove and our insert here would leave a stale handle
+            // forever. `is_finished()` closes that window.
+            //
+            // Residual race: if the task finishes between is_finished()
+            // returning false and the insert below, cleanup already ran
+            // and found nothing; insert then leaves a completed entry.
+            // The entry is harmless — AbortHandle::abort() on an already-
+            // finished task is a no-op, and the next turn for the same
+            // (agent, session) will overwrite it with a fresh RunningTask.
+            if handle.is_finished() {
                 tracing::debug!(
                     agent_id = %agent_id,
                     session_id = %effective_session_id,
-                    "aborting previous running task before starting new one"
+                    "spawned task already finished; skipping running_tasks registration"
                 );
-                old_task.abort.abort();
+            } else {
+                let new_task = RunningTask {
+                    abort: handle.abort_handle(),
+                    started_at: chrono::Utc::now(),
+                    task_id: turn_task_id,
+                };
+                if let Some(old_task) = self
+                    .running_tasks
+                    .insert((agent_id, effective_session_id), new_task)
+                {
+                    tracing::debug!(
+                        agent_id = %agent_id,
+                        session_id = %effective_session_id,
+                        "aborting previous running task before starting new one"
+                    );
+                    old_task.abort.abort();
+                }
             }
         }
 
@@ -7021,7 +7065,7 @@ system_prompt = "You are a helpful assistant."
         // Note: this is kernel-scoped (not agent-scoped) — sending owner
         // notifications via channel adapters touches `kernel.send_channel_message`
         // which has its own lifecycle. No per-agent tracking needed here.
-        tokio::spawn(async move {
+        spawn_logged("owner_notify", async move {
             let kernel = match weak.upgrade() {
                 Some(k) => k,
                 None => return,
@@ -11448,7 +11492,7 @@ system_prompt = "You are a helpful assistant."
                         // using the now-updated effective list).
                         if let Some(weak) = self.self_handle.get() {
                             if let Some(kernel) = weak.upgrade() {
-                                tokio::spawn(async move {
+                                spawn_logged("mcp_reconnect", async move {
                                     for name in &to_reconnect {
                                         kernel.disconnect_mcp_server(name).await;
                                     }
@@ -12530,7 +12574,7 @@ system_prompt = "You are a helpful assistant."
             let kernel = Arc::clone(self);
             // Stagger agent startup to prevent rate-limit storm on shared providers.
             // Each agent gets a 500ms delay before the next one starts.
-            tokio::spawn(async move {
+            spawn_logged("background_agents_staggered_start", async move {
                 for (i, (id, name, schedule)) in bg_agents.into_iter().enumerate() {
                     kernel.start_background_for_agent(id, &name, &schedule);
                     if i > 0 {
@@ -12550,7 +12594,7 @@ system_prompt = "You are a helpful assistant."
         // Start OFP peer node if network is enabled
         if cfg.network_enabled && !cfg.network.shared_secret.is_empty() {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("ofp_node", async move {
                 kernel.start_ofp_node().await;
             });
         }
@@ -12590,7 +12634,7 @@ system_prompt = "You are a helpful assistant."
                 60
             };
             let mut shutdown_rx = self.supervisor.subscribe();
-            tokio::spawn(async move {
+            spawn_logged("local_provider_probe", async move {
                 let mut interval =
                     tokio::time::interval(std::time::Duration::from_secs(probe_interval_secs));
                 // Race the tick against the shutdown watch so daemon
@@ -12614,7 +12658,7 @@ system_prompt = "You are a helpful assistant."
         // Periodic usage data cleanup (every 24 hours, retain 90 days)
         {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("metering_cleanup", async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 3600));
                 interval.tick().await; // Skip first immediate tick
                 loop {
@@ -12701,7 +12745,7 @@ system_prompt = "You are a helpful assistant."
             let kernel = Arc::clone(self);
             let retention = cfg.audit.retention_days;
             if retention > 0 {
-                tokio::spawn(async move {
+                spawn_logged("audit_log_pruner", async move {
                     let mut interval =
                         tokio::time::interval(std::time::Duration::from_secs(24 * 3600));
                     interval.tick().await; // Skip first immediate tick
@@ -12734,7 +12778,7 @@ system_prompt = "You are a helpful assistant."
             if trim_interval > 0 {
                 let kernel = Arc::clone(self);
                 let retention = cfg.audit.retention.clone();
-                tokio::spawn(async move {
+                spawn_logged("audit_retention_trim", async move {
                     let mut interval =
                         tokio::time::interval(std::time::Duration::from_secs(trim_interval));
                     interval.tick().await; // Skip first immediate tick.
@@ -12786,7 +12830,7 @@ system_prompt = "You are a helpful assistant."
                 session_cfg.retention_days > 0 || session_cfg.max_sessions_per_agent > 0;
             if needs_cleanup && session_cfg.cleanup_interval_hours > 0 {
                 let kernel = Arc::clone(self);
-                tokio::spawn(async move {
+                spawn_logged("session_retention_cleanup", async move {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         u64::from(session_cfg.cleanup_interval_hours) * 3600,
                     ));
@@ -12872,7 +12916,7 @@ system_prompt = "You are a helpful assistant."
         // Periodic cleanup of expired image uploads (24h TTL)
         {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("upload_cleanup", async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600)); // every hour
                 interval.tick().await; // skip first immediate tick
                 loop {
@@ -12907,7 +12951,7 @@ system_prompt = "You are a helpful assistant."
             let interval_hours = cfg.memory.consolidation_interval_hours;
             if interval_hours > 0 {
                 let kernel = Arc::clone(self);
-                tokio::spawn(async move {
+                spawn_logged("memory_consolidation", async move {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         interval_hours * 3600,
                     ));
@@ -12944,7 +12988,7 @@ system_prompt = "You are a helpful assistant."
             if decay_config.enabled && decay_config.decay_interval_hours > 0 {
                 let kernel = Arc::clone(self);
                 let interval_hours = decay_config.decay_interval_hours;
-                tokio::spawn(async move {
+                spawn_logged("memory_decay", async move {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         u64::from(interval_hours) * 3600,
                     ));
@@ -12973,7 +13017,7 @@ system_prompt = "You are a helpful assistant."
         // Periodic GC sweep for unbounded in-memory caches (every 5 minutes)
         {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("gc_sweep", async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(5 * 60));
                 interval.tick().await; // Skip first immediate tick
                 loop {
@@ -12995,7 +13039,7 @@ system_prompt = "You are a helpful assistant."
             .unwrap_or(false);
         if has_mcp {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("connect_mcp_servers", async move {
                 kernel.connect_mcp_servers().await;
             });
         }
@@ -13188,7 +13232,7 @@ system_prompt = "You are a helpful assistant."
                                 // Shadow so outer `job_name` survives the move
                                 // for the post-arm per-job persist warn.
                                 let job_name = job_name.clone();
-                                tokio::spawn(async move {
+                                spawn_logged("cron_agent_turn", async move {
                                     // Acquire the lane permit before any work
                                     // so concurrent fires are still capped.
                                     let _permit = match cron_sem_for_job.acquire_owned().await {
@@ -13482,7 +13526,7 @@ system_prompt = "You are a helpful assistant."
             if a2a_config.enabled && !a2a_config.external_agents.is_empty() {
                 let kernel = Arc::clone(self);
                 let agents = a2a_config.external_agents.clone();
-                tokio::spawn(async move {
+                spawn_logged("a2a_discover_external", async move {
                     let discovered =
                         librefang_runtime::a2a::discover_external_agents(&agents).await;
                     if let Ok(mut store) = kernel.a2a_external_agents.lock() {
@@ -13495,7 +13539,7 @@ system_prompt = "You are a helpful assistant."
         // Start WhatsApp Web gateway if WhatsApp channel is configured
         if cfg.channels.whatsapp.is_some() {
             let kernel = Arc::clone(self);
-            tokio::spawn(async move {
+            spawn_logged("whatsapp_gateway_starter", async move {
                 crate::whatsapp_gateway::start_whatsapp_gateway(&kernel).await;
             });
         }
@@ -13610,7 +13654,7 @@ system_prompt = "You are a helpful assistant."
         let config = HeartbeatConfig::from_toml(&kernel.config.load().heartbeat);
         let interval_secs = config.check_interval_secs;
 
-        tokio::spawn(async move {
+        spawn_logged("heartbeat_monitor", async move {
             let mut interval =
                 tokio::time::interval(std::time::Duration::from_secs(config.check_interval_secs));
             // Track which agents are already known-unresponsive to avoid
@@ -17026,7 +17070,7 @@ impl KernelHandle for LibreFangKernel {
                 // depth=0 scope, defeating the depth cap on chains that
                 // travel through memory updates.
                 let parent_depth = PUBLISH_EVENT_DEPTH.try_with(|c| c.get()).unwrap_or(0);
-                tokio::spawn(PUBLISH_EVENT_DEPTH.scope(
+                spawn_logged("memory_event_publish", PUBLISH_EVENT_DEPTH.scope(
                     std::cell::Cell::new(parent_depth),
                     async move {
                         kernel.publish_event(event).await;
@@ -17897,7 +17941,7 @@ impl KernelHandle for LibreFangKernel {
                     .ok_or_else(|| "Kernel self-handle unavailable".to_string())?,
             );
             let deferred_clone = def.clone();
-            tokio::spawn(async move {
+            spawn_logged("approval_resolution", async move {
                 kernel
                     .handle_approval_resolution(request_id, decision_clone, deferred_clone)
                     .await;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -970,15 +970,12 @@ impl LibreFangKernel {
     /// All writes are serialised through an `RwLock` write-guard, which
     /// eliminates the data-race hazard of the old raw-pointer approach.
     pub fn update_budget_config(&self, f: impl FnOnce(&mut librefang_types::config::BudgetConfig)) {
-        let mut guard = self
-            .budget_config
-            .write()
-            .unwrap_or_else(|p| {
-                tracing::warn!(
-                    "budget_config write lock was poisoned, recovering with last-known state"
-                );
-                p.into_inner()
-            });
+        let mut guard = self.budget_config.write().unwrap_or_else(|p| {
+            tracing::warn!(
+                "budget_config write lock was poisoned, recovering with last-known state"
+            );
+            p.into_inner()
+        });
         f(&mut guard);
     }
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17067,12 +17067,12 @@ impl KernelHandle for LibreFangKernel {
                 // depth=0 scope, defeating the depth cap on chains that
                 // travel through memory updates.
                 let parent_depth = PUBLISH_EVENT_DEPTH.try_with(|c| c.get()).unwrap_or(0);
-                spawn_logged("memory_event_publish", PUBLISH_EVENT_DEPTH.scope(
-                    std::cell::Cell::new(parent_depth),
-                    async move {
+                spawn_logged(
+                    "memory_event_publish",
+                    PUBLISH_EVENT_DEPTH.scope(std::cell::Cell::new(parent_depth), async move {
                         kernel.publish_event(event).await;
-                    },
-                ));
+                    }),
+                );
             }
         }
         Ok(())

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -3680,6 +3680,7 @@ fn test_running_tasks_two_concurrent_sessions_for_same_agent() {
         RunningTask {
             abort: h_a.abort_handle(),
             started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
         },
     );
     kernel.running_tasks.insert(
@@ -3687,6 +3688,7 @@ fn test_running_tasks_two_concurrent_sessions_for_same_agent() {
         RunningTask {
             abort: h_b.abort_handle(),
             started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
         },
     );
 
@@ -3755,6 +3757,7 @@ fn test_stop_agent_run_fans_out_across_sessions() {
         RunningTask {
             abort: mk_handle(),
             started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
         },
     );
     kernel.running_tasks.insert(
@@ -3762,6 +3765,7 @@ fn test_stop_agent_run_fans_out_across_sessions() {
         RunningTask {
             abort: mk_handle(),
             started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
         },
     );
     // Different agent — must NOT be touched by stop_agent_run.
@@ -3770,6 +3774,7 @@ fn test_stop_agent_run_fans_out_across_sessions() {
         RunningTask {
             abort: mk_handle(),
             started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
         },
     );
 
@@ -3851,6 +3856,7 @@ fn test_fork_does_not_overwrite_parent_registration() {
         RunningTask {
             abort: parent_abort,
             started_at: parent_started_at,
+            task_id: uuid::Uuid::new_v4(),
         },
     );
     let parent_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -30,6 +30,7 @@ pub mod scheduler;
 pub mod session_lifecycle;
 pub mod session_policy;
 pub mod session_stream_hub;
+pub mod supervised_spawn;
 pub mod supervisor;
 pub mod trajectory;
 pub mod triggers;

--- a/crates/librefang-kernel/src/session_stream_hub.rs
+++ b/crates/librefang-kernel/src/session_stream_hub.rs
@@ -132,7 +132,7 @@ pub fn install_stream_fanout(
         tokio::sync::mpsc::channel::<StreamEvent>(SESSION_BROADCAST_CAPACITY);
     let broadcast_tx = hub.sender(session_id);
 
-    tokio::spawn(async move {
+    crate::supervised_spawn::spawn_supervised("session_stream_fanout", async move {
         while let Some(event) = producer_rx.recv().await {
             // Best-effort fan-out to attached clients. `broadcast::send`
             // returns Err only when there are zero receivers — fine, just

--- a/crates/librefang-kernel/src/supervised_spawn.rs
+++ b/crates/librefang-kernel/src/supervised_spawn.rs
@@ -1,0 +1,84 @@
+//! Supervised `tokio::spawn` wrapper that surfaces panics (#3740).
+//!
+//! Plain `tokio::spawn(async { ... })` for fire-and-forget tasks silently
+//! drops the `JoinHandle`, so any panic inside the future vanishes — the
+//! supervisor never learns the task died, and downstream subscribers
+//! (channel listeners, cron tickers, inbox pumps, persist loops) just stop
+//! producing without an error.
+//!
+//! `spawn_supervised(name, future)` wraps the future in `AssertUnwindSafe`
+//! + `catch_unwind` so a panic is logged at `error!` level with the task
+//! name and (when available) panic payload, instead of being lost. The
+//! returned `JoinHandle` is the same shape `tokio::spawn` returns, so call
+//! sites can be migrated mechanically.
+
+use futures::FutureExt as _;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use tokio::task::JoinHandle;
+use tracing::error;
+
+/// Spawn a fire-and-forget task with panic logging.
+///
+/// `name` is purely for log correlation — pass a static string identifying
+/// the call site (e.g. `"channel_bridge_loop"`). The returned handle can
+/// be discarded; the panic is caught and logged inside the wrapper.
+///
+/// On panic the future is dropped immediately — its internal state is
+/// not preserved or retried. This wrapper is a diagnostic aid, not a
+/// restart mechanism; callers that need retry logic must implement it
+/// inside the future itself.
+pub fn spawn_supervised<F>(name: &'static str, future: F) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        // catch_unwind requires UnwindSafe; futures rarely advertise that
+        // bound but in practice tokio tasks already isolate state at the
+        // poll boundary. AssertUnwindSafe is the standard escape hatch
+        // (mirrors what the tracing-subscriber and tower implementations
+        // do for the same reason).
+        let result = AssertUnwindSafe(future).catch_unwind().await;
+        if let Err(payload) = result {
+            // Best-effort: extract a string description from the payload.
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            error!(task = name, panic = %msg, "supervised task panicked");
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn ok_path_runs_to_completion() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let f = flag.clone();
+        let h = spawn_supervised("test_ok", async move {
+            f.store(true, Ordering::SeqCst);
+        });
+        h.await.unwrap();
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn panic_is_caught_and_handle_resolves() {
+        // Without spawn_supervised, awaiting this handle would yield a
+        // JoinError. With supervision, the panic is swallowed inside and
+        // the handle resolves cleanly to ().
+        let h = spawn_supervised("test_panic", async {
+            panic!("boom");
+        });
+        let result = h.await;
+        assert!(result.is_ok(), "supervised handle must not propagate panic");
+    }
+}

--- a/crates/librefang-kernel/src/supervised_spawn.rs
+++ b/crates/librefang-kernel/src/supervised_spawn.rs
@@ -7,7 +7,7 @@
 //! producing without an error.
 //!
 //! `spawn_supervised(name, future)` wraps the future in `AssertUnwindSafe`
-//! + `catch_unwind` so a panic is logged at `error!` level with the task
+//! plus `catch_unwind` so a panic is logged at `error!` level with the task
 //! name and (when available) panic payload, instead of being lost. The
 //! returned `JoinHandle` is the same shape `tokio::spawn` returns, so call
 //! sites can be migrated mechanically.

--- a/crates/librefang-kernel/src/whatsapp_gateway.rs
+++ b/crates/librefang-kernel/src/whatsapp_gateway.rs
@@ -197,7 +197,7 @@ pub async fn start_whatsapp_gateway(kernel: &Arc<super::kernel::LibreFangKernel>
     let kernel_weak = Arc::downgrade(kernel);
     let gateway_pid = Arc::clone(&kernel.whatsapp_gateway_pid);
 
-    tokio::spawn(async move {
+    crate::supervised_spawn::spawn_supervised("whatsapp_gateway_supervisor", async move {
         let mut restarts = 0u32;
 
         loop {

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 /// Unique identifier for a workflow definition.
@@ -602,14 +602,25 @@ impl WorkflowEngine {
     }
 
     /// Async wrapper for `persist_runs` — delegates to a blocking task.
-    async fn persist_runs_async(&self) {
+    ///
+    /// Returns `Err` when the spawn_blocking task itself panics so callers
+    /// can surface the failure instead of silently dropping it (#3753).
+    /// The inner `persist_runs` already logs and swallows IO/serde errors;
+    /// only a JoinError (panic / cancel) bubbles up here.
+    async fn persist_runs_async(&self) -> Result<(), String> {
         if self.persist_path.is_none() {
-            return;
+            return Ok(());
         }
         let engine = self.clone();
         match tokio::task::spawn_blocking(move || engine.persist_runs()).await {
-            Ok(()) => {}
-            Err(e) => warn!("workflow persist task panicked: {e}"),
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // JoinError = the blocking task panicked or was cancelled.
+                // Log loudly AND propagate so the workflow run reports the
+                // persistence failure instead of pretending to have saved.
+                error!("workflow persist task panicked: {e}");
+                Err(format!("workflow persist task panicked: {e}"))
+            }
         }
     }
 
@@ -1255,7 +1266,13 @@ impl WorkflowEngine {
                 .await
         };
         self.cleanup_terminal_pause_state(run_id).await;
-        self.persist_runs_async().await;
+        // If persistence panicked, surface it instead of returning a fake Ok.
+        if let Err(persist_err) = self.persist_runs_async().await {
+            return Err(match result {
+                Ok(_) => persist_err,
+                Err(run_err) => format!("{run_err}; additionally: {persist_err}"),
+            });
+        }
         result
     }
 
@@ -1312,7 +1329,13 @@ impl WorkflowEngine {
                 .await
         };
         self.cleanup_terminal_pause_state(run_id).await;
-        self.persist_runs_async().await;
+        // Surface persist panics instead of swallowing them (#3753).
+        if let Err(persist_err) = self.persist_runs_async().await {
+            return Err(match result {
+                Ok(_) => persist_err,
+                Err(run_err) => format!("{run_err}; additionally: {persist_err}"),
+            });
+        }
         result
     }
 


### PR DESCRIPTION
## Summary

Five kernel-side fixes around spawned-task lifecycle, lock recovery,
and per-session task tracking.

- **`persist_runs_async`**: stop swallowing the outer `JoinError` from
  `spawn_blocking`. Now returns `Result<(), String>` and both
  `execute_run` / `resume_run` propagate persistence failures into the
  run result. Closes #3753.
- **`spawn_supervised` helper** in a new `supervised_spawn` module:
  wraps a fire-and-forget future in `AssertUnwindSafe(...).catch_unwind()`
  and emits a tagged `error!` on panic. Existing `spawn_logged`
  becomes a thin alias. ~14 critical-path fire-and-forget sites
  migrated (inbox, whatsapp gateway, session stream fan-out, auto_dream,
  cron agent turns, mcp connect/reconnect, a2a discover, approval
  resolution, memory event publish, daemon-loop tickers around audit
  trim / metering cleanup / memory consolidation+decay / GC sweep /
  session retention / upload cleanup / heartbeat / local provider
  probe / staggered background-agent start). Remaining raw
  `tokio::spawn` calls are in three buckets that don't fit
  fire-and-forget: test code, handles collected for join, and
  closures whose `JoinHandle` is the contract. Partially closes #3740.
- **`running_tasks` overwrite (#3739)**: kept the existing atomic
  insert-then-abort-displaced pattern under the DashMap shard lock
  and documented why it's correct. Closes #3739.
- **`running_tasks` insert-after-spawn race (#3445)**: gave
  `RunningTask` a unique `task_id` (Uuid). Cleanup uses
  `remove_if(... task_id matches ...)` so a slow predecessor can't
  evict a successor, and the registration site skips insert when
  `handle.is_finished()` so a task that completed before we got to
  register can't leave a stale `AbortHandle`. Closes #3445.
- **`budget_config` poison (#3447)**: the `RwLock` read/write paths
  already recovered with `unwrap_or_else(|p| p.into_inner())`, but
  silently. Added `tracing::warn` so operators can see when an
  upstream panic poisoned the lock. Closes #3447.

## Test plan

- [ ] CI green (clippy, workspace tests)
- [ ] Trigger a panic inside one of the migrated background loops
      (e.g. inbox watcher) — verify `error!` shows up with
      `task=inbox_watcher`
- [ ] Run two concurrent `send_message_full` calls for the same
      `(agent, session)` and verify the older `AbortHandle` is the one
      aborted, and that cleanup of the older task does not evict the
      new entry
- [ ] Cause a panic inside a `RwLock` write critical section (in a
      test) and verify the next `budget_config()` call logs a warn
      and proceeds with the recovered state