### PR TITLE
perf(hot-path): cut Vec/Arc clones, regex compiles, and N+1 SUMs

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1629,7 +1629,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
 
     async fn subscribe_events(
         &self,
-    ) -> Option<tokio::sync::broadcast::Receiver<librefang_types::event::Event>> {
+    ) -> Option<tokio::sync::broadcast::Receiver<std::sync::Arc<librefang_types::event::Event>>>
+    {
         Some(self.kernel.event_bus_ref().subscribe_all())
     }
 

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -364,7 +364,8 @@ pub trait ChannelBridgeHandle: Send + Sync {
     /// Default returns None (event subscription not available).
     async fn subscribe_events(
         &self,
-    ) -> Option<tokio::sync::broadcast::Receiver<librefang_types::event::Event>> {
+    ) -> Option<tokio::sync::broadcast::Receiver<std::sync::Arc<librefang_types::event::Event>>>
+    {
         None
     }
 
@@ -1271,7 +1272,7 @@ impl BridgeManager {
                     result = rx.recv() => {
                         match result {
                             Ok(event) => {
-                                if let librefang_types::event::EventPayload::ApprovalRequested(ref approval) = event.payload {
+                                if let librefang_types::event::EventPayload::ApprovalRequested(approval) = &event.payload {
                                     let msg = format!(
                                         "Approval required for agent {}\n\
                                          Tool: {}\n\

--- a/crates/librefang-channels/src/qq.rs
+++ b/crates/librefang-channels/src/qq.rs
@@ -118,7 +118,33 @@ impl QqAdapter {
 }
 
 /// Strip markdown formatting to plain text for QQ.
+///
+/// All regexes are compiled once via `LazyLock` — this fires on every
+/// outbound QQ message and per-pattern `Regex::new` was hundreds of
+/// microseconds wasted per call (#3491).
 fn strip_markdown(text: &str) -> String {
+    use std::sync::LazyLock;
+    static RE_CODEBLOCK: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"```\w*\n?([\s\S]*?)```").unwrap());
+    static RE_INLINE: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"`([^`]+)`").unwrap());
+    static RE_BOLD: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\*\*([^*]+)\*\*").unwrap());
+    static RE_ITALIC: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\*([^*]+)\*").unwrap());
+    static RE_HEADING: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?m)^#{1,6}\s+").unwrap());
+    static RE_TABLE_SEP: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?m)^\|[-:| ]+\|$").unwrap());
+    static RE_LINK: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\[([^\]]+)\]\([^)]+\)").unwrap());
+    static RE_QUOTE: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?m)^>\s?").unwrap());
+    static RE_HR: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"(?m)^---+$").unwrap());
+    static RE_NEWLINES: LazyLock<regex_lite::Regex> =
+        LazyLock::new(|| regex_lite::Regex::new(r"\n{3,}").unwrap());
+
     let mut s = text.to_string();
     // Remove <think>...</think> reasoning tags
     while let Some(start) = s.find("<think>") {
@@ -128,36 +154,16 @@ fn strip_markdown(text: &str) -> String {
             break;
         }
     }
-    // Code blocks: keep content, remove fences
-    let re_codeblock = regex_lite::Regex::new(r"```\w*\n?([\s\S]*?)```").unwrap();
-    s = re_codeblock.replace_all(&s, "$1").to_string();
-    // Inline code
-    let re_inline = regex_lite::Regex::new(r"`([^`]+)`").unwrap();
-    s = re_inline.replace_all(&s, "$1").to_string();
-    // Bold
-    let re_bold = regex_lite::Regex::new(r"\*\*([^*]+)\*\*").unwrap();
-    s = re_bold.replace_all(&s, "$1").to_string();
-    // Italic
-    let re_italic = regex_lite::Regex::new(r"\*([^*]+)\*").unwrap();
-    s = re_italic.replace_all(&s, "$1").to_string();
-    // Headings
-    let re_heading = regex_lite::Regex::new(r"(?m)^#{1,6}\s+").unwrap();
-    s = re_heading.replace_all(&s, "").to_string();
-    // Table separator rows
-    let re_table_sep = regex_lite::Regex::new(r"(?m)^\|[-:| ]+\|$").unwrap();
-    s = re_table_sep.replace_all(&s, "").to_string();
-    // Links
-    let re_link = regex_lite::Regex::new(r"\[([^\]]+)\]\([^)]+\)").unwrap();
-    s = re_link.replace_all(&s, "$1").to_string();
-    // Blockquotes
-    let re_quote = regex_lite::Regex::new(r"(?m)^>\s?").unwrap();
-    s = re_quote.replace_all(&s, "").to_string();
-    // Horizontal rules
-    let re_hr = regex_lite::Regex::new(r"(?m)^---+$").unwrap();
-    s = re_hr.replace_all(&s, "").to_string();
-    // Excess newlines
-    let re_newlines = regex_lite::Regex::new(r"\n{3,}").unwrap();
-    s = re_newlines.replace_all(&s, "\n\n").to_string();
+    s = RE_CODEBLOCK.replace_all(&s, "$1").to_string();
+    s = RE_INLINE.replace_all(&s, "$1").to_string();
+    s = RE_BOLD.replace_all(&s, "$1").to_string();
+    s = RE_ITALIC.replace_all(&s, "$1").to_string();
+    s = RE_HEADING.replace_all(&s, "").to_string();
+    s = RE_TABLE_SEP.replace_all(&s, "").to_string();
+    s = RE_LINK.replace_all(&s, "$1").to_string();
+    s = RE_QUOTE.replace_all(&s, "").to_string();
+    s = RE_HR.replace_all(&s, "").to_string();
+    s = RE_NEWLINES.replace_all(&s, "\n\n").to_string();
     s.trim().to_string()
 }
 

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -126,7 +126,9 @@ pub struct ServerHandleHolder(pub std::sync::Mutex<Option<server::ServerHandle>>
 /// logs rather than a silent `warn!` on a per-listener counter (issue #3630).
 pub async fn forward_kernel_events(
     app_handle: tauri::AppHandle,
-    event_rx: &mut tokio::sync::broadcast::Receiver<librefang_types::event::Event>,
+    event_rx: &mut tokio::sync::broadcast::Receiver<
+        std::sync::Arc<librefang_types::event::Event>,
+    >,
     kernel: &Arc<LibreFangKernel>,
 ) {
     while let Some(event) =

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -1093,11 +1093,13 @@ fn phrase_matches(message: &str, phrase: &str) -> bool {
     }
 
     if is_ascii_phrase(candidate) {
+        // Reuse the global REGEX_CACHE so the same phrase across many incoming
+        // messages compiles only once (#3491). The cache key already includes
+        // the same `(?i)` casing applied here, so we avoid double-compilation
+        // by using `regex_matches` with a pattern that mirrors that contract.
         let escaped = regex_lite::escape(&candidate.to_lowercase()).replace("\\ ", r"[\s_-]+");
-        let pattern = format!(r"(?i)(^|[^a-z0-9]){}([^a-z0-9]|$)", escaped);
-        return Regex::new(&pattern)
-            .map(|regex| regex.is_match(&message.to_lowercase()))
-            .unwrap_or(false);
+        let pattern = format!(r"(^|[^a-z0-9]){}([^a-z0-9]|$)", escaped);
+        return regex_matches(&message.to_lowercase(), &pattern);
     }
 
     message.to_lowercase().contains(&candidate.to_lowercase())

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -13,11 +13,15 @@ use tracing::{debug, error, warn};
 const HISTORY_SIZE: usize = 1000;
 
 /// The central event bus for inter-agent and system communication.
+///
+/// Events are wrapped in `Arc<Event>` before broadcast so each subscriber
+/// receives a cheap reference-counted handle instead of a deep clone of
+/// the (potentially large) payload. See #3380.
 pub struct EventBus {
     /// Broadcast channel for all events.
-    sender: broadcast::Sender<Event>,
+    sender: broadcast::Sender<Arc<Event>>,
     /// Per-agent event channels.
-    agent_channels: DashMap<AgentId, broadcast::Sender<Event>>,
+    agent_channels: DashMap<AgentId, broadcast::Sender<Arc<Event>>>,
     /// Event history ring buffer.
     history: Arc<RwLock<VecDeque<Event>>>,
     /// Count of events dropped because the per-agent channel had no active receiver.
@@ -59,6 +63,10 @@ impl EventBus {
     }
 
     /// Publish an event to the bus.
+    ///
+    /// The event is wrapped in `Arc<Event>` so dispatching to N subscribers
+    /// performs N cheap atomic ref-count bumps instead of N deep clones of
+    /// the payload (#3380).
     pub async fn publish(&self, event: Event) {
         debug!(
             event_id = %event.id,
@@ -67,7 +75,8 @@ impl EventBus {
             "Publishing event"
         );
 
-        // Store in history
+        // Store in history (history needs an owned copy — we keep this clone
+        // only at the boundary; the broadcast hot path uses Arc throughout).
         {
             let mut history = self.history.write().await;
             if history.len() >= HISTORY_SIZE {
@@ -76,11 +85,14 @@ impl EventBus {
             history.push_back(event.clone());
         }
 
+        // Wrap once, share via Arc clones — no payload deep-clone per subscriber.
+        let event = Arc::new(event);
+
         // Route to target
         match &event.target {
             EventTarget::Agent(agent_id) => {
                 if let Some(sender) = self.agent_channels.get(agent_id) {
-                    if sender.send(event.clone()).is_err() {
+                    if sender.send(Arc::clone(&event)).is_err() {
                         let total = self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
                         if let Ok(mut last) = self.last_drop_warn.lock() {
                             if last.elapsed() >= std::time::Duration::from_secs(10) {
@@ -98,7 +110,7 @@ impl EventBus {
                 }
             }
             EventTarget::Broadcast => {
-                if self.sender.send(event.clone()).is_err() {
+                if self.sender.send(Arc::clone(&event)).is_err() {
                     debug!(
                         event_id = %event.id,
                         event_kind = payload_kind(&event.payload),
@@ -107,7 +119,7 @@ impl EventBus {
                 }
                 let mut agent_drops: u64 = 0;
                 for entry in self.agent_channels.iter() {
-                    if entry.value().send(event.clone()).is_err() {
+                    if entry.value().send(Arc::clone(&event)).is_err() {
                         agent_drops += 1;
                     }
                 }
@@ -128,7 +140,7 @@ impl EventBus {
                 }
             }
             EventTarget::Pattern(_pattern) => {
-                if self.sender.send(event.clone()).is_err() {
+                if self.sender.send(Arc::clone(&event)).is_err() {
                     debug!(
                         event_id = %event.id,
                         event_kind = payload_kind(&event.payload),
@@ -137,7 +149,7 @@ impl EventBus {
                 }
             }
             EventTarget::System => {
-                if self.sender.send(event.clone()).is_err() {
+                if self.sender.send(Arc::clone(&event)).is_err() {
                     debug!(
                         event_id = %event.id,
                         event_kind = payload_kind(&event.payload),
@@ -154,7 +166,7 @@ impl EventBus {
     /// warning, then `continue` — the skipped events are already lost but future
     /// events can still be received.  Exiting on `Lagged` turns a transient
     /// slow-consumer condition into a permanent trigger miss (issue #3630).
-    pub fn subscribe_agent(&self, agent_id: AgentId) -> broadcast::Receiver<Event> {
+    pub fn subscribe_agent(&self, agent_id: AgentId) -> broadcast::Receiver<Arc<Event>> {
         let entry = self.agent_channels.entry(agent_id).or_insert_with(|| {
             // 2 048-event buffer per agent (up from 256).  Trigger-driving events
             // are published in bursts; a deeper queue keeps slow consumers from
@@ -166,7 +178,7 @@ impl EventBus {
     }
 
     /// Subscribe to all broadcast/system events.
-    pub fn subscribe_all(&self) -> broadcast::Receiver<Event> {
+    pub fn subscribe_all(&self) -> broadcast::Receiver<Arc<Event>> {
         self.sender.subscribe()
     }
 
@@ -302,7 +314,7 @@ mod tests {
         bus.publish(event).await;
 
         let received = rx.recv().await.unwrap();
-        match received.payload {
+        match &received.payload {
             EventPayload::System(SystemEvent::HealthCheck { status }) => {
                 assert_eq!(status, "ok");
             }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -7123,7 +7123,7 @@ system_prompt = "You are a helpful assistant."
 
         let request = CompletionRequest {
             model: String::new(), // use driver default
-            messages: vec![Message::user(message.to_string())],
+            messages: std::sync::Arc::new(vec![Message::user(message.to_string())]),
             tools: vec![],
             max_tokens: 20,
             temperature: 0.0,
@@ -7922,7 +7922,9 @@ system_prompt = "You are a helpful assistant."
             // Build a probe request to score complexity
             let probe = CompletionRequest {
                 model: strip_provider_prefix(&manifest.model.model, &manifest.model.provider),
-                messages: vec![librefang_types::message::Message::user(message)],
+                messages: std::sync::Arc::new(vec![librefang_types::message::Message::user(
+                    message,
+                )]),
                 tools: tools.clone(),
                 max_tokens: manifest.model.max_tokens,
                 temperature: manifest.model.temperature,
@@ -11747,7 +11749,7 @@ system_prompt = "You are a helpful assistant."
 
         let request = CompletionRequest {
             model: model.to_string(),
-            messages: vec![Message::user(prompt.to_string())],
+            messages: std::sync::Arc::new(vec![Message::user(prompt.to_string())]),
             tools: vec![],
             max_tokens: 10,
             temperature: 0.0,
@@ -15276,7 +15278,7 @@ system_prompt = "You are a helpful assistant."
         let model_for_review = strip_provider_prefix(&default_model.model, &default_model.provider);
         let request = CompletionRequest {
             model: model_for_review,
-            messages: vec![Message::user(user_msg)],
+            messages: std::sync::Arc::new(vec![Message::user(user_msg)]),
             tools: vec![],
             max_tokens: 2000,
             temperature: 0.0,
@@ -15652,7 +15654,13 @@ system_prompt = "You are a helpful assistant."
     /// 3. Return None if no valid JSON object can be found
     fn extract_json_from_llm_response(text: &str) -> Option<String> {
         // Strategy 1: Extract from Markdown code block (```json ... ``` or ``` ... ```)
-        let code_block_re = regex::Regex::new(r"(?s)```(?:json)?\s*\n?(\{.*?\})\s*```").ok()?;
+        // Cached: this runs on every structured-output LLM response (#3491).
+        static CODE_BLOCK_RE: std::sync::LazyLock<regex::Regex> =
+            std::sync::LazyLock::new(|| {
+                regex::Regex::new(r"(?s)```(?:json)?\s*\n?(\{.*?\})\s*```")
+                    .expect("static json code-block regex compiles")
+            });
+        let code_block_re: &regex::Regex = &CODE_BLOCK_RE;
         if let Some(caps) = code_block_re.captures(text) {
             let candidate = caps.get(1)?.as_str().to_string();
             if serde_json::from_str::<serde_json::Value>(&candidate).is_ok() {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -15655,11 +15655,10 @@ system_prompt = "You are a helpful assistant."
     fn extract_json_from_llm_response(text: &str) -> Option<String> {
         // Strategy 1: Extract from Markdown code block (```json ... ``` or ``` ... ```)
         // Cached: this runs on every structured-output LLM response (#3491).
-        static CODE_BLOCK_RE: std::sync::LazyLock<regex::Regex> =
-            std::sync::LazyLock::new(|| {
-                regex::Regex::new(r"(?s)```(?:json)?\s*\n?(\{.*?\})\s*```")
-                    .expect("static json code-block regex compiles")
-            });
+        static CODE_BLOCK_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+            regex::Regex::new(r"(?s)```(?:json)?\s*\n?(\{.*?\})\s*```")
+                .expect("static json code-block regex compiles")
+        });
         let code_block_re: &regex::Regex = &CODE_BLOCK_RE;
         if let Some(caps) = code_block_re.captures(text) {
             let candidate = caps.get(1)?.as_str().to_string();

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -11664,7 +11664,9 @@ system_prompt = "You are a helpful assistant."
 
             let req = CompletionRequest {
                 model,
-                messages: vec![librefang_types::message::Message::user(prompt)],
+                messages: std::sync::Arc::new(vec![librefang_types::message::Message::user(
+                    prompt,
+                )]),
                 tools: vec![],
                 max_tokens: 32,
                 temperature: 0.2,

--- a/crates/librefang-kernel/src/orchestration.rs
+++ b/crates/librefang-kernel/src/orchestration.rs
@@ -226,6 +226,24 @@ impl QualityGate {
     }
 }
 
+/// Cache compiled `MatchesRegex` patterns so quality gates evaluated on every
+/// workflow step don't pay the per-call `Regex::new` cost (#3491).
+static QUALITY_REGEX_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<HashMap<String, regex_lite::Regex>>,
+> = std::sync::OnceLock::new();
+
+fn matches_quality_regex(pattern: &str, output: &str) -> bool {
+    let cache = QUALITY_REGEX_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
+    let entry = map.entry(pattern.to_string()).or_insert_with(|| {
+        regex_lite::Regex::new(pattern).unwrap_or_else(|_| {
+            // Never-match sentinel: an invalid pattern fails the gate forever.
+            regex_lite::Regex::new("(?!x)x").expect("static never-match regex compiles")
+        })
+    });
+    entry.is_match(output)
+}
+
 impl QualityCheck {
     /// Returns `true` when the check passes for the given output.
     pub fn passes(&self, output: &str) -> bool {
@@ -234,9 +252,7 @@ impl QualityCheck {
             QualityCheck::NotContains(s) => !output.to_lowercase().contains(&s.to_lowercase()),
             QualityCheck::MinLength(n) => output.len() >= *n,
             QualityCheck::MaxLength(n) => output.len() <= *n,
-            QualityCheck::MatchesRegex(pattern) => regex_lite::Regex::new(pattern)
-                .map(|re| re.is_match(output))
-                .unwrap_or(false),
+            QualityCheck::MatchesRegex(pattern) => matches_quality_regex(pattern, output),
             QualityCheck::All(checks) => checks.iter().all(|c| c.passes(output)),
             QualityCheck::Any(checks) => checks.iter().any(|c| c.passes(output)),
         }

--- a/crates/librefang-kernel/src/orchestration.rs
+++ b/crates/librefang-kernel/src/orchestration.rs
@@ -238,7 +238,10 @@ fn matches_quality_regex(pattern: &str, output: &str) -> bool {
     let entry = map.entry(pattern.to_string()).or_insert_with(|| {
         regex_lite::Regex::new(pattern).unwrap_or_else(|_| {
             // Never-match sentinel: an invalid pattern fails the gate forever.
-            regex_lite::Regex::new("(?!x)x").expect("static never-match regex compiles")
+            // `regex_lite` rejects look-around (`(?!x)x`), so use the negated
+            // class containing both \s and \S — that's the universe of chars,
+            // negated to the empty set — supported by regex_lite syntax.
+            regex_lite::Regex::new(r"[^\s\S]").expect("static never-match regex compiles")
         })
     });
     entry.is_match(output)

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -213,7 +213,13 @@ pub struct CompletionRequest {
     /// Model identifier.
     pub model: String,
     /// Conversation messages.
-    pub messages: Vec<Message>,
+    ///
+    /// Wrapped in `Arc` so cloning the request (e.g. retry on rate-limit
+    /// inside `call_with_retry`) only bumps a refcount instead of deep-copying
+    /// 200-600 KB of message history every turn (#3766). All driver code
+    /// reads through `&request.messages` / `request.messages.iter()`, both
+    /// of which auto-deref through `Arc<Vec<_>>`.
+    pub messages: std::sync::Arc<Vec<Message>>,
     /// Available tools the model can use.
     pub tools: Vec<ToolDefinition>,
     /// Maximum tokens to generate.
@@ -725,7 +731,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(16);
         let request = CompletionRequest {
             model: "test".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -1384,7 +1384,7 @@ mod tests {
         };
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")],
+            messages: std::sync::Arc::new(vec![Message::user("hi")]),
             tools: vec![tool_a, tool_b],
             max_tokens: 100,
             temperature: 0.0,
@@ -1422,7 +1422,7 @@ mod tests {
         };
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")],
+            messages: std::sync::Arc::new(vec![Message::user("hi")]),
             tools: vec![tool],
             max_tokens: 100,
             temperature: 0.0,
@@ -1462,13 +1462,13 @@ mod tests {
     fn multi_turn_rolling_window_stamps_last_three() {
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![
+            messages: std::sync::Arc::new(vec![
                 Message::user("u1"),
                 Message::assistant("a1"),
                 Message::user("u2"),
                 Message::assistant("a2"),
                 Message::user("u3 (last)"),
-            ],
+            ]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,
@@ -1511,14 +1511,14 @@ mod tests {
         };
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![
+            messages: std::sync::Arc::new(vec![
                 Message::user("u1"),
                 Message::assistant("a1"),
                 Message::user("u2"),
                 Message::assistant("a2"),
                 Message::user("u3"),
                 Message::assistant("a3 (last)"),
-            ],
+            ]),
             tools: vec![tool.clone(), tool],
             max_tokens: 100,
             temperature: 0.0,
@@ -1565,7 +1565,7 @@ mod tests {
         }]);
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![tool_result_msg],
+            messages: std::sync::Arc::new(vec![tool_result_msg]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,
@@ -1601,7 +1601,7 @@ mod tests {
     fn system_block_always_stamped_when_caching_on() {
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")], // dummy: api requires >=1 user msg
+            messages: std::sync::Arc::new(vec![Message::user("hi")]), // dummy: api requires >=1 user msg
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,
@@ -1637,11 +1637,11 @@ mod tests {
         };
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![
+            messages: std::sync::Arc::new(vec![
                 Message::user("u1"),
                 Message::assistant("a1"),
                 Message::user("u2 (last)"),
-            ],
+            ]),
             tools: vec![tool],
             max_tokens: 100,
             temperature: 0.0,
@@ -1683,7 +1683,7 @@ mod tests {
     fn ttl_default_omits_ttl_field_and_skips_beta_header() {
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")],
+            messages: std::sync::Arc::new(vec![Message::user("hi")]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,
@@ -1715,7 +1715,7 @@ mod tests {
     fn test_messages_cache_control_absent_when_caching_off() {
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")],
+            messages: std::sync::Arc::new(vec![Message::user("hi")]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,
@@ -1821,13 +1821,13 @@ mod tests {
         };
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![
+            messages: std::sync::Arc::new(vec![
                 Message::user("u1"),
                 Message::assistant("a1"),
                 Message::user("u2"),
                 Message::assistant("a2"),
                 Message::user("u3 (last)"),
-            ],
+            ]),
             tools: vec![tool],
             max_tokens: 100,
             temperature: 0.0,
@@ -1912,7 +1912,7 @@ mod tests {
     fn test_tools_cache_control_empty_tools_list() {
         let request = CompletionRequest {
             model: "claude-sonnet-4-5".to_string(),
-            messages: vec![Message::user("hi")],
+            messages: std::sync::Arc::new(vec![Message::user("hi")]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -1118,12 +1118,12 @@ mod tests {
     fn test_build_responses_request_basic() {
         let req = CompletionRequest {
             model: "gpt-4o".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Text("Hello".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: Vec::new(),
             max_tokens: 1024,
             temperature: 0.7,
@@ -1148,7 +1148,7 @@ mod tests {
     fn test_build_responses_request_system_merged() {
         let req = CompletionRequest {
             model: "gpt-4o".to_string(),
-            messages: vec![
+            messages: std::sync::Arc::new(vec![
                 Message {
                     role: Role::System,
                     content: MessageContent::Text("System prompt.".to_string()),
@@ -1161,7 +1161,7 @@ mod tests {
                     pinned: false,
                     timestamp: None,
                 },
-            ],
+            ]),
             tools: Vec::new(),
             max_tokens: 0,
             temperature: 1.0,
@@ -1185,12 +1185,12 @@ mod tests {
     fn test_build_responses_request_appends_json_response_format() {
         let req = CompletionRequest {
             model: "gpt-4o".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Text("Hi".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: Vec::new(),
             max_tokens: 0,
             temperature: 1.0,
@@ -1213,12 +1213,12 @@ mod tests {
     fn test_build_responses_request_appends_json_schema_response_format() {
         let req = CompletionRequest {
             model: "gpt-4o".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Text("Hi".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: Vec::new(),
             max_tokens: 0,
             temperature: 1.0,

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -370,7 +370,7 @@ impl ChatGptDriver {
         let mut instructions: Option<String> = request.system.clone();
         let mut input_items = Vec::new();
 
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             let role_str = match msg.role {
                 Role::System => {
                     // Merge system messages into instructions

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1215,12 +1215,12 @@ mod tests {
 
         let request = CompletionRequest {
             model: "claude-code/sonnet".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::text("Hello"),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1251,7 +1251,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "claude-code/sonnet".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![
                     ContentBlock::Text {
@@ -1265,7 +1265,7 @@ mod tests {
                 ]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1313,7 +1313,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "claude-code/sonnet".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![
                     ContentBlock::Text {
@@ -1327,7 +1327,7 @@ mod tests {
                 ]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1391,7 +1391,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "claude-code/sonnet".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![
                     ContentBlock::Image {
@@ -1405,7 +1405,7 @@ mod tests {
                 ]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -186,7 +186,7 @@ impl ClaudeCodeDriver {
             parts.push(format!("[System]\n{sys}"));
         }
 
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             let role_label = match msg.role {
                 Role::User => "User",
                 Role::Assistant => "Assistant",

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -111,7 +111,7 @@ impl CodexCliDriver {
             parts.push(format!("[System]\n{sys}"));
         }
 
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             let role_label = match msg.role {
                 Role::User => "User",
                 Role::Assistant => "Assistant",

--- a/crates/librefang-llm-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback.rs
@@ -404,7 +404,7 @@ mod tests {
     fn test_request() -> CompletionRequest {
         CompletionRequest {
             model: "test".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -345,7 +345,7 @@ mod tests {
     fn test_request() -> CompletionRequest {
         CompletionRequest {
             model: "test-model".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -1456,7 +1456,7 @@ mod tests {
     fn test_convert_tools() {
         let request = CompletionRequest {
             model: "gemini-2.0-flash".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![ToolDefinition {
                 name: "web_search".to_string(),
                 description: "Search the web".to_string(),
@@ -1489,7 +1489,7 @@ mod tests {
     fn test_convert_tools_empty() {
         let request = CompletionRequest {
             model: "gemini-2.0-flash".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -97,7 +97,7 @@ impl GeminiCliDriver {
             parts.push(format!("[System]\n{sys}"));
         }
 
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             let role_label = match msg.role {
                 Role::User => "User",
                 Role::Assistant => "Assistant",

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -2369,12 +2369,12 @@ mod tests {
         let driver = OpenAIDriver::new("".to_string(), "http://127.0.0.1:11434/v1".to_string());
         let request = CompletionRequest {
             model: "qwen3:8b".to_string(),
-            messages: vec![librefang_types::message::Message {
+            messages: std::sync::Arc::new(vec![librefang_types::message::Message {
                 role: librefang_types::message::Role::User,
                 content: librefang_types::message::MessageContent::Text("hi".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 256,
             temperature: 0.7,
@@ -2397,12 +2397,12 @@ mod tests {
         let driver = OpenAIDriver::new("".to_string(), "http://127.0.0.1:11434/v1".to_string());
         let request = CompletionRequest {
             model: "qwen3:8b".to_string(),
-            messages: vec![librefang_types::message::Message {
+            messages: std::sync::Arc::new(vec![librefang_types::message::Message {
                 role: librefang_types::message::Role::User,
                 content: librefang_types::message::MessageContent::Text("hi".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 256,
             temperature: 0.7,
@@ -2425,12 +2425,12 @@ mod tests {
         let driver = OpenAIDriver::new("k".to_string(), "https://api.openai.com/v1".to_string());
         let request = CompletionRequest {
             model: "gpt-4o".to_string(),
-            messages: vec![librefang_types::message::Message {
+            messages: std::sync::Arc::new(vec![librefang_types::message::Message {
                 role: librefang_types::message::Role::User,
                 content: librefang_types::message::MessageContent::Text("hi".to_string()),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 256,
             temperature: 0.7,

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -652,7 +652,7 @@ impl OpenAIDriver {
         }
 
         // Convert messages
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             match (&msg.role, &msg.content) {
                 (Role::System, MessageContent::Text(text)) if request.system.is_none() => {
                     oai_messages.push(OaiMessage {

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -225,7 +225,14 @@ impl OpenAIDriver {
         use base64::Engine;
         use sha2::{Digest, Sha256};
 
-        for msg in &mut request.messages {
+        // `request.messages` is `Arc<Vec<Message>>` (#3766). Get an exclusive
+        // `&mut Vec<Message>` via `Arc::make_mut` — when the refcount is 1
+        // (the common case: fresh `CompletionRequest` for this call) this is
+        // O(1); on a shared Arc it clones once, which is unavoidable since
+        // we must mutate. Without this, `for msg in &mut request.messages`
+        // doesn't compile because `Arc<Vec<_>>` only derefs to `&Vec<_>`.
+        let messages = std::sync::Arc::make_mut(&mut request.messages);
+        for msg in messages.iter_mut() {
             let blocks = match &mut msg.content {
                 MessageContent::Blocks(b) => b,
                 _ => continue,

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -246,7 +246,7 @@ impl QwenCodeDriver {
             parts.push(format!("[System]\n{sys}"));
         }
 
-        for msg in &request.messages {
+        for msg in request.messages.iter() {
             let role_label = match msg.role {
                 Role::User => "User",
                 Role::Assistant => "Assistant",

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -1052,12 +1052,12 @@ mod tests {
 
         let request = CompletionRequest {
             model: "qwen-code/qwen3-coder".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::text("Hello"),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1093,7 +1093,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "qwen-code/qwen-vl-max".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![
                     ContentBlock::Text {
@@ -1107,7 +1107,7 @@ mod tests {
                 ]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1176,7 +1176,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "qwen-code/qwen-vl-max".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![ContentBlock::ImageFile {
                     media_type: "image/png".to_string(),
@@ -1184,7 +1184,7 @@ mod tests {
                 }]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1271,7 +1271,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "qwen-code/qwen-vl-max".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![
                     ContentBlock::Text {
@@ -1286,7 +1286,7 @@ mod tests {
                 ]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,
@@ -1323,7 +1323,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: "qwen-code/qwen-vl-max".to_string(),
-            messages: vec![Message {
+            messages: std::sync::Arc::new(vec![Message {
                 role: Role::User,
                 content: MessageContent::Blocks(vec![ContentBlock::ImageFile {
                     media_type: "image/png".to_string(),
@@ -1331,7 +1331,7 @@ mod tests {
                 }]),
                 pinned: false,
                 timestamp: None,
-            }],
+            }]),
             tools: vec![],
             max_tokens: 1024,
             temperature: 0.7,

--- a/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
+++ b/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
@@ -358,7 +358,7 @@ mod tests {
     fn test_request() -> CompletionRequest {
         CompletionRequest {
             model: "test".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 100,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/tests/shared_rate_guard_integration.rs
+++ b/crates/librefang-llm-drivers/tests/shared_rate_guard_integration.rs
@@ -88,7 +88,7 @@ async fn spawn_stub_429_server() -> (String, Arc<AtomicUsize>) {
 fn simple_request(model: &str) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("hello")],
+        messages: std::sync::Arc::new(vec![Message::user("hello")]),
         tools: Vec::new(),
         max_tokens: 16,
         temperature: 0.0,

--- a/crates/librefang-memory/src/usage.rs
+++ b/crates/librefang-memory/src/usage.rs
@@ -558,182 +558,145 @@ impl UsageStore {
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         let agent_str = record.agent_id.0.to_string();
+        let has_provider = !record.provider.is_empty();
 
-        // ── Per-agent quota checks ──────────────────────────────────
-        if agent_max_hourly > 0.0 {
-            let cost: f64 = tx
+        // Each window collapses what was previously up to 3 separate `SUM(...)`
+        // queries (agent / global / provider) into one row of conditional
+        // sums (#3382). The full hot path drops from up to 10 round-trips per
+        // LLM call to 4 (3 cost windows + 1 token window) when every limit is
+        // configured, while preserving identical semantics.
+        struct WindowCosts {
+            agent: f64,
+            global: f64,
+            provider: f64,
+        }
+
+        // Helper closure: run one combined SUM query for a given time window.
+        // `where_clause` selects the rows for the window (e.g. `timestamp > datetime(...)`).
+        let window_costs = |where_clause: &str| -> LibreFangResult<WindowCosts> {
+            let sql = format!(
+                "SELECT \
+                    COALESCE(SUM(CASE WHEN agent_id = ?1 THEN cost_usd ELSE 0 END), 0.0), \
+                    COALESCE(SUM(cost_usd), 0.0), \
+                    COALESCE(SUM(CASE WHEN provider = ?2 THEN cost_usd ELSE 0 END), 0.0) \
+                 FROM usage_events WHERE {where_clause}"
+            );
+            let row: (f64, f64, f64) = tx
                 .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE agent_id = ?1 AND timestamp > datetime('now', '-1 hour')",
-                    rusqlite::params![&agent_str],
-                    |row| row.get(0),
+                    &sql,
+                    rusqlite::params![&agent_str, &record.provider],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
                 )
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= agent_max_hourly {
+            Ok(WindowCosts {
+                agent: row.0,
+                global: row.1,
+                provider: row.2,
+            })
+        };
+
+        let need_hourly = agent_max_hourly > 0.0
+            || global_max_hourly > 0.0
+            || (has_provider && provider_max_hourly > 0.0);
+        if need_hourly {
+            let costs = window_costs("timestamp > datetime('now', '-1 hour')")?;
+            if agent_max_hourly > 0.0 && costs.agent + record.cost_usd >= agent_max_hourly {
                 return Err(LibreFangError::QuotaExceeded(format!(
                     "Agent {} exceeded hourly cost quota: ${:.4} + ${:.4} / ${:.4}",
-                    record.agent_id, cost, record.cost_usd, agent_max_hourly
+                    record.agent_id, costs.agent, record.cost_usd, agent_max_hourly
                 )));
             }
-        }
-
-        if agent_max_daily > 0.0 {
-            let cost: f64 = tx
-                .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE agent_id = ?1 AND timestamp > datetime('now', 'start of day')",
-                    rusqlite::params![&agent_str],
-                    |row| row.get(0),
-                )
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= agent_max_daily {
-                return Err(LibreFangError::QuotaExceeded(format!(
-                    "Agent {} exceeded daily cost quota: ${:.4} + ${:.4} / ${:.4}",
-                    record.agent_id, cost, record.cost_usd, agent_max_daily
-                )));
-            }
-        }
-
-        if agent_max_monthly > 0.0 {
-            let cost: f64 = tx
-                .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE agent_id = ?1 AND timestamp > datetime('now', 'start of month')",
-                    rusqlite::params![&agent_str],
-                    |row| row.get(0),
-                )
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= agent_max_monthly {
-                return Err(LibreFangError::QuotaExceeded(format!(
-                    "Agent {} exceeded monthly cost quota: ${:.4} + ${:.4} / ${:.4}",
-                    record.agent_id, cost, record.cost_usd, agent_max_monthly
-                )));
-            }
-        }
-
-        // ── Global budget checks ────────────────────────────────────
-        if global_max_hourly > 0.0 {
-            let cost: f64 = tx
-                .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE timestamp > datetime('now', '-1 hour')",
-                    [],
-                    |row| row.get(0),
-                )
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= global_max_hourly {
+            if global_max_hourly > 0.0 && costs.global + record.cost_usd >= global_max_hourly {
                 return Err(LibreFangError::QuotaExceeded(format!(
                     "Global hourly budget exceeded: ${:.4} + ${:.4} / ${:.4}",
-                    cost, record.cost_usd, global_max_hourly
+                    costs.global, record.cost_usd, global_max_hourly
+                )));
+            }
+            if has_provider
+                && provider_max_hourly > 0.0
+                && costs.provider + record.cost_usd >= provider_max_hourly
+            {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Provider '{}' exceeded hourly cost budget: ${:.4} + ${:.4} / ${:.4}",
+                    record.provider, costs.provider, record.cost_usd, provider_max_hourly
                 )));
             }
         }
 
-        if global_max_daily > 0.0 {
-            let cost: f64 = tx
-                .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE timestamp > datetime('now', 'start of day')",
-                    [],
-                    |row| row.get(0),
-                )
-                .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= global_max_daily {
+        let need_daily = agent_max_daily > 0.0
+            || global_max_daily > 0.0
+            || (has_provider && provider_max_daily > 0.0);
+        if need_daily {
+            let costs = window_costs("timestamp > datetime('now', 'start of day')")?;
+            if agent_max_daily > 0.0 && costs.agent + record.cost_usd >= agent_max_daily {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Agent {} exceeded daily cost quota: ${:.4} + ${:.4} / ${:.4}",
+                    record.agent_id, costs.agent, record.cost_usd, agent_max_daily
+                )));
+            }
+            if global_max_daily > 0.0 && costs.global + record.cost_usd >= global_max_daily {
                 return Err(LibreFangError::QuotaExceeded(format!(
                     "Global daily budget exceeded: ${:.4} + ${:.4} / ${:.4}",
-                    cost, record.cost_usd, global_max_daily
+                    costs.global, record.cost_usd, global_max_daily
+                )));
+            }
+            if has_provider
+                && provider_max_daily > 0.0
+                && costs.provider + record.cost_usd >= provider_max_daily
+            {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Provider '{}' exceeded daily cost budget: ${:.4} + ${:.4} / ${:.4}",
+                    record.provider, costs.provider, record.cost_usd, provider_max_daily
                 )));
             }
         }
 
-        if global_max_monthly > 0.0 {
-            let cost: f64 = tx
+        let need_monthly = agent_max_monthly > 0.0
+            || global_max_monthly > 0.0
+            || (has_provider && provider_max_monthly > 0.0);
+        if need_monthly {
+            let costs = window_costs("timestamp > datetime('now', 'start of month')")?;
+            if agent_max_monthly > 0.0 && costs.agent + record.cost_usd >= agent_max_monthly {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Agent {} exceeded monthly cost quota: ${:.4} + ${:.4} / ${:.4}",
+                    record.agent_id, costs.agent, record.cost_usd, agent_max_monthly
+                )));
+            }
+            if global_max_monthly > 0.0 && costs.global + record.cost_usd >= global_max_monthly {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Global monthly budget exceeded: ${:.4} + ${:.4} / ${:.4}",
+                    costs.global, record.cost_usd, global_max_monthly
+                )));
+            }
+            if has_provider
+                && provider_max_monthly > 0.0
+                && costs.provider + record.cost_usd >= provider_max_monthly
+            {
+                return Err(LibreFangError::QuotaExceeded(format!(
+                    "Provider '{}' exceeded monthly cost budget: ${:.4} + ${:.4} / ${:.4}",
+                    record.provider, costs.provider, record.cost_usd, provider_max_monthly
+                )));
+            }
+        }
+
+        // Provider hourly token budget — separate aggregate (input+output tokens),
+        // kept as its own query because it sums different columns.
+        if has_provider && provider_max_tokens_per_hour > 0 {
+            let tokens: i64 = tx
                 .query_row(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                     WHERE timestamp > datetime('now', 'start of month')",
-                    [],
+                    "SELECT COALESCE(SUM(input_tokens) + SUM(output_tokens), 0) FROM usage_events
+                     WHERE provider = ?1 AND timestamp > datetime('now', '-1 hour')",
+                    rusqlite::params![&record.provider],
                     |row| row.get(0),
                 )
                 .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-            if cost + record.cost_usd >= global_max_monthly {
+            let current = tokens.max(0) as u64;
+            let incoming = record.input_tokens.saturating_add(record.output_tokens);
+            if current.saturating_add(incoming) >= provider_max_tokens_per_hour {
                 return Err(LibreFangError::QuotaExceeded(format!(
-                    "Global monthly budget exceeded: ${:.4} + ${:.4} / ${:.4}",
-                    cost, record.cost_usd, global_max_monthly
+                    "Provider '{}' exceeded hourly token budget: {} + {} / {}",
+                    record.provider, current, incoming, provider_max_tokens_per_hour
                 )));
-            }
-        }
-
-        // ── Per-provider budget checks ─────────────────────────────
-        // Only applies when the record carries a provider id.
-        if !record.provider.is_empty() {
-            if provider_max_hourly > 0.0 {
-                let cost: f64 = tx
-                    .query_row(
-                        "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                         WHERE provider = ?1 AND timestamp > datetime('now', '-1 hour')",
-                        rusqlite::params![&record.provider],
-                        |row| row.get(0),
-                    )
-                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-                if cost + record.cost_usd >= provider_max_hourly {
-                    return Err(LibreFangError::QuotaExceeded(format!(
-                        "Provider '{}' exceeded hourly cost budget: ${:.4} + ${:.4} / ${:.4}",
-                        record.provider, cost, record.cost_usd, provider_max_hourly
-                    )));
-                }
-            }
-
-            if provider_max_daily > 0.0 {
-                let cost: f64 = tx
-                    .query_row(
-                        "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                         WHERE provider = ?1 AND timestamp > datetime('now', 'start of day')",
-                        rusqlite::params![&record.provider],
-                        |row| row.get(0),
-                    )
-                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-                if cost + record.cost_usd >= provider_max_daily {
-                    return Err(LibreFangError::QuotaExceeded(format!(
-                        "Provider '{}' exceeded daily cost budget: ${:.4} + ${:.4} / ${:.4}",
-                        record.provider, cost, record.cost_usd, provider_max_daily
-                    )));
-                }
-            }
-
-            if provider_max_monthly > 0.0 {
-                let cost: f64 = tx
-                    .query_row(
-                        "SELECT COALESCE(SUM(cost_usd), 0.0) FROM usage_events
-                         WHERE provider = ?1 AND timestamp > datetime('now', 'start of month')",
-                        rusqlite::params![&record.provider],
-                        |row| row.get(0),
-                    )
-                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-                if cost + record.cost_usd >= provider_max_monthly {
-                    return Err(LibreFangError::QuotaExceeded(format!(
-                        "Provider '{}' exceeded monthly cost budget: ${:.4} + ${:.4} / ${:.4}",
-                        record.provider, cost, record.cost_usd, provider_max_monthly
-                    )));
-                }
-            }
-
-            if provider_max_tokens_per_hour > 0 {
-                let tokens: i64 = tx
-                    .query_row(
-                        "SELECT COALESCE(SUM(input_tokens) + SUM(output_tokens), 0) FROM usage_events
-                         WHERE provider = ?1 AND timestamp > datetime('now', '-1 hour')",
-                        rusqlite::params![&record.provider],
-                        |row| row.get(0),
-                    )
-                    .map_err(|e| LibreFangError::Memory(e.to_string()))?;
-                let current = tokens.max(0) as u64;
-                let incoming = record.input_tokens.saturating_add(record.output_tokens);
-                if current.saturating_add(incoming) >= provider_max_tokens_per_hour {
-                    return Err(LibreFangError::QuotaExceeded(format!(
-                        "Provider '{}' exceeded hourly token budget: {} + {} / {}",
-                        record.provider, current, incoming, provider_max_tokens_per_hour
-                    )));
-                }
             }
         }
 

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2592,7 +2592,9 @@ async fn generate_search_queries(
 
     let request = CompletionRequest {
         model: strip_provider_prefix(&manifest.model.model, &manifest.model.provider),
-        messages: vec![Message::user(format!("{history}\nUser: {user_message}"))],
+        messages: std::sync::Arc::new(vec![Message::user(format!(
+            "{history}\nUser: {user_message}"
+        ))]),
         tools: vec![],
         max_tokens: 200,
         temperature: 0.0,
@@ -3515,9 +3517,11 @@ pub async fn run_agent_loop(
                 }
             });
 
+        // Wrap messages once per turn — call_with_retry's `request.clone()`
+        // becomes a refcount bump instead of a deep clone of the history (#3766).
         let request = CompletionRequest {
             model: api_model,
-            messages: messages.clone(),
+            messages: std::sync::Arc::new(messages.clone()),
             tools: resolve_request_tools(available_tools, &session_loaded_tools, lazy_tools),
             max_tokens: manifest.model.max_tokens,
             temperature: manifest.model.temperature,
@@ -4914,9 +4918,10 @@ pub async fn run_agent_loop_streaming(
                 }
             });
 
+        // Same Arc-wrap as the non-streaming hot path (#3766).
         let request = CompletionRequest {
             model: api_model,
-            messages: messages.clone(),
+            messages: std::sync::Arc::new(messages.clone()),
             tools: resolve_request_tools(available_tools, &session_loaded_tools, lazy_tools),
             max_tokens: manifest.model.max_tokens,
             temperature: manifest.model.temperature,
@@ -5991,9 +5996,11 @@ fn recover_text_tool_calls(text: &str, available_tools: &[ToolDefinition]) -> Ve
     // The parameters value is HTML-entity-escaped JSON (&quot; etc.).
     {
         use regex_lite::Regex;
-        // Match both self-closing <function ... /> and <function ...></function>
-        let re =
-            Regex::new(r#"<function\s+name="([^"]+)"\s+parameters="([^"]*)"[^/]*/?>"#).unwrap();
+        // Cached: this parser runs on every LLM response (#3491).
+        static FUNCTION_TAG_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new(r#"<function\s+name="([^"]+)"\s+parameters="([^"]*)"[^/]*/?>"#).unwrap()
+        });
+        let re = &*FUNCTION_TAG_RE;
         for caps in re.captures_iter(text) {
             let tool_name = caps.get(1).unwrap().as_str();
             let raw_params = caps.get(2).unwrap().as_str();

--- a/crates/librefang-runtime/src/aux_client.rs
+++ b/crates/librefang-runtime/src/aux_client.rs
@@ -367,7 +367,7 @@ mod tests {
 
         let req = CompletionRequest {
             model: "test".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 32,
             temperature: 0.0,

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -663,7 +663,7 @@ async fn summarize_messages(
 
     let request = CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message {
+        messages: std::sync::Arc::new(vec![Message {
             role: Role::User,
             content: MessageContent::Blocks(vec![ContentBlock::Text {
                 text: summarize_prompt,
@@ -671,7 +671,7 @@ async fn summarize_messages(
             }]),
             pinned: false,
             timestamp: None,
-        }],
+        }]),
         tools: vec![],
         max_tokens: config.max_summary_tokens,
         temperature: 0.3,
@@ -789,7 +789,7 @@ async fn summarize_in_chunks(
 
     let merge_request = CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message {
+        messages: std::sync::Arc::new(vec![Message {
             role: Role::User,
             content: MessageContent::Blocks(vec![ContentBlock::Text {
                 text: merge_prompt,
@@ -797,7 +797,7 @@ async fn summarize_in_chunks(
             }]),
             pinned: false,
             timestamp: None,
-        }],
+        }]),
         tools: vec![],
         max_tokens: config.max_summary_tokens,
         temperature: 0.3,

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -402,9 +402,9 @@ impl MemoryExtractor for LlmMemoryExtractor {
         // (libre-code's `extractMemories` shape); that's a separate PR.
         let request = crate::llm_driver::CompletionRequest {
             model: self.model.clone(),
-            messages: vec![librefang_types::message::Message::user(format!(
+            messages: std::sync::Arc::new(vec![librefang_types::message::Message::user(format!(
                 "Extract memories from this conversation:\n\n{conversation_text}"
-            ))],
+            ))]),
             tools: Vec::new(),
             max_tokens: 1024,
             temperature: 0.1,
@@ -556,7 +556,7 @@ impl MemoryExtractor for LlmMemoryExtractor {
         // fires dozens of times per session.
         let request = crate::llm_driver::CompletionRequest {
             model: self.model.clone(),
-            messages: vec![librefang_types::message::Message::user(user_msg)],
+            messages: std::sync::Arc::new(vec![librefang_types::message::Message::user(user_msg)]),
             tools: Vec::new(),
             max_tokens: 256,
             temperature: 0.0,

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -187,7 +187,7 @@ mod tests {
     fn make_request(messages: Vec<Message>, tools: Vec<ToolDefinition>) -> CompletionRequest {
         CompletionRequest {
             model: "placeholder".to_string(),
-            messages,
+            messages: std::sync::Arc::new(messages),
             tools,
             max_tokens: 4096,
             temperature: 0.7,

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -103,7 +103,7 @@ async fn test_mock_llm_driver_recording() {
 
     let request = CompletionRequest {
         model: "test-model".into(),
-        messages: vec![],
+        messages: std::sync::Arc::new(vec![]),
         tools: vec![],
         max_tokens: 100,
         temperature: 0.0,
@@ -276,7 +276,7 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
 
     let request = CompletionRequest {
         model: "test-model".into(),
-        messages: vec![],
+        messages: std::sync::Arc::new(vec![]),
         tools: vec![],
         max_tokens: 100,
         temperature: 0.0,
@@ -318,7 +318,7 @@ async fn test_failing_llm_driver() {
 
     let request = CompletionRequest {
         model: "test-model".into(),
-        messages: vec![],
+        messages: std::sync::Arc::new(vec![]),
         tools: vec![],
         max_tokens: 100,
         temperature: 0.0,


### PR DESCRIPTION
## Summary

Four independent hot-path optimizations that all fire on every LLM turn:

* **`messages: Arc<Vec<Message>>` in `CompletionRequest`** — `call_with_retry`'s
  `request.clone()` and the trait-handoff into `driver.complete(request)` now
  bump a refcount instead of deep-copying a 200-600 KB message history every
  turn. Retry on rate-limit / overload was particularly bad before.
  Closes #3766.

* **`EventBus` broadcasts `Arc<Event>`** — `publish` wraps the event in an
  `Arc` once and hands every subscriber a refcount-bumped clone. The hot
  `EventTarget::Broadcast` path used to deep-clone the full payload once for
  the global sender plus once per per-agent channel. Closes #3380.

* **`check_all_with_provider_and_record` runs 4 queries instead of up to 10** —
  collapses the per-window agent / global / provider `SUM(cost_usd)` queries
  into a single `SUM(CASE WHEN ...)` row per time window, keeping the token
  budget aggregate as its own (different columns) query. Same semantics, same
  early-exit ordering. Closes #3382.

* **Cached regexes on five hot paths** — `LazyLock` / shared mutex cache for
  the LLM `<function name=... />` recovery parser, the QQ markdown stripper
  (10 regexes per outbound message), the structured-output JSON code-block
  extractor, the kernel-router phrase matcher (now reuses the existing
  `REGEX_CACHE`), and `QualityCheck::MatchesRegex` for workflow gates.
  Closes #3491.

## Test plan
- [ ] CI: `cargo build --workspace --lib`
- [ ] CI: `cargo test --workspace`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Live: send a real LLM message and confirm response cost is metered
      (`/api/budget` reflects spend; per-window quotas still trigger).
- [ ] Live: subscribe to `/api/events` SSE while another agent publishes;
      payload arrives intact.