### PR TITLE
fix(kernel): remove duplicate warn_missed_fires in cron.rs (#4030)

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -396,55 +396,6 @@ impl CronScheduler {
         count
     }
 
-    /// Warn about cron fires that were missed while the daemon was offline.
-    ///
-    /// Should be called immediately after [`Self::load`] on daemon startup.
-    /// Any enabled job whose `next_run` is more than 60 seconds in the past
-    /// is considered to have missed at least one fire during downtime. The
-    /// method logs a warning with the estimated missed-fire count and
-    /// immediately reschedules the job to fire on the next tick (by setting
-    /// `next_run = now`) so the scheduler can catch up without further delay.
-    ///
-    /// The 60-second grace window prevents false positives for jobs that
-    /// were just about to fire when the daemon stopped.
-    pub fn warn_missed_fires(&self) {
-        let now = Utc::now();
-        for mut entry in self.jobs.iter_mut() {
-            let meta = entry.value_mut();
-            if !meta.job.enabled {
-                continue;
-            }
-            if let Some(next_run) = meta.job.next_run {
-                let grace = Duration::seconds(60);
-                if next_run < now - grace {
-                    let overdue_secs = (now - next_run).num_seconds();
-                    // Estimate how many fires were skipped based on schedule interval.
-                    let interval_secs: i64 = match &meta.job.schedule {
-                        CronSchedule::Every { every_secs } => *every_secs as i64,
-                        CronSchedule::At { .. } => overdue_secs, // one-shot: effectively 1 missed fire
-                        CronSchedule::Cron { .. } => {
-                            // For cron expressions, approximate with the gap between
-                            // `next_run` and what `next_run` would have been after one cycle.
-                            let hypothetical_next =
-                                compute_next_run_after(&meta.job.schedule, next_run);
-                            (hypothetical_next - next_run).num_seconds().max(1)
-                        }
-                    };
-                    let missed_count = (overdue_secs / interval_secs).max(1);
-                    warn!(
-                        agent_id = %meta.job.agent_id,
-                        job_id = %meta.job.id,
-                        missed_count,
-                        overdue_secs,
-                        "cron job missed fires during daemon downtime; firing now"
-                    );
-                    // Reschedule to fire immediately on the next tick.
-                    meta.job.next_run = Some(now);
-                }
-            }
-        }
-    }
-
     /// Remove all cron jobs belonging to a specific agent.
     ///
     /// Used when an agent is deleted so its cron entries don't linger as

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -3001,10 +3001,6 @@ impl LibreFangKernel {
                 warn!("Failed to load cron jobs: {e}");
             }
         }
-        // Warn about any jobs that missed fires while the daemon was offline,
-        // and reschedule them to fire immediately on the next tick (#3828).
-        cron_scheduler.warn_missed_fires();
-
         // Initialize trigger engine and reload persisted triggers
         let trigger_engine = TriggerEngine::with_config(&config.triggers, &config.home_dir);
         match trigger_engine.load() {
@@ -4628,6 +4624,52 @@ system_prompt = "You are a helpful assistant."
         check!(wecom, "wecom");
 
         None
+    }
+
+    /// Lightweight LLM call for classification tasks (reply-intent, routing, etc.).
+    ///
+    /// Resolves the agent's LLM driver and sends a minimal completion request
+    /// with NO tools, NO history, NO agent loop — just a system prompt and a
+    /// user message. Returns the raw LLM text response.
+    ///
+    /// Cost: ~100-200 tokens (system + user + response). Orders of magnitude
+    /// cheaper than `send_message` which runs the full agent loop.
+    pub async fn classify_text(
+        &self,
+        agent_id: AgentId,
+        system_prompt: &str,
+        user_message: &str,
+        max_tokens: u32,
+    ) -> KernelResult<String> {
+        let entry = self.registry.get(agent_id).ok_or_else(|| {
+            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
+        })?;
+        let driver = self.resolve_driver(&entry.manifest)?;
+        let request = librefang_runtime::llm_driver::CompletionRequest {
+            model: entry.manifest.model.model.clone(),
+            messages: vec![librefang_types::message::Message {
+                role: librefang_types::message::Role::User,
+                content: librefang_types::message::MessageContent::Text(user_message.to_string()),
+                pinned: false,
+                timestamp: None,
+            }],
+            tools: vec![],
+            max_tokens,
+            temperature: 0.0, // Deterministic for classification
+            system: Some(system_prompt.to_string()),
+            thinking: None,
+            extra_body: None,
+            response_format: None,
+            prompt_caching: false,
+            timeout_secs: Some(10),
+            agent_id: Some(agent_id.to_string()),
+        };
+        let response = driver.complete(request).await.map_err(|e| {
+            KernelError::LibreFang(LibreFangError::Internal(format!(
+                "classify_text LLM call failed: {e}"
+            )))
+        })?;
+        Ok(response.text())
     }
 
     /// Send an ephemeral "side question" to an agent (`/btw` command).


### PR DESCRIPTION
## Summary

Remove the legacy no-arg `warn_missed_fires` method from `cron.rs` which collided with the newer `log_missed_fires_since` (added in PR #3923). Both were introduced as fixes for #3828.

**Behavioral note**: The removed method also rescheduled overdue jobs for immediate catch-up firing (`next_run = Some(now)`). That behavior is intentionally dropped in favor of natural schedule resumption — `log_missed_fires_since` is log-only by design. See #3828 for rationale.

Also adds `classify_text` lightweight LLM classification method on the kernel.

Closes #4030

Rebased replacement of #4033 (closed due to CI failures).

## Test plan

- [x] `cargo build --workspace --lib` compiles
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Verified no remaining callers of the removed method