### PR TITLE
fix(api,kernel,channels): close 6 endpoint reliability holes

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -108,6 +108,10 @@ fn is_owner_only_write(method: &axum::http::Method, path: &str) -> bool {
             | "/api/approvals/totp/setup"
             | "/api/approvals/totp/confirm"
             | "/api/approvals/totp/revoke"
+            // A2A discover registers a remote agent into the pending registry,
+            // expanding the trust surface; restrict to Owner so non-Owner API keys
+            // cannot fill the registry or stage impersonation attempts (#3483).
+            | "/api/a2a/discover"
     ) {
         return true;
     }

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -867,6 +867,24 @@ pub async fn a2a_discover_external(
 
             let card_json = serde_json::to_value(&card).unwrap_or_default();
 
+            // SECURITY (Bug #3483): cap the pending registry to prevent unbounded
+            // growth. Updating an existing pending entry (same URL) is always
+            // allowed; only NEW URLs are blocked once the cap is reached.
+            const MAX_PENDING_A2A_AGENTS: usize = 1024;
+            if !state.pending_a2a_agents.contains_key(&url)
+                && state.pending_a2a_agents.len() >= MAX_PENDING_A2A_AGENTS
+            {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "Pending A2A registry full ({} entries). Approve or remove existing entries first.",
+                            MAX_PENDING_A2A_AGENTS
+                        )
+                    })),
+                );
+            }
+
             // SECURITY (Bug #3786): Store in the PENDING list, not the trusted kernel
             // list. The agent cannot receive tasks until the operator explicitly
             // approves it via POST /api/a2a/agents/{url}/approve.

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -1243,7 +1243,7 @@ pub struct PaginationParams {
 }
 
 impl PaginationParams {
-    const DEFAULT_LIMIT: usize = 100;
+    const DEFAULT_LIMIT: usize = 50;
     const MAX_LIMIT: usize = 500;
 
     fn effective_limit(&self) -> usize {
@@ -1263,7 +1263,7 @@ impl PaginationParams {
     path = "/api/sessions",
     tag = "sessions",
     params(
-        ("limit" = Option<usize>, Query, description = "Max items (default 100, max 500)"),
+        ("limit" = Option<usize>, Query, description = "Max items (default 50, max 500)"),
         ("offset" = Option<usize>, Query, description = "Items to skip"),
     ),
     responses(
@@ -1274,19 +1274,18 @@ pub async fn list_sessions(
     State(state): State<Arc<AppState>>,
     Query(pagination): Query<PaginationParams>,
 ) -> impl IntoResponse {
-    match state.kernel.memory_substrate().list_sessions() {
-        Ok(all_sessions) => {
-            let total = all_sessions.len();
-            let offset = pagination.effective_offset();
-            let limit = pagination.effective_limit();
-            let items: Vec<_> = all_sessions.into_iter().skip(offset).take(limit).collect();
-            Json(serde_json::json!({
-                "sessions": items,
-                "total": total,
-                "offset": offset,
-                "limit": limit,
-            }))
-        }
+    let offset = pagination.effective_offset();
+    let limit = pagination.effective_limit();
+    let substrate = state.kernel.memory_substrate();
+    // Push pagination into SQLite so we don't deserialize every session blob (#3485).
+    let total = substrate.count_sessions().unwrap_or(0);
+    match substrate.list_sessions_paginated(Some(limit), offset) {
+        Ok(items) => Json(serde_json::json!({
+            "sessions": items,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+        })),
         Err(_) => Json(serde_json::json!({
             "sessions": [],
             "total": 0,
@@ -1606,7 +1605,7 @@ fn approval_to_json(
     path = "/api/approvals",
     tag = "approvals",
     params(
-        ("limit" = Option<usize>, Query, description = "Max items (default 100, max 500)"),
+        ("limit" = Option<usize>, Query, description = "Max items (default 50, max 500)"),
         ("offset" = Option<usize>, Query, description = "Items to skip"),
     ),
     responses((status = 200, description = "Paginated list of pending and recent approvals", body = serde_json::Value))

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -14510,7 +14510,7 @@
       ]
     },
     "max_request_body_bytes": {
-      "default": 1048576,
+      "default": 8388608,
       "description": "Maximum request body size in bytes (global safety net). Individual endpoints may enforce tighter limits.",
       "format": "uint",
       "minimum": 0.0,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -6260,6 +6260,42 @@ mod tests {
             let (drained_msg, _) = result.unwrap();
             assert_content_eq(&drained_msg.content, "1\n2");
         }
+
+        // Regression test for #3742: simulates the race where the manual
+        // max-buffer flush path AND the max_timer task BOTH enqueue the same
+        // key on flush_tx. The receiver loop calls drain() once per dequeued
+        // key, so the second call must be a noop — i.e. drain() relies on
+        // `buffers.remove(key)` as the atomic single-take guard. If anything
+        // ever regresses to e.g. `buffers.get(key)` + side effects, this test
+        // catches the resulting double-send.
+        #[tokio::test]
+        async fn test_debouncer_double_drain_is_idempotent() {
+            let (debouncer, _rx) = MessageDebouncer::new(1000, 5000, 10);
+            let mut buffers: HashMap<String, SenderBuffer> = HashMap::new();
+
+            debouncer.push(
+                "discord:userX",
+                PendingMessage {
+                    message: make_test_message("only"),
+                    image_blocks: None,
+                },
+                &mut buffers,
+            );
+
+            // First drain takes the buffer atomically.
+            let first = debouncer.drain("discord:userX", &mut buffers);
+            assert!(first.is_some());
+            // Second drain on the same key must observe an empty entry and noop.
+            let second = debouncer.drain("discord:userX", &mut buffers);
+            assert!(
+                second.is_none(),
+                "double-flush race must not duplicate-send (#3742)"
+            );
+            assert!(
+                !buffers.contains_key("discord:userX"),
+                "drain must remove the buffer entry"
+            );
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -172,6 +172,19 @@ pub fn proxied_client() -> reqwest::Client {
         .expect("HTTP client with proxy/TLS config should always build")
 }
 
+/// Build a fallback [`reqwest::Client`] used when a per-provider proxy override
+/// is invalid. Identical to [`proxied_client`] but also enforces a total
+/// per-request timeout so a stuck upstream cannot wedge the agent loop
+/// indefinitely (#3756). Callers should `tracing::warn!` before invoking.
+pub fn proxied_client_fallback() -> reqwest::Client {
+    proxied_client_builder()
+        // Total per-request budget on top of connect/read timeouts. 300s aligns
+        // with the read_timeout already set in build_http_client.
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .expect("HTTP fallback client with proxy/TLS config should always build")
+}
+
 /// Build a [`reqwest::Client`] that routes all traffic through the given proxy URL,
 /// ignoring the global proxy config. Used for per-provider proxy overrides.
 ///

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9549,13 +9549,16 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Snapshot previous skill list so we can roll back the in-memory mutation
-        // if the DB persist fails (#3499 — previously `let _ =` swallowed the error
-        // and left the registry drifted from disk).
-        let prev_skills = self
+        // Snapshot previous skill list AND skills_disabled flag so we can roll
+        // back the in-memory mutation if the DB persist fails (#3499 — previously
+        // `let _ =` swallowed the error and left the registry drifted from disk).
+        // Note: capture both fields because `update_skills` always sets
+        // `skills_disabled = false`, so a rollback that only restored `skills`
+        // would silently leave the disabled flag flipped on persist failure.
+        let prev_skills_state = self
             .registry
             .get(agent_id)
-            .map(|e| e.manifest.skills.clone());
+            .map(|e| (e.manifest.skills.clone(), e.manifest.skills_disabled));
 
         self.registry
             .update_skills(agent_id, skills.clone())
@@ -9563,8 +9566,10 @@ system_prompt = "You are a helpful assistant."
 
         if let Some(entry) = self.registry.get(agent_id) {
             if let Err(e) = self.memory.save_agent(&entry) {
-                if let Some(p_skills) = prev_skills {
-                    let _ = self.registry.update_skills(agent_id, p_skills);
+                if let Some((p_skills, p_disabled)) = prev_skills_state {
+                    let _ = self
+                        .registry
+                        .restore_skills_state(agent_id, p_skills, p_disabled);
                 }
                 return Err(KernelError::LibreFang(e));
             }
@@ -9658,12 +9663,17 @@ system_prompt = "You are a helpful assistant."
             "Agent tool filters updated"
         );
 
-        // Snapshot previous tool config for rollback on DB persist failure (#3499).
+        // Snapshot previous tool config + tools_disabled flag for rollback on
+        // DB persist failure (#3499). Capture all four fields because
+        // `update_tool_config` always sets `tools_disabled = false`, so a
+        // rollback that only restored the lists would silently leave the
+        // disabled flag flipped on persist failure.
         let prev_tool_state = self.registry.get(agent_id).map(|e| {
             (
                 e.manifest.capabilities.tools.clone(),
                 e.manifest.tool_allowlist.clone(),
                 e.manifest.tool_blocklist.clone(),
+                e.manifest.tools_disabled,
             )
         });
 
@@ -9673,12 +9683,13 @@ system_prompt = "You are a helpful assistant."
 
         if let Some(entry) = self.registry.get(agent_id) {
             if let Err(e) = self.memory.save_agent(&entry) {
-                if let Some((p_caps, p_allow, p_block)) = prev_tool_state {
-                    let _ = self.registry.update_tool_config(
+                if let Some((p_caps, p_allow, p_block, p_disabled)) = prev_tool_state {
+                    let _ = self.registry.restore_tool_state(
                         agent_id,
-                        Some(p_caps),
-                        Some(p_allow),
-                        Some(p_block),
+                        p_caps,
+                        p_allow,
+                        p_block,
+                        p_disabled,
                     );
                 }
                 return Err(KernelError::LibreFang(e));

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9301,6 +9301,16 @@ system_prompt = "You are a helpful assistant."
             model.to_string()
         };
 
+        // Snapshot the full model state for rollback on DB persist failure (#3499).
+        let prev_model_state = self.registry.get(agent_id).map(|e| {
+            (
+                e.manifest.model.model.clone(),
+                e.manifest.model.provider.clone(),
+                e.manifest.model.api_key_env.clone(),
+                e.manifest.model.base_url.clone(),
+            )
+        });
+
         if let Some(provider) = provider {
             // When the provider changes, also clear any per-agent api_key_env
             // and base_url overrides — they belonged to the previous provider
@@ -9339,9 +9349,22 @@ system_prompt = "You are a helpful assistant."
             info!(agent_id = %agent_id, model = %normalized_model, "Agent model updated (provider unchanged)");
         }
 
-        // Persist the updated entry
+        // Persist the updated entry. On DB failure, roll back the in-memory model
+        // mutation and propagate the error so the API caller sees a 500 instead of
+        // silently drifting registry vs. disk (#3499).
         if let Some(entry) = self.registry.get(agent_id) {
-            let _ = self.memory.save_agent(&entry);
+            if let Err(e) = self.memory.save_agent(&entry) {
+                if let Some((p_model, p_provider, p_api_key_env, p_base_url)) = prev_model_state {
+                    let _ = self.registry.update_model_provider_config(
+                        agent_id,
+                        p_model,
+                        p_provider,
+                        p_api_key_env,
+                        p_base_url,
+                    );
+                }
+                return Err(KernelError::LibreFang(e));
+            }
         }
 
         // Write updated manifest to agent.toml so changes survive restart (#996, #1018)
@@ -9526,12 +9549,25 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        // Snapshot previous skill list so we can roll back the in-memory mutation
+        // if the DB persist fails (#3499 — previously `let _ =` swallowed the error
+        // and left the registry drifted from disk).
+        let prev_skills = self
+            .registry
+            .get(agent_id)
+            .map(|e| e.manifest.skills.clone());
+
         self.registry
             .update_skills(agent_id, skills.clone())
             .map_err(KernelError::LibreFang)?;
 
         if let Some(entry) = self.registry.get(agent_id) {
-            let _ = self.memory.save_agent(&entry);
+            if let Err(e) = self.memory.save_agent(&entry) {
+                if let Some(p_skills) = prev_skills {
+                    let _ = self.registry.update_skills(agent_id, p_skills);
+                }
+                return Err(KernelError::LibreFang(e));
+            }
         }
 
         // Invalidate cached tool list — skill allowlist change affects available tools
@@ -9576,12 +9612,23 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        // Snapshot previous MCP server allowlist for rollback on DB persist failure (#3499).
+        let prev_servers = self
+            .registry
+            .get(agent_id)
+            .map(|e| e.manifest.mcp_servers.clone());
+
         self.registry
             .update_mcp_servers(agent_id, servers.clone())
             .map_err(KernelError::LibreFang)?;
 
         if let Some(entry) = self.registry.get(agent_id) {
-            let _ = self.memory.save_agent(&entry);
+            if let Err(e) = self.memory.save_agent(&entry) {
+                if let Some(p_servers) = prev_servers {
+                    let _ = self.registry.update_mcp_servers(agent_id, p_servers);
+                }
+                return Err(KernelError::LibreFang(e));
+            }
         }
 
         // Invalidate cached tool list — MCP server allowlist change affects available tools
@@ -9611,12 +9658,31 @@ system_prompt = "You are a helpful assistant."
             "Agent tool filters updated"
         );
 
+        // Snapshot previous tool config for rollback on DB persist failure (#3499).
+        let prev_tool_state = self.registry.get(agent_id).map(|e| {
+            (
+                e.manifest.capabilities.tools.clone(),
+                e.manifest.tool_allowlist.clone(),
+                e.manifest.tool_blocklist.clone(),
+            )
+        });
+
         self.registry
             .update_tool_config(agent_id, capabilities_tools, allowlist, blocklist)
             .map_err(KernelError::LibreFang)?;
 
         if let Some(entry) = self.registry.get(agent_id) {
-            let _ = self.memory.save_agent(&entry);
+            if let Err(e) = self.memory.save_agent(&entry) {
+                if let Some((p_caps, p_allow, p_block)) = prev_tool_state {
+                    let _ = self.registry.update_tool_config(
+                        agent_id,
+                        Some(p_caps),
+                        Some(p_allow),
+                        Some(p_block),
+                    );
+                }
+                return Err(KernelError::LibreFang(e));
+            }
         }
 
         self.persist_manifest_to_disk(agent_id);

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -398,6 +398,51 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Rollback helper for [`Self::update_skills`]: restores both the skill
+    /// allowlist AND the `skills_disabled` flag. `update_skills` always sets
+    /// `skills_disabled = false` (deliberate "re-enable on update" semantics),
+    /// so a rollback that only restored `skills` would silently leave the flag
+    /// flipped on a failed DB persist (#3499).
+    pub fn restore_skills_state(
+        &self,
+        id: AgentId,
+        skills: Vec<String>,
+        skills_disabled: bool,
+    ) -> LibreFangResult<()> {
+        let mut entry = self
+            .agents
+            .get_mut(&id)
+            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+        entry.manifest.skills = skills;
+        entry.manifest.skills_disabled = skills_disabled;
+        entry.last_active = chrono::Utc::now();
+        Ok(())
+    }
+
+    /// Rollback helper for [`Self::update_tool_config`]: restores tool fields
+    /// AND the `tools_disabled` flag. `update_tool_config` always sets
+    /// `tools_disabled = false`; a rollback that only restored the lists would
+    /// silently leave the flag flipped on a failed DB persist (#3499).
+    pub fn restore_tool_state(
+        &self,
+        id: AgentId,
+        capabilities_tools: Vec<String>,
+        allowlist: Vec<String>,
+        blocklist: Vec<String>,
+        tools_disabled: bool,
+    ) -> LibreFangResult<()> {
+        let mut entry = self
+            .agents
+            .get_mut(&id)
+            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+        entry.manifest.capabilities.tools = capabilities_tools;
+        entry.manifest.tool_allowlist = allowlist;
+        entry.manifest.tool_blocklist = blocklist;
+        entry.manifest.tools_disabled = tools_disabled;
+        entry.last_active = chrono::Utc::now();
+        Ok(())
+    }
+
     /// Update an agent's system prompt (hot-swap, takes effect on next message).
     pub fn update_system_prompt(&self, id: AgentId, new_prompt: String) -> LibreFangResult<()> {
         let mut entry = self

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -49,8 +49,14 @@ impl AnthropicDriver {
     ) -> Self {
         let client = match proxy_url {
             Some(url) => librefang_http::proxied_client_with_override(url).unwrap_or_else(|e| {
-                tracing::warn!(url, error = %e, "Invalid per-provider proxy URL, using global proxy");
-                librefang_http::proxied_client()
+                // Use the bounded fallback so a global client without a per-request
+                // total timeout cannot leave a request hanging indefinitely (#3756).
+                tracing::warn!(
+                    url,
+                    error = %e,
+                    "Invalid per-provider proxy URL; falling back to global proxy with bounded timeout"
+                );
+                librefang_http::proxied_client_fallback()
             }),
             None => librefang_http::proxied_client(),
         };

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -55,8 +55,14 @@ impl GeminiDriver {
     ) -> Self {
         let client = match proxy_url {
             Some(url) => librefang_http::proxied_client_with_override(url).unwrap_or_else(|e| {
-                tracing::warn!(url, error = %e, "Invalid per-provider proxy URL, using global proxy");
-                librefang_http::proxied_client()
+                // Use the bounded fallback so a global client without a per-request
+                // total timeout cannot leave a request hanging indefinitely (#3756).
+                tracing::warn!(
+                    url,
+                    error = %e,
+                    "Invalid per-provider proxy URL; falling back to global proxy with bounded timeout"
+                );
+                librefang_http::proxied_client_fallback()
             }),
             None => librefang_http::proxied_client(),
         };

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -594,10 +594,35 @@ impl SessionStore {
     /// `session_id IS NULL` and contribute nothing — list views will show
     /// `null` for those rows, not stale data.
     pub fn list_sessions(&self) -> LibreFangResult<Vec<serde_json::Value>> {
+        self.list_sessions_paginated(None, 0)
+    }
+
+    /// Total number of sessions stored.
+    pub fn count_sessions(&self) -> LibreFangResult<usize> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        Ok(total.max(0) as usize)
+    }
+
+    /// Paginated session listing. `limit = None` returns all rows from `offset` onward.
+    /// Pushes LIMIT/OFFSET into SQLite so we never deserialize message blobs we won't return (#3485).
+    pub fn list_sessions_paginated(
+        &self,
+        limit: Option<usize>,
+        offset: usize,
+    ) -> LibreFangResult<Vec<serde_json::Value>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        // SQLite uses -1 for "no limit"
+        let lim_sql: i64 = limit.map(|n| n as i64).unwrap_or(-1);
+        let off_sql: i64 = offset as i64;
         let mut stmt = conn
             .prepare(
                 "SELECT s.id, s.agent_id, s.messages, s.context_window_tokens, s.created_at, s.label,
@@ -612,12 +637,12 @@ impl SessionStore {
                      WHERE session_id IS NOT NULL
                      GROUP BY session_id
                  ) u ON u.session_id = s.id
-                 ORDER BY s.created_at DESC",
+                 ORDER BY s.created_at DESC LIMIT ?1 OFFSET ?2",
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         let rows = stmt
-            .query_map([], |row| {
+            .query_map(rusqlite::params![lim_sql, off_sql], |row| {
                 let session_id: String = row.get(0)?;
                 let agent_id: String = row.get(1)?;
                 let messages_blob: Vec<u8> = row.get(2)?;

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -273,6 +273,20 @@ impl MemorySubstrate {
         self.sessions.list_sessions()
     }
 
+    /// Paginated session listing — pushes LIMIT/OFFSET into SQLite (#3485).
+    pub fn list_sessions_paginated(
+        &self,
+        limit: Option<usize>,
+        offset: usize,
+    ) -> LibreFangResult<Vec<serde_json::Value>> {
+        self.sessions.list_sessions_paginated(limit, offset)
+    }
+
+    /// Total number of sessions stored.
+    pub fn count_sessions(&self) -> LibreFangResult<usize> {
+        self.sessions.count_sessions()
+    }
+
     /// Delete a session by ID.
     pub fn delete_session(&self, session_id: SessionId) -> LibreFangResult<()> {
         self.sessions.delete_session(session_id)

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3961,9 +3961,13 @@ fn default_max_agent_call_depth() -> u32 {
     5
 }
 
-/// Default maximum request body size in bytes (1 MB).
+/// Default maximum request body size in bytes (8 MiB).
+///
+/// Raised from 1 MiB so that dashboard uploads of ~1 MiB files (which incur
+/// multipart-form overhead) no longer get rejected with 413. Per-route caps
+/// (A2A 1 MiB, webhook 1 MiB) still bound external attack surface (#3493).
 fn default_max_request_body_bytes() -> usize {
-    1_024 * 1_024
+    8 * 1_024 * 1_024
 }
 
 /// Audit log configuration.


### PR DESCRIPTION
## Summary

Six independent reliability fixes across API, kernel, and channel layers.

- **#3493** (`librefang-types`): default `max_request_body_bytes` 1 MiB → 8 MiB so dashboard uploads of ~1 MiB files no longer hit 413 from multipart overhead. Per-route caps (A2A 1 MiB, webhook 1 MiB) still bound external attack surface.
- **#3485** (`librefang-api`, `librefang-memory`): push `LIMIT`/`OFFSET` into SQLite for `GET /api/sessions`. Add `count_sessions` + `list_sessions_paginated` to substrate so we no longer deserialize every session blob just to slice. Default page size 100 → 50.
- **#3483** (`librefang-api`): cap pending A2A registry to 1024 entries (returns 429 once full, but lets re-discovery of an existing URL update in place). Gate `POST /api/a2a/discover` to Owner via the existing `is_owner_only_write` allowlist.
- **#3499** (`librefang-kernel`): `set_agent_model` / `set_agent_skills` / `set_agent_mcp_servers` / `set_agent_tool_filters` previously did `let _ = self.memory.save_agent(&entry)`, silently swallowing DB persist failures and leaving the in-memory registry drifted from disk. Each now snapshots the previous state, propagates the error as `KernelError`, and rolls the registry back to the snapshot — yes, in-memory rollback is introduced. The API handlers already returned 500 on `Err`, so the contract change is just that they now actually do.
- **#3756** (`librefang-http`, `librefang-llm-drivers`): add `proxied_client_fallback()` with an explicit total per-request timeout (300s) on top of the existing connect/read timeouts. Anthropic and Gemini drivers' invalid-override fallback path now uses it, so a stuck upstream can't wedge the agent loop indefinitely.
- **#3742** (`librefang-channels`): the existing `MessageDebouncer::drain` already uses `buffers.remove(key)` as the atomic single-take guard against the max-buffer + max_timer double-fire race. Add a regression test (`test_debouncer_double_drain_is_idempotent`) so any future refactor away from atomic take fails CI loudly.

Closes #3493
Closes #3485
Closes #3483
Closes #3499
Closes #3756
Closes #3742

## Test plan

- [ ] CI: `cargo build --workspace --lib`
- [ ] CI: `cargo test --workspace`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Live: `curl -X POST /api/sessions?limit=10&offset=0` returns paginated `{sessions, total, offset, limit}` and only deserializes the requested page (verified by examining the SQL stmt).
- [ ] Live: `POST /api/a2a/discover` from a non-Owner API key returns 403; from Owner, the 1025th distinct URL returns 429.
- [ ] Live: induce `save_agent` failure (e.g. read-only DB) and verify `PUT /api/agents/{id}/model` returns 500 and a subsequent `GET` shows the model unchanged.
- [ ] Live: dashboard upload of a ~1 MiB file no longer 413s.