### PR TITLE
fix(dashboard): overview margins, dark default, per-session metering

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/store.ts
+++ b/crates/librefang-api/dashboard/src/lib/store.ts
@@ -62,7 +62,7 @@ interface UIState {
 export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
-      theme: (typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: light)").matches) ? "light" : "dark",
+      theme: "dark",
       language: i18n.language || "en",
       isMobileMenuOpen: false,
       isSidebarCollapsed: false,

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -162,18 +162,33 @@ function sessionTokens(session: {
 
 function budgetUsageRatio(budget?: Record<string, unknown>): { ratio: number; used?: number; cap?: number } | null {
   if (!budget) return null;
+  // Backend `/api/budget` (BudgetStatus) ships `daily_spend` / `daily_limit`
+  // / `daily_pct`. The legacy `*_usd`-suffixed names below are kept as a
+  // fallback so older builds and any wrapper layer that re-shapes the
+  // payload still resolve.
   const usedCandidates = [
+    budget.daily_spend,
     budget.spend_today_usd,
     budget.today_spend_usd,
     budget.daily_spend_usd,
     budget.current_daily_usd,
     budget.today_cost_usd,
   ];
-  const capCandidates = [budget.max_daily_usd, budget.daily_cap_usd, budget.daily_budget_usd];
+  const capCandidates = [
+    budget.daily_limit,
+    budget.max_daily_usd,
+    budget.daily_cap_usd,
+    budget.daily_budget_usd,
+  ];
   const used = usedCandidates.find((v): v is number => typeof v === "number" && Number.isFinite(v));
   const cap = capCandidates.find((v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0);
   if (used == null || cap == null) return null;
-  return { ratio: used / cap, used, cap };
+  // Backend pre-computes `daily_pct` as a 0..1 fraction — prefer it when
+  // present so a future change to the formula doesn't drift.
+  const pct = typeof budget.daily_pct === "number" && Number.isFinite(budget.daily_pct as number)
+    ? (budget.daily_pct as number)
+    : used / cap;
+  return { ratio: pct, used, cap };
 }
 
 type AlertKind = "error" | "warning" | "pending";
@@ -257,7 +272,22 @@ export function OverviewPage() {
   const pendingApprovals = approvalCountQuery.data ?? 0;
   const budgetUsage = budgetUsageRatio(budgetStatusQuery.data as Record<string, unknown> | undefined);
 
-  const sessionsCount = snapshot?.status?.session_count ?? 0;
+  // 24h session count — derived from the sessions list (sorted DESC by
+  // created_at, default page size 100). `snapshot.status.session_count` is
+  // an all-time tally so it overstates the KPI by an order of magnitude on
+  // long-lived installs. If the list is a full page we may undercount when
+  // traffic is >100/24h — that's acceptable for the dashboard headline; the
+  // Sessions page paginates if the user wants a full roster.
+  const sessionsCount = useMemo(() => {
+    const list = sessionsQuery.data ?? [];
+    if (list.length === 0) return 0;
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    return list.filter((s) => {
+      if (!s.created_at) return false;
+      const t = Date.parse(s.created_at);
+      return Number.isFinite(t) && t >= cutoff;
+    }).length;
+  }, [sessionsQuery.data]);
   const defaultModel = agents.find((a) => a.model_name)?.model_name ?? "-";
 
   const rangeData = RANGE_DATA[range];
@@ -427,16 +457,14 @@ export function OverviewPage() {
 
   if (isError) {
     return (
-      <div className="max-w-[1380px] mx-auto">
-        <Card padding="lg" className="surface-lit">
-          <ErrorState onRetry={refresh} />
-        </Card>
-      </div>
+      <Card padding="lg" className="surface-lit">
+        <ErrorState onRetry={refresh} />
+      </Card>
     );
   }
 
   return (
-    <div className="flex flex-col gap-4 max-w-[1380px] mx-auto">
+    <div className="flex flex-col gap-4">
       {/* Hero strip */}
       <header className="flex items-end justify-between gap-4 flex-wrap">
         <div>

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4840,6 +4840,8 @@ system_prompt = "You are a helpful assistant."
         );
         // Ephemeral side-questions have no sender context — no user/channel
         // attribution to record. Per-user budget rollup will skip these.
+        // session_id is also None: ephemerals run on a throwaway session
+        // that is not persisted in the sessions table.
         let usage_record = librefang_memory::usage::UsageRecord {
             agent_id,
             provider: manifest.model.provider.clone(),
@@ -4851,6 +4853,7 @@ system_prompt = "You are a helpful assistant."
             latency_ms,
             user_id: None,
             channel: None,
+            session_id: None,
         };
         if let Err(e) = self.metering.check_all_and_record(
             &usage_record,
@@ -6480,6 +6483,7 @@ system_prompt = "You are a helpful assistant."
                         // before the spawn — moves into this async block.
                         user_id: attribution_user_id,
                         channel: attribution_channel.clone(),
+                        session_id: Some(effective_session_id),
                     };
                     if let Err(e) = kernel_clone.metering.check_all_and_record(
                         &usage_record,
@@ -8153,6 +8157,7 @@ system_prompt = "You are a helpful assistant."
             latency_ms,
             user_id: attribution_user_id,
             channel: attribution_channel.clone(),
+            session_id: Some(effective_session_id),
         };
         if let Err(e) = self.metering.check_all_and_record(
             &usage_record,
@@ -14984,6 +14989,7 @@ system_prompt = "You are a helpful assistant."
                 // attribution. Spend rolls up under `system`.
                 user_id: None,
                 channel: Some("system".to_string()),
+                session_id: None,
             };
             if let Err(e) = kernel.metering.record(&usage_record) {
                 tracing::debug!(error = %e, "Failed to record background review usage");

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 29;
+const SCHEMA_VERSION: u32 = 30;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -68,6 +68,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(27, migrate_v27);
     run_step!(28, migrate_v28);
     run_step!(29, migrate_v29);
+    run_step!(30, migrate_v30);
 
     Ok(())
 }
@@ -897,6 +898,26 @@ fn migrate_v29(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (29, datetime('now'), 'Add deleted_at/finished_at retention timestamps')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 30: Add `session_id` column to `usage_events` so spend/tokens can
+/// be rolled up per session (Recent sessions table on the dashboard).
+/// Pre-v30 rows leave `session_id` NULL and are simply excluded from
+/// per-session aggregates.
+fn migrate_v30(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !column_exists(conn, "usage_events", "session_id") {
+        conn.execute("ALTER TABLE usage_events ADD COLUMN session_id TEXT", [])?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_events(session_id)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (30, datetime('now'), 'Add session_id column to usage_events for per-session cost rollup')",
         [],
     )?;
     Ok(())

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -518,14 +518,24 @@ impl SessionStore {
         Ok(())
     }
 
-    /// List all sessions with metadata (session_id, agent_id, message_count, created_at).
+    /// List all sessions with metadata (session_id, agent_id, message_count,
+    /// created_at, label, duration_ms, cost_usd, total_tokens).
     ///
     /// `label` resolution: an explicit user-set label wins; otherwise a
     /// snippet of the first user message's text is returned so list views
     /// (Overview "Recent sessions", Sessions page, etc.) have something
-    /// readable instead of "(no label)" on every row. The Messages blob is
+    /// readable instead of "(no label)" on every row.
+    ///
+    /// `duration_ms` is the wall-clock span between the first and last
+    /// message timestamps — `None` for empty sessions or sessions whose
+    /// messages all pre-date the timestamp field. The Messages blob is
     /// already being deserialized for `message_count`, so this adds no
     /// extra round-trip per row.
+    ///
+    /// `cost_usd` and `total_tokens` are aggregated from `usage_events`
+    /// joined on `session_id` (added in schema v30). Pre-v30 events have
+    /// `session_id IS NULL` and contribute nothing — list views will show
+    /// `null` for those rows, not stale data.
     pub fn list_sessions(&self) -> LibreFangResult<Vec<serde_json::Value>> {
         let conn = self
             .conn
@@ -533,7 +543,19 @@ impl SessionStore {
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, agent_id, messages, context_window_tokens, created_at, label FROM sessions ORDER BY created_at DESC",
+                "SELECT s.id, s.agent_id, s.messages, s.context_window_tokens, s.created_at, s.label,
+                        COALESCE(u.total_cost_usd, 0.0) AS total_cost_usd,
+                        COALESCE(u.total_tokens, 0)    AS total_tokens
+                 FROM sessions s
+                 LEFT JOIN (
+                     SELECT session_id,
+                            SUM(cost_usd)                       AS total_cost_usd,
+                            SUM(input_tokens + output_tokens)   AS total_tokens
+                     FROM usage_events
+                     WHERE session_id IS NOT NULL
+                     GROUP BY session_id
+                 ) u ON u.session_id = s.id
+                 ORDER BY s.created_at DESC",
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
@@ -545,10 +567,30 @@ impl SessionStore {
                 let context_window_tokens: i64 = row.get(3)?;
                 let created_at: String = row.get(4)?;
                 let label: Option<String> = row.get(5)?;
+                let total_cost_usd: f64 = row.get(6)?;
+                let total_tokens: i64 = row.get(7)?;
                 let messages: Vec<Message> =
                     rmp_serde::from_slice(&messages_blob).unwrap_or_default();
                 let msg_count = messages.len();
                 let resolved_label = label.clone().or_else(|| derive_session_label(&messages));
+                // Duration spans the first to the last message that carries
+                // a timestamp. Skip messages with no timestamp so
+                // pre-`Message::timestamp` sessions don't anchor the span
+                // to "now-vs-now". `None` if fewer than two stamped
+                // messages exist.
+                let duration_ms: Option<i64> = {
+                    let mut stamps = messages.iter().filter_map(|m| m.timestamp);
+                    let first = stamps.next();
+                    let last = stamps.last().or(first);
+                    match (first, last) {
+                        (Some(a), Some(b)) if b > a => Some((b - a).num_milliseconds()),
+                        _ => None,
+                    }
+                };
+                // Cost / tokens default to 0 via COALESCE. Surface them as
+                // numeric (not null) so the dashboard formatter can
+                // distinguish "session existed but cost zero" from
+                // "no metering data" using the message_count.
                 Ok(serde_json::json!({
                     "session_id": session_id,
                     "agent_id": agent_id,
@@ -556,6 +598,9 @@ impl SessionStore {
                     "context_window_tokens": context_window_tokens.max(0),
                     "created_at": created_at,
                     "label": resolved_label,
+                    "duration_ms": duration_ms,
+                    "cost_usd": total_cost_usd,
+                    "total_tokens": total_tokens.max(0),
                 }))
             })
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -1645,5 +1690,94 @@ mod tests {
 
         let results = store.search_sessions("searchable", None).unwrap();
         assert!(results.is_empty());
+    }
+
+    /// list_sessions surfaces per-session aggregates (cost_usd, total_tokens,
+    /// duration_ms) so the Overview "Recent sessions" table can render them
+    /// without a follow-up round-trip per row. Cost/tokens come from a
+    /// LEFT JOIN on usage_events keyed by session_id (schema v30); duration
+    /// is computed from the message timestamps already in the messages blob.
+    #[test]
+    fn list_sessions_includes_cost_tokens_duration_aggregates() {
+        let conn = Arc::new(Mutex::new(Connection::open_in_memory().unwrap()));
+        run_migrations(&conn.lock().unwrap()).unwrap();
+        let store = SessionStore::new(Arc::clone(&conn));
+
+        let agent_id = AgentId::new();
+        let mut session = store.create_session(agent_id).unwrap();
+
+        // Two messages 5s apart so duration_ms = 5000. We override the
+        // timestamps Message::* would otherwise stamp at "now".
+        let t0 = chrono::Utc::now();
+        let t1 = t0 + chrono::Duration::seconds(5);
+        let mut user = Message::user("hi");
+        user.timestamp = Some(t0);
+        let mut asst = Message::assistant("ack");
+        asst.timestamp = Some(t1);
+        session.messages.push(user);
+        session.messages.push(asst);
+        store.save_session(&session).unwrap();
+
+        // Two usage_events tagged to this session: one tagged, one NULL.
+        // The aggregate must include only the tagged one.
+        {
+            let c = conn.lock().unwrap();
+            c.execute(
+                "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, session_id)
+                 VALUES (?1, ?2, datetime('now'), 'm', 'p', 100, 50, 0.012, 0, 0, ?3)",
+                rusqlite::params![
+                    uuid::Uuid::new_v4().to_string(),
+                    agent_id.0.to_string(),
+                    session.id.0.to_string(),
+                ],
+            )
+            .unwrap();
+            c.execute(
+                "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, session_id)
+                 VALUES (?1, ?2, datetime('now'), 'm', 'p', 999, 999, 9.99, 0, 0, NULL)",
+                rusqlite::params![
+                    uuid::Uuid::new_v4().to_string(),
+                    agent_id.0.to_string(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let listed = store.list_sessions().unwrap();
+        let row = listed
+            .iter()
+            .find(|v| v["session_id"].as_str() == Some(&session.id.0.to_string()))
+            .expect("created session must be listed");
+
+        assert_eq!(row["message_count"].as_u64(), Some(2));
+        // 5s span between the two stamped messages — within ~50ms tolerance.
+        let duration_ms = row["duration_ms"].as_i64().expect("duration present");
+        assert!(
+            (4900..=5100).contains(&duration_ms),
+            "duration_ms = {} not within tolerance",
+            duration_ms,
+        );
+        assert!((row["cost_usd"].as_f64().unwrap() - 0.012).abs() < 1e-9);
+        assert_eq!(row["total_tokens"].as_u64(), Some(150));
+    }
+
+    /// Sessions with no usage_events still list with cost_usd=0 and
+    /// total_tokens=0 (NOT null). duration_ms is null when fewer than two
+    /// timestamped messages exist.
+    #[test]
+    fn list_sessions_zero_aggregates_for_unmetered_session() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        let session = store.create_session(agent_id).unwrap();
+
+        let listed = store.list_sessions().unwrap();
+        let row = listed
+            .iter()
+            .find(|v| v["session_id"].as_str() == Some(&session.id.0.to_string()))
+            .expect("created session must be listed");
+
+        assert_eq!(row["cost_usd"].as_f64(), Some(0.0));
+        assert_eq!(row["total_tokens"].as_u64(), Some(0));
+        assert!(row["duration_ms"].is_null());
     }
 }

--- a/crates/librefang-memory/src/usage.rs
+++ b/crates/librefang-memory/src/usage.rs
@@ -1,7 +1,7 @@
 //! Usage tracking store — records LLM usage events for cost monitoring.
 
 use chrono::Utc;
-use librefang_types::agent::{AgentId, UserId};
+use librefang_types::agent::{AgentId, SessionId, UserId};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use rusqlite::{Connection, TransactionBehavior};
 use serde::{Deserialize, Serialize};
@@ -39,6 +39,11 @@ pub struct UsageRecord {
     /// "discord", "api", "cron", "cli"). `None` for unattributed calls.
     #[serde(default)]
     pub channel: Option<String>,
+    /// Session this LLM call belonged to, when available. `None` for
+    /// session-less paths (ephemeral side-questions, background review)
+    /// and for pre-v30 records that pre-date this column.
+    #[serde(default)]
+    pub session_id: Option<SessionId>,
 }
 
 impl UsageRecord {
@@ -73,6 +78,7 @@ impl UsageRecord {
             latency_ms,
             user_id: None,
             channel: None,
+            session_id: None,
         }
     }
 }
@@ -186,12 +192,13 @@ impl UsageStore {
     fn insert_record(conn: &Connection, record: &UsageRecord) -> LibreFangResult<()> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
-        // RBAC M5: persist user_id/channel alongside the existing columns.
-        // Schema v23 added these as NULL-able, so missing attribution still
+        // RBAC M5 + session attribution: persist user_id/channel/session_id
+        // alongside the existing columns. Schema v23 added user_id/channel,
+        // v30 added session_id — all are NULL-able so missing attribution
         // round-trips as NULL.
         conn.execute(
-            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, user_id, channel)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, user_id, channel, session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             rusqlite::params![
                 id,
                 record.agent_id.0.to_string(),
@@ -205,6 +212,7 @@ impl UsageStore {
                 record.latency_ms as i64,
                 record.user_id.map(|u| u.to_string()),
                 record.channel.as_deref(),
+                record.session_id.map(|s| s.0.to_string()),
             ],
         )
         .map_err(|e| LibreFangError::Memory(e.to_string()))?;


### PR DESCRIPTION
## Summary
- **Overview layout**: drop the `max-w-[1380px] mx-auto` that was misreading the design canvas's 1380px (full frame width incl. sidebar) as a content-area cap. Wide screens were squeezing content into the middle with huge left/right gutters.
- **Default dark**: stop probing `prefers-color-scheme: light` — the team never used the light surface and the design only exists in dark.
- **KPI fields aligned with API**: Budget alert never fired because `budgetUsageRatio` looked for five `*_usd` field names that don't exist on `/api/budget` (real fields are `daily_spend / daily_limit / daily_pct`). Sessions KPI labelled "24h" was showing the all-time `session_count` (1911 on this install); now filters the sessions list by `created_at >= now-24h`.
- **Per-session cost/tokens/duration**: the Recent sessions table's Cost / Tokens / Dur columns were always "-" because `usage_events` had no `session_id` column to join on, and `Message` carries no token usage. This PR adds:
  - schema v30: `usage_events.session_id` (TEXT NULL) + `idx_usage_session`
  - `UsageRecord.session_id: Option<SessionId>` (`#[serde(default)]`, so existing struct literals using `..Default::default()` compile unchanged)
  - kernel passes `effective_session_id` at the streaming + non-streaming `send_message_full` callsites; ephemeral / background-review keep `None` (they have no session row)
  - `list_sessions` LEFT JOINs `usage_events` for `SUM(cost_usd)` / `SUM(input_tokens + output_tokens)` and computes `duration_ms` from the first/last timestamped message in the messages blob
  - 2 regression tests on the new aggregates and the unmetered fallback

## Out of scope (placeholder data flagged at `OverviewPage.tsx:33-39`)
The cost trend chart, token bars, latency trend, P95 hardcoded `218`, and "Tokens by agent" rows are still synthetic constants — the source comment explicitly notes "until backend exposes them" via `/api/usage/daily` and `/api/sessions/density`. Separate task.

## Test plan
- [x] `cargo build --workspace --lib`
- [x] `cargo test -p librefang-memory --lib` (174 + 2 new = 176 pass)
- [x] `cargo clippy -p librefang-memory -p librefang-kernel --lib --all-targets -- -D warnings`
- [x] `pnpm test --run` in dashboard (346 pass)
- [ ] Live: start daemon, send a real LLM call, verify `/api/sessions` returns non-zero `cost_usd` / `total_tokens` / `duration_ms` on that session's row, and Overview's Recent sessions table shows real values
- [ ] Live: confirm Overview content fills the main column on wide screens (no left/right gutter); page renders dark by default on a fresh localStorage
- [ ] Live: trigger a daily budget hit and confirm the Budget alert pill surfaces with the correct percentage