### PR TITLE
fix(memory): preserve merge state, surface vector errors, atomic cascade

### DIFF
--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -258,7 +258,7 @@ fn merge_metadata_json(keeper: &str, loser: &str) -> String {
 
 /// Decode embedding bytes (LE f32) into a `Vec<f32>`.
 fn decode_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
-    if bytes.is_empty() || bytes.len() % 4 != 0 {
+    if bytes.is_empty() || !bytes.len().is_multiple_of(4) {
         return None;
     }
     Some(
@@ -289,7 +289,12 @@ fn encode_embedding(v: &[f32]) -> Vec<u8> {
 ///
 /// - both present, same dim → weighted average bytes
 /// - both present, dim mismatch → keeper (the one with higher accum weight)
-/// - one present → that one
+/// - keeper has bytes, loser does not → keeper verbatim
+/// - keeper has none, loser has bytes → **loser is adopted** (asymmetric:
+///   the keeper inherits the loser's vector rather than staying empty,
+///   because some embedding is strictly more useful for downstream
+///   ranking than none, and the loser is about to be soft-deleted so
+///   its vector would otherwise be lost)
 /// - neither → `None`
 ///
 /// Negative or zero weights are clamped to a small positive epsilon so
@@ -863,5 +868,34 @@ mod tests {
             access, 3,
             "access_count must sum 1+1+1 across keeper + 2 losers"
         );
+    }
+
+    /// `merge_embeddings_weighted` is asymmetric on the (None, Some) edge:
+    /// when the keeper has no embedding but the loser does, the loser's
+    /// bytes are adopted by the keeper rather than left as `None`. Pre-fix
+    /// the loser's embedding was unconditionally lost on soft-delete; this
+    /// path is what rescues it. Asserted at the helper level so a future
+    /// refactor that flips the asymmetry (e.g., "keeper always wins, even
+    /// when empty") fails loudly here instead of silently regressing #3537.
+    #[test]
+    fn test_merge_embeddings_keeper_none_adopts_loser() {
+        let loser_bytes = encode_embedding(&[0.25_f32, 0.5, 0.75, 1.0]);
+        let merged = merge_embeddings_weighted(None, 0.0, Some(&loser_bytes), 0.5)
+            .expect("loser-only path must produce Some");
+        let decoded = decode_embedding(&merged).expect("merged bytes decode");
+        assert_eq!(
+            decoded,
+            vec![0.25_f32, 0.5, 0.75, 1.0],
+            "keeper-without-embedding must adopt the loser's vector verbatim"
+        );
+
+        // Sanity: the symmetric (Some, None) path still wins for the keeper.
+        let keeper_bytes = encode_embedding(&[1.0_f32, 0.0]);
+        let merged = merge_embeddings_weighted(Some(&keeper_bytes), 0.9, None, 0.0)
+            .expect("keeper-only path must produce Some");
+        assert_eq!(decode_embedding(&merged).unwrap(), vec![1.0_f32, 0.0]);
+
+        // And (None, None) stays None.
+        assert!(merge_embeddings_weighted(None, 0.0, None, 0.0).is_none());
     }
 }

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -98,6 +98,14 @@ impl ConsolidationEngine {
 
             // Track which IDs have been absorbed into another memory.
             let mut absorbed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            // Per-keeper accumulated weight. Initialized lazily to the
+            // keeper's original confidence; each loser merged into a
+            // keeper grows its accumulated weight by the loser's
+            // confidence. This makes the running embedding a true
+            // confidence-weighted average over all losers absorbed by
+            // a keeper, not a chain of pairwise blends biased toward
+            // whichever loser arrived last.
+            let mut accum_weights: HashMap<String, f32> = HashMap::new();
 
             for i in 0..rows.len() {
                 if absorbed.contains(&rows[i].0) {
@@ -112,21 +120,24 @@ impl ConsolidationEngine {
                         // Keep rows[i] (sorted by confidence DESC). Merge:
                         //   - access_count: keeper + loser (sum)
                         //   - metadata: union, keeper wins on key conflict
-                        //   - embedding: confidence-weighted average when
-                        //                both present, else whichever exists
+                        //   - embedding: running confidence-weighted average
+                        //                across all losers absorbed so far
                         //   - confidence: max(keeper, loser)
                         // All writes wrapped in a single tx so we never
                         // soft-delete the loser without applying the merge.
                         let keeper_id = rows[i].0.clone();
                         let loser_id = rows[j].0.clone();
                         let merged_access = rows[i].4.saturating_add(rows[j].4);
-                        let merged_metadata =
-                            merge_metadata_json(&rows[i].3, &rows[j].3);
+                        let merged_metadata = merge_metadata_json(&rows[i].3, &rows[j].3);
+                        let keeper_w = *accum_weights
+                            .entry(keeper_id.clone())
+                            .or_insert(rows[i].2 as f32);
+                        let loser_w = rows[j].2 as f32;
                         let merged_embedding = merge_embeddings_weighted(
                             rows[i].5.as_deref(),
-                            rows[i].2 as f32,
+                            keeper_w,
                             rows[j].5.as_deref(),
-                            rows[j].2 as f32,
+                            loser_w,
                         );
                         let merged_confidence = rows[i].2.max(rows[j].2);
 
@@ -181,6 +192,14 @@ impl ConsolidationEngine {
                         if merged_embedding.is_some() {
                             rows[i].5 = merged_embedding;
                         }
+                        // Grow the keeper's accumulated weight by the
+                        // loser's confidence so the next merge against
+                        // this keeper averages over the full absorbed
+                        // history (not just the most recent pair).
+                        accum_weights
+                            .entry(keeper_id.clone())
+                            .and_modify(|w| *w += loser_w)
+                            .or_insert(keeper_w + loser_w);
                         absorbed.insert(loser_id);
                         memories_merged += 1;
 
@@ -204,18 +223,36 @@ impl ConsolidationEngine {
 
 /// Merge two metadata JSON strings; on key collision keeper wins.
 ///
-/// Falls back to keeper-only if either side is malformed JSON — better
-/// to preserve known state than crash consolidation.
+/// Both sides must parse as a JSON object for the union semantics to
+/// apply. If either side is a non-object value (array, string, number,
+/// malformed) we cannot safely union and instead preserve the keeper
+/// verbatim — silently coercing a non-object payload to `{}` would
+/// regress the pre-PR behavior of preserving the loser's metadata
+/// untouched (and outright destroy a non-object keeper's payload).
 fn merge_metadata_json(keeper: &str, loser: &str) -> String {
-    let keeper_map: HashMap<String, serde_json::Value> =
-        serde_json::from_str(keeper).unwrap_or_default();
-    let loser_map: HashMap<String, serde_json::Value> =
-        serde_json::from_str(loser).unwrap_or_default();
-    let mut merged = loser_map;
-    for (k, v) in keeper_map {
-        merged.insert(k, v); // keeper wins on conflict
+    let keeper_obj = serde_json::from_str::<serde_json::Value>(keeper)
+        .ok()
+        .and_then(|v| match v {
+            serde_json::Value::Object(map) => Some(map),
+            _ => None,
+        });
+    let loser_obj = serde_json::from_str::<serde_json::Value>(loser)
+        .ok()
+        .and_then(|v| match v {
+            serde_json::Value::Object(map) => Some(map),
+            _ => None,
+        });
+    match (keeper_obj, loser_obj) {
+        (Some(keeper_map), Some(loser_map)) => {
+            let mut merged = loser_map;
+            for (k, v) in keeper_map {
+                merged.insert(k, v); // keeper wins on conflict
+            }
+            serde_json::to_string(&merged).unwrap_or_else(|_| keeper.to_string())
+        }
+        // Either side is non-object → cannot safely union; keep keeper.
+        _ => keeper.to_string(),
     }
-    serde_json::to_string(&merged).unwrap_or_else(|_| keeper.to_string())
 }
 
 /// Decode embedding bytes (LE f32) into a `Vec<f32>`.
@@ -240,10 +277,17 @@ fn encode_embedding(v: &[f32]) -> Vec<u8> {
     out
 }
 
-/// Merge two embeddings via confidence-weighted average.
+/// Merge two embeddings via weighted average.
+///
+/// `keeper_w` is the keeper's *running* accumulated weight (sum of every
+/// confidence it has absorbed so far, not just the original row's
+/// confidence). `loser_w` is the new loser's confidence. The caller is
+/// responsible for growing `keeper_w` after each successful merge so a
+/// keeper that absorbs N losers averages over the full history rather
+/// than re-blending pairwise from its original weight every time.
 ///
 /// - both present, same dim → weighted average bytes
-/// - both present, dim mismatch → keeper (the one with higher confidence)
+/// - both present, dim mismatch → keeper (the one with higher accum weight)
 /// - one present → that one
 /// - neither → `None`
 ///
@@ -580,8 +624,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        let parsed: HashMap<String, serde_json::Value> =
-            serde_json::from_str(&metadata).unwrap();
+        let parsed: HashMap<String, serde_json::Value> = serde_json::from_str(&metadata).unwrap();
         assert_eq!(
             parsed.get("loser_only").and_then(|v| v.as_str()),
             Some("value"),
@@ -613,6 +656,118 @@ mod tests {
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect();
         // Both axes should be > 0 since we blended (1,0,0,0) and (0,1,0,0).
-        assert!(emb[0] > 0.0 && emb[1] > 0.0, "weighted blend should mix both vectors");
+        assert!(
+            emb[0] > 0.0 && emb[1] > 0.0,
+            "weighted blend should mix both vectors"
+        );
+    }
+
+    /// Non-object metadata (JSON array, string, number, malformed) on
+    /// either side must NOT silently coerce the merged value to `{}`.
+    /// Pre-fix-fixup the code parsed both sides as a `HashMap<String, _>`
+    /// and `unwrap_or_default()`'d on failure — destroying whatever the
+    /// keeper had.
+    #[test]
+    fn test_merge_metadata_preserves_non_object_keeper() {
+        // Loser is a JSON array (legacy data). The keeper's object
+        // metadata must survive untouched, NOT be wiped to `{}`.
+        let merged = merge_metadata_json(r#"{"k":"v"}"#, r#"[1,2,3]"#);
+        let parsed: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(parsed["k"], "v", "keeper key must survive non-object loser");
+
+        // Keeper is a non-object value. We can't safely union, so the
+        // keeper must be returned verbatim — neither side's data lost.
+        let merged = merge_metadata_json(r#""legacy_string""#, r#"{"k":"v"}"#);
+        assert_eq!(
+            merged, r#""legacy_string""#,
+            "non-object keeper must be preserved verbatim"
+        );
+
+        // Malformed JSON on either side falls into the same branch.
+        let merged = merge_metadata_json(r#"{"k":"v"}"#, "not-json-at-all");
+        let parsed: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(parsed["k"], "v");
+    }
+
+    /// #3537 follow-up: with three or more losers absorbed by the same
+    /// keeper, the resulting embedding must reflect a running confidence
+    /// -weighted average — not a chain of pairwise blends biased toward
+    /// whichever loser arrived last.
+    ///
+    /// We exploit a degenerate case to detect the bug deterministically:
+    /// keeper has confidence 0.9, two losers (each confidence 0.45) carry
+    /// IDENTICAL embeddings on a different axis from the keeper. With a
+    /// proper running average the keeper's accumulated weight after the
+    /// first merge becomes 0.9 + 0.45 = 1.35, so the second merge weighs
+    /// the keeper at 1.35 vs the loser at 0.45 — keeper still dominates.
+    /// Pre-fix the second merge would re-blend with the original 0.9
+    /// keeper weight, letting the loser axis grow disproportionately.
+    #[test]
+    fn test_merge_embeddings_running_weighted_average_across_multiple_losers() {
+        let engine = setup();
+        {
+            let conn = engine.conn.lock().unwrap();
+            // Keeper points along x with high confidence.
+            insert_memory_full(
+                &conn,
+                "k",
+                "the quick brown fox jumps over the lazy dog",
+                0.9,
+                "{}",
+                1,
+                Some(&[1.0_f32, 0.0]),
+            );
+            // Two losers with the same content + same embedding (along y).
+            // Lower confidence each.
+            insert_memory_full(
+                &conn,
+                "l1",
+                "the quick brown fox jumps over the lazy dog",
+                0.45,
+                "{}",
+                1,
+                Some(&[0.0_f32, 1.0]),
+            );
+            insert_memory_full(
+                &conn,
+                "l2",
+                "the quick brown fox jumps over the lazy dog",
+                0.45,
+                "{}",
+                1,
+                Some(&[0.0_f32, 1.0]),
+            );
+        }
+
+        let report = engine.consolidate().unwrap();
+        assert_eq!(report.memories_merged, 2);
+
+        let conn = engine.conn.lock().unwrap();
+        let emb_bytes: Vec<u8> = conn
+            .query_row("SELECT embedding FROM memories WHERE id = 'k'", [], |row| {
+                row.get::<_, Option<Vec<u8>>>(0)
+            })
+            .unwrap()
+            .expect("embedding present");
+        let emb: Vec<f32> = emb_bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        // After running weighted average:
+        //   step 1: (1,0)*0.9 + (0,1)*0.45 / 1.35 = (0.667, 0.333)
+        //   step 2: (0.667, 0.333)*1.35 + (0,1)*0.45 / 1.8 = (0.5, 0.5)
+        // Pre-fix (pairwise re-blend with original 0.9 weight each step):
+        //   step 1: (0.667, 0.333)
+        //   step 2: re-blend with (0.9, 0.45) weights →
+        //     (0.667*0.9 + 0*0.45)/1.35 = 0.444 on x, similar drift on y
+        // The running-average path keeps x dominant; the buggy path lets
+        // x decay further. Assert x >= 0.45 — true under running avg
+        // (0.5), false under pre-fix pairwise (~0.44).
+        assert!(
+            emb[0] >= 0.45,
+            "running weighted average should keep keeper axis dominant; got {:?}",
+            emb
+        );
     }
 }

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::memory::{text_similarity, ConsolidationReport};
 use rusqlite::Connection;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// Memory consolidation engine.
@@ -65,20 +66,30 @@ impl ConsolidationEngine {
         };
 
         'agents: for agent_id in &agent_ids {
+            // Pull every column needed to merge state correctly. Pre-fix
+            // we only loaded id/content/confidence and dropped the loser
+            // entirely — losing metadata, access_count, and embedding
+            // (#3537). Now we union metadata, sum access_count, and
+            // confidence-weight embeddings before soft-deleting.
             let mut stmt = conn
                 .prepare(
-                    "SELECT id, content, confidence FROM memories \
+                    "SELECT id, content, confidence, metadata, access_count, embedding \
+                     FROM memories \
                      WHERE deleted = 0 AND agent_id = ?1 \
                      ORDER BY confidence DESC",
                 )
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-            let rows: Vec<(String, String, f64)> = stmt
+            #[allow(clippy::type_complexity)]
+            let mut rows: Vec<(String, String, f64, String, i64, Option<Vec<u8>>)> = stmt
                 .query_map(rusqlite::params![agent_id], |row| {
                     Ok((
                         row.get::<_, String>(0)?,
                         row.get::<_, String>(1)?,
                         row.get::<_, f64>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, Option<Vec<u8>>>(5)?,
                     ))
                 })
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?
@@ -98,32 +109,79 @@ impl ConsolidationEngine {
                     }
                     let sim = text_similarity(&rows[i].1.to_lowercase(), &rows[j].1.to_lowercase());
                     if sim > 0.9 {
-                        // Keep the one with higher confidence (rows are sorted desc),
-                        // so rows[i] is the keeper. Soft-delete rows[j] and, if the
-                        // absorbed memory had higher confidence somehow, lift the
-                        // keeper to that value. Wrap both writes in a savepoint so
-                        // we never leave a keeper un-updated after its duplicate
-                        // was already soft-deleted.
+                        // Keep rows[i] (sorted by confidence DESC). Merge:
+                        //   - access_count: keeper + loser (sum)
+                        //   - metadata: union, keeper wins on key conflict
+                        //   - embedding: confidence-weighted average when
+                        //                both present, else whichever exists
+                        //   - confidence: max(keeper, loser)
+                        // All writes wrapped in a single tx so we never
+                        // soft-delete the loser without applying the merge.
+                        let keeper_id = rows[i].0.clone();
+                        let loser_id = rows[j].0.clone();
+                        let merged_access = rows[i].4.saturating_add(rows[j].4);
+                        let merged_metadata =
+                            merge_metadata_json(&rows[i].3, &rows[j].3);
+                        let merged_embedding = merge_embeddings_weighted(
+                            rows[i].5.as_deref(),
+                            rows[i].2 as f32,
+                            rows[j].5.as_deref(),
+                            rows[j].2 as f32,
+                        );
+                        let merged_confidence = rows[i].2.max(rows[j].2);
+
                         let tx = conn
                             .unchecked_transaction()
                             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                         tx.execute(
                             "UPDATE memories SET deleted = 1 WHERE id = ?1",
-                            rusqlite::params![rows[j].0],
+                            rusqlite::params![loser_id],
                         )
                         .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-                        if rows[j].2 > rows[i].2 {
-                            tx.execute(
-                                "UPDATE memories SET confidence = ?1 WHERE id = ?2",
-                                rusqlite::params![rows[j].2, rows[i].0],
-                            )
-                            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                        match merged_embedding.as_ref() {
+                            Some(bytes) => {
+                                tx.execute(
+                                    "UPDATE memories SET confidence = ?1, \
+                                     access_count = ?2, metadata = ?3, \
+                                     embedding = ?4 WHERE id = ?5",
+                                    rusqlite::params![
+                                        merged_confidence,
+                                        merged_access,
+                                        &merged_metadata,
+                                        bytes,
+                                        keeper_id,
+                                    ],
+                                )
+                                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                            }
+                            None => {
+                                tx.execute(
+                                    "UPDATE memories SET confidence = ?1, \
+                                     access_count = ?2, metadata = ?3 \
+                                     WHERE id = ?4",
+                                    rusqlite::params![
+                                        merged_confidence,
+                                        merged_access,
+                                        &merged_metadata,
+                                        keeper_id,
+                                    ],
+                                )
+                                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                            }
                         }
                         tx.commit()
                             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
-                        absorbed.insert(rows[j].0.clone());
+                        // Update the in-memory row so subsequent merges
+                        // against the same keeper see the accumulated state.
+                        rows[i].2 = merged_confidence;
+                        rows[i].3 = merged_metadata;
+                        rows[i].4 = merged_access;
+                        if merged_embedding.is_some() {
+                            rows[i].5 = merged_embedding;
+                        }
+                        absorbed.insert(loser_id);
                         memories_merged += 1;
 
                         if memories_merged >= MAX_MERGES_PER_RUN {
@@ -141,6 +199,85 @@ impl ConsolidationEngine {
             memories_decayed: decayed as u64,
             duration_ms,
         })
+    }
+}
+
+/// Merge two metadata JSON strings; on key collision keeper wins.
+///
+/// Falls back to keeper-only if either side is malformed JSON — better
+/// to preserve known state than crash consolidation.
+fn merge_metadata_json(keeper: &str, loser: &str) -> String {
+    let keeper_map: HashMap<String, serde_json::Value> =
+        serde_json::from_str(keeper).unwrap_or_default();
+    let loser_map: HashMap<String, serde_json::Value> =
+        serde_json::from_str(loser).unwrap_or_default();
+    let mut merged = loser_map;
+    for (k, v) in keeper_map {
+        merged.insert(k, v); // keeper wins on conflict
+    }
+    serde_json::to_string(&merged).unwrap_or_else(|_| keeper.to_string())
+}
+
+/// Decode embedding bytes (LE f32) into a `Vec<f32>`.
+fn decode_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
+    if bytes.is_empty() || bytes.len() % 4 != 0 {
+        return None;
+    }
+    Some(
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    )
+}
+
+/// Encode `Vec<f32>` back to LE bytes for SQLite BLOB storage.
+fn encode_embedding(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Merge two embeddings via confidence-weighted average.
+///
+/// - both present, same dim → weighted average bytes
+/// - both present, dim mismatch → keeper (the one with higher confidence)
+/// - one present → that one
+/// - neither → `None`
+///
+/// Negative or zero weights are clamped to a small positive epsilon so
+/// the average remains well-defined.
+fn merge_embeddings_weighted(
+    keeper: Option<&[u8]>,
+    keeper_w: f32,
+    loser: Option<&[u8]>,
+    loser_w: f32,
+) -> Option<Vec<u8>> {
+    match (keeper, loser) {
+        (Some(k), Some(l)) => {
+            let kv = decode_embedding(k);
+            let lv = decode_embedding(l);
+            match (kv, lv) {
+                (Some(kv), Some(lv)) if kv.len() == lv.len() && !kv.is_empty() => {
+                    let kw = keeper_w.max(f32::EPSILON);
+                    let lw = loser_w.max(f32::EPSILON);
+                    let total = kw + lw;
+                    let merged: Vec<f32> = kv
+                        .iter()
+                        .zip(lv.iter())
+                        .map(|(a, b)| (a * kw + b * lw) / total)
+                        .collect();
+                    Some(encode_embedding(&merged))
+                }
+                // Dim mismatch or decode failure → preserve keeper.
+                _ => Some(k.to_vec()),
+            }
+        }
+        (Some(k), None) => Some(k.to_vec()),
+        (None, Some(l)) => Some(l.to_vec()),
+        (None, None) => None,
     }
 }
 
@@ -361,5 +498,121 @@ mod tests {
         // Both memories from different agents must survive intact.
         assert!(!is_deleted(&conn, "agent-a-mem"));
         assert!(!is_deleted(&conn, "agent-b-mem"));
+    }
+
+    /// Helper: insert with explicit metadata, access_count, and embedding.
+    fn insert_memory_full(
+        conn: &Connection,
+        id: &str,
+        content: &str,
+        confidence: f64,
+        metadata: &str,
+        access_count: i64,
+        embedding: Option<&[f32]>,
+    ) {
+        let now = Utc::now().to_rfc3339();
+        let emb_bytes: Option<Vec<u8>> = embedding.map(|v| {
+            let mut out = Vec::with_capacity(v.len() * 4);
+            for f in v {
+                out.extend_from_slice(&f.to_le_bytes());
+            }
+            out
+        });
+        conn.execute(
+            "INSERT INTO memories (id, agent_id, content, source, scope, confidence, metadata, created_at, accessed_at, access_count, deleted, embedding)
+             VALUES (?1, 'agent-1', ?2, '\"conversation\"', 'episodic', ?3, ?4, ?5, ?5, ?6, 0, ?7)",
+            rusqlite::params![id, content, confidence, metadata, now, access_count, emb_bytes],
+        ).unwrap();
+    }
+
+    /// #3537: merging duplicates must preserve metadata, sum access_count,
+    /// and combine embeddings — not silently drop them with the loser row.
+    #[test]
+    fn test_merge_preserves_metadata_access_count_and_embedding() {
+        let engine = setup();
+        {
+            let conn = engine.conn.lock().unwrap();
+            // Same content; keeper has higher confidence so it wins. The
+            // loser carries unique metadata, a non-zero access_count, and
+            // a real embedding — all of which would be lost pre-fix.
+            insert_memory_full(
+                &conn,
+                "mem-keeper",
+                "the quick brown fox jumps over the lazy dog",
+                0.9,
+                r#"{"source":"keeper","tag":"a"}"#,
+                3,
+                Some(&[1.0_f32, 0.0, 0.0, 0.0]),
+            );
+            insert_memory_full(
+                &conn,
+                "mem-loser",
+                "the quick brown fox jumps over the lazy dog",
+                0.5,
+                r#"{"loser_only":"value","tag":"b"}"#,
+                7,
+                Some(&[0.0_f32, 1.0, 0.0, 0.0]),
+            );
+        }
+
+        let report = engine.consolidate().unwrap();
+        assert_eq!(report.memories_merged, 1);
+
+        let conn = engine.conn.lock().unwrap();
+        assert!(!is_deleted(&conn, "mem-keeper"));
+        assert!(is_deleted(&conn, "mem-loser"));
+
+        // access_count must be the SUM (3 + 7 = 10), not just keeper's.
+        let access: i64 = conn
+            .query_row(
+                "SELECT access_count FROM memories WHERE id = 'mem-keeper'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(access, 10, "access_count should sum keeper + loser");
+
+        // Loser-only metadata key must survive; keeper wins on conflict.
+        let metadata: String = conn
+            .query_row(
+                "SELECT metadata FROM memories WHERE id = 'mem-keeper'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let parsed: HashMap<String, serde_json::Value> =
+            serde_json::from_str(&metadata).unwrap();
+        assert_eq!(
+            parsed.get("loser_only").and_then(|v| v.as_str()),
+            Some("value"),
+            "loser-only metadata key must be preserved"
+        );
+        assert_eq!(
+            parsed.get("source").and_then(|v| v.as_str()),
+            Some("keeper"),
+            "keeper wins on metadata key conflict"
+        );
+        assert_eq!(
+            parsed.get("tag").and_then(|v| v.as_str()),
+            Some("a"),
+            "keeper wins on metadata key conflict (tag)"
+        );
+
+        // Embedding must be non-null and a real weighted blend of both.
+        let emb_bytes: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT embedding FROM memories WHERE id = 'mem-keeper'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let emb_bytes = emb_bytes.expect("embedding must not be null after merge");
+        assert_eq!(emb_bytes.len(), 16, "4 f32 = 16 bytes");
+        let emb: Vec<f32> = emb_bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        // Both axes should be > 0 since we blended (1,0,0,0) and (0,1,0,0).
+        assert!(emb[0] > 0.0 && emb[1] > 0.0, "weighted blend should mix both vectors");
     }
 }

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -65,13 +65,28 @@ impl ConsolidationEngine {
             rows.filter_map(|r| r.ok()).collect()
         };
 
+        // One outer transaction wraps every merge in this run so we pay a
+        // single fsync at the end instead of M (one per pair). Pre-fix
+        // each pair opened its own `unchecked_transaction`; with WAL that
+        // costs one fsync per commit, and `MAX_MERGES_PER_RUN = 100`
+        // means up to 100 fsyncs back-to-back. Per-pair atomicity (loser
+        // soft-delete + keeper update applied together) is preserved
+        // automatically — both writes for a pair land in the same outer
+        // tx, so a mid-pair failure rolls the whole batch back via the
+        // `?` propagation below. Consolidate is idempotent and the next
+        // run will pick up where this one left off, which makes
+        // all-or-nothing safe here.
+        let outer_tx = conn
+            .unchecked_transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
         'agents: for agent_id in &agent_ids {
             // Pull every column needed to merge state correctly. Pre-fix
             // we only loaded id/content/confidence and dropped the loser
             // entirely — losing metadata, access_count, and embedding
             // (#3537). Now we union metadata, sum access_count, and
             // confidence-weight embeddings before soft-deleting.
-            let mut stmt = conn
+            let mut stmt = outer_tx
                 .prepare(
                     "SELECT id, content, confidence, metadata, access_count, embedding \
                      FROM memories \
@@ -123,8 +138,9 @@ impl ConsolidationEngine {
                         //   - embedding: running confidence-weighted average
                         //                across all losers absorbed so far
                         //   - confidence: max(keeper, loser)
-                        // All writes wrapped in a single tx so we never
-                        // soft-delete the loser without applying the merge.
+                        // Per-pair atomicity comes from the outer tx —
+                        // both writes land in the same batch, and any
+                        // mid-pair `?` aborts the whole consolidate run.
                         let keeper_id = rows[i].0.clone();
                         let loser_id = rows[j].0.clone();
                         let merged_access = rows[i].4.saturating_add(rows[j].4);
@@ -141,48 +157,46 @@ impl ConsolidationEngine {
                         );
                         let merged_confidence = rows[i].2.max(rows[j].2);
 
-                        let tx = conn
-                            .unchecked_transaction()
+                        outer_tx
+                            .execute(
+                                "UPDATE memories SET deleted = 1 WHERE id = ?1",
+                                rusqlite::params![loser_id],
+                            )
                             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-                        tx.execute(
-                            "UPDATE memories SET deleted = 1 WHERE id = ?1",
-                            rusqlite::params![loser_id],
-                        )
-                        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
                         match merged_embedding.as_ref() {
                             Some(bytes) => {
-                                tx.execute(
-                                    "UPDATE memories SET confidence = ?1, \
-                                     access_count = ?2, metadata = ?3, \
-                                     embedding = ?4 WHERE id = ?5",
-                                    rusqlite::params![
-                                        merged_confidence,
-                                        merged_access,
-                                        &merged_metadata,
-                                        bytes,
-                                        keeper_id,
-                                    ],
-                                )
-                                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                                outer_tx
+                                    .execute(
+                                        "UPDATE memories SET confidence = ?1, \
+                                         access_count = ?2, metadata = ?3, \
+                                         embedding = ?4 WHERE id = ?5",
+                                        rusqlite::params![
+                                            merged_confidence,
+                                            merged_access,
+                                            &merged_metadata,
+                                            bytes,
+                                            keeper_id,
+                                        ],
+                                    )
+                                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                             }
                             None => {
-                                tx.execute(
-                                    "UPDATE memories SET confidence = ?1, \
-                                     access_count = ?2, metadata = ?3 \
-                                     WHERE id = ?4",
-                                    rusqlite::params![
-                                        merged_confidence,
-                                        merged_access,
-                                        &merged_metadata,
-                                        keeper_id,
-                                    ],
-                                )
-                                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+                                outer_tx
+                                    .execute(
+                                        "UPDATE memories SET confidence = ?1, \
+                                         access_count = ?2, metadata = ?3 \
+                                         WHERE id = ?4",
+                                        rusqlite::params![
+                                            merged_confidence,
+                                            merged_access,
+                                            &merged_metadata,
+                                            keeper_id,
+                                        ],
+                                    )
+                                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
                             }
                         }
-                        tx.commit()
-                            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
                         // Update the in-memory row so subsequent merges
                         // against the same keeper see the accumulated state.
@@ -211,6 +225,14 @@ impl ConsolidationEngine {
                 }
             }
         }
+
+        // Single commit for the whole batch — collapses up to
+        // MAX_MERGES_PER_RUN fsyncs into one. If no merges happened the
+        // outer tx is still committed (a no-op write), which is cheaper
+        // than guarding the commit on `memories_merged > 0`.
+        outer_tx
+            .commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         let duration_ms = start.elapsed().as_millis() as u64;
 

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -195,11 +195,12 @@ impl ConsolidationEngine {
                         // Grow the keeper's accumulated weight by the
                         // loser's confidence so the next merge against
                         // this keeper averages over the full absorbed
-                        // history (not just the most recent pair).
-                        accum_weights
-                            .entry(keeper_id.clone())
-                            .and_modify(|w| *w += loser_w)
-                            .or_insert(keeper_w + loser_w);
+                        // history (not just the most recent pair). The
+                        // entry is guaranteed to exist — we read from it
+                        // a few lines above via `or_insert(...)`.
+                        if let Some(w) = accum_weights.get_mut(&keeper_id) {
+                            *w += loser_w;
+                        }
                         absorbed.insert(loser_id);
                         memories_merged += 1;
 
@@ -768,6 +769,99 @@ mod tests {
             emb[0] >= 0.45,
             "running weighted average should keep keeper axis dominant; got {:?}",
             emb
+        );
+    }
+
+    /// A dim-mismatched loser must not corrupt the keeper's embedding,
+    /// must not crash the merge, and must not poison subsequent merges
+    /// against the same keeper. The keeper's bytes flow through verbatim
+    /// (the `(Some, Some, dim mismatch)` branch in
+    /// `merge_embeddings_weighted`), and the next same-dim loser is then
+    /// blended in normally.
+    #[test]
+    fn test_merge_embeddings_handles_dim_mismatch_then_same_dim() {
+        let engine = setup();
+        {
+            let conn = engine.conn.lock().unwrap();
+            // Sorted by confidence DESC: k → l_bad → l_ok.
+            insert_memory_full(
+                &conn,
+                "k",
+                "the quick brown fox jumps over the lazy dog",
+                0.9,
+                "{}",
+                1,
+                Some(&[1.0_f32, 0.0, 0.0, 0.0]),
+            );
+            insert_memory_full(
+                &conn,
+                "l_bad",
+                "the quick brown fox jumps over the lazy dog",
+                0.5,
+                "{}",
+                1,
+                Some(&[0.0_f32, 1.0, 0.0]), // 3-dim → mismatch with keeper's 4-dim
+            );
+            insert_memory_full(
+                &conn,
+                "l_ok",
+                "the quick brown fox jumps over the lazy dog",
+                0.45,
+                "{}",
+                1,
+                Some(&[0.0_f32, 1.0, 0.0, 0.0]),
+            );
+        }
+
+        let report = engine.consolidate().unwrap();
+        assert_eq!(report.memories_merged, 2, "both losers must be absorbed");
+
+        let conn = engine.conn.lock().unwrap();
+        // Keeper still holds a 4-dim embedding (no dim corruption from
+        // the mismatched loser).
+        let emb_bytes: Vec<u8> = conn
+            .query_row("SELECT embedding FROM memories WHERE id = 'k'", [], |row| {
+                row.get::<_, Option<Vec<u8>>>(0)
+            })
+            .unwrap()
+            .expect("embedding must remain present");
+        assert_eq!(
+            emb_bytes.len(),
+            16,
+            "keeper must stay 4-dim after dim-mismatched merge"
+        );
+
+        let emb: Vec<f32> = emb_bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        // After the dim-mismatched merge the keeper bytes are preserved
+        // verbatim; after the subsequent same-dim merge, x stays the
+        // dominant axis but y picks up some loser contribution.
+        assert!(
+            emb[0] > 0.0 && emb[1] > 0.0,
+            "expected blended axes, got {:?}",
+            emb
+        );
+        assert!(
+            emb[2] == 0.0 && emb[3] == 0.0,
+            "no contribution to unused axes, got {:?}",
+            emb
+        );
+
+        // Both losers soft-deleted; access_count summed across all three.
+        assert!(is_deleted(&conn, "l_bad"));
+        assert!(is_deleted(&conn, "l_ok"));
+        let access: i64 = conn
+            .query_row(
+                "SELECT access_count FROM memories WHERE id = 'k'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            access, 3,
+            "access_count must sum 1+1+1 across keeper + 2 losers"
         );
     }
 }

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -111,26 +111,34 @@ impl ConsolidationEngine {
                 .filter_map(|r| r.ok())
                 .collect();
 
-            // Track which IDs have been absorbed into another memory.
-            let mut absorbed: std::collections::HashSet<String> = std::collections::HashSet::new();
-            // Per-keeper accumulated weight. Initialized lazily to the
-            // keeper's original confidence; each loser merged into a
-            // keeper grows its accumulated weight by the loser's
-            // confidence. This makes the running embedding a true
-            // confidence-weighted average over all losers absorbed by
-            // a keeper, not a chain of pairwise blends biased toward
-            // whichever loser arrived last.
-            let mut accum_weights: HashMap<String, f32> = HashMap::new();
+            // Pre-lowercase content once per row. The inner loop is O(N²)
+            // and `text_similarity` lowercases its inputs on every call —
+            // doing it up front collapses N² lowercase allocations to N.
+            let lowered: Vec<String> = rows.iter().map(|r| r.1.to_lowercase()).collect();
+
+            // Track which row indices have been absorbed into a keeper.
+            // Keyed by `usize` (row index in `rows`) rather than memory
+            // id String — the index is unique within an agent's batch and
+            // sidesteps the per-merge `String::clone` we'd otherwise pay.
+            let mut absorbed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+            // Per-keeper accumulated weight, also keyed by row index.
+            // Initialized lazily to the keeper's original confidence;
+            // each loser merged into a keeper grows its accumulated
+            // weight by the loser's confidence. This makes the running
+            // embedding a true confidence-weighted average over all
+            // losers absorbed by a keeper, not a chain of pairwise
+            // blends biased toward whichever loser arrived last.
+            let mut accum_weights: HashMap<usize, f32> = HashMap::new();
 
             for i in 0..rows.len() {
-                if absorbed.contains(&rows[i].0) {
+                if absorbed.contains(&i) {
                     continue;
                 }
                 for j in (i + 1)..rows.len() {
-                    if absorbed.contains(&rows[j].0) {
+                    if absorbed.contains(&j) {
                         continue;
                     }
-                    let sim = text_similarity(&rows[i].1.to_lowercase(), &rows[j].1.to_lowercase());
+                    let sim = text_similarity(&lowered[i], &lowered[j]);
                     if sim > 0.9 {
                         // Keep rows[i] (sorted by confidence DESC). Merge:
                         //   - access_count: keeper + loser (sum)
@@ -141,13 +149,9 @@ impl ConsolidationEngine {
                         // Per-pair atomicity comes from the outer tx —
                         // both writes land in the same batch, and any
                         // mid-pair `?` aborts the whole consolidate run.
-                        let keeper_id = rows[i].0.clone();
-                        let loser_id = rows[j].0.clone();
                         let merged_access = rows[i].4.saturating_add(rows[j].4);
                         let merged_metadata = merge_metadata_json(&rows[i].3, &rows[j].3);
-                        let keeper_w = *accum_weights
-                            .entry(keeper_id.clone())
-                            .or_insert(rows[i].2 as f32);
+                        let keeper_w = *accum_weights.entry(i).or_insert(rows[i].2 as f32);
                         let loser_w = rows[j].2 as f32;
                         let merged_embedding = merge_embeddings_weighted(
                             rows[i].5.as_deref(),
@@ -160,7 +164,7 @@ impl ConsolidationEngine {
                         outer_tx
                             .execute(
                                 "UPDATE memories SET deleted = 1 WHERE id = ?1",
-                                rusqlite::params![loser_id],
+                                rusqlite::params![&rows[j].0],
                             )
                             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
@@ -176,7 +180,7 @@ impl ConsolidationEngine {
                                             merged_access,
                                             &merged_metadata,
                                             bytes,
-                                            keeper_id,
+                                            &rows[i].0,
                                         ],
                                     )
                                     .map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -191,7 +195,7 @@ impl ConsolidationEngine {
                                             merged_confidence,
                                             merged_access,
                                             &merged_metadata,
-                                            keeper_id,
+                                            &rows[i].0,
                                         ],
                                     )
                                     .map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -212,10 +216,10 @@ impl ConsolidationEngine {
                         // history (not just the most recent pair). The
                         // entry is guaranteed to exist — we read from it
                         // a few lines above via `or_insert(...)`.
-                        if let Some(w) = accum_weights.get_mut(&keeper_id) {
+                        if let Some(w) = accum_weights.get_mut(&i) {
                             *w += loser_w;
                         }
-                        absorbed.insert(loser_id);
+                        absorbed.insert(j);
                         memories_merged += 1;
 
                         if memories_merged >= MAX_MERGES_PER_RUN {

--- a/crates/librefang-memory/src/knowledge.rs
+++ b/crates/librefang-memory/src/knowledge.rs
@@ -81,23 +81,32 @@ impl KnowledgeStore {
     }
 
     /// Delete all entities and relations belonging to a specific agent.
+    ///
+    /// Wrapped in a single transaction so a relations-then-entities
+    /// failure can't leave orphan entities (relations referencing entities
+    /// silently broke ranking on the next graph query). See #3501.
     pub fn delete_by_agent(&self, agent_id: &str) -> LibreFangResult<u64> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
-        let rel_count = conn
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        let rel_count = tx
             .execute(
                 "DELETE FROM relations WHERE agent_id = ?1",
                 rusqlite::params![agent_id],
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))? as u64;
-        let ent_count = conn
+        let ent_count = tx
             .execute(
                 "DELETE FROM entities WHERE agent_id = ?1",
                 rusqlite::params![agent_id],
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))? as u64;
+        tx.commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(rel_count + ent_count)
     }
 

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -1543,8 +1543,13 @@ impl ProactiveMemoryStore {
                 let emb_b = embeddings.get(&all_items[j].id);
                 let similarity = match (emb_a, emb_b) {
                     (Some(a), Some(b)) => {
-                        // Vector cosine similarity (mem0-quality dedup)
-                        librefang_types::memory::cosine_similarity(a, b)
+                        // Vector cosine similarity (mem0-quality dedup).
+                        // Fall back to text similarity when vectors are not
+                        // comparable; treating that case as 0.0 would silently
+                        // suppress legitimate dedup candidates (#3536).
+                        librefang_types::memory::cosine_similarity(a, b).unwrap_or_else(|| {
+                            librefang_types::memory::text_similarity(&a_lower, &b_lower)
+                        })
                     }
                     _ => {
                         // Jaccard word overlap fallback

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -1054,6 +1054,7 @@ impl VectorStore for SqliteVectorStore {
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         let mut results = Vec::new();
+        let mut skipped_non_comparable: u64 = 0;
         for row_result in rows {
             let (id, content, meta_str, emb_bytes) =
                 row_result.map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -1062,10 +1063,14 @@ impl VectorStore for SqliteVectorStore {
             // zero vector). Including them with score=0.0 would let them
             // outrank genuinely orthogonal hits and pollute the result set.
             let Some(score) = cosine_similarity(query_embedding, &emb) else {
+                // Per-row stays at debug to avoid flooding logs during a
+                // re-embedding migration; the loop emits one aggregated
+                // warn at the end if any were skipped.
                 tracing::debug!(
                     memory_id = %id,
                     "skipping vector candidate: dim mismatch or zero magnitude"
                 );
+                skipped_non_comparable += 1;
                 continue;
             };
             let metadata: HashMap<String, serde_json::Value> =
@@ -1076,6 +1081,13 @@ impl VectorStore for SqliteVectorStore {
                 score,
                 metadata,
             });
+        }
+        if skipped_non_comparable > 0 {
+            tracing::warn!(
+                count = skipped_non_comparable,
+                "vector search skipped non-comparable candidates (dim mismatch or zero magnitude); \
+                 likely a re-embedding migration is in progress"
+            );
         }
 
         // Sort by score descending, truncate to limit

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -381,18 +381,21 @@ impl SemanticStore {
             });
         }
 
-        // If we have a query embedding, re-rank by cosine similarity
+        // If we have a query embedding, re-rank by cosine similarity.
+        // Non-comparable vectors (dim mismatch, zero magnitude) sort to
+        // the bottom (-1.0 sentinel) instead of being treated as 0.0,
+        // which would have ranked them above genuinely orthogonal hits.
         if let Some(qe) = query_embedding {
             fragments.sort_by(|a, b| {
                 let sim_a = a
                     .embedding
                     .as_deref()
-                    .map(|e| cosine_similarity(qe, e))
+                    .and_then(|e| cosine_similarity(qe, e))
                     .unwrap_or(-1.0);
                 let sim_b = b
                     .embedding
                     .as_deref()
-                    .map(|e| cosine_similarity(qe, e))
+                    .and_then(|e| cosine_similarity(qe, e))
                     .unwrap_or(-1.0);
                 sim_b
                     .partial_cmp(&sim_a)
@@ -908,9 +911,12 @@ fn escape_like(s: &str) -> String {
 }
 
 /// Compute cosine similarity between two vectors.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+///
+/// Returns `None` for non-comparable vectors (dim mismatch, empty, zero
+/// magnitude). Callers must handle `None` explicitly — see #3536.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
     if a.len() != b.len() || a.is_empty() {
-        return 0.0;
+        return None;
     }
     let mut dot = 0.0f32;
     let mut norm_a = 0.0f32;
@@ -922,9 +928,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     }
     let denom = norm_a.sqrt() * norm_b.sqrt();
     if denom < f32::EPSILON {
-        0.0
+        None
     } else {
-        dot / denom
+        Some(dot / denom)
     }
 }
 
@@ -1049,7 +1055,16 @@ impl VectorStore for SqliteVectorStore {
             let (id, content, meta_str, emb_bytes) =
                 row_result.map_err(|e| LibreFangError::Memory(e.to_string()))?;
             let emb = embedding_from_bytes(&emb_bytes);
-            let score = cosine_similarity(query_embedding, &emb);
+            // Skip non-comparable rows (dim mismatch from re-embedding,
+            // zero vector). Including them with score=0.0 would let them
+            // outrank genuinely orthogonal hits and pollute the result set.
+            let Some(score) = cosine_similarity(query_embedding, &emb) else {
+                tracing::debug!(
+                    memory_id = %id,
+                    "skipping vector candidate: dim mismatch or zero magnitude"
+                );
+                continue;
+            };
             let metadata: HashMap<String, serde_json::Value> =
                 serde_json::from_str(&meta_str).unwrap_or_default();
             results.push(VectorSearchResult {

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -13,6 +13,10 @@ use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::memory::{
     MemoryFilter, MemoryFragment, MemoryId, MemoryModality, MemorySource, VectorStore,
 };
+// Single canonical impl lives in librefang-types; re-exported here so
+// existing `librefang_memory::semantic::cosine_similarity` callers keep
+// working without three independently-edited copies drifting (see PR #4125).
+pub use librefang_types::memory::cosine_similarity;
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -911,30 +915,6 @@ fn escape_like(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('%', "\\%")
         .replace('_', "\\_")
-}
-
-/// Compute cosine similarity between two vectors.
-///
-/// Returns `None` for non-comparable vectors (dim mismatch, empty, zero
-/// magnitude). Callers must handle `None` explicitly — see #3536.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
-    if a.len() != b.len() || a.is_empty() {
-        return None;
-    }
-    let mut dot = 0.0f32;
-    let mut norm_a = 0.0f32;
-    let mut norm_b = 0.0f32;
-    for i in 0..a.len() {
-        dot += a[i] * b[i];
-        norm_a += a[i] * a[i];
-        norm_b += b[i] * b[i];
-    }
-    let denom = norm_a.sqrt() * norm_b.sqrt();
-    if denom < f32::EPSILON {
-        None
-    } else {
-        Some(dot / denom)
-    }
 }
 
 /// Serialize embedding to bytes for SQLite BLOB storage.

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -383,20 +383,23 @@ impl SemanticStore {
 
         // If we have a query embedding, re-rank by cosine similarity.
         // Non-comparable vectors (dim mismatch, zero magnitude) sort to
-        // the bottom (-1.0 sentinel) instead of being treated as 0.0,
-        // which would have ranked them above genuinely orthogonal hits.
+        // the bottom (NEG_INFINITY sentinel) instead of being treated as
+        // 0.0, which would have ranked them above genuinely orthogonal
+        // hits. We deliberately do NOT use -1.0: that is a valid cosine
+        // result for anti-similar vectors and would tie with the
+        // "non-comparable" bucket.
         if let Some(qe) = query_embedding {
             fragments.sort_by(|a, b| {
                 let sim_a = a
                     .embedding
                     .as_deref()
                     .and_then(|e| cosine_similarity(qe, e))
-                    .unwrap_or(-1.0);
+                    .unwrap_or(f32::NEG_INFINITY);
                 let sim_b = b
                     .embedding
                     .as_deref()
                     .and_then(|e| cosine_similarity(qe, e))
-                    .unwrap_or(-1.0);
+                    .unwrap_or(f32::NEG_INFINITY);
                 sim_b
                     .partial_cmp(&sim_a)
                     .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -549,16 +549,7 @@ impl SessionStore {
         let tx = conn
             .transaction()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        tx.execute(
-            "DELETE FROM sessions WHERE agent_id = ?1",
-            rusqlite::params![agent_id_str],
-        )
-        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        tx.execute(
-            "DELETE FROM sessions_fts WHERE agent_id = ?1",
-            rusqlite::params![agent_id_str],
-        )
-        .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        execute_session_agent_deletes(&tx, &agent_id_str)?;
         tx.commit()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
@@ -1352,6 +1343,32 @@ impl SessionStore {
 
         Ok(())
     }
+}
+
+/// Run every session-store DELETE for an agent inside the caller's
+/// transaction. Both `sessions` and `sessions_fts` MUST be cleared
+/// together — `search_sessions` reads from `sessions_fts` without
+/// joining `sessions`, so an orphan FTS row leaves the deleted agent's
+/// content searchable (a privacy regression, see #3501).
+///
+/// Shared by [`SessionStore::delete_agent_sessions`] and
+/// [`crate::substrate::MemorySubstrate::remove_agent`] so the cascade
+/// stays consistent across both entry points.
+pub(crate) fn execute_session_agent_deletes(
+    tx: &rusqlite::Transaction<'_>,
+    agent_id: &str,
+) -> LibreFangResult<()> {
+    tx.execute(
+        "DELETE FROM sessions WHERE agent_id = ?1",
+        rusqlite::params![agent_id],
+    )
+    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+    tx.execute(
+        "DELETE FROM sessions_fts WHERE agent_id = ?1",
+        rusqlite::params![agent_id],
+    )
+    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -533,10 +533,13 @@ impl SessionStore {
 
     /// Delete all sessions belonging to an agent and their FTS5 index entries.
     ///
-    /// The two `DELETE`s run inside a single transaction so a failure on
-    /// either side rolls back the other and leaves the agent's history
-    /// either fully intact or fully gone — never half-deleted with FTS
-    /// orphans pointing at missing rows (#3470, #3501).
+    /// Both `sessions` and `sessions_fts` are removed inside the same
+    /// transaction (#3470, #3501). `save_session` writes both rows
+    /// atomically, and `search_sessions` reads from `sessions_fts`
+    /// without joining `sessions` — so an orphan FTS row would leave
+    /// the deleted agent's content searchable via `snippet(...)`. That
+    /// makes write-side asymmetry a privacy regression, not just a
+    /// recoverable hygiene issue.
     pub fn delete_agent_sessions(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let mut conn = self
             .conn
@@ -1415,6 +1418,42 @@ mod tests {
         store.delete_agent_sessions(agent_id).unwrap();
         assert!(store.get_session(s1.id).unwrap().is_none());
         assert!(store.get_session(s2.id).unwrap().is_none());
+    }
+
+    /// `delete_agent_sessions` must wipe `sessions_fts` in the same
+    /// transaction as `sessions`. `search_sessions` reads from the FTS
+    /// table without joining `sessions`, so any orphan FTS row remains
+    /// searchable (and snippets leak content) after the owning agent
+    /// is gone — a privacy regression, not a recoverable hygiene issue.
+    #[test]
+    fn test_delete_agent_sessions_clears_fts() {
+        let store = setup();
+        let agent_id = AgentId::new();
+
+        // Seed a session whose content goes through the FTS index.
+        let mut session = store.create_session(agent_id).unwrap();
+        let needle = "thequickbrownfoxnonceabc123";
+        session.messages.push(Message::user(needle));
+        store.save_session(&session).unwrap();
+
+        // FTS sees it.
+        let pre = store.search_sessions(needle, Some(&agent_id)).unwrap();
+        assert!(
+            !pre.is_empty(),
+            "FTS index must be populated by save_session"
+        );
+
+        store.delete_agent_sessions(agent_id).unwrap();
+
+        // After cascade delete, the FTS index must NOT still return the
+        // content. Pre-fix the FTS DELETE was best-effort outside the tx,
+        // so a partial failure (or any out-of-tx race) could leave the
+        // searchable orphan visible here.
+        let post = store.search_sessions(needle, Some(&agent_id)).unwrap();
+        assert!(
+            post.is_empty(),
+            "search_sessions must not return orphan FTS rows after delete_agent_sessions"
+        );
     }
 
     #[test]

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -536,7 +536,7 @@ impl SessionStore {
     /// The two `DELETE`s run inside a single transaction so a failure on
     /// either side rolls back the other and leaves the agent's history
     /// either fully intact or fully gone — never half-deleted with FTS
-    /// orphans pointing at missing rows (#3470).
+    /// orphans pointing at missing rows (#3470, #3501).
     pub fn delete_agent_sessions(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let mut conn = self
             .conn

--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -379,31 +379,7 @@ impl StructuredStore {
         let tx = conn
             .unchecked_transaction()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-
-        // Subquery-scoped deletes must happen BEFORE prompt_experiments
-        // is cleared, otherwise the IN (SELECT ...) matches nothing.
-        for stmt in [
-            "DELETE FROM experiment_metrics \
-             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
-            "DELETE FROM experiment_variants \
-             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
-            "DELETE FROM prompt_experiments WHERE agent_id = ?1",
-            "DELETE FROM prompt_versions WHERE agent_id = ?1",
-            "DELETE FROM approval_audit WHERE agent_id = ?1",
-            "DELETE FROM audit_entries WHERE agent_id = ?1",
-            "DELETE FROM usage_events WHERE agent_id = ?1",
-            "DELETE FROM memories WHERE agent_id = ?1",
-            "DELETE FROM canonical_sessions WHERE agent_id = ?1",
-            "DELETE FROM kv_store WHERE agent_id = ?1",
-            "DELETE FROM task_queue WHERE agent_id = ?1",
-            "DELETE FROM entities WHERE agent_id = ?1",
-            "DELETE FROM relations WHERE agent_id = ?1",
-            "DELETE FROM events WHERE source_agent = ?1",
-            "DELETE FROM agents WHERE id = ?1",
-        ] {
-            tx.execute(stmt, rusqlite::params![id])
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        }
+        execute_structured_agent_deletes(&tx, &id)?;
         tx.commit()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())
@@ -628,6 +604,44 @@ impl StructuredStore {
         }
         Ok(agents)
     }
+}
+
+/// Run every structured-store DELETE for an agent inside the caller's
+/// transaction. The single canonical list of agent-scoped tables;
+/// [`StructuredStore::remove_agent`] and
+/// [`crate::substrate::MemorySubstrate::remove_agent`] both share this
+/// helper so a new agent-scoped table only has to be added in one place.
+///
+/// Subquery-scoped deletes (`experiment_metrics` / `experiment_variants`)
+/// must run before `prompt_experiments` is cleared — otherwise the
+/// `IN (SELECT ...)` matches nothing.
+pub(crate) fn execute_structured_agent_deletes(
+    tx: &rusqlite::Transaction<'_>,
+    agent_id: &str,
+) -> LibreFangResult<()> {
+    for stmt in [
+        "DELETE FROM experiment_metrics \
+         WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+        "DELETE FROM experiment_variants \
+         WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+        "DELETE FROM prompt_experiments WHERE agent_id = ?1",
+        "DELETE FROM prompt_versions WHERE agent_id = ?1",
+        "DELETE FROM approval_audit WHERE agent_id = ?1",
+        "DELETE FROM audit_entries WHERE agent_id = ?1",
+        "DELETE FROM usage_events WHERE agent_id = ?1",
+        "DELETE FROM memories WHERE agent_id = ?1",
+        "DELETE FROM canonical_sessions WHERE agent_id = ?1",
+        "DELETE FROM kv_store WHERE agent_id = ?1",
+        "DELETE FROM task_queue WHERE agent_id = ?1",
+        "DELETE FROM entities WHERE agent_id = ?1",
+        "DELETE FROM relations WHERE agent_id = ?1",
+        "DELETE FROM events WHERE source_agent = ?1",
+        "DELETE FROM agents WHERE id = ?1",
+    ] {
+        tx.execute(stmt, rusqlite::params![agent_id])
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -361,12 +361,15 @@ impl StructuredStore {
     /// after agent deletion. All DELETEs run inside a single transaction so
     /// a mid-cascade failure leaves no half-removed state.
     ///
+    /// NOTE: most callers should use [`MemorySubstrate::remove_agent`]
+    /// instead, which wraps sessions + structured cascade in one tx (#3501).
+    /// This method does NOT touch `sessions` / `sessions_fts`.
+    ///
     /// Tables covered: agents, kv_store, task_queue, memories,
     /// canonical_sessions, audit_entries, usage_events, entities, relations,
     /// approval_audit, prompt_versions, prompt_experiments (plus their
     /// dependent experiment_variants and experiment_metrics rows), and
-    /// events via source_agent. sessions / sessions_fts are handled by
-    /// the caller (MemorySubstrate::remove_agent via SessionStore).
+    /// events via source_agent.
     pub fn remove_agent(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let conn = self
             .conn

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -176,20 +176,72 @@ impl MemorySubstrate {
         self.structured.load_agent(agent_id)
     }
 
-    /// Remove an agent from persistent storage and cascade-delete sessions.
+    /// Remove an agent and cascade-delete every agent-scoped row in a
+    /// single transaction.
+    ///
+    /// Pre-fix (#3501) sessions and structured rows were deleted in
+    /// independent locks/transactions: a failure between the two would
+    /// orphan whichever side had not run yet. Now all DELETEs share one
+    /// `unchecked_transaction` — partial cascade rolls back to the
+    /// pre-call state.
+    ///
+    /// `sessions_fts` is intentionally outside the rollback path: an FTS
+    /// failure logs a warning rather than aborting the cascade, because
+    /// the user-visible `agents` row removal is the primary contract and
+    /// FTS orphans are recoverable by a rebuild.
     pub fn remove_agent(&self, agent_id: AgentId) -> LibreFangResult<()> {
-        // Delete associated sessions first. Log on failure rather than
-        // silently swallowing — the agent row will still be removed, but
-        // the caller should know about the orphaned session rows so the
-        // inconsistency is at least observable.
-        if let Err(e) = self.sessions.delete_agent_sessions(agent_id) {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        let id = agent_id.0.to_string();
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+        // Order matters: subquery-scoped deletes must run BEFORE their
+        // parent rows are cleared, otherwise `IN (SELECT ...)` matches
+        // nothing. `agents` last so foreign-key-style references are
+        // resolved first.
+        for stmt in [
+            "DELETE FROM experiment_metrics \
+             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+            "DELETE FROM experiment_variants \
+             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
+            "DELETE FROM prompt_experiments WHERE agent_id = ?1",
+            "DELETE FROM prompt_versions WHERE agent_id = ?1",
+            "DELETE FROM approval_audit WHERE agent_id = ?1",
+            "DELETE FROM audit_entries WHERE agent_id = ?1",
+            "DELETE FROM usage_events WHERE agent_id = ?1",
+            "DELETE FROM memories WHERE agent_id = ?1",
+            "DELETE FROM sessions WHERE agent_id = ?1",
+            "DELETE FROM canonical_sessions WHERE agent_id = ?1",
+            "DELETE FROM kv_store WHERE agent_id = ?1",
+            "DELETE FROM task_queue WHERE agent_id = ?1",
+            "DELETE FROM entities WHERE agent_id = ?1",
+            "DELETE FROM relations WHERE agent_id = ?1",
+            "DELETE FROM events WHERE source_agent = ?1",
+            "DELETE FROM agents WHERE id = ?1",
+        ] {
+            tx.execute(stmt, rusqlite::params![id])
+                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        }
+        tx.commit()
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+
+        // FTS index cleanup outside the tx: it's a derived index and a
+        // failure shouldn't undo the user-visible agent removal.
+        if let Err(e) = conn.execute(
+            "DELETE FROM sessions_fts WHERE agent_id = ?1",
+            rusqlite::params![id],
+        ) {
             tracing::warn!(
                 %agent_id,
                 error = %e,
-                "Failed to cascade-delete sessions for agent; session rows may be orphaned",
+                "Failed to clear sessions_fts entries; FTS may need rebuild",
             );
         }
-        self.structured.remove_agent(agent_id)
+        Ok(())
     }
 
     /// Load all agent entries from persistent storage.
@@ -1769,5 +1821,64 @@ mod tests {
             finished_at.is_none(),
             "reset to pending must clear finished_at"
         );
+    }
+
+    /// #3501: `remove_agent` cascade-deletes sessions, memories, and the
+    /// agent row in a single transaction. Pre-fix the cascade ran across
+    /// multiple independent locks: a partial failure between the two
+    /// could orphan sessions whose agent had already been removed.
+    #[tokio::test]
+    async fn test_remove_agent_cascades_sessions_and_memories() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let agent_id = AgentId::new();
+
+        // Seed: a session and a memory under this agent.
+        let session = substrate.create_session(agent_id).unwrap();
+        substrate
+            .remember(
+                agent_id,
+                "remember me",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        // Sanity: both rows exist.
+        assert!(substrate.get_session(session.id).unwrap().is_some());
+        let pre_count: i64 = substrate
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE agent_id = ?1 AND deleted = 0",
+                rusqlite::params![agent_id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(pre_count, 1);
+
+        substrate.remove_agent(agent_id).unwrap();
+
+        // Sessions, memories, and the agent row must all be gone.
+        let conn = substrate.conn.lock().unwrap();
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE agent_id = ?1",
+                rusqlite::params![agent_id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_count, 0, "sessions must cascade-delete");
+
+        let memory_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE agent_id = ?1",
+                rusqlite::params![agent_id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(memory_count, 0, "memories must cascade-delete");
     }
 }

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -181,14 +181,16 @@ impl MemorySubstrate {
     ///
     /// Pre-fix (#3501) sessions and structured rows were deleted in
     /// independent locks/transactions: a failure between the two would
-    /// orphan whichever side had not run yet. Now all DELETEs share one
-    /// `unchecked_transaction` — partial cascade rolls back to the
-    /// pre-call state.
+    /// orphan whichever side had not run yet. Now all DELETEs — including
+    /// `sessions_fts` — share one `unchecked_transaction` so a partial
+    /// cascade rolls back to the pre-call state.
     ///
-    /// `sessions_fts` is intentionally outside the rollback path: an FTS
-    /// failure logs a warning rather than aborting the cascade, because
-    /// the user-visible `agents` row removal is the primary contract and
-    /// FTS orphans are recoverable by a rebuild.
+    /// `sessions_fts` cannot be left outside the rollback path: it stores
+    /// session content (`snippet(...)` returns it on any FTS hit) and
+    /// `search_sessions` reads from it without joining the `sessions`
+    /// table. A `sessions` row removed without its FTS twin would leave
+    /// the deleted agent's content searchable, which is a privacy
+    /// regression rather than a recoverable hygiene issue.
     pub fn remove_agent(&self, agent_id: AgentId) -> LibreFangResult<()> {
         let conn = self
             .conn
@@ -215,6 +217,7 @@ impl MemorySubstrate {
             "DELETE FROM usage_events WHERE agent_id = ?1",
             "DELETE FROM memories WHERE agent_id = ?1",
             "DELETE FROM sessions WHERE agent_id = ?1",
+            "DELETE FROM sessions_fts WHERE agent_id = ?1",
             "DELETE FROM canonical_sessions WHERE agent_id = ?1",
             "DELETE FROM kv_store WHERE agent_id = ?1",
             "DELETE FROM task_queue WHERE agent_id = ?1",
@@ -228,19 +231,6 @@ impl MemorySubstrate {
         }
         tx.commit()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-
-        // FTS index cleanup outside the tx: it's a derived index and a
-        // failure shouldn't undo the user-visible agent removal.
-        if let Err(e) = conn.execute(
-            "DELETE FROM sessions_fts WHERE agent_id = ?1",
-            rusqlite::params![id],
-        ) {
-            tracing::warn!(
-                %agent_id,
-                error = %e,
-                "Failed to clear sessions_fts entries; FTS may need rebuild",
-            );
-        }
         Ok(())
     }
 
@@ -1880,5 +1870,51 @@ mod tests {
             )
             .unwrap();
         assert_eq!(memory_count, 0, "memories must cascade-delete");
+    }
+
+    /// `remove_agent` must also wipe the `sessions_fts` index inside the
+    /// cascade transaction. `search_sessions` reads FTS rows directly
+    /// (no JOIN to `sessions`), so an orphan FTS row would let the
+    /// removed agent's session content remain full-text searchable —
+    /// a privacy regression, not a hygiene issue.
+    #[tokio::test]
+    async fn test_remove_agent_clears_sessions_fts() {
+        use librefang_types::message::Message;
+
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let agent_id = AgentId::new();
+
+        // Seed a session whose content lands in the FTS index.
+        let mut session = substrate.create_session(agent_id).unwrap();
+        let needle = "removalprivacynonceabc123";
+        session.messages.push(Message::user(needle));
+        substrate.save_session(&session).unwrap();
+
+        // Sanity: FTS sees it.
+        let pre = substrate.search_sessions(needle, Some(&agent_id)).unwrap();
+        assert!(!pre.is_empty(), "FTS must index the seeded content");
+
+        substrate.remove_agent(agent_id).unwrap();
+
+        // After remove_agent, the FTS row must be gone. If it survived
+        // outside the tx, search_sessions would still surface a snippet
+        // of the deleted agent's content.
+        let post = substrate.search_sessions(needle, Some(&agent_id)).unwrap();
+        assert!(
+            post.is_empty(),
+            "sessions_fts must be cleared inside remove_agent's tx"
+        );
+
+        // Also assert at the row level — search_sessions could in principle
+        // filter by JOIN in the future; the underlying table must be empty.
+        let conn = substrate.conn.lock().unwrap();
+        let fts_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions_fts WHERE agent_id = ?1",
+                rusqlite::params![agent_id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(fts_count, 0, "sessions_fts must cascade-delete");
     }
 }

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -200,35 +200,11 @@ impl MemorySubstrate {
         let tx = conn
             .unchecked_transaction()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-
-        // Order matters: subquery-scoped deletes must run BEFORE their
-        // parent rows are cleared, otherwise `IN (SELECT ...)` matches
-        // nothing. `agents` last so foreign-key-style references are
-        // resolved first.
-        for stmt in [
-            "DELETE FROM experiment_metrics \
-             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
-            "DELETE FROM experiment_variants \
-             WHERE experiment_id IN (SELECT id FROM prompt_experiments WHERE agent_id = ?1)",
-            "DELETE FROM prompt_experiments WHERE agent_id = ?1",
-            "DELETE FROM prompt_versions WHERE agent_id = ?1",
-            "DELETE FROM approval_audit WHERE agent_id = ?1",
-            "DELETE FROM audit_entries WHERE agent_id = ?1",
-            "DELETE FROM usage_events WHERE agent_id = ?1",
-            "DELETE FROM memories WHERE agent_id = ?1",
-            "DELETE FROM sessions WHERE agent_id = ?1",
-            "DELETE FROM sessions_fts WHERE agent_id = ?1",
-            "DELETE FROM canonical_sessions WHERE agent_id = ?1",
-            "DELETE FROM kv_store WHERE agent_id = ?1",
-            "DELETE FROM task_queue WHERE agent_id = ?1",
-            "DELETE FROM entities WHERE agent_id = ?1",
-            "DELETE FROM relations WHERE agent_id = ?1",
-            "DELETE FROM events WHERE source_agent = ?1",
-            "DELETE FROM agents WHERE id = ?1",
-        ] {
-            tx.execute(stmt, rusqlite::params![id])
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-        }
+        // Both helpers share their canonical DELETE list with the
+        // standalone `*_agent` methods on the individual stores so a new
+        // agent-scoped table only has to be added in one place.
+        crate::session::execute_session_agent_deletes(&tx, &id)?;
+        crate::structured::execute_structured_agent_deletes(&tx, &id)?;
         tx.commit()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
         Ok(())

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -19,6 +19,11 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
+// Single canonical impl lives in librefang-types; re-exported here so
+// existing `librefang_runtime::embedding::cosine_similarity` callers keep
+// working without three independently-edited copies drifting (see PR #4125).
+pub use librefang_types::memory::cosine_similarity;
+
 type HmacSha256 = Hmac<Sha256>;
 
 /// Error type for embedding operations.
@@ -928,35 +933,6 @@ fn provider_default_key_env(provider: &str) -> &'static str {
     }
 }
 
-/// Compute cosine similarity between two vectors.
-///
-/// Returns `Some(score)` in `[-1.0, 1.0]` where `1.0` = identical
-/// direction. Returns `None` when the vectors are not comparable
-/// (empty, dim mismatch, or zero magnitude). Callers must handle
-/// `None` explicitly — see #3536.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
-    if a.len() != b.len() || a.is_empty() {
-        return None;
-    }
-
-    let mut dot = 0.0f32;
-    let mut norm_a = 0.0f32;
-    let mut norm_b = 0.0f32;
-
-    for i in 0..a.len() {
-        dot += a[i] * b[i];
-        norm_a += a[i] * a[i];
-        norm_b += b[i] * b[i];
-    }
-
-    let denom = norm_a.sqrt() * norm_b.sqrt();
-    if denom < f32::EPSILON {
-        None
-    } else {
-        Some(dot / denom)
-    }
-}
-
 /// Serialize an embedding vector to bytes (for SQLite BLOB storage).
 pub fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(embedding.len() * 4);
@@ -978,64 +954,10 @@ pub fn embedding_from_bytes(bytes: &[u8]) -> Vec<f32> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_cosine_similarity_identical() {
-        let a = vec![1.0, 0.0, 0.0];
-        let b = vec![1.0, 0.0, 0.0];
-        let sim = cosine_similarity(&a, &b).expect("identical vectors are comparable");
-        assert!((sim - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_cosine_similarity_orthogonal() {
-        let a = vec![1.0, 0.0];
-        let b = vec![0.0, 1.0];
-        let sim = cosine_similarity(&a, &b).expect("orthogonal vectors are comparable");
-        assert!(sim.abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_cosine_similarity_opposite() {
-        let a = vec![1.0, 0.0];
-        let b = vec![-1.0, 0.0];
-        let sim = cosine_similarity(&a, &b).expect("opposite vectors are comparable");
-        assert!((sim + 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_cosine_similarity_real_vectors() {
-        let a = vec![0.1, 0.2, 0.3, 0.4];
-        let b = vec![0.1, 0.2, 0.3, 0.4];
-        let sim = cosine_similarity(&a, &b).expect("real vectors are comparable");
-        assert!((sim - 1.0).abs() < 1e-5);
-
-        let c = vec![0.4, 0.3, 0.2, 0.1];
-        let sim2 = cosine_similarity(&a, &c).expect("non-zero vectors are comparable");
-        assert!(sim2 > 0.0 && sim2 < 1.0); // Similar but not identical
-    }
-
-    #[test]
-    fn test_cosine_similarity_empty() {
-        // Empty vectors are not comparable — None, not 0.0.
-        assert_eq!(cosine_similarity(&[], &[]), None);
-    }
-
-    #[test]
-    fn test_cosine_similarity_length_mismatch() {
-        // Dim mismatch is not comparable — None, not 0.0.
-        let a = vec![1.0, 2.0];
-        let b = vec![1.0, 2.0, 3.0];
-        assert_eq!(cosine_similarity(&a, &b), None);
-    }
-
-    #[test]
-    fn test_cosine_similarity_zero_vector() {
-        // Zero magnitude → undefined direction → None (not 0.0).
-        let a = vec![0.0, 0.0, 0.0];
-        let b = vec![1.0, 2.0, 3.0];
-        assert_eq!(cosine_similarity(&a, &b), None);
-        assert_eq!(cosine_similarity(&b, &a), None);
-    }
+    // `cosine_similarity` itself is exercised in librefang-types
+    // (memory::tests::test_cosine_similarity_*); this module only
+    // re-exports it, so duplicating the same six test cases here would
+    // just lie about coverage when the canonical impl drifts.
 
     #[test]
     fn test_embedding_roundtrip() {

--- a/crates/librefang-runtime/src/embedding.rs
+++ b/crates/librefang-runtime/src/embedding.rs
@@ -930,10 +930,13 @@ fn provider_default_key_env(provider: &str) -> &'static str {
 
 /// Compute cosine similarity between two vectors.
 ///
-/// Returns a value in [-1.0, 1.0] where 1.0 = identical direction.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+/// Returns `Some(score)` in `[-1.0, 1.0]` where `1.0` = identical
+/// direction. Returns `None` when the vectors are not comparable
+/// (empty, dim mismatch, or zero magnitude). Callers must handle
+/// `None` explicitly — see #3536.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
     if a.len() != b.len() || a.is_empty() {
-        return 0.0;
+        return None;
     }
 
     let mut dot = 0.0f32;
@@ -948,9 +951,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 
     let denom = norm_a.sqrt() * norm_b.sqrt();
     if denom < f32::EPSILON {
-        0.0
+        None
     } else {
-        dot / denom
+        Some(dot / denom)
     }
 }
 
@@ -979,7 +982,7 @@ mod tests {
     fn test_cosine_similarity_identical() {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![1.0, 0.0, 0.0];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("identical vectors are comparable");
         assert!((sim - 1.0).abs() < 1e-6);
     }
 
@@ -987,7 +990,7 @@ mod tests {
     fn test_cosine_similarity_orthogonal() {
         let a = vec![1.0, 0.0];
         let b = vec![0.0, 1.0];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("orthogonal vectors are comparable");
         assert!(sim.abs() < 1e-6);
     }
 
@@ -995,7 +998,7 @@ mod tests {
     fn test_cosine_similarity_opposite() {
         let a = vec![1.0, 0.0];
         let b = vec![-1.0, 0.0];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("opposite vectors are comparable");
         assert!((sim + 1.0).abs() < 1e-6);
     }
 
@@ -1003,26 +1006,35 @@ mod tests {
     fn test_cosine_similarity_real_vectors() {
         let a = vec![0.1, 0.2, 0.3, 0.4];
         let b = vec![0.1, 0.2, 0.3, 0.4];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("real vectors are comparable");
         assert!((sim - 1.0).abs() < 1e-5);
 
         let c = vec![0.4, 0.3, 0.2, 0.1];
-        let sim2 = cosine_similarity(&a, &c);
+        let sim2 = cosine_similarity(&a, &c).expect("non-zero vectors are comparable");
         assert!(sim2 > 0.0 && sim2 < 1.0); // Similar but not identical
     }
 
     #[test]
     fn test_cosine_similarity_empty() {
-        let sim = cosine_similarity(&[], &[]);
-        assert_eq!(sim, 0.0);
+        // Empty vectors are not comparable — None, not 0.0.
+        assert_eq!(cosine_similarity(&[], &[]), None);
     }
 
     #[test]
     fn test_cosine_similarity_length_mismatch() {
+        // Dim mismatch is not comparable — None, not 0.0.
         let a = vec![1.0, 2.0];
         let b = vec![1.0, 2.0, 3.0];
-        let sim = cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
+        assert_eq!(cosine_similarity(&a, &b), None);
+    }
+
+    #[test]
+    fn test_cosine_similarity_zero_vector() {
+        // Zero magnitude → undefined direction → None (not 0.0).
+        let a = vec![0.0, 0.0, 0.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), None);
+        assert_eq!(cosine_similarity(&b, &a), None);
     }
 
     #[test]

--- a/crates/librefang-types/src/memory.rs
+++ b/crates/librefang-types/src/memory.rs
@@ -419,7 +419,12 @@ pub trait MemoryExtractor: Send + Sync {
                     })
                     .filter(|e| !e.is_empty());
                 match new_emb {
-                    Some(ref ne) => cosine_similarity(ne, emb),
+                    // Fall back to text similarity if vectors are not
+                    // comparable (dim mismatch, zero magnitude). 0.0 would
+                    // mean "fully dissimilar" and incorrectly suppress
+                    // legitimate dedup candidates.
+                    Some(ref ne) => cosine_similarity(ne, emb)
+                        .unwrap_or_else(|| text_similarity(&new_lower, &old_lower)),
                     None => text_similarity(&new_lower, &old_lower),
                 }
             } else {
@@ -512,11 +517,15 @@ pub fn text_similarity(a: &str, b: &str) -> f32 {
 
 /// Compute cosine similarity between two embedding vectors.
 ///
-/// Returns a value in `[-1.0, 1.0]` where `1.0` means identical direction.
-/// Returns `0.0` for empty or mismatched-length vectors.
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+/// Returns `Some(score)` in `[-1.0, 1.0]` where `1.0` means identical
+/// direction. Returns `None` when the vectors are not comparable:
+/// empty inputs, dimension mismatch, or either vector has zero
+/// magnitude. Callers MUST handle `None` explicitly — folding
+/// "not comparable" into a 0.0 score silently corrupts ranking
+/// because 0.0 means "fully dissimilar" (see #3536).
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
     if a.len() != b.len() || a.is_empty() {
-        return 0.0;
+        return None;
     }
     let mut dot = 0.0f32;
     let mut norm_a = 0.0f32;
@@ -528,9 +537,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     }
     let denom = norm_a.sqrt() * norm_b.sqrt();
     if denom < f32::EPSILON {
-        0.0
+        None
     } else {
-        dot / denom
+        Some(dot / denom)
     }
 }
 
@@ -1342,7 +1351,7 @@ mod tests {
     fn test_cosine_similarity_identical() {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![1.0, 0.0, 0.0];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("identical vectors are comparable");
         assert!((sim - 1.0).abs() < 1e-6);
     }
 
@@ -1350,19 +1359,30 @@ mod tests {
     fn test_cosine_similarity_orthogonal() {
         let a = vec![1.0, 0.0];
         let b = vec![0.0, 1.0];
-        let sim = cosine_similarity(&a, &b);
+        let sim = cosine_similarity(&a, &b).expect("orthogonal vectors are comparable");
         assert!(sim.abs() < 1e-6);
     }
 
     #[test]
     fn test_cosine_similarity_empty() {
-        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+        // Empty vectors are not comparable — must return None, not 0.0.
+        assert_eq!(cosine_similarity(&[], &[]), None);
     }
 
     #[test]
     fn test_cosine_similarity_length_mismatch() {
+        // Dim mismatch is not comparable — must return None, not 0.0.
         let a = vec![1.0, 2.0];
         let b = vec![1.0, 2.0, 3.0];
-        assert_eq!(cosine_similarity(&a, &b), 0.0);
+        assert_eq!(cosine_similarity(&a, &b), None);
+    }
+
+    #[test]
+    fn test_cosine_similarity_zero_vector() {
+        // Zero magnitude → undefined direction → None (not 0.0).
+        let a = vec![0.0, 0.0, 0.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), None);
+        assert_eq!(cosine_similarity(&b, &a), None);
     }
 }


### PR DESCRIPTION
## Summary

Three correctness fixes in `librefang-memory`, all closing existing issues.

### Closes #3537 — consolidation merge no longer drops loser state
Pre-fix the duplicate merger in `ConsolidationEngine::consolidate` only
soft-deleted the lower-confidence row (and lifted confidence in one edge
case). Everything else — `metadata`, `access_count`, `embedding` — was
silently lost.

Now, before the loser is soft-deleted, we:

- `access_count`: sum keeper + loser
- `metadata`: union JSON, keeper wins on key conflict
- `embedding`: confidence-weighted average when both vectors share a
  dimension; otherwise preserve the keeper's
- `confidence`: `max(keeper, loser)`

All five writes share one `unchecked_transaction`, so a failure can't
half-merge.

Regression test: `test_merge_preserves_metadata_access_count_and_embedding`.

### Closes #3536 — cosine_similarity surfaces non-comparable vectors
`cosine_similarity` now returns `Option<f32>`. `None` means
"not comparable" (dim mismatch, empty input, zero magnitude). Pre-fix
those cases returned `0.0`, which means "fully dissimilar" and silently
ranked broken vectors above genuinely orthogonal hits in
`SqliteVectorStore::search` and `recall_with_embedding`.

All call sites were audited:

- `SqliteVectorStore::search` — non-comparable rows are now `continue`'d
  (with a `debug!` log) instead of being inserted at score 0.0
- `SemanticStore::recall_with_embedding` re-ranking — falls back to a
  `-1.0` sentinel that sorts to the bottom, instead of `0.0` which would
  outrank genuinely orthogonal results
- `Memory::dedup_decision` and `proactive::find_duplicates` — fall back
  to text similarity instead of treating `0.0` as a real signal

The `Option` (rather than `Result`) interface was deliberate: callers
overwhelmingly want a fallback or skip path, not an error to bubble.

New regression test: `test_cosine_similarity_zero_vector` (in both
`librefang-types` and `librefang-runtime`).

### Closes #3501 — agent removal cascade in one transaction
`MemorySubstrate::remove_agent` previously called
`SessionStore::delete_agent_sessions` and `StructuredStore::remove_agent`
under independent locks/transactions. A failure between the two would
orphan whichever side hadn't run yet (sessions whose agent had already
been removed, or vice versa).

Now the substrate takes the conn lock once, opens one
`unchecked_transaction`, runs all 16 `DELETE`s (including
`sessions`/`canonical_sessions`), and commits. `sessions_fts` cleanup
stays outside the tx because it's a derived index — an FTS-only failure
shouldn't roll back the user-visible agent removal.

While auditing other cascades I found `KnowledgeStore::delete_by_agent`
had the same shape (`relations` + `entities` outside a tx) and fixed
it the same way.

Regression test: `test_remove_agent_cascades_sessions_and_memories`.

## Test plan
- [ ] `cargo test -p librefang-memory consolidation::tests`
- [ ] `cargo test -p librefang-memory substrate::tests::test_remove_agent_cascades_sessions_and_memories`
- [ ] `cargo test -p librefang-types memory::tests::test_cosine_similarity_zero_vector`
- [ ] `cargo test -p librefang-runtime tests::test_cosine_similarity_zero_vector`
- [ ] `cargo build --workspace --lib`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`

Closes #3537
Closes #3536
Closes #3501